### PR TITLE
chore(data-warehouse): Added a timeout for postgres connections

### DIFF
--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -42,6 +42,7 @@ PostgresErrors = {
     "could not translate host name": "Could not connect to the host",
     "Is the server running on that host and accepting TCP/IP connections": "Could not connect to the host on the port given",
     'database "': "Database does not exist",
+    "timeout expired": "Connection timed out. Does your database have our IP addresses allowed?",
 }
 
 

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -87,6 +87,7 @@ def get_postgres_schemas(host: str, port: str, database: str, user: str, passwor
         user=user,
         password=password,
         sslmode="prefer",
+        connect_timeout=5,
         sslrootcert="/tmp/no.txt",
         sslcert="/tmp/no.txt",
         sslkey="/tmp/no.txt",


### PR DESCRIPTION
## Problem
- If a users postgres doesn't allow our IP addresses, then the SQL connection to check for schemas just hangs until after the the 60sec request timeout, returning a 5xx error to the user with a very unhelpful error message

## Changes
- Reduce the connection timeout to 5secs
- Add a friendly error message for when the timeout occurs

## Does this work well for both Cloud and self-hosted?
- Yes

## How did you test this code?
- Via browser clicky clicks