### PR TITLE
fix: update billing error parsing

### DIFF
--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -232,8 +232,9 @@ export const billingLogic = kea<billingLogicType>([
                         } else {
                             actions.setUnsubscribeError({
                                 detail:
-                                    error.detail ||
-                                    `We encountered a problem. Please try again or submit a support ticket.`,
+                                    typeof error.detail === 'string'
+                                        ? error.detail
+                                        : `We encountered a problem. Please try again or submit a support ticket.`,
                             } as UnsubscribeError)
                         }
                         console.error(error)


### PR DESCRIPTION
## Problem

An error popped up about the billing response not being rendered correctly: https://posthog.sentry.io/issues/5421139394/?alert_rule_id=14968077&alert_type=issue&notification_uuid=d914ba48-b1f9-46e4-8d2a-6fc2abb88a60&project=1899813&referrer=slack

Sometimes, `error.detail` is an object, and can't render an object. 

## Changes

This PR checks if `error.detail` is an object, otherwise renders a generic message. 