### PR TITLE
chore: stringify uuid in temporal log

### DIFF
--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -39,7 +39,7 @@ async def bind_temporal_org_worker_logger(
     logger = structlog.get_logger()
     temporal_context = get_temporal_context()
 
-    return logger.new(organization_id=organization_id, destination=destination, **temporal_context)
+    return logger.new(organization_id=str(organization_id), destination=destination, **temporal_context)
 
 
 def configure_logger(


### PR DESCRIPTION
## Problem

It was coming through as 'UUID("0000-...etc")'

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
