### PR TITLE
refactor(insightTooltipUtils): Splits getFormattedDate to new getFormattedTimeInterval method

### DIFF
--- a/cypress/e2e/insights-canvas-tooltips.cy.ts
+++ b/cypress/e2e/insights-canvas-tooltips.cy.ts
@@ -1,0 +1,48 @@
+import { urls } from 'scenes/urls'
+
+// For tests related to trends please check trendsElements.js
+// insight tests were split up because Cypress was struggling with this many tests in one file🙈
+describe('Insights', () => {
+    beforeEach(() => {
+        cy.visit(urls.insightNew())
+    })
+
+    it('Trend graph tooltip it not empty', () => {
+        cy.get('[role=tab]').contains('Trends').click()
+        cy.get('[data-attr=date-filter]').click()
+        cy.get('.Popover__box .LemonButton__content').contains('Last 14 days').click()
+        cy.get('.LineGraph').should('exist')
+        cy.get('.LineGraph canvas').trigger('mousemove')
+        cy.get('.InsightTooltip .LemonTable').should('exist')
+        cy.get(
+            '.InsightTooltip .LemonTable .LemonTable__content .LemonTable__boundary .LemonTable__header-content >div>span'
+        ).should('not.be.empty')
+    })
+
+    it('Funnel historical graph tooltip it not empty', () => {
+        cy.get('[role=tab]').contains('Funnels').click()
+        cy.get('.EditorFilterGroup button.LemonSelect').contains('Conversion steps').click()
+        cy.get('.Popover__box .LemonButton__content').contains('Historical trends').click()
+        cy.get('[data-attr=add-action-event-button-empty-state]').click()
+        cy.get('[data-attr=date-filter]').click()
+        cy.get('.Popover__box .LemonButton__content').contains('Last 30 days').click()
+        cy.get('.LineGraph').should('exist')
+        cy.get('.LineGraph canvas').trigger('mousemove')
+        cy.get('.InsightTooltip .LemonTable').should('exist')
+        cy.get(
+            '.InsightTooltip .LemonTable .LemonTable__content .LemonTable__boundary .LemonTable__header-content >div>span'
+        ).should('not.be.empty')
+    })
+
+    it('Stickiness graph tooltip it not empty', () => {
+        cy.get('[role=tab]').contains('Stickiness').click()
+        cy.get('[data-attr=date-filter]').click()
+        cy.get('.Popover__box .LemonButton__content').contains('Last 30 days').click()
+        cy.get('.LineGraph').should('exist')
+        cy.get('.LineGraph canvas').trigger('mousemove')
+        cy.get('.InsightTooltip .LemonTable').should('exist')
+        cy.get('.InsightTooltip .LemonTable .LemonTable__content .LemonTable__boundary .LemonTable__header-content')
+            .contains(/^\d+\s+days?(.*)$/i)
+            .should('exist')
+    })
+})

--- a/cypress/e2e/insights-canvas-tooltips.cy.ts
+++ b/cypress/e2e/insights-canvas-tooltips.cy.ts
@@ -14,9 +14,9 @@ describe('Insights', () => {
         cy.get('.LineGraph').should('exist')
         cy.get('.LineGraph canvas').trigger('mousemove')
         cy.get('.InsightTooltip .LemonTable').should('exist')
-        cy.get(
-            '.InsightTooltip .LemonTable .LemonTable__content .LemonTable__boundary .LemonTable__header-content >div>span'
-        ).should('not.be.empty')
+        cy.get('.InsightTooltip .LemonTable .LemonTable__content .LemonTable__boundary .LemonTable__header-content')
+            .invoke('text')
+            .should('match', /^.+/i)
     })
 
     it('Funnel historical graph tooltip it not empty', () => {
@@ -29,9 +29,9 @@ describe('Insights', () => {
         cy.get('.LineGraph').should('exist')
         cy.get('.LineGraph canvas').trigger('mousemove')
         cy.get('.InsightTooltip .LemonTable').should('exist')
-        cy.get(
-            '.InsightTooltip .LemonTable .LemonTable__content .LemonTable__boundary .LemonTable__header-content >div>span'
-        ).should('not.be.empty')
+        cy.get('.InsightTooltip .LemonTable .LemonTable__content .LemonTable__boundary')
+            .invoke('text')
+            .should('match', /^.+/i)
     })
 
     it('Stickiness graph tooltip it not empty', () => {
@@ -42,7 +42,7 @@ describe('Insights', () => {
         cy.get('.LineGraph canvas').trigger('mousemove')
         cy.get('.InsightTooltip .LemonTable').should('exist')
         cy.get('.InsightTooltip .LemonTable .LemonTable__content .LemonTable__boundary .LemonTable__header-content')
-            .contains(/^\d+\s+days?(.*)$/i)
-            .should('exist')
+            .invoke('text')
+            .should('match', /^\d+\s+days?(.*)$/i)
     })
 })

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -13,7 +13,7 @@ import { FormatPropertyValueForDisplayFunction, propertyDefinitionsModel } from 
 
 import {
     COL_CUTOFF,
-    getFormattedDate,
+    getFormattedTimeInterval,
     getTooltipTitle,
     InsightTooltipProps,
     invertDataSource,
@@ -100,8 +100,8 @@ export function InsightTooltip({
 
     const title: ReactNode | null =
         getTooltipTitle(seriesData, altTitle, date) ||
-        (date
-            ? `${getFormattedDate(date, seriesData?.[0]?.filter?.interval)} (${
+        (date && typeof date === 'number'
+            ? `${getFormattedTimeInterval(date, seriesData?.[0]?.filter?.interval)} (${
                   timezone ? shortTimeZone(timezone) : 'UTC'
               })`
             : null)

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -13,6 +13,7 @@ import { FormatPropertyValueForDisplayFunction, propertyDefinitionsModel } from 
 
 import {
     COL_CUTOFF,
+    getFormattedDate,
     getFormattedTimeInterval,
     getTooltipTitle,
     InsightTooltipProps,
@@ -100,10 +101,14 @@ export function InsightTooltip({
 
     const title: ReactNode | null =
         getTooltipTitle(seriesData, altTitle, date) ||
-        (date && typeof date === 'number'
-            ? `${getFormattedTimeInterval(date, seriesData?.[0]?.filter?.interval)} (${
-                  timezone ? shortTimeZone(timezone) : 'UTC'
-              })`
+        (date
+            ? typeof date === 'string'
+                ? `${getFormattedDate(date, seriesData?.[0]?.filter?.interval)} (${
+                      timezone ? shortTimeZone(timezone) : 'UTC'
+                  })`
+                : `${getFormattedTimeInterval(date, seriesData?.[0]?.filter?.interval)} (${
+                      timezone ? shortTimeZone(timezone) : 'UTC'
+                  })`
             : null)
     const rightTitle: ReactNode | null = getTooltipTitle(seriesData, altRightTitle, date) || null
 

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.test.ts
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.test.ts
@@ -1,27 +1,13 @@
-import { getFormattedDate } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
+import {
+    getFormattedDate,
+    getFormattedTimeInterval,
+    getTooltipTitle,
+    SeriesDatum,
+} from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 
 import { IntervalType } from '~/types'
 
 describe('getFormattedDate', () => {
-    const paramsToExpectedWithNumericInput: [number, IntervalType, string][] = [
-        [1, 'minute', '1 minute'],
-        [2, 'minute', '2 minutes'],
-        [1, 'hour', '1 hour'],
-        [2, 'hour', '2 hours'],
-        [1, 'day', '1 day'],
-        [2, 'day', '2 days'],
-        [1, 'week', '1 week'],
-        [2, 'week', '2 weeks'],
-        [1, 'month', '1 month'],
-        [2, 'month', '2 months'],
-    ]
-
-    paramsToExpectedWithNumericInput.forEach(([input, intervall, expected]) => {
-        it(`expects "${expected}" for numeric input "${input}" and intervall "${intervall}"`, () => {
-            expect(getFormattedDate(input, intervall)).toEqual(expected)
-        })
-    })
-
     const paramsToExpectedWithDateString: [string, string][] = [
         ['2024-04-28', '28 Apr 2024'],
         ['2024-05-12', '12 May 2024'],
@@ -40,8 +26,52 @@ describe('getFormattedDate', () => {
             expect(getFormattedDate(input)).toEqual(expected)
         })
     })
+})
 
-    it('expects undefined string if no inputs', () => {
-        expect(getFormattedDate()).toEqual('undefined')
+describe('getFormattedTimeInterval', () => {
+    const paramsToExpectedWithNumericInput: [number, IntervalType, string][] = [
+        [1, 'minute', '1 minute'],
+        [2, 'minute', '2 minutes'],
+        [1, 'hour', '1 hour'],
+        [2, 'hour', '2 hours'],
+        [1, 'day', '1 day'],
+        [2, 'day', '2 days'],
+        [1, 'week', '1 week'],
+        [2, 'week', '2 weeks'],
+        [1, 'month', '1 month'],
+        [2, 'month', '2 months'],
+    ]
+
+    paramsToExpectedWithNumericInput.forEach(([input, intervall, expected]) => {
+        it(`expects "${expected}" for numeric input "${input}" and intervall "${intervall}"`, () => {
+            expect(getFormattedTimeInterval(input, intervall)).toEqual(expected)
+        })
+    })
+
+    it('expects defaults to input string "i am a string" for wrong string input "i am a string"', () => {
+        expect(getFormattedTimeInterval('i am a string' as any, 'day')).toEqual('i am a string')
+    })
+})
+
+describe('getTooltipTitle', () => {
+    const paramsToExpectedWithNumericInput: [
+        SeriesDatum[],
+        string | ((tooltipData: SeriesDatum[], date: string) => React.ReactNode) | undefined,
+        string | number | undefined,
+        React.ReactNode | null
+    ][] = [
+        [[], 'Users', '2024-04-28', 'Users'],
+        [[], 'Users', undefined, 'Users'],
+        [[], 'Users', 5, 'Users'],
+        [[], (_, date) => date, '2024-04-28', '28 Apr 2024'],
+        [[], (_, date) => date, undefined, null],
+        [[], (_, date) => date, 5, null],
+        [[], undefined, '2024-04-28', null],
+    ]
+
+    paramsToExpectedWithNumericInput.forEach(([seriesData, altTitleOrFn, date, expected]) => {
+        it(`expects "${expected}" for getTooltipTitle for 2nd argument of type "${typeof altTitleOrFn} and 3rd of type "${typeof date}"`, () => {
+            expect(getTooltipTitle(seriesData, altTitleOrFn, date)).toEqual(expected)
+        })
     })
 })

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -52,7 +52,7 @@ export interface InsightTooltipProps extends Omit<TooltipConfig, 'renderSeries' 
      * @default false
      */
     embedded?: boolean
-    date?: string
+    date?: string | number
     hideInspectActorsSection?: boolean
     seriesData: SeriesDatum[]
     formula?: boolean
@@ -66,12 +66,15 @@ export const ROW_CUTOFF = 8
 export function getTooltipTitle(
     seriesData: SeriesDatum[],
     altTitleOrFn?: string | ((tooltipData: SeriesDatum[], date: string) => React.ReactNode),
-    date?: string
+    date?: string | number
 ): React.ReactNode | null {
     // Use tooltip alternate title (or generate one if it's a function). Else default to date.
     if (altTitleOrFn) {
         if (typeof altTitleOrFn === 'function') {
-            return altTitleOrFn(seriesData, getFormattedDate(date))
+            if (typeof date === 'string') {
+                return altTitleOrFn(seriesData, getFormattedDate(date))
+            }
+            return null
         }
         return altTitleOrFn
     }
@@ -86,17 +89,22 @@ export const INTERVAL_UNIT_TO_DAYJS_FORMAT: Record<IntervalType, string> = {
     month: 'MMMM YYYY',
 }
 
-export function getFormattedDate(input?: string | number, interval: IntervalType = 'day'): string {
-    // Number of intervals (i.e. days, weeks)
-    if (Number.isInteger(input)) {
-        return pluralize(input as number, interval)
-    }
+export function getFormattedDate(input: string, interval: IntervalType = 'day'): string {
     const day = dayjs(input)
     // Dayjs formatted day
     if (input !== undefined && day.isValid()) {
         return day.format(INTERVAL_UNIT_TO_DAYJS_FORMAT[interval])
     }
     return String(input)
+}
+
+export function getFormattedTimeInterval(intervalAmount: number, interval: IntervalType = 'day'): string {
+    // Number of intervals (i.e. days, weeks)
+    if (Number.isInteger(intervalAmount)) {
+        return pluralize(intervalAmount, interval)
+    }
+
+    return String(intervalAmount)
 }
 
 export function invertDataSource(seriesData: SeriesDatum[]): InvertedSeriesDatum[] {


### PR DESCRIPTION
## "Problem"
In `insightTooltipUtils.tsx`, the method `getFormattedDate` may be overloaded. The method generates a formatted date, as the name implies, but it also generates an interval amount like "2 days, 4 weeks, ..." depending on the type of the first argument, which may not be intuitive for future maintainers.

## Propose
Extract the part for the interval amount from the method `getFormattedDate` into a new method `getFormattedTimeInterval`

## Changes
- Created a new method `getFormattedTimeInterval(intervalAmount: number, interval: IntervalType = 'day')``
- Changed Input type from `getFormattedDate` to string and make it required
- Changed the `InsightTooltipProps.date` to `string | number` to reflect the possibility that the date can either be a string (hopefully a date string) or a number
- Changed the `getTooltipTitle` method a bit to reflect the change that the date can be undefined or a number, which would result in a "bad" title
- Adds unit tests for `getFormattedTimeInterval` and `getTooltipTitle`

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Add a new insight on a dashboard, test the different tabs, and check if the tooltip is the same as before.
