### PR TITLE
fix(insights): Re-enable refresh on async queries

### DIFF
--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -270,28 +270,30 @@ def enqueue_process_query_task(
     query_status = QueryStatus(id=query_id, team_id=team.id, start_time=datetime.datetime.now(datetime.timezone.utc))
     manager.store_query_status(query_status)
 
-    try:
-        cached_response = process_query_dict(
-            team=team,
-            query_json=query_json,
-            limit_context=LimitContext.QUERY_ASYNC,
-            execution_mode=ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
-        )
-        if not isinstance(cached_response, CacheMissResponse):
-            if isinstance(cached_response, BaseModel):
-                cached_response = cached_response.model_dump(by_alias=True)
-            # We got a response with results, rather than a `CacheMissResponse`
-            query_status.complete = True
-            query_status.error = False
-            query_status.results = cached_response
-            query_status.end_time = datetime.datetime.now(datetime.timezone.utc)
-            query_status.expiration_time = query_status.end_time + datetime.timedelta(
-                seconds=manager.STATUS_TTL_SECONDS
+    # Skip cache if refresh requested
+    if not refresh_requested:
+        try:
+            cached_response = process_query_dict(
+                team=team,
+                query_json=query_json,
+                limit_context=LimitContext.QUERY_ASYNC,
+                execution_mode=ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
             )
-            manager.store_query_status(query_status)
-            return query_status
-    except:
-        sentry_sdk.capture_exception()  # Carry on async, if we couldn't get to cache
+            if not isinstance(cached_response, CacheMissResponse):
+                if isinstance(cached_response, BaseModel):
+                    cached_response = cached_response.model_dump(by_alias=True)
+                # We got a response with results, rather than a `CacheMissResponse`
+                query_status.complete = True
+                query_status.error = False
+                query_status.results = cached_response
+                query_status.end_time = datetime.datetime.now(datetime.timezone.utc)
+                query_status.expiration_time = query_status.end_time + datetime.timedelta(
+                    seconds=manager.STATUS_TTL_SECONDS
+                )
+                manager.store_query_status(query_status)
+                return query_status
+        except:
+            sentry_sdk.capture_exception()  # Carry on async, if we couldn't get to cache
 
     if _test_only_bypass_celery:
         process_query_task(


### PR DESCRIPTION
## Problem

Async queries can't be forced refreshed at the moment
https://app.slack.com/client/TSS5W8YQZ/C04F85S6BGQ

## Changes

Enable force refresh for async

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

On dev and unit test
