### PR TITLE
feat: Add $is_identified to taxonomy

### DIFF
--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -992,7 +992,7 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
         },
         $is_identified: {
             label: 'Is Identified',
-            description: 'Has the user called identify()',
+            description: 'When the person was identified',
         },
     },
     numerical_event_properties: {}, // Same as event properties, see assignment below

--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -990,6 +990,10 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
             label: 'ttclid',
             description: 'TikTok Click ID',
         },
+        $is_identified: {
+            label: 'Is Identified',
+            description: 'Has the user called identify()',
+        },
     },
     numerical_event_properties: {}, // Same as event properties, see assignment below
     person_properties: {}, // Currently person properties are the same as event properties, see assignment below


### PR DESCRIPTION
## Problem
https://posthog.slack.com/archives/C0351B1DMUY/p1715202714823589

## Changes
Add $is_identified to taxonomy

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?


<img width="437" alt="Screenshot 2024-05-09 at 10 02 28" src="https://github.com/PostHog/posthog/assets/2056078/8a585f3d-c366-4421-b9f8-c5ffa34cf1de">


