### PR TITLE
fix: code should never care about anything with session_recording_events

### DIFF
--- a/ee/api/test/test_instance_settings.py
+++ b/ee/api/test/test_instance_settings.py
@@ -5,9 +5,6 @@ from ee.api.test.base import APILicensedTest
 from posthog.client import sync_execute
 from posthog.models.instance_setting import get_instance_setting
 from posthog.models.performance.sql import PERFORMANCE_EVENT_DATA_TABLE
-from posthog.session_recordings.sql.session_recording_event_sql import (
-    SESSION_RECORDING_EVENTS_DATA_TABLE,
-)
 from posthog.settings.data_stores import CLICKHOUSE_DATABASE
 from posthog.test.base import ClickhouseTestMixin, snapshot_clickhouse_alter_queries
 
@@ -17,27 +14,6 @@ class TestInstanceSettings(ClickhouseTestMixin, APILicensedTest):
         super().setUp()
         self.user.is_staff = True
         self.user.save()
-
-    @snapshot_clickhouse_alter_queries
-    def test_update_recordings_ttl_setting(self):
-        response = self.client.get(f"/api/instance_settings/RECORDINGS_TTL_WEEKS")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["value"], 3)
-
-        response = self.client.patch(f"/api/instance_settings/RECORDINGS_TTL_WEEKS", {"value": 5})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["value"], 5)
-
-        self.assertEqual(get_instance_setting("RECORDINGS_TTL_WEEKS"), 5)
-
-        table_engine = sync_execute(
-            "SELECT engine_full FROM system.tables WHERE database = %(database)s AND name = %(table)s",
-            {
-                "database": CLICKHOUSE_DATABASE,
-                "table": SESSION_RECORDING_EVENTS_DATA_TABLE(),
-            },
-        )
-        self.assertIn("TTL toDate(created_at) + toIntervalWeek(5)", table_engine[0][0])
 
     @snapshot_clickhouse_alter_queries
     def test_update_recordings_performance_events_ttl_setting(self):

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -17,7 +17,7 @@ ColumnName = str
 DEFAULT_TABLE_COLUMN: Literal["properties"] = "properties"
 
 
-TablesWithMaterializedColumns = Union[TableWithProperties, Literal["session_recording_events"]]
+TablesWithMaterializedColumns = Union[TableWithProperties]
 
 TRIM_AND_EXTRACT_PROPERTY = trim_quotes_expr("JSONExtractRaw({table_column}, %(property)s)")
 

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -42,19 +42,6 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
             EVENTS_TABLE_DEFAULT_MATERIALIZED_COLUMNS,
         )
         self.assertCountEqual(get_materialized_columns("person"), [])
-        self.assertEqual(
-            get_materialized_columns("session_recording_events"),
-            {
-                ("has_full_snapshot", "properties"): "has_full_snapshot",
-                ("events_summary", "properties"): "events_summary",
-                ("click_count", "properties"): "click_count",
-                ("keypress_count", "properties"): "keypress_count",
-                ("timestamps_summary", "properties"): "timestamps_summary",
-                ("first_event_timestamp", "properties"): "first_event_timestamp",
-                ("last_event_timestamp", "properties"): "last_event_timestamp",
-                ("urls", "properties"): "urls",
-            },
-        )
 
     def test_caching_and_materializing(self):
         with freeze_time("2020-01-04T13:01:01Z"):

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -61,6 +61,12 @@ LOG_RATE_LIMITER = Limiter(
 SESSION_RECORDING_DEDICATED_KAFKA_EVENTS = ("$snapshot_items",)
 SESSION_RECORDING_EVENT_NAMES = ("$snapshot", "$performance_event", *SESSION_RECORDING_DEDICATED_KAFKA_EVENTS)
 
+# TODO we should eventually be able to remove the code path this is counting
+LEGACY_SNAPSHOT_EVENTS_RECEIVED_COUNTER = Counter(
+    "capture_legacy_snapshot_events_received_total",
+    "Legacy snapshot events received by capture, we should receive zero of these.",
+)
+
 EVENTS_RECEIVED_COUNTER = Counter(
     "capture_events_received_total",
     "Events received by capture, tagged by resource type.",
@@ -154,6 +160,7 @@ def _kafka_topic(event_name: str, historical: bool = False, overflowing: bool = 
 
     match event_name:
         case "$snapshot":
+            LEGACY_SNAPSHOT_EVENTS_RECEIVED_COUNTER.inc()
             return KAFKA_SESSION_RECORDING_EVENTS
         case "$snapshot_items":
             if overflowing:

--- a/posthog/clickhouse/materialized_columns/column.py
+++ b/posthog/clickhouse/materialized_columns/column.py
@@ -1,12 +1,12 @@
 from datetime import timedelta
-from typing import Literal, Union
+from typing import Union
 
 from posthog.cache_utils import cache_for
 from posthog.models.property import PropertyName, TableColumn, TableWithProperties
 
 ColumnName = str
 
-TablesWithMaterializedColumns = Union[TableWithProperties, Literal["session_recording_events"]]
+TablesWithMaterializedColumns = Union[TableWithProperties]
 
 
 @cache_for(timedelta(minutes=15))

--- a/posthog/session_recordings/queries/test/test_session_recording_list_from_filters.py
+++ b/posthog/session_recordings/queries/test/test_session_recording_list_from_filters.py
@@ -37,10 +37,6 @@ from posthog.test.base import (
 
 @freeze_time("2021-01-01T13:46:23")
 class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
-    # this test does not create any session_recording_events, only writes to the session_replay summary table
-    # it is a pair with test_session_recording_list
-    # it should pass all the same tests but without needing the session_recording_events table at all
-
     def setUp(self):
         super().setUp()
         sync_execute(TRUNCATE_SESSION_REPLAY_EVENTS_TABLE_SQL())

--- a/posthog/session_recordings/queries/test/test_session_recording_list_from_session_replay.py
+++ b/posthog/session_recordings/queries/test/test_session_recording_list_from_session_replay.py
@@ -36,10 +36,6 @@ from posthog.test.base import (
 
 @freeze_time("2021-01-01T13:46:23")
 class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, APIBaseTest):
-    # this test does not create any session_recording_events, only writes to the session_replay summary table
-    # it is a pair with test_session_recording_list
-    # it should pass all the same tests but without needing the session_recording_events table at all
-
     @classmethod
     def teardown_class(cls):
         sync_execute(TRUNCATE_SESSION_REPLAY_EVENTS_TABLE_SQL())

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -173,8 +173,6 @@ CLICKHOUSE_TABLES = [
     "sharded_session_replay_events",
     "log_entries",
 ]
-if not is_cloud():
-    CLICKHOUSE_TABLES.append("session_recording_events")
 
 
 @shared_task(ignore_result=True)


### PR DESCRIPTION
see https://posthog.slack.com/archives/C03PB072FMJ/p1715205103647789

we don't query this but we've never completely tidied up what is there... let's see what tests fail if we do this

it's way too late (for me today) to think about removing the table but this will leave only the SQL setup and teardown in the code

---

follow-up

- [ ] add the new counter to the replay dashboard to make sure we're not trying to ingest events to this table
- [ ] think about how we can remove/deprecate the RECORDINGS_TTL_WEEKS instance setting
- [ ] think about how we can remove the recording events table without upsetting someone self-hosted (this should be totally safe)