### PR TITLE
feat: Use transformationsLogic instead of pluginsLogic for onboarding

### DIFF
--- a/frontend/src/scenes/onboarding/OnboardingProductConfiguration.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingProductConfiguration.tsx
@@ -1,7 +1,7 @@
 import { LemonDivider, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import React, { useEffect, useRef } from 'react'
-import { pluginsLogic } from 'scenes/plugins/pluginsLogic'
+import { pipelineDefaultEnabledLogic } from 'scenes/pipeline/pipelineDefaultEnabledLogic'
 
 import { OnboardingStepKey } from './onboardingLogic'
 import { onboardingProductConfigurationLogic, ProductConfigOption } from './onboardingProductConfigurationLogic'
@@ -26,19 +26,6 @@ type ConfigOption =
           onChange: (newValue: boolean) => void
       }
 
-interface PluginContent {
-    title: string
-    description: string
-}
-type PluginContentMapping = Record<string, PluginContent>
-const pluginContentMapping: PluginContentMapping = {
-    GeoIP: {
-        title: 'Capture location information',
-        description:
-            'Enrich PostHog events and persons with IP location data. This is useful for understanding where your users are coming from. This setting can be found under the data pipelines apps.',
-    },
-}
-
 export const OnboardingProductConfiguration = ({
     stepKey = OnboardingStepKey.PRODUCT_CONFIGURATION,
     options,
@@ -47,9 +34,9 @@ export const OnboardingProductConfiguration = ({
     options: (ProductConfigOption | undefined)[]
 }): JSX.Element | null => {
     const { configOptions } = useValues(onboardingProductConfigurationLogic)
-    const { defaultEnabledPlugins } = useValues(pluginsLogic)
+    const { pipelineDefaultEnabled } = useValues(pipelineDefaultEnabledLogic)
     const { setConfigOptions, saveConfiguration } = useActions(onboardingProductConfigurationLogic)
-    const { toggleEnabled } = useActions(pluginsLogic)
+    const { toggleEnabled } = useActions(pipelineDefaultEnabledLogic)
 
     const configOptionsRef = useRef(configOptions)
 
@@ -79,17 +66,16 @@ export const OnboardingProductConfiguration = ({
                     setConfigOptions(updatedConfigOptions)
                 },
             })),
-        ...defaultEnabledPlugins.map((plugin) => {
-            const pluginContent = pluginContentMapping[plugin.name]
+        ...pipelineDefaultEnabled.map((item) => {
             return {
-                title: pluginContent?.title || plugin.name,
-                description: pluginContent?.description || plugin.description,
+                title: item.title,
+                description: item.description,
                 type: 'plugin' as PluginType,
-                value: plugin.pluginConfig?.enabled || false,
-                onChange: (newValue: boolean) => {
+                value: item.enabled,
+                onChange: (enabled: boolean) => {
                     toggleEnabled({
-                        id: plugin.pluginConfig?.id,
-                        enabled: newValue,
+                        id: item.id,
+                        enabled: enabled,
                     })
                 },
             }

--- a/frontend/src/scenes/pipeline/pipelineDefaultEnabledLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineDefaultEnabledLogic.tsx
@@ -1,0 +1,55 @@
+import { connect, kea, path, selectors } from 'kea'
+
+import type { pipelineDefaultEnabledLogicType } from './pipelineDefaultEnabledLogicType'
+import { pipelineTransformationsLogic } from './transformationsLogic'
+
+interface PluginContent {
+    title: string
+    description: string
+}
+type PluginContentMapping = Record<string, PluginContent>
+const pluginContentMapping: PluginContentMapping = {
+    GeoIP: {
+        title: 'Capture location information',
+        description:
+            'Enrich PostHog events and persons with IP location data. This is useful for understanding where your users are coming from. This setting can be found under data pipeline.',
+    },
+}
+
+export interface DefaultEnabledType {
+    title: string
+    description?: string
+    id: number
+    enabled: boolean
+}
+
+export const pipelineDefaultEnabledLogic = kea<pipelineDefaultEnabledLogicType>([
+    path(['scenes', 'pipeline', 'pipelineDefaultEnabledLogic']),
+    connect({
+        values: [pipelineTransformationsLogic, ['plugins', 'pluginConfigs']],
+        actions: [pipelineTransformationsLogic, ['toggleEnabled']],
+    }),
+    selectors({
+        pipelineDefaultEnabled: [
+            (s) => [s.plugins, s.pluginConfigs],
+            (plugins, pluginConfigs): DefaultEnabledType[] => {
+                const defaultEnabledPluginIds = Object.values(plugins)
+                    .filter((plugin) => plugin.name in pluginContentMapping)
+                    .map((plugin) => plugin.id)
+                const defaultEnabledPluginConfigs = Object.values(pluginConfigs).filter((pluginConfig) =>
+                    defaultEnabledPluginIds.includes(pluginConfig.plugin)
+                )
+                return defaultEnabledPluginConfigs.map((pluginConfig) => {
+                    const plugin = plugins[pluginConfig.plugin]
+                    const pluginContent = pluginContentMapping[plugin.name]
+                    return {
+                        title: pluginContent?.title || plugin.name,
+                        description: pluginContent?.description || plugin.description,
+                        id: pluginConfig.id,
+                        enabled: pluginConfig.enabled,
+                    }
+                })
+            },
+        ],
+    }),
+])


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We're nuking pluginsLogic soon. We might want to default enable some destinations in the future - so I didn't want to put this into transformations

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
