### PR TITLE
chore: fix ordering of proxy in create response

### DIFF
--- a/frontend/src/scenes/settings/project/proxyLogic.ts
+++ b/frontend/src/scenes/settings/project/proxyLogic.ts
@@ -43,7 +43,7 @@ export const proxyLogic = kea<proxyLogicType>([
                 })
                 lemonToast.success('Record created')
                 actions.completeForm()
-                return [...values.proxyRecords, response]
+                return [response, ...values.proxyRecords]
             },
             deleteRecord: async (id: ProxyRecord['id']) => {
                 void api.delete(`api/organizations/${values.currentOrganization?.id}/proxy_records/${id}`)


### PR DESCRIPTION

## Problem

we list newer proxies first, not last

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
