### PR TITLE
feat: send updated owner/admin emails to billing

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -223,6 +223,17 @@ class BillingManager:
         except Exception as e:
             capture_exception(e)
 
+    def update_billing_admin_emails(self, organization: Organization) -> None:
+        try:
+            admin_emails = list(
+                organization.members.filter(level_gte=OrganizationMembership.Level.ADMIN).values_list(
+                    "user__email", flat=True
+                )
+            )
+            self.update_billing(organization, {"org_admin_emails": admin_emails})
+        except Exception as e:
+            capture_exception(e)
+
     def deactivate_products(self, organization: Organization, products: str) -> None:
         res = requests.get(
             f"{BILLING_SERVICE_URL}/api/billing/deactivate?products={products}",

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -226,9 +226,9 @@ class BillingManager:
     def update_billing_admin_emails(self, organization: Organization) -> None:
         try:
             admin_emails = list(
-                organization.members.filter(level_gte=OrganizationMembership.Level.ADMIN).values_list(
-                    "user__email", flat=True
-                )
+                organization.members.filter(
+                    organization_membership__level__gte=OrganizationMembership.Level.ADMIN
+                ).values_list("email", flat=True)
             )
             self.update_billing(organization, {"org_admin_emails": admin_emails})
         except Exception as e:

--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -71,11 +71,15 @@ class OrganizationMemberSerializer(serializers.ModelSerializer):
             organization=updated_membership.organization,
             user=self.context["request"].user,
         )
+        level_changed = False
         for attr, value in validated_data.items():
             if attr == "level":
                 requesting_membership.validate_update(updated_membership, value)
+                level_changed = True
             setattr(updated_membership, attr, value)
         updated_membership.save()
+        if level_changed:
+            self.context["request"].user.update_billing_admin_emails(updated_membership.organization)
         return updated_membership
 
 

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -1,4 +1,5 @@
 from rest_framework import status
+from unittest.mock import call, patch
 
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.user import User
@@ -48,7 +49,8 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json(), self.permission_denied_response())
 
-    def test_delete_organization_member(self):
+    @patch("posthog.models.user.User.update_billing_admin_emails")
+    def test_delete_organization_member(self, mock_update_billing_admin_emails):
         user = User.objects.create_and_join(self.organization, "test@x.com", None, "X")
         membership_queryset = OrganizationMembership.objects.filter(user=user, organization=self.organization)
         self.assertTrue(membership_queryset.exists())
@@ -63,14 +65,26 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.status_code, 204)
         self.assertFalse(membership_queryset.exists(), False)
 
-    def test_leave_organization(self):
+        assert mock_update_billing_admin_emails.call_count == 1
+        assert mock_update_billing_admin_emails.call_args_list == [
+            call(self.organization),
+        ]
+
+    @patch("posthog.models.user.User.update_billing_admin_emails")
+    def test_leave_organization(self, mock_update_billing_admin_emails):
         membership_queryset = OrganizationMembership.objects.filter(user=self.user, organization=self.organization)
         self.assertEqual(membership_queryset.count(), 1)
         response = self.client.delete(f"/api/organizations/@current/members/{self.user.uuid}/")
         self.assertEqual(response.status_code, 204)
         self.assertEqual(membership_queryset.count(), 0)
 
-    def test_change_organization_member_level(self):
+        assert mock_update_billing_admin_emails.call_count == 1
+        assert mock_update_billing_admin_emails.call_args_list == [
+            call(self.organization),
+        ]
+
+    @patch("posthog.models.user.User.update_billing_admin_emails")
+    def test_change_organization_member_level(self, mock_update_billing_admin_emails):
         self.organization_membership.level = OrganizationMembership.Level.OWNER
         self.organization_membership.save()
         user = User.objects.create_user("test@x.com", None, "X")
@@ -104,8 +118,13 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
                 "level": OrganizationMembership.Level.ADMIN.value,
             },
         )
+        assert mock_update_billing_admin_emails.call_count == 1
+        assert mock_update_billing_admin_emails.call_args_list == [
+            call(self.organization),
+        ]
 
-    def test_admin_can_promote_to_admin(self):
+    @patch("posthog.models.user.User.update_billing_admin_emails")
+    def test_admin_can_promote_to_admin(self, mock_update_billing_admin_emails):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
         user = User.objects.create_user("test@x.com", None, "X")
@@ -119,7 +138,13 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
         updated_membership = OrganizationMembership.objects.get(user=user, organization=self.organization)
         self.assertEqual(updated_membership.level, OrganizationMembership.Level.ADMIN)
 
-    def test_change_organization_member_level_requires_admin(self):
+        assert mock_update_billing_admin_emails.call_count == 1
+        assert mock_update_billing_admin_emails.call_args_list == [
+            call(self.organization),
+        ]
+
+    @patch("posthog.models.user.User.update_billing_admin_emails")
+    def test_change_organization_member_level_requires_admin(self, mock_update_billing_admin_emails):
         user = User.objects.create_user("test@x.com", None, "X")
         membership = OrganizationMembership.objects.create(user=user, organization=self.organization)
         self.assertEqual(membership.level, OrganizationMembership.Level.MEMBER)
@@ -140,6 +165,8 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
             },
         )
         self.assertEqual(response.status_code, 403)
+
+        assert mock_update_billing_admin_emails.call_count == 0
 
     def test_cannot_change_own_organization_member_level(self):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -574,6 +574,7 @@ class TestSignupAPI(APIBaseTest):
     @patch("posthoganalytics.capture")
     @mock.patch("ee.billing.billing_manager.BillingManager.update_billing_distinct_ids")
     @mock.patch("ee.billing.billing_manager.BillingManager.update_billing_customer_email")
+    @mock.patch("ee.billing.billing_manager.BillingManager.update_billing_admin_emails")
     @mock.patch("social_core.backends.base.BaseAuth.request")
     @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @mock.patch("posthog.tasks.user_identify.identify_task")
@@ -585,12 +586,14 @@ class TestSignupAPI(APIBaseTest):
         mock_request,
         mock_update_distinct_ids,
         mock_update_billing_customer_email,
+        mock_update_billing_admin_emails,
         mock_capture,
     ):
         with self.is_cloud(True):
             self.run_test_for_allowed_domain(mock_sso_providers, mock_request, mock_capture)
         assert mock_update_distinct_ids.called_once()
         assert mock_update_billing_customer_email.called_once()
+        assert mock_update_billing_admin_emails.called_once()
 
     @mock.patch("social_core.backends.base.BaseAuth.request")
     @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -265,6 +265,7 @@ class User(AbstractUser, UUIDClassicModel):
                 )
                 self.team = self.current_team  # Update cached property
                 self.save()
+        self.update_billing_admin_emails(organization)
         self.update_billing_distinct_ids(organization)
 
     def update_billing_distinct_ids(self, organization: Organization) -> None:

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -240,6 +240,8 @@ class User(AbstractUser, UUIDClassicModel):
             self.save()
         if level == OrganizationMembership.Level.OWNER and not self.current_organization.customer_id:
             self.update_billing_customer_email(organization)
+        if level >= OrganizationMembership.Level.ADMIN:
+            self.update_billing_admin_emails(organization)
         self.update_billing_distinct_ids(organization)
         return membership
 
@@ -276,6 +278,12 @@ class User(AbstractUser, UUIDClassicModel):
 
         if is_cloud() and get_cached_instance_license() is not None:
             BillingManager(get_cached_instance_license()).update_billing_customer_email(organization)
+
+    def update_billing_admin_emails(self, organization: Organization) -> None:
+        from ee.billing.billing_manager import BillingManager
+
+        if is_cloud() and get_cached_instance_license() is not None:
+            BillingManager(get_cached_instance_license()).update_billing_admin_emails(organization)
 
     def get_analytics_metadata(self):
         team_member_count_all: int = (


### PR DESCRIPTION
We are updating how billing emails are sent in billing and we want to send them to all owners and admin on the organization. This will sync them to billing when a new member joins, leaves or a level is changed

Related: https://github.com/PostHog/billing/pull/621

❓Should we backfill these?