### PR TITLE
fix(hogql): support non-string funnel breakdowns

### DIFF
--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
@@ -999,7 +999,7 @@
 # name: TestFunnelBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen
   '''
   /* cohort_calculation: */
-  SELECT [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS value,
+  SELECT [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS value,
          count(*) AS count
   FROM events AS e
   INNER JOIN
@@ -1084,7 +1084,7 @@
                            if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                            if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
                            if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS prop_basic,
+                           [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                            prop_basic AS prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
                     FROM events AS e
@@ -1115,7 +1115,7 @@
 # name: TestFunnelBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen_for_step
   '''
   /* cohort_calculation: */
-  SELECT [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS value,
+  SELECT [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS value,
          count(*) AS count
   FROM events AS e
   INNER JOIN
@@ -1202,7 +1202,7 @@
                            if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                            if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
                            if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS prop_basic,
+                           [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                            if(ifNull(equals(step_0, 1), 0), prop_basic, []) AS prop_0,
                            if(ifNull(equals(step_1, 1), 0), prop_basic, []) AS prop_1,
                            prop_1 AS prop,
@@ -1237,7 +1237,7 @@
 # ---
 # name: TestFunnelBreakdown.test_funnel_step_multiple_breakdown_snapshot
   '''
-  SELECT [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), ''), ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), '')] AS value,
+  SELECT [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', '')), '')] AS value,
          count(*) AS count
   FROM events AS e
   INNER JOIN
@@ -1321,7 +1321,7 @@
                            if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                            if(equals(e.event, 'buy'), 1, 0) AS step_1,
                            if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), ''), ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), '')] AS prop_basic,
+                           [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                            prop_basic AS prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
                     FROM events AS e
@@ -1351,7 +1351,7 @@
 # ---
 # name: TestFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events
   '''
-  SELECT ifNull(e__group_0.properties___industry, '') AS value,
+  SELECT ifNull(toString(e__group_0.properties___industry), '') AS value,
          count(*) AS count
   FROM events AS e
   LEFT JOIN
@@ -1475,7 +1475,7 @@
                                  if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
                                  if(equals(e.event, 'buy'), 1, 0) AS step_2,
                                  if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                 ifNull(e__group_0.properties___industry, '') AS prop_basic,
+                                 ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
                                  prop_basic AS prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
                           FROM events AS e
@@ -1506,7 +1506,7 @@
 # ---
 # name: TestFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events_poe_v2
   '''
-  SELECT ifNull(e__group_0.properties___industry, '') AS value,
+  SELECT ifNull(toString(e__group_0.properties___industry), '') AS value,
          count(*) AS count
   FROM events AS e
   LEFT OUTER JOIN
@@ -1636,7 +1636,7 @@
                                  if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
                                  if(equals(e.event, 'buy'), 1, 0) AS step_2,
                                  if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                 ifNull(e__group_0.properties___industry, '') AS prop_basic,
+                                 ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
                                  prop_basic AS prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
                           FROM events AS e
@@ -1667,7 +1667,7 @@
 # ---
 # name: TestFunnelGroupBreakdown.test_funnel_breakdown_group
   '''
-  SELECT ifNull(e__group_0.properties___industry, '') AS value,
+  SELECT ifNull(toString(e__group_0.properties___industry), '') AS value,
          count(*) AS count
   FROM events AS e
   INNER JOIN
@@ -1798,7 +1798,7 @@
                                  if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
                                  if(equals(e.event, 'buy'), 1, 0) AS step_2,
                                  if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                 ifNull(e__group_0.properties___industry, '') AS prop_basic,
+                                 ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
                                  prop_basic AS prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
                           FROM events AS e

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_breakdowns_by_current_url.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_breakdowns_by_current_url.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestFunnelBreakdownsByCurrentURL.test_breakdown_by_current_url
   '''
-  SELECT [if(empty(replaceRegexpOne(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '[\\/?#]*$', '')), '/', replaceRegexpOne(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '[\\/?#]*$', ''))] AS value,
+  SELECT [if(empty(replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', '')), '/', replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', ''))] AS value,
          count(*) AS count
   FROM events AS e
   INNER JOIN
@@ -85,7 +85,7 @@
                            if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                            if(equals(e.event, 'terminate funnel'), 1, 0) AS step_1,
                            if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           [if(empty(replaceRegexpOne(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '[\\/?#]*$', '')), '/', replaceRegexpOne(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '[\\/?#]*$', ''))] AS prop_basic,
+                           [if(empty(replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', '')), '/', replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$current_url'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', ''))] AS prop_basic,
                            prop_basic AS prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
                     FROM events AS e
@@ -115,7 +115,7 @@
 # ---
 # name: TestFunnelBreakdownsByCurrentURL.test_breakdown_by_pathname
   '''
-  SELECT [if(empty(replaceRegexpOne(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$pathname'), ''), 'null'), '^"|"$', ''), ''), '[\\/?#]*$', '')), '/', replaceRegexpOne(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$pathname'), ''), 'null'), '^"|"$', ''), ''), '[\\/?#]*$', ''))] AS value,
+  SELECT [if(empty(replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$pathname'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', '')), '/', replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$pathname'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', ''))] AS value,
          count(*) AS count
   FROM events AS e
   INNER JOIN
@@ -199,7 +199,7 @@
                            if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                            if(equals(e.event, 'terminate funnel'), 1, 0) AS step_1,
                            if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           [if(empty(replaceRegexpOne(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$pathname'), ''), 'null'), '^"|"$', ''), ''), '[\\/?#]*$', '')), '/', replaceRegexpOne(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$pathname'), ''), 'null'), '^"|"$', ''), ''), '[\\/?#]*$', ''))] AS prop_basic,
+                           [if(empty(replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$pathname'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', '')), '/', replaceRegexpOne(ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$pathname'), ''), 'null'), '^"|"$', '')), ''), '[\\/?#]*$', ''))] AS prop_basic,
                            prop_basic AS prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
                     FROM events AS e

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestFunnelStrictStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen
   '''
-  SELECT [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS value,
+  SELECT [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS value,
          count(*) AS count
   FROM events AS e
   INNER JOIN
@@ -84,7 +84,7 @@
                            if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                            if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
                            if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS prop_basic,
+                           [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                            prop_basic AS prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
                     FROM events AS e
@@ -114,7 +114,7 @@
 # ---
 # name: TestFunnelStrictStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen_for_step
   '''
-  SELECT [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS value,
+  SELECT [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS value,
          count(*) AS count
   FROM events AS e
   INNER JOIN
@@ -199,7 +199,7 @@
                            if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                            if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
                            if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS prop_basic,
+                           [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                            if(ifNull(equals(step_0, 1), 0), prop_basic, []) AS prop_0,
                            if(ifNull(equals(step_1, 1), 0), prop_basic, []) AS prop_1,
                            prop_1 AS prop,
@@ -234,7 +234,7 @@
 # ---
 # name: TestFunnelStrictStepsBreakdown.test_funnel_step_multiple_breakdown_snapshot
   '''
-  SELECT [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), ''), ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), '')] AS value,
+  SELECT [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', '')), '')] AS value,
          count(*) AS count
   FROM events AS e
   INNER JOIN
@@ -317,7 +317,7 @@
                            if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                            if(equals(e.event, 'buy'), 1, 0) AS step_1,
                            if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), ''), ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), '')] AS prop_basic,
+                           [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                            prop_basic AS prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
                     FROM events AS e
@@ -347,7 +347,7 @@
 # ---
 # name: TestStrictFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events
   '''
-  SELECT ifNull(e__group_0.properties___industry, '') AS value,
+  SELECT ifNull(toString(e__group_0.properties___industry), '') AS value,
          count(*) AS count
   FROM events AS e
   LEFT JOIN
@@ -471,7 +471,7 @@
                                  if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
                                  if(equals(e.event, 'buy'), 1, 0) AS step_2,
                                  if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                 ifNull(e__group_0.properties___industry, '') AS prop_basic,
+                                 ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
                                  prop_basic AS prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
                           FROM events AS e
@@ -502,7 +502,7 @@
 # ---
 # name: TestStrictFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events_poe_v2
   '''
-  SELECT ifNull(e__group_0.properties___industry, '') AS value,
+  SELECT ifNull(toString(e__group_0.properties___industry), '') AS value,
          count(*) AS count
   FROM events AS e
   LEFT OUTER JOIN
@@ -632,7 +632,7 @@
                                  if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
                                  if(equals(e.event, 'buy'), 1, 0) AS step_2,
                                  if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                 ifNull(e__group_0.properties___industry, '') AS prop_basic,
+                                 ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
                                  prop_basic AS prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
                           FROM events AS e
@@ -663,7 +663,7 @@
 # ---
 # name: TestStrictFunnelGroupBreakdown.test_funnel_breakdown_group
   '''
-  SELECT ifNull(e__group_0.properties___industry, '') AS value,
+  SELECT ifNull(toString(e__group_0.properties___industry), '') AS value,
          count(*) AS count
   FROM events AS e
   INNER JOIN
@@ -794,7 +794,7 @@
                                  if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
                                  if(equals(e.event, 'buy'), 1, 0) AS step_2,
                                  if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                 ifNull(e__group_0.properties___industry, '') AS prop_basic,
+                                 ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
                                  prop_basic AS prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
                           FROM events AS e

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestFunnelUnorderedStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen
   '''
-  SELECT [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS value,
+  SELECT [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS value,
          count(*) AS count
   FROM events AS e
   INNER JOIN
@@ -84,7 +84,7 @@
                            if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                            if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
                            if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS prop_basic,
+                           [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                            prop_basic AS prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
                     FROM events AS e
@@ -136,7 +136,7 @@
                            if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                            if(equals(e.event, 'sign up'), 1, 0) AS step_1,
                            if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS prop_basic,
+                           [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                            prop_basic AS prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
                     FROM events AS e
@@ -166,7 +166,7 @@
 # ---
 # name: TestFunnelUnorderedStepsBreakdown.test_funnel_breakdown_correct_breakdown_props_are_chosen_for_step
   '''
-  SELECT [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS value,
+  SELECT [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS value,
          count(*) AS count
   FROM events AS e
   INNER JOIN
@@ -251,7 +251,7 @@
                            if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                            if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
                            if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS prop_basic,
+                           [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                            if(ifNull(equals(step_0, 1), 0), prop_basic, []) AS prop_0,
                            if(ifNull(equals(step_1, 1), 0), prop_basic, []) AS prop_1,
                            prop_1 AS prop,
@@ -310,7 +310,7 @@
                            if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                            if(equals(e.event, 'sign up'), 1, 0) AS step_1,
                            if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), '')] AS prop_basic,
+                           [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                            if(ifNull(equals(step_0, 1), 0), prop_basic, []) AS prop_0,
                            if(ifNull(equals(step_1, 1), 0), prop_basic, []) AS prop_1,
                            prop_1 AS prop,
@@ -345,7 +345,7 @@
 # ---
 # name: TestFunnelUnorderedStepsBreakdown.test_funnel_step_multiple_breakdown_snapshot
   '''
-  SELECT [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), ''), ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), '')] AS value,
+  SELECT [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', '')), '')] AS value,
          count(*) AS count
   FROM events AS e
   INNER JOIN
@@ -428,7 +428,7 @@
                            if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                            if(equals(e.event, 'buy'), 1, 0) AS step_1,
                            if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), ''), ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), '')] AS prop_basic,
+                           [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                            prop_basic AS prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
                     FROM events AS e
@@ -480,7 +480,7 @@
                            if(ifNull(equals(step_0, 1), 0), timestamp, NULL) AS latest_0,
                            if(equals(e.event, 'sign up'), 1, 0) AS step_1,
                            if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
-                           [ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', ''), ''), ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), '')] AS prop_basic,
+                           [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                            prop_basic AS prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) OVER (PARTITION BY aggregation_target) AS prop_vals
                     FROM events AS e
@@ -510,7 +510,7 @@
 # ---
 # name: TestUnorderedFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events
   '''
-  SELECT ifNull(e__group_0.properties___industry, '') AS value,
+  SELECT ifNull(toString(e__group_0.properties___industry), '') AS value,
          count(*) AS count
   FROM events AS e
   LEFT JOIN
@@ -634,7 +634,7 @@
                                  if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
                                  if(equals(e.event, 'buy'), 1, 0) AS step_2,
                                  if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                 ifNull(e__group_0.properties___industry, '') AS prop_basic,
+                                 ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
                                  prop_basic AS prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
                           FROM events AS e
@@ -665,7 +665,7 @@
 # ---
 # name: TestUnorderedFunnelGroupBreakdown.test_funnel_aggregate_by_groups_breakdown_group_person_on_events_poe_v2
   '''
-  SELECT ifNull(e__group_0.properties___industry, '') AS value,
+  SELECT ifNull(toString(e__group_0.properties___industry), '') AS value,
          count(*) AS count
   FROM events AS e
   LEFT OUTER JOIN
@@ -795,7 +795,7 @@
                                  if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
                                  if(equals(e.event, 'buy'), 1, 0) AS step_2,
                                  if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                 ifNull(e__group_0.properties___industry, '') AS prop_basic,
+                                 ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
                                  prop_basic AS prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
                           FROM events AS e
@@ -826,7 +826,7 @@
 # ---
 # name: TestUnorderedFunnelGroupBreakdown.test_funnel_breakdown_group
   '''
-  SELECT ifNull(e__group_0.properties___industry, '') AS value,
+  SELECT ifNull(toString(e__group_0.properties___industry), '') AS value,
          count(*) AS count
   FROM events AS e
   INNER JOIN
@@ -957,7 +957,7 @@
                                  if(ifNull(equals(step_1, 1), 0), timestamp, NULL) AS latest_1,
                                  if(equals(e.event, 'buy'), 1, 0) AS step_2,
                                  if(ifNull(equals(step_2, 1), 0), timestamp, NULL) AS latest_2,
-                                 ifNull(e__group_0.properties___industry, '') AS prop_basic,
+                                 ifNull(toString(e__group_0.properties___industry), '') AS prop_basic,
                                  prop_basic AS prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) OVER (PARTITION BY aggregation_target) AS prop_vals
                           FROM events AS e

--- a/posthog/hogql_queries/insights/funnels/utils.py
+++ b/posthog/hogql_queries/insights/funnels/utils.py
@@ -64,14 +64,21 @@ def get_breakdown_expr(
 ) -> ast.Expr:
     if isinstance(breakdowns, str) or isinstance(breakdowns, int) or breakdowns is None:
         return ast.Call(
-            name="ifNull", args=[ast.Field(chain=[*properties_column.split("."), breakdowns]), ast.Constant(value="")]
+            name="ifNull",
+            args=[
+                ast.Call(name="toString", args=[ast.Field(chain=[*properties_column.split("."), breakdowns])]),
+                ast.Constant(value=""),
+            ],
         )
     else:
         exprs = []
         for breakdown in breakdowns:
             expr: ast.Expr = ast.Call(
                 name="ifNull",
-                args=[ast.Field(chain=[*properties_column.split("."), breakdown]), ast.Constant(value="")],
+                args=[
+                    ast.Call(name="toString", args=[ast.Field(chain=[*properties_column.split("."), breakdown])]),
+                    ast.Constant(value=""),
+                ],
             )
             if normalize_url:
                 regex = "[\\\\/?#]*$"


### PR DESCRIPTION
## Problem

We're getting errors like this for breakdowns on properties other than strings:

```
DB::Exception: There is no supertype for types Bool, String because some of them are String/FixedString and some of them are not: While processing [ifNull(transform(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'is_light_mode'), ''), 'null')...
```

## Changes

Casts all breakdown values to strings, preventing the problem

## How did you test this code?

Tried a failing insight locally