### PR TITLE
fix: fix delete-proxy workflow

### DIFF
--- a/posthog/temporal/proxy_service/delete.py
+++ b/posthog/temporal/proxy_service/delete.py
@@ -65,10 +65,10 @@ async def delete_hosted_proxy(inputs: DeleteHostedProxyInputs):
         inputs.domain,
     )
 
-    client = get_grpc_client()
+    client = await get_grpc_client()
 
     try:
-        await client.Create(
+        await client.Delete(
             DeleteRequest(
                 uuid=str(inputs.proxy_record_id),
                 domain=inputs.domain,


### PR DESCRIPTION
## Problem

weirdly not awaiting client was caught by linting/type checking at some point and i fixed it but it got undone?

Also calling Create instead of Delete :oops:

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
