### PR TITLE
fix: add web analytics to the product analytics product intro page

### DIFF
--- a/frontend/src/scenes/sceneLogic.ts
+++ b/frontend/src/scenes/sceneLogic.ts
@@ -25,7 +25,7 @@ export const productUrlMapping: Partial<Record<ProductKey, string[]>> = {
     [ProductKey.SESSION_REPLAY]: [urls.replay()],
     [ProductKey.FEATURE_FLAGS]: [urls.featureFlags(), urls.earlyAccessFeatures(), urls.experiments()],
     [ProductKey.SURVEYS]: [urls.surveys()],
-    [ProductKey.PRODUCT_ANALYTICS]: [urls.insights()],
+    [ProductKey.PRODUCT_ANALYTICS]: [urls.insights(), urls.webAnalytics()],
 }
 
 export const sceneLogic = kea<sceneLogicType>([


### PR DESCRIPTION
## Problem

@robbie-c mentioned the web analytics sidebar link doesn't do anything for users who haven't onboarded to any products yet: https://posthog.slack.com/archives/C043VJ93L3B/p1716463697142889. Since the feature flag is rolled out to 100% of users, all new users would see this.

## Changes

The fix was to link the web analytics onboarding page to the product analytics onboarding - copying the pattern from a/b testing and early access link to the feature flags onboarding. 

There is room for improvement here on how we handle these products that don't yet have an onboarding. 