### PR TITLE
fix: pipeline-3000 multiple creation

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -653,15 +653,6 @@ class PluginConfigSerializer(serializers.ModelSerializer):
             raise ValidationError("Plugin configuration is not available for the current organization!")
         validated_data["team_id"] = self.context["team_id"]
         _fix_formdata_config_json(self.context["request"], validated_data)
-        # Legacy pipeline UI doesn't show multiple plugin configs per plugin, so we don't allow it
-        # pipeline 3000 UI does, but to keep things simple we for now pass this flag to not break old users
-        # name field is something that only the new UI sends
-        if "config" not in validated_data or "name" not in validated_data["config"]:
-            existing_config = PluginConfig.objects.filter(
-                team_id=validated_data["team_id"], plugin_id=validated_data["plugin"]
-            )
-            if existing_config.exists():
-                return self.update(existing_config.first(), validated_data)  # type: ignore
 
         validated_data["web_token"] = generate_random_token()
         plugin_config = super().create(validated_data)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Something changed somewhere, but it doesn't matter we can just remove the safeguard that legacy UI needed since we're about to nuke it. 
The unlikely problem old UI will run into is that if a user clicks on create multiple times they might get two and it doesn't show both. They can view them in the new UI and remove one.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
