### PR TITLE
feat: Add confirm to proxy deletion

### DIFF
--- a/frontend/src/scenes/settings/project/ManagedReverseProxy.tsx
+++ b/frontend/src/scenes/settings/project/ManagedReverseProxy.tsx
@@ -2,6 +2,7 @@ import { IconEllipsis, IconInfo, IconPlus } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
+    LemonDialog,
     LemonInput,
     LemonMenu,
     LemonTable,
@@ -76,7 +77,22 @@ export function ManagedReverseProxy(): JSX.Element {
                                 {
                                     label: 'Delete',
                                     status: 'danger',
-                                    onClick: () => deleteRecord(id),
+                                    onClick: () => {
+                                        LemonDialog.open({
+                                            title: 'Delete managed proxy',
+                                            width: '20rem',
+                                            content:
+                                                'Are you sure you want to delete this managed proxy? This cannot be undone and if it is in use then events sent to the domain will not be processed.',
+                                            primaryButton: {
+                                                status: 'danger',
+                                                onClick: () => deleteRecord(id),
+                                                children: 'Delete',
+                                            },
+                                            secondaryButton: {
+                                                children: 'Cancel',
+                                            },
+                                        })
+                                    },
                                 },
                             ]}
                         >


### PR DESCRIPTION
## Problem

Surprised me we didn't have this already given how dangerous it is...

## Changes

<img width="584" alt="Screenshot 2024-05-24 at 09 19 16" src="https://github.com/PostHog/posthog/assets/2536520/5822dfef-18b3-441a-82e9-4d5afdc8e294">

* Adds a delete confirmation to the reverse proxy item

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
