### PR TITLE
fix: only saying website

### DIFF
--- a/frontend/src/scenes/onboarding/OnboardingProductIntroduction.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingProductIntroduction.tsx
@@ -49,7 +49,7 @@ const GetStartedButton = ({ product }: { product: BillingProductV2Type }): JSX.E
     const { isFirstProductOnboarding } = useValues(onboardingLogic)
     const { hasSnippetEvents } = useValues(sdksLogic)
     const cta: Partial<Record<ProductKey, string>> = {
-        [ProductKey.SESSION_REPLAY]: 'Start recording my website or app',
+        [ProductKey.SESSION_REPLAY]: 'Start recording my website or mobile app',
         [ProductKey.FEATURE_FLAGS]: 'Create a feature flag or experiment',
         [ProductKey.SURVEYS]: 'Create a survey',
     }

--- a/frontend/src/scenes/onboarding/OnboardingProductIntroduction.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingProductIntroduction.tsx
@@ -49,7 +49,7 @@ const GetStartedButton = ({ product }: { product: BillingProductV2Type }): JSX.E
     const { isFirstProductOnboarding } = useValues(onboardingLogic)
     const { hasSnippetEvents } = useValues(sdksLogic)
     const cta: Partial<Record<ProductKey, string>> = {
-        [ProductKey.SESSION_REPLAY]: 'Start recording my website',
+        [ProductKey.SESSION_REPLAY]: 'Start recording my website or app',
         [ProductKey.FEATURE_FLAGS]: 'Create a feature flag or experiment',
         [ProductKey.SURVEYS]: 'Create a survey',
     }


### PR DESCRIPTION
I watched an onboarding where someone had selected Android on product analytics onboarding, 

clicked into replay 

it said "start recording your website" 

and they clicked on past

so now it'll say "start recording your website or mobile app"