### PR TITLE
fix: add _timestamp filter to event deletion by Person

### DIFF
--- a/posthog/models/event/util.py
+++ b/posthog/models/event/util.py
@@ -124,6 +124,7 @@ def bulk_create_events(
     params: dict[str, Any] = {}
     for index, event in enumerate(events):
         datetime64_default_timestamp = timezone.now().astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%d %H:%M:%S")
+        _timestamp = event.get("_timestamp") or dt.datetime.now()
         timestamp = event.get("timestamp") or dt.datetime.now()
         if isinstance(timestamp, str):
             timestamp = isoparse(timestamp)
@@ -162,7 +163,7 @@ def bulk_create_events(
                 %(group4_created_at_{i})s,
                 %(person_mode_{i})s,
                 %(created_at_{i})s,
-                now(),
+                %(_timestamp_{i})s,
                 0
             )""".format(i=index)
         )
@@ -258,6 +259,7 @@ def bulk_create_events(
             "group4_created_at": (
                 event["group4_created_at"] if event.get("group4_created_at") else datetime64_default_timestamp
             ),
+            "_timestamp": _timestamp,
             "person_mode": person_mode,
         }
 

--- a/posthog/models/test/__snapshots__/test_async_deletion_model.ambr
+++ b/posthog/models/test/__snapshots__/test_async_deletion_model.ambr
@@ -164,6 +164,7 @@
   DELETE
   WHERE (team_id = 2
          AND person_id = '00000000-0000-0000-0000-000000000000')
+    AND _timestamp <= '2024-01-01 00:00:00'
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_person_unrelated
@@ -173,6 +174,7 @@
   DELETE
   WHERE (team_id = 2
          AND person_id = '00000000-0000-0000-0000-000000000000')
+    AND _timestamp <= '2024-01-01 00:00:00'
   '''
 # ---
 # name: TestAsyncDeletion.test_delete_teams
@@ -339,6 +341,7 @@
   FROM events
   WHERE (team_id = 2
          AND person_id = '00000000-0000-0000-0000-000000000000')
+    AND _timestamp <= '2024-01-01 00:00:00'
   '''
 # ---
 # name: TestAsyncDeletion.test_mark_deletions_done_person_when_not_done
@@ -349,6 +352,7 @@
   FROM events
   WHERE (team_id = 2
          AND person_id = '00000000-0000-0000-0000-000000000000')
+    AND _timestamp <= '2024-01-01 00:00:00'
   '''
 # ---
 # name: TestAsyncDeletion.test_mark_deletions_done_team_when_not_done


### PR DESCRIPTION
## Problem

Now that `person_id` is deterministic, it is reasonable for someone to want to delete a Person, but then for that `person_id` to show up again in events between when they create the deletion and when the deletion occurs.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add `_timestamp` filter to event deletion by Person based on when the async deletion was created.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Updated existing
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
