### PR TITLE
fix: stop swallowing grpc errors in delete

### DIFF
--- a/posthog/api/proxy_record.py
+++ b/posthog/api/proxy_record.py
@@ -83,7 +83,6 @@ class ProxyRecordViewset(TeamAndOrgViewSetMixin, ModelViewSet):
         if record and record.status in (ProxyRecord.Status.WAITING, ProxyRecord.Status.ERRORING):
             record.delete()
         elif record:
-            record.status = ProxyRecord.Status.DELETING
             temporal = sync_connect()
             inputs = DeleteHostedProxyInputs(
                 organization_id=record.organization_id,
@@ -99,6 +98,7 @@ class ProxyRecordViewset(TeamAndOrgViewSetMixin, ModelViewSet):
                     task_queue=GENERAL_PURPOSE_TASK_QUEUE,
                 )
             )
+            record.status = ProxyRecord.Status.DELETING
             record.save()
 
         return Response(

--- a/posthog/temporal/proxy_service/create.py
+++ b/posthog/temporal/proxy_service/create.py
@@ -97,6 +97,7 @@ async def create_hosted_proxy(inputs: CreateHostedProxyInputs):
     except grpc.aio.AioRpcError as e:
         if e.code() == grpc.StatusCode.INVALID_ARGUMENT:
             raise NonRetriableException("invalid argument") from e
+        raise
 
 
 @activity.defn

--- a/posthog/temporal/proxy_service/delete.py
+++ b/posthog/temporal/proxy_service/delete.py
@@ -77,6 +77,9 @@ async def delete_hosted_proxy(inputs: DeleteHostedProxyInputs):
     except grpc.aio.AioRpcError as e:
         if e.code() == grpc.StatusCode.INVALID_ARGUMENT:
             raise NonRetriableException("invalid argument") from e
+        if e.code() == grpc.StatusCode.NOT_FOUND:
+            raise NonRetriableException("not found") from e
+        raise
 
 
 @workflow.defn(name="delete-proxy")


### PR DESCRIPTION
## Problem

we were catching some errors to throw NonRetriableErrors but forgot to re-raise other errors, silently swallowing them

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
