### PR TITLE
fix(stickiness): display correct interval for dates

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.test.ts
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.test.ts
@@ -1,0 +1,24 @@
+import { getFormattedDate } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+
+import { IntervalType } from '~/types'
+
+describe('getFormattedDate', () => {
+    const paramsToExpected: [number, IntervalType, string][] = [
+        [1, 'minute', '1 minute'],
+        [2, 'minute', '2 minutes'],
+        [1, 'hour', '1 hour'],
+        [2, 'hour', '2 hours'],
+        [1, 'day', '1 day'],
+        [2, 'day', '2 days'],
+        [1, 'week', '1 week'],
+        [2, 'week', '2 weeks'],
+        [1, 'month', '1 month'],
+        [2, 'month', '2 months'],
+    ]
+
+    paramsToExpected.forEach(([input, intervall, expected]) => {
+        it(`expect "${expected}" for numeric input "${input}" and intervall "${intervall}"`, () => {
+            expect(getFormattedDate(input, intervall)).toEqual(expected)
+        })
+    })
+})

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.test.ts
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.test.ts
@@ -3,7 +3,7 @@ import { getFormattedDate } from 'scenes/insights/InsightTooltip/insightTooltipU
 import { IntervalType } from '~/types'
 
 describe('getFormattedDate', () => {
-    const paramsToExpected: [number, IntervalType, string][] = [
+    const paramsToExpectedWithNumericInput: [number, IntervalType, string][] = [
         [1, 'minute', '1 minute'],
         [2, 'minute', '2 minutes'],
         [1, 'hour', '1 hour'],
@@ -16,9 +16,32 @@ describe('getFormattedDate', () => {
         [2, 'month', '2 months'],
     ]
 
-    paramsToExpected.forEach(([input, intervall, expected]) => {
-        it(`expect "${expected}" for numeric input "${input}" and intervall "${intervall}"`, () => {
+    paramsToExpectedWithNumericInput.forEach(([input, intervall, expected]) => {
+        it(`expects "${expected}" for numeric input "${input}" and intervall "${intervall}"`, () => {
             expect(getFormattedDate(input, intervall)).toEqual(expected)
         })
+    })
+
+    const paramsToExpectedWithDateString: [string, string][] = [
+        ['2024-04-28', '28 Apr 2024'],
+        ['2024-05-12', '12 May 2024'],
+    ]
+
+    paramsToExpectedWithDateString.forEach(([input, expected]) => {
+        it(`expects "${expected}" for date string input "${input}"`, () => {
+            expect(getFormattedDate(input)).toEqual(expected)
+        })
+    })
+
+    const paramsToExpectedWithWrongDateString: [string, string][] = [['this is not a date', 'this is not a date']]
+
+    paramsToExpectedWithWrongDateString.forEach(([input, expected]) => {
+        it(`expects "${expected}" for wrong date string "${input}"`, () => {
+            expect(getFormattedDate(input)).toEqual(expected)
+        })
+    })
+
+    it('expects undefined string if no inputs', () => {
+        expect(getFormattedDate()).toEqual('undefined')
     })
 })

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -87,9 +87,9 @@ export const INTERVAL_UNIT_TO_DAYJS_FORMAT: Record<IntervalType, string> = {
 }
 
 export function getFormattedDate(dayInput?: string | number, interval: IntervalType = 'day'): string {
-    // Number of days
+    // Number of intervals (i.e. days, weeks)
     if (Number.isInteger(dayInput)) {
-        return pluralize(dayInput as number, 'day')
+        return pluralize(dayInput as number, interval)
     }
     const day = dayjs(dayInput)
     // Dayjs formatted day

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -86,17 +86,17 @@ export const INTERVAL_UNIT_TO_DAYJS_FORMAT: Record<IntervalType, string> = {
     month: 'MMMM YYYY',
 }
 
-export function getFormattedDate(dayInput?: string | number, interval: IntervalType = 'day'): string {
+export function getFormattedDate(input?: string | number, interval: IntervalType = 'day'): string {
     // Number of intervals (i.e. days, weeks)
-    if (Number.isInteger(dayInput)) {
-        return pluralize(dayInput as number, interval)
+    if (Number.isInteger(input)) {
+        return pluralize(input as number, interval)
     }
-    const day = dayjs(dayInput)
+    const day = dayjs(input)
     // Dayjs formatted day
-    if (dayInput !== undefined && day.isValid()) {
+    if (input !== undefined && day.isValid()) {
         return day.format(INTERVAL_UNIT_TO_DAYJS_FORMAT[interval])
     }
-    return String(dayInput)
+    return String(input)
 }
 
 export function invertDataSource(seriesData: SeriesDatum[]): InvertedSeriesDatum[] {


### PR DESCRIPTION
Datapoint labels on stickiness graphs always count in days (#22209)

## Problem

The tooltip does not replicate the correct "group by" interval in the insights stickiness line graph.

## Changes
Bugfix: The `getFormattedDate()` method in insightTooltipUtils.tsx had a bug for numeric first param input. The `pluralize()` method had a fixed second argument instead of the interval param.

Nit: Changed the name for the first parameter from `dayInput` to `input`, because it can vary between the `IntervalType`. (Other possible names could be `intervalAmount`or `timeQuantity`)



👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

- open a dashboard
- click Add Insight in top right corner
- choose the Stickiness tab
- set the group by interval to weeks for example
- mouseover the line graph and the heading is now corresponding to the interval

Added automated unit tests for the `getFormattedDate()` method.
<img width="1502" alt="SCR-20240515-tvrz" src="https://github.com/PostHog/posthog/assets/25659904/4228f9b1-9457-46bc-bcbf-3480335708b7">
