### PR TITLE
chore: include more details in logs

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -273,7 +273,11 @@ export class SessionRecordingIngester {
         const { partition, highOffset } = event.metadata
         const isDebug = this.debugPartition === partition
         if (isDebug) {
-            status.info('🔁', '[blob_ingester_consumer] - [PARTITION DEBUG] - consuming event', { ...event.metadata })
+            status.info('🔁', '[blob_ingester_consumer] - [PARTITION DEBUG] - consuming event', {
+                ...event.metadata,
+                team_id,
+                session_id,
+            })
         }
 
         function dropEvent(dropCause: string) {


### PR DESCRIPTION
We log event metadata from blob ingestion when debug logging is on

So, I can see that there are events >3MB which are probably what are causing the current slow down

But I can't see anything about them in the logs

Include team and session id 