### PR TITLE
fix: toolbar clickmap reset

### DIFF
--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -592,6 +592,8 @@ export const heatmapLogic = kea<heatmapLogicType>([
             actions.loadAllEnabled(1000)
         },
         setCommonFilters: () => {
+            // the filters have changed, so we need to load new data not page on top of it
+            actions.resetElementStats()
             actions.loadAllEnabled(200)
         },
 

--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -225,7 +225,11 @@ export const heatmapLogic = kea<heatmapLogicType>([
                     }
 
                     return {
-                        results: [...(values.elementStats?.results || []), ...paginatedResults.results],
+                        results: [
+                            // if url is present we are paginating and merge results, otherwise we only use the new results
+                            ...(url ? values.elementStats?.results || [] : []),
+                            ...(paginatedResults.results || []),
+                        ],
                         next: paginatedResults.next,
                         previous: paginatedResults.previous,
                     } as PaginatedResponse<ElementsEventType>
@@ -592,8 +596,6 @@ export const heatmapLogic = kea<heatmapLogicType>([
             actions.loadAllEnabled(1000)
         },
         setCommonFilters: () => {
-            // the filters have changed, so we need to load new data not page on top of it
-            actions.resetElementStats()
             actions.loadAllEnabled(200)
         },
 


### PR DESCRIPTION
In https://posthoghelp.zendesk.com/agent/tickets/13638 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15773) a user reports that when they change date range in the toolbar the clickmap count only ever increases

this resets the element stats whenever we are loading the first page for a combination of filters

(tested by seeing the toolbar work properly when changing date range after applying the fix)