### PR TITLE
chore: remove update admin emails in billing

### DIFF
--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -327,8 +327,6 @@ def send_report_to_billing_service(org_id: str, report: dict[str, Any]) -> None:
 
         response_data: BillingStatus = response.json()
         BillingManager(license).update_org_details(organization, response_data)
-        # TODO(@zach): remove the following after 2024-05-24
-        BillingManager(license).update_billing_admin_emails(organization)
 
     except Exception as err:
         logger.error(f"UsageReport failed sending to Billing for organization: {organization.id}: {err}")


### PR DESCRIPTION
Removing the forced admin email sync to billing. It was backfilled via this and in the future it will stay in sync via hooks. 

https://github.com/PostHog/posthog/pull/22374