### PR TITLE
fix: waterfall disk cache wrapping

### DIFF
--- a/frontend/src/scenes/session-recordings/apm/NetworkView.tsx
+++ b/frontend/src/scenes/session-recordings/apm/NetworkView.tsx
@@ -56,7 +56,7 @@ function NetworkStatus({ item }: { item: PerformanceEvent }): JSX.Element | null
     return (
         <div className="flex flex-row justify-around">
             <MethodTag item={item} label={false} />
-            <StatusTag item={item} label={false} />
+            <StatusTag item={item} detailed={false} />
         </div>
     )
 }

--- a/frontend/src/scenes/session-recordings/apm/playerInspector/ItemPerformanceEvent.tsx
+++ b/frontend/src/scenes/session-recordings/apm/playerInspector/ItemPerformanceEvent.tsx
@@ -462,7 +462,7 @@ function StatusRow({ item }: { item: PerformanceEvent }): JSX.Element | null {
     }
 
     if (item.method) {
-        methodRow = <MethodTag item={item} />
+        methodRow = <MethodTag item={item} label={false} />
     }
 
     return methodRow || statusRow ? (

--- a/frontend/src/scenes/session-recordings/apm/playerInspector/ItemPerformanceEvent.tsx
+++ b/frontend/src/scenes/session-recordings/apm/playerInspector/ItemPerformanceEvent.tsx
@@ -462,7 +462,7 @@ function StatusRow({ item }: { item: PerformanceEvent }): JSX.Element | null {
     }
 
     if (item.method) {
-        methodRow = <MethodTag item={item} label={false} />
+        methodRow = <MethodTag item={item} label={true} />
     }
 
     return methodRow || statusRow ? (

--- a/frontend/src/scenes/session-recordings/apm/playerInspector/ItemPerformanceEvent.tsx
+++ b/frontend/src/scenes/session-recordings/apm/playerInspector/ItemPerformanceEvent.tsx
@@ -411,7 +411,7 @@ export function HeadersDisplay({
     )
 }
 
-export function StatusTag({ item, label }: { item: PerformanceEvent; label?: boolean }): JSX.Element | null {
+export function StatusTag({ item, detailed }: { item: PerformanceEvent; detailed: boolean }): JSX.Element | null {
     if (item.response_status === undefined) {
         return null
     }
@@ -432,10 +432,10 @@ export function StatusTag({ item, label }: { item: PerformanceEvent; label?: boo
 
     return (
         <div className="flex gap-4 items-center justify-between overflow-hidden">
-            {label ? <div className="font-semibold">Status code</div> : null}
+            {detailed ? <div className="font-semibold">Status code</div> : null}
             <div>
                 <LemonTag type={statusType}>{statusDescription}</LemonTag>
-                {fromDiskCache && <span className="text-muted"> (from cache)</span>}
+                {detailed && fromDiskCache ? <span className="text-muted"> (from cache)</span> : null}
             </div>
         </div>
     )
@@ -458,7 +458,7 @@ function StatusRow({ item }: { item: PerformanceEvent }): JSX.Element | null {
     let methodRow = null
 
     if (item.response_status) {
-        statusRow = <StatusTag item={item} />
+        statusRow = <StatusTag item={item} detailed={true} />
     }
 
     if (item.method) {


### PR DESCRIPTION
the status tag takes up more space than the waterfall view has to display it

![image](https://github.com/PostHog/posthog/assets/984817/7886ecc7-461a-40f4-a6ce-481d2ec3dbf9)

we still want to share the logic hidden inside it, for now lets not show the from disk cache info in waterfall view. we have more space and can treat this better later on

## after

<img width="1129" alt="Screenshot 2024-05-28 at 17 38 41" src="https://github.com/PostHog/posthog/assets/984817/ee832658-52c6-4852-8995-b5a141d11826">
<img width="580" alt="Screenshot 2024-05-28 at 17 41 35" src="https://github.com/PostHog/posthog/assets/984817/b1c136d3-9376-40c8-9eb0-2ea736d0a7c3">

