### PR TITLE
fix: Missing scope on events endpoint

### DIFF
--- a/posthog/api/event.py
+++ b/posthog/api/event.py
@@ -258,7 +258,7 @@ class EventViewSet(
         res = ClickhouseEventSerializer(query_result[0], many=False, context=query_context).data
         return response.Response(res)
 
-    @action(methods=["GET"], detail=False)
+    @action(methods=["GET"], detail=False, required_scopes=["query:read"])
     def values(self, request: request.Request, **kwargs) -> response.Response:
         team = self.team
 


### PR DESCRIPTION
## Problem

[Related ticket](https://posthoghelp.zendesk.com/agent/tickets/14142)

Missing a scope for the events endpoint

## Changes

* Adds the missing scope

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
