### PR TITLE
fix(insights): Make async query execution use the same cache as sync

### DIFF
--- a/ee/api/test/test_organization.py
+++ b/ee/api/test/test_organization.py
@@ -1,5 +1,4 @@
 import datetime as dt
-import random
 from unittest import mock
 from unittest.mock import ANY, call, patch
 
@@ -29,9 +28,8 @@ class TestOrganizationEnterpriseAPI(APILicensedTest):
             OrganizationMembership.Level.OWNER,
         )
 
-    def test_create_two_similarly_named_organizations(self):
-        random.seed(0)
-
+    @patch("secrets.choice", return_value="Y")
+    def test_create_two_similarly_named_organizations(self, mock_choice):
         response = self.client.post(
             "/api/organizations/",
             {"name": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},
@@ -53,7 +51,7 @@ class TestOrganizationEnterpriseAPI(APILicensedTest):
         self.assertDictContainsSubset(
             {
                 "name": "#XXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxX",
-                "slug": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-yWAc",
+                "slug": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-YYYY",
             },
             response.json(),
         )

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -118,8 +118,13 @@ async function executeQuery<N extends DataNode>(
 
     const response = await api.query(queryNode, methodOptions, queryId, refresh, isAsyncQuery)
 
-    if (!isAsyncQuery || !response.query_async) {
+    if (!response.query_async) {
+        // Executed query synchronously
         return response
+    }
+    if (response.complete || response.error) {
+        // Async query returned immediately
+        return response.results
     }
 
     const pollStart = performance.now()

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -6495,7 +6495,9 @@
                     "type": "string"
                 },
                 "query_async": {
+                    "const": true,
                     "default": true,
+                    "description": "ONLY async queries use QueryStatus.",
                     "type": "boolean"
                 },
                 "query_progress": {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -937,8 +937,11 @@ export type ClickhouseQueryStatus = {
 
 export type QueryStatus = {
     id: string
-    /**  @default true */
-    query_async: boolean
+    /**
+     * ONLY async queries use QueryStatus.
+     * @default true
+     */
+    query_async: true
     team_id: integer
     /**  @default false */
     error: boolean

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -666,7 +666,6 @@ posthog/api/search.py:0: error: Argument "extra_fields" to "class_queryset" has 
 posthog/api/search.py:0: error: "type[Model]" has no attribute "objects"  [attr-defined]
 posthog/api/search.py:0: error: Argument 1 to "reduce" has incompatible type "Callable[[SearchVector, SearchVector], CombinedExpression]"; expected "Callable[[SearchVector, SearchVector], SearchVector]"  [arg-type]
 posthog/api/search.py:0: error: Incompatible return value type (got "CombinedExpression", expected "SearchVector")  [return-value]
-posthog/api/query.py:0: error: Argument "user_id" to "enqueue_process_query_task" has incompatible type "int | AutoField[Combinable | int | str | None, int] | Any"; expected "int"  [arg-type]
 posthog/api/property_definition.py:0: error: Item "AnonymousUser" of "User | AnonymousUser" has no attribute "organization"  [union-attr]
 posthog/api/property_definition.py:0: error: Item "None" of "Organization | Any | None" has no attribute "is_feature_available"  [union-attr]
 posthog/api/property_definition.py:0: error: Item "ForeignObjectRel" of "Field[Any, Any] | ForeignObjectRel | GenericForeignKey" has no attribute "cached_col"  [union-attr]

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -66,8 +66,8 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
 
         if data.async_:
             query_status = enqueue_process_query_task(
-                team_id=self.team.pk,
-                user_id=self.request.user.pk,
+                team=self.team,
+                user=self.request.user,
                 query_json=request.data["query"],
                 query_id=client_query_id,
                 refresh_requested=data.refresh or False,

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -1,4 +1,5 @@
 import re
+from typing import cast
 import uuid
 
 from django.http import JsonResponse
@@ -67,7 +68,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         if data.async_:
             query_status = enqueue_process_query_task(
                 team=self.team,
-                user=self.request.user,
+                user=cast(User, self.request.user),
                 query_json=request.data["query"],
                 query_id=client_query_id,
                 refresh_requested=data.refresh or False,

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -4,6 +4,7 @@ import uuid
 
 from django.http import JsonResponse
 from drf_spectacular.utils import OpenApiResponse
+from pydantic import BaseModel
 from posthog.hogql_queries.query_runner import ExecutionMode
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -84,6 +85,8 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 if data.refresh
                 else ExecutionMode.RECENT_CACHE_CALCULATE_IF_STALE,
             )
+            if isinstance(result, BaseModel):
+                result = result.model_dump()
             return Response(result)
         except (ExposedHogQLError, ExposedCHQueryError) as e:
             raise ValidationError(str(e), getattr(e, "code_name", None))

--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -28,14 +28,14 @@ from posthog.schema import (
 logger = structlog.get_logger(__name__)
 
 
-def process_query(
+def process_query_dict(
     team: Team,
     query_json: dict,
     *,
     dashboard_filters_json: Optional[dict] = None,
     limit_context: Optional[LimitContext] = None,
     execution_mode: ExecutionMode = ExecutionMode.RECENT_CACHE_CALCULATE_IF_STALE,
-) -> dict:
+) -> dict | BaseModel:
     model = QuerySchemaRoot.model_validate(query_json)
     tag_queries(query=query_json)
     dashboard_filters = DashboardFilter.model_validate(dashboard_filters_json) if dashboard_filters_json else None
@@ -55,7 +55,7 @@ def process_query_model(
     dashboard_filters: Optional[DashboardFilter] = None,
     limit_context: Optional[LimitContext] = None,
     execution_mode: ExecutionMode = ExecutionMode.RECENT_CACHE_CALCULATE_IF_STALE,
-) -> dict:
+) -> dict | BaseModel:
     result: dict | BaseModel
 
     try:
@@ -98,6 +98,4 @@ def process_query_model(
             query_runner.apply_dashboard_filters(dashboard_filters)
         result = query_runner.run(execution_mode=execution_mode)
 
-    if isinstance(result, BaseModel):
-        return result.model_dump()
     return result

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -1467,6 +1467,92 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             self.assertEqual(response["last_modified_at"], "2012-01-15T04:01:34Z")
             self.assertTrue(response["is_cached"])
 
+    @parameterized.expand(
+        [
+            [  # Property group filter, which is what's actually used these days
+                PropertyGroupFilter(
+                    type=FilterLogicalOperator.AND,
+                    values=[
+                        PropertyGroupFilterValue(
+                            type=FilterLogicalOperator.OR,
+                            values=[EventPropertyFilter(key="another", value="never_return_this", operator="is_not")],
+                        )
+                    ],
+                )
+            ],
+            [  # Classic list of filters
+                [EventPropertyFilter(key="another", value="never_return_this", operator="is_not")]
+            ],
+        ]
+    )
+    @patch("posthog.hogql_queries.insights.trends.trends_query_runner.execute_hogql_query", wraps=execute_hogql_query)
+    def test_insight_refreshing_query_async(self, properties_filter, spy_execute_hogql_query) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"filters": {"date_from": "-14d"}})
+
+        with freeze_time("2012-01-14T03:21:34.000Z"):
+            _create_event(
+                team=self.team,
+                event="$pageview",
+                distinct_id="1",
+                properties={"prop": "val"},
+            )
+            _create_event(
+                team=self.team,
+                event="$pageview",
+                distinct_id="2",
+                properties={"prop": "another_val"},
+            )
+            _create_event(
+                team=self.team,
+                event="$pageview",
+                distinct_id="2",
+                properties={"prop": "val", "another": "never_return_this"},
+            )
+
+        query_dict = TrendsQuery(
+            series=[
+                EventsNode(
+                    event="$pageview",
+                )
+            ],
+            properties=properties_filter,
+        ).model_dump()
+
+        with freeze_time("2012-01-15T04:01:34.000Z"):
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/insights",
+                data={
+                    "query": query_dict,
+                    "dashboards": [dashboard_id],
+                },
+            ).json()
+            self.assertNotIn("code", response)  # Watching out for an error code
+            self.assertEqual(response["last_refresh"], None)
+            insight_id = response["id"]
+
+            response = self.client.get(f"/api/projects/{self.team.id}/insights/{insight_id}/?refresh=true").json()
+            self.assertNotIn("code", response)
+            self.assertEqual(spy_execute_hogql_query.call_count, 1)
+            self.assertEqual(response["result"][0]["data"], [0, 0, 0, 0, 0, 0, 2, 0])
+            self.assertEqual(response["last_refresh"], "2012-01-15T04:01:34Z")
+            self.assertEqual(response["last_modified_at"], "2012-01-15T04:01:34Z")
+            self.assertFalse(response["is_cached"])
+
+        with freeze_time("2012-01-15T05:17:39.000Z"):
+            # Make sure the /query/ endpoint reuses the same cached result - ASYNC EXECUTION HERE!
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/query/", {"query": query_dict, "async": True}
+            ).json()
+            self.assertNotIn("code", response)
+            self.assertTrue(response.get("query_async"))
+            self.assertTrue(response.get("complete"))
+            results = response["results"]
+
+            self.assertEqual(spy_execute_hogql_query.call_count, 1)
+            self.assertEqual(results["results"][0]["data"], [0, 0, 0, 0, 0, 0, 2, 0])
+            self.assertEqual(results["last_refresh"], "2012-01-15T04:01:34Z")  # Using cached result
+            self.assertTrue(results["is_cached"])
+
     def test_dashboard_filters_applied_to_sql_data_table_node(self):
         dashboard_id, _ = self.dashboard_api.create_dashboard(
             {"name": "the dashboard", "filters": {"date_from": "-180d"}}

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from freezegun import freeze_time
 from rest_framework import status
 
-from posthog.api.services.query import process_query
+from posthog.api.services.query import process_query_dict
 from posthog.hogql.query import LimitContext
 from posthog.models.property_definition import PropertyDefinition, PropertyType
 from posthog.models.utils import UUIDT
@@ -604,14 +604,14 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         with freeze_time("2020-01-10 12:14:00"):
-            response = process_query(
+            response = process_query_dict(
                 team=self.team,
                 query_json={
                     "kind": "HogQLQuery",
                     "query": f"select event from events where distinct_id='{random_uuid}'",
                 },
             )
-            self.assertEqual(len(response.get("results", [])), 10)
+            self.assertEqual(len(response.results), 10)
 
     @patch("posthog.hogql.constants.DEFAULT_RETURNED_ROWS", 10)
     @patch("posthog.hogql.constants.MAX_SELECT_RETURNED_ROWS", 15)
@@ -628,7 +628,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         with freeze_time("2020-01-10 12:14:00"):
-            response = process_query(
+            response = process_query_dict(
                 team=self.team,
                 query_json={
                     "kind": "HogQLQuery",
@@ -636,7 +636,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 },
                 limit_context=LimitContext.EXPORT,  # This is the only difference
             )
-            self.assertEqual(len(response.get("results", [])), 15)
+            self.assertEqual(len(response.results), 15)
 
     @patch("posthog.hogql.constants.DEFAULT_RETURNED_ROWS", 10)
     @patch("posthog.hogql.constants.MAX_SELECT_RETURNED_ROWS", 15)
@@ -653,7 +653,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         with freeze_time("2020-01-10 12:14:00"):
-            response = process_query(
+            response = process_query_dict(
                 team=self.team,
                 query_json={
                     "kind": "EventsQuery",
@@ -662,7 +662,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 },
             )
 
-        self.assertEqual(len(response.get("results", [])), 10)
+        self.assertEqual(len(response.results), 10)
 
     @patch("posthog.hogql.constants.DEFAULT_RETURNED_ROWS", 10)
     @patch("posthog.hogql.constants.MAX_SELECT_RETURNED_ROWS", 15)
@@ -679,7 +679,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         with freeze_time("2020-01-10 12:14:00"):
-            response = process_query(
+            response = process_query_dict(
                 team=self.team,
                 query_json={
                     "kind": "EventsQuery",
@@ -689,13 +689,13 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 limit_context=LimitContext.EXPORT,
             )
 
-        self.assertEqual(len(response.get("results", [])), 15)
+        self.assertEqual(len(response.results), 15)
 
     def test_property_definition_annotation_does_not_break_things(self):
         PropertyDefinition.objects.create(team=self.team, name="$browser", property_type=PropertyType.String)
 
         with freeze_time("2020-01-10 12:14:00"):
-            response = process_query(
+            response = process_query_dict(
                 team=self.team,
                 query_json={
                     "kind": "EventsQuery",
@@ -712,7 +712,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                     ],
                 },
             )
-        self.assertEqual(response.get("columns"), ["event"])
+        self.assertEqual(response.columns, ["event"])
 
     def test_invalid_query_kind(self):
         api_response = self.client.post(f"/api/projects/{self.team.id}/query/", {"query": {"kind": "Tomato Soup"}})
@@ -860,7 +860,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         with freeze_time("2020-01-10 12:14:00"):
-            response = process_query(
+            response = process_query_dict(
                 team=self.team,
                 query_json={
                     "kind": "HogQLQuery",
@@ -869,7 +869,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 },
             )
 
-        self.assertEqual(response.get("results", [])[0][0], 20)
+        self.assertEqual(response.results[0][0], 20)
 
     def test_dashboard_filters_applied(self):
         random_uuid = f"RANDOM_TEST_ID::{UUIDT()}"
@@ -890,14 +890,14 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
         flush_persons_and_events()
 
         with freeze_time("2020-01-10 19:00:00"):
-            response_without_dashboard_filters = process_query(
+            response_without_dashboard_filters = process_query_dict(
                 team=self.team,
                 query_json={
                     "kind": "HogQLQuery",
                     "query": "select count() from events where {filters}",
                 },
             )
-            response_with_dashboard_filters = process_query(
+            response_with_dashboard_filters = process_query_dict(
                 team=self.team,
                 query_json={
                     "kind": "HogQLQuery",
@@ -906,8 +906,8 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 dashboard_filters_json={"date_from": "2020-01-09", "date_to": "2020-01-11"},
             )
 
-        self.assertEqual(response_without_dashboard_filters.get("results", []), [(2,)])
-        self.assertEqual(response_with_dashboard_filters.get("results", []), [(1,)])
+        self.assertEqual(response_without_dashboard_filters.results, [(2,)])
+        self.assertEqual(response_with_dashboard_filters.results, [(1,)])
 
 
 class TestQueryRetrieve(APIBaseTest):

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -10,6 +10,7 @@ from posthog.hogql.query import LimitContext
 from posthog.models.property_definition import PropertyDefinition, PropertyType
 from posthog.models.utils import UUIDT
 from posthog.schema import (
+    CachedEventsQueryResponse,
     EventPropertyFilter,
     EventsQuery,
     HogQLPropertyFilter,
@@ -611,7 +612,8 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                     "query": f"select event from events where distinct_id='{random_uuid}'",
                 },
             )
-            self.assertEqual(len(response.results), 10)
+        assert isinstance(response, CachedHogQLQueryResponse)
+        self.assertEqual(len(response.results), 10)
 
     @patch("posthog.hogql.constants.DEFAULT_RETURNED_ROWS", 10)
     @patch("posthog.hogql.constants.MAX_SELECT_RETURNED_ROWS", 15)
@@ -636,7 +638,8 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 },
                 limit_context=LimitContext.EXPORT,  # This is the only difference
             )
-            self.assertEqual(len(response.results), 15)
+        assert isinstance(response, CachedHogQLQueryResponse)
+        self.assertEqual(len(response.results), 15)
 
     @patch("posthog.hogql.constants.DEFAULT_RETURNED_ROWS", 10)
     @patch("posthog.hogql.constants.MAX_SELECT_RETURNED_ROWS", 15)
@@ -662,6 +665,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 },
             )
 
+        assert isinstance(response, CachedEventsQueryResponse)
         self.assertEqual(len(response.results), 10)
 
     @patch("posthog.hogql.constants.DEFAULT_RETURNED_ROWS", 10)
@@ -689,6 +693,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 limit_context=LimitContext.EXPORT,
             )
 
+        assert isinstance(response, CachedEventsQueryResponse)
         self.assertEqual(len(response.results), 15)
 
     def test_property_definition_annotation_does_not_break_things(self):
@@ -712,6 +717,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                     ],
                 },
             )
+        assert isinstance(response, CachedEventsQueryResponse)
         self.assertEqual(response.columns, ["event"])
 
     def test_invalid_query_kind(self):
@@ -869,6 +875,7 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 },
             )
 
+        assert isinstance(response, CachedHogQLQueryResponse)
         self.assertEqual(response.results[0][0], 20)
 
     def test_dashboard_filters_applied(self):
@@ -906,7 +913,9 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
                 dashboard_filters_json={"date_from": "2020-01-09", "date_to": "2020-01-11"},
             )
 
+        assert isinstance(response_without_dashboard_filters, CachedHogQLQueryResponse)
         self.assertEqual(response_without_dashboard_filters.results, [(2,)])
+        assert isinstance(response_with_dashboard_filters, CachedHogQLQueryResponse)
         self.assertEqual(response_with_dashboard_filters.results, [(1,)])
 
 

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -138,8 +138,7 @@ def calculate_for_query_based_insight(
         else ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
     )
 
-    if "results" not in response:
-        # Translating `CacheMissResponse` to legacy insights shape
+    if response.keys() == {"cache_key"}:  # Translating `CacheMissResponse` to legacy insights shape
         return NothingInCacheResult(cache_key=response.get("cache_key"))
 
     return InsightResult(

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+from pydantic import BaseModel
 import structlog
 from sentry_sdk import capture_exception
 
@@ -37,7 +38,7 @@ from posthog.queries.paths import Paths
 from posthog.queries.retention import Retention
 from posthog.queries.stickiness import Stickiness
 from posthog.queries.trends.trends import Trends
-from posthog.schema import DashboardFilter
+from posthog.schema import CacheMissResponse, DashboardFilter
 from posthog.types import FilterType
 
 if TYPE_CHECKING:
@@ -122,14 +123,14 @@ def get_cache_type(cacheable: Optional[FilterType] | Optional[dict]) -> CacheTyp
 def calculate_for_query_based_insight(
     insight: Insight, *, dashboard: Optional[Dashboard] = None, refresh_requested: bool
 ) -> "InsightResult":
-    from posthog.api.services.query import process_query, ExecutionMode
+    from posthog.api.services.query import process_query_dict, ExecutionMode
     from posthog.caching.fetch_from_cache import InsightResult, NothingInCacheResult
 
     tag_queries(team_id=insight.team_id, insight_id=insight.pk)
     if dashboard:
         tag_queries(dashboard_id=dashboard.pk)
 
-    response = process_query(
+    response = process_query_dict(
         insight.team,
         insight.query,
         dashboard_filters_json=dashboard.filters if dashboard is not None else None,
@@ -138,13 +139,16 @@ def calculate_for_query_based_insight(
         else ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
     )
 
-    if response.keys() == {"cache_key"}:  # Translating `CacheMissResponse` to legacy insights shape
-        return NothingInCacheResult(cache_key=response.get("cache_key"))
+    if isinstance(response, CacheMissResponse):
+        return NothingInCacheResult(cache_key=response.cache_key)
+
+    if isinstance(response, BaseModel):
+        response = response.model_dump()
 
     return InsightResult(
         # Translating `QueryResponse` to legacy insights shape
-        # Only `results` is guaranteed even for non-insight queries, such as `EventsQueryResponse`
-        result=response["results"],
+        # The response may not be conformant with that, hence these are all `.get()`s
+        result=response.get("results"),
         columns=response.get("columns"),
         last_refresh=response.get("last_refresh"),
         cache_key=response.get("cache_key"),

--- a/posthog/caching/insight_cache.py
+++ b/posthog/caching/insight_cache.py
@@ -12,7 +12,7 @@ from prometheus_client import Counter
 from sentry_sdk.api import capture_exception
 from statshog.defaults.django import statsd
 
-from posthog.api.services.query import process_query
+from posthog.api.services.query import process_query_dict
 from posthog.caching.calculate_results import calculate_for_filter_based_insight
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.hogql_queries.legacy_compatibility.flagged_conversion_manager import flagged_conversion_to_query_based
@@ -116,14 +116,14 @@ def update_cache(caching_state_id: UUID):
     with flagged_conversion_to_query_based(insight):
         try:
             if insight.query:
-                response = process_query(
+                response = process_query_dict(
                     insight.team,
                     insight.query,
                     dashboard_filters_json=dashboard.filters if dashboard is not None else None,
                     execution_mode=ExecutionMode.CALCULATION_ALWAYS,
                 )
                 # TRICKY: `result` is null, because `process_query` already set the cache. `cache_type` also irrelevant
-                cache_key, cache_type, result = response.get("cache_key"), None, None
+                cache_key, cache_type, result = getattr(response, "cache_key", None), None, None
             else:
                 cache_key, cache_type, result = calculate_for_filter_based_insight(insight=insight, dashboard=dashboard)
         except Exception as err:

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -278,10 +278,12 @@ def enqueue_process_query_task(
             execution_mode=ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
         )
         if not isinstance(cached_response, CacheMissResponse):
+            if isinstance(cached_response, BaseModel):
+                cached_response = cached_response.model_dump()
             # We got a response with results, rather than a `CacheMissResponse`
             query_status.complete = True
             query_status.error = False
-            query_status.results = cached_response.model_dump()
+            query_status.results = cached_response
             query_status.end_time = datetime.datetime.now(datetime.timezone.utc)
             query_status.expiration_time = query_status.end_time + datetime.timedelta(
                 seconds=manager.STATUS_TTL_SECONDS

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -79,7 +79,7 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
         self.assertRaises(
             ExposedHogQLError,
             client.enqueue_process_query_task,
-            **{"team_id": self.team_id, "user_id": self.user_id, "query_json": query, "_test_only_bypass_celery": True},
+            **{"team": self.team, "user": self.user, "query_json": query, "_test_only_bypass_celery": True},
         )
         query_id = uuid.uuid4().hex
         try:

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -43,7 +43,7 @@ class TestExecuteProcessQuery(TestCase):
         mock_process_query.return_value = [float("inf"), float("-inf"), float("nan"), 1.0, "👍"]
 
         execute_process_query(
-            self.team, self.user, self.query_id, self.query_json, self.limit_context, self.refresh_requested
+            self.team.id, self.user.id, self.query_id, self.query_json, self.limit_context, self.refresh_requested
         )
 
         mock_redis_client.assert_called_once()

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -32,22 +32,22 @@ class TestExecuteProcessQuery(TestCase):
         self.manager = QueryStatusManager(self.query_id, self.team.id)
 
     @patch("posthog.clickhouse.client.execute_async.redis.get_client")
-    @patch("posthog.api.services.query.process_query")
-    def test_execute_process_query(self, mock_process_query, mock_redis_client):
+    @patch("posthog.api.services.query.process_query_dict")
+    def test_execute_process_query(self, mock_process_query_dict, mock_redis_client):
         mock_redis = MagicMock()
         mock_redis.get.return_value = json.dumps(
             {"id": self.query_id, "team_id": self.team.id, "complete": False, "error": False}
         ).encode()
         mock_redis_client.return_value = mock_redis
 
-        mock_process_query.return_value = [float("inf"), float("-inf"), float("nan"), 1.0, "👍"]
+        mock_process_query_dict.return_value = [float("inf"), float("-inf"), float("nan"), 1.0, "👍"]
 
         execute_process_query(
             self.team.id, self.user.id, self.query_id, self.query_json, self.limit_context, self.refresh_requested
         )
 
         mock_redis_client.assert_called_once()
-        mock_process_query.assert_called_once()
+        mock_process_query_dict.assert_called_once()
 
         # Assert that Redis set method was called with the correct arguments
         mock_redis.set.assert_called_once()

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -351,7 +351,6 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
     def run(
         self, execution_mode: ExecutionMode = ExecutionMode.RECENT_CACHE_CALCULATE_IF_STALE
     ) -> CR | CacheMissResponse:
-        # TODO: `self.limit_context` should probably just be in get_cache_key()
         cache_key = self.get_cache_key()
         tag_queries(cache_key=cache_key)
         CachedResponse: type[CR] = self.cached_response_type

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -337,6 +337,13 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             isinstance(data, dict) and "is_cached" in data
         )
 
+    @property
+    def _limit_context_aliased_for_cache(self) -> LimitContext:
+        # For caching purposes, QUERY_ASYNC is equivalent to QUERY (max query duration should be the only difference)
+        if not self.limit_context or self.limit_context == LimitContext.QUERY_ASYNC:
+            return LimitContext.QUERY
+        return self.limit_context
+
     @abstractmethod
     def calculate(self) -> R:
         raise NotImplementedError()
@@ -345,7 +352,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         self, execution_mode: ExecutionMode = ExecutionMode.RECENT_CACHE_CALCULATE_IF_STALE
     ) -> CR | CacheMissResponse:
         # TODO: `self.limit_context` should probably just be in get_cache_key()
-        cache_key = f"{self.get_cache_key()}_{self.limit_context or LimitContext.QUERY}_v2"
+        cache_key = self.get_cache_key()
         tag_queries(cache_key=cache_key)
         CachedResponse: type[CR] = self.cached_response_type
 
@@ -437,7 +444,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
     def get_cache_key(self) -> str:
         modifiers = self.modifiers.model_dump_json(exclude_defaults=True, exclude_none=True)
         return generate_cache_key(
-            f"query_{self.to_json()}_{self.__class__.__name__}_{self.team.pk}_{self.team.timezone}_{modifiers}"
+            f"query_{self.to_json()}_{self.__class__.__name__}_{self.team.pk}_{self.team.timezone}_{modifiers}_{self._limit_context_aliased_for_cache}_v2"
         )
 
     @abstractmethod

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -106,7 +106,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_b6f14c97c218e0b9c9a8258f7460fd5b")
+        self.assertEqual(cache_key, "cache_151bd63c5cbbbcb8dec547811cc684f4")
 
     def test_cache_key_runner_subclass(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -120,7 +120,7 @@ class TestQueryRunner(BaseTest):
         runner = TestSubclassQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_ec1c2f9715cf9c424b1284b94b1205e6")
+        self.assertEqual(cache_key, "cache_23f3317da40b07e4ce7796c4bbd1615c")
 
     def test_cache_key_different_timezone(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -131,7 +131,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_a6614c0fb564f9c98b1d7b830928c7a1")
+        self.assertEqual(cache_key, "cache_a687040d3a8e4116afbab194490be520")
 
     def test_cache_response(self):
         TestQueryRunner = self.setup_test_query_runner_class()

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -3,9 +3,8 @@ import string
 import uuid
 from collections import defaultdict, namedtuple
 from contextlib import contextmanager
-from random import Random, choice
 from time import time
-from typing import Any, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Optional, TypeVar
 from collections.abc import Callable, Iterator
 
 from django.db import IntegrityError, connections, models, transaction
@@ -15,6 +14,9 @@ from django.db.models.constraints import BaseConstraint
 from django.utils.text import slugify
 
 from posthog.constants import MAX_SLUG_LENGTH
+
+if TYPE_CHECKING:
+    from random import Random
 
 T = TypeVar("T")
 
@@ -48,7 +50,7 @@ class UUIDT(uuid.UUID):
         unix_time_ms: Optional[int] = None,
         uuid_str: Optional[str] = None,
         *,
-        seeded_random: Optional[Random] = None,
+        seeded_random: Optional["Random"] = None,
     ) -> None:
         if uuid_str and self.is_valid_uuid(uuid_str):
             super().__init__(uuid_str)
@@ -185,7 +187,7 @@ class LowercaseSlugField(models.SlugField):
 
 def generate_random_short_suffix():
     """Return a 4 letter suffix made up random ASCII letters, useful for disambiguation of duplicates."""
-    return "".join(choice(string.ascii_letters) for _ in range(4))
+    return "".join(secrets.choice(string.ascii_letters) for _ in range(4))
 
 
 def create_with_slug(create_func: Callable[..., T], default_slug: str = "", *args, **kwargs) -> T:

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -762,7 +762,7 @@ class QueryStatus(BaseModel):
     error_message: Optional[str] = None
     expiration_time: Optional[AwareDatetime] = None
     id: str
-    query_async: Optional[bool] = True
+    query_async: Literal[True] = Field(default=True, description="ONLY async queries use QueryStatus.")
     query_progress: Optional[ClickhouseQueryStatus] = None
     results: Optional[Any] = None
     start_time: Optional[AwareDatetime] = None

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 from collections.abc import Generator
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 
+from pydantic import BaseModel
 import requests
 import structlog
 from openpyxl import Workbook
@@ -11,7 +12,7 @@ from django.http import QueryDict
 from sentry_sdk import capture_exception, push_scope
 from requests.exceptions import HTTPError
 
-from posthog.api.services.query import process_query
+from posthog.api.services.query import process_query_dict
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.jwt import PosthogJwtAudience, encode_jwt
 from posthog.models.exported_asset import ExportedAsset, save_content
@@ -249,7 +250,7 @@ def get_from_hogql_query(exported_asset: ExportedAsset, limit: int, resource: di
 
     while True:
         try:
-            query_response = process_query(
+            query_response = process_query_dict(
                 team=exported_asset.team,
                 query_json=query,
                 limit_context=LimitContext.EXPORT,
@@ -264,6 +265,8 @@ def get_from_hogql_query(exported_asset: ExportedAsset, limit: int, resource: di
             query["breakdownFilter"]["breakdown_limit"] = limit
             continue
 
+        if isinstance(query_response, BaseModel):
+            query_response = query_response.model_dump()
         yield from _convert_response_to_csv_data(query_response)
         return
 

--- a/posthog/tasks/exports/test/test_csv_exporter_renders.py
+++ b/posthog/tasks/exports/test/test_csv_exporter_renders.py
@@ -24,9 +24,9 @@ for file in os.listdir(directory):
 @pytest.mark.parametrize("mode", ("legacy", "hogql"))
 @pytest.mark.django_db
 @patch("posthog.tasks.exports.csv_exporter.requests.request")
-@patch("posthog.tasks.exports.csv_exporter.process_query")
+@patch("posthog.tasks.exports.csv_exporter.process_query_dict")
 @patch("posthog.models.exported_asset.settings")
-def test_csv_rendering(mock_settings, mock_process_query, mock_request, filename, mode):
+def test_csv_rendering(mock_settings, mock_process_query_dict, mock_request, filename, mode):
     mock_settings.OBJECT_STORAGE_ENABLED = False
     org = Organization.objects.create(name="org")
     team = Team.objects.create(organization=org, name="team")
@@ -58,13 +58,13 @@ def test_csv_rendering(mock_settings, mock_process_query, mock_request, filename
         asset.save()
         if fixture.get("hogql_response"):
             # If HogQL has a different response structure, add it to the fixture as `hogql_response`
-            mock_process_query.return_value = fixture["hogql_response"]
+            mock_process_query_dict.return_value = fixture["hogql_response"]
         elif fixture["response"].get("results") is not None:
-            mock_process_query.return_value = fixture["response"]
+            mock_process_query_dict.return_value = fixture["response"]
         else:
-            mock_process_query.return_value = fixture["response"]
+            mock_process_query_dict.return_value = fixture["response"]
             if "result" in fixture["response"]:
-                mock_process_query.return_value["results"] = fixture["response"].pop("result")
+                mock_process_query_dict.return_value["results"] = fixture["response"].pop("result")
         csv_exporter.export_tabular(asset)
         csv_rows = asset.content.decode("utf-8").split("\r\n")
 

--- a/posthog/warehouse/models/datawarehouse_saved_query.py
+++ b/posthog/warehouse/models/datawarehouse_saved_query.py
@@ -53,11 +53,11 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDModel, DeletedMetaFields):
         ]
 
     def get_columns(self) -> dict[str, str]:
-        from posthog.api.services.query import process_query
+        from posthog.api.services.query import process_query_dict
         from posthog.hogql_queries.query_runner import ExecutionMode
 
-        response = process_query(self.team, self.query, execution_mode=ExecutionMode.CALCULATION_ALWAYS)
-        types = response.get("types", {})
+        response = process_query_dict(self.team, self.query, execution_mode=ExecutionMode.CALCULATION_ALWAYS)
+        types = getattr(response, "types", {})
         return dict(types)
 
     @property


### PR DESCRIPTION
## Problem

When a query is executed async (via `/query/`), we aren't able to reuse its results in sync execution (`/insights/` or `/dashboards/`), because we treat `LimitContext.QUERY` and `LimitContext.QUERY_ASYNC` as different in the cache key. This doesn't make sense, because the queries are the same, max query duration is the only difference.

## Changes

This works as a follow-up to #22151. Now, async queries have the same cache key as sync. Also, if cached results are available, we immediately return the `QueryStatus` with results – no polling needed.

## How did you test this code?

Added `test_insight_refreshing_query_async`.