### PR TITLE
fix(hogql): robust funnel cache keys

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -49,6 +49,7 @@ from posthog.schema import (
     HogQLQueryModifiers,
     InsightActorsQueryOptions,
 )
+from posthog.schema_helpers import to_json
 from posthog.utils import generate_cache_key, get_safe_cache, get_from_dict_or_attr
 
 logger = structlog.get_logger(__name__)
@@ -437,13 +438,10 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 "hogql",
             )
 
-    def to_json(self) -> str:
-        return self.query.model_dump_json(exclude_defaults=True, exclude_none=True)
-
     def get_cache_key(self) -> str:
         modifiers = self.modifiers.model_dump_json(exclude_defaults=True, exclude_none=True)
         return generate_cache_key(
-            f"query_{self.to_json()}_{self.__class__.__name__}_{self.team.pk}_{self.team.timezone}_{modifiers}_{self._limit_context_aliased_for_cache}_v2"
+            f"query_{to_json(self.query)}_{self.__class__.__name__}_{self.team.pk}_{self.team.timezone}_{modifiers}_{self._limit_context_aliased_for_cache}_v2"
         )
 
     @abstractmethod

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -71,33 +71,6 @@ class TestQueryRunner(BaseTest):
 
         self.assertEqual(runner.query, TestQuery(some_attr="bla"))
 
-    def test_serializes_to_json(self):
-        TestQueryRunner = self.setup_test_query_runner_class()
-
-        runner = TestQueryRunner(query={"some_attr": "bla"}, team=self.team)
-
-        json = runner.to_json()
-        self.assertEqual(json, '{"some_attr":"bla"}')
-
-    def test_serializes_to_json_ignores_empty_dict(self):
-        # The below behaviour is not currently implemented, since we're auto-
-        # generating the pydantic models for queries, which doesn't allow us
-        # setting a custom default value for list and dict type properties.
-        #
-        # :KLUDGE: In order to receive a stable JSON representation for cache
-        # keys we want to ignore semantically equal attributes. E.g. an empty
-        # list and None should be treated equally.
-        #
-        # To achieve this behaviour we ignore None and the default value, which
-        # we set to an empty list. It would be even better, if we would
-        # implement custom validators for this.
-        TestQueryRunner = self.setup_test_query_runner_class()
-
-        runner = TestQueryRunner(query={"some_attr": "bla", "other_attr": []}, team=self.team)
-
-        json = runner.to_json()
-        self.assertEqual(json, '{"some_attr":"bla"}')
-
     def test_cache_key(self):
         TestQueryRunner = self.setup_test_query_runner_class()
         # set the pk directly as it affects the hash in the _cache_key call

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -1,0 +1,81 @@
+from pydantic import BaseModel
+
+from posthog.schema import (
+    FunnelStepReference,
+    FunnelsFilter,
+    FunnelsQuery,
+    FunnelVizType,
+    FunnelConversionWindowTimeUnit,
+    FunnelLayout,
+    BreakdownAttributionType,
+    StepOrderValue,
+)
+
+
+def clean_funnels_filter(funnelsFilter: FunnelsFilter | None) -> FunnelsFilter:
+    if funnelsFilter is None:
+        funnelsFilter = FunnelsFilter()
+
+    # binCount: Optional[int] = None
+    if funnelsFilter.funnelVizType != FunnelVizType.time_to_convert:
+        funnelsFilter.binCount = None
+
+    # breakdownAttributionType: Optional[BreakdownAttributionType] = None
+    if funnelsFilter.breakdownAttributionType == BreakdownAttributionType.first_touch:
+        funnelsFilter.breakdownAttributionType = None
+
+    # breakdownAttributionValue: Optional[int] = None
+    if funnelsFilter.breakdownAttributionType != BreakdownAttributionType.step:
+        funnelsFilter.breakdownAttributionValue = None
+
+    # exclusions: Optional[list[Union[FunnelExclusionEventsNode, FunnelExclusionActionsNode]]] = None
+    if funnelsFilter.exclusions == []:
+        funnelsFilter.exclusions = None
+
+    # funnelAggregateByHogQL: Optional[str] = None
+    if funnelsFilter.funnelAggregateByHogQL == "":
+        funnelsFilter.funnelAggregateByHogQL = None
+
+    # funnelFromStep: Optional[int] = None
+    # funnelToStep: Optional[int] = None
+
+    # funnelOrderType: Optional[StepOrderValue] = None
+    if funnelsFilter.funnelOrderType == StepOrderValue.ordered:
+        funnelsFilter.funnelOrderType = None
+
+    # funnelStepReference: Optional[FunnelStepReference] = None
+    if funnelsFilter.funnelStepReference == FunnelStepReference.total:
+        funnelsFilter.funnelStepReference = None
+
+    # funnelVizType: Optional[FunnelVizType] = None
+    if funnelsFilter.funnelVizType == FunnelVizType.steps:
+        funnelsFilter.funnelVizType = None
+
+    # funnelWindowInterval: Optional[int] = None
+    if funnelsFilter.funnelWindowInterval == 14:
+        funnelsFilter.funnelWindowInterval = None
+
+    # funnelWindowIntervalUnit: Optional[FunnelConversionWindowTimeUnit] = None
+    if funnelsFilter.funnelWindowIntervalUnit == FunnelConversionWindowTimeUnit.day:
+        funnelsFilter.funnelWindowIntervalUnit = None
+
+    # hidden_legend_breakdowns: Optional[list[str]] = None
+    if funnelsFilter.hidden_legend_breakdowns is not None:
+        funnelsFilter.hidden_legend_breakdowns = None
+
+    # layout: Optional[FunnelLayout] = None
+    if funnelsFilter.layout == FunnelLayout.vertical:
+        funnelsFilter.layout = None
+
+    return funnelsFilter
+
+
+def clean_query(query: FunnelsQuery) -> FunnelsQuery:
+    query.funnelsFilter = clean_funnels_filter(query.funnelsFilter)
+    return query
+
+
+def to_json(query: BaseModel) -> str:
+    if isinstance(query, FunnelsQuery):
+        query = clean_query(query)
+    return query.model_dump_json(exclude_defaults=True, exclude_none=True)

--- a/posthog/test/test_schema_helpers.py
+++ b/posthog/test/test_schema_helpers.py
@@ -1,0 +1,104 @@
+import json
+from typing import Any
+from parameterized import parameterized
+
+from django.test.testcases import TestCase
+
+from posthog.schema import (
+    FunnelConversionWindowTimeUnit,
+    FunnelExclusionEventsNode,
+    FunnelStepReference,
+    FunnelsQuery,
+    FunnelVizType,
+    FunnelLayout,
+    StepOrderValue,
+    BreakdownAttributionType,
+)
+from posthog.schema_helpers import to_json
+
+
+base_funnel: dict[str, Any] = {"series": []}
+
+
+class TestSchemaHelpers(TestCase):
+    maxDiff = None
+
+    @parameterized.expand(
+        [
+            # general: missing filter
+            (None, {}, 0),
+            # general: ordering of keys
+            (
+                {"funnelVizType": FunnelVizType.time_to_convert, "funnelOrderType": StepOrderValue.strict},
+                {"funnelOrderType": StepOrderValue.strict, "funnelVizType": FunnelVizType.time_to_convert},
+                2,
+            ),
+            # binCount
+            ({}, {"binCount": 4}, 0),
+            (
+                {"binCount": 4, "funnelVizType": FunnelVizType.time_to_convert},
+                {"binCount": 4, "funnelVizType": FunnelVizType.time_to_convert},
+                2,
+            ),
+            # breakdownAttributionType
+            ({}, {"breakdownAttributionType": BreakdownAttributionType.first_touch}, 0),
+            (
+                {"breakdownAttributionType": BreakdownAttributionType.last_touch},
+                {"breakdownAttributionType": BreakdownAttributionType.last_touch},
+                1,
+            ),
+            # breakdownAttributionValue
+            ({}, {"breakdownAttributionValue": 2}, 0),
+            (
+                {"breakdownAttributionType": BreakdownAttributionType.step, "breakdownAttributionValue": 2},
+                {"breakdownAttributionType": BreakdownAttributionType.step, "breakdownAttributionValue": 2},
+                2,
+            ),
+            # exclusions
+            ({}, {"exclusions": []}, 0),
+            (
+                {"exclusions": [FunnelExclusionEventsNode(funnelFromStep=0, funnelToStep=1)]},
+                {"exclusions": [FunnelExclusionEventsNode(funnelFromStep=0, funnelToStep=1)]},
+                1,
+            ),
+            # funnelAggregateByHogQL
+            ({}, {"funnelAggregateByHogQL": ""}, 0),
+            ({"funnelAggregateByHogQL": "distinct_id"}, {"funnelAggregateByHogQL": "distinct_id"}, 1),
+            # funnelFromStep and funnelToStep
+            ({"funnelFromStep": 1, "funnelToStep": 2}, {"funnelFromStep": 1, "funnelToStep": 2}, 2),
+            # funnelOrderType
+            ({}, {"funnelOrderType": StepOrderValue.ordered}, 0),
+            ({"funnelOrderType": StepOrderValue.strict}, {"funnelOrderType": StepOrderValue.strict}, 1),
+            # funnelStepReference
+            ({}, {"funnelStepReference": FunnelStepReference.total}, 0),
+            (
+                {"funnelStepReference": FunnelStepReference.previous},
+                {"funnelStepReference": FunnelStepReference.previous},
+                1,
+            ),
+            # funnelVizType
+            ({}, {"funnelVizType": FunnelVizType.steps}, 0),
+            ({"funnelVizType": FunnelVizType.trends}, {"funnelVizType": FunnelVizType.trends}, 1),
+            # funnelWindowInterval
+            ({}, {"funnelWindowInterval": 14}, 0),
+            ({"funnelWindowInterval": 12}, {"funnelWindowInterval": 12}, 1),
+            # funnelWindowIntervalUnit
+            ({}, {"funnelWindowIntervalUnit": FunnelConversionWindowTimeUnit.day}, 0),
+            (
+                {"funnelWindowIntervalUnit": FunnelConversionWindowTimeUnit.week},
+                {"funnelWindowIntervalUnit": FunnelConversionWindowTimeUnit.week},
+                1,
+            ),
+            # hidden_legend_breakdowns
+            ({}, {"hidden_legend_breakdowns": []}, 0),
+            # layout
+            ({}, {"layout": FunnelLayout.vertical}, 0),
+            ({"layout": FunnelLayout.horizontal}, {"layout": FunnelLayout.horizontal}, 1),
+        ]
+    )
+    def test_clean_query_funnel_filter(self, f1, f2, num_keys):
+        q1 = FunnelsQuery(**base_funnel, funnelsFilter=f1)
+        q2 = FunnelsQuery(**base_funnel, funnelsFilter=f2)
+
+        self.assertEqual(to_json(q1), to_json(q2))
+        self.assertEqual(num_keys, len(json.loads(to_json(q1))["funnelsFilter"].keys()))


### PR DESCRIPTION
## Problem

Cache keys for unset and default values are differning. This is a problem, since queries are passed in from the frontend (regular insights `/api/projects/1/query/`) and derived on the backend (`/api/projects/1/insights/56/?refresh=true&from_dashboard=15`).

## Changes

This PR adds a `clean_query` method that cleans the `funnelsFilter` of funnel queries for now. 

I've been thinking about other ways to avoid adding another dreaded cleaning function, but haven't found a smart way. Pydantic would support removing default values during serialization, but we're auto generating the schema file and there is no good way (that I can see) to adapt the generated classes.

## How did you test this code?

Verified a previously differing cache key is now the same