### PR TITLE
fix(web-analytics): Fix referring domain with sessions

### DIFF
--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -395,6 +395,7 @@ ORDER BY "context.columns.visitors" DESC,
             get_property_type(p) == "session" for p in self.query.properties + self._test_account_filters
         ) or self.query.breakdownBy in {
             WebStatsBreakdown.InitialChannelType,
+            WebStatsBreakdown.InitialReferringDomain,
             WebStatsBreakdown.InitialUTMSource,
             WebStatsBreakdown.InitialUTMCampaign,
             WebStatsBreakdown.InitialUTMMedium,


### PR DESCRIPTION
## Problem

zendesk: https://posthoghelp.zendesk.com/agent/tickets/13346 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15708)

## Changes

Add referring domain to the queries that need the session table

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Running locally
