### PR TITLE
fix: persons modal recordings

### DIFF
--- a/posthog/hogql_queries/actor_strategies.py
+++ b/posthog/hogql_queries/actor_strategies.py
@@ -6,7 +6,7 @@ from posthog.hogql import ast
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.parser import parse_expr
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
-from posthog.hogql_queries.utils.recordings import RecordingsHelper
+from posthog.hogql_queries.utils.recordings_helper import RecordingsHelper
 from posthog.models import Team, Person, Group
 from posthog.schema import ActorsQuery
 

--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -67,7 +67,9 @@ class ActorsQueryRunner(QueryRunner):
                 )
             yield new_row
 
-    def prepare_recordings(self, column_name, input_columns):
+    def prepare_recordings(
+        self, column_name: str, input_columns: list[str]
+    ) -> tuple[int | None, dict[str, list[dict]] | None]:
         if (column_name != "person" and column_name != "actor") or "matched_recordings" not in input_columns:
             return None, None
 

--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -64,7 +64,7 @@ class ActorsQueryRunner(QueryRunner):
             new_row[actor_column_index] = actor if actor else {"id": actor_id}
             if recordings_column_index is not None and recordings_lookup is not None:
                 new_row[recordings_column_index] = (
-                    self.get_recordings(result[recordings_column_index], recordings_lookup) or None
+                    self._get_recordings(result[recordings_column_index], recordings_lookup) or None
                 )
             yield new_row
 

--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -41,14 +41,15 @@ class ActorsQueryRunner(QueryRunner):
             return GroupStrategy(self.group_type_index, team=self.team, query=self.query, paginator=self.paginator)
         return PersonStrategy(team=self.team, query=self.query, paginator=self.paginator)
 
-    def get_recordings(self, event_results, recordings_lookup) -> Generator[dict, None, None]:
+    @staticmethod
+    def _get_recordings(event_results: list, recordings_lookup: dict) -> Generator[dict, None, None]:
         return (
             {"session_id": session_id, "events": recordings_lookup[session_id]}
             for session_id in {event[2] for event in event_results}
             if session_id in recordings_lookup
         )
 
-    def enrich_with_actors(
+    def _enrich_with_actors(
         self,
         results,
         actor_column_index,
@@ -97,7 +98,7 @@ class ActorsQueryRunner(QueryRunner):
             recordings_column_index, recordings_lookup = self.prepare_recordings(column_name, input_columns)
 
             missing_actors_count = len(self.paginator.results) - len(actors_lookup)
-            results = self.enrich_with_actors(
+            results = self._enrich_with_actors(
                 results, actor_column_index, actors_lookup, recordings_column_index, recordings_lookup
             )
 

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -451,7 +451,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:40:33.701463', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:54:08.619719', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -598,7 +598,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:40:34.151179', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:54:09.049130', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -745,7 +745,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:40:34.593259', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:54:09.870703', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -892,7 +892,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:40:35.050182', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:54:10.311246', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -450,12 +450,8 @@
 # name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties.2
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:16:39.462676', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -601,12 +597,8 @@
 # name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties.4
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:16:39.907679', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -752,12 +744,8 @@
 # name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties.6
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:16:40.349666', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -903,12 +891,8 @@
 # name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties.8
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:16:40.783025', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -451,7 +451,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:28:40.074481', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:40:33.701463', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -598,7 +598,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:28:40.524091', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:40:34.151179', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -745,7 +745,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:28:40.969952', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:40:34.593259', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -892,7 +892,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:28:41.808259', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:40:35.050182', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -451,7 +451,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:54:08.619719', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 13:06:08.731411', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -598,7 +598,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:54:09.049130', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 13:06:09.170508', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -745,7 +745,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:54:09.870703', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 13:06:09.613261', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -892,7 +892,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:54:10.311246', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 13:06:10.071421', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -451,7 +451,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:16:39.462676', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:28:40.074481', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -598,7 +598,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:16:39.907679', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:28:40.524091', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -745,7 +745,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:16:40.349666', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:28:40.969952', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -892,7 +892,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:16:40.783025', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:28:41.808259', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -451,7 +451,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 13:06:08.731411', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2019-12-31 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -598,7 +598,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 13:06:09.170508', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2019-12-31 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -745,7 +745,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 13:06:09.613261', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2019-12-31 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -892,7 +892,757 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 13:06:10.071421', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2019-12-31 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=1000000,
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
+  '''
+# ---
+# name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties_materialized
+  '''
+  SELECT concat(ifNull(toString((aggregation_target_with_props.prop).1), ''), '::', ifNull(toString((aggregation_target_with_props.prop).2), '')) AS name,
+         countDistinctIf(aggregation_target_with_props.actor_id, ifNull(equals(aggregation_target_with_props.steps, 2), 0)) AS success_count,
+         countDistinctIf(aggregation_target_with_props.actor_id, ifNull(notEquals(aggregation_target_with_props.steps, 2), 1)) AS failure_count
+  FROM
+    (SELECT funnel_actors.actor_id AS actor_id,
+            funnel_actors.steps AS steps,
+            arrayJoin(arrayZip(['$browser'], [JSONExtractString(persons.person_props, '$browser')])) AS prop
+     FROM
+       (SELECT aggregation_target AS actor_id,
+               timestamp AS timestamp,
+               steps AS steps,
+               final_timestamp AS final_timestamp,
+               first_timestamp AS first_timestamp
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
+                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
+                  argMax(latest_0, steps) AS timestamp,
+                  argMax(latest_1, steps) AS final_timestamp,
+                  argMax(latest_0, steps) AS first_timestamp
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     steps AS steps,
+                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
+                                     step_1_conversion_time AS step_1_conversion_time,
+                                     latest_0 AS latest_0,
+                                     latest_1 AS latest_1,
+                                     latest_0 AS latest_0
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        latest_1 AS latest_1,
+                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
+                 FROM
+                   (SELECT aggregation_target AS aggregation_target,
+                           timestamp AS timestamp,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           step_1 AS step_1,
+                           min(latest_1) OVER (PARTITION BY aggregation_target
+                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              e__pdi.person_id AS aggregation_target,
+                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
+                       FROM events AS e
+                       INNER JOIN
+                         (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
+                                 person_distinct_id2.distinct_id AS distinct_id
+                          FROM person_distinct_id2
+                          WHERE equals(person_distinct_id2.team_id, 2)
+                          GROUP BY person_distinct_id2.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id)
+                       WHERE and(equals(e.team_id, 2), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+                 WHERE ifNull(equals(step_0, 1), 0)))
+           GROUP BY aggregation_target,
+                    steps
+           HAVING ifNull(equals(steps, max_steps), isNull(steps)
+                         and isNull(max_steps)))
+        WHERE ifNull(in(steps, [1, 2]), 0)
+        ORDER BY aggregation_target ASC) AS funnel_actors
+     JOIN
+       (SELECT persons.id AS id,
+               persons.properties AS person_props
+        FROM
+          (SELECT person.id AS id,
+                  person.properties AS properties
+           FROM person
+           WHERE and(equals(person.team_id, 2), ifNull(in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 2)
+                                                             GROUP BY person.id
+                                                             HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons) AS persons ON equals(persons.id, funnel_actors.actor_id)) AS aggregation_target_with_props
+  GROUP BY (aggregation_target_with_props.prop).1, (aggregation_target_with_props.prop).2
+  HAVING ifNull(notIn((aggregation_target_with_props.prop).1, []), 0)
+  LIMIT 100
+  UNION ALL
+  SELECT 'Total_Values_In_Query' AS name,
+         countDistinctIf(funnel_actors.actor_id, ifNull(equals(funnel_actors.steps, 2), 0)) AS success_count,
+         countDistinctIf(funnel_actors.actor_id, ifNull(notEquals(funnel_actors.steps, 2), 1)) AS failure_count
+  FROM
+    (SELECT aggregation_target AS actor_id,
+            timestamp AS timestamp,
+            steps AS steps,
+            final_timestamp AS final_timestamp,
+            first_timestamp AS first_timestamp
+     FROM
+       (SELECT aggregation_target AS aggregation_target,
+               steps AS steps,
+               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
+               median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
+               argMax(latest_0, steps) AS timestamp,
+               argMax(latest_1, steps) AS final_timestamp,
+               argMax(latest_0, steps) AS first_timestamp
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
+                                  step_1_conversion_time AS step_1_conversion_time,
+                                  latest_0 AS latest_0,
+                                  latest_1 AS latest_1,
+                                  latest_0 AS latest_0
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     timestamp AS timestamp,
+                     step_0 AS step_0,
+                     latest_0 AS latest_0,
+                     step_1 AS step_1,
+                     latest_1 AS latest_1,
+                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        step_1 AS step_1,
+                        min(latest_1) OVER (PARTITION BY aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1
+                 FROM
+                   (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                           e__pdi.person_id AS aggregation_target,
+                           if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                           if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                           if(equals(e.event, 'paid'), 1, 0) AS step_1,
+                           if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1
+                    FROM events AS e
+                    INNER JOIN
+                      (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
+                              person_distinct_id2.distinct_id AS distinct_id
+                       FROM person_distinct_id2
+                       WHERE equals(person_distinct_id2.team_id, 2)
+                       GROUP BY person_distinct_id2.distinct_id
+                       HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id)
+                    WHERE and(equals(e.team_id, 2), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+              WHERE ifNull(equals(step_0, 1), 0)))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING ifNull(equals(steps, max_steps), isNull(steps)
+                      and isNull(max_steps)))
+     WHERE ifNull(in(steps, [1, 2]), 0)
+     ORDER BY aggregation_target ASC) AS funnel_actors
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=1000000,
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
+  '''
+# ---
+# name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties_materialized.1
+  '''
+  SELECT persons.id,
+         persons.id AS id,
+         source.matching_events AS matching_events
+  FROM
+    (SELECT funnel_actors.actor_id AS actor_id,
+            any(funnel_actors.matching_events) AS matching_events
+     FROM
+       (SELECT aggregation_target AS actor_id,
+               final_matching_events AS matching_events,
+               timestamp AS timestamp,
+               steps AS steps,
+               final_timestamp AS final_timestamp,
+               first_timestamp AS first_timestamp
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
+                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
+                  groupArray(10)(step_0_matching_event) AS step_0_matching_events,
+                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
+                  groupArray(10)(final_matching_event) AS final_matching_events,
+                  argMax(latest_0, steps) AS timestamp,
+                  argMax(latest_1, steps) AS final_timestamp,
+                  argMax(latest_0, steps) AS first_timestamp
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     steps AS steps,
+                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
+                                     step_1_conversion_time AS step_1_conversion_time,
+                                     tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
+                                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
+                                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
+                                     latest_0 AS latest_0,
+                                     latest_1 AS latest_1,
+                                     latest_0 AS latest_0
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        uuid_0 AS uuid_0,
+                        `$session_id_0` AS `$session_id_0`,
+                        `$window_id_0` AS `$window_id_0`,
+                        step_1 AS step_1,
+                        latest_1 AS latest_1,
+                        uuid_1 AS uuid_1,
+                        `$session_id_1` AS `$session_id_1`,
+                        `$window_id_1` AS `$window_id_1`,
+                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
+                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
+                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
+                 FROM
+                   (SELECT aggregation_target AS aggregation_target,
+                           timestamp AS timestamp,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           uuid_0 AS uuid_0,
+                           `$session_id_0` AS `$session_id_0`,
+                           `$window_id_0` AS `$window_id_0`,
+                           step_1 AS step_1,
+                           min(latest_1) OVER (PARTITION BY aggregation_target
+                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
+                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
+                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
+                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
+                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
+                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              e__pdi.person_id AS aggregation_target,
+                              e.uuid AS uuid,
+                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
+                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
+                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
+                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
+                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
+                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
+                       FROM events AS e
+                       INNER JOIN
+                         (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
+                                 argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS e__pdi___person_id,
+                                 person_distinct_id2.distinct_id AS distinct_id
+                          FROM person_distinct_id2
+                          WHERE equals(person_distinct_id2.team_id, 2)
+                          GROUP BY person_distinct_id2.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id)
+                       INNER JOIN
+                         (SELECT person.id AS id,
+                                 nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
+                          FROM person
+                          WHERE and(equals(person.team_id, 2), ifNull(in(tuple(person.id, person.version),
+                                                                           (SELECT person.id AS id, max(person.version) AS version
+                                                                            FROM person
+                                                                            WHERE equals(person.team_id, 2)
+                                                                            GROUP BY person.id
+                                                                            HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__pdi__person ON equals(e__pdi.e__pdi___person_id, e__pdi__person.id)
+                       WHERE and(equals(e.team_id, 2), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__pdi__person.`properties___$browser`, 'Positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+                 WHERE ifNull(equals(step_0, 1), 0)))
+           GROUP BY aggregation_target,
+                    steps
+           HAVING ifNull(equals(steps, max_steps), isNull(steps)
+                         and isNull(max_steps)))
+        WHERE ifNull(in(steps, [1, 2]), 0)
+        ORDER BY aggregation_target ASC) AS funnel_actors
+     WHERE ifNull(equals(funnel_actors.steps, 2), 0)
+     GROUP BY funnel_actors.actor_id
+     ORDER BY funnel_actors.actor_id ASC) AS source
+  INNER JOIN
+    (SELECT person.id AS id
+     FROM person
+     WHERE equals(person.team_id, 2)
+     GROUP BY person.id
+     HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons ON equals(persons.id, source.actor_id)
+  ORDER BY persons.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
+  '''
+# ---
+# name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties_materialized.2
+  '''
+  SELECT DISTINCT session_replay_events.session_id AS session_id
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2019-12-31 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=1000000,
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
+  '''
+# ---
+# name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties_materialized.3
+  '''
+  SELECT persons.id,
+         persons.id AS id,
+         source.matching_events AS matching_events
+  FROM
+    (SELECT funnel_actors.actor_id AS actor_id,
+            any(funnel_actors.matching_events) AS matching_events
+     FROM
+       (SELECT aggregation_target AS actor_id,
+               final_matching_events AS matching_events,
+               timestamp AS timestamp,
+               steps AS steps,
+               final_timestamp AS final_timestamp,
+               first_timestamp AS first_timestamp
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
+                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
+                  groupArray(10)(step_0_matching_event) AS step_0_matching_events,
+                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
+                  groupArray(10)(final_matching_event) AS final_matching_events,
+                  argMax(latest_0, steps) AS timestamp,
+                  argMax(latest_1, steps) AS final_timestamp,
+                  argMax(latest_0, steps) AS first_timestamp
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     steps AS steps,
+                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
+                                     step_1_conversion_time AS step_1_conversion_time,
+                                     tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
+                                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
+                                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
+                                     latest_0 AS latest_0,
+                                     latest_1 AS latest_1,
+                                     latest_0 AS latest_0
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        uuid_0 AS uuid_0,
+                        `$session_id_0` AS `$session_id_0`,
+                        `$window_id_0` AS `$window_id_0`,
+                        step_1 AS step_1,
+                        latest_1 AS latest_1,
+                        uuid_1 AS uuid_1,
+                        `$session_id_1` AS `$session_id_1`,
+                        `$window_id_1` AS `$window_id_1`,
+                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
+                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
+                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
+                 FROM
+                   (SELECT aggregation_target AS aggregation_target,
+                           timestamp AS timestamp,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           uuid_0 AS uuid_0,
+                           `$session_id_0` AS `$session_id_0`,
+                           `$window_id_0` AS `$window_id_0`,
+                           step_1 AS step_1,
+                           min(latest_1) OVER (PARTITION BY aggregation_target
+                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
+                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
+                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
+                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
+                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
+                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              e__pdi.person_id AS aggregation_target,
+                              e.uuid AS uuid,
+                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
+                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
+                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
+                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
+                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
+                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
+                       FROM events AS e
+                       INNER JOIN
+                         (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
+                                 argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS e__pdi___person_id,
+                                 person_distinct_id2.distinct_id AS distinct_id
+                          FROM person_distinct_id2
+                          WHERE equals(person_distinct_id2.team_id, 2)
+                          GROUP BY person_distinct_id2.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id)
+                       INNER JOIN
+                         (SELECT person.id AS id,
+                                 nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
+                          FROM person
+                          WHERE and(equals(person.team_id, 2), ifNull(in(tuple(person.id, person.version),
+                                                                           (SELECT person.id AS id, max(person.version) AS version
+                                                                            FROM person
+                                                                            WHERE equals(person.team_id, 2)
+                                                                            GROUP BY person.id
+                                                                            HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__pdi__person ON equals(e__pdi.e__pdi___person_id, e__pdi__person.id)
+                       WHERE and(equals(e.team_id, 2), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__pdi__person.`properties___$browser`, 'Positive'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+                 WHERE ifNull(equals(step_0, 1), 0)))
+           GROUP BY aggregation_target,
+                    steps
+           HAVING ifNull(equals(steps, max_steps), isNull(steps)
+                         and isNull(max_steps)))
+        WHERE ifNull(in(steps, [1, 2]), 0)
+        ORDER BY aggregation_target ASC) AS funnel_actors
+     WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
+     GROUP BY funnel_actors.actor_id
+     ORDER BY funnel_actors.actor_id ASC) AS source
+  INNER JOIN
+    (SELECT person.id AS id
+     FROM person
+     WHERE equals(person.team_id, 2)
+     GROUP BY person.id
+     HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons ON equals(persons.id, source.actor_id)
+  ORDER BY persons.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
+  '''
+# ---
+# name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties_materialized.4
+  '''
+  SELECT DISTINCT session_replay_events.session_id AS session_id
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2019-12-31 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=1000000,
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
+  '''
+# ---
+# name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties_materialized.5
+  '''
+  SELECT persons.id,
+         persons.id AS id,
+         source.matching_events AS matching_events
+  FROM
+    (SELECT funnel_actors.actor_id AS actor_id,
+            any(funnel_actors.matching_events) AS matching_events
+     FROM
+       (SELECT aggregation_target AS actor_id,
+               final_matching_events AS matching_events,
+               timestamp AS timestamp,
+               steps AS steps,
+               final_timestamp AS final_timestamp,
+               first_timestamp AS first_timestamp
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
+                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
+                  groupArray(10)(step_0_matching_event) AS step_0_matching_events,
+                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
+                  groupArray(10)(final_matching_event) AS final_matching_events,
+                  argMax(latest_0, steps) AS timestamp,
+                  argMax(latest_1, steps) AS final_timestamp,
+                  argMax(latest_0, steps) AS first_timestamp
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     steps AS steps,
+                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
+                                     step_1_conversion_time AS step_1_conversion_time,
+                                     tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
+                                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
+                                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
+                                     latest_0 AS latest_0,
+                                     latest_1 AS latest_1,
+                                     latest_0 AS latest_0
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        uuid_0 AS uuid_0,
+                        `$session_id_0` AS `$session_id_0`,
+                        `$window_id_0` AS `$window_id_0`,
+                        step_1 AS step_1,
+                        latest_1 AS latest_1,
+                        uuid_1 AS uuid_1,
+                        `$session_id_1` AS `$session_id_1`,
+                        `$window_id_1` AS `$window_id_1`,
+                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
+                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
+                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
+                 FROM
+                   (SELECT aggregation_target AS aggregation_target,
+                           timestamp AS timestamp,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           uuid_0 AS uuid_0,
+                           `$session_id_0` AS `$session_id_0`,
+                           `$window_id_0` AS `$window_id_0`,
+                           step_1 AS step_1,
+                           min(latest_1) OVER (PARTITION BY aggregation_target
+                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
+                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
+                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
+                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
+                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
+                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              e__pdi.person_id AS aggregation_target,
+                              e.uuid AS uuid,
+                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
+                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
+                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
+                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
+                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
+                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
+                       FROM events AS e
+                       INNER JOIN
+                         (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
+                                 argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS e__pdi___person_id,
+                                 person_distinct_id2.distinct_id AS distinct_id
+                          FROM person_distinct_id2
+                          WHERE equals(person_distinct_id2.team_id, 2)
+                          GROUP BY person_distinct_id2.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id)
+                       INNER JOIN
+                         (SELECT person.id AS id,
+                                 nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
+                          FROM person
+                          WHERE and(equals(person.team_id, 2), ifNull(in(tuple(person.id, person.version),
+                                                                           (SELECT person.id AS id, max(person.version) AS version
+                                                                            FROM person
+                                                                            WHERE equals(person.team_id, 2)
+                                                                            GROUP BY person.id
+                                                                            HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__pdi__person ON equals(e__pdi.e__pdi___person_id, e__pdi__person.id)
+                       WHERE and(equals(e.team_id, 2), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__pdi__person.`properties___$browser`, 'Negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+                 WHERE ifNull(equals(step_0, 1), 0)))
+           GROUP BY aggregation_target,
+                    steps
+           HAVING ifNull(equals(steps, max_steps), isNull(steps)
+                         and isNull(max_steps)))
+        WHERE ifNull(in(steps, [1, 2]), 0)
+        ORDER BY aggregation_target ASC) AS funnel_actors
+     WHERE ifNull(equals(funnel_actors.steps, 2), 0)
+     GROUP BY funnel_actors.actor_id
+     ORDER BY funnel_actors.actor_id ASC) AS source
+  INNER JOIN
+    (SELECT person.id AS id
+     FROM person
+     WHERE equals(person.team_id, 2)
+     GROUP BY person.id
+     HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons ON equals(persons.id, source.actor_id)
+  ORDER BY persons.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
+  '''
+# ---
+# name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties_materialized.6
+  '''
+  SELECT DISTINCT session_replay_events.session_id AS session_id
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2019-12-31 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=1000000,
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
+  '''
+# ---
+# name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties_materialized.7
+  '''
+  SELECT persons.id,
+         persons.id AS id,
+         source.matching_events AS matching_events
+  FROM
+    (SELECT funnel_actors.actor_id AS actor_id,
+            any(funnel_actors.matching_events) AS matching_events
+     FROM
+       (SELECT aggregation_target AS actor_id,
+               final_matching_events AS matching_events,
+               timestamp AS timestamp,
+               steps AS steps,
+               final_timestamp AS final_timestamp,
+               first_timestamp AS first_timestamp
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
+                  median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
+                  groupArray(10)(step_0_matching_event) AS step_0_matching_events,
+                  groupArray(10)(step_1_matching_event) AS step_1_matching_events,
+                  groupArray(10)(final_matching_event) AS final_matching_events,
+                  argMax(latest_0, steps) AS timestamp,
+                  argMax(latest_1, steps) AS final_timestamp,
+                  argMax(latest_0, steps) AS first_timestamp
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     steps AS steps,
+                     max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
+                                     step_1_conversion_time AS step_1_conversion_time,
+                                     tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
+                                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
+                                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event,
+                                     latest_0 AS latest_0,
+                                     latest_1 AS latest_1,
+                                     latest_0 AS latest_0
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        uuid_0 AS uuid_0,
+                        `$session_id_0` AS `$session_id_0`,
+                        `$window_id_0` AS `$window_id_0`,
+                        step_1 AS step_1,
+                        latest_1 AS latest_1,
+                        uuid_1 AS uuid_1,
+                        `$session_id_1` AS `$session_id_1`,
+                        `$window_id_1` AS `$window_id_1`,
+                        if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1) AS steps,
+                        if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                        tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
+                        tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
+                        if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, step_1_matching_event)) AS final_matching_event
+                 FROM
+                   (SELECT aggregation_target AS aggregation_target,
+                           timestamp AS timestamp,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           uuid_0 AS uuid_0,
+                           `$session_id_0` AS `$session_id_0`,
+                           `$window_id_0` AS `$window_id_0`,
+                           step_1 AS step_1,
+                           min(latest_1) OVER (PARTITION BY aggregation_target
+                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                              last_value(uuid_1) OVER (PARTITION BY aggregation_target
+                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
+                                                                      last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
+                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
+                                                                                                       last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
+                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`
+                    FROM
+                      (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                              e__pdi.person_id AS aggregation_target,
+                              e.uuid AS uuid,
+                              if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
+                              if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                              if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
+                              if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
+                              if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
+                              if(equals(e.event, 'paid'), 1, 0) AS step_1,
+                              if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                              if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
+                              if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
+                              if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`
+                       FROM events AS e
+                       INNER JOIN
+                         (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
+                                 argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS e__pdi___person_id,
+                                 person_distinct_id2.distinct_id AS distinct_id
+                          FROM person_distinct_id2
+                          WHERE equals(person_distinct_id2.team_id, 2)
+                          GROUP BY person_distinct_id2.distinct_id
+                          HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id)
+                       INNER JOIN
+                         (SELECT person.id AS id,
+                                 nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
+                          FROM person
+                          WHERE and(equals(person.team_id, 2), ifNull(in(tuple(person.id, person.version),
+                                                                           (SELECT person.id AS id, max(person.version) AS version
+                                                                            FROM person
+                                                                            WHERE equals(person.team_id, 2)
+                                                                            GROUP BY person.id
+                                                                            HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0))), 0)) SETTINGS optimize_aggregation_in_order=1) AS e__pdi__person ON equals(e__pdi.e__pdi___person_id, e__pdi__person.id)
+                       WHERE and(equals(e.team_id, 2), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-14 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('paid', 'user signed up')), ifNull(equals(e__pdi__person.`properties___$browser`, 'Negative'), 0)), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0)))))
+                 WHERE ifNull(equals(step_0, 1), 0)))
+           GROUP BY aggregation_target,
+                    steps
+           HAVING ifNull(equals(steps, max_steps), isNull(steps)
+                         and isNull(max_steps)))
+        WHERE ifNull(in(steps, [1, 2]), 0)
+        ORDER BY aggregation_target ASC) AS funnel_actors
+     WHERE ifNull(notEquals(funnel_actors.steps, 2), 1)
+     GROUP BY funnel_actors.actor_id
+     ORDER BY funnel_actors.actor_id ASC) AS source
+  INNER JOIN
+    (SELECT person.id AS id
+     FROM person
+     WHERE equals(person.team_id, 2)
+     GROUP BY person.id
+     HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons ON equals(persons.id, source.actor_id)
+  ORDER BY persons.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
+  '''
+# ---
+# name: TestClickhouseFunnelCorrelation.test_basic_funnel_correlation_with_properties_materialized.8
+  '''
+  SELECT DISTINCT session_replay_events.session_id AS session_id
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2019-12-31 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -132,12 +132,8 @@
 # name: TestFunnelCorrelationsActors.test_funnel_correlation_on_event_with_recordings.1
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -346,12 +342,8 @@
 # name: TestFunnelCorrelationsActors.test_funnel_correlation_on_event_with_recordings.3
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -497,12 +489,8 @@
 # name: TestFunnelCorrelationsActors.test_funnel_correlation_on_properties_with_recordings.1
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -648,12 +636,8 @@
 # name: TestFunnelCorrelationsActors.test_strict_funnel_correlation_with_recordings.1
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -799,12 +783,8 @@
 # name: TestFunnelCorrelationsActors.test_strict_funnel_correlation_with_recordings.3
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s3']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s3']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -133,7 +133,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -343,7 +343,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -490,7 +490,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -637,7 +637,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -784,7 +784,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s3']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s3']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_persons.ambr
@@ -1,185 +1,9 @@
 # serializer version: 1
-# name: TestFunnelPersons.test_funnel_person_recordings
-  '''
-  SELECT persons.id,
-         persons.id AS id,
-         source.matching_events AS matching_events
-  FROM
-    (SELECT aggregation_target AS actor_id,
-            step_0_matching_events AS matching_events
-     FROM
-       (SELECT aggregation_target AS aggregation_target,
-               steps AS steps,
-               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
-               avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
-               median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
-               median(step_2_conversion_time) AS step_2_median_conversion_time_inner,
-               groupArray(10)(step_0_matching_event) AS step_0_matching_events,
-               groupArray(10)(step_1_matching_event) AS step_1_matching_events,
-               groupArray(10)(step_2_matching_event) AS step_2_matching_events,
-               groupArray(10)(final_matching_event) AS final_matching_events
-        FROM
-          (SELECT aggregation_target AS aggregation_target,
-                  steps AS steps,
-                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
-                                  step_1_conversion_time AS step_1_conversion_time,
-                                  step_2_conversion_time AS step_2_conversion_time,
-                                  tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                                  tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                                  tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                                  if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event
-           FROM
-             (SELECT aggregation_target AS aggregation_target,
-                     timestamp AS timestamp,
-                     step_0 AS step_0,
-                     latest_0 AS latest_0,
-                     uuid_0 AS uuid_0,
-                     `$session_id_0` AS `$session_id_0`,
-                     `$window_id_0` AS `$window_id_0`,
-                     step_1 AS step_1,
-                     latest_1 AS latest_1,
-                     uuid_1 AS uuid_1,
-                     `$session_id_1` AS `$session_id_1`,
-                     `$window_id_1` AS `$window_id_1`,
-                     step_2 AS step_2,
-                     latest_2 AS latest_2,
-                     uuid_2 AS uuid_2,
-                     `$session_id_2` AS `$session_id_2`,
-                     `$window_id_2` AS `$window_id_2`,
-                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
-                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
-                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
-                     tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
-                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
-                     tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
-                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event
-              FROM
-                (SELECT aggregation_target AS aggregation_target,
-                        timestamp AS timestamp,
-                        step_0 AS step_0,
-                        latest_0 AS latest_0,
-                        uuid_0 AS uuid_0,
-                        `$session_id_0` AS `$session_id_0`,
-                        `$window_id_0` AS `$window_id_0`,
-                        step_1 AS step_1,
-                        latest_1 AS latest_1,
-                        uuid_1 AS uuid_1,
-                        `$session_id_1` AS `$session_id_1`,
-                        `$window_id_1` AS `$window_id_1`,
-                        step_2 AS step_2,
-                        min(latest_2) OVER (PARTITION BY aggregation_target
-                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                           last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                   last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                    last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-                 FROM
-                   (SELECT aggregation_target AS aggregation_target,
-                           timestamp AS timestamp,
-                           step_0 AS step_0,
-                           latest_0 AS latest_0,
-                           uuid_0 AS uuid_0,
-                           `$session_id_0` AS `$session_id_0`,
-                           `$window_id_0` AS `$window_id_0`,
-                           step_1 AS step_1,
-                           latest_1 AS latest_1,
-                           uuid_1 AS uuid_1,
-                           `$session_id_1` AS `$session_id_1`,
-                           `$window_id_1` AS `$window_id_1`,
-                           step_2 AS step_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, uuid_2) AS uuid_2,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, `$session_id_2`) AS `$session_id_2`,
-                           if(ifNull(less(latest_2, latest_1), 0), NULL, `$window_id_2`) AS `$window_id_2`
-                    FROM
-                      (SELECT aggregation_target AS aggregation_target,
-                              timestamp AS timestamp,
-                              step_0 AS step_0,
-                              latest_0 AS latest_0,
-                              uuid_0 AS uuid_0,
-                              `$session_id_0` AS `$session_id_0`,
-                              `$window_id_0` AS `$window_id_0`,
-                              step_1 AS step_1,
-                              min(latest_1) OVER (PARTITION BY aggregation_target
-                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
-                                                 last_value(uuid_1) OVER (PARTITION BY aggregation_target
-                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
-                                                                         last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
-                                                                                                          last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
-                                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`,
-                                                                                                                                          step_2 AS step_2,
-                                                                                                                                          min(latest_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
-                                                                                                                                                             last_value(uuid_2) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
-                                                                                                                                                                                     last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
-                                                                                                                                                                                                                      last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
-                                                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
-                       FROM
-                         (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
-                                 e__pdi.person_id AS aggregation_target,
-                                 e.uuid AS uuid,
-                                 if(equals(e.event, 'step one'), 1, 0) AS step_0,
-                                 if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
-                                 if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
-                                 if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
-                                 if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
-                                 if(equals(e.event, 'step two'), 1, 0) AS step_1,
-                                 if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                                 if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
-                                 if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
-                                 if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`,
-                                 if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                                 if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                 if(ifNull(equals(step_2, 1), 0), uuid, NULL) AS uuid_2,
-                                 if(ifNull(equals(step_2, 1), 0), e.`$session_id`, NULL) AS `$session_id_2`,
-                                 if(ifNull(equals(step_2, 1), 0), e.`$window_id`, NULL) AS `$window_id_2`
-                          FROM events AS e
-                          INNER JOIN
-                            (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
-                                    person_distinct_id2.distinct_id AS distinct_id
-                             FROM person_distinct_id2
-                             WHERE equals(person_distinct_id2.team_id, 2)
-                             GROUP BY person_distinct_id2.distinct_id
-                             HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id)
-                          WHERE and(equals(e.team_id, 2), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2021-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2021-01-08 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
-              WHERE ifNull(equals(step_0, 1), 0)))
-        GROUP BY aggregation_target,
-                 steps
-        HAVING ifNull(equals(steps, max_steps), isNull(steps)
-                      and isNull(max_steps)))
-     WHERE ifNull(in(steps, [1, 2, 3]), 0)
-     ORDER BY aggregation_target ASC) AS source
-  INNER JOIN
-    (SELECT person.id AS id
-     FROM person
-     WHERE equals(person.team_id, 2)
-     GROUP BY person.id
-     HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons ON equals(persons.id, source.actor_id)
-  ORDER BY persons.id ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0,
-                    max_ast_elements=1000000,
-                    max_expanded_ast_elements=1000000,
-                    max_query_size=524288
-  '''
-# ---
 # name: TestFunnelPersons.test_funnel_person_recordings.1
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s1']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s1']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -364,12 +188,8 @@
 # name: TestFunnelPersons.test_funnel_person_recordings.3
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -554,12 +374,8 @@
 # name: TestFunnelPersons.test_funnel_person_recordings.5
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_persons.ambr
@@ -1,9 +1,181 @@
 # serializer version: 1
+# name: TestFunnelPersons.test_funnel_person_recordings
+  '''
+  SELECT persons.id,
+         persons.id AS id,
+         source.matching_events AS matching_events
+  FROM
+    (SELECT aggregation_target AS actor_id,
+            step_0_matching_events AS matching_events
+     FROM
+       (SELECT aggregation_target AS aggregation_target,
+               steps AS steps,
+               avg(step_1_conversion_time) AS step_1_average_conversion_time_inner,
+               avg(step_2_conversion_time) AS step_2_average_conversion_time_inner,
+               median(step_1_conversion_time) AS step_1_median_conversion_time_inner,
+               median(step_2_conversion_time) AS step_2_median_conversion_time_inner,
+               groupArray(10)(step_0_matching_event) AS step_0_matching_events,
+               groupArray(10)(step_1_matching_event) AS step_1_matching_events,
+               groupArray(10)(step_2_matching_event) AS step_2_matching_events,
+               groupArray(10)(final_matching_event) AS final_matching_events
+        FROM
+          (SELECT aggregation_target AS aggregation_target,
+                  steps AS steps,
+                  max(steps) OVER (PARTITION BY aggregation_target) AS max_steps,
+                                  step_1_conversion_time AS step_1_conversion_time,
+                                  step_2_conversion_time AS step_2_conversion_time,
+                                  tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
+                                  tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
+                                  tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
+                                  if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event
+           FROM
+             (SELECT aggregation_target AS aggregation_target,
+                     timestamp AS timestamp,
+                     step_0 AS step_0,
+                     latest_0 AS latest_0,
+                     uuid_0 AS uuid_0,
+                     `$session_id_0` AS `$session_id_0`,
+                     `$window_id_0` AS `$window_id_0`,
+                     step_1 AS step_1,
+                     latest_1 AS latest_1,
+                     uuid_1 AS uuid_1,
+                     `$session_id_1` AS `$session_id_1`,
+                     `$window_id_1` AS `$window_id_1`,
+                     step_2 AS step_2,
+                     latest_2 AS latest_2,
+                     uuid_2 AS uuid_2,
+                     `$session_id_2` AS `$session_id_2`,
+                     `$window_id_2` AS `$window_id_2`,
+                     if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0), ifNull(lessOrEquals(latest_1, latest_2), 0), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 3, if(and(ifNull(lessOrEquals(latest_0, latest_1), 0), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), 2, 1)) AS steps,
+                     if(and(isNotNull(latest_1), ifNull(lessOrEquals(latest_1, plus(toTimeZone(latest_0, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_0, latest_1), NULL) AS step_1_conversion_time,
+                     if(and(isNotNull(latest_2), ifNull(lessOrEquals(latest_2, plus(toTimeZone(latest_1, 'UTC'), toIntervalDay(14))), 0)), dateDiff('second', latest_1, latest_2), NULL) AS step_2_conversion_time,
+                     tuple(latest_0, uuid_0, `$session_id_0`, `$window_id_0`) AS step_0_matching_event,
+                     tuple(latest_1, uuid_1, `$session_id_1`, `$window_id_1`) AS step_1_matching_event,
+                     tuple(latest_2, uuid_2, `$session_id_2`, `$window_id_2`) AS step_2_matching_event,
+                     if(isNull(latest_0), tuple(NULL, NULL, NULL, NULL), if(isNull(latest_1), step_0_matching_event, if(isNull(latest_2), step_1_matching_event, step_2_matching_event))) AS final_matching_event
+              FROM
+                (SELECT aggregation_target AS aggregation_target,
+                        timestamp AS timestamp,
+                        step_0 AS step_0,
+                        latest_0 AS latest_0,
+                        uuid_0 AS uuid_0,
+                        `$session_id_0` AS `$session_id_0`,
+                        `$window_id_0` AS `$window_id_0`,
+                        step_1 AS step_1,
+                        latest_1 AS latest_1,
+                        uuid_1 AS uuid_1,
+                        `$session_id_1` AS `$session_id_1`,
+                        `$window_id_1` AS `$window_id_1`,
+                        step_2 AS step_2,
+                        min(latest_2) OVER (PARTITION BY aggregation_target
+                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
+                                           last_value(uuid_2) OVER (PARTITION BY aggregation_target
+                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
+                                                                   last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
+                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
+                                                                                                    last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
+                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
+                 FROM
+                   (SELECT aggregation_target AS aggregation_target,
+                           timestamp AS timestamp,
+                           step_0 AS step_0,
+                           latest_0 AS latest_0,
+                           uuid_0 AS uuid_0,
+                           `$session_id_0` AS `$session_id_0`,
+                           `$window_id_0` AS `$window_id_0`,
+                           step_1 AS step_1,
+                           latest_1 AS latest_1,
+                           uuid_1 AS uuid_1,
+                           `$session_id_1` AS `$session_id_1`,
+                           `$window_id_1` AS `$window_id_1`,
+                           step_2 AS step_2,
+                           if(ifNull(less(latest_2, latest_1), 0), NULL, latest_2) AS latest_2,
+                           if(ifNull(less(latest_2, latest_1), 0), NULL, uuid_2) AS uuid_2,
+                           if(ifNull(less(latest_2, latest_1), 0), NULL, `$session_id_2`) AS `$session_id_2`,
+                           if(ifNull(less(latest_2, latest_1), 0), NULL, `$window_id_2`) AS `$window_id_2`
+                    FROM
+                      (SELECT aggregation_target AS aggregation_target,
+                              timestamp AS timestamp,
+                              step_0 AS step_0,
+                              latest_0 AS latest_0,
+                              uuid_0 AS uuid_0,
+                              `$session_id_0` AS `$session_id_0`,
+                              `$window_id_0` AS `$window_id_0`,
+                              step_1 AS step_1,
+                              min(latest_1) OVER (PARTITION BY aggregation_target
+                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_1,
+                                                 last_value(uuid_1) OVER (PARTITION BY aggregation_target
+                                                                          ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_1,
+                                                                         last_value(`$session_id_1`) OVER (PARTITION BY aggregation_target
+                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_1`,
+                                                                                                          last_value(`$window_id_1`) OVER (PARTITION BY aggregation_target
+                                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_1`,
+                                                                                                                                          step_2 AS step_2,
+                                                                                                                                          min(latest_2) OVER (PARTITION BY aggregation_target
+                                                                                                                                                              ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS latest_2,
+                                                                                                                                                             last_value(uuid_2) OVER (PARTITION BY aggregation_target
+                                                                                                                                                                                      ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS uuid_2,
+                                                                                                                                                                                     last_value(`$session_id_2`) OVER (PARTITION BY aggregation_target
+                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$session_id_2`,
+                                                                                                                                                                                                                      last_value(`$window_id_2`) OVER (PARTITION BY aggregation_target
+                                                                                                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) AS `$window_id_2`
+                       FROM
+                         (SELECT toTimeZone(e.timestamp, 'UTC') AS timestamp,
+                                 e__pdi.person_id AS aggregation_target,
+                                 e.uuid AS uuid,
+                                 if(equals(e.event, 'step one'), 1, 0) AS step_0,
+                                 if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
+                                 if(ifNull(equals(step_0, 1), 0), uuid, NULL) AS uuid_0,
+                                 if(ifNull(equals(step_0, 1), 0), e.`$session_id`, NULL) AS `$session_id_0`,
+                                 if(ifNull(equals(step_0, 1), 0), e.`$window_id`, NULL) AS `$window_id_0`,
+                                 if(equals(e.event, 'step two'), 1, 0) AS step_1,
+                                 if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
+                                 if(ifNull(equals(step_1, 1), 0), uuid, NULL) AS uuid_1,
+                                 if(ifNull(equals(step_1, 1), 0), e.`$session_id`, NULL) AS `$session_id_1`,
+                                 if(ifNull(equals(step_1, 1), 0), e.`$window_id`, NULL) AS `$window_id_1`,
+                                 if(equals(e.event, 'step three'), 1, 0) AS step_2,
+                                 if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
+                                 if(ifNull(equals(step_2, 1), 0), uuid, NULL) AS uuid_2,
+                                 if(ifNull(equals(step_2, 1), 0), e.`$session_id`, NULL) AS `$session_id_2`,
+                                 if(ifNull(equals(step_2, 1), 0), e.`$window_id`, NULL) AS `$window_id_2`
+                          FROM events AS e
+                          INNER JOIN
+                            (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
+                                    person_distinct_id2.distinct_id AS distinct_id
+                             FROM person_distinct_id2
+                             WHERE equals(person_distinct_id2.team_id, 2)
+                             GROUP BY person_distinct_id2.distinct_id
+                             HAVING ifNull(equals(argMax(person_distinct_id2.is_deleted, person_distinct_id2.version), 0), 0)) AS e__pdi ON equals(e.distinct_id, e__pdi.distinct_id)
+                          WHERE and(equals(e.team_id, 2), and(and(greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2021-01-01 00:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2021-01-08 23:59:59.999999', 6, 'UTC'))), in(e.event, tuple('step one', 'step three', 'step two'))), or(ifNull(equals(step_0, 1), 0), ifNull(equals(step_1, 1), 0), ifNull(equals(step_2, 1), 0)))))))
+              WHERE ifNull(equals(step_0, 1), 0)))
+        GROUP BY aggregation_target,
+                 steps
+        HAVING ifNull(equals(steps, max_steps), isNull(steps)
+                      and isNull(max_steps)))
+     WHERE ifNull(in(steps, [1, 2, 3]), 0)
+     ORDER BY aggregation_target ASC) AS source
+  INNER JOIN
+    (SELECT person.id AS id
+     FROM person
+     WHERE equals(person.team_id, 2)
+     GROUP BY person.id
+     HAVING ifNull(equals(argMax(person.is_deleted, person.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS persons ON equals(persons.id, source.actor_id)
+  ORDER BY persons.id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=1000000,
+                    max_expanded_ast_elements=1000000,
+                    max_query_size=524288
+  '''
+# ---
 # name: TestFunnelPersons.test_funnel_person_recordings.1
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s1']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s1']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -189,7 +361,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -375,7 +547,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
@@ -134,12 +134,8 @@
 # name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.1
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s1']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s1']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -284,12 +280,8 @@
 # name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.3
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -434,12 +426,8 @@
 # name: TestFunnelStrictStepsPersons.test_strict_funnel_person_recordings.5
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s2']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
@@ -135,7 +135,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s1']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s1']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -281,7 +281,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -427,7 +427,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s2']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-01-02 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s2']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
@@ -160,12 +160,8 @@
 # name: TestFunnelTrendsPersons.test_funnel_trend_persons_returns_recordings.1
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s1b']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s1b']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -336,12 +332,8 @@
 # name: TestFunnelTrendsPersons.test_funnel_trend_persons_with_drop_off.1
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s1a']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s1a']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -512,12 +504,8 @@
 # name: TestFunnelTrendsPersons.test_funnel_trend_persons_with_no_to_step.1
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s1c']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s1c']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
@@ -161,7 +161,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s1b']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s1b']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -333,7 +333,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s1a']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s1a']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -505,7 +505,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s1c']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2021-05-01 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s1c']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlation.py
@@ -1,6 +1,7 @@
 from typing import Any, cast
 import unittest
 
+from freezegun import freeze_time
 from rest_framework.exceptions import ValidationError
 
 from posthog.constants import INSIGHT_FUNNELS
@@ -494,8 +495,10 @@ class TestClickhouseFunnelCorrelation(ClickhouseTestMixin, APIBaseTest):
             1,
         )
 
-    # :FIXME: This should also work with materialized columns
-    # @also_test_with_materialized_columns(event_properties=[], person_properties=["$browser"])
+    @also_test_with_materialized_columns(
+        event_properties=[], person_properties=["$browser"], verify_no_jsonextract=False
+    )
+    @freeze_time("2019-12-31")
     @snapshot_clickhouse_queries
     def test_basic_funnel_correlation_with_properties(self):
         filters = {

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_correlations_persons.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_correlations_persons.py
@@ -524,13 +524,11 @@ class TestFunnelCorrelationsActors(ClickhouseTestMixin, APIBaseTest):
             properties={"$session_id": "s2", "$window_id": "w2"},
             event_uuid="41111111-1111-1111-1111-111111111111",
         )
-        timestamp = datetime(2021, 1, 2, 0, 0, 0)
+
         produce_replay_summary(
             team_id=self.team.pk,
             session_id="s2",
             distinct_id="user_1",
-            first_timestamp=timestamp,
-            last_timestamp=timestamp,
         )
 
         # Second user with strict funnel drop off, but completed the step events for a normal funnel
@@ -559,13 +557,11 @@ class TestFunnelCorrelationsActors(ClickhouseTestMixin, APIBaseTest):
             properties={"$session_id": "s3", "$window_id": "w2"},
             event_uuid="71111111-1111-1111-1111-111111111111",
         )
-        timestamp1 = datetime(2021, 1, 2, 0, 0, 0)
+
         produce_replay_summary(
             team_id=self.team.pk,
             session_id="s3",
             distinct_id="user_2",
-            first_timestamp=timestamp1,
-            last_timestamp=timestamp1,
         )
 
         # Success filter

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_persons.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_persons.py
@@ -527,13 +527,12 @@ class TestFunnelPersons(ClickhouseTestMixin, APIBaseTest):
             properties={"$session_id": "s2", "$window_id": "w2"},
             event_uuid="21111111-1111-1111-1111-111111111111",
         )
-        timestamp = datetime(2021, 1, 3, 0, 0, 0)
+
         produce_replay_summary(
             team_id=self.team.pk,
             session_id="s2",
             distinct_id="user_1",
-            first_timestamp=timestamp,
-            last_timestamp=timestamp,
+            first_timestamp=timezone.now() + timedelta(days=1),
         )
 
         # First event, but no recording

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_persons.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends_persons.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta
 
+from freezegun import freeze_time
+
 from posthog.constants import INSIGHT_FUNNELS, FunnelVizType
 from posthog.hogql_queries.insights.funnels.test.test_funnel_persons import get_actors
 from posthog.session_recordings.queries.test.session_replay_sql import (
@@ -28,6 +30,7 @@ filters = {
 }
 
 
+@freeze_time("2021-05-01")
 class TestFunnelTrendsPersons(ClickhouseTestMixin, APIBaseTest):
     @snapshot_clickhouse_queries
     def test_funnel_trend_persons_returns_recordings(self):

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_paths_query_runner_ee.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_paths_query_runner_ee.ambr
@@ -2457,7 +2457,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['s3', 's1', 's5']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2011-12-11 03:21:34.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s3', 's1', 's5']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -2719,25 +2719,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['s1']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2011-12-11 03:21:34.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0))
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=0,
-                     max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000,
-                     max_query_size=524288
-  '''
-# ---
-# name: TestClickhousePaths.test_recording_for_dropoff.3
-  '''
-  SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s1']), 0)
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s1']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -2874,7 +2856,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2011-12-11 03:21:34.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(NULL, toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -3020,7 +3002,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['s1']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2011-12-11 03:21:34.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s1']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_paths_query_runner_ee.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_paths_query_runner_ee.ambr
@@ -2457,7 +2457,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s3', 's1', 's5']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s3', 's1', 's5']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -2719,7 +2719,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s1']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s1']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -2856,7 +2856,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(NULL, toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -3002,7 +3002,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC'), toIntervalDay(21))), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0), in(session_replay_events.session_id, ['s1']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['s1']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_paths_query_runner_ee.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_paths_query_runner_ee.ambr
@@ -2456,12 +2456,8 @@
 # name: TestClickhousePaths.test_recording.1
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s3', 's1', 's5']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['s3', 's1', 's5']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2011-12-11 03:21:34.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -2597,24 +2593,6 @@
 # ---
 # name: TestClickhousePaths.test_recording_for_dropoff.1
   '''
-  SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, []), 0)
-  LIMIT 100 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     format_csv_allow_double_quotes=0,
-                     max_ast_elements=1000000,
-                     max_expanded_ast_elements=1000000,
-                     max_query_size=524288
-  '''
-# ---
-# name: TestClickhousePaths.test_recording_for_dropoff.2
-  '''
   SELECT persons.id AS id,
          toTimeZone(persons.created_at, 'UTC') AS created_at,
          source.event_count AS event_count,
@@ -2735,6 +2713,20 @@
                     max_ast_elements=1000000,
                     max_expanded_ast_elements=1000000,
                     max_query_size=524288
+  '''
+# ---
+# name: TestClickhousePaths.test_recording_for_dropoff.2
+  '''
+  SELECT DISTINCT session_replay_events.session_id AS session_id
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['s1']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2011-12-11 03:21:34.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=1000000,
+                     max_expanded_ast_elements=1000000,
+                     max_query_size=524288
   '''
 # ---
 # name: TestClickhousePaths.test_recording_for_dropoff.3
@@ -2881,12 +2873,8 @@
 # name: TestClickhousePaths.test_recording_with_no_window_or_session_id.1
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2011-12-11 03:21:34.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -3031,12 +3019,8 @@
 # name: TestClickhousePaths.test_recording_with_start_and_end.1
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['s1']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['s1']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2011-12-11 03:21:34.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2012-01-01 03:21:34.000000', 6, 'UTC')), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -317,7 +317,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 09:48:39.660558', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 09:48:39.660564', 6, 'UTC')), 0))
+  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 10:00:42.153818', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 10:00:42.153823', 6, 'UTC')), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 09:49:35.332055', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 09:49:35.332061', 6, 'UTC')), 0))
+  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 10:01:38.112008', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 10:01:38.112014', 6, 'UTC')), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -317,7 +317,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:42:20.972025', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:54:26.969871', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:43:17.643776', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:55:24.592334', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 13:59:21.493308', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 14:10:57.973712', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -317,7 +317,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 09:37:17.403059', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 09:37:17.403064', 6, 'UTC')), 0))
+  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 09:48:39.660558', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 09:48:39.660564', 6, 'UTC')), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 09:38:12.934239', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 09:38:12.934245', 6, 'UTC')), 0))
+  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 09:49:35.332055', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 09:49:35.332061', 6, 'UTC')), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -317,7 +317,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 09:25:29.210375', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 09:25:29.210382', 6, 'UTC')), 0))
+  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 09:37:17.403059', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 09:37:17.403064', 6, 'UTC')), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 09:26:24.030504', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 09:26:24.030509', 6, 'UTC')), 0))
+  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 09:38:12.934239', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 09:38:12.934245', 6, 'UTC')), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -317,7 +317,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:54:26.969871', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:55:24.592334', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 13:07:43.323802', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -317,7 +317,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:30:46.101109', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:42:20.972025', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:31:40.883233', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:43:17.643776', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -316,12 +316,8 @@
 # name: TestTrends.test_breakdown_by_group_props_person_on_events.3
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 09:25:29.210375', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 09:25:29.210382', 6, 'UTC')), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -1380,12 +1376,8 @@
 # name: TestTrends.test_filtering_by_multiple_groups_person_on_events.2
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
-  FROM
-    (SELECT session_replay_events.session_id AS session_id
-     FROM session_replay_events
-     WHERE equals(session_replay_events.team_id, 2)
-     GROUP BY session_replay_events.session_id) AS session_replay_events
-  WHERE ifNull(in(session_replay_events.session_id, ['']), 0)
+  FROM session_replay_events
+  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 09:26:24.030504', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 09:26:24.030509', 6, 'UTC')), 0))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 14:35:02.444770', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 14:46:51.560257', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 14:22:54.946839', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 14:35:02.444770', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -317,7 +317,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 10:00:42.153818', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 10:00:42.153823', 6, 'UTC')), 0))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:18:19.142637', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), in(session_replay_events.session_id, ['']), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), toDateTime64('2024-04-18 10:01:38.112008', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'), toDateTime64('2024-05-09 10:01:38.112014', 6, 'UTC')), 0))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:19:13.689374', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 13:30:00.958629', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 13:59:21.493308', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -317,7 +317,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:18:19.142637', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:30:46.101109', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:19:13.689374', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 12:31:40.883233', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 14:10:57.973712', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 14:22:54.946839', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 13:07:43.323802', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 13:30:00.958629', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -1377,7 +1377,7 @@
   '''
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
-  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2024-05-09 14:46:51.560257', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
+  WHERE and(equals(session_replay_events.team_id, 2), ifNull(greaterOrEquals(toTimeZone(session_replay_events.min_first_timestamp, 'UTC'), minus(toDateTime64('2020-01-01 00:00:00.000000', 6, 'UTC'), toIntervalDay(21))), 0), in(session_replay_events.session_id, ['']))
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql_queries/insights/trends/test/test_trends.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends.py
@@ -8416,6 +8416,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
             response = self._run(filter, self.team)
             self.assertEqual(response[0]["count"], 1)
 
+    @freeze_time("2020-01-01")
     @also_test_with_materialized_columns(
         group_properties=[(0, "industry"), (2, "name")],
         materialize_only_with_person_on_events=True,

--- a/posthog/hogql_queries/insights/trends/test/test_trends.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends.py
@@ -8092,6 +8092,7 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(res[0][1]["distinct_ids"], ["person1"])
 
+    @freeze_time("2020-01-01")
     @also_test_with_materialized_columns(
         group_properties=[(0, "industry")], materialize_only_with_person_on_events=True
     )

--- a/posthog/hogql_queries/utils/recordings.py
+++ b/posthog/hogql_queries/utils/recordings.py
@@ -32,7 +32,6 @@ class RecordingsHelper:
             date_to = datetime.now()
 
         query = """
-          -- from {class_name}
           SELECT DISTINCT session_id
           FROM raw_session_replay_events
           WHERE session_id in {session_ids}
@@ -46,7 +45,6 @@ class RecordingsHelper:
                 "session_ids": ast.Array(exprs=[ast.Constant(value=s) for s in session_ids]),
                 "date_from": ast.Constant(value=date_from),
                 "date_to": ast.Constant(value=date_to),
-                "class_name": self.__name__,
             },
             team=self.team,
         )

--- a/posthog/hogql_queries/utils/recordings.py
+++ b/posthog/hogql_queries/utils/recordings.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
+from collections.abc import Iterable
 
 from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
@@ -14,7 +15,10 @@ class RecordingsHelper:
         self._ttl = ttl_days(team)
 
     def session_ids_all(
-        self, session_ids: list[str], date_from: datetime | None = None, date_to: datetime | None = None
+        self,
+        session_ids: Iterable[str],
+        date_from: datetime | None = None,
+        date_to: datetime | None = None,
     ) -> set[str]:
         if not session_ids:
             # no need to query if we get invalid input

--- a/posthog/hogql_queries/utils/recordings_helper.py
+++ b/posthog/hogql_queries/utils/recordings_helper.py
@@ -41,11 +41,15 @@ class RecordingsHelper:
             ),
         )
 
-        starts_before_fixed_date_or_now = ast.CompareOperation(
-            op=ast.CompareOperationOp.LtEq,
-            left=ast.Field(chain=["min_first_timestamp"]),
-            right=ast.Constant(value=date_to if date_to and date_to < current_now else current_now),
-        )
+        # TRICKY: really we should clamp before now, but we can't do that
+        # because the tests set "now" and then setup test data in the future
+        # it's only an optimization though
+        # TODO: let's fix this now since customers are reporting it, and then make test setup sensible
+        # starts_before_fixed_date_or_now = ast.CompareOperation(
+        #     op=ast.CompareOperationOp.LtEq,
+        #     left=ast.Field(chain=["min_first_timestamp"]),
+        #     right=ast.Constant(value=date_to if date_to and date_to <= current_now else current_now),
+        # )
 
         matches_provided_session_ids = ast.CompareOperation(
             op=ast.CompareOperationOp.In,
@@ -65,7 +69,7 @@ class RecordingsHelper:
                 "where_predicates": ast.And(
                     exprs=[
                         starts_since_fixed_date_or_ttl_before_now,
-                        starts_before_fixed_date_or_now,
+                        # starts_before_fixed_date_or_now,
                         matches_provided_session_ids,
                     ]
                 ),

--- a/posthog/session_recordings/queries/test/session_replay_sql.py
+++ b/posthog/session_recordings/queries/test/session_replay_sql.py
@@ -94,7 +94,7 @@ def _sensible_last_timestamp(
             if isinstance(first_timestamp, str):
                 first_timestamp = parse(first_timestamp)
 
-            sensible_timestamp = (first_timestamp - relativedelta(seconds=3600)).isoformat()
+            sensible_timestamp = (first_timestamp + relativedelta(seconds=3600)).isoformat()
 
     return format_clickhouse_timestamp(cast_timestamp_or_now(sensible_timestamp))
 

--- a/posthog/session_recordings/queries/test/session_replay_sql.py
+++ b/posthog/session_recordings/queries/test/session_replay_sql.py
@@ -94,7 +94,7 @@ def _sensible_last_timestamp(
             if isinstance(first_timestamp, str):
                 first_timestamp = parse(first_timestamp)
 
-            sensible_timestamp = (first_timestamp + relativedelta(seconds=3600)).isoformat()
+            sensible_timestamp = (first_timestamp - relativedelta(seconds=3600)).isoformat()
 
     return format_clickhouse_timestamp(cast_timestamp_or_now(sensible_timestamp))
 


### PR DESCRIPTION
	The persons modal shows recordings locally but not in production

there are multiple customer reports of this... at least:

* https://posthoghelp.zendesk.com/agent/tickets/13236 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15695)
* https://posthoghelp.zendesk.com/agent/tickets/13235 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15694)
* https://posthoghelp.zendesk.com/agent/tickets/13337 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15865)

My spidey senses say that something is timing out based on the query that's being generated

See https://posthog.slack.com/archives/C0368RPHLQH/p1715243351603999 for even more context

We're currently running a query like

```
/* user_id:5042 celery:posthog.tasks.tasks.process_query_task */ SELECT
    DISTINCT session_replay_events.session_id AS session_id
FROM
    (SELECT
        session_replay_events.session_id AS session_id
    FROM
        session_replay_events
    WHERE
        equals(session_replay_events.team_id, 2)
    GROUP BY
        session_replay_events.session_id) AS session_replay_events
WHERE
    ifNull(in(session_replay_events.session_id, ['a list of session ids']), 0)
LIMIT 100 SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=1000000, max_expanded_ast_elements=1000000, max_query_size=524288
```

so we're loading every replay for a team and then restricting that query by the desired list - no bueno

we could just lift the subquery up or push the predicate down but...

We should always restrict the query by date range or it'll take too long

So, first, let's restrict to the default range between explicit TTL date and implicit now

But we can probably follow up to pass a more specific time range through to the query from the parent since it'll have time bounds already anyway

---

the testing was tricky to clamp to an explicit now since it turns out its common for us to freeze time in the tests and then setup data in the relative future so restricting by now means you exclude the test data

---

I also did a little renaming and typehinting because there's a lot there to think about coming to this file fresh and it'll be a little easier for the future traveller now
