### PR TITLE
fix(trends): formula mode tooltip

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.stories.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.stories.tsx
@@ -147,7 +147,7 @@ Default.args = {}
 
 export const Columns: Story = BasicTemplate.bind({})
 Columns.args = {
-    entitiesAsColumnsOverride: true,
+    formula: true,
 }
 
 export function InWrapper(): JSX.Element {

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -82,7 +82,7 @@ export function InsightTooltip({
     embedded = false,
     hideColorCol = false,
     hideInspectActorsSection = false,
-    entitiesAsColumnsOverride,
+    formula,
     rowCutoff = ROW_CUTOFF,
     colCutoff = COL_CUTOFF,
     showHeader = true,
@@ -90,9 +90,9 @@ export function InsightTooltip({
 }: InsightTooltipProps): JSX.Element {
     // If multiple entities exist (i.e., pageview + autocapture) and there is a breakdown/compare/multi-group happening, itemize entities as columns to save vertical space..
     // If only a single entity exists, itemize entity counts as rows.
-    // Throw these rules out the window if `entitiesAsColumnsOverride` is set
+    // Throw these rules out the window if `formula` is set
     const itemizeEntitiesAsColumns =
-        entitiesAsColumnsOverride ??
+        !!formula ||
         ((seriesData?.length ?? 0) > 1 &&
             (seriesData?.[0]?.breakdown_value !== undefined || seriesData?.[0]?.compare_label !== undefined))
 
@@ -153,7 +153,7 @@ export function InsightTooltip({
                                 colIdx
                             )),
                     render: function renderSeriesColumnData(_, datum) {
-                        const seriesColumnData = datum.seriesData?.[colIdx]
+                        const seriesColumnData: SeriesDatum | undefined = datum.seriesData?.[colIdx]
                         return renderDatumToTableCell(
                             seriesColumnData?.action?.math_property,
                             seriesColumnData?.count,

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -55,7 +55,7 @@ export interface InsightTooltipProps extends Omit<TooltipConfig, 'renderSeries' 
     date?: string
     hideInspectActorsSection?: boolean
     seriesData: SeriesDatum[]
-    entitiesAsColumnsOverride?: boolean
+    formula?: boolean
     groupTypeLabel?: string
     timezone?: string | null
 }

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -520,7 +520,7 @@ export function LineGraph_({
                                             )} (${percentageLabel}%)`
                                         })
                                     }
-                                    formula={formula}
+                                    formula={!!formula}
                                     hideInspectActorsSection={!onClick || !showPersonsModal}
                                     groupTypeLabel={
                                         labelGroupType === 'people'

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -520,7 +520,7 @@ export function LineGraph_({
                                             )} (${percentageLabel}%)`
                                         })
                                     }
-                                    entitiesAsColumnsOverride={formula ? false : undefined}
+                                    formula={formula}
                                     hideInspectActorsSection={!onClick || !showPersonsModal}
                                     groupTypeLabel={
                                         labelGroupType === 'people'


### PR DESCRIPTION
## Problem

The tooltip is not useful in formula mode with breakdowns:

![2024-05-08 22 14 10](https://github.com/PostHog/posthog/assets/53387/95ed2477-c4ca-4641-a15b-ea23cc2739de)

## Changes

![2024-05-08 22 10 51](https://github.com/PostHog/posthog/assets/53387/7abd5766-4b94-43d5-82e4-51958afb1c23)

## How did you test this code?

Gifs above. Let's see what CI catches.

## Note

I might be AFK, so would love if whoever reviews also merges. This will solve user pain points.