### PR TITLE
fix(ci): fix storybook deploy

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -19,6 +19,8 @@ jobs:
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4
+              with:
+                  package_json_file: posthog/package.json
 
             - name: Set up Node.js
               uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

When upgrading the pnpm action we removed the version requirement. For the storybook deploy action github is cloned into a folder `posthog` and the subsequent pnpm install action can't find a package.json to determine the pnpm version to install.

## Changes

This PR specifies the package.json location.

## How did you test this code?

CI run