### PR TITLE
fix: artificial lag resetting date_to

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -220,7 +220,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                         hog_ql_filtering: values.useHogQLFiltering,
                     }
 
-                    if (values.artificialLag) {
+                    if (values.artificialLag && !params.date_to) {
                         // values.artificalLag is a number of seconds to delay the recordings by
                         // convert it to an absolute UTC timestamp as the relative date parsing in the backend
                         // can't cope with seconds as a relative date


### PR DESCRIPTION
## Problem

Fixes https://posthoghelp.zendesk.com/agent/tickets/13789 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15793)

## Changes

Artificial lag is only needed when `date_to` is not set (custom date ranges should not be affected)