### PR TITLE
fix(exports): allow actors query to run

### DIFF
--- a/posthog/hogql_queries/actor_strategies.py
+++ b/posthog/hogql_queries/actor_strategies.py
@@ -66,10 +66,10 @@ class PersonStrategy(ActorStrategy):
             )
             distinct_ids = cursor.fetchall()
 
-        person_id_to_raw_person_and_set: dict[int, tuple] = {person[0]: (person, set()) for person in people}
+        person_id_to_raw_person_and_set: dict[int, tuple] = {person[0]: (person, []) for person in people}
 
         for pdid in distinct_ids:
-            person_id_to_raw_person_and_set[pdid[0]][1].add(pdid[1])
+            person_id_to_raw_person_and_set[pdid[0]][1].append(pdid[1])
         del distinct_ids
 
         person_uuid_to_person = {

--- a/posthog/hogql_queries/actor_strategies.py
+++ b/posthog/hogql_queries/actor_strategies.py
@@ -1,14 +1,16 @@
 from typing import cast, Literal, Optional
 
-from django.db.models import Prefetch
+from django.db import connection
 
 from posthog.hogql import ast
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.parser import parse_expr
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.utils.recordings_helper import RecordingsHelper
-from posthog.models import Team, Person, Group
+from posthog.models import Team, Group
 from posthog.schema import ActorsQuery
+
+import orjson as json
 
 
 class ActorStrategy:
@@ -42,18 +44,46 @@ class PersonStrategy(ActorStrategy):
     origin = "persons"
     origin_id = "id"
 
+    # This is hand written instead of using the ORM because the ORM was blowing up the memory on exports and taking forever
     def get_actors(self, actor_ids) -> dict[str, dict]:
-        return {
-            str(p.uuid): {
-                "id": p.uuid,
-                **{field: getattr(p, field) for field in ("distinct_ids", "properties", "created_at", "is_identified")},
-            }
-            for p in Person.objects.filter(
-                team_id=self.team.pk, persondistinctid__team_id=self.team.pk, uuid__in=actor_ids
+        # If actor queries start quietly dying again, this might need batching at some point
+        # but currently works with 800,000 persondistinctid entries (May 24, 2024)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """SELECT posthog_person.id, posthog_person.uuid, posthog_person.properties, posthog_person.is_identified, posthog_person.created_at
+            FROM posthog_person
+            WHERE posthog_person.uuid = ANY(%(uuids)s)
+            AND posthog_person.team_id = %(team_id)s""",
+                {"uuids": list(actor_ids), "team_id": self.team.pk},
             )
-            .prefetch_related(Prefetch("persondistinctid_set", to_attr="distinct_ids_cache"))
-            .iterator(chunk_size=self.paginator.limit)
+            people = cursor.fetchall()
+            cursor.execute(
+                """SELECT posthog_persondistinctid.person_id, posthog_persondistinctid.distinct_id
+            FROM posthog_persondistinctid
+            WHERE posthog_persondistinctid.person_id = ANY(%(people_ids)s)
+            AND posthog_persondistinctid.team_id = %(team_id)s""",
+                {"people_ids": [x[0] for x in people], "team_id": self.team.pk},
+            )
+            distinct_ids = cursor.fetchall()
+
+        person_id_to_raw_person_and_set: dict[int, tuple] = {person[0]: (person, set()) for person in people}
+
+        for pdid in distinct_ids:
+            person_id_to_raw_person_and_set[pdid[0]][1].add(pdid[1])
+        del distinct_ids
+
+        person_uuid_to_person = {
+            str(person[1]): {
+                "id": person[1],
+                "properties": json.loads(person[2]),
+                "is_identified": person[3],
+                "created_at": person[4],
+                "distinct_ids": distinct_ids,
+            }
+            for person, distinct_ids in person_id_to_raw_person_and_set.values()
         }
+
+        return person_uuid_to_person
 
     def get_recordings(self, matching_events) -> dict[str, list[dict]]:
         return RecordingsHelper(self.team).get_recordings(matching_events)


### PR DESCRIPTION
## Problem

The actors query was blowing up on exports. There was nothing in the logs about it.

When you run the export code in prod in the shell, it quickly takes up 10 gigs of RAM before the kernel kills it. Poof. Gone. Not even logs to show it was killed. Just `command terminated with exit code 137` (Exit code 137 is a signal that occurs when a container's memory exceeds the memory limit provided in the pod specification).

Our export that was dying had about 2000 people and 800,000 peopledistinctids. This isn't that big.

Client Issue Here:
https://app.slack.com/client/TSS5W8YQZ/C05PKRLD7B4

## Changes

We use pgbouncer, so we can't use server-side cursors, so we have to have cursors on the client.

At first I attempted to just load it in a few pages, like @neilkakkar did in [cohort.py:596](https://github.com/PostHog/posthog/blob/82be493b9d059e5973b61fad1f6680e329eb7f78/posthog/api/cohort.py#L596). This worked, but it took about an hour to load 800,000 rows. Insane.

So I just pulled the necessary data by hand.

This runs in about 10 seconds. Memory still spikes a bit (python takes a lot of memory), so it's important to remember that and page this with sane limits in the future as exports expands even more.

## Does this work well for both Cloud and self-hosted?

No Impact

## How did you test this code?

Passed local tests. Ran the code on prod against the UUIDs from the client's actors query, and it returns without a problem.

Tested export on local data on master and on this branch, verified same output, modulo export order (people aren't sorted inside of each number of event level, so the order can change)
