### PR TITLE
fix: Patch the usage_summary value for rows_synced

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -344,7 +344,7 @@ class BillingManager:
             usage_info = OrganizationUsageInfo(
                 events=usage_summary["events"],
                 recordings=usage_summary["recordings"],
-                rows_synced=usage_summary.get("rows_synced", None),
+                rows_synced=usage_summary.get("rows_synced", {}),
                 period=[
                     data["billing_period"]["current_period_start"],
                     data["billing_period"]["current_period_end"],

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -310,7 +310,7 @@ def set_org_usage_summary(
             resource_usage["todays_usage"] = todays_usage.get(field, 0)
         else:
             # TRICKY: If we are not explictly setting todays_usage, we want to reset it to 0 IF the incoming new_usage is different
-            if (organization.usage or {}).get(field, {}).get("usage") != resource_usage.get("usage"):
+            if ((organization.usage or {}).get(field, {}) or {}).get("usage") != resource_usage.get("usage"):
                 resource_usage["todays_usage"] = 0
             else:
                 resource_usage["todays_usage"] = organization.usage.get(field, {}).get("todays_usage") or 0

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -309,8 +309,11 @@ def set_org_usage_summary(
         if todays_usage:
             resource_usage["todays_usage"] = todays_usage.get(field, 0)
         else:
+            org_usage_data = organization.usage or {}
+            org_field_usage = org_usage_data.get(field, {}) or {}
+            org_usage = org_field_usage.get("usage")
             # TRICKY: If we are not explictly setting todays_usage, we want to reset it to 0 IF the incoming new_usage is different
-            if ((organization.usage or {}).get(field, {}) or {}).get("usage") != resource_usage.get("usage"):
+            if org_usage != resource_usage.get("usage"):
                 resource_usage["todays_usage"] = 0
             else:
                 resource_usage["todays_usage"] = organization.usage.get(field, {}).get("todays_usage") or 0


### PR DESCRIPTION
## Problem

The billing response usage_summary value for rows_synced was getting set to `null` by default. This causes problems when  checking to see if we should update the `posthog_organization` usage_summary value to the billing response value because the code expects a dictionary, not a None object. This PR updates the default usage_summary value and patches the failing dict access. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
