### PR TITLE
chore(data-warehouse): add minimize button

### DIFF
--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -6,6 +6,7 @@ import { useActions, useValues } from 'kea'
 import { CodeEditor } from 'lib/components/CodeEditors'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { IconChevronLeft, IconChevronRight } from 'lib/lemon-ui/icons'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton, LemonButtonWithDropdown } from 'lib/lemon-ui/LemonButton'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -111,6 +112,7 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
     const artificialHogHeight = featureFlags[FEATURE_FLAGS.ARTIFICIAL_HOG] ? 40 : 0
     const [panelHeight, setPanelHeight] = useState<number>(TABLE_PANEL_HEIGHT + artificialHogHeight)
+    const [panelHidden, setPanelHidden] = useState(false)
 
     const [key] = useState(() => uniqueNode++)
     const [monacoAndEditor, setMonacoAndEditor] = useState(
@@ -151,13 +153,25 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
         <div className="space-y-2 flex flex-row">
             <FlaggedFeature flag={FEATURE_FLAGS.DATA_WAREHOUSE}>
                 {/* eslint-disable-next-line react/forbid-dom-props */}
-                <div className="flex pt-2 max-sm:hidden min-w-96 mr-2" style={{ height: panelHeight }}>
-                    <DatabaseTableTreeWithItems inline />
+                <div
+                    className={clsx('flex flex-col space-y-2 pt-2 max-sm:hidden mr-2 min-w-84')}
+                    style={{ height: panelHeight }}
+                >
+                    <div className="flex flex-row justify-between items-center">
+                        <span className={clsx('card-secondary', panelHidden ? 'hidden' : '')}>Schemas</span>
+                        <LemonButton
+                            type="tertiary"
+                            size="small"
+                            onClick={() => setPanelHidden(!panelHidden)}
+                            icon={panelHidden ? <IconChevronRight /> : <IconChevronLeft />}
+                        />
+                    </div>
+                    <DatabaseTableTreeWithItems className={clsx(panelHidden ? 'hidden' : '')} inline />
                 </div>
             </FlaggedFeature>
             <div
                 data-attr="hogql-query-editor"
-                className={clsx('flex flex-col rounded space-y-2 w-full', !props.embedded && 'p-2 border')}
+                className={clsx('flex flex-col rounded space-y-2 w-full mr-1', !props.embedded && 'p-2 border')}
             >
                 <FlaggedFeature flag={FEATURE_FLAGS.ARTIFICIAL_HOG}>
                     <div className="flex gap-2">

--- a/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
+++ b/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
@@ -26,9 +26,10 @@ export const DataWarehouseTables = (): JSX.Element => {
 
 interface DatabaseTableTreeProps {
     inline?: boolean
+    className?: string
 }
 
-export const DatabaseTableTreeWithItems = ({ inline }: DatabaseTableTreeProps): JSX.Element => {
+export const DatabaseTableTreeWithItems = ({ inline, className }: DatabaseTableTreeProps): JSX.Element => {
     const { dataWarehouseTablesBySourceType, posthogTables, databaseLoading, views, selectedRow } =
         useValues(dataWarehouseSceneLogic)
     const { selectRow } = useActions(dataWarehouseSceneLogic)
@@ -132,5 +133,12 @@ export const DatabaseTableTreeWithItems = ({ inline }: DatabaseTableTreeProps): 
         return items
     }
 
-    return <DatabaseTableTree onSelectRow={selectRow} items={treeItems()} selectedRow={selectedRow} />
+    return (
+        <DatabaseTableTree
+            className={className}
+            onSelectRow={selectRow}
+            items={treeItems()}
+            selectedRow={selectedRow}
+        />
+    )
 }


### PR DESCRIPTION
## Problem

- schemas get in the way once you're already familiar with the fields

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- add a minimize button

https://github.com/PostHog/posthog/assets/13127476/46f22c94-49c5-4dcb-adff-e87ce74130e6


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
