### PR TITLE
feat: Pipeline UI: metrics page use insights like date selection

### DIFF
--- a/frontend/src/scenes/pipeline/PipelineNodeMetrics.tsx
+++ b/frontend/src/scenes/pipeline/PipelineNodeMetrics.tsx
@@ -1,14 +1,14 @@
-import { IconCollapse, IconExpand, IconInfo } from '@posthog/icons'
+import { IconCalendar, IconCollapse, IconExpand, IconInfo } from '@posthog/icons'
 import { useActions, useValues } from 'kea'
 import { Chart, ChartDataset, ChartItem } from 'lib/Chart'
 import { getColorVar } from 'lib/colors'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { TZLabel } from 'lib/components/TZLabel'
 import { IconChevronLeft, IconChevronRight } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel/LemonLabel'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
-import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
 import { Link } from 'lib/lemon-ui/Link'
@@ -32,22 +32,24 @@ export interface MetricsOverviewProps {
 export function PipelineNodeMetrics({ id }: PipelineNodeMetricsProps): JSX.Element {
     const logic = pipelineNodeMetricsLogic({ id })
 
-    const { appMetricsResponse, appMetricsResponseLoading, dateFrom } = useValues(logic)
-    const { setDateFrom } = useActions(logic)
+    const { appMetricsResponse, appMetricsResponseLoading, dateRange } = useValues(logic)
+    const { setDateRange } = useActions(logic)
 
     return (
         <div className="space-y-8">
             <div className="flex items-start justify-between gap-2">
                 <MetricsOverview metrics={appMetricsResponse?.metrics} metricsLoading={appMetricsResponseLoading} />
 
-                <LemonSelect
-                    value={dateFrom}
-                    onChange={(newValue) => setDateFrom(newValue)}
-                    options={[
-                        { label: 'Last 30 days', value: '-30d' },
-                        { label: 'Last 7 days', value: '-7d' },
-                        { label: 'Last 24 hours', value: '-24h' },
-                    ]}
+                <DateFilter
+                    dateTo={dateRange.to}
+                    dateFrom={dateRange.from}
+                    onChange={(from, to) => setDateRange(from, to)}
+                    allowedRollingDateOptions={['days', 'weeks', 'months', 'years']}
+                    makeLabel={(key) => (
+                        <>
+                            <IconCalendar /> {key}
+                        </>
+                    )}
                 />
             </div>
 

--- a/frontend/src/scenes/pipeline/pipelineNodeMetricsLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineNodeMetricsLogic.tsx
@@ -55,7 +55,7 @@ export const pipelineNodeMetricsLogic = kea<pipelineNodeMetricsLogicType>([
         values: [teamLogic, ['currentTeamId']],
     }),
     actions({
-        setDateFrom: (dateFrom: string) => ({ dateFrom }),
+        setDateRange: (from: string | null, to: string | null) => ({ from, to }),
         openErrorDetailsModal: (errorType: string) => ({
             errorType,
         }),
@@ -66,7 +66,7 @@ export const pipelineNodeMetricsLogic = kea<pipelineNodeMetricsLogicType>([
             null as AppMetricsResponse | null,
             {
                 loadMetrics: async () => {
-                    const params = toParams({ date_from: values.dateFrom })
+                    const params = toParams({ date_from: values.dateRange.from, date_to: values.dateRange.to ?? 'now' })
                     return await api.get(
                         `api/projects/${teamLogic.values.currentTeamId}/app_metrics/${props.id}?${params}`
                     )
@@ -87,10 +87,10 @@ export const pipelineNodeMetricsLogic = kea<pipelineNodeMetricsLogicType>([
         ],
     })),
     reducers({
-        dateFrom: [
-            DEFAULT_DATE_FROM as string,
+        dateRange: [
+            { from: DEFAULT_DATE_FROM, to: null } as { from: string; to: string | null },
             {
-                setDateFrom: (_, { dateFrom }) => dateFrom,
+                setDateRange: (_, { from, to }) => ({ from: from ?? DEFAULT_DATE_FROM, to: to }),
             },
         ],
         errorDetailsModalError: [
@@ -102,7 +102,7 @@ export const pipelineNodeMetricsLogic = kea<pipelineNodeMetricsLogicType>([
         ],
     }),
     listeners(({ actions }) => ({
-        setDateFrom: () => {
+        setDateRange: () => {
             actions.loadMetrics()
         },
     })),


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
There's no reason we should limit users to those 3 date selection options we have now.

Before:
<img width="161" alt="Screenshot 2024-05-31 at 02 00 27" src="https://github.com/PostHog/posthog/assets/890921/25243d18-04aa-4a77-8ceb-10ad34d12837">

After:
<img width="325" alt="Screenshot 2024-05-31 at 02 00 20" src="https://github.com/PostHog/posthog/assets/890921/bf426583-2cef-4a44-8438-6e0c8723b79f">

The dates on the graph look ugly - but making that component use insights graphing is going to be in a separate PR
<img width="977" alt="Screenshot 2024-05-31 at 02 00 02" src="https://github.com/PostHog/posthog/assets/890921/040a2957-85ee-4e10-9189-e0a272dee1d3">

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
