### PR TITLE
fix: Extend both the worker and worker_env definitions in docker-compose.base

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -74,7 +74,7 @@ services:
     worker: &worker
         command: ./bin/docker-worker-celery --with-scheduler
         restart: on-failure
-        environment:
+        environment: &worker_env
             DISABLE_SECURE_SSL_REDIRECT: 'true'
             IS_BEHIND_PROXY: 'true'
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
@@ -133,6 +133,7 @@ services:
         deploy:
             replicas: 0
         environment:
+            <<: *worker_env
             SKIP_ASYNC_MIGRATIONS_SETUP: 0
 
     # Temporal containers
@@ -193,4 +194,5 @@ services:
         command: ./bin/temporal-django-worker
         restart: on-failure
         environment:
+            <<: *worker_env
             TEMPORAL_HOST: temporal


### PR DESCRIPTION
## Problem

We have an issue with our compose stack where we pave over our env vars.
https://github.com/PostHog/posthog/issues/16169#issuecomment-1625351591

potential fix is:
https://github.com/PostHog/posthog/pull/22240

but this is a little heavy handed. We do still want to extend the worker definition for consistency. We just also want to extend the `environment` field as well


## Changes

extend the environments for subclasses of worker with `worker_env`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
