### PR TITLE
fix(hogql): fix explore tab for trends queries

### DIFF
--- a/frontend/src/queries/nodes/DataTable/InsightActorsQueryOptions.tsx
+++ b/frontend/src/queries/nodes/DataTable/InsightActorsQueryOptions.tsx
@@ -1,5 +1,6 @@
 import { useMountedLogic, useValues } from 'kea'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { cleanedInsightActorsQueryOptions } from 'scenes/trends/persons-modal/persons-modal-utils'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { insightActorsQueryOptionsLogic } from '~/queries/nodes/DataTable/insightActorsQueryOptionsLogic'
@@ -20,25 +21,23 @@ export function InsightActorsQueryOptions({ setQuery, query }: InsightActorsQuer
 
     return query && insightActorsQueryOptions ? (
         <>
-            {Object.entries(insightActorsQueryOptions)
-                .filter(([, value]) => !!value)
-                .map(([key, options]) => (
-                    <div key={key}>
-                        <LemonSelect
-                            fullWidth
-                            className="min-w-32"
-                            placeholder={key}
-                            value={query?.[key] ?? null}
-                            onChange={(v) =>
-                                setQuery?.({
-                                    ...query,
-                                    [key]: v,
-                                })
-                            }
-                            options={options}
-                        />
-                    </div>
-                ))}
+            {cleanedInsightActorsQueryOptions(insightActorsQueryOptions).map(([key, options]) => (
+                <div key={key}>
+                    <LemonSelect
+                        fullWidth
+                        className="min-w-32"
+                        placeholder={key}
+                        value={query?.[key] ?? null}
+                        onChange={(v) =>
+                            setQuery?.({
+                                ...query,
+                                [key]: v,
+                            })
+                        }
+                        options={options}
+                    />
+                </div>
+            ))}
         </>
     ) : null
 }

--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -44,6 +44,7 @@ import {
     SessionRecordingType,
 } from '~/types'
 
+import { cleanedInsightActorsQueryOptions } from './persons-modal-utils'
 import { PersonModalLogicProps, personsModalLogic } from './personsModalLogic'
 import { SaveCohortModal } from './SaveCohortModal'
 
@@ -160,25 +161,17 @@ export function PersonsModal({
                     ) : null}
 
                     {query &&
-                        Object.entries(insightActorsQueryOptions ?? {})
-                            .filter(([, value]) => {
-                                if (Array.isArray(value)) {
-                                    return !!value.length
-                                }
-
-                                return !!value
-                            })
-                            .map(([key, options]) => (
-                                <div key={key}>
-                                    <LemonSelect
-                                        fullWidth
-                                        className="mb-2"
-                                        value={query?.[key] ?? null}
-                                        onChange={(v) => updateActorsQuery({ [key]: v })}
-                                        options={options}
-                                    />
-                                </div>
-                            ))}
+                        cleanedInsightActorsQueryOptions(insightActorsQueryOptions).map(([key, options]) => (
+                            <div key={key}>
+                                <LemonSelect
+                                    fullWidth
+                                    className="mb-2"
+                                    value={query?.[key] ?? null}
+                                    onChange={(v) => updateActorsQuery({ [key]: v })}
+                                    options={options}
+                                />
+                            </div>
+                        ))}
 
                     <div className="flex items-center gap-2 text-muted">
                         {actorsResponseLoading ? (

--- a/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
+++ b/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
@@ -11,6 +11,7 @@ import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { cleanFilters } from 'scenes/insights/utils/cleanFilters'
 
 import { FormatPropertyValueForDisplayFunction } from '~/models/propertyDefinitionsModel'
+import { InsightActorsQueryOptionsResponse } from '~/queries/schema'
 import {
     CohortType,
     FunnelsFilterType,
@@ -191,12 +192,11 @@ export const buildPeopleUrl = ({
             const cleanedParams = cleanFilters(params)
             const funnelParams = toParams(cleanedParams)
             return `api/person/funnel/?${funnelParams}&cache_invalidation_key=${cacheInvalidationKey}`
-        } else {
-            // TODO: We should never land in this case; Remove this if Sentry doesn't unexpectedly capture this.
-            Sentry.captureException(new Error('buildPeopleUrl used for non-trends funnel'), {
-                extra: { filters },
-            })
         }
+        // TODO: We should never land in this case; Remove this if Sentry doesn't unexpectedly capture this.
+        Sentry.captureException(new Error('buildPeopleUrl used for non-trends funnel'), {
+            extra: { filters },
+        })
     } else if (isPathsFilter(filters)) {
         const cleanedParams = cleanFilters(filters)
         const pathParams = toParams(cleanedParams)
@@ -207,4 +207,12 @@ export const buildPeopleUrl = ({
             extra: { filters },
         })
     }
+}
+
+export const cleanedInsightActorsQueryOptions = (
+    insightActorsQueryOptions: InsightActorsQueryOptionsResponse | null
+): [string, any[]][] => {
+    return Object.entries(insightActorsQueryOptions ?? {}).filter(([, value]) => {
+        return Array.isArray(value) && !!value.length
+    })
 }


### PR DESCRIPTION
## Problem

The explore tab is broken when navigating from a trends actors modal, see e.g. https://posthog.slack.com/archives/C05PKRLD7B4/p1715698779608559.

## Changes

This is because invalid options are passed to the LemonSelect. Only options that are arrays are valid. I also couldn't find a case where a valid option would result in anything else. Thus I extracted a helper that unifies handling for these options and only passes on arrays with content.

## How did you test this code?

Clicking around