### PR TITLE
fix: Increase timeout limit on initial breakdown query on funnels

### DIFF
--- a/posthog/hogql_queries/insights/funnels/base.py
+++ b/posthog/hogql_queries/insights/funnels/base.py
@@ -204,7 +204,9 @@ class FunnelBase(ABC):
                 )
 
             # execute query
-            results = execute_hogql_query(values_query, self.context.team, limit_context=self.limit_context).results
+            results = execute_hogql_query(
+                values_query, self.context.team, limit_context=self.context.limit_context
+            ).results
             if results is None:
                 raise ValidationError("Apologies, there has been an error computing breakdown values.")
             return [row[0] for row in results[0:breakdown_limit_or_default]]

--- a/posthog/hogql_queries/insights/funnels/base.py
+++ b/posthog/hogql_queries/insights/funnels/base.py
@@ -204,7 +204,7 @@ class FunnelBase(ABC):
                 )
 
             # execute query
-            results = execute_hogql_query(values_query, self.context.team).results
+            results = execute_hogql_query(values_query, self.context.team, limit_context=self.limit_context).results
             if results is None:
                 raise ValidationError("Apologies, there has been an error computing breakdown values.")
             return [row[0] for row in results[0:breakdown_limit_or_default]]


### PR DESCRIPTION
## Problem

Lack of context meant the timeout was set to 60 seconds, even though it can run longer if running async.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
