### PR TITLE
fix: waterfall empty statae

### DIFF
--- a/frontend/src/scenes/session-recordings/apm/NetworkView.tsx
+++ b/frontend/src/scenes/session-recordings/apm/NetworkView.tsx
@@ -137,7 +137,7 @@ function WaterfallMeta(): JSX.Element | null {
 
 export function NetworkView({ sessionRecordingId }: { sessionRecordingId: string }): JSX.Element {
     const logic = networkViewLogic({ sessionRecordingId })
-    const { isLoading, currentPage } = useValues(logic)
+    const { isLoading, currentPage, hasPageViews } = useValues(logic)
 
     if (isLoading) {
         return (
@@ -157,6 +157,11 @@ export function NetworkView({ sessionRecordingId }: { sessionRecordingId: string
                         className="NetworkView__table"
                         size="small"
                         dataSource={currentPage}
+                        emptyState={
+                            hasPageViews
+                                ? 'error displaying network data'
+                                : 'network data does not include any "navigation" events'
+                        }
                         columns={[
                             {
                                 title: 'URL',

--- a/frontend/src/scenes/session-recordings/apm/networkViewLogic.ts
+++ b/frontend/src/scenes/session-recordings/apm/networkViewLogic.ts
@@ -150,5 +150,6 @@ export const networkViewLogic = kea<networkViewLogicType>([
                 }
             },
         ],
+        hasPageViews: [(s) => [s.pageCount], (pageCount) => pageCount > 0],
     }),
 ])


### PR DESCRIPTION
Sometimes we don't capture the navigation event when capturing network information.

The waterfall view discards any network data before the first navigation - since it's a page by page display

That means if there's no navigation you can see network data in the inspector but not in the waterfall - confusing

Adds a better empty state

# a session with network data but no navigation event

<img width="599" alt="Screenshot 2024-05-24 at 15 32 18" src="https://github.com/PostHog/posthog/assets/984817/0c9551cf-27e2-4a53-9d04-235d8fb802a5">

<img width="612" alt="Screenshot 2024-05-24 at 15 32 10" src="https://github.com/PostHog/posthog/assets/984817/3863e749-99ec-48de-8a05-a4b492713b54">
