### PR TITLE
fix(insights): Fix problem with updated filters showing blank chart

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -298,7 +298,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
     subscriptions(({ props, actions, values }) => ({
         columns: (value: { name: string; type: string }[], oldValue: { name: string; type: string }[]) => {
             // If response is cleared, then don't update any internal values
-            if (!values.response) {
+            if (!values.response || !values.response.results) {
                 return
             }
 


### PR DESCRIPTION
## Problem

- user puts a HogQL query with line chart visualization on a dashboard
- when filters change, data is updated
- chart is blank however, because logic clears some ySeries value  


https://posthoghelp.zendesk.com/agent/tickets/13605 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/16156) 

It fails here because `ySeries` got set to null:

https://github.com/PostHog/posthog/blob/e43166ed27a7a5e00b6881fc3926c483f131146c/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts#L196-L198

## Changes

- make sure to clear when results are null as well (during rerender)

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

👀 