### PR TITLE
perf: Nuke clickhouse_lag celery task

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -18,7 +18,6 @@ from posthog.tasks.tasks import (
     clear_clickhouse_deleted_person,
     clickhouse_clear_removed_data,
     clickhouse_errors_count,
-    clickhouse_lag,
     clickhouse_mark_all_materialized,
     clickhouse_materialize_columns,
     clickhouse_mutation_count,
@@ -153,13 +152,6 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
 
     if settings.INGESTION_LAG_METRIC_TEAM_IDS:
         sender.add_periodic_task(60, ingestion_lag.s(), name="ingestion lag")
-
-    add_periodic_task_with_expiry(
-        sender,
-        120,
-        clickhouse_lag.s(),
-        name="clickhouse table lag",
-    )
 
     add_periodic_task_with_expiry(
         sender,

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -174,35 +174,6 @@ CLICKHOUSE_TABLES = [
 ]
 
 
-@shared_task(ignore_result=True)
-def clickhouse_lag() -> None:
-    from statshog.defaults.django import statsd
-
-    from posthog.client import sync_execute
-
-    with pushed_metrics_registry("celery_clickhouse_lag") as registry:
-        lag_gauge = Gauge(
-            "posthog_celery_clickhouse_lag_seconds",
-            "Age of the latest ingested record per ClickHouse table.",
-            labelnames=["table_name"],
-            registry=registry,
-        )
-        for table in CLICKHOUSE_TABLES:
-            try:
-                QUERY = """SELECT max(_timestamp) observed_ts, now() now_ts, now() - max(_timestamp) as lag
-                    FROM {table}"""
-                query = QUERY.format(table=table)
-                lag = sync_execute(query)[0][2]
-                statsd.gauge(
-                    "posthog_celery_clickhouse__table_lag_seconds",
-                    lag,
-                    tags={"table": table},
-                )
-                lag_gauge.labels(table_name=table).set(lag)
-            except:
-                pass
-
-
 HEARTBEAT_EVENT_TO_INGESTION_LAG_METRIC = {
     "heartbeat": "ingestion",
     "heartbeat_buffer": "ingestion_buffer",


### PR DESCRIPTION
## Problem

This query reads 110TB of data, about 50% of all non-mutation reads!

[it was added in 2020](https://github.com/PostHog/posthog/commit/a25217463d2d7554b57fe5dfe152543364fb4c57), and as far as I can tell it's not used at all.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
