### PR TITLE
feat(data-warehouse): add table list in sql editor

### DIFF
--- a/frontend/src/lib/components/DatabaseTableTree/DatabaseTableTree.tsx
+++ b/frontend/src/lib/components/DatabaseTableTree/DatabaseTableTree.tsx
@@ -1,6 +1,6 @@
 import { DataWarehouseTableType } from 'scenes/data-warehouse/types'
 
-import { TreeFolderRow, TreeRow } from './TreeRow'
+import { TreeFolderRow, TreeRow, TreeTableRow } from './TreeRow'
 
 export interface TreeProps extends React.HTMLAttributes<HTMLUListElement> {
     children?: React.ReactNode
@@ -11,7 +11,7 @@ export interface TreeProps extends React.HTMLAttributes<HTMLUListElement> {
     selectedRow?: DataWarehouseTableType | null
 }
 
-export type TreeItem = TreeItemFolder | TreeItemLeaf
+export type TreeItem = TreeItemFolder | TreeItemLeaf | TreeTableItemLeaf
 
 export interface TreeItemFolder {
     name: string
@@ -20,8 +20,14 @@ export interface TreeItemFolder {
     isLoading?: boolean
 }
 
-export interface TreeItemLeaf {
+export interface TreeTableItemLeaf {
     table: DataWarehouseTableType
+    icon?: React.ReactNode
+}
+
+export interface TreeItemLeaf {
+    name: string
+    type: string
     icon?: React.ReactNode
 }
 
@@ -35,7 +41,7 @@ export function DatabaseTableTree({
 }: TreeProps): JSX.Element {
     return (
         <ul
-            className={`bg-bg-light ${depth == 1 ? 'p-4 overflow-y-scroll h-full' : ''} rounded-lg ${className}`}
+            className={`bg-bg-light ${depth == 1 ? 'p-4 overflow-y-scroll h-full w-full' : ''} rounded-lg ${className}`}
             {...props}
         >
             {items.map((item, index) => {
@@ -50,13 +56,26 @@ export function DatabaseTableTree({
                         />
                     )
                 }
+
+                if ('table' in item) {
+                    return (
+                        <TreeTableRow
+                            key={depth + '_' + index}
+                            item={item}
+                            depth={depth}
+                            onClick={onSelectRow}
+                            selected={!!(selectedRow?.name == item.table.name)}
+                        />
+                    )
+                }
+
                 return (
                     <TreeRow
                         key={depth + '_' + index}
                         item={item}
                         depth={depth}
                         onClick={onSelectRow}
-                        selected={!!(selectedRow?.name == item.table.name)}
+                        selected={!!(selectedRow?.name == item.name)}
                     />
                 )
             })}

--- a/frontend/src/lib/components/DatabaseTableTree/TreeRow.tsx
+++ b/frontend/src/lib/components/DatabaseTableTree/TreeRow.tsx
@@ -7,7 +7,7 @@ import { IconChevronRight } from 'lib/lemon-ui/icons'
 import { useCallback, useState } from 'react'
 import { DataWarehouseTableType } from 'scenes/data-warehouse/types'
 
-import { DatabaseTableTree, TreeItemFolder, TreeItemLeaf } from './DatabaseTableTree'
+import { DatabaseTableTree, TreeItemFolder, TreeItemLeaf, TreeTableItemLeaf } from './DatabaseTableTree'
 
 export interface TreeRowProps {
     item: TreeItemLeaf
@@ -16,7 +16,28 @@ export interface TreeRowProps {
     selected?: boolean
 }
 
-export function TreeRow({ item, onClick, selected }: TreeRowProps): JSX.Element {
+export function TreeRow({ item, selected }: TreeRowProps): JSX.Element {
+    return (
+        <li>
+            <div className={clsx('TreeRow text-ellipsis cursor-default', selected ? 'TreeRow__selected' : '')}>
+                <span className="mr-2">{item.icon}</span>
+                <div className="flex flex-row justify-between w-100">
+                    <div className="w-40 overflow-hidden text-ellipsis whitespace-nowrap">{item.name}</div>
+                    <div className="text-right whitespace-nowrap">{item.type}</div>
+                </div>
+            </div>
+        </li>
+    )
+}
+
+export interface TreeTableRowProps {
+    item: TreeTableItemLeaf
+    depth: number
+    onClick?: (row: DataWarehouseTableType) => void
+    selected?: boolean
+}
+
+export function TreeTableRow({ item, onClick, selected }: TreeTableRowProps): JSX.Element {
     const _onClick = useCallback(() => {
         onClick && onClick(item.table)
     }, [onClick, item])
@@ -39,8 +60,11 @@ export interface TreeFolderRowProps {
 }
 
 export function TreeFolderRow({ item, depth, onClick, selectedRow }: TreeFolderRowProps): JSX.Element {
-    const [collapsed, setCollapsed] = useState(false)
     const { name, items, emptyLabel } = item
+
+    const isColumnType = items.length > 0 && 'type' in items[0]
+
+    const [collapsed, setCollapsed] = useState(isColumnType)
 
     const _onClick = useCallback(() => {
         setCollapsed(!collapsed)
@@ -48,7 +72,7 @@ export function TreeFolderRow({ item, depth, onClick, selectedRow }: TreeFolderR
 
     return (
         <li>
-            <div className={clsx('TreeRow', 'font-bold')} onClick={_onClick}>
+            <div className={clsx('TreeRow', isColumnType ? '' : 'font-bold')} onClick={_onClick}>
                 <span className="mr-2">{collapsed ? <IconChevronRight /> : <IconChevronDown />}</span>
                 {name}
             </div>
@@ -59,13 +83,13 @@ export function TreeFolderRow({ item, depth, onClick, selectedRow }: TreeFolderR
                         depth={depth + 1}
                         onSelectRow={onClick}
                         selectedRow={selectedRow}
-                        style={{ marginLeft: `2rem`, padding: 0 }}
+                        style={{ marginLeft: `14px`, padding: 0 }}
                     />
                 ) : (
                     <div
                         // eslint-disable-next-line react/forbid-dom-props
                         style={{
-                            marginLeft: `${2 * depth}rem`,
+                            marginLeft: `${14 * depth}px`,
                         }}
                     >
                         {item.isLoading ? (

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
@@ -39,6 +39,7 @@ function CategoryPill({
             data-attr={`taxonomic-tab-${groupType}`}
             onClick={canInteract ? onClick : undefined}
             weight="normal"
+            aria-disabled
         >
             {group?.render ? (
                 group?.name

--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -13,7 +13,6 @@ import type { editor as importedEditor, IDisposable } from 'monaco-editor'
 import { languages } from 'monaco-editor'
 import { useEffect, useRef, useState } from 'react'
 import { DatabaseTableTreeWithItems } from 'scenes/data-warehouse/external/DataWarehouseTables'
-import { urls } from 'scenes/urls'
 import useResizeObserver from 'use-resize-observer'
 
 import { query } from '~/queries/query'
@@ -206,17 +205,7 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
                                         <Link to="https://posthog.com/manual/hogql" target="_blank">
                                             HogQL
                                         </Link>
-                                        , our wrapper around ClickHouse SQL. Explore the{' '}
-                                        <Link
-                                            to={
-                                                featureFlags[FEATURE_FLAGS.DATA_WAREHOUSE]
-                                                    ? urls.dataWarehouse()
-                                                    : urls.database()
-                                            }
-                                        >
-                                            database schema
-                                        </Link>{' '}
-                                        available to you.
+                                        , our wrapper around ClickHouse SQL
                                     </div>
                                 ),
                                 placement: 'right-start',

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownPopover.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownPopover.tsx
@@ -31,6 +31,7 @@ export const TaxonomicBreakdownPopover = ({ open, setOpen, children }: Taxonomic
         ...(includeSessions ? [TaxonomicFilterGroupType.SessionProperties] : []),
         TaxonomicFilterGroupType.HogQLExpression,
         TaxonomicFilterGroupType.DataWarehouseProperties,
+        TaxonomicFilterGroupType.DataWarehousePersonProperties,
     ]
 
     return (


### PR DESCRIPTION
## Problem

- hard to query tables without knowing what tables exist

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- show tables in sql editor
- behind data warehouse flag

https://github.com/PostHog/posthog/assets/13127476/bac86964-011f-41a6-b190-1d7c50f22050


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
