### PR TITLE
fix: Change default to allow safe methods for time sensitive views

### DIFF
--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -270,6 +270,11 @@ class TimeSensitiveActionPermission(BasePermission):
         if not isinstance(request.successful_authenticator, SessionAuthentication):
             return True
 
+        allow_safe_methods = getattr(view, "time_sensitive_allow_safe_methods", True)
+
+        if allow_safe_methods and request.method in SAFE_METHODS:
+            return True
+
         session_created_at = request.session.get(settings.SESSION_COOKIE_CREATED_AT_KEY)
 
         if not session_created_at:


### PR DESCRIPTION
## Problem

At first I had thought this made sense for all methods but in retrospect we should only protect modifications as otherwise there are all sorts of parts of the UI that get blocked

## Changes

* Allow safe methods by default with an option for overriding

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
