### PR TITLE
fix: make sure available features get set

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -344,6 +344,11 @@ class BillingManager:
                 org_modified = True
                 sync_org_quota_limits(organization)
 
+        available_features = data.get("available_features", None)
+        if available_features and available_features != organization.available_features:
+            organization.available_features = data["available_features"]
+            org_modified = True
+
         available_product_features = data.get("available_product_features", None)
         if available_product_features and available_product_features != organization.available_product_features:
             organization.available_product_features = data["available_product_features"]


### PR DESCRIPTION
We're moving from `available_features` to `available_product_features` and the code to set `available_features` was removed even though we are still using them for permission checks.

see https://github.com/PostHog/posthog/pull/22337 for original change