### PR TITLE
fix: heatmap wildcard matching

### DIFF
--- a/posthog/heatmaps/heatmaps_api.py
+++ b/posthog/heatmaps/heatmaps_api.py
@@ -86,6 +86,31 @@ class HeatmapsRequestSerializer(serializers.Serializer):
     def validate_date_to(self, value) -> date:
         return self.validate_date(value, "date_to")
 
+    def validate_url_pattern(self, value: str | None) -> str | None:
+        if value is None:
+            return None
+
+        validated_value = value
+
+        # we insist on the pattern being anchored
+        if not value.startswith("^"):
+            validated_value = f"^{value}"
+        if not value.endswith("$"):
+            validated_value = f"{validated_value}$"
+
+        # KLUDGE: we allow API callers to send something that isn't really `re2` syntax used in match()
+        # KLUDGE: so if it has * but not .* then we expect at least one character to match, so we use .+ instead
+        # KLUDGE: this means we don't support valid regex since we can't support matching aaaaa with a*
+        # KLUDGE: but you could send a+ and it would match aaaaa
+        validated_value = "".join(
+            [
+                f".+" if c == "*" and i > 0 and validated_value[i - 1] != "." else c
+                for i, c in enumerate(validated_value)
+            ]
+        )
+
+        return validated_value
+
     def validate(self, values) -> dict:
         url_exact = values.get("url_exact", None)
         url_pattern = values.get("url_pattern", None)

--- a/posthog/heatmaps/test/__snapshots__/test_heatmaps_api.ambr
+++ b/posthog/heatmaps/test/__snapshots__/test_heatmaps_api.ambr
@@ -51,32 +51,6 @@
                          max_query_size=524288
   '''
 # ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
 # name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com*
   '''
   /* user_id:0 request:_snapshot_ */
@@ -116,241 +90,7 @@
             round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
             multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
      FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com*.2
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
      WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com.+$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com*.3
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products.+$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com*.4
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/1.+$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com*.5
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/.+/reviews/.+$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com.1
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com.2
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com.+$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com.3
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products.+$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com.4
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/1.+$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com.5
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/.+/reviews/.+$')))
   GROUP BY pointer_target_fixed,
            pointer_relative_x,
            client_y
@@ -402,58 +142,6 @@
             round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
             multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
      FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products*.2
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com.+$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products*.3
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
      WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products.+$')))
   GROUP BY pointer_target_fixed,
            pointer_relative_x,
@@ -467,7 +155,7 @@
                          max_query_size=524288
   '''
 # ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products*.4
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/*/parts/*
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT pointer_target_fixed AS pointer_target_fixed,
@@ -480,7 +168,7 @@
             round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
             multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
      FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/1.+$')))
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com$')))
   GROUP BY pointer_target_fixed,
            pointer_relative_x,
            client_y
@@ -493,7 +181,7 @@
                          max_query_size=524288
   '''
 # ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products*.5
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/*/parts/*.1
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT pointer_target_fixed AS pointer_target_fixed,
@@ -506,7 +194,7 @@
             round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
             multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
      FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/.+/reviews/.+$')))
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/.+/parts/.+$')))
   GROUP BY pointer_target_fixed,
            pointer_relative_x,
            client_y
@@ -546,110 +234,6 @@
   '''
 # ---
 # name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/*/reviews/*.1
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/*/reviews/*.2
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com.+$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/*/reviews/*.3
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products.+$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/*/reviews/*.4
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/1.+$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/*/reviews/*.5
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT pointer_target_fixed AS pointer_target_fixed,
@@ -714,84 +298,6 @@
             round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
             multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
      FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/1*.2
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com.+$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/1*.3
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products.+$')))
-  GROUP BY pointer_target_fixed,
-           pointer_relative_x,
-           client_y
-  LIMIT 1000000 SETTINGS readonly=2,
-                         max_execution_time=60,
-                         allow_experimental_object_type=1,
-                         format_csv_allow_double_quotes=0,
-                         max_ast_elements=1000000,
-                         max_expanded_ast_elements=1000000,
-                         max_query_size=524288
-  '''
-# ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/1*.4
-  '''
-  /* user_id:0 request:_snapshot_ */
-  SELECT pointer_target_fixed AS pointer_target_fixed,
-         pointer_relative_x AS pointer_relative_x,
-         client_y AS client_y,
-         count(*) AS cnt
-  FROM
-    (SELECT heatmaps.distinct_id AS distinct_id,
-            heatmaps.pointer_target_fixed AS pointer_target_fixed,
-            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
-            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
-     FROM heatmaps
      WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/1.+$')))
   GROUP BY pointer_target_fixed,
            pointer_relative_x,
@@ -805,7 +311,7 @@
                          max_query_size=524288
   '''
 # ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/1*.5
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/1*/parts/*
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT pointer_target_fixed AS pointer_target_fixed,
@@ -818,7 +324,33 @@
             round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
             multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
      FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/.+/reviews/.+$')))
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/1*/parts/*.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/1.+/parts/.+$')))
   GROUP BY pointer_target_fixed,
            pointer_relative_x,
            client_y

--- a/posthog/heatmaps/test/__snapshots__/test_heatmaps_api.ambr
+++ b/posthog/heatmaps/test/__snapshots__/test_heatmaps_api.ambr
@@ -51,7 +51,7 @@
                          max_query_size=524288
   '''
 # ---
-# name: TestSessionRecordings.test_can_filter_by_exact_url.2
+# name: TestSessionRecordings.test_can_filter_by_url_pattern
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT pointer_target_fixed AS pointer_target_fixed,
@@ -64,7 +64,137 @@
             round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
             multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
      FROM heatmaps
-     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, 'http://example.com*')))
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern.2
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern.3
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern.4
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/1.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern.5
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/.+/reviews/.+$')))
   GROUP BY pointer_target_fixed,
            pointer_relative_x,
            client_y

--- a/posthog/heatmaps/test/__snapshots__/test_heatmaps_api.ambr
+++ b/posthog/heatmaps/test/__snapshots__/test_heatmaps_api.ambr
@@ -51,7 +51,7 @@
                          max_query_size=524288
   '''
 # ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT pointer_target_fixed AS pointer_target_fixed,
@@ -77,7 +77,33 @@
                          max_query_size=524288
   '''
 # ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern.1
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com*
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com*.1
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT pointer_target_fixed AS pointer_target_fixed,
@@ -103,7 +129,7 @@
                          max_query_size=524288
   '''
 # ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern.2
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com*.2
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT pointer_target_fixed AS pointer_target_fixed,
@@ -129,7 +155,7 @@
                          max_query_size=524288
   '''
 # ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern.3
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com*.3
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT pointer_target_fixed AS pointer_target_fixed,
@@ -155,7 +181,7 @@
                          max_query_size=524288
   '''
 # ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern.4
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com*.4
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT pointer_target_fixed AS pointer_target_fixed,
@@ -181,7 +207,7 @@
                          max_query_size=524288
   '''
 # ---
-# name: TestSessionRecordings.test_can_filter_by_url_pattern.5
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com*.5
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT pointer_target_fixed AS pointer_target_fixed,
@@ -195,6 +221,630 @@
             multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
      FROM heatmaps
      WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/.+/reviews/.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com.2
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com.3
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com.4
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/1.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com.5
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/.+/reviews/.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products*
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products*.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products*.2
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products*.3
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products*.4
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/1.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products*.5
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/.+/reviews/.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/*/reviews/*
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/*/reviews/*.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/*/reviews/*.2
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/*/reviews/*.3
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/*/reviews/*.4
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/1.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/*/reviews/*.5
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/.+/reviews/.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/1*
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/1*.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/1*.2
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/1*.3
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/1*.4
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/1.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_http://example.com/products/1*.5
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com/products/.+/reviews/.+$')))
+  GROUP BY pointer_target_fixed,
+           pointer_relative_x,
+           client_y
+  LIMIT 1000000 SETTINGS readonly=2,
+                         max_execution_time=60,
+                         allow_experimental_object_type=1,
+                         format_csv_allow_double_quotes=0,
+                         max_ast_elements=1000000,
+                         max_expanded_ast_elements=1000000,
+                         max_query_size=524288
+  '''
+# ---
+# name: TestSessionRecordings.test_can_filter_by_url_pattern_where_end_is_anchored
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT pointer_target_fixed AS pointer_target_fixed,
+         pointer_relative_x AS pointer_relative_x,
+         client_y AS client_y,
+         count(*) AS cnt
+  FROM
+    (SELECT heatmaps.distinct_id AS distinct_id,
+            heatmaps.pointer_target_fixed AS pointer_target_fixed,
+            round(divide(heatmaps.x, heatmaps.viewport_width), 2) AS pointer_relative_x,
+            multiply(heatmaps.y, heatmaps.scale_factor) AS client_y
+     FROM heatmaps
+     WHERE and(equals(heatmaps.team_id, 2), equals(heatmaps.type, 'rageclick'), greaterOrEquals(toTimeZone(heatmaps.timestamp, 'UTC'), toDate('2023-03-08')), match(heatmaps.current_url, '^http://example.com$')))
   GROUP BY pointer_target_fixed,
            pointer_relative_x,
            client_y

--- a/posthog/heatmaps/test/test_heatmaps_api.py
+++ b/posthog/heatmaps/test/test_heatmaps_api.py
@@ -158,11 +158,12 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
 
     @parameterized.expand(
         [
-            ["http://example.com", 1],
             ["http://example.com*", 6],
             ["http://example.com/products*", 5],
             ["http://example.com/products/1*", 2],
             ["http://example.com/products/*/reviews/*", 2],
+            ["http://example.com/products/*/parts/*", 2],
+            ["http://example.com/products/1*/parts/*", 1],
         ],
         name_func=lambda f, n, p: f"{f.__name__}_{p.args[0]}",
     )
@@ -204,30 +205,9 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             {"date_from": "2023-03-08", "url_pattern": "http://example.com", "type": "rageclick"}
         )
 
-        # should match only the homepage
         self._assert_heatmap_single_result_count(
-            {"date_from": "2023-03-08", "url_pattern": "http://example.com/", "type": "rageclick"}, 1
-        )
-
-        # should match all 6
-        self._assert_heatmap_single_result_count(
-            {"date_from": "2023-03-08", "url_pattern": "http://example.com*", "type": "rageclick"}, 6
-        )
-
-        # should match 5 events across both products
-        self._assert_heatmap_single_result_count(
-            {"date_from": "2023-03-08", "url_pattern": "http://example.com/products*", "type": "rageclick"}, 5
-        )
-
-        # should match all events for one product
-        self._assert_heatmap_single_result_count(
-            {"date_from": "2023-03-08", "url_pattern": "http://example.com/products/1*", "type": "rageclick"}, 2
-        )
-
-        # should match all reviews - i.e. proves we can have more than one wildcard
-        self._assert_heatmap_single_result_count(
-            {"date_from": "2023-03-08", "url_pattern": "http://example.com/products/*/reviews/*", "type": "rageclick"},
-            2,
+            {"date_from": "2023-03-08", "url_pattern": pattern, "type": "rageclick"},
+            expected_matches,
         )
 
     @snapshot_clickhouse_queries

--- a/posthog/heatmaps/test/test_heatmaps_api.py
+++ b/posthog/heatmaps/test/test_heatmaps_api.py
@@ -138,8 +138,68 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             {"date_from": "2023-03-08", "url_exact": "http://example.com/about", "type": "rageclick"}, 2
         )
 
+    @snapshot_clickhouse_queries
+    def test_can_filter_by_url_pattern(self) -> None:
+        # the home page
+        self._create_heatmap_event("session_2", "rageclick", "2023-03-08T08:01:00", current_url="http://example.com/")
+
+        # a product page with a review
+        self._create_heatmap_event(
+            "session_1",
+            "rageclick",
+            "2023-03-08T08:00:00",
+            current_url="http://example.com/products/12345/reviews/4567",
+        )
+
+        # a different product page with a review
+        self._create_heatmap_event(
+            "session_1", "rageclick", "2023-03-08T08:00:00", current_url="http://example.com/products/3456/reviews/defg"
+        )
+
+        # all reviews for one product
+        self._create_heatmap_event(
+            "session_1", "rageclick", "2023-03-08T08:00:00", current_url="http://example.com/products/3456/reviews/"
+        )
+
+        # the same product but a different sub-route
+        self._create_heatmap_event(
+            "session_3", "rageclick", "2023-03-08T08:01:00", current_url="http://example.com/products/12345/parts/abcd"
+        )
+
+        # a different product that shares a part
+        self._create_heatmap_event(
+            "session_3", "rageclick", "2023-03-08T08:01:00", current_url="http://example.com/products/3456/parts/abcd"
+        )
+
+        # should match nothing, no trailing slash
+        self._assert_heatmap_no_result_count(
+            {"date_from": "2023-03-08", "url_pattern": "http://example.com", "type": "rageclick"}
+        )
+
+        # should match only the homepage
         self._assert_heatmap_single_result_count(
-            {"date_from": "2023-03-08", "url_pattern": "http://example.com*", "type": "rageclick"}, 3
+            {"date_from": "2023-03-08", "url_pattern": "http://example.com/", "type": "rageclick"}, 1
+        )
+
+        # should match all 6
+        self._assert_heatmap_single_result_count(
+            {"date_from": "2023-03-08", "url_pattern": "http://example.com*", "type": "rageclick"}, 6
+        )
+
+        # should match 5 events across both products
+        self._assert_heatmap_single_result_count(
+            {"date_from": "2023-03-08", "url_pattern": "http://example.com/products*", "type": "rageclick"}, 5
+        )
+
+        # should match all events for one product
+        self._assert_heatmap_single_result_count(
+            {"date_from": "2023-03-08", "url_pattern": "http://example.com/products/1*", "type": "rageclick"}, 2
+        )
+
+        # should match all reviews - i.e. proves we can have more than one wildcard
+        self._assert_heatmap_single_result_count(
+            {"date_from": "2023-03-08", "url_pattern": "http://example.com/products/*/reviews/*", "type": "rageclick"},
+            2,
         )
 
     @snapshot_clickhouse_queries


### PR DESCRIPTION
reported in https://posthoghelp.zendesk.com/agent/tickets/13696 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15908)

hackathon mode strikes again

we had a single test case to cover pattern matching in the new heatmaps API and it basically didn't work 🙈 

since we want to send patterns like `https://example.com/products/*/reviews/*?myValue=true` and ClickHouse uses `re2` syntax for `match` 

but I also don't want to support arbitrary regex here 

we ensure all values are anchored to ^submitted$
and we replace any asterisk that isn't a `.*` with `.+` since it means "at least one of any character here"

because in regex terms `https://example.com/*` matches `https://example.com` and `https://example.com//////` but not `https://example.com/home` and we mean the last thing only 