### PR TITLE
fix(insights): Fix early exit hooks error from loading bar flag

### DIFF
--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -177,11 +177,12 @@ export function InsightLoadingState({
     insightProps: InsightLogicProps
 }): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
+    const { suggestedSamplingPercentage, samplingPercentage } = useValues(samplingFilterLogic(insightProps))
+
     if (featureFlags[FEATURE_FLAGS.INSIGHT_LOADING_BAR]) {
         return <InsightLoadingStateWithLoadingBar queryId={queryId} insightProps={insightProps} />
     }
 
-    const { suggestedSamplingPercentage, samplingPercentage } = useValues(samplingFilterLogic(insightProps))
     return (
         <div className="insight-empty-state warning">
             <Animation type={AnimationType.LaptopHog} />


### PR DESCRIPTION
## Problem

Logged in as a customer to check out an insight issue, and ran into the "Rendered fewer hooks than expected. This may be caused by an accidental early return statement." error. This is because `InsightLoadingState` can sometimes calls `useValues(samplingFilterLogic(insightProps))`, and sometimes it exits before that. Normally isn't an issue here, but it does become when when logging in as a customer, because you go from flag enabled to flag disabled without full reload.
 
## Changes

React components must always call the same hooks, i.e. hooks can't be depended on `if`s. Refactored the component so that we avoid the bug.