### PR TITLE
fix: Trust score update in quota_limiting was using the wrong key

### DIFF
--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -1,8 +1,8 @@
 import copy
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 from enum import Enum
 from typing import Optional, TypedDict, cast
-from collections.abc import Mapping, Sequence
 
 import dateutil.parser
 import posthoganalytics
@@ -152,7 +152,7 @@ def org_quota_limited_until(
         # Set them to the default trust score and immediately limit
         if trust_score is None:
             organization.customer_trust_scores[resource.value] = 0
-            organization.save(update_fields=["usage"])
+            organization.save(update_fields=["customer_trust_scores", "usage"])
         return {
             "quota_limited_until": billing_period_end,
             "quota_limiting_suspended_until": None,

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -151,7 +151,7 @@ def org_quota_limited_until(
     if not trust_score:
         # Set them to the default trust score and immediately limit
         if trust_score is None:
-            organization.customer_trust_scores[resource] = 0
+            organization.customer_trust_scores[resource.value] = 0
             organization.save(update_fields=["usage"])
         return {
             "quota_limited_until": billing_period_end,

--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -621,6 +621,17 @@ class TestQuotaLimiting(BaseTest):
                 "quota_limiting_suspended_until": None,
             }
 
+        self.organization.customer_trust_scores = {"events": 7, "rows_synced": 10}
+        self.organization.save()
+        assert org_quota_limited_until(
+            self.organization, QuotaResource.RECORDINGS, previously_quota_limited_team_tokens_rows_synced
+        ) == {
+            "quota_limited_until": 1612137599,
+            "quota_limiting_suspended_until": None,
+        }
+        self.organization.refresh_from_db()
+        assert self.organization.customer_trust_scores == {"events": 7, "recordings": 0, "rows_synced": 10}
+
     def test_over_quota_but_not_dropped_org(self):
         self.organization.usage = None
         previously_quota_limited_team_tokens_events = list_limited_team_attributes(


### PR DESCRIPTION
## Problem

Fix this sentry error: https://posthog.sentry.io/issues/5417615070/?alert_rule_id=7093241&alert_type=issue&notification_uuid=1994817f-73f2-47be-b25a-7631a854fd01&project=1899813&referrer=slack#breadcrumbs

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
