### PR TITLE
feat(exports): Add sentry trace headers to PNG asset screenshot request

### DIFF
--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -3,6 +3,7 @@ import os
 import uuid
 from datetime import timedelta
 from typing import Literal, Optional
+import sentry_sdk
 
 import structlog
 from django.conf import settings
@@ -128,6 +129,14 @@ def _screenshot_asset(
     try:
         driver = get_driver()
         driver.set_window_size(screenshot_width, screenshot_width * 0.5)
+
+        headers = {
+            "sentry-trace": sentry_sdk.get_traceparent(),
+            "baggage": sentry_sdk.get_baggage(),
+        }
+        driver.execute_cdp_cmd("Network.enable", {})
+        driver.execute_cdp_cmd("Network.setExtraHTTPHeaders", {"headers": headers})
+
         driver.get(url_to_render)
         WebDriverWait(driver, 20).until(lambda x: x.find_element_by_css_selector(wait_for_css_selector))
         # Also wait until nothing is loading


### PR DESCRIPTION
## Problem

PNG exports use a screenshot which makes a request. When the request fails, we capture the errors, but maybe it would also be possible to associate the original export task to it (since it's not visible easily in Sentry why the task failed).

Example:
https://posthog.sentry.io/issues/4147753916/events/e933dec5bd624777b47d526a26c4ae9e/?project=1899813

## Changes

Grab the sentry trace id and pass it on.

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

- checked with debugger that trace id is available and that it's then in the request to the insight
- not sure how to check it Sentry actually does something with this 🤷🏻 