### PR TITLE
feat(web-analytics): add time of activity query

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1477,6 +1477,65 @@
             ],
             "type": "object"
         },
+        "CachedWebTimeOfActivityQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "cache_key": {
+                    "type": "string"
+                },
+                "columns": {
+                    "items": {},
+                    "type": "array"
+                },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "is_cached": {
+                    "type": "boolean"
+                },
+                "last_refresh": {
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "next_allowed_client_refresh": {
+                    "type": "string"
+                },
+                "results": {
+                    "$ref": "#/definitions/WebTimeOfActivityResults"
+                },
+                "timezone": {
+                    "type": "string"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                },
+                "types": {
+                    "items": {},
+                    "type": "array"
+                }
+            },
+            "required": [
+                "cache_key",
+                "is_cached",
+                "last_refresh",
+                "next_allowed_client_refresh",
+                "results",
+                "timezone"
+            ],
+            "type": "object"
+        },
         "CachedWebTopClicksQueryResponse": {
             "additionalProperties": false,
             "properties": {
@@ -5032,6 +5091,7 @@
                 "WebOverviewQuery",
                 "WebTopClicksQuery",
                 "WebStatsTableQuery",
+                "WebTimeOfActivityQuery",
                 "TimeToSeeDataSessionsQuery",
                 "TimeToSeeDataQuery",
                 "TimeToSeeDataSessionsJSONNode",
@@ -8071,6 +8131,91 @@
                 }
             },
             "required": ["results"],
+            "type": "object"
+        },
+        "WebTimeOfActivityQuery": {
+            "additionalProperties": false,
+            "properties": {
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "kind": {
+                    "const": "WebTimeOfActivityQuery",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "properties": {
+                    "$ref": "#/definitions/WebAnalyticsPropertyFilters"
+                },
+                "response": {
+                    "$ref": "#/definitions/WebStatsTableQueryResponse"
+                },
+                "sampling": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "forceSamplingRate": {
+                            "$ref": "#/definitions/SamplingRate"
+                        }
+                    },
+                    "type": "object"
+                },
+                "useSessionsTable": {
+                    "type": "boolean"
+                }
+            },
+            "required": ["kind", "properties"],
+            "type": "object"
+        },
+        "WebTimeOfActivityQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "columns": {
+                    "items": {},
+                    "type": "array"
+                },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "results": {
+                    "$ref": "#/definitions/WebTimeOfActivityResults"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                },
+                "types": {
+                    "items": {},
+                    "type": "array"
+                }
+            },
+            "required": ["results"],
+            "type": "object"
+        },
+        "WebTimeOfActivityResults": {
+            "additionalProperties": {
+                "items": {
+                    "type": "number"
+                },
+                "type": "array"
+            },
             "type": "object"
         },
         "WebTopClicksQuery": {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -82,6 +82,7 @@ export enum NodeKind {
     WebOverviewQuery = 'WebOverviewQuery',
     WebTopClicksQuery = 'WebTopClicksQuery',
     WebStatsTableQuery = 'WebStatsTableQuery',
+    WebTimeOfActivityQuery = 'WebTimeOfActivityQuery',
 
     // Time to see data
     TimeToSeeDataSessionsQuery = 'TimeToSeeDataSessionsQuery',
@@ -1106,7 +1107,29 @@ export interface WebStatsTableQueryResponse extends AnalyticsQueryResponseBase<u
     limit?: integer
     offset?: integer
 }
+
+export interface WebStatsTableQueryResponse extends AnalyticsQueryResponseBase<unknown[]> {
+    types?: unknown[]
+    columns?: unknown[]
+    hogql?: string
+    samplingRate?: SamplingRate
+    hasMore?: boolean
+    limit?: integer
+    offset?: integer
+}
 export type CachedWebStatsTableQueryResponse = WebStatsTableQueryResponse & CachedQueryResponseMixin
+
+export interface WebTimeOfActivityQuery extends WebAnalyticsQueryBase<WebStatsTableQueryResponse> {
+    kind: NodeKind.WebTimeOfActivityQuery
+}
+export type WebTimeOfActivityResults = Record<string, Record<number, number>>
+
+export interface WebTimeOfActivityQueryResponse extends AnalyticsQueryResponseBase<WebTimeOfActivityResults> {
+    types?: unknown[]
+    columns?: unknown[]
+    hogql?: string
+}
+export type CachedWebTimeOfActivityQueryResponse = WebTimeOfActivityQueryResponse & CachedQueryResponseMixin
 
 export type InsightQueryNode =
     | TrendsQuery

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -314,6 +314,12 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
         icon: IconTrends,
         inMenu: true,
     },
+    [NodeKind.WebTimeOfActivityQuery]: {
+        name: 'Activity by time',
+        description: 'View activity by time/dat',
+        icon: IconTrends,
+        inMenu: true,
+    },
 }
 
 export const INSIGHT_TYPE_OPTIONS: LemonSelectOptions<string> = [

--- a/posthog/hogql_queries/web_analytics/test/test_time_of_activity.py
+++ b/posthog/hogql_queries/web_analytics/test/test_time_of_activity.py
@@ -1,0 +1,70 @@
+from freezegun import freeze_time
+
+from posthog.hogql_queries.web_analytics.time_of_activity import WebTimeOfActivityQueryRunner
+from posthog.schema import DateRange, WebTimeOfActivityQuery
+from posthog.test.base import (
+    APIBaseTest,
+    ClickhouseTestMixin,
+    _create_event,
+    _create_person,
+)
+
+
+class TestTimeOfActivityQueryRunner(ClickhouseTestMixin, APIBaseTest):
+    def _create_events(self, data, event="$pageview"):
+        person_result = []
+        for id, timestamps in data:
+            with freeze_time(timestamps[0][0]):
+                person_result.append(
+                    _create_person(
+                        team_id=self.team.pk,
+                        distinct_ids=[id],
+                        properties={
+                            "name": id,
+                            **({"email": "test@posthog.com"} if id == "test" else {}),
+                        },
+                    )
+                )
+            for timestamp, session_id, pathname in timestamps:
+                _create_event(
+                    team=self.team,
+                    event=event,
+                    distinct_id=id,
+                    timestamp=timestamp,
+                    properties={"$session_id": session_id, "$pathname": pathname},
+                )
+        return person_result
+
+    def _run_time_of_activity_query(
+        self,
+        date_from,
+        date_to,
+        properties=None,
+    ):
+        query = WebTimeOfActivityQuery(
+            dateRange=DateRange(date_from=date_from, date_to=date_to),
+            properties=properties or [],
+        )
+
+        runner = WebTimeOfActivityQueryRunner(team=self.team, query=query)
+        return runner.calculate()
+
+    def test_no_crash_when_no_data(self):
+        results = self._run_time_of_activity_query("2023-12-08", "2023-12-15").results
+        self.assertEqual({}, results)
+
+    def test_one_session(self):
+        self._create_events(
+            [
+                (
+                    "test",
+                    [
+                        ("2023-12-09T12:34", "session1", "/"),
+                        ("2023-12-09T12:56", "session1", "/"),
+                        ("2023-12-09T13:37", "session1", "/"),
+                    ],
+                )
+            ]
+        )
+        results = self._run_time_of_activity_query("2023-12-08", "2023-12-15").results
+        self.assertEqual({"saturday": {12: 2, 13: 1}}, results)

--- a/posthog/hogql_queries/web_analytics/time_of_activity.py
+++ b/posthog/hogql_queries/web_analytics/time_of_activity.py
@@ -1,0 +1,112 @@
+from collections import defaultdict
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
+from posthog.hogql.property import (
+    property_to_expr,
+)
+from posthog.hogql.query import execute_hogql_query
+from posthog.hogql_queries.web_analytics.web_analytics_query_runner import (
+    WebAnalyticsQueryRunner,
+    map_columns,
+)
+from posthog.schema import (
+    WebTimeOfActivityQuery,
+    CachedWebTimeOfActivityQueryResponse,
+    WebTimeOfActivityQueryResponse,
+)
+
+
+class WebTimeOfActivityQueryRunner(WebAnalyticsQueryRunner):
+    query: WebTimeOfActivityQuery
+    response: WebTimeOfActivityQueryResponse
+    cached_response: CachedWebTimeOfActivityQueryResponse
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def to_query(self) -> ast.SelectQuery:
+        with self.timings.measure("time_of_activity_query"):
+            query = parse_select(
+                """
+
+    SELECT
+        uniq(events.$session_id) AS num_sessions,
+        toDayOfWeek(timestamp, 0) AS day_of_week,
+        toHour(timestamp) AS hour
+    FROM events
+    WHERE and(
+        timestamp >= {date_from},
+        timestamp < {date_to},
+        or (
+            events.event == '$pageview',
+            events.event == 'autocapture'
+        ),
+        {all_properties}
+    )
+    GROUP BY day_of_week, hour
+    ORDER BY day_of_week ASC, hour ASC
+""",
+                timings=self.timings,
+                placeholders={
+                    "all_properties": self._all_properties(),
+                    "date_from": self._date_from(),
+                    "date_to": self._date_to(),
+                },
+            )
+        assert isinstance(query, ast.SelectQuery)
+        return query
+
+    def _all_properties(self) -> ast.Expr:
+        properties = self.query.properties  # + self._test_account_filters
+        return property_to_expr(properties, team=self.team)
+
+    def _date_to(self) -> ast.Expr:
+        return self.query_date_range.date_to_as_hogql()
+
+    def _date_from(self) -> ast.Expr:
+        return self.query_date_range.date_from_as_hogql()
+
+    def calculate(self):
+        response = execute_hogql_query(
+            query_type="stats_table_query",
+            query=self.to_query(),
+            team=self.team,
+            timings=self.timings,
+            modifiers=self.modifiers,
+        )
+        results = response.results
+
+        assert results is not None
+
+        # we used clickhouse's toDayOfWeek function with mode=0
+        # convert this to a string, so that it's easier to read the response body
+        num_to_day = {
+            1: "monday",
+            2: "tuesday",
+            3: "wednesday",
+            4: "thursday",
+            5: "friday",
+            6: "saturday",
+            7: "sunday",
+        }
+
+        results_mapped = map_columns(
+            results,
+            {
+                1: num_to_day.get,
+            },
+        )
+
+        results_dict: dict[str, dict[int, int]] = defaultdict(lambda: {})
+        for result in results_mapped:
+            results_dict[result[1]][result[2]] = result[0]
+
+        return WebTimeOfActivityQueryResponse(
+            columns=response.columns,
+            results=results_dict,
+            timings=response.timings,
+            types=response.types,
+            hogql=response.hogql,
+            modifiers=self.modifiers,
+        )

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -25,10 +25,11 @@ from posthog.schema import (
     PersonPropertyFilter,
     SamplingRate,
     SessionPropertyFilter,
+    WebTimeOfActivityQuery,
 )
 from posthog.utils import generate_cache_key, get_safe_cache
 
-WebQueryNode = Union[WebOverviewQuery, WebTopClicksQuery, WebStatsTableQuery]
+WebQueryNode = Union[WebOverviewQuery, WebTopClicksQuery, WebStatsTableQuery, WebTimeOfActivityQuery]
 
 
 class WebAnalyticsQueryRunner(QueryRunner, ABC):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -636,6 +636,7 @@ class NodeKind(str, Enum):
     WebOverviewQuery = "WebOverviewQuery"
     WebTopClicksQuery = "WebTopClicksQuery"
     WebStatsTableQuery = "WebStatsTableQuery"
+    WebTimeOfActivityQuery = "WebTimeOfActivityQuery"
     TimeToSeeDataSessionsQuery = "TimeToSeeDataSessionsQuery"
     TimeToSeeDataQuery = "TimeToSeeDataQuery"
     TimeToSeeDataSessionsJSONNode = "TimeToSeeDataSessionsJSONNode"
@@ -1543,6 +1544,31 @@ class CachedWebStatsTableQueryResponse(BaseModel):
     offset: Optional[int] = None
     results: list
     samplingRate: Optional[SamplingRate] = None
+    timezone: str
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: Optional[list] = None
+
+
+class CachedWebTimeOfActivityQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    columns: Optional[list] = None
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    is_cached: bool
+    last_refresh: str
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    next_allowed_client_refresh: str
+    results: dict[str, list[float]]
     timezone: str
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
@@ -2573,6 +2599,41 @@ class WebStatsTableQuery(BaseModel):
     response: Optional[WebStatsTableQueryResponse] = None
     sampling: Optional[Sampling] = None
     useSessionsTable: Optional[bool] = None
+
+
+class WebTimeOfActivityQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: Optional[DateRange] = None
+    kind: Literal["WebTimeOfActivityQuery"] = "WebTimeOfActivityQuery"
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    properties: list[Union[EventPropertyFilter, PersonPropertyFilter, SessionPropertyFilter]]
+    response: Optional[WebStatsTableQueryResponse] = None
+    sampling: Optional[Sampling] = None
+    useSessionsTable: Optional[bool] = None
+
+
+class WebTimeOfActivityQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: Optional[list] = None
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    results: dict[str, list[float]]
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: Optional[list] = None
 
 
 class WebTopClicksQuery(BaseModel):


### PR DESCRIPTION
## Problem

The retention query is not that helpful for web analytics, and isn't useful at all with personless events. This replaces it with a query that tells you what time/day of the week your website is most active.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
