### PR TITLE
refactor: Preventing mousewheel from altering port value in batch export form

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
@@ -51,7 +51,7 @@ interface LemonInputPropsBase
 }
 
 export interface LemonInputPropsText extends LemonInputPropsBase {
-    type?: 'text' | 'email' | 'search' | 'url' | 'password' | 'time'
+    type?: 'text' | 'email' | 'search' | 'url' | 'password' | 'time' | 'tel'
     value?: string
     defaultValue?: string
     onChange?: (newValue: string) => void

--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
@@ -23,6 +23,7 @@ interface LemonInputPropsBase
         | 'autoCapitalize'
         | 'spellCheck'
         | 'inputMode'
+        | 'pattern'
     > {
     ref?: React.Ref<HTMLInputElement>
     id?: string
@@ -55,6 +56,8 @@ export interface LemonInputPropsText extends LemonInputPropsBase {
     value?: string
     defaultValue?: string
     onChange?: (newValue: string) => void
+    min?: string
+    max?: string
 }
 
 export interface LemonInputPropsNumber

--- a/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
@@ -391,7 +391,7 @@ export function BatchExportsEditFields({
                         </LemonField>
 
                         <LemonField name="port" label="Port">
-                            <LemonInput placeholder="5432" type="number" min="0" max="65535" />
+                            <LemonInput placeholder="5432" type="tel" min="0" max="65535" />
                         </LemonField>
 
                         <LemonField name="database" label="Database">
@@ -456,7 +456,7 @@ export function BatchExportsEditFields({
                         </LemonField>
 
                         <LemonField name="port" label="Port">
-                            <LemonInput placeholder="5439" type="number" min="0" max="65535" />
+                            <LemonInput placeholder="5439" type="tel" min="0" max="65535" />
                         </LemonField>
 
                         <LemonField name="database" label="Database">

--- a/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
@@ -456,7 +456,7 @@ export function BatchExportsEditFields({
                         </LemonField>
 
                         <LemonField name="port" label="Port">
-                            <LemonInput placeholder="5439" type="tel" min="0" max="65535" />
+                            <LemonInput placeholder="5439" type="number" min="0" max="65535" />
                         </LemonField>
 
                         <LemonField name="database" label="Database">


### PR DESCRIPTION
## Problem

A user pointed out (in ZenDesk ticket 11999) that the value in the port number field, in the batch export config screen, can be changed unintentionally by scrolling with the mouse wheel.  This PR is to prevent that by changing the field type from `number` to `tel`.

## Changes
Changed field type from `number` to `tel` on line 371 of
`frontend/src/scenes/batch_exports/BatchExportEditForm.tsx`

Before:
![before-number](https://github.com/PostHog/posthog/assets/227448/2df02ee5-b3a5-4238-b49b-d2d4ffb071fc)

After:
![CleanShot 2024-05-02 at 14 21 16](https://github.com/PostHog/posthog/assets/227448/6a401b53-63c7-4549-837c-2188da862db0)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Tested on my local (see the 'after' gif above)

#### Note
Codespaces became displeased with the branch I used for PR [https://github.com/PostHog/posthog/pull/22051](22051), hence this new PR from a new branch.
