### PR TITLE
fix: Add favicon to admin pages

### DIFF
--- a/posthog/templates/admin/base_site.html
+++ b/posthog/templates/admin/base_site.html
@@ -1,0 +1,4 @@
+{% extends "admin/base_site.html" %}
+{% block extrahead %}
+    <link rel="shortcut icon" href="/static/icons/favicon.ico?v=2023-07-07">
+{% endblock %}


### PR DESCRIPTION
## Problem

The favicon was defaulting to /favicon.ico which hits our django app not static files

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

verified working locally