### PR TITLE
fix: refactor proxy polling

### DIFF
--- a/frontend/src/scenes/settings/project/proxyLogic.ts
+++ b/frontend/src/scenes/settings/project/proxyLogic.ts
@@ -55,19 +55,10 @@ export const proxyLogic = kea<proxyLogicType>([
             },
         },
     })),
-    listeners(({ actions, values, cache }) => ({
+    listeners(({ actions }) => ({
         collapseForm: () => actions.loadRecords(),
         deleteRecordFailure: () => actions.loadRecords(),
-        deleteRecordSuccess: () => actions.loadRecords(),
         createRecordSuccess: () => actions.loadRecords(),
-        loadRecordsSuccess: () => {
-            const shouldRefresh = values.proxyRecords.some((r) => ['waiting', 'issuing', 'deleting'].includes(r.status))
-            if (shouldRefresh) {
-                cache.refreshTimeout = setTimeout(() => {
-                    actions.loadRecords()
-                }, 5000)
-            }
-        },
     })),
     forms(({ actions }) => ({
         createRecord: {
@@ -84,8 +75,14 @@ export const proxyLogic = kea<proxyLogicType>([
             },
         },
     })),
-    afterMount(({ actions }) => {
+    afterMount(({ actions, values, cache }) => {
         actions.loadRecords()
+        cache.refreshTimeout = setTimeout(() => {
+            const shouldRefresh = values.proxyRecords.some((r) => ['waiting', 'issuing', 'deleting'].includes(r.status))
+            if (shouldRefresh) {
+                actions.loadRecords()
+            }
+        }, 5000)
     }),
     beforeUnmount(({ cache }) => {
         if (cache.refreshTimeout) {


### PR DESCRIPTION
## Problem

previously we started polling manually but we often got into a state where the polling was not running when it should have been

instead make it so the polling is always running, but only does the network fetch if it needs to at the time

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
