### PR TITLE
fix: timeout less

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -46,7 +46,7 @@ require('@sentry/tracing')
 // WARNING: Do not change this - it will essentially reset the consumer
 const KAFKA_CONSUMER_GROUP_ID = 'session-recordings-blob'
 const KAFKA_CONSUMER_GROUP_ID_OVERFLOW = 'session-recordings-blob-overflow'
-const KAFKA_CONSUMER_SESSION_TIMEOUT_MS = 30000
+const KAFKA_CONSUMER_SESSION_TIMEOUT_MS = 90_000
 const SHUTDOWN_FLUSH_TIMEOUT_MS = 30000
 const CAPTURE_OVERFLOW_REDIS_KEY = '@posthog/capture-overflow/replay'
 


### PR DESCRIPTION
Sometimes, when under load, it feels like blobby is too keen to rebalance. 

The rebalances aren't being caused by restarts but we get stuck rebalancing

If a pod doesn't manage to heartbeat for 30 seconds then we consider it timed out and would rebalance

We don't need to be eager to rebalance, so we can be less strict here. If a consumer is struggling to get through a message then it could consistently cause a rebalance by being "stuck" working for ~30 seconds

----

opening this since I've been reading and thinking but this can wait until I'm back