### PR TITLE
fix: objectstorage endpoints for hobby deployment

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -76,6 +76,8 @@ services:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
             SECRET_KEY: $POSTHOG_SECRET
+            OBJECT_STORAGE_ENDPOINT: http://objectstorage:19000
+            OBJECT_STORAGE_ENABLED: true
         depends_on:
             - db
             - redis
@@ -116,6 +118,9 @@ services:
         restart: on-failure
         volumes:
             - objectstorage:/data
+        ports:
+            - '19000:19000'
+            - '19001:19001'
 
     asyncmigrationscheck:
         extends:


### PR DESCRIPTION
t.Currently, default objectstorage address is http://127.0.0.1:19000, but ports are not exposed from docker-compose-hobby, hence object storage is effectively unaccessible from other containers for self-hosted setups.

This commit exposes ports AND updates `OBJECT_STORAGE_ENDPOINT` to direct requests to MinIO container rather than to localhost, but open localhost port is useful either way for admin and testing purposes.

Addresses https://github.com/PostHog/posthog/issues/20947 , our instance with this fix works flawlessly records and plays back sessions for 3+ days already. Prior it lasted only several hours after initial install.

