### PR TITLE
fix: record heatmap as dropped only when there is heatmap data

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
@@ -92,18 +92,6 @@ function extractScrollDepthHeatmapData(event: PreIngestionEvent): RawClickhouseH
 
     let heatmapData = $heatmap_data as HeatmapData | null
 
-    if (!isValidString(distinctId) || isDistinctIdIllegal(distinctId)) {
-        return drop('invalid_distinct_id')
-    }
-
-    if (!isValidNumber($viewport_height) || !isValidNumber($viewport_width)) {
-        status.warn('👀', '[extract-heatmap-data] dropping because invalid viewport dimensions', {
-            $viewport_height,
-            $viewport_width,
-        })
-        return drop('invalid_viewport_dimensions')
-    }
-
     if ($prev_pageview_pathname && $current_url) {
         // We are going to add the scroll depth info derived from the previous pageview to the current pageview's heatmap data
         if (!heatmapData) {
@@ -122,8 +110,22 @@ function extractScrollDepthHeatmapData(event: PreIngestionEvent): RawClickhouseH
 
     let heatmapEvents: RawClickhouseHeatmapEvent[] = []
 
-    if (!heatmapData) {
+    if (!heatmapData || Object.entries(heatmapData).length === 0) {
         return []
+    }
+
+    if (!isValidString(distinctId) || isDistinctIdIllegal(distinctId)) {
+        return drop('invalid_distinct_id')
+    }
+
+    if (!isValidNumber($viewport_height) || !isValidNumber($viewport_width)) {
+        status.warn('👀', '[extract-heatmap-data] dropping because invalid viewport dimensions', {
+            parent: event.event,
+            teamId: teamId,
+            eventTimestamp: timestamp,
+            $current_url,
+        })
+        return drop('invalid_viewport_dimensions')
     }
 
     Object.entries(heatmapData).forEach(([url, items]) => {

--- a/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
@@ -123,7 +123,8 @@ function extractScrollDepthHeatmapData(event: PreIngestionEvent): RawClickhouseH
             parent: event.event,
             teamId: teamId,
             eventTimestamp: timestamp,
-            $current_url,
+            $viewport_height,
+            $viewport_width,
         })
         return drop('invalid_viewport_dimensions')
     }


### PR DESCRIPTION
We're reporting lots of dropped heatmap data but that includes events with no heatmap data 

Move validation until after we know there is heatmap data to process