### PR TITLE
fix: add volumes for Caddy to enable certificate persistence on self-hosted 

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -109,8 +109,8 @@ services:
             - '443:443'
         volumes:
             - ./Caddyfile:/etc/caddy/Caddyfile
-            - /etc/caddy/data:/data
-            - /etc/caddy/config:/config            
+            - caddy-data:/data
+            - caddy-config:/config            
         depends_on:
             - web
     objectstorage:
@@ -193,3 +193,5 @@ volumes:
     objectstorage:
     postgres-data:
     clickhouse-data:
+    caddy-data:
+    caddy-config:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -109,6 +109,8 @@ services:
             - '443:443'
         volumes:
             - ./Caddyfile:/etc/caddy/Caddyfile
+            - /etc/caddy/data:/data
+            - /etc/caddy/config:/config            
         depends_on:
             - web
     objectstorage:


### PR DESCRIPTION
## Problem

 `docker-compose.hobby.yml` does not provide volumes for Caddy to store certificates, this makes Caddy to attempt certificates re-issue upon each container re-build, which in turn can keep website down if IP was rate limited or letsencrypt / zeross is down. Details : https://hub.docker.com/_/caddy (Automatic TLS with the Caddy image)

## Changes

Added volumes to Caddy section