### PR TITLE
fix: Limit retention to 31 intervals and fix onChange/onBlur

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
@@ -23,6 +23,7 @@ interface LemonInputPropsBase
         | 'autoCapitalize'
         | 'spellCheck'
         | 'inputMode'
+        | 'pattern'
     > {
     ref?: React.Ref<HTMLInputElement>
     id?: string

--- a/frontend/src/scenes/insights/EditorFilters/RetentionSummary.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/RetentionSummary.tsx
@@ -95,7 +95,7 @@ export function RetentionSummary({ insightProps }: EditorFilterProps): JSX.Eleme
                             }
                             toast.warn(
                                 <>
-                                    The maximum amount of {dateOptionPlurals[period || 'Day']} is <strong>31</strong>
+                                    The maximum number of {dateOptionPlurals[period || 'Day']} is <strong>31</strong>
                                 </>
                             )
                         }

--- a/frontend/src/scenes/insights/EditorFilters/RetentionSummary.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/RetentionSummary.tsx
@@ -3,6 +3,7 @@ import { LemonInput, LemonSelect } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { toast } from 'react-toastify'
 import { AggregationSelect } from 'scenes/insights/filters/AggregationSelect'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
@@ -81,8 +82,26 @@ export function RetentionSummary({ insightProps }: EditorFilterProps): JSX.Eleme
                 <LemonInput
                     type="number"
                     className="ml-2 w-20"
-                    value={(totalIntervals ?? 11) - 1}
-                    onChange={(value) => updateInsightFilter({ totalIntervals: (value || 0) + 1 })}
+                    defaultValue={(totalIntervals ?? 11) - 1}
+                    min={1}
+                    max={31}
+                    onBlur={({ target }) => {
+                        let newValue = Number(target.value)
+                        if (newValue > 31) {
+                            // See if just the first two numbers are under 31 (when someone mashed keys)
+                            newValue = Number(target.value.substring(0, 2))
+                            if (newValue > 31) {
+                                newValue = 10
+                            }
+                            toast.warn(
+                                <>
+                                    The maximum amount of {dateOptionPlurals[period || 'Day']} is <strong>31</strong>
+                                </>
+                            )
+                        }
+                        target.value = newValue.toString()
+                        updateInsightFilter({ totalIntervals: (newValue || 0) + 1 })
+                    }}
                 />
                 <LemonSelect
                     className="mx-2"


### PR DESCRIPTION
## Problem

- I think we could massively speed up retention queries by using the clickhouse [retention](https://clickhouse.com/docs/en/sql-reference/aggregate-functions/parametric-functions#retention) query. However, that query only supports 32 items. We also have some people (probably accidentally) doing _tons_ of intervals, which harms performance and isn't useful anyway. 31 means you can do a full month's worth of data. I want to see if people complain about this before we rewrite the query.
- I always get super annoyed that intervals was onChange, so you'd end up making way more requests than you want. Changing it to onBlur is a much nicer experience
- 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
<img width="806" alt="image" src="https://github.com/PostHog/posthog/assets/1727427/98960031-76be-4f1c-a689-b4f10e0798e7">


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
