### PR TITLE
fix: Fix Stickiness Actors

### DIFF
--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -172,12 +172,13 @@ export function ActionsLineGraph({
                               openPersonsModal({
                                   title,
                                   query: datasetToActorsQuery({ dataset, query: query.source, day }),
-                                  additionalSelect: isLifecycle
-                                      ? {}
-                                      : {
-                                            value_at_data_point: 'event_count',
-                                            matched_recordings: 'matched_recordings',
-                                        },
+                                  additionalSelect:
+                                      isLifecycle || isStickiness
+                                          ? {}
+                                          : {
+                                                value_at_data_point: 'event_count',
+                                                matched_recordings: 'matched_recordings',
+                                            },
                               })
                           } else {
                               const datasetUrls = urlsForDatasets(


### PR DESCRIPTION
## Problem

Issue: https://posthoghelp.zendesk.com/agent/tickets/13258 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15305)

Stickyness actors query was asking for event_count and matched_recording.

There is no event_count for stickiness, just number of days in a row that the event was recorded.

<img width="578" alt="image" src="https://github.com/PostHog/posthog/assets/1855120/fc40c222-80a2-4816-8451-45f475dc4694">
