### PR TITLE
fix: inspector min height

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/PlayerInspector.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/PlayerInspector.tsx
@@ -36,7 +36,11 @@ export function PlayerInspector({
             className={clsx('SessionRecordingPlayer__inspector')}
             ref={ref}
             // eslint-disable-next-line react/forbid-dom-props
-            style={isVerticallyStacked ? { height: desiredSize ?? undefined } : { width: desiredSize ?? undefined }}
+            style={
+                isVerticallyStacked
+                    ? { height: desiredSize ?? undefined, minHeight: 110 }
+                    : { width: desiredSize ?? undefined }
+            }
         >
             <Resizer
                 logicKey={logicKey}


### PR DESCRIPTION
## Problem

Looks to address https://posthoghelp.zendesk.com/agent/tickets/13892 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/16186)

## Changes

Make sure the inspector is always visible vertically with min height