### PR TITLE
chore(data-warehouse): Increased data warehouse monthly sync limit

### DIFF
--- a/posthog/tasks/warehouse.py
+++ b/posthog/tasks/warehouse.py
@@ -12,7 +12,7 @@ from posthog.warehouse.models import ExternalDataJob, ExternalDataSource
 
 logger = structlog.get_logger(__name__)
 
-MONTHLY_LIMIT = 100_000_000
+MONTHLY_LIMIT = 200_000_000
 
 
 def check_synced_row_limits() -> None:


### PR DESCRIPTION
## Problem
- We have a user hitting the monthly sync limit due to us not having incremental postgres syncs

## Changes
- Increase the limit
- But, we need to add incremental postgres support fairly soon, otherwise, this will happen a lot in general availability release
