### PR TITLE
fix: Simplify delete processing on ClickHouse by removing join table

### DIFF
--- a/posthog/management/commands/start_delete_mutation.py
+++ b/posthog/management/commands/start_delete_mutation.py
@@ -1,0 +1,25 @@
+import logging
+
+import structlog
+from django.core.management.base import BaseCommand
+
+from posthog.tasks.tasks import clickhouse_clear_removed_data
+
+logger = structlog.get_logger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class Command(BaseCommand):
+    help = (
+        "Kick off the job to remove all data associated with a team."
+        "Useful when you need data deleted asap (cannot wait for the scheduled job)"
+    )
+
+    def handle(self, *args, **options):
+        run()
+
+
+def run():
+    logger.info("Starting deletion of data for teams")
+    clickhouse_clear_removed_data()
+    logger.info("Finished deletion of data for teams")

--- a/posthog/models/async_deletion/async_deletion.py
+++ b/posthog/models/async_deletion/async_deletion.py
@@ -1,6 +1,9 @@
 from django.db import models
 
 
+MAX_QUERY_SIZE = 2_621_440
+
+
 class DeletionType(models.IntegerChoices):
     Team = 0
     Person = 1

--- a/posthog/models/async_deletion/async_deletion.py
+++ b/posthog/models/async_deletion/async_deletion.py
@@ -4,7 +4,7 @@ from django.db import models
 class DeletionType(models.IntegerChoices):
     Team = 0
     Person = 1
-    Group = 2  # IMPORTANT: Group deletions are not supported at the moment
+    Group = 2
     Cohort_stale = 3
     Cohort_full = 4
 
@@ -47,16 +47,3 @@ class AsyncDeletion(models.Model):
 
     # When was the data verified to be deleted - we can skip it in the next round
     delete_verified_at: models.DateTimeField = models.DateTimeField(null=True, blank=True)
-
-
-CLICKHOUSE_ASYNC_DELETION_TABLE = """
-CREATE OR REPLACE TABLE {table_name} ON CLUSTER '{cluster}'
-(
-    `id` UInt64,
-    `deletion_type` UInt8,
-    `key` String,
-    `group_type_index` String,
-    `team_id` Int64
-)
-ENGINE = Join(ANY, LEFT, team_id, deletion_type, key)
-"""

--- a/posthog/models/async_deletion/delete_cohorts.py
+++ b/posthog/models/async_deletion/delete_cohorts.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from posthog.client import sync_execute
-from posthog.models.async_deletion import AsyncDeletion, DeletionType
+from posthog.models.async_deletion import AsyncDeletion, DeletionType, MAX_QUERY_SIZE
 from posthog.models.async_deletion.delete import AsyncDeletionProcess, logger
 
 
@@ -29,6 +29,7 @@ class AsyncCohortDeletion(AsyncDeletionProcess):
             WHERE {" OR ".join(conditions)}
             """,
             args,
+            settings={"max_query_size": MAX_QUERY_SIZE},
         )
 
     def _verify_by_group(self, deletion_type: int, async_deletions: list[AsyncDeletion]) -> list[AsyncDeletion]:
@@ -49,6 +50,7 @@ class AsyncCohortDeletion(AsyncDeletionProcess):
             WHERE {" OR ".join(conditions)}
             """,
             args,
+            settings={"max_query_size": MAX_QUERY_SIZE},
         )
         return {tuple(row) for row in clickhouse_result}
 

--- a/posthog/models/async_deletion/delete_cohorts.py
+++ b/posthog/models/async_deletion/delete_cohorts.py
@@ -3,7 +3,6 @@ from typing import Any
 from posthog.client import sync_execute
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.async_deletion.delete import AsyncDeletionProcess, logger
-from posthog.clickhouse.client.connection import Workload
 
 
 class AsyncCohortDeletion(AsyncDeletionProcess):
@@ -30,7 +29,6 @@ class AsyncCohortDeletion(AsyncDeletionProcess):
             WHERE {" OR ".join(conditions)}
             """,
             args,
-            workload=Workload.OFFLINE,
         )
 
     def _verify_by_group(self, deletion_type: int, async_deletions: list[AsyncDeletion]) -> list[AsyncDeletion]:
@@ -51,7 +49,6 @@ class AsyncCohortDeletion(AsyncDeletionProcess):
             WHERE {" OR ".join(conditions)}
             """,
             args,
-            workload=Workload.OFFLINE,
         )
         return {tuple(row) for row in clickhouse_result}
 

--- a/posthog/models/async_deletion/delete_events.py
+++ b/posthog/models/async_deletion/delete_events.py
@@ -1,11 +1,9 @@
 from typing import Any
 
 from posthog.client import sync_execute
-from posthog.models.async_deletion import AsyncDeletion, DeletionType, CLICKHOUSE_ASYNC_DELETION_TABLE
+from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.async_deletion.delete import AsyncDeletionProcess, logger
-from posthog.clickhouse.client.connection import Workload
-from posthog.settings.data_stores import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE
-from posthog.clickhouse.client.escape import substitute_params
+from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
 
 # Note: Session recording, dead letter queue, logs deletion will be handled by TTL
 TABLES_TO_DELETE_TEAM_DATA_FROM = [
@@ -20,7 +18,7 @@ TABLES_TO_DELETE_TEAM_DATA_FROM = [
 
 
 class AsyncEventDeletion(AsyncDeletionProcess):
-    DELETION_TYPES = [DeletionType.Team, DeletionType.Person]
+    DELETION_TYPES = [DeletionType.Team, DeletionType.Group, DeletionType.Person]
 
     def process(self, deletions: list[AsyncDeletion]):
         if len(deletions) == 0:
@@ -36,29 +34,15 @@ class AsyncEventDeletion(AsyncDeletionProcess):
                 "team_ids": team_ids,
             },
         )
-        temp_table_name = f"{CLICKHOUSE_DATABASE}.async_deletion_run"
 
-        self._fill_table(deletions, temp_table_name)
-
-        # joinGet is not an obvious function to wrap your head around, but in this case it's essentially
-        # joinGet(async_deletion_run, [id, we're just looking for it to be non-zero], team_id, [deletion type], [key of the object to be deleted])
-        #
-        # the async_deletion_run table defines the keys you join on as (team_id, deletion_type, key)
-        # you always have to pass all of the join keys to joinGet
+        conditions, args = self._conditions(deletions)
         sync_execute(
             f"""
             ALTER TABLE sharded_events
             ON CLUSTER '{CLICKHOUSE_CLUSTER}'
-            DELETE
-            WHERE
-                team_id IN %(team_ids)s AND
-                (
-                    joinGet({temp_table_name}, 'id', team_id, 0, toString(team_id)) > 0 OR
-                    joinGet({temp_table_name}, 'id', team_id, 1, toString(person_id)) > 0
-                )
+            DELETE WHERE {" OR ".join(conditions)}
             """,
-            {"team_ids": team_ids},
-            workload=Workload.OFFLINE,
+            args,
         )
 
         # Team data needs to be deleted from other models as well, groups/persons handles deletions on a schema level
@@ -74,41 +58,15 @@ class AsyncEventDeletion(AsyncDeletionProcess):
                 "team_ids": list({row.team_id for row in deletions}),
             },
         )
+        conditions, args = self._conditions(team_deletions)
         for table in TABLES_TO_DELETE_TEAM_DATA_FROM:
             sync_execute(
                 f"""
                 ALTER TABLE {table}
                 ON CLUSTER '{CLICKHOUSE_CLUSTER}'
-                DELETE WHERE
-                team_id IN %(team_ids)s AND
-                joinGet({temp_table_name}, 'id', team_id, 0, toString(team_id)) > 0
+                DELETE WHERE {" OR ".join(conditions)}
                 """,
-                {"team_ids": [deletion.team_id for deletion in team_deletions]},
-                workload=Workload.OFFLINE,
-            )
-
-    def _fill_table(self, deletions: list[AsyncDeletion], temp_table_name: str):
-        sync_execute(f"DROP TABLE IF EXISTS {temp_table_name}", workload=Workload.OFFLINE)
-        sync_execute(
-            CLICKHOUSE_ASYNC_DELETION_TABLE.format(table_name=temp_table_name, cluster=CLICKHOUSE_CLUSTER),
-            workload=Workload.OFFLINE,
-        )
-
-        for i in range(0, len(deletions), 1000):
-            chunk = deletions[i : i + 1000]
-            append = []
-            for item in chunk:
-                append.append(
-                    substitute_params(
-                        "(%(id)s, %(deletion_type)s, %(key)s, %(group_type_index)s, %(team_id)s)", item.__dict__
-                    )
-                )
-
-            sync_execute(
-                "INSERT INTO {} (id, deletion_type, key, group_type_index, team_id) VALUES {}".format(
-                    temp_table_name, ",".join(append)
-                ),
-                workload=Workload.OFFLINE,
+                args,
             )
 
     def _verify_by_group(self, deletion_type: int, async_deletions: list[AsyncDeletion]) -> list[AsyncDeletion]:
@@ -131,7 +89,6 @@ class AsyncEventDeletion(AsyncDeletionProcess):
             WHERE {" OR ".join(conditions)}
             """,
             args,
-            workload=Workload.OFFLINE,
         )
         return {tuple(row) for row in clickhouse_result}
 

--- a/posthog/models/async_deletion/delete_events.py
+++ b/posthog/models/async_deletion/delete_events.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from posthog.client import sync_execute
-from posthog.models.async_deletion import AsyncDeletion, DeletionType
+from posthog.models.async_deletion import AsyncDeletion, DeletionType, MAX_QUERY_SIZE
 from posthog.models.async_deletion.delete import AsyncDeletionProcess, logger
 from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
 
@@ -43,6 +43,7 @@ class AsyncEventDeletion(AsyncDeletionProcess):
             DELETE WHERE {" OR ".join(conditions)}
             """,
             args,
+            settings={"max_query_size": MAX_QUERY_SIZE},
         )
 
         # Team data needs to be deleted from other models as well, groups/persons handles deletions on a schema level
@@ -67,6 +68,7 @@ class AsyncEventDeletion(AsyncDeletionProcess):
                 DELETE WHERE {" OR ".join(conditions)}
                 """,
                 args,
+                settings={"max_query_size": MAX_QUERY_SIZE},
             )
 
     def _verify_by_group(self, deletion_type: int, async_deletions: list[AsyncDeletion]) -> list[AsyncDeletion]:
@@ -89,6 +91,7 @@ class AsyncEventDeletion(AsyncDeletionProcess):
             WHERE {" OR ".join(conditions)}
             """,
             args,
+            settings={"max_query_size": MAX_QUERY_SIZE},
         )
         return {tuple(row) for row in clickhouse_result}
 

--- a/posthog/models/async_deletion/delete_person.py
+++ b/posthog/models/async_deletion/delete_person.py
@@ -1,12 +1,17 @@
 from posthog.clickhouse.client import sync_execute
 
+from posthog.models.async_deletion import MAX_QUERY_SIZE
+
+from posthog.clickhouse.client.connection import Workload
+
 
 def remove_deleted_person_data(mutations_sync=False):
-    settings = {"mutations_sync": 1 if mutations_sync else 0}
+    settings = {"mutations_sync": 1 if mutations_sync else 0, "max_query_size": MAX_QUERY_SIZE}
     sync_execute(
         """
         ALTER TABLE person
         DELETE WHERE id IN (SELECT id FROM person WHERE is_deleted > 0)
         """,
         settings=settings,
+        workload=Workload.OFFLINE,
     )

--- a/posthog/models/async_deletion/delete_person.py
+++ b/posthog/models/async_deletion/delete_person.py
@@ -1,9 +1,6 @@
 from posthog.clickhouse.client import sync_execute
 
 
-from posthog.clickhouse.client.connection import Workload
-
-
 def remove_deleted_person_data(mutations_sync=False):
     settings = {"mutations_sync": 1 if mutations_sync else 0}
     sync_execute(
@@ -12,5 +9,4 @@ def remove_deleted_person_data(mutations_sync=False):
         DELETE WHERE id IN (SELECT id FROM person WHERE is_deleted > 0)
         """,
         settings=settings,
-        workload=Workload.OFFLINE,
     )

--- a/posthog/models/async_deletion/test_delete_person.py
+++ b/posthog/models/async_deletion/test_delete_person.py
@@ -18,6 +18,6 @@ class TestDeletePerson(BaseTest, ClickhouseTestMixin):
 
         remove_deleted_person_data(mutations_sync=True)
 
-        count = sync_execute("SELECT count() FROM person where team_id = {}".format(self.team.pk))[0][0]
+        count = sync_execute("SELECT count() FROM person")[0][0]
 
         assert count == 1

--- a/posthog/models/test/__snapshots__/test_async_deletion_model.ambr
+++ b/posthog/models/test/__snapshots__/test_async_deletion_model.ambr
@@ -4,9 +4,7 @@
   
   ALTER TABLE sharded_events ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND (joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
-         OR joinGet(posthog_test.async_deletion_run, 'id', team_id, 1, toString(person_id)) > 0)
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team.1
@@ -14,8 +12,7 @@
   
   ALTER TABLE person ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team.2
@@ -23,8 +20,7 @@
   
   ALTER TABLE person_distinct_id ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team.3
@@ -32,8 +28,7 @@
   
   ALTER TABLE person_distinct_id2 ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team.4
@@ -41,8 +36,7 @@
   
   ALTER TABLE groups ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team.5
@@ -50,8 +44,7 @@
   
   ALTER TABLE cohortpeople ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team.6
@@ -59,8 +52,7 @@
   
   ALTER TABLE person_static_cohort ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team.7
@@ -68,8 +60,7 @@
   
   ALTER TABLE plugin_log_entries ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated
@@ -77,9 +68,7 @@
   
   ALTER TABLE sharded_events ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND (joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
-         OR joinGet(posthog_test.async_deletion_run, 'id', team_id, 1, toString(person_id)) > 0)
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated.1
@@ -87,8 +76,7 @@
   
   ALTER TABLE person ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated.2
@@ -96,8 +84,7 @@
   
   ALTER TABLE person_distinct_id ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated.3
@@ -105,8 +92,7 @@
   
   ALTER TABLE person_distinct_id2 ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated.4
@@ -114,8 +100,7 @@
   
   ALTER TABLE groups ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated.5
@@ -123,8 +108,7 @@
   
   ALTER TABLE cohortpeople ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated.6
@@ -132,8 +116,7 @@
   
   ALTER TABLE person_static_cohort ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_auxilary_models_via_team_unrelated.7
@@ -141,8 +124,7 @@
   
   ALTER TABLE plugin_log_entries ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_cohortpeople
@@ -157,14 +139,31 @@
   FROM cohortpeople
   '''
 # ---
+# name: TestAsyncDeletion.test_delete_group
+  '''
+  
+  ALTER TABLE sharded_events ON CLUSTER 'posthog'
+  DELETE
+  WHERE (team_id = 2
+         AND $group_0 = 'foo')
+  '''
+# ---
+# name: TestAsyncDeletion.test_delete_group_unrelated
+  '''
+  
+  ALTER TABLE sharded_events ON CLUSTER 'posthog'
+  DELETE
+  WHERE (team_id = 2
+         AND $group_0 = 'foo')
+  '''
+# ---
 # name: TestAsyncDeletion.test_delete_person
   '''
   
   ALTER TABLE sharded_events ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND (joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
-         OR joinGet(posthog_test.async_deletion_run, 'id', team_id, 1, toString(person_id)) > 0)
+  WHERE (team_id = 2
+         AND person_id = '00000000-0000-0000-0000-000000000000')
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_person_unrelated
@@ -172,9 +171,8 @@
   
   ALTER TABLE sharded_events ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND (joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
-         OR joinGet(posthog_test.async_deletion_run, 'id', team_id, 1, toString(person_id)) > 0)
+  WHERE (team_id = 2
+         AND person_id = '00000000-0000-0000-0000-000000000000')
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams
@@ -182,9 +180,7 @@
   
   ALTER TABLE sharded_events ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND (joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
-         OR joinGet(posthog_test.async_deletion_run, 'id', team_id, 1, toString(person_id)) > 0)
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams.1
@@ -192,8 +188,7 @@
   
   ALTER TABLE person ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams.2
@@ -201,8 +196,7 @@
   
   ALTER TABLE person_distinct_id ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams.3
@@ -210,8 +204,7 @@
   
   ALTER TABLE person_distinct_id2 ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams.4
@@ -219,8 +212,7 @@
   
   ALTER TABLE groups ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams.5
@@ -228,8 +220,7 @@
   
   ALTER TABLE cohortpeople ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams.6
@@ -237,8 +228,7 @@
   
   ALTER TABLE person_static_cohort ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams.7
@@ -246,8 +236,7 @@
   
   ALTER TABLE plugin_log_entries ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams_unrelated
@@ -255,9 +244,7 @@
   
   ALTER TABLE sharded_events ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND (joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
-         OR joinGet(posthog_test.async_deletion_run, 'id', team_id, 1, toString(person_id)) > 0)
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams_unrelated.1
@@ -265,8 +252,7 @@
   
   ALTER TABLE person ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams_unrelated.2
@@ -274,8 +260,7 @@
   
   ALTER TABLE person_distinct_id ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams_unrelated.3
@@ -283,8 +268,7 @@
   
   ALTER TABLE person_distinct_id2 ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams_unrelated.4
@@ -292,8 +276,7 @@
   
   ALTER TABLE groups ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams_unrelated.5
@@ -301,8 +284,7 @@
   
   ALTER TABLE cohortpeople ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams_unrelated.6
@@ -310,8 +292,7 @@
   
   ALTER TABLE person_static_cohort ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams_unrelated.7
@@ -319,8 +300,28 @@
   
   ALTER TABLE plugin_log_entries ON CLUSTER 'posthog'
   DELETE
-  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
-    AND joinGet(posthog_test.async_deletion_run, 'id', team_id, 0, toString(team_id)) > 0
+  WHERE team_id = 2
+  '''
+# ---
+# name: TestAsyncDeletion.test_mark_deletions_done_groups
+  '''
+  
+  SELECT DISTINCT team_id,
+                  $group_0
+  FROM events
+  WHERE (team_id = 2
+         AND $group_0 = 'foo')
+  '''
+# ---
+# name: TestAsyncDeletion.test_mark_deletions_done_groups_when_not_done
+  '''
+  
+  SELECT DISTINCT team_id,
+                  $group_0
+  FROM events
+  WHERE (team_id = 2
+         AND $group_0 = 'foo')
+>>>>>>> parent of b28e44cca4 (fix: Fix deletion job by using join tables (#21323))
   '''
 # ---
 # name: TestAsyncDeletion.test_mark_deletions_done_person

--- a/posthog/models/test/__snapshots__/test_async_deletion_model.ambr
+++ b/posthog/models/test/__snapshots__/test_async_deletion_model.ambr
@@ -321,7 +321,6 @@
   FROM events
   WHERE (team_id = 2
          AND $group_0 = 'foo')
->>>>>>> parent of b28e44cca4 (fix: Fix deletion job by using join tables (#21323))
   '''
 # ---
 # name: TestAsyncDeletion.test_mark_deletions_done_person

--- a/posthog/models/test/__snapshots__/test_async_deletion_model.ambr
+++ b/posthog/models/test/__snapshots__/test_async_deletion_model.ambr
@@ -181,6 +181,7 @@
   ALTER TABLE sharded_events ON CLUSTER 'posthog'
   DELETE
   WHERE team_id = 2
+    OR team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams.1
@@ -189,6 +190,7 @@
   ALTER TABLE person ON CLUSTER 'posthog'
   DELETE
   WHERE team_id = 2
+    OR team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams.2
@@ -197,6 +199,7 @@
   ALTER TABLE person_distinct_id ON CLUSTER 'posthog'
   DELETE
   WHERE team_id = 2
+    OR team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams.3
@@ -205,6 +208,7 @@
   ALTER TABLE person_distinct_id2 ON CLUSTER 'posthog'
   DELETE
   WHERE team_id = 2
+    OR team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams.4
@@ -213,6 +217,7 @@
   ALTER TABLE groups ON CLUSTER 'posthog'
   DELETE
   WHERE team_id = 2
+    OR team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams.5
@@ -221,6 +226,7 @@
   ALTER TABLE cohortpeople ON CLUSTER 'posthog'
   DELETE
   WHERE team_id = 2
+    OR team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams.6
@@ -229,6 +235,7 @@
   ALTER TABLE person_static_cohort ON CLUSTER 'posthog'
   DELETE
   WHERE team_id = 2
+    OR team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams.7
@@ -237,6 +244,7 @@
   ALTER TABLE plugin_log_entries ON CLUSTER 'posthog'
   DELETE
   WHERE team_id = 2
+    OR team_id = 2
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams_unrelated


### PR DESCRIPTION
## Problem

We've corrupted two replicas by partially applying mutations using a join table. We are either going to need to invest in a workflow for inserting into a delete join table or we can simply ship larger queries with everything embedded. This PR increases the max allowable size of delete statements and should work as long as volume is very low


## Changes

Increase max query statement size for ALTER DELETE statements

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
