### PR TITLE
fix(dev): Fix heatmaps migration blocking `bin/e2e-test-runner`

### DIFF
--- a/posthog/clickhouse/migrations/0061_add_ttl_to_heatmaps.py
+++ b/posthog/clickhouse/migrations/0061_add_ttl_to_heatmaps.py
@@ -1,10 +1,9 @@
+from django.conf import settings
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.heatmaps.sql import ALTER_TABLE_ADD_TTL_PERIOD
 
 """
-heatmaps table is compressing at >70% but we don't want it to grow unbounded
-so we are adding a TTL to it
+Heatmaps table is compressing at >70% but we don't want it to grow unbounded so we are adding a TTL to it.
+No TTL in tests, see `ttl_period()`'s definition
 """
-operations = [
-    run_sql_with_exceptions(ALTER_TABLE_ADD_TTL_PERIOD()),
-]
+operations = [run_sql_with_exceptions(ALTER_TABLE_ADD_TTL_PERIOD())] if not settings.TEST else []


### PR DESCRIPTION
## Problem

Currently `bin/e2e-test-runner` doesn't work, because SQL of the `0061_add_ttl_to_heatmaps` migration is malformed when `settings.TEST` is true. We ran into this with @zlwaterfield when trying to merge his hackathon PR.

## Changes

We effectively won't run the migration in test mode. Let me know if this is right.