### PR TITLE
fix: fcp matching can't work

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -998,7 +998,12 @@ function matchPaintEvents(performanceEvents: PerformanceEvent[]): PerformanceEve
     for (const event of performanceEvents) {
         if (event.entry_type === 'navigation') {
             lastNavigationEvent = event
-        } else if (event.entry_type === 'paint' && event.name === 'first-contentful-paint' && lastNavigationEvent) {
+        } else if (
+            event.entry_type === 'paint' &&
+            event.name === 'first-contentful-paint' &&
+            lastNavigationEvent &&
+            lastNavigationEvent.first_contentful_paint === undefined
+        ) {
             lastNavigationEvent.first_contentful_paint = event.start_time
         }
     }

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -444,8 +444,10 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 // but we decided to instead store them in the recording data
                 // we gather more info than rrweb, so we mix the two back together here
 
-                return deduplicatePerformanceEvents(
-                    filterUnwanted(matchNetworkEvents(sessionPlayerData.snapshotsByWindowId))
+                return matchPaintEvents(
+                    deduplicatePerformanceEvents(
+                        filterUnwanted(matchNetworkEvents(sessionPlayerData.snapshotsByWindowId))
+                    ).sort((a, b) => (a.timestamp.valueOf() > b.timestamp.valueOf() ? 1 : -1))
                 )
             },
         ],
@@ -496,20 +498,6 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                 const performanceEventsArr = performanceEvents || []
                 for (const event of performanceEventsArr) {
                     const responseStatus = event.response_status || 200
-
-                    // NOTE: Navigation events are missing the first contentful paint info
-                    // so, we find the relevant first contentful paint event and add it to the navigation event
-                    if (event.entry_type === 'navigation' && !event.first_contentful_paint) {
-                        const firstContentfulPaint = performanceEventsArr.find(
-                            (x) =>
-                                x.pageview_id === event.pageview_id &&
-                                x.entry_type === 'paint' &&
-                                x.name === 'first-contentful-paint'
-                        )
-                        if (firstContentfulPaint) {
-                            event.first_contentful_paint = firstContentfulPaint.start_time
-                        }
-                    }
 
                     if (event.entry_type === 'paint') {
                         // We don't include paint events as they are covered in the navigation events
@@ -998,4 +986,22 @@ function deduplicatePerformanceEvents(events: PerformanceEvent[]): PerformanceEv
             return true
         })
         .reverse()
+}
+
+/**
+ * If we have paint events we should add them to the appropriate navigation event
+ * this makes it easier to draw performance cards for navigation events
+ */
+function matchPaintEvents(performanceEvents: PerformanceEvent[]): PerformanceEvent[] {
+    // KLUDGE: this assumes that the input is sorted by timestamp and relies on the identity of the events to mutate them
+    let lastNavigationEvent: PerformanceEvent | null = null
+    for (const event of performanceEvents) {
+        if (event.entry_type === 'navigation') {
+            lastNavigationEvent = event
+        } else if (event.entry_type === 'paint' && event.name === 'first-contentful-paint' && lastNavigationEvent) {
+            lastNavigationEvent.first_contentful_paint = event.start_time
+        }
+    }
+
+    return performanceEvents
 }

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -993,9 +993,9 @@ function deduplicatePerformanceEvents(events: PerformanceEvent[]): PerformanceEv
  * this makes it easier to draw performance cards for navigation events
  */
 function matchPaintEvents(performanceEvents: PerformanceEvent[]): PerformanceEvent[] {
-    // KLUDGE: this assumes that the input is sorted by timestamp and relies on the identity of the events to mutate them
+    // KLUDGE: this relies on the identity of the events to mutate them, because that's cheaper than copying the potentially large list
     let lastNavigationEvent: PerformanceEvent | null = null
-    for (const event of performanceEvents) {
+    for (const event of performanceEvents.sort((a, b) => (a.timestamp.valueOf() > b.timestamp.valueOf() ? 1 : -1))) {
         if (event.entry_type === 'navigation') {
             lastNavigationEvent = event
         } else if (


### PR DESCRIPTION
we match FCP measurements onto navigation events using the pageview_id

but we don't send a pageview_id any more, so that can't work

we can assume that an FCP is for the last navigation event

@coderabbitai ignore