### PR TITLE
chore(dev): Add pre-push hook to confirm pushing to master

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,22 +2,11 @@
 . "$(dirname "$0")/_/husky.sh"
 
 protected_branch='master'
-current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+current_branch=$(git branch --show-current)
 
 if [ $protected_branch = $current_branch ]
 then
-    if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then
-        # /dev/tty is available and usable
-        read -p "You're about to push to $protected_branch! Is this what you intend? [yN] " -n 1 -r < /dev/tty
-        echo
-        if echo $REPLY | grep -E '^[Yy]$' > /dev/null
-        then
-            exit 0 # push will execute
-        fi
-    else
-        # /dev/tty is not available
-        echo "You're about to push to $protected_branch! To confirm, run ``git push`` from the command line."
-    fi
+    echo "Pushing to $protected_branch is a sin! Instead, create a pull request and repent."
     exit 1 # push will not execute
 else
     exit 0 # push will execute

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,24 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+protected_branch='master'
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+if [ $protected_branch = $current_branch ]
+then
+    if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then
+        # /dev/tty is available and usable
+        read -p "You're about to push to $protected_branch! Is this what you intend? [yN] " -n 1 -r < /dev/tty
+        echo
+        if echo $REPLY | grep -E '^[Yy]$' > /dev/null
+        then
+            exit 0 # push will execute
+        fi
+    else
+        # /dev/tty is not available
+        echo "You're about to push to $protected_branch! To confirm, run ``git push`` from the command line."
+    fi
+    exit 1 # push will not execute
+else
+    exit 0 # push will execute
+fi


### PR DESCRIPTION
## Problem

I accidentally pushed to master: cc43c9c37798f6b442ee7833615a877de802e375. Branch protection rules prevent this for non-admins, but I _am_ repo admin AND we have "Do not allow bypassing the above settings" (branch protection) turned off. We could check that box, but then we wouldn't be able to force-merge, which does come in handy and is also safely explicit – as opposed to this accidental push risk.

I also have `~/.gitconfig` set up with a [tip](https://posthog.slack.com/archives/C0113360FFV/p1708342332280009?thread_ts=1708341684.784579&cid=C0113360FFV) from @frankh included:
```
[branch.master]
	pushRemote =
```
This prevents accidental pushes to master using plain `git push`, requiring an explicit `git push origin master`. But there are two problems:
1. Only a few folks have this in their config and ever will, because you have to add it manually.
2. I for one use GitHub Desktop a lot because it's handy – while it does use `~/.gitconfig`, clearly also it does explicitly run `git push origin main`, bypassing the protective setting, which is what happened in this case.

While there's no need to roll back this tiny update to a test, next time it may be something more annoying. Let's just prevent any accidental pushes to master.

## Changes

Looks like a pre-push hook is the right way to go about validating pushes. Fortunately, we use `husky`, so setting up Git hooks is a breeze. Here's one that requires pushes to master to be confirmed on the command line, while leaving all other branches alone:

<img width="654" alt="terminal" src="https://github.com/PostHog/posthog/assets/4550621/cc1f648d-a1cc-4620-8b96-6040526db026">

<img width="698" alt="gh-desktop" src="https://github.com/PostHog/posthog/assets/4550621/1a4a20a1-db03-4cf2-a9dc-f5aee4c7313a">
