### PR TITLE
fix(dashboards): do not cancel full dashboard refresh on query timeout

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1664,10 +1664,17 @@ export function inStorybookTestRunner(): boolean {
     return navigator.userAgent.includes('StorybookTestRunner')
 }
 
+/** We issue a cancel request, when the request is aborted or times out (frontend side), since in these cases the backend query might still be running. */
 export function shouldCancelQuery(error: any): boolean {
-    // We cancel queries "manually" when the request times out or is aborted since in these cases
-    // the query will continue running in ClickHouse
-    return error.name === 'AbortError' || error.message?.name === 'AbortError' || error.status === 504
+    return isAbortedRequest(error) || isTimedOutRequest(error)
+}
+
+export function isAbortedRequest(error: any): boolean {
+    return error.name === 'AbortError' || error.message?.name === 'AbortError'
+}
+
+export function isTimedOutRequest(error: any): boolean {
+    return error.status === 504
 }
 
 export function flattenObject(ob: Record<string, any>): Record<string, any> {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -913,7 +913,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         refreshAllDashboardItems: async ({ tiles, action, initialLoad, dashboardQueryId = uuid() }, breakpoint) => {
             const dashboardId: number = props.id
 
-            const insights = values
+            const insightsToRefresh = values
                 .sortTilesByLayout(tiles || values.insightTiles || [])
                 .filter((t) => {
                     if (!initialLoad || !t.last_refresh) {
@@ -932,13 +932,13 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 .filter((i): i is InsightModel => !!i)
 
             // Don't do anything if there's nothing to refresh
-            if (insights.length === 0) {
+            if (insightsToRefresh.length === 0) {
                 return
             }
 
             let cancelled = false
             actions.setRefreshStatuses(
-                insights.map((item) => item.short_id),
+                insightsToRefresh.map((item) => item.short_id),
                 false,
                 true
             )
@@ -960,7 +960,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
             )
 
             // array of functions that reload each item
-            const fetchItemFunctions = insights.map((insight) => async () => {
+            const fetchItemFunctions = insightsToRefresh.map((insight) => async () => {
                 // :TODO: Support query cancellation and use this queryId in the actual query.
                 // :TODO: in the future we should use dataNodeCollectionLogic.reloadAll()
                 const queryId = `${dashboardQueryId}::${uuid()}`
@@ -1015,7 +1015,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 }
 
                 refreshesFinished += 1
-                if (!cancelled && refreshesFinished === insights.length) {
+                if (!cancelled && refreshesFinished === insightsToRefresh.length) {
                     const payload: TimeToSeeDataPayload = {
                         type: 'dashboard_load',
                         context: 'dashboard',
@@ -1023,7 +1023,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         primary_interaction_id: dashboardQueryId,
                         api_response_bytes: totalResponseBytes,
                         time_to_see_data_ms: Math.floor(performance.now() - refreshStartTime),
-                        insights_fetched: insights.length,
+                        insights_fetched: insightsToRefresh.length,
                         insights_fetched_cached: 0,
                     }
                     void captureTimeToSeeData(values.currentTeamId, {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -25,7 +25,7 @@ import { captureTimeToSeeData, currentSessionId, TimeToSeeDataPayload } from 'li
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { Link } from 'lib/lemon-ui/Link'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { clearDOMTextSelection, isUserLoggedIn, shouldCancelQuery, toParams, uuid } from 'lib/utils'
+import { clearDOMTextSelection, isAbortedRequest, isUserLoggedIn, shouldCancelQuery, toParams, uuid } from 'lib/utils'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { Layout, Layouts } from 'react-grid-layout'
 import { calculateLayouts } from 'scenes/dashboard/tileLayouts'
@@ -1008,7 +1008,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
                             // cancel all insight requests for this query in one go
                             actions.abortQuery({ dashboardQueryId: dashboardQueryId, queryId: queryId, queryStartTime })
                         }
-                        cancelled = true
+                        if (isAbortedRequest(e)) {
+                            cancelled = true
+                        }
                     } else {
                         actions.setRefreshError(insight.short_id)
                     }


### PR DESCRIPTION
## Problem

We refresh dashboard insights in sequence. When one of the insights on a dashboard would time out, resulting in a 504 error, we would cancel all subsequent requests.

Related PRs
https://github.com/PostHog/posthog/pull/15156
https://github.com/PostHog/posthog/pull/13178

## Changes

**Before**
![2024-05-17 18 25 31](https://github.com/PostHog/posthog/assets/1851359/80f2fbb1-51bc-4af4-a709-ec7c5130f9b1)

**After**
![2024-05-17 18 45 01](https://github.com/PostHog/posthog/assets/1851359/677da3ae-7993-4ee2-9986-97ef32b5ef4d)

## How did you test this code?

Tried locally