### PR TITLE
fix: plugin access for orgs who can configure them

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -314,7 +314,7 @@ class PluginViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def safely_get_queryset(self, queryset):
         queryset = queryset.select_related("organization")
 
-        if self.action == "get" or self.action == "list":
+        if self.action == "retrieve" or self.action == "list":
             if can_install_plugins(self.organization) or can_configure_plugins(self.organization):
                 return queryset
         else:


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
New UI for plugin creation gets the single plugin, i.e. calls sth like 
http://localhost:8000/api/organizations/@current/plugins/6  - and got 404
http://localhost:8000/api/organizations/@current/plugins - works

Problem was that we allowed `list` but didn't allow `retrieve` it was mistakenly `get` which afaik isn't an action option.

Ticket: https://posthoghelp.zendesk.com/agent/tickets/13942 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/16119)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
http://localhost:8000/api/organizations/@current/plugins/6  - works locally after changing plugins_access_level to CONFIG=3
