### PR TITLE
fix: Ignore static assets in logout middleware

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -667,7 +667,10 @@ class AutoLogoutImpersonateMiddleware:
             # 2. For any other endpoint we want to redirect to the logout page
             # 3. BUT we wan't to intercept the /logout endpoint so that we can restore the original login
 
-            if request.path.startswith("/api/"):
+            if request.path.startswith("/static/"):
+                # Skip static files
+                pass
+            elif request.path.startswith("/api/"):
                 return HttpResponse(
                     "Impersonation session has expired. Please log in again.",
                     status=401,


### PR DESCRIPTION
## Problem

Can't say for sure if this solves the issue but there seemed to be an issue with static assets triggering a logout scenario. Could be a red-herring but also doesn't hurt to ignore static assets.

## Changes

* Skips logout for static assets

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
