### PR TITLE
fix: Use safer dict accessor when computing tiers information 

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -167,13 +167,13 @@ class BillingManager:
             product["percentage_usage"] = current_usage / usage_limit if usage_limit else 0
 
             # Also update the tiers
-            if product["tiers"]:
+            if product.get("tiers"):
                 product["tiers"] = compute_usage_per_tier(current_usage, product["projected_usage"], product["tiers"])
                 product["current_amount_usd"] = sum_total_across_tiers(product["tiers"])
 
             # Update the add on tiers
             # TODO: enhanced_persons: make sure this updates properly for addons with different usage keys
-            for addon in product["addons"]:
+            for addon in product.get("addons"):
                 if not addon["subscribed"]:
                     continue
                 addon_usage_key = addon.get("usage_key")


### PR DESCRIPTION
## Problem

Self-hosted deploys don't have access to plans information: https://github.com/PostHog/posthog/issues/22198

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
