### PR TITLE
fix: isinstance check on get_invoices error handler was backwards

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -161,7 +161,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         except Exception as e:
             if len(e.args) > 2:
                 detail_object = e.args[2]
-                if isinstance(detail_object, dict):
+                if not isinstance(detail_object, dict):
                     raise e
                 return Response(
                     {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
