### PR TITLE
fix: Remove 10,000 Cohort Limit when Loading from Actors 

### DIFF
--- a/posthog/hogql/modifiers.py
+++ b/posthog/hogql/modifiers.py
@@ -45,7 +45,7 @@ def set_default_modifier_values(modifiers: HogQLQueryModifiers, team: "Team"):
 
 
 def set_default_in_cohort_via(modifiers: HogQLQueryModifiers) -> HogQLQueryModifiers:
-    if modifiers.inCohortVia == InCohortVia.auto:
+    if modifiers.inCohortVia is None or modifiers.inCohortVia == InCohortVia.auto:
         modifiers.inCohortVia = InCohortVia.subquery
 
     return modifiers

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -13,6 +13,7 @@ from posthog.client import sync_execute
 from posthog.constants import PropertyOperatorType
 from posthog.hogql.constants import LimitContext
 from posthog.hogql.hogql import HogQLContext
+from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.printer import print_ast
 from posthog.models import Action, Filter, Team
 from posthog.models.action.util import format_action_filter
@@ -77,7 +78,10 @@ def print_cohort_hogql_query(cohort: Cohort, hogql_context: HogQLContext) -> str
     query = get_query_runner(
         persons_query, team=cast(Team, cohort.team), limit_context=LimitContext.COHORT_CALCULATION
     ).to_query()
+
     hogql_context.enable_select_queries = True
+    hogql_context.limit_top_select = False
+    create_default_modifiers_for_team(hogql_context.modifiers, cohort.team)
     return print_ast(query, context=hogql_context, dialect="clickhouse")
 
 

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -81,7 +81,7 @@ def print_cohort_hogql_query(cohort: Cohort, hogql_context: HogQLContext) -> str
 
     hogql_context.enable_select_queries = True
     hogql_context.limit_top_select = False
-    create_default_modifiers_for_team(hogql_context.modifiers, cohort.team)
+    create_default_modifiers_for_team(cohort.team, hogql_context.modifiers)
     return print_ast(query, context=hogql_context, dialect="clickhouse")
 
 


### PR DESCRIPTION
## Problem

When you try to create a cohort from the actors modal in a trend, it only pulls in the first 10k
https://posthoghelp.zendesk.com/agent/tickets/13099 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/17165)

## Changes

Add the options required to prevent the limit from happening.

<img width="538" alt="image" src="https://github.com/PostHog/posthog/assets/1855120/b25880d7-3028-4da3-9501-1b9209dfa245">


## How did you test this code?

I tested the code manually. The cohort flow in util.py is a little bit of a hack around the normal code path, as we generate clickhouse from a hogql actors query that is then inserted into other clickhouse manually, so it is a little untested which is how this bug slipped in.