### PR TITLE
fix: add copy for the survey wait period as part of the display conditions summary

### DIFF
--- a/frontend/src/scenes/surveys/Survey.tsx
+++ b/frontend/src/scenes/surveys/Survey.tsx
@@ -167,6 +167,16 @@ export function SurveyDisplaySummary({
                     )}
                 </div>
             )}
+            {survey.conditions?.seenSurveyWaitPeriodInDays && (
+                <div className="flex flex-col font-medium gap-1">
+                    <div className="flex-row">
+                        <span>Wait period after seeing survey:</span>{' '}
+                        <span className="simple-tag tag-light-blue text-primary-alt">
+                            {survey.conditions.seenSurveyWaitPeriodInDays} days
+                        </span>
+                    </div>
+                </div>
+            )}
             {targetingFlagFilters && (
                 <BindLogic logic={featureFlagLogic} props={{ id: survey.targeting_flag?.id || 'new' }}>
                     <span className="font-medium">User properties:</span>{' '}

--- a/frontend/src/scenes/surveys/Survey.tsx
+++ b/frontend/src/scenes/surveys/Survey.tsx
@@ -172,7 +172,8 @@ export function SurveyDisplaySummary({
                     <div className="flex-row">
                         <span>Wait period after seeing survey:</span>{' '}
                         <span className="simple-tag tag-light-blue text-primary-alt">
-                            {survey.conditions.seenSurveyWaitPeriodInDays} days
+                            {survey.conditions.seenSurveyWaitPeriodInDays}{' '}
+                            {survey.conditions.seenSurveyWaitPeriodInDays === 1 ? 'day' : 'days'}
                         </span>
                     </div>
                 </div>

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -531,7 +531,10 @@ export default function SurveyEdit(): JSX.Element {
                                                                     }}
                                                                     className="w-12"
                                                                 />{' '}
-                                                                days.
+                                                                {value?.seenSurveyWaitPeriodInDays === 1
+                                                                    ? 'day'
+                                                                    : 'days'}
+                                                                .
                                                             </div>
                                                         </LemonField.Pure>
                                                     </>


### PR DESCRIPTION
## Problem

As part of [this PR](https://github.com/PostHog/posthog/pull/22496), I made a change to how we show the survey display conditions summary.  However, as [Neil pointed out](https://github.com/PostHog/posthog/pull/22496#discussion_r1615829309), I missed a condition for the waiting period, so it displays nothing in that case.


## Changes

Before (buggy behavior)

<img width="958" alt="Screenshot 2024-05-27 at 11 26 27 AM" src="https://github.com/PostHog/posthog/assets/4853149/6c7ed8a6-03d6-4347-856d-7b85b4a7f6e1">

After (fix)

<img width="951" alt="Screenshot 2024-05-27 at 11 25 48 AM" src="https://github.com/PostHog/posthog/assets/4853149/8af6fefc-b4fe-43f7-9517-678a2d310e17">

