### PR TITLE
perf: Always execute API requests on offline cluster

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -382,7 +382,7 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
             ]
             for actor in serialized_actors:
                 if actor["properties"].get("email"):
-                    actor["email"] = actor["properties"]["email"]
+                    actor["email"] = actor["properties"]["email"]  # type: ignore
                     del actor["properties"]["email"]
             serialized_actors = [
                 {
@@ -393,7 +393,7 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
                     )
                     if k not in DELETE_KEYS
                 }
-                for actor in serialized_actors
+                for actor in serialized_actors  # type: ignore
             ]
 
         # TEMPORARY: Work out usage patterns of this endpoint

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -1,5 +1,5 @@
 import csv
-import json
+from posthog.clickhouse.client.connection import Workload
 
 from django.db import DatabaseError
 from sentry_sdk import start_span
@@ -13,8 +13,6 @@ from posthog.models.feature_flag.flag_matching import (
 from posthog.models.person.person import PersonDistinctId
 from posthog.models.property.property import Property, PropertyGroup
 from posthog.queries.base import property_group_to_Q
-from posthog.queries.insight import insight_sync_execute
-import posthoganalytics
 from posthog.metrics import LABEL_TEAM_ID
 from posthog.renderers import SafeJSONRenderer
 from datetime import datetime
@@ -67,7 +65,6 @@ from posthog.models.person.sql import (
 from posthog.queries.actor_base_query import (
     ActorBaseQuery,
     get_people,
-    serialize_people,
 )
 from posthog.queries.paths import PathsActors
 from posthog.queries.person_query import PersonQuery
@@ -350,50 +347,16 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
         elif not filter.limit:
             filter = filter.shallow_clone({LIMIT: 100})
 
-        if posthoganalytics.feature_enabled(
-            "load-person-fields-from-clickhouse",
-            request.user.distinct_id,
-            person_properties={"email": request.user.email},
-        ):
-            person_query = PersonQuery(
-                filter,
-                team.pk,
-                cohort=cohort,
-                extra_fields=[
-                    "created_at",
-                    "properties",
-                    "is_identified",
-                ],
-                include_distinct_ids=True,
-            )
-            paginated_query, paginated_params = person_query.get_query(paginate=True, filter_future_persons=True)
-            serialized_actors = insight_sync_execute(
-                paginated_query,
-                {**paginated_params, **filter.hogql_context.values},
-                filter=filter,
-                query_type="cohort_persons",
-                team_id=team.pk,
-            )
-            persons = []
-            for p in serialized_actors:
-                person = Person(
-                    uuid=p[0],
-                    created_at=p[1],
-                    is_identified=p[2],
-                    properties=json.loads(p[3]),
-                )
-                person._distinct_ids = p[4]
-                persons.append(person)
+        query, params = PersonQuery(filter, team.pk, cohort=cohort).get_query(paginate=True)
+        raw_result = sync_execute(
+            query,
+            {**params, **filter.hogql_context.values},
+            workload=Workload.OFFLINE,  # this endpoint is only used by external API requests
+        )
+        actor_ids = [row[0] for row in raw_result]
+        actors, serialized_actors = get_people(team, actor_ids, distinct_id_limit=10)
 
-            serialized_actors = serialize_people(team, data=persons)
-            _should_paginate = len(serialized_actors) >= filter.limit
-        else:
-            query, params = PersonQuery(filter, team.pk, cohort=cohort).get_query(paginate=True)
-            raw_result = sync_execute(query, {**params, **filter.hogql_context.values})
-            actor_ids = [row[0] for row in raw_result]
-            actors, serialized_actors = get_people(team, actor_ids, distinct_id_limit=10)
-
-            _should_paginate = len(actor_ids) >= filter.limit
+        _should_paginate = len(actor_ids) >= filter.limit
 
         next_url = format_query_params_absolute_url(request, filter.offset + filter.limit) if _should_paginate else None
         previous_url = (

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -385,7 +385,7 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
                     actor["email"] = actor["properties"]["email"]  # type: ignore
                     del actor["properties"]["email"]
             serialized_actors = [
-                {
+                {  # type: ignore
                     k: v
                     for k, v in sorted(
                         actor.items(),
@@ -393,7 +393,7 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
                     )
                     if k not in DELETE_KEYS
                 }
-                for actor in serialized_actors  # type: ignore
+                for actor in serialized_actors
             ]
 
         # TEMPORARY: Work out usage patterns of this endpoint

--- a/posthog/api/test/__snapshots__/test_person.ambr
+++ b/posthog/api/test/__snapshots__/test_person.ambr
@@ -534,273 +534,145 @@
 # name: TestPersonFromClickhouse.test_filter_person_email
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND has(['another@gmail.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND has(['another@gmail.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_filter_person_email_materialized
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND has(['another@gmail.com'], "pmat_email")
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND has(['another@gmail.com'], "pmat_email")
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_filter_person_list
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND id IN
-       (SELECT person_id
-        FROM
-          (SELECT distinct_id,
-                  argMax(person_id, version) as person_id
-           FROM person_distinct_id2
-           WHERE team_id = 2
-           GROUP BY distinct_id
-           HAVING argMax(is_deleted, version) = 0)
-        where distinct_id = 'distinct_id' )
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND id IN
+    (SELECT person_id
+     FROM
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0)
+     where distinct_id = 'distinct_id' )
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_filter_person_list.1
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND id IN
-       (SELECT person_id
-        FROM
-          (SELECT distinct_id,
-                  argMax(person_id, version) as person_id
-           FROM person_distinct_id2
-           WHERE team_id = 2
-           GROUP BY distinct_id
-           HAVING argMax(is_deleted, version) = 0)
-        where distinct_id = 'another_one' )
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND id IN
+    (SELECT person_id
+     FROM
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0)
+     where distinct_id = 'another_one' )
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_filter_person_list.2
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND has(['another@gmail.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND has(['another@gmail.com'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_filter_person_list.3
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND has(['inexistent'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND has(['inexistent'], replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', ''))
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_filter_person_list.4
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND id IN
-       (SELECT person_id
-        FROM
-          (SELECT distinct_id,
-                  argMax(person_id, version) as person_id
-           FROM person_distinct_id2
-           WHERE team_id = 2
-           GROUP BY distinct_id
-           HAVING argMax(is_deleted, version) = 0)
-        where distinct_id = 'inexistent' )
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND id IN
+    (SELECT person_id
+     FROM
+       (SELECT distinct_id,
+               argMax(person_id, version) as person_id
+        FROM person_distinct_id2
+        WHERE team_id = 2
+        GROUP BY distinct_id
+        HAVING argMax(is_deleted, version) = 0)
+     where distinct_id = 'inexistent' )
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_filter_person_prop
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND (has(['some_value'], replaceRegexpAll(JSONExtractRaw(properties, 'some_prop'), '^"|"$', ''))) )
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND (has(['some_value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'some_prop'), '^"|"$', '')))
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+    AND id IN
+      (SELECT id
+       FROM person
+       WHERE team_id = 2
+         AND (has(['some_value'], replaceRegexpAll(JSONExtractRaw(properties, 'some_prop'), '^"|"$', ''))) )
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND (has(['some_value'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'some_prop'), '^"|"$', '')))
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_person_property_values
@@ -880,474 +752,314 @@
 # name: TestPersonFromClickhouse.test_properties
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND (JSONHas(properties, 'email')) )
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND (JSONHas(argMax(person.properties, version), 'email'))
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+    AND id IN
+      (SELECT id
+       FROM person
+       WHERE team_id = 2
+         AND (JSONHas(properties, 'email')) )
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND (JSONHas(argMax(person.properties, version), 'email'))
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_properties.1
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%another@gm%') )
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%another@gm%')
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+    AND id IN
+      (SELECT id
+       FROM person
+       WHERE team_id = 2
+         AND (replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%another@gm%') )
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND (replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%another@gm%')
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_properties_materialized
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND (notEmpty("pmat_email")) )
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND (notEmpty(argMax(person."pmat_email", version)))
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+    AND id IN
+      (SELECT id
+       FROM person
+       WHERE team_id = 2
+         AND (notEmpty("pmat_email")) )
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND (notEmpty(argMax(person."pmat_email", version)))
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_properties_materialized.1
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND ("pmat_email" ILIKE '%another@gm%') )
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND (argMax(person."pmat_email", version) ILIKE '%another@gm%')
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+    AND id IN
+      (SELECT id
+       FROM person
+       WHERE team_id = 2
+         AND ("pmat_email" ILIKE '%another@gm%') )
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND (argMax(person."pmat_email", version) ILIKE '%another@gm%')
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_search
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%another@gm%')
-                 OR id IN
-                   (SELECT person_id
-                    FROM
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0)
-                    WHERE distinct_id = 'another@gm' )) )
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%another@gm%')
-          OR id IN
-            (SELECT person_id
-             FROM
-               (SELECT distinct_id,
-                       argMax(person_id, version) as person_id
-                FROM person_distinct_id2
-                WHERE team_id = 2
-                GROUP BY distinct_id
-                HAVING argMax(is_deleted, version) = 0)
-             WHERE distinct_id = 'another@gm' ))
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+    AND id IN
+      (SELECT id
+       FROM person
+       WHERE team_id = 2
+         AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%another@gm%')
+              OR id IN
+                (SELECT person_id
+                 FROM
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0)
+                 WHERE distinct_id = 'another@gm' )) )
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%another@gm%')
+       OR id IN
+         (SELECT person_id
+          FROM
+            (SELECT distinct_id,
+                    argMax(person_id, version) as person_id
+             FROM person_distinct_id2
+             WHERE team_id = 2
+             GROUP BY distinct_id
+             HAVING argMax(is_deleted, version) = 0)
+          WHERE distinct_id = 'another@gm' ))
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_search.1
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%distinct_id_3%')
-                 OR id IN
-                   (SELECT person_id
-                    FROM
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0)
-                    WHERE distinct_id = 'distinct_id_3' )) )
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%distinct_id_3%')
-          OR id IN
-            (SELECT person_id
-             FROM
-               (SELECT distinct_id,
-                       argMax(person_id, version) as person_id
-                FROM person_distinct_id2
-                WHERE team_id = 2
-                GROUP BY distinct_id
-                HAVING argMax(is_deleted, version) = 0)
-             WHERE distinct_id = 'distinct_id_3' ))
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+    AND id IN
+      (SELECT id
+       FROM person
+       WHERE team_id = 2
+         AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%distinct_id_3%')
+              OR id IN
+                (SELECT person_id
+                 FROM
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0)
+                 WHERE distinct_id = 'distinct_id_3' )) )
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%distinct_id_3%')
+       OR id IN
+         (SELECT person_id
+          FROM
+            (SELECT distinct_id,
+                    argMax(person_id, version) as person_id
+             FROM person_distinct_id2
+             WHERE team_id = 2
+             GROUP BY distinct_id
+             HAVING argMax(is_deleted, version) = 0)
+          WHERE distinct_id = 'distinct_id_3' ))
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_search_materialized
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND (("pmat_email" ILIKE '%another@gm%')
-                 OR id IN
-                   (SELECT person_id
-                    FROM
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0)
-                    WHERE distinct_id = 'another@gm' )) )
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND ((argMax(person."pmat_email", version) ILIKE '%another@gm%')
-          OR id IN
-            (SELECT person_id
-             FROM
-               (SELECT distinct_id,
-                       argMax(person_id, version) as person_id
-                FROM person_distinct_id2
-                WHERE team_id = 2
-                GROUP BY distinct_id
-                HAVING argMax(is_deleted, version) = 0)
-             WHERE distinct_id = 'another@gm' ))
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+    AND id IN
+      (SELECT id
+       FROM person
+       WHERE team_id = 2
+         AND (("pmat_email" ILIKE '%another@gm%')
+              OR id IN
+                (SELECT person_id
+                 FROM
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0)
+                 WHERE distinct_id = 'another@gm' )) )
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND ((argMax(person."pmat_email", version) ILIKE '%another@gm%')
+       OR id IN
+         (SELECT person_id
+          FROM
+            (SELECT distinct_id,
+                    argMax(person_id, version) as person_id
+             FROM person_distinct_id2
+             WHERE team_id = 2
+             GROUP BY distinct_id
+             HAVING argMax(is_deleted, version) = 0)
+          WHERE distinct_id = 'another@gm' ))
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_search_materialized.1
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND (("pmat_email" ILIKE '%distinct_id_3%')
-                 OR id IN
-                   (SELECT person_id
-                    FROM
-                      (SELECT distinct_id,
-                              argMax(person_id, version) as person_id
-                       FROM person_distinct_id2
-                       WHERE team_id = 2
-                       GROUP BY distinct_id
-                       HAVING argMax(is_deleted, version) = 0)
-                    WHERE distinct_id = 'distinct_id_3' )) )
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND ((argMax(person."pmat_email", version) ILIKE '%distinct_id_3%')
-          OR id IN
-            (SELECT person_id
-             FROM
-               (SELECT distinct_id,
-                       argMax(person_id, version) as person_id
-                FROM person_distinct_id2
-                WHERE team_id = 2
-                GROUP BY distinct_id
-                HAVING argMax(is_deleted, version) = 0)
-             WHERE distinct_id = 'distinct_id_3' ))
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+    AND id IN
+      (SELECT id
+       FROM person
+       WHERE team_id = 2
+         AND (("pmat_email" ILIKE '%distinct_id_3%')
+              OR id IN
+                (SELECT person_id
+                 FROM
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 2
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0)
+                 WHERE distinct_id = 'distinct_id_3' )) )
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND ((argMax(person."pmat_email", version) ILIKE '%distinct_id_3%')
+       OR id IN
+         (SELECT person_id
+          FROM
+            (SELECT distinct_id,
+                    argMax(person_id, version) as person_id
+             FROM person_distinct_id2
+             WHERE team_id = 2
+             GROUP BY distinct_id
+             HAVING argMax(is_deleted, version) = 0)
+          WHERE distinct_id = 'distinct_id_3' ))
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_search_person_id
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000000%')
-                 OR (id = '00000000-0000-4000-8000-000000000000'
-                     OR id IN
-                       (SELECT person_id
-                        FROM
-                          (SELECT distinct_id,
-                                  argMax(person_id, version) as person_id
-                           FROM person_distinct_id2
-                           WHERE team_id = 2
-                           GROUP BY distinct_id
-                           HAVING argMax(is_deleted, version) = 0)
-                        WHERE distinct_id = '00000000-0000-4000-8000-000000000000' ))) )
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000000%')
-          OR (id = '00000000-0000-4000-8000-000000000000'
-              OR id IN
-                (SELECT person_id
-                 FROM
-                   (SELECT distinct_id,
-                           argMax(person_id, version) as person_id
-                    FROM person_distinct_id2
-                    WHERE team_id = 2
-                    GROUP BY distinct_id
-                    HAVING argMax(is_deleted, version) = 0)
-                 WHERE distinct_id = '00000000-0000-4000-8000-000000000000' )))
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+    AND id IN
+      (SELECT id
+       FROM person
+       WHERE team_id = 2
+         AND ((replaceRegexpAll(JSONExtractRaw(properties, 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000000%')
+              OR (id = '00000000-0000-4000-8000-000000000000'
+                  OR id IN
+                    (SELECT person_id
+                     FROM
+                       (SELECT distinct_id,
+                               argMax(person_id, version) as person_id
+                        FROM person_distinct_id2
+                        WHERE team_id = 2
+                        GROUP BY distinct_id
+                        HAVING argMax(is_deleted, version) = 0)
+                     WHERE distinct_id = '00000000-0000-4000-8000-000000000000' ))) )
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND ((replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '') ILIKE '%00000000-0000-4000-8000-000000000000%')
+       OR (id = '00000000-0000-4000-8000-000000000000'
+           OR id IN
+             (SELECT person_id
+              FROM
+                (SELECT distinct_id,
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
+                 WHERE team_id = 2
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0)
+              WHERE distinct_id = '00000000-0000-4000-8000-000000000000' )))
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---
 # name: TestPersonFromClickhouse.test_search_person_id_materialized
   '''
   /* user_id:0 request:_snapshot_ */
-  SELECT person.*,
-         groupArray(pdi.distinct_id) as distinct_ids
-  FROM
-    (SELECT id,
-            argMax(created_at, version) as created_at,
-            argMax(is_identified, version) as is_identified,
-            argMax(properties, version) as person_props
-     FROM person
-     WHERE team_id = 2
-       AND id IN
-         (SELECT id
-          FROM person
-          WHERE team_id = 2
-            AND (("pmat_email" ILIKE '%00000000-0000-4000-8000-000000000000%')
-                 OR (id = '00000000-0000-4000-8000-000000000000'
-                     OR id IN
-                       (SELECT person_id
-                        FROM
-                          (SELECT distinct_id,
-                                  argMax(person_id, version) as person_id
-                           FROM person_distinct_id2
-                           WHERE team_id = 2
-                           GROUP BY distinct_id
-                           HAVING argMax(is_deleted, version) = 0)
-                        WHERE distinct_id = '00000000-0000-4000-8000-000000000000' ))) )
-     GROUP BY id
-     HAVING max(is_deleted) = 0
-     AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
-     AND ((argMax(person."pmat_email", version) ILIKE '%00000000-0000-4000-8000-000000000000%')
-          OR (id = '00000000-0000-4000-8000-000000000000'
-              OR id IN
-                (SELECT person_id
-                 FROM
-                   (SELECT distinct_id,
-                           argMax(person_id, version) as person_id
-                    FROM person_distinct_id2
-                    WHERE team_id = 2
-                    GROUP BY distinct_id
-                    HAVING argMax(is_deleted, version) = 0)
-                 WHERE distinct_id = '00000000-0000-4000-8000-000000000000' )))
-     ORDER BY argMax(person.created_at, version) DESC, id DESC
-     LIMIT 100 SETTINGS optimize_aggregation_in_order = 1) person
-  LEFT JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 2
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) as pdi ON person.id=pdi.person_id
-  GROUP BY person.*
-  ORDER BY created_at desc,
-           id desc
+  SELECT id
+  FROM person
+  WHERE team_id = 2
+    AND id IN
+      (SELECT id
+       FROM person
+       WHERE team_id = 2
+         AND (("pmat_email" ILIKE '%00000000-0000-4000-8000-000000000000%')
+              OR (id = '00000000-0000-4000-8000-000000000000'
+                  OR id IN
+                    (SELECT person_id
+                     FROM
+                       (SELECT distinct_id,
+                               argMax(person_id, version) as person_id
+                        FROM person_distinct_id2
+                        WHERE team_id = 2
+                        GROUP BY distinct_id
+                        HAVING argMax(is_deleted, version) = 0)
+                     WHERE distinct_id = '00000000-0000-4000-8000-000000000000' ))) )
+  GROUP BY id
+  HAVING max(is_deleted) = 0
+  AND argMax(person.created_at, version) < now() + INTERVAL 1 DAY
+  AND ((argMax(person."pmat_email", version) ILIKE '%00000000-0000-4000-8000-000000000000%')
+       OR (id = '00000000-0000-4000-8000-000000000000'
+           OR id IN
+             (SELECT person_id
+              FROM
+                (SELECT distinct_id,
+                        argMax(person_id, version) as person_id
+                 FROM person_distinct_id2
+                 WHERE team_id = 2
+                 GROUP BY distinct_id
+                 HAVING argMax(is_deleted, version) = 0)
+              WHERE distinct_id = '00000000-0000-4000-8000-000000000000' )))
+  ORDER BY argMax(person.created_at, version) DESC, id DESC
+  LIMIT 100 SETTINGS optimize_aggregation_in_order = 1
   '''
 # ---

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -355,7 +355,7 @@ email@example.org,
         )
         self.assertEqual(len(response.json()["results"]), 1, response)
 
-    def test_filter_by_cohort_prop_from_clickhouse(self, patch_feature_enabled):
+    def test_filter_by_cohort_prop_from_clickhouse(self):
         for i in range(5):
             _create_person(
                 team=self.team,

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -355,8 +355,6 @@ email@example.org,
         )
         self.assertEqual(len(response.json()["results"]), 1, response)
 
-    # TODO: Remove this when load-person-field-from-clickhouse feature flag is removed
-    @patch("posthog.api.person.posthoganalytics.feature_enabled", return_value=True)
     def test_filter_by_cohort_prop_from_clickhouse(self, patch_feature_enabled):
         for i in range(5):
             _create_person(

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -1,7 +1,7 @@
 import json
 from typing import Optional, cast
 from unittest import mock
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 from django.utils import timezone
 from freezegun.api import freeze_time
@@ -994,8 +994,6 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         self.assertCountEqual(activity, expected)
 
 
-# TODO: Remove this when load-person-field-from-clickhouse feature flag is removed
-@patch("posthog.api.person.posthoganalytics.feature_enabled", Mock())
 class TestPersonFromClickhouse(TestPerson):
     @override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=False)
     def test_pagination_limit(self):

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -88,6 +88,10 @@ def sync_execute(
         except ModuleNotFoundError:  # when we run plugin server tests it tries to run above, ignore
             pass
 
+    # When someone uses an API key, always put their query to the offline cluster
+    if workload == Workload.DEFAULT and get_query_tag_value("access_method") == "personal_api_key":
+        workload = Workload.OFFLINE
+
     with get_pool(workload, team_id, readonly).get_client() as client:
         start_time = perf_counter()
 


### PR DESCRIPTION
## Problem

Direct API requests are still about 24% of throughput on US cluster (mostly person endpoint and trends). This PR makes sure we automatically move that workload to the offline cluster

Also get rid of an old feature flag.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
