### PR TITLE
fix(notebooks): Fix notebook history warning layout

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/NotebookHistory.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookHistory.tsx
@@ -143,7 +143,7 @@ export function NotebookHistoryWarning(): JSX.Element | null {
 
     return (
         <LemonBanner type="info" className="my-4">
-            <span className="flex items-center gap-2">
+            <span className="flex flex-col gap-2">
                 <span className="flex-1">
                     <b>Hello time traveller!</b>
                     <br /> You are viewing an older revision of this Notebook. You can choose to revert to this version,


### PR DESCRIPTION
## Problem

The flex direction of the notebook history warning is set to row which breaks the layout. The content is not readable and one of the action buttons gets clipped.

![notebook history before](https://github.com/PostHog/posthog/assets/11791251/905a37b6-d0d8-4997-9434-a2b9075f8fa7)

## Changes

Changed flex direction to column.

![notebook history warning after](https://github.com/PostHog/posthog/assets/11791251/79745f55-0f41-474e-b41f-f4a90debe3c8)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually verified visuals.