### PR TITLE
revert(exports): Revert "feat(exports): Add sentry trace headers to PNG asset screenshot request"

### DIFF
--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -3,7 +3,6 @@ import os
 import uuid
 from datetime import timedelta
 from typing import Literal, Optional
-import sentry_sdk
 
 import structlog
 from django.conf import settings
@@ -129,14 +128,6 @@ def _screenshot_asset(
     try:
         driver = get_driver()
         driver.set_window_size(screenshot_width, screenshot_width * 0.5)
-
-        headers = {
-            "sentry-trace": sentry_sdk.get_traceparent(),
-            "baggage": sentry_sdk.get_baggage(),
-        }
-        driver.execute_cdp_cmd("Network.enable", {})
-        driver.execute_cdp_cmd("Network.setExtraHTTPHeaders", {"headers": headers})
-
         driver.get(url_to_render)
         WebDriverWait(driver, 20).until(lambda x: x.find_element_by_css_selector(wait_for_css_selector))
         # Also wait until nothing is loading


### PR DESCRIPTION
Reverts PostHog/posthog#22537

We get issues with CORS inside the webdriver request because of the added sentry-trace header.

See https://posthog.sentry.io/issues/4147753916/events/5ce87cb52f284108b94ac921f9f753e8/