### PR TITLE
fix: Move TEMPORAL_HOST to docker-compose.hobby.yml

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -192,5 +192,5 @@ services:
         <<: *worker
         command: ./bin/temporal-django-worker
         restart: on-failure
-        environment:
-            TEMPORAL_HOST: temporal
+        # environment:
+        #    TEMPORAL_HOST: temporal

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -171,6 +171,7 @@ services:
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
+            TEMPORAL_HOST: temporal
         depends_on:
             - db
             - redis


### PR DESCRIPTION
## Problem

Self-hosted installation has been broken out-of-the-box for more than a year now due to overwriting (not merging) of `environment` section inside `posthog/docker-compose.base.yml`: the `temporal-django-worker` dict extends the `&worker` reference, but then overwrites the environment to set `TEMPORAL_HOST: temporal` instead of merging. See https://github.com/PostHog/posthog/issues/16169#issuecomment-1625351591 for details.

## Changes
Ditch `environment` section in posthog/docker-compose.base.yml and move `TEMPORAL_HOST` to  docker-compose.hobby.yml

## Does this work well for both Cloud and self-hosted?

self-hosted

## How did you test this code?

Had to do this manually per each install and it's wearing me thin.