### PR TITLE
feat: test small values for artificial lag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -210,6 +210,7 @@ export const FEATURE_FLAGS = {
     THEME: 'theme', // owner: @aprilfools
     SESSION_TABLE_PROPERTY_FILTERS: 'session-table-property-filters', // owner: @robbie-c
     SESSION_REPLAY_HOG_QL_FILTERING: 'session-replay-hogql-filtering', // owner: #team-replay
+    SESSION_REPLAY_ARTIFICIAL_LAG: 'artificial-lag-query-performance', // owner: #team-replay
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -219,6 +219,10 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                         hog_ql_filtering: values.useHogQLFiltering,
                     }
 
+                    if (values.artificialLag) {
+                        params['date_to'] = values.artificialLag
+                    }
+
                     if (values.orderBy === 'start_time') {
                         if (direction === 'older') {
                             params['date_to'] =
@@ -487,6 +491,14 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
         },
     })),
     selectors({
+        artificialLag: [
+            (s) => [s.featureFlags],
+            (featureFlags): string | null => {
+                const lag = featureFlags[FEATURE_FLAGS.SESSION_REPLAY_ARTIFICIAL_LAG]
+                // you can't edit variants right now, and I didn't put minus on the variant name 🤷
+                return lag === undefined || lag === 'control' ? null : '-' + lag
+            },
+        ],
         useHogQLFiltering: [
             (s) => [s.featureFlags],
             (featureFlags) => !!featureFlags[FEATURE_FLAGS.SESSION_REPLAY_HOG_QL_FILTERING],


### PR DESCRIPTION
We know from the recent "live mode" test that if we can avoid unmerged parts the query to list recordings is faster and less variable.

In that test we were introducing artificial lag of 1 hour and confused people

let's run experiment https://us.posthog.com/project/2/experiments/33596 and see if much smaller values have an impact