### PR TITLE
fix(insights): dont set default date_from during serialization

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -91,7 +91,6 @@ from posthog.settings import CAPTURE_TIME_TO_SEE_DATA, SITE_URL
 from prometheus_client import Counter
 from posthog.user_permissions import UserPermissionsSerializerMixin
 from posthog.utils import (
-    DEFAULT_DATE_FROM_DAYS,
     refresh_requested_by_client,
     relative_date_parse,
     str_to_bool,
@@ -212,9 +211,6 @@ class InsightBasicSerializer(TaggedItemSerializerMixin, serializers.ModelSeriali
             representation["query"] = instance.query or instance.query_from_filters
         else:
             filters = instance.dashboard_filters()
-
-            if not filters.get("date_from") and not instance.query:
-                filters.update({"date_from": f"-{DEFAULT_DATE_FROM_DAYS}d"})
             representation["filters"] = filters
 
         return representation

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -1003,7 +1003,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             {
                 "events": [{"id": "$pageview"}],
                 "insight": "TRENDS",
-                "date_from": "-7d",
+                "date_from": None,
                 "date_to": None,
             },
         )

--- a/posthog/api/test/test_insight_query.py
+++ b/posthog/api/test/test_insight_query.py
@@ -105,26 +105,6 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         )
         assert insight_json["filters"] == {}
 
-    def test_default_filters_on_non_query_insight(self) -> None:
-        _, insight_json = self.dashboard_api.create_insight(
-            {
-                "name": "Old-Fashioned Insight",
-                "filters": {
-                    "events": [
-                        {"id": "$pageview"},
-                    ],
-                },
-            },
-            expected_status=status.HTTP_201_CREATED,
-        )
-        assert insight_json["filters"] == {
-            "events": [
-                {"id": "$pageview"},
-            ],
-            "insight": "TRENDS",
-            "date_from": "-7d",
-        }
-
     def test_can_save_insights_query_to_an_insight(self) -> None:
         self.dashboard_api.create_insight(
             {


### PR DESCRIPTION
## Problem

The cache key of queries originating from the backend and frontend don't match. This is because the backend adds a default `date_from` to filters during serialization. 

## Changes

Removes the default for `date_from` during serialization. 

Note: The offending line was introduced here https://github.com/PostHog/posthog/pull/10462/files#diff-4ca30e20c18794d6e844528d5a1ec9932d914c4092c9ec27ece05be70b9d580b and doesn't seem to be necessary any more.

## How did you test this code?

Debugger + clicking around

This needs https://github.com/PostHog/posthog/pull/22234 to fully work as well 