### PR TITLE
feat: add person delete to the django management command to delete

### DIFF
--- a/posthog/management/commands/start_delete_mutation.py
+++ b/posthog/management/commands/start_delete_mutation.py
@@ -3,7 +3,7 @@ import logging
 import structlog
 from django.core.management.base import BaseCommand
 
-from posthog.tasks.tasks import clickhouse_clear_removed_data
+from posthog.tasks.tasks import clickhouse_clear_removed_data, clear_clickhouse_deleted_person
 
 logger = structlog.get_logger(__name__)
 logger.setLevel(logging.INFO)
@@ -23,3 +23,7 @@ def run():
     logger.info("Starting deletion of data for teams")
     clickhouse_clear_removed_data()
     logger.info("Finished deletion of data for teams")
+
+    logger.info("Starting deletion of data for persons")
+    clear_clickhouse_deleted_person()
+    logger.info("Finished deletion of data for persons")


### PR DESCRIPTION
## Problem

Current command only deletes events

## Changes

This adds deletes for persons to the run

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
