### PR TITLE
fix(cohorts): fix cohort actors query

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -59,6 +59,9 @@
                     "items": {
                         "anyOf": [
                             {
+                                "$ref": "#/definitions/CohortPropertyFilter"
+                            },
+                            {
                                 "$ref": "#/definitions/PersonPropertyFilter"
                             },
                             {
@@ -92,6 +95,9 @@
                     "description": "Currently only person filters supported (including via HogQL). see `filter_conditions()` in actor_strategies.py.",
                     "items": {
                         "anyOf": [
+                            {
+                                "$ref": "#/definitions/CohortPropertyFilter"
+                            },
                             {
                                 "$ref": "#/definitions/PersonPropertyFilter"
                             },

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -6,6 +6,7 @@ import {
     BreakdownType,
     ChartDisplayCategory,
     ChartDisplayType,
+    CohortPropertyFilter,
     CountPerActorMathType,
     EventPropertyFilter,
     EventType,
@@ -991,9 +992,9 @@ export interface ActorsQuery extends DataNode<ActorsQueryResponse> {
     select?: HogQLExpression[]
     search?: string
     /** Currently only person filters supported (including via HogQL). see `filter_conditions()` in actor_strategies.py. */
-    properties?: (PersonPropertyFilter | HogQLPropertyFilter)[]
+    properties?: (CohortPropertyFilter | PersonPropertyFilter | HogQLPropertyFilter)[]
     /** Currently only person filters supported (including via HogQL), See `filter_conditions()` in actor_strategies.py. */
-    fixedProperties?: (PersonPropertyFilter | HogQLPropertyFilter)[]
+    fixedProperties?: (CohortPropertyFilter | PersonPropertyFilter | HogQLPropertyFilter)[]
     orderBy?: string[]
     limit?: integer
     offset?: integer

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4134,7 +4134,7 @@ class ActorsQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    fixedProperties: Optional[list[Union[PersonPropertyFilter, HogQLPropertyFilter]]] = Field(
+    fixedProperties: Optional[list[Union[CohortPropertyFilter, PersonPropertyFilter, HogQLPropertyFilter]]] = Field(
         default=None,
         description="Currently only person filters supported (including via HogQL), See `filter_conditions()` in actor_strategies.py.",
     )
@@ -4145,7 +4145,7 @@ class ActorsQuery(BaseModel):
     )
     offset: Optional[int] = None
     orderBy: Optional[list[str]] = None
-    properties: Optional[list[Union[PersonPropertyFilter, HogQLPropertyFilter]]] = Field(
+    properties: Optional[list[Union[CohortPropertyFilter, PersonPropertyFilter, HogQLPropertyFilter]]] = Field(
         default=None,
         description="Currently only person filters supported (including via HogQL). see `filter_conditions()` in actor_strategies.py.",
     )


### PR DESCRIPTION
## Problem

Persons on the cohorts page are broken see https://github.com/PostHog/posthog/issues/22450 and e.g. https://us.posthog.com/project/2/cohorts/71789.

## Changes

This is because we started disallowing cohort filters (https://github.com/PostHog/posthog/pull/21820/files). This PR simply allows them again.

@Twixes Don't have context on the other PR and stepping through in debugger I can't see why this shouldn't work. Let me know if something should be changed here.

## How did you test this code?

Tried locally