### PR TITLE
feat: send detected client side priority when opening a zendesk ticket

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -11,7 +11,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
-import { Region, SidePanelTab, TeamType, UserType } from '~/types'
+import { AvailableFeature, Region, SidePanelTab, TeamType, UserType } from '~/types'
 
 import type { supportLogicType } from './supportLogicType'
 import { openSupportModal } from './SupportModal'
@@ -259,7 +259,16 @@ export const supportLogic = kea<supportLogicType>([
     props({} as SupportFormLogicProps),
     path(['lib', 'components', 'support', 'supportLogic']),
     connect(() => ({
-        values: [userLogic, ['user'], preflightLogic, ['preflight'], sidePanelStateLogic, ['sidePanelAvailable']],
+        values: [
+            userLogic,
+            ['user'],
+            preflightLogic,
+            ['preflight'],
+            sidePanelStateLogic,
+            ['sidePanelAvailable'],
+            userLogic,
+            ['hasAvailableFeature'],
+        ],
         actions: [sidePanelStateLogic, ['openSidePanel', 'setSidePanelOptions']],
     })),
     actions(() => ({
@@ -386,6 +395,14 @@ export const supportLogic = kea<supportLogicType>([
                         {
                             id: 22129191462555,
                             value: posthog.get_distinct_id(),
+                        },
+                        {
+                            id: 26073267652251,
+                            value: values.hasAvailableFeature(AvailableFeature.PRIORITY_SUPPORT)
+                                ? 'priority_support'
+                                : values.hasAvailableFeature(AvailableFeature.EMAIL_SUPPORT)
+                                ? 'email_support'
+                                : 'free_support',
                         },
                     ],
                     comment: {


### PR DESCRIPTION
## Problem

Sometimes the priority in Zendesk is wrong, this will allow us to create a view where the `client priority` doesn't match the actual `priority`.