### PR TITLE
fix: Remove time sensitive from team api

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -44,7 +44,6 @@ from posthog.permissions import (
     OrganizationMemberPermissions,
     TeamMemberLightManagementPermission,
     TeamMemberStrictManagementPermission,
-    TimeSensitiveActionPermission,
     get_organization_from_view,
 )
 from posthog.tasks.demo_create_data import create_data_for_demo_team

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -429,7 +429,6 @@ class TeamViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             IsAuthenticated,
             APIScopePermission,
             PremiumMultiProjectPermissions,
-            TimeSensitiveActionPermission,
             *self.permission_classes,
         ]
 


### PR DESCRIPTION
## Problem

This is causing issues. Ideally we would protect team settings this way but we need to come up with a better flow for it.

## Changes

* Removes time sensitive permission from team api
 
👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
