### PR TITLE
fix: artificial lag

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -5,6 +5,7 @@ import { actionToUrl, router, urlToAction } from 'kea-router'
 import { subscriptions } from 'kea-subscriptions'
 import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { now } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectClean, objectsEqual } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -220,7 +221,11 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                     }
 
                     if (values.artificialLag) {
-                        params['date_to'] = values.artificialLag
+                        // values.artificalLag is a number of seconds to delay the recordings by
+                        // convert it to an absolute UTC timestamp as the relative date parsing in the backend
+                        // can't cope with seconds as a relative date
+                        const absoluteLag = now().subtract(values.artificialLag, 'second')
+                        params['date_to'] = absoluteLag.toISOString()
                     }
 
                     if (values.orderBy === 'start_time') {
@@ -493,10 +498,12 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
     selectors({
         artificialLag: [
             (s) => [s.featureFlags],
-            (featureFlags): string | null => {
+            (featureFlags) => {
                 const lag = featureFlags[FEATURE_FLAGS.SESSION_REPLAY_ARTIFICIAL_LAG]
-                // you can't edit variants right now, and I didn't put minus on the variant name 🤷
-                return lag === undefined || lag === 'control' ? null : '-' + lag
+                // lag needs to match `\d+` when present it is a number of seconds delay
+                // relative_date parsing in the backend can't cope with seconds
+                // so it will be converted to an absolute date when added to API call
+                return typeof lag === 'string' && /^\d+$/.test(lag) ? Number.parseInt(lag) : null
             },
         ],
         useHogQLFiltering: [


### PR DESCRIPTION
follow-up to https://github.com/PostHog/posthog/pull/22296

We know from the recent "live mode" test that if we can avoid unmerged parts the query to list recordings is faster and less variable.

In that test we were introducing artificial lag of 1 hour and confused people

let's run experiment and see if much smaller values have an impact

backend relative date parsing can't cope with seconds as a unit and only has hour as a granularity

so this takes the flag variant and if it is an integer makes an absolute date that many seconds before "now" as the date_to for the query

it is tolerant of unexpected values _only_ acting if the value provided is an integer