### PR TITLE
chore: Add a few flags to PERSISTED_FEATURE_FLAGS

### DIFF
--- a/.github/pr-deploy/values.yaml.tmpl
+++ b/.github/pr-deploy/values.yaml.tmpl
@@ -12,8 +12,6 @@ env:
   value: "1"
 - name: COMMIT_SHA
   value: $COMMIT_SHA
-- name: PERSISTED_FEATURE_FLAGS
-  value: "hogql"
 
 siteUrl: https://$NAMESPACE.hedgehog-kitefin.ts.net
 tailscale:

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -9,4 +9,9 @@ PERSISTED_FEATURE_FLAGS = [
     "simplify-actions",
     "historical-exports-v2",
     "ingestion-warnings-enabled",
+    "new-experiments-ui",
+    "hogql-in-insight-serialization",
+    "hogql-insights-preview",
+    "persons-hogql-query",
+    "datanode-concurrency-limit",
 ]

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -14,4 +14,5 @@ PERSISTED_FEATURE_FLAGS = [
     "hogql-insights-preview",
     "persons-hogql-query",
     "datanode-concurrency-limit",
+    "session-table-property-filters",
 ]

--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -9,7 +9,6 @@ PERSISTED_FEATURE_FLAGS = [
     "simplify-actions",
     "historical-exports-v2",
     "ingestion-warnings-enabled",
-    "new-experiments-ui",
     "hogql-in-insight-serialization",
     "hogql-insights-preview",
     "persons-hogql-query",


### PR DESCRIPTION
## Changes

We have a bunch of flags rolled out to 100%. The next step for them is to unflag their behavior and remove the relevant pre-flag code paths, if there were any.
But first, let's add them to `PERSISTED_FEATURE_FLAGS`, so that they're also always rolled out in dev and in hobby deployments.

The flags being promoted here are:
- ~~`new-experiments-ui` owned by @jurajmajerik~~
- `hogql-in-insight-serialization` owned by @Twixes 
- `hogql-insights-preview` owned by @mariusandra
- `persons-hogql-query` owned by @mariusandra
- `datanode-concurrency-limit` owned by @robbie-c 
- `session-table-property-filters` owned by @robbie-c 