### PR TITLE
fix: add persistence to redis and kafka on hobby

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -199,3 +199,5 @@ volumes:
     clickhouse-data:
     caddy-data:
     caddy-config:
+    redis-data:
+    kafka-data:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -22,6 +22,8 @@ services:
         extends:
             file: docker-compose.base.yml
             service: redis
+        volumes:
+            - redis-data:/data    
     clickhouse:
         #
         # Note: please keep the default version in sync across
@@ -54,6 +56,8 @@ services:
             service: kafka
         depends_on:
             - zookeeper
+        volumes:
+            - kafka-data:/var/lib/kafka    
 
     worker:
         extends:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -57,7 +57,7 @@ services:
         depends_on:
             - zookeeper
         volumes:
-            - kafka-data:/var/lib/kafka    
+            - kafka-data:/bitnami/kafka   
 
     worker:
         extends:


### PR DESCRIPTION
## Problem

This is to address https://github.com/PostHog/posthog/issues/22291, but potentially fixes other redis/kafka related conditions over containers updates / rebuilds. Currently rebuilding resets `high_water_mark` value stored in redis due to lack of volume mapping. 

## Changes

Added volumes for redis and kafka

## Does this work well for both Cloud and self-hosted?

self-hosted.

## How did you test this code?

using it on our prod for a week now, updates run smoothly, session recordings never stop flowing.
