### PR TITLE
remove unnecessary deleteRecordSuccess call in managed proxy

### DIFF
--- a/frontend/src/scenes/settings/project/proxyLogic.ts
+++ b/frontend/src/scenes/settings/project/proxyLogic.ts
@@ -67,7 +67,6 @@ export const proxyLogic = kea<proxyLogicType>([
     listeners(({ actions, values }) => ({
         collapseForm: () => actions.loadRecords(),
         deleteRecordFailure: () => actions.loadRecords(),
-        deleteRecordSuccess: () => actions.loadRecords(),
         createRecordSuccess: () => actions.loadRecords(),
         maybeRefreshRecords: () => {
             if (values.shouldRefreshRecords) {


### PR DESCRIPTION

## Problem
this was just to restart polling back in the dark ages before we always ran the poll check

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
