### PR TITLE
fix: heatmap validation on ingestion

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
@@ -136,7 +136,7 @@ function extractScrollDepthHeatmapData(event: PreIngestionEvent): RawClickhouseH
                             target_fixed: boolean
                             type: string
                         }): RawClickhouseHeatmapEvent | null => {
-                            if (isValidNumber(hme.x) || isValidNumber(hme.y) || !isValidString(hme.type)) {
+                            if (!isValidNumber(hme.x) || !isValidNumber(hme.y) || !isValidString(hme.type)) {
                                 return null
                             }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
@@ -115,10 +115,7 @@ function extractScrollDepthHeatmapData(event: PreIngestionEvent): RawClickhouseH
                             target_fixed: boolean
                             type: string
                         }): RawClickhouseHeatmapEvent | null => {
-                            if (isNaN(hme.x) || isNaN(hme.y)) {
-                                return null
-                            }
-                            if (hme.type.trim() === '' || hme.type.length > 255) {
+                            if (isNaN(hme.x) || isNaN(hme.y) || hme.type.trim() === '') {
                                 return null
                             }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
@@ -92,7 +92,6 @@ function extractScrollDepthHeatmapData(event: PreIngestionEvent): RawClickhouseH
     let heatmapData = $heatmap_data as HeatmapData | null
 
     if (!isValidString(distinctId) || isDistinctIdIllegal(distinctId)) {
-        // TODO should this be an ingestion warning
         return drop('invalid_distinct_id')
     }
 

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -74,7 +74,7 @@ const CASE_SENSITIVE_ILLEGAL_IDS = new Set(
     )
 )
 
-const isDistinctIdIllegal = (id: string): boolean => {
+export const isDistinctIdIllegal = (id: string): boolean => {
     const trimmed = id.trim()
     return trimmed === '' || CASE_INSENSITIVE_ILLEGAL_IDS.has(id.toLowerCase()) || CASE_SENSITIVE_ILLEGAL_IDS.has(id)
 }

--- a/plugin-server/tests/worker/ingestion/event-pipeline/extractHeatmapDataStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/extractHeatmapDataStep.test.ts
@@ -14,7 +14,6 @@ const preIngestionEvent: PreIngestionEvent = {
         $pathname: '/',
         $viewport_height: 1328,
         $viewport_width: 1071,
-        distinct_id: '018eebf3-79b1-7082-a7c6-eeb56a36002f',
         $device_id: '018eebf3-79b1-7082-a7c6-eeb56a36002f',
         $session_id: '018eebf3-79cd-70da-895f-b6cf352bd688',
         $window_id: '018eebf3-79cd-70da-895f-b6d09add936a',


### PR DESCRIPTION
we were reading distinct id from event properties during heatmap event ingestion

this isn't guaranteed to be present and isn't validated earlier in the pipeline

so, now we read the correct distinct id but also do some belt and braces validation to drop invalid data instead of upsetting clickhouse