### PR TITLE
feat(personless-events): Change persons join for personless events

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -212,6 +212,7 @@ export const FEATURE_FLAGS = {
     SESSION_REPLAY_ARTIFICIAL_LAG: 'artificial-lag-query-performance', // owner: #team-replay
     PROXY_AS_A_SERVICE: 'proxy-as-a-service', // owner: #team-infrastructure
     ENABLE_SESSION_REPLAY_PA_ONBOARDING: 'enable-session-replay-pa-onboarding', // owner: #team-growth
+    SETTINGS_PERSONS_JOIN_MODE: 'settings-persons-join-mode', // owner: @robbie-c
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -347,6 +347,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         ) => ({ component, project_timezone, device_timezone }),
         reportTestAccountFiltersUpdated: (filters: Record<string, any>[]) => ({ filters }),
         reportPoEModeUpdated: (mode: string) => ({ mode }),
+        reportPersonsJoinModeUpdated: (mode: string) => ({ mode }),
         reportPropertySelectOpened: true,
         reportCreatedDashboardFromModal: true,
         reportSavedInsightToDashboard: true,
@@ -823,6 +824,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         },
         reportPoEModeUpdated: async ({ mode }) => {
             posthog.capture('persons on events mode updated', { mode })
+        },
+        reportPersonJoinModeUpdated: async ({ mode }) => {
+            posthog.capture('persons join mode updated', { mode })
         },
         reportInsightFilterRemoved: async ({ index }) => {
             posthog.capture('local filter removed', { index })

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -4145,7 +4145,7 @@
                     "type": "string"
                 },
                 "personsJoinMode": {
-                    "enum": ["inner_excluding_deleted", "left"],
+                    "enum": ["inner", "left"],
                     "type": "string"
                 },
                 "personsOnEventsMode": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -4144,6 +4144,10 @@
                     "enum": ["auto", "v1", "v2"],
                     "type": "string"
                 },
+                "personsJoinMode": {
+                    "enum": ["inner_excluding_deleted", "left"],
+                    "type": "string"
+                },
                 "personsOnEventsMode": {
                     "enum": [
                         "disabled",

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -197,6 +197,7 @@ export interface HogQLQueryModifiers {
     dataWarehouseEventsModifiers?: DataWarehouseEventsModifier[]
     debug?: boolean
     s3TableUseInvalidColumns?: boolean
+    personsJoinMode?: 'inner_excluding_deleted' | 'left'
 }
 
 export interface DataWarehouseEventsModifier {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -197,7 +197,7 @@ export interface HogQLQueryModifiers {
     dataWarehouseEventsModifiers?: DataWarehouseEventsModifier[]
     debug?: boolean
     s3TableUseInvalidColumns?: boolean
-    personsJoinMode?: 'inner_excluding_deleted' | 'left'
+    personsJoinMode?: 'inner' | 'left'
 }
 
 export interface DataWarehouseEventsModifier {

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -1,3 +1,4 @@
+import { PersonsJoinMode } from 'scenes/settings/project/PersonsJoinMode'
 import { PersonsOnEvents } from 'scenes/settings/project/PersonsOnEvents'
 
 import { Invites } from './organization/Invites'
@@ -151,6 +152,12 @@ export const SettingsMap: SettingSection[] = [
                 id: 'group-analytics',
                 title: 'Group analytics',
                 component: <GroupAnalyticsConfig />,
+            },
+            {
+                id: 'persons-join-mode',
+                title: 'Persons join mode',
+                component: <PersonsJoinMode />,
+                flag: 'SETTINGS_PERSONS_JOIN_MODE',
             },
         ],
     },

--- a/frontend/src/scenes/settings/project/PersonsJoinMode.tsx
+++ b/frontend/src/scenes/settings/project/PersonsJoinMode.tsx
@@ -1,0 +1,68 @@
+import { useActions, useValues } from 'kea'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonRadio, LemonRadioOption } from 'lib/lemon-ui/LemonRadio'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { useState } from 'react'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { HogQLQueryModifiers } from '~/queries/schema'
+
+type PersonsJoinMode = NonNullable<HogQLQueryModifiers['personsJoinMode']>
+
+const personsJoinOpttions: LemonRadioOption<PersonsJoinMode>[] = [
+    {
+        value: 'inner_excluding_deleted',
+        label: (
+            <>
+                <div>Does an inner join, and excludes soft-deleted users</div>
+                <div className="text-muted">
+                    This is the default. You want this one unless you know what you are doing.
+                </div>
+            </>
+        ),
+    },
+    {
+        value: 'left',
+        label: (
+            <>
+                <div>Does a left join.</div>
+                <div className="text-muted">Experimental mode for personless events </div>
+            </>
+        ),
+    },
+]
+
+export function PersonsJoinMode(): JSX.Element {
+    const { updateCurrentTeam } = useActions(teamLogic)
+    const { currentTeam } = useValues(teamLogic)
+    const { reportPersonsJoinModeUpdated } = useActions(eventUsageLogic)
+
+    const savedPersonsJoinMode =
+        currentTeam?.modifiers?.personsJoinMode ??
+        currentTeam?.default_modifiers?.personsJoinMode ??
+        'inner_excluding_deleted'
+    const [personsJoinMode, setPersonsJoinMode] = useState<PersonsJoinMode>(savedPersonsJoinMode)
+
+    const handleChange = (mode: PersonsJoinMode): void => {
+        updateCurrentTeam({ modifiers: { ...currentTeam?.modifiers, personsJoinMode: mode } })
+        reportPersonsJoinModeUpdated(mode)
+    }
+
+    return (
+        <>
+            <p>
+                Choose how persons are joined to events. Do not change this setting unless you know what you are doing.
+            </p>
+            <LemonRadio value={personsJoinMode} onChange={setPersonsJoinMode} options={personsJoinOpttions} />
+            <div className="mt-4">
+                <LemonButton
+                    type="primary"
+                    onClick={() => handleChange(personsJoinMode)}
+                    disabledReason={personsJoinMode === savedPersonsJoinMode ? 'No changes to save' : undefined}
+                >
+                    Save
+                </LemonButton>
+            </div>
+        </>
+    )
+}

--- a/frontend/src/scenes/settings/project/PersonsJoinMode.tsx
+++ b/frontend/src/scenes/settings/project/PersonsJoinMode.tsx
@@ -14,7 +14,7 @@ const personsJoinOptions: LemonRadioOption<PersonsJoinMode>[] = [
         value: 'inner',
         label: (
             <>
-                <div>Does an inner join, and excludes soft-deleted users</div>
+                <div>Does an inner join</div>
                 <div className="text-muted">
                     This is the default. You want this one unless you know what you are doing.
                 </div>

--- a/frontend/src/scenes/settings/project/PersonsJoinMode.tsx
+++ b/frontend/src/scenes/settings/project/PersonsJoinMode.tsx
@@ -9,9 +9,9 @@ import { HogQLQueryModifiers } from '~/queries/schema'
 
 type PersonsJoinMode = NonNullable<HogQLQueryModifiers['personsJoinMode']>
 
-const personsJoinOpttions: LemonRadioOption<PersonsJoinMode>[] = [
+const personsJoinOptions: LemonRadioOption<PersonsJoinMode>[] = [
     {
-        value: 'inner_excluding_deleted',
+        value: 'inner',
         label: (
             <>
                 <div>Does an inner join, and excludes soft-deleted users</div>
@@ -38,9 +38,7 @@ export function PersonsJoinMode(): JSX.Element {
     const { reportPersonsJoinModeUpdated } = useActions(eventUsageLogic)
 
     const savedPersonsJoinMode =
-        currentTeam?.modifiers?.personsJoinMode ??
-        currentTeam?.default_modifiers?.personsJoinMode ??
-        'inner_excluding_deleted'
+        currentTeam?.modifiers?.personsJoinMode ?? currentTeam?.default_modifiers?.personsJoinMode ?? 'inner'
     const [personsJoinMode, setPersonsJoinMode] = useState<PersonsJoinMode>(savedPersonsJoinMode)
 
     const handleChange = (mode: PersonsJoinMode): void => {
@@ -53,7 +51,7 @@ export function PersonsJoinMode(): JSX.Element {
             <p>
                 Choose how persons are joined to events. Do not change this setting unless you know what you are doing.
             </p>
-            <LemonRadio value={personsJoinMode} onChange={setPersonsJoinMode} options={personsJoinOpttions} />
+            <LemonRadio value={personsJoinMode} onChange={setPersonsJoinMode} options={personsJoinOptions} />
             <div className="mt-4">
                 <LemonButton
                     type="primary"

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -80,6 +80,7 @@ export type SettingId =
     | 'replay-ai-config'
     | 'heatmaps'
     | 'hedgehog-mode'
+    | 'persons-join-mode'
 
 export type Setting = {
     id: SettingId

--- a/posthog/hogql/database/schema/persons.py
+++ b/posthog/hogql/database/schema/persons.py
@@ -56,7 +56,6 @@ def select_from_persons_table(requested_fields: dict[str, list[str | int]], modi
             )
             """
         )
-
         query.settings = HogQLQuerySettings(optimize_aggregation_in_order=True)
 
         for field_name, field_chain in requested_fields.items():

--- a/posthog/hogql/database/schema/persons.py
+++ b/posthog/hogql/database/schema/persons.py
@@ -49,11 +49,7 @@ def select_from_persons_table(requested_fields: dict[str, list[str | int]], modi
         if modifiers.personsJoinMode == PersonsJoinMode.left:
             query = parse_select(
                 """
-                SELECT id FROM raw_persons WHERE (id, version) IN (
-                   SELECT id, max(version) as version
-                   FROM raw_persons
-                   GROUP BY id
-                )
+                SELECT DISTINCT id FROM raw_persons
                 """
             )
         else:

--- a/posthog/hogql/database/schema/persons_pdi.py
+++ b/posthog/hogql/database/schema/persons_pdi.py
@@ -9,6 +9,7 @@ from posthog.hogql.database.models import (
     FieldOrTable,
 )
 from posthog.hogql.errors import ResolutionError
+from posthog.schema import PersonsJoinMode
 
 
 # :NOTE: We already have person_distinct_ids.py, which most tables link to. This persons_pdi.py is a hack to
@@ -40,7 +41,10 @@ def persons_pdi_join(
     if not requested_fields:
         raise ResolutionError("No fields requested from person_distinct_ids")
     join_expr = ast.JoinExpr(table=persons_pdi_select(requested_fields))
-    join_expr.join_type = "INNER JOIN"
+    if context.modifiers.personsJoinMode == PersonsJoinMode.left:
+        join_expr.join_type = "LEFT JOIN"
+    else:
+        join_expr.join_type = "INNER JOIN"
     join_expr.alias = to_table
     join_expr.constraint = ast.JoinConstraint(
         expr=ast.CompareOperation(

--- a/posthog/hogql/modifiers.py
+++ b/posthog/hogql/modifiers.py
@@ -6,6 +6,7 @@ from posthog.schema import (
     MaterializationMode,
     PersonsArgMaxVersion,
     PersonsOnEventsMode,
+    PersonsJoinMode,
 )
 
 if TYPE_CHECKING:
@@ -42,6 +43,9 @@ def set_default_modifier_values(modifiers: HogQLQueryModifiers, team: "Team"):
 
     if modifiers.materializationMode is None or modifiers.materializationMode == MaterializationMode.auto:
         modifiers.materializationMode = MaterializationMode.legacy_null_as_null
+
+    if modifiers.personsJoinMode is None:
+        modifiers.personsJoinMode = PersonsJoinMode.inner
 
 
 def set_default_in_cohort_via(modifiers: HogQLQueryModifiers) -> HogQLQueryModifiers:

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -79,7 +79,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_151bd63c5cbbbcb8dec547811cc684f4")
+        self.assertEqual(cache_key, "cache_0d86ca6e2a5198f7831e45a9cfef74bf")
 
     def test_cache_key_runner_subclass(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -93,7 +93,7 @@ class TestQueryRunner(BaseTest):
         runner = TestSubclassQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_23f3317da40b07e4ce7796c4bbd1615c")
+        self.assertEqual(cache_key, "cache_1d3b5f01b09c6df03e60e0c88a24c12b")
 
     def test_cache_key_different_timezone(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -104,7 +104,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_a687040d3a8e4116afbab194490be520")
+        self.assertEqual(cache_key, "cache_fb3bac966786fa05510fec5401803b8b")
 
     def test_cache_response(self):
         TestQueryRunner = self.setup_test_query_runner_class()

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -512,6 +512,11 @@ class PersonsArgMaxVersion(str, Enum):
     v2 = "v2"
 
 
+class PersonsJoinMode(str, Enum):
+    inner_excluding_deleted = "inner_excluding_deleted"
+    left = "left"
+
+
 class PersonsOnEventsMode(str, Enum):
     disabled = "disabled"
     person_id_no_override_properties_on_events = "person_id_no_override_properties_on_events"
@@ -528,6 +533,7 @@ class HogQLQueryModifiers(BaseModel):
     inCohortVia: Optional[InCohortVia] = None
     materializationMode: Optional[MaterializationMode] = None
     personsArgMaxVersion: Optional[PersonsArgMaxVersion] = None
+    personsJoinMode: Optional[PersonsJoinMode] = None
     personsOnEventsMode: Optional[PersonsOnEventsMode] = None
     s3TableUseInvalidColumns: Optional[bool] = None
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -513,7 +513,7 @@ class PersonsArgMaxVersion(str, Enum):
 
 
 class PersonsJoinMode(str, Enum):
-    inner_excluding_deleted = "inner_excluding_deleted"
+    inner = "inner"
     left = "left"
 
 


### PR DESCRIPTION
## Problem

See internal thread here https://posthog.slack.com/archives/C06R39WNY5B/p1716305779378389?thread_ts=1715617239.055309&cid=C06R39WNY5B

Should we also change how we handle soft deletes? Answer: no
From @tiina303:
> we should keep the deleted filtering as is (iiuc we run the same code for person page filter persons as we do in insights and person page query should definitely exclude deleted person) and only do inner join -> left join change.
This would mean that event.person_properties mode as before would show all events including events tied to deleted persons. person.properties  would also, because if we filter out deleted persons in the subquery, then left join treats them the same way as personless.

## Changes

Adds a new persons join mode (changes the inner join to a left join), behind a Setting behind a FF so that we can test internally

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

This PR is mostly what enables testing
