### PR TITLE
Duplicate "user" in read_only_fields

### DIFF
--- a/ee/api/dashboard_collaborator.py
+++ b/ee/api/dashboard_collaborator.py
@@ -43,7 +43,7 @@ class DashboardCollaboratorSerializer(serializers.ModelSerializer, UserPermissio
             "updated_at",
             "user_uuid",  # write_only (see above)
         ]
-        read_only_fields = ["id", "dashboard_id", "user", "user"]
+        read_only_fields = ["id", "dashboard_id", "user"]
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         dashboard: Dashboard = self.context["dashboard"]


### PR DESCRIPTION
The read_only_fields list contains "user" twice

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
