### PR TITLE
fix(experiments): fix failing cypress test

### DIFF
--- a/cypress/e2e/experiments.cy.ts
+++ b/cypress/e2e/experiments.cy.ts
@@ -133,11 +133,15 @@ describe('Experiments', () => {
         cy.get('[data-attr="lemon-calendar-month-previous"]').first().click()
         cy.get('[data-attr="lemon-calendar-day"]').first().click()
         cy.get('[data-attr="lemon-calendar-select-apply"]').first().click()
-        cy.get('[data-attr="experiment-start-date"]').contains('month ago').should('be.visible')
+        cy.get('[data-attr="experiment-start-date"]')
+            .contains(/months? ago/)
+            .should('be.visible')
 
         cy.reload()
 
         // Check that the start date persists
-        cy.get('[data-attr="experiment-start-date"]').contains('month ago').should('be.visible')
+        cy.get('[data-attr="experiment-start-date"]')
+            .contains(/months? ago/)
+            .should('be.visible')
     })
 })


### PR DESCRIPTION
## Problem

The test is failing in master.

## Changes

This is because the label can read "2 months ago" or "1 month ago" from the given test conditions. We now check for both.

## How did you test this code?

CI run