### PR TITLE
fix: Pipeline node logs kea logic types

### DIFF
--- a/frontend/src/scenes/pipeline/appCodeLogic.tsx
+++ b/frontend/src/scenes/pipeline/appCodeLogic.tsx
@@ -117,7 +117,9 @@ export async function formatSource(filename: string, source: string): Promise<st
     }
 
     // Lazy-load prettier, as it's pretty big and its only use is formatting app source code
+    // @ts-expect-error
     const prettier = (await import('prettier/standalone')).default
+    // @ts-expect-error
     const parserTypeScript = (await import('prettier/parser-typescript')).default
 
     return prettier.format(source, {

--- a/frontend/src/scenes/pipeline/appCodeLogic.tsx
+++ b/frontend/src/scenes/pipeline/appCodeLogic.tsx
@@ -117,9 +117,7 @@ export async function formatSource(filename: string, source: string): Promise<st
     }
 
     // Lazy-load prettier, as it's pretty big and its only use is formatting app source code
-    // @ts-expect-error
     const prettier = (await import('prettier/standalone')).default
-    // @ts-expect-error
     const parserTypeScript = (await import('prettier/parser-typescript')).default
 
     return prettier.format(source, {

--- a/frontend/src/scenes/pipeline/pipelineNodeLogsLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineNodeLogsLogic.tsx
@@ -39,90 +39,94 @@ export const pipelineNodeLogsLogic = kea<pipelineNodeLogsLogicType>([
         markLogsEnd: true,
     }),
     loaders(({ props: { id }, values, actions, cache }) => ({
-        logs: {
-            __default: [] as PluginLogEntry[] | BatchExportLogEntry[],
-            loadLogs: async () => {
-                let results: LogEntry[]
-                if (values.nodeBackend === PipelineBackend.BatchExport) {
-                    results = await api.batchExportLogs.search(
-                        id as string,
-                        values.searchTerm,
-                        values.selectedLogLevels
-                    )
-                } else {
-                    results = await api.pluginLogs.search(
-                        id as number,
-                        values.searchTerm,
-                        logLevelsToTypeFilters(values.selectedLogLevels)
-                    )
-                }
+        logs: [
+            [] as LogEntry[],
+            {
+                loadLogs: async () => {
+                    let results: LogEntry[]
+                    if (values.nodeBackend === PipelineBackend.BatchExport) {
+                        results = await api.batchExportLogs.search(
+                            id as string,
+                            values.searchTerm,
+                            values.selectedLogLevels
+                        )
+                    } else {
+                        results = await api.pluginLogs.search(
+                            id as number,
+                            values.searchTerm,
+                            logLevelsToTypeFilters(values.selectedLogLevels)
+                        )
+                    }
 
-                if (!cache.pollingInterval) {
-                    cache.pollingInterval = setInterval(actions.pollBackgroundLogs, 5000)
-                }
-                actions.clearBackgroundLogs()
-                return results
-            },
-            loadMoreLogs: async () => {
-                let results: LogEntry[]
-                if (values.nodeBackend === PipelineBackend.BatchExport) {
-                    results = await api.batchExportLogs.search(
-                        id as string,
-                        values.searchTerm,
-                        values.selectedLogLevels,
-                        values.trailingEntry as BatchExportLogEntry | null
-                    )
-                } else {
-                    results = await api.pluginLogs.search(
-                        id as number,
-                        values.searchTerm,
-                        logLevelsToTypeFilters(values.selectedLogLevels),
-                        values.trailingEntry as PluginLogEntry | null
-                    )
-                }
+                    if (!cache.pollingInterval) {
+                        cache.pollingInterval = setInterval(actions.pollBackgroundLogs, 5000)
+                    }
+                    actions.clearBackgroundLogs()
+                    return results
+                },
+                loadMoreLogs: async () => {
+                    let results: LogEntry[]
+                    if (values.nodeBackend === PipelineBackend.BatchExport) {
+                        results = await api.batchExportLogs.search(
+                            id as string,
+                            values.searchTerm,
+                            values.selectedLogLevels,
+                            values.trailingEntry as BatchExportLogEntry | null
+                        )
+                    } else {
+                        results = await api.pluginLogs.search(
+                            id as number,
+                            values.searchTerm,
+                            logLevelsToTypeFilters(values.selectedLogLevels),
+                            values.trailingEntry as PluginLogEntry | null
+                        )
+                    }
 
-                if (results.length < LOGS_PORTION_LIMIT) {
-                    actions.markLogsEnd()
-                }
-                return [...values.logs, ...results]
+                    if (results.length < LOGS_PORTION_LIMIT) {
+                        actions.markLogsEnd()
+                    }
+                    return [...values.logs, ...results]
+                },
+                revealBackground: () => {
+                    const newArray = [...values.backgroundLogs, ...values.logs]
+                    actions.clearBackgroundLogs()
+                    return newArray
+                },
             },
-            revealBackground: () => {
-                const newArray = [...values.backgroundLogs, ...values.logs]
-                actions.clearBackgroundLogs()
-                return newArray
-            },
-        },
-        backgroundLogs: {
-            __default: [] as PluginLogEntry[] | BatchExportLogEntry[],
-            pollBackgroundLogs: async () => {
-                // we fetch new logs in the background and allow the user to expand
-                // them into the array of visible logs
-                if (values.logsLoading) {
-                    return values.backgroundLogs
-                }
+        ],
+        backgroundLogs: [
+            [] as LogEntry[],
+            {
+                pollBackgroundLogs: async () => {
+                    // we fetch new logs in the background and allow the user to expand
+                    // them into the array of visible logs
+                    if (values.logsLoading) {
+                        return values.backgroundLogs
+                    }
 
-                let results: LogEntry[]
-                if (values.nodeBackend === PipelineBackend.BatchExport) {
-                    results = await api.batchExportLogs.search(
-                        id as string,
-                        values.searchTerm,
-                        values.selectedLogLevels,
-                        null,
-                        values.leadingEntry as BatchExportLogEntry | null
-                    )
-                } else {
-                    results = await api.pluginLogs.search(
-                        id as number,
-                        values.searchTerm,
-                        logLevelsToTypeFilters(values.selectedLogLevels),
-                        null,
-                        values.leadingEntry as PluginLogEntry | null
-                    )
-                }
+                    let results: LogEntry[]
+                    if (values.nodeBackend === PipelineBackend.BatchExport) {
+                        results = await api.batchExportLogs.search(
+                            id as string,
+                            values.searchTerm,
+                            values.selectedLogLevels,
+                            null,
+                            values.leadingEntry as BatchExportLogEntry | null
+                        )
+                    } else {
+                        results = await api.pluginLogs.search(
+                            id as number,
+                            values.searchTerm,
+                            logLevelsToTypeFilters(values.selectedLogLevels),
+                            null,
+                            values.leadingEntry as PluginLogEntry | null
+                        )
+                    }
 
-                return [...results, ...values.backgroundLogs]
+                    return [...results, ...values.backgroundLogs]
+                },
             },
-        },
+        ],
     })),
     reducers({
         selectedLogLevels: [
@@ -132,7 +136,7 @@ export const pipelineNodeLogsLogic = kea<pipelineNodeLogsLogicType>([
             },
         ],
         backgroundLogs: [
-            [] as PluginLogEntry[] | BatchExportLogEntry[],
+            [] as LogEntry[],
             {
                 clearBackgroundLogs: () => [],
             },


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
This was the only logic with different way to use loaders and it was also wrong, the type of `PluginLogEntry[] | BatchExportLogEntry[]` is not the same as `(BatchExportLogEntry | BatchExportLogEntry)[]`.

There was a typing error in the app source code file too, not sure who fixed prettier or what changed.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
