### PR TITLE
feat: add env var for number of nginx unit worker processes

### DIFF
--- a/bin/docker-server-unit
+++ b/bin/docker-server-unit
@@ -12,6 +12,7 @@ trap 'rm -rf "$PROMETHEUS_MULTIPROC_DIR"' EXIT
 export PROMETHEUS_METRICS_EXPORT_PORT=8001
 export STATSD_PORT=${STATSD_PORT:-8125}
 export NGINX_UNIT_PYTHON_PROTOCOL=${NGINX_UNIT_PYTHON_PROTOCOL:-wsgi}
+export NGINX_UNIT_APP_PROCESSES=${NGINX_UNIT_APP_PROCESSES:-4}
 envsubst < /docker-entrypoint.d/unit.json.tpl > /docker-entrypoint.d/unit.json
 
 

--- a/unit.json.tpl
+++ b/unit.json.tpl
@@ -40,7 +40,7 @@
     "applications": {
         "posthog": {
             "type": "python 3.10",
-            "processes": 4,
+            "processes": $NGINX_UNIT_APP_PROCESSES,
             "working_directory": "/code",
             "path": ".",
             "module": "posthog.$NGINX_UNIT_PYTHON_PROTOCOL",


### PR DESCRIPTION
## Problem

i suspect that with asgi we'll be better off with 1 instead of 4 worker processes - i'd like us to be able to test this per deployment via an env var


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
