### PR TITLE
fix: Revert #22512, removing `SETTINGS max_table_size_to_drop = 0` from migration

### DIFF
--- a/posthog/clickhouse/migrations/0063_drop_partition_stats.py
+++ b/posthog/clickhouse/migrations/0063_drop_partition_stats.py
@@ -3,25 +3,18 @@ from posthog.kafka_client.topics import KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW, 
 from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE
 from posthog.settings.data_stores import KAFKA_EVENTS_PLUGIN_INGESTION
 
-
-def get_drop_table_sql(table: str) -> str:
-    return f"""\
-        DROP TABLE IF EXISTS `{CLICKHOUSE_DATABASE}`.{table}
-        ON CLUSTER '{CLICKHOUSE_CLUSTER}' SYNC
-        SETTINGS max_table_size_to_drop = 0
-    """
-
-
-DROP_EVENTS_PLUGIN_INGESTION_PARTITION_STATISTICS_TABLE = get_drop_table_sql(
-    "events_plugin_ingestion_partition_statistics"
+DROP_EVENTS_PLUGIN_INGESTION_PARTITION_STATISTICS_TABLE = (
+    lambda: f"DROP TABLE IF EXISTS `{CLICKHOUSE_DATABASE}`.events_plugin_ingestion_partition_statistics ON CLUSTER '{CLICKHOUSE_CLUSTER}' SYNC"
 )
 
-DROP_PARTITION_STATISTICS_MV = lambda monitored_topic: get_drop_table_sql(f"{monitored_topic}_partition_statistics_mv")
+DROP_PARTITION_STATISTICS_MV = (
+    lambda monitored_topic: f"DROP TABLE IF EXISTS `{CLICKHOUSE_DATABASE}`.{monitored_topic}_partition_statistics_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}' SYNC"
+)
 
 operations = map(
     run_sql_with_exceptions,
     [
-        DROP_EVENTS_PLUGIN_INGESTION_PARTITION_STATISTICS_TABLE,
+        DROP_EVENTS_PLUGIN_INGESTION_PARTITION_STATISTICS_TABLE(),
         DROP_PARTITION_STATISTICS_MV(KAFKA_EVENTS_PLUGIN_INGESTION),
         DROP_PARTITION_STATISTICS_MV(KAFKA_EVENTS_PLUGIN_INGESTION_OVERFLOW),
         DROP_PARTITION_STATISTICS_MV(KAFKA_SESSION_RECORDING_EVENTS),


### PR DESCRIPTION
This:

1. did not actually have the effect that it was described to have in the error message
2. did not work on EU as that cluster is running an older version than US