### PR TITLE
fix: ignore external style on canvas image

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
@@ -89,6 +89,8 @@ export const CanvasReplayerPlugin = (events: eventWithTime[]): ReplayPlugin => {
                 const img = containers.get(e.data.id)
                 if (img) {
                     img.src = target.toDataURL('image/jpeg', 0.6)
+                    img.style.width = 'initial'
+                    img.style.height = 'initial'
                 }
             }
         },


### PR DESCRIPTION
## Problem

A customer reported that their canvas was not rendered. Looking at the recording it seems like 
there are some external styles that are affecting the image e.g.
```
.external-style canvas * {
  height: 0px;
}
```

This means that the image representation of the canvas becomes 0x0 px
<img width="245" alt="Screenshot 2024-05-15 at 20 11 06" src="https://github.com/PostHog/posthog/assets/6685876/7b8cc0c1-315d-4e97-9061-bce8fad92ba7">

## Changes

Override external classes by applying styles directly on the image

Image renders to its intended size when the width / height are reset to `initial`
<img width="536" alt="Screenshot 2024-05-15 at 20 14 42" src="https://github.com/PostHog/posthog/assets/6685876/361f6cf0-dccb-4a0d-ba46-e9d8874ba64c">

## Does this work well for both Cloud and self-hosted?

Yes