### PR TITLE
feat(personless-events): Set the posthog app to always create person profiles

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -43,7 +43,7 @@ export function loadPostHogJS(): void {
                 autocapture: {
                     capture_copied_text: true,
                 },
-                process_person: 'identified_only',
+                person_profiles: 'always',
 
                 // Helper to capture events for assertions in Cypress
                 _onCapture: (window as any)._cypress_posthog_captures


### PR DESCRIPTION
## Problem

We probably should have had this before, it makes more sense to have identified_only for the marketing site. The goal is to make these two graphs the same:

https://us.posthog.com/project/2/insights/RZ3Kjn0v/edit
https://us.posthog.com/project/2/insights/R50Vf7Hs

I realised that one source of the discrepency is direct traffic to the posthog app (change the breakdowns above to entry url and you can see), and we're not doing anything special to create person profiles there. This PR fixes that.

## Changes

Set the posthog app to always create person profiles
## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Manually
