### PR TITLE
feat: Allow users to enable session replay during product analytics onboarding

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -185,7 +185,6 @@ export const FEATURE_FLAGS = {
     FEATURE_FLAG_COHORT_CREATION: 'feature-flag-cohort-creation', // owner: @neilkakkar #team-feature-success
     INSIGHT_HORIZONTAL_CONTROLS: 'insight-horizontal-controls', // owner: @benjackwhite
     SURVEYS_WIDGETS: 'surveys-widgets', // owner: @liyiy
-    INVITE_TEAM_MEMBER_ONBOARDING: 'invite-team-member-onboarding', // owner: @biancayang
     YEAR_IN_HOG: 'year-in-hog', // owner: #team-replay
     SESSION_REPLAY_EXPORT_MOBILE_DATA: 'session-replay-export-mobile-data', // owner: #team-replay
     DISCUSSIONS: 'discussions', // owner: #team-replay
@@ -197,7 +196,6 @@ export const FEATURE_FLAGS = {
     SESSION_REPLAY_DOCTOR: 'session-replay-doctor', // owner: #team-replay
     REPLAY_SIMILAR_RECORDINGS: 'session-replay-similar-recordings', // owner: #team-replay
     SAVED_NOT_PINNED: 'saved-not-pinned', // owner: #team-replay
-    BILLING_UPGRADE_LANGUAGE: 'billing-upgrade-language', // owner: @biancayang
     NEW_EXPERIMENTS_UI: 'new-experiments-ui', // owner: @jurajmajerik #team-feature-success
     SESSION_REPLAY_FILTER_ORDERING: 'session-replay-filter-ordering', // owner: #team-replay
     REPLAY_ERROR_CLUSTERING: 'session-replay-error-clustering', // owner: #team-replay
@@ -213,6 +211,7 @@ export const FEATURE_FLAGS = {
     INSIGHT_LOADING_BAR: 'insight-loading-bar', // owner: @aspicer
     SESSION_REPLAY_ARTIFICIAL_LAG: 'artificial-lag-query-performance', // owner: #team-replay
     PROXY_AS_A_SERVICE: 'proxy-as-a-service', // owner: #team-infrastructure
+    ENABLE_SESSION_REPLAY_PA_ONBOARDING: 'enable-session-replay-pa-onboarding', // owner: #team-growth
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -92,6 +92,7 @@ const ProductAnalyticsOnboarding = (): JSX.Element => {
             value: !currentTeam?.autocapture_opt_out,
             type: 'toggle',
             inverseToggle: true,
+            visible: true,
         },
         {
             title: 'Enable heatmaps',
@@ -101,16 +102,34 @@ const ProductAnalyticsOnboarding = (): JSX.Element => {
             teamProperty: 'heatmaps_opt_in',
             value: currentTeam?.heatmaps_opt_in ?? true,
             type: 'toggle',
+            visible: true,
         },
     ]
 
     if (featureFlags[FEATURE_FLAGS.ENABLE_SESSION_REPLAY_PA_ONBOARDING]) {
         options.push({
             title: 'Enable session recordings',
-            description: `Turn on session recordings and watch how users experience your app.`,
+            description: `Turn on session recordings and watch how users experience your app. We will also turn on console log and network performance recording. You can change these settings any time in the settings panel.`,
             teamProperty: 'session_recording_opt_in',
             value: currentTeam?.session_recording_opt_in ?? true,
             type: 'toggle',
+            visible: true,
+        })
+        options.push({
+            title: 'Capture console logs',
+            description: `Automatically enable console log capture`,
+            teamProperty: 'capture_console_log_opt_in',
+            value: true,
+            type: 'toggle',
+            visible: false,
+        })
+        options.push({
+            title: 'Capture network performance',
+            description: `Automatically enable network performance capture`,
+            teamProperty: 'capture_performance_opt_in',
+            value: true,
+            type: 'toggle',
+            visible: false,
         })
     }
     return (
@@ -139,6 +158,7 @@ const SessionReplayOnboarding = (): JSX.Element => {
                             Use the console logs alongside recordings to debug any issues with your app.`,
             teamProperty: 'capture_console_log_opt_in',
             value: currentTeam?.capture_console_log_opt_in ?? true,
+            visible: true,
         },
         {
             type: 'toggle',
@@ -147,6 +167,7 @@ const SessionReplayOnboarding = (): JSX.Element => {
                             network requests and timings in the recording player to help you debug issues with your app.`,
             teamProperty: 'capture_performance_opt_in',
             value: currentTeam?.capture_performance_opt_in ?? true,
+            visible: true,
         },
     ]
 
@@ -159,6 +180,7 @@ const SessionReplayOnboarding = (): JSX.Element => {
             teamProperty: 'session_recording_minimum_duration_milliseconds',
             value: currentTeam?.session_recording_minimum_duration_milliseconds || null,
             selectOptions: SESSION_REPLAY_MINIMUM_DURATION_OPTIONS,
+            visible: true,
         })
     }
 

--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -80,7 +80,39 @@ const OnboardingWrapper = ({ children }: { children: React.ReactNode }): JSX.Ele
 
 const ProductAnalyticsOnboarding = (): JSX.Element => {
     const { currentTeam } = useValues(teamLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
+    const options: ProductConfigOption[] = [
+        {
+            title: 'Autocapture frontend interactions',
+            description: `If you use our JavaScript or React Native libraries, we'll automagically 
+            capture frontend interactions like clicks, submits, and more. Fine-tune what you 
+            capture directly in your code snippet.`,
+            teamProperty: 'autocapture_opt_out',
+            value: !currentTeam?.autocapture_opt_out,
+            type: 'toggle',
+            inverseToggle: true,
+        },
+        {
+            title: 'Enable heatmaps',
+            description: `If you use our JavaScript libraries, we can capture general clicks, mouse movements,
+                   and scrolling to create heatmaps. 
+                   No additional events are created, and you can disable this at any time.`,
+            teamProperty: 'heatmaps_opt_in',
+            value: currentTeam?.heatmaps_opt_in ?? true,
+            type: 'toggle',
+        },
+    ]
+
+    if (featureFlags[FEATURE_FLAGS.ENABLE_SESSION_REPLAY_PA_ONBOARDING]) {
+        options.push({
+            title: 'Enable session recordings',
+            description: `Turn on session recordings and watch how users experience your app.`,
+            teamProperty: 'session_recording_opt_in',
+            value: currentTeam?.session_recording_opt_in ?? true,
+            type: 'toggle',
+        })
+    }
     return (
         <OnboardingWrapper>
             <SDKs
@@ -88,31 +120,7 @@ const ProductAnalyticsOnboarding = (): JSX.Element => {
                 sdkInstructionMap={ProductAnalyticsSDKInstructions}
                 stepKey={OnboardingStepKey.INSTALL}
             />
-            <OnboardingProductConfiguration
-                stepKey={OnboardingStepKey.PRODUCT_CONFIGURATION}
-                options={[
-                    {
-                        title: 'Autocapture frontend interactions',
-                        description: `If you use our JavaScript or React Native libraries, we'll automagically 
-                        capture frontend interactions like clicks, submits, and more. Fine-tune what you 
-                        capture directly in your code snippet.`,
-                        teamProperty: 'autocapture_opt_out',
-                        value: !currentTeam?.autocapture_opt_out,
-                        type: 'toggle',
-                        inverseToggle: true,
-                    },
-
-                    {
-                        title: 'Enable heatmaps',
-                        description: `If you use our JavaScript libraries, we can capture general clicks, mouse movements,
-                               and scrolling to create heatmaps. 
-                               No additional events are created, and you can disable this at any time.`,
-                        teamProperty: 'heatmaps_opt_in',
-                        value: currentTeam?.heatmaps_opt_in ?? true,
-                        type: 'toggle',
-                    },
-                ]}
-            />
+            <OnboardingProductConfiguration stepKey={OnboardingStepKey.PRODUCT_CONFIGURATION} options={options} />
         </OnboardingWrapper>
     )
 }

--- a/frontend/src/scenes/onboarding/OnboardingProductConfiguration.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingProductConfiguration.tsx
@@ -62,21 +62,23 @@ export const OnboardingProductConfiguration = ({
     }, [])
 
     const combinedList: ConfigOption[] = [
-        ...configOptions.map((option) => ({
-            title: option.title,
-            description: option.description,
-            type: option.type as ConfigType,
-            selectOptions: option.selectOptions,
-            value: option.value,
-            onChange: (newValue: boolean | string | number) => {
-                // Use the current value from the ref to ensure that onChange always accesses
-                // the latest state of configOptions, preventing the closure from using stale data.
-                const updatedConfigOptions = configOptionsRef.current.map((o) =>
-                    o.teamProperty === option.teamProperty ? { ...o, value: newValue } : o
-                )
-                setConfigOptions(updatedConfigOptions)
-            },
-        })),
+        ...configOptions
+            .filter((option) => option.visible)
+            .map((option) => ({
+                title: option.title,
+                description: option.description,
+                type: option.type as ConfigType,
+                selectOptions: option.selectOptions,
+                value: option.value,
+                onChange: (newValue: boolean | string | number) => {
+                    // Use the current value from the ref to ensure that onChange always accesses
+                    // the latest state of configOptions, preventing the closure from using stale data.
+                    const updatedConfigOptions = configOptionsRef.current.map((o) =>
+                        o.teamProperty === option.teamProperty ? { ...o, value: newValue } : o
+                    )
+                    setConfigOptions(updatedConfigOptions)
+                },
+            })),
         ...defaultEnabledPlugins.map((plugin) => {
             const pluginContent = pluginContentMapping[plugin.name]
             return {

--- a/frontend/src/scenes/onboarding/onboardingProductConfigurationLogic.ts
+++ b/frontend/src/scenes/onboarding/onboardingProductConfigurationLogic.ts
@@ -10,6 +10,7 @@ export interface ProductConfigOptionBase {
     title: string
     description: string
     teamProperty: keyof TeamType
+    visible: boolean
 }
 
 export interface ProductConfigurationToggle extends ProductConfigOptionBase {


### PR DESCRIPTION
## Problem

The toggle is gated behind a 50% flag. https://us.posthog.com/project/2/experiments/33719

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
