### PR TITLE
feat: Management cmd for fixing future person creation dates

### DIFF
--- a/posthog/management/commands/fix_future_person_created_at.py
+++ b/posthog/management/commands/fix_future_person_created_at.py
@@ -1,0 +1,70 @@
+from datetime import timedelta
+import logging
+
+import structlog
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from dateutil.parser import isoparse
+
+from posthog.kafka_client.client import KafkaProducer
+from posthog.models.person.person import Person
+from posthog.models.person.util import create_person
+from django.utils.timezone import now
+
+logger = structlog.get_logger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class Command(BaseCommand):
+    help = "Fix update persons created_at to not be in the future for a single team"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--team-id", default=None, type=int, help="Specify a team to fix data for.")
+        parser.add_argument("--new-date", default="2024-01-01", type=str, help="New create_at value to use")
+        parser.add_argument("--live-run", action="store_true", help="Run changes, default is dry-run")
+
+    def handle(self, *args, **options):
+        run(options)
+
+
+def run(options):
+    live_run = options["live_run"]
+
+    if not options["team_id"]:
+        logger.error("You must specify --team-id to run this script")
+        exit(1)
+
+    team_id = options["team_id"]
+    new_date = isoparse(options["new_date"])
+
+    future_date = now() + timedelta(days=2)
+
+    # Get all persons with future created_at value
+    persons = Person.objects.filter(team_id=team_id, created_at__gt=future_date)
+
+    logger.info(
+        f'Found {len(persons)} persons with future created_at value, updating them to {new_date.strftime("%Y-%m-%d %H:%M:%S.%f")}'
+    )
+
+    # If someone else updated the person at the same time these could conflict, which isn't ideal, but this is a one-off script
+    for person in persons:
+        logger.info(f'Updating person {person.uuid} created_at to {new_date.strftime("%Y-%m-%d %H:%M:%S.%f")}')
+        if live_run:
+            with transaction.atomic():
+                person.created_at = new_date
+                person.version += 1
+                person.save()
+            create_person(
+                uuid=str(person.uuid),
+                team_id=team_id,
+                properties=person.properties,
+                is_identified=person.is_identified,
+                is_deleted=False,
+                created_at=person.created_at,
+                version=person.version,
+                sync=True,
+            )
+
+    logger.info("Waiting on Kafka producer flush, for up to 5 minutes")
+    KafkaProducer().flush(5 * 60)
+    logger.info("Kafka producer queue flushed.")


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

It's not possible to have future timestamps anymore and hasn't been for a while.
We still have some old data with future timestamps, specifically persons with a future created_at value, this means we need to exclude those in queries to not make the persons page look weird. Problem with this exclusion is that it then also excludes them when someone clicks on a data point from an insight. So what we really want is those persons to have some past date as 'created_at' it doesn't really matter what as anything is better than the future, then we can remove the exclusion from the queries & not step into this hole again.

https://posthog.slack.com/archives/C02E3BKC78F/p1716503393145799

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Tested locally - created 2 persons with future dates and they got properly updated in PG and CH
