### PR TITLE
fix: Only show DNS record tooltip if in waiting state

### DIFF
--- a/frontend/src/scenes/settings/project/Proxy.tsx
+++ b/frontend/src/scenes/settings/project/Proxy.tsx
@@ -55,9 +55,11 @@ export function Proxy(): JSX.Element {
                     >
                         {status === 'issuing' && <Spinner />}
                         <span className="capitalize">{status}</span>
-                        <Tooltip title="Waiting for DNS records to be created">
-                            <IconInfo className="cursor-pointer" />
-                        </Tooltip>
+                        {status === 'waiting' && (
+                            <Tooltip title="Waiting for DNS records to be created">
+                                <IconInfo className="cursor-pointer" />
+                            </Tooltip>
+                        )}
                     </div>
                 )
             },


### PR DESCRIPTION
## Problem

tooltip was showing up when it's not supposed to
![image](https://github.com/PostHog/posthog/assets/2088870/575388b8-ca5c-4e21-866a-8ec322b014d8)


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
