### PR TITLE
fix(hogql): ignore frontend-only keys in cache key payload

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3753,9 +3753,6 @@
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
-                    "default": {
-                        "date_from": "-7d"
-                    },
                     "description": "Date range for the query"
                 },
                 "filterTestAccounts": {
@@ -4678,9 +4675,6 @@
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
-                    "default": {
-                        "date_from": "-7d"
-                    },
                     "description": "Date range for the query"
                 },
                 "filterTestAccounts": {
@@ -4731,9 +4725,6 @@
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
-                    "default": {
-                        "date_from": "-7d"
-                    },
                     "description": "Date range for the query"
                 },
                 "filterTestAccounts": {
@@ -4784,9 +4775,6 @@
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
-                    "default": {
-                        "date_from": "-7d"
-                    },
                     "description": "Date range for the query"
                 },
                 "filterTestAccounts": {
@@ -4837,9 +4825,6 @@
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
-                    "default": {
-                        "date_from": "-7d"
-                    },
                     "description": "Date range for the query"
                 },
                 "filterTestAccounts": {
@@ -4890,9 +4875,6 @@
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
-                    "default": {
-                        "date_from": "-7d"
-                    },
                     "description": "Date range for the query"
                 },
                 "filterTestAccounts": {
@@ -4984,9 +4966,6 @@
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
-                    "default": {
-                        "date_from": "-7d"
-                    },
                     "description": "Date range for the query"
                 },
                 "filterTestAccounts": {
@@ -5305,9 +5284,6 @@
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
-                    "default": {
-                        "date_from": "-7d"
-                    },
                     "description": "Date range for the query"
                 },
                 "filterTestAccounts": {
@@ -7022,9 +6998,6 @@
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
-                    "default": {
-                        "date_from": "-7d"
-                    },
                     "description": "Date range for the query"
                 },
                 "filterTestAccounts": {
@@ -7424,9 +7397,6 @@
             "properties": {
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
-                    "default": {
-                        "date_from": "-7d"
-                    },
                     "description": "Date range for the query"
                 },
                 "filterTestAccounts": {
@@ -7854,9 +7824,6 @@
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
-                    "default": {
-                        "date_from": "-7d"
-                    },
                     "description": "Date range for the query"
                 },
                 "filterTestAccounts": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3768,9 +3768,6 @@
                 },
                 "funnelsFilter": {
                     "$ref": "#/definitions/FunnelsFilter",
-                    "default": {
-                        "exclusions": []
-                    },
                     "description": "Properties specific to the funnels insight"
                 },
                 "interval": {
@@ -5011,9 +5008,6 @@
                 },
                 "lifecycleFilter": {
                     "$ref": "#/definitions/LifecycleFilter",
-                    "default": {
-                        "showLegend": false
-                    },
                     "description": "Properties specific to the lifecycle insight"
                 },
                 "modifiers": {
@@ -7487,9 +7481,6 @@
                 },
                 "stickinessFilter": {
                     "$ref": "#/definitions/StickinessFilter",
-                    "default": {
-                        "compare": false
-                    },
                     "description": "Properties specific to the stickiness insight"
                 }
             },
@@ -7923,9 +7914,6 @@
                 },
                 "trendsFilter": {
                     "$ref": "#/definitions/TrendsFilter",
-                    "default": {
-                        "display": "ActionsLineGraph"
-                    },
                     "description": "Properties specific to the trends insight"
                 }
             },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3749,9 +3749,6 @@
                 },
                 "breakdownFilter": {
                     "$ref": "#/definitions/BreakdownFilter",
-                    "default": {
-                        "breakdown_type": "event"
-                    },
                     "description": "Breakdown of the events and actions"
                 },
                 "dateRange": {
@@ -7853,9 +7850,6 @@
                 },
                 "breakdownFilter": {
                     "$ref": "#/definitions/BreakdownFilter",
-                    "default": {
-                        "breakdown_type": "event"
-                    },
                     "description": "Breakdown of the events and actions"
                 },
                 "dateRange": {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -720,19 +720,7 @@ export interface TrendsQuery extends InsightsQueryBase<TrendsQueryResponse> {
     interval?: IntervalType
     /** Events and actions to include */
     series: AnyEntityNode[]
-    /**
-     * Properties specific to the trends insight
-     *
-     * @default {"display": "ActionsLineGraph"}
-     */
-    // :TRICKY: We can't set the default to an empty dict, as otherwise
-    // datamodel-code-generator does not generate a model with a factory.
-    //
-    // This would cause a different serialization of an empty and a missing
-    // prop, which we don't want for stable cache keys.
-    //
-    // As a workaround we simply set any prop to its default, so that a
-    // factory is used to instantiate an empty model for a missing prop.
+    /** Properties specific to the trends insight */
     trendsFilter?: TrendsFilter
     /**
      * Breakdown of the events and actions
@@ -805,18 +793,7 @@ export interface FunnelsQuery extends InsightsQueryBase<FunnelsQueryResponse> {
     interval?: IntervalType
     /** Events and actions to include */
     series: AnyEntityNode[]
-    /** Properties specific to the funnels insight
-     *
-     * @default {"exclusions":[]}
-     */
-    // :TRICKY: We can't set the default to an empty dict, as otherwise
-    // datamodel-code-generator does not generate a model with a factory.
-    //
-    // This would cause a different serialization of an empty and a missing
-    // prop, which we don't want for stable cache keys.
-    //
-    // As a workaround we simply set any prop to its default, so that a
-    // factory is used to instantiate an empty model for a missing prop.
+    /** Properties specific to the funnels insight */
     funnelsFilter?: FunnelsFilter
     /**
      * Breakdown of the events and actions
@@ -960,18 +937,7 @@ export interface StickinessQuery
     interval?: IntervalType
     /** Events and actions to include */
     series: AnyEntityNode[]
-    /** Properties specific to the stickiness insight
-     *
-     * @default {"compare":false}
-     */
-    // :TRICKY: We can't set the default to an empty dict, as otherwise
-    // datamodel-code-generator does not generate a model with a factory.
-    //
-    // This would cause a different serialization of an empty and a missing
-    // prop, which we don't want for stable cache keys.
-    //
-    // As a workaround we simply set any prop to its default, so that a
-    // factory is used to instantiate an empty model for a missing prop.
+    /** Properties specific to the stickiness insight */
     stickinessFilter?: StickinessFilter
 }
 
@@ -1095,18 +1061,7 @@ export interface LifecycleQuery extends InsightsQueryBase<LifecycleQueryResponse
     interval?: IntervalType
     /** Events and actions to include */
     series: AnyEntityNode[]
-    /** Properties specific to the lifecycle insight
-     *
-     * @default {"showLegend":false}
-     */
-    // :TRICKY: We can't set the default to an empty dict, as otherwise
-    // datamodel-code-generator does not generate a model with a factory.
-    //
-    // This would cause a different serialization of an empty and a missing
-    // prop, which we don't want for stable cache keys.
-    //
-    // As a workaround we simply set any prop to its default, so that a
-    // factory is used to instantiate an empty model for a missing prop.
+    /** Properties specific to the lifecycle insight */
     lifecycleFilter?: LifecycleFilter
 }
 

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -640,19 +640,7 @@ interface InsightVizNodeViewProps {
 
 /** Base class for insight query nodes. Should not be used directly. */
 export interface InsightsQueryBase<R extends AnalyticsQueryResponseBase<any>> extends Node<R> {
-    /**
-     * Date range for the query
-     *
-     * @default {"date_from": "-7d"}
-     */
-    // :TRICKY: We can't set the default to an empty dict, as otherwise
-    // datamodel-code-generator does not generate a model with a factory.
-    //
-    // This would cause a different serialization of an empty and a missing
-    // prop, which we don't want for stable cache keys.
-    //
-    // As a workaround we simply set any prop to its default, so that a
-    // factory is used to instantiate an empty model for a missing prop.
+    /** Date range for the query */
     dateRange?: InsightDateRange
     /**
      * Exclude internal and test users by applying the respective filters

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -722,19 +722,7 @@ export interface TrendsQuery extends InsightsQueryBase<TrendsQueryResponse> {
     series: AnyEntityNode[]
     /** Properties specific to the trends insight */
     trendsFilter?: TrendsFilter
-    /**
-     * Breakdown of the events and actions
-     *
-     * @default {"breakdown_type": "event"}
-     */
-    // :TRICKY: We can't set the default to an empty dict, as otherwise
-    // datamodel-code-generator does not generate a model with a factory.
-    //
-    // This would cause a different serialization of an empty and a missing
-    // prop, which we don't want for stable cache keys.
-    //
-    // As a workaround we simply set any prop to its default, so that a
-    // factory is used to instantiate an empty model for a missing prop.
+    /** Breakdown of the events and actions */
     breakdownFilter?: BreakdownFilter
 }
 
@@ -795,19 +783,7 @@ export interface FunnelsQuery extends InsightsQueryBase<FunnelsQueryResponse> {
     series: AnyEntityNode[]
     /** Properties specific to the funnels insight */
     funnelsFilter?: FunnelsFilter
-    /**
-     * Breakdown of the events and actions
-     *
-     * @default {"breakdown_type": "event"}
-     */
-    // :TRICKY: We can't set the default to an empty dict, as otherwise
-    // datamodel-code-generator does not generate a model with a factory.
-    //
-    // This would cause a different serialization of an empty and a missing
-    // prop, which we don't want for stable cache keys.
-    //
-    // As a workaround we simply set any prop to its default, so that a
-    // factory is used to instantiate an empty model for a missing prop.
+    /** Breakdown of the events and actions */
     breakdownFilter?: BreakdownFilter
 }
 

--- a/frontend/src/scenes/insights/utils/compareInsightQuery.ts
+++ b/frontend/src/scenes/insights/utils/compareInsightQuery.ts
@@ -44,6 +44,7 @@ const cleanInsightQuery = (query: InsightQueryNode, ignoreVisualizationOnlyChang
     }
 
     if (ignoreVisualizationOnlyChanges) {
+        // Keep this in sync with the backend side clean_insight_queries method
         const insightFilter = filterForQuery(cleanedQuery)
         const insightFilterKey = filterKeyForQuery(cleanedQuery)
         cleanedQuery[insightFilterKey] = {

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -921,7 +921,7 @@ class TestFilterToQuery(BaseTest):
 
         self.assertEqual(
             query.model_dump(exclude_defaults=True),
-            {"series": []},
+            {"breakdownFilter": {}, "dateRange": {}, "series": [], "trendsFilter": {}},
         )
 
     def test_base_funnel(self):
@@ -1566,6 +1566,8 @@ class TestFilterToQuery(BaseTest):
                     ],
                     filterTestAccounts=True,
                     funnelsFilter=FunnelsFilter(funnelVizType=FunnelVizType.steps, exclusions=[]),
+                    breakdownFilter=BreakdownFilter(),
+                    dateRange=InsightDateRange(),
                 ),
                 funnelStep=2,
             ),

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -49,7 +49,7 @@ from posthog.schema import (
     HogQLQueryModifiers,
     InsightActorsQueryOptions,
 )
-from posthog.schema_helpers import to_json
+from posthog.schema_helpers import to_dict, to_json
 from posthog.utils import generate_cache_key, get_safe_cache, get_from_dict_or_attr
 
 logger = structlog.get_logger(__name__)
@@ -438,11 +438,19 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 "hogql",
             )
 
+    def get_cache_payload(self) -> dict:
+        return {
+            "query_runner": self.__class__.__name__,
+            "query": to_dict(self.query),
+            "team_id": self.team.pk,
+            "hogql_modifiers": to_dict(self.modifiers),
+            "limit_context": self._limit_context_aliased_for_cache,
+            "timezone": self.team.timezone,
+            "version": 2,
+        }
+
     def get_cache_key(self) -> str:
-        modifiers = self.modifiers.model_dump_json(exclude_defaults=True, exclude_none=True)
-        return generate_cache_key(
-            f"query_{bytes.decode(to_json(self.query))}_{self.__class__.__name__}_{self.team.pk}_{self.team.timezone}_{modifiers}_{self._limit_context_aliased_for_cache}_v2"
-        )
+        return generate_cache_key(f"query_{bytes.decode(to_json(self.get_cache_payload()))}")
 
     @abstractmethod
     def _is_stale(self, cached_result_package):

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -76,7 +76,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_dab38b39ff519359567966c68039d175")
+        self.assertEqual(cache_key, "cache_9ec4601658411f9463234bf079d8f5b6")
 
     def test_cache_key_runner_subclass(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -90,7 +90,7 @@ class TestQueryRunner(BaseTest):
         runner = TestSubclassQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_9a21e8b579b853a58f0492ccbbb52e1c")
+        self.assertEqual(cache_key, "cache_73b92e9e9263aec396fcbf8e296037c5")
 
     def test_cache_key_different_timezone(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -101,7 +101,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_3d45f92fb589f0a7bdd39d95cb3627e8")
+        self.assertEqual(cache_key, "cache_426bf3a1a0a1d8eb3073c65028f3b485")
 
     def test_cache_response(self):
         TestQueryRunner = self.setup_test_query_runner_class()

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3536,10 +3536,7 @@ class TrendsQuery(BaseModel):
         extra="forbid",
     )
     aggregation_group_type_index: Optional[int] = Field(default=None, description="Groups aggregation")
-    breakdownFilter: Optional[BreakdownFilter] = Field(
-        default_factory=lambda: BreakdownFilter.model_validate({"breakdown_type": "event"}),
-        description="Breakdown of the events and actions",
-    )
+    breakdownFilter: Optional[BreakdownFilter] = Field(default=None, description="Breakdown of the events and actions")
     dateRange: Optional[InsightDateRange] = Field(
         default_factory=lambda: InsightDateRange.model_validate({"date_from": "-7d"}),
         description="Date range for the query",
@@ -3642,10 +3639,7 @@ class FunnelsQuery(BaseModel):
         extra="forbid",
     )
     aggregation_group_type_index: Optional[int] = Field(default=None, description="Groups aggregation")
-    breakdownFilter: Optional[BreakdownFilter] = Field(
-        default_factory=lambda: BreakdownFilter.model_validate({"breakdown_type": "event"}),
-        description="Breakdown of the events and actions",
-    )
+    breakdownFilter: Optional[BreakdownFilter] = Field(default=None, description="Breakdown of the events and actions")
     dateRange: Optional[InsightDateRange] = Field(
         default_factory=lambda: InsightDateRange.model_validate({"date_from": "-7d"}),
         description="Date range for the query",

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3444,10 +3444,7 @@ class RetentionQuery(BaseModel):
         extra="forbid",
     )
     aggregation_group_type_index: Optional[int] = Field(default=None, description="Groups aggregation")
-    dateRange: Optional[InsightDateRange] = Field(
-        default_factory=lambda: InsightDateRange.model_validate({"date_from": "-7d"}),
-        description="Date range for the query",
-    )
+    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
     filterTestAccounts: Optional[bool] = Field(
         default=False, description="Exclude internal and test users by applying the respective filters"
     )
@@ -3485,10 +3482,7 @@ class StickinessQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    dateRange: Optional[InsightDateRange] = Field(
-        default_factory=lambda: InsightDateRange.model_validate({"date_from": "-7d"}),
-        description="Date range for the query",
-    )
+    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
     filterTestAccounts: Optional[bool] = Field(
         default=False, description="Exclude internal and test users by applying the respective filters"
     )
@@ -3537,10 +3531,7 @@ class TrendsQuery(BaseModel):
     )
     aggregation_group_type_index: Optional[int] = Field(default=None, description="Groups aggregation")
     breakdownFilter: Optional[BreakdownFilter] = Field(default=None, description="Breakdown of the events and actions")
-    dateRange: Optional[InsightDateRange] = Field(
-        default_factory=lambda: InsightDateRange.model_validate({"date_from": "-7d"}),
-        description="Date range for the query",
-    )
+    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
     filterTestAccounts: Optional[bool] = Field(
         default=False, description="Exclude internal and test users by applying the respective filters"
     )
@@ -3640,10 +3631,7 @@ class FunnelsQuery(BaseModel):
     )
     aggregation_group_type_index: Optional[int] = Field(default=None, description="Groups aggregation")
     breakdownFilter: Optional[BreakdownFilter] = Field(default=None, description="Breakdown of the events and actions")
-    dateRange: Optional[InsightDateRange] = Field(
-        default_factory=lambda: InsightDateRange.model_validate({"date_from": "-7d"}),
-        description="Date range for the query",
-    )
+    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
     filterTestAccounts: Optional[bool] = Field(
         default=False, description="Exclude internal and test users by applying the respective filters"
     )
@@ -3690,10 +3678,7 @@ class InsightsQueryBaseFunnelsQueryResponse(BaseModel):
         extra="forbid",
     )
     aggregation_group_type_index: Optional[int] = Field(default=None, description="Groups aggregation")
-    dateRange: Optional[InsightDateRange] = Field(
-        default_factory=lambda: InsightDateRange.model_validate({"date_from": "-7d"}),
-        description="Date range for the query",
-    )
+    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
     filterTestAccounts: Optional[bool] = Field(
         default=False, description="Exclude internal and test users by applying the respective filters"
     )
@@ -3731,10 +3716,7 @@ class InsightsQueryBaseLifecycleQueryResponse(BaseModel):
         extra="forbid",
     )
     aggregation_group_type_index: Optional[int] = Field(default=None, description="Groups aggregation")
-    dateRange: Optional[InsightDateRange] = Field(
-        default_factory=lambda: InsightDateRange.model_validate({"date_from": "-7d"}),
-        description="Date range for the query",
-    )
+    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
     filterTestAccounts: Optional[bool] = Field(
         default=False, description="Exclude internal and test users by applying the respective filters"
     )
@@ -3772,10 +3754,7 @@ class InsightsQueryBasePathsQueryResponse(BaseModel):
         extra="forbid",
     )
     aggregation_group_type_index: Optional[int] = Field(default=None, description="Groups aggregation")
-    dateRange: Optional[InsightDateRange] = Field(
-        default_factory=lambda: InsightDateRange.model_validate({"date_from": "-7d"}),
-        description="Date range for the query",
-    )
+    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
     filterTestAccounts: Optional[bool] = Field(
         default=False, description="Exclude internal and test users by applying the respective filters"
     )
@@ -3813,10 +3792,7 @@ class InsightsQueryBaseRetentionQueryResponse(BaseModel):
         extra="forbid",
     )
     aggregation_group_type_index: Optional[int] = Field(default=None, description="Groups aggregation")
-    dateRange: Optional[InsightDateRange] = Field(
-        default_factory=lambda: InsightDateRange.model_validate({"date_from": "-7d"}),
-        description="Date range for the query",
-    )
+    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
     filterTestAccounts: Optional[bool] = Field(
         default=False, description="Exclude internal and test users by applying the respective filters"
     )
@@ -3854,10 +3830,7 @@ class InsightsQueryBaseTrendsQueryResponse(BaseModel):
         extra="forbid",
     )
     aggregation_group_type_index: Optional[int] = Field(default=None, description="Groups aggregation")
-    dateRange: Optional[InsightDateRange] = Field(
-        default_factory=lambda: InsightDateRange.model_validate({"date_from": "-7d"}),
-        description="Date range for the query",
-    )
+    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
     filterTestAccounts: Optional[bool] = Field(
         default=False, description="Exclude internal and test users by applying the respective filters"
     )
@@ -3895,10 +3868,7 @@ class LifecycleQuery(BaseModel):
         extra="forbid",
     )
     aggregation_group_type_index: Optional[int] = Field(default=None, description="Groups aggregation")
-    dateRange: Optional[InsightDateRange] = Field(
-        default_factory=lambda: InsightDateRange.model_validate({"date_from": "-7d"}),
-        description="Date range for the query",
-    )
+    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
     filterTestAccounts: Optional[bool] = Field(
         default=False, description="Exclude internal and test users by applying the respective filters"
     )
@@ -4070,10 +4040,7 @@ class PathsQuery(BaseModel):
         extra="forbid",
     )
     aggregation_group_type_index: Optional[int] = Field(default=None, description="Groups aggregation")
-    dateRange: Optional[InsightDateRange] = Field(
-        default_factory=lambda: InsightDateRange.model_validate({"date_from": "-7d"}),
-        description="Date range for the query",
-    )
+    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
     filterTestAccounts: Optional[bool] = Field(
         default=False, description="Exclude internal and test users by applying the respective filters"
     )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3527,8 +3527,7 @@ class StickinessQuery(BaseModel):
         ..., description="Events and actions to include"
     )
     stickinessFilter: Optional[StickinessFilter] = Field(
-        default_factory=lambda: StickinessFilter.model_validate({"compare": False}),
-        description="Properties specific to the stickiness insight",
+        default=None, description="Properties specific to the stickiness insight"
     )
 
 
@@ -3582,10 +3581,7 @@ class TrendsQuery(BaseModel):
     series: list[Union[EventsNode, ActionsNode, DataWarehouseNode]] = Field(
         ..., description="Events and actions to include"
     )
-    trendsFilter: Optional[TrendsFilter] = Field(
-        default_factory=lambda: TrendsFilter.model_validate({"display": "ActionsLineGraph"}),
-        description="Properties specific to the trends insight",
-    )
+    trendsFilter: Optional[TrendsFilter] = Field(default=None, description="Properties specific to the trends insight")
 
 
 class FilterType(BaseModel):
@@ -3658,8 +3654,7 @@ class FunnelsQuery(BaseModel):
         default=False, description="Exclude internal and test users by applying the respective filters"
     )
     funnelsFilter: Optional[FunnelsFilter] = Field(
-        default_factory=lambda: FunnelsFilter.model_validate({"exclusions": []}),
-        description="Properties specific to the funnels insight",
+        default=None, description="Properties specific to the funnels insight"
     )
     interval: Optional[IntervalType] = Field(
         default=None, description="Granularity of the response. Can be one of `hour`, `day`, `week` or `month`"
@@ -3919,8 +3914,7 @@ class LifecycleQuery(BaseModel):
     )
     kind: Literal["LifecycleQuery"] = "LifecycleQuery"
     lifecycleFilter: Optional[LifecycleFilter] = Field(
-        default_factory=lambda: LifecycleFilter.model_validate({"showLegend": False}),
-        description="Properties specific to the lifecycle insight",
+        default=None, description="Properties specific to the lifecycle insight"
     )
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -31,11 +31,6 @@ def to_json(query: BaseModel) -> bytes:
                 if get_origin(field_info.annotation) == Literal:
                     dumped[name] = getattr(self, name)
 
-            ###
-            # Frontend only settings like which graph type is displayed, that don't affect
-            # the generated dataset should be removed.
-            #
-            # Keep this in sync with the frontend side "cleanInsightQuery" function.
             if isinstance(
                 self,
                 (TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery),
@@ -46,6 +41,11 @@ def to_json(query: BaseModel) -> bytes:
                     if name not in dumped:
                         continue
 
+                    ###
+                    # Frontend only settings like which graph type is displayed, that don't affect
+                    # the generated dataset should be removed.
+                    #
+                    # Keep this in sync with the frontend side "cleanInsightQuery" function.
                     if name == "series":
                         # remove frontend-only props from series
                         dumped["series"] = [
@@ -81,12 +81,11 @@ def to_json(query: BaseModel) -> bytes:
                             else:
                                 dumped[insightFilterKey]["display"] = canonical_display
 
-                        # remove empty insight filters, so that empty and not existing filter serialize to the same json
-                        if len(dumped[insightFilterKey]) == 0:
-                            del dumped[insightFilterKey]
-                    elif name == "breakdownFilter":
-                        if len(dumped["breakdownFilter"]) == 0:
-                            del dumped["breakdownFilter"]
+                    ###
+                    # Remove empty nested models, so that empty and not existing models serialize to the same json.
+                    filterKeys = [insightFilterKey, "breakdownFilter", "dateRange"]
+                    if name in filterKeys and len(dumped[name]) == 0:
+                        del dumped[name]
 
             return dumped
 

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -84,6 +84,9 @@ def to_json(query: BaseModel) -> bytes:
                         # remove empty insight filters, so that empty and not existing filter serialize to the same json
                         if len(dumped[insightFilterKey]) == 0:
                             del dumped[insightFilterKey]
+                    elif name == "breakdownFilter":
+                        if len(dumped["breakdownFilter"]) == 0:
+                            del dumped["breakdownFilter"]
 
             return dumped
 

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -15,7 +15,7 @@ from posthog.schema import (
 from posthog.types import InsightQueryNode
 
 
-def to_json(query: BaseModel) -> bytes:
+def to_dict(query: BaseModel) -> dict:
     klass: Any = type(query)
 
     class ExtendedQuery(klass):
@@ -95,9 +95,13 @@ def to_json(query: BaseModel) -> bytes:
     # generate a dict from the pydantic model
     instance_dict = query.model_dump(exclude_none=True, exclude_defaults=True)
 
+    return instance_dict
+
+
+def to_json(obj: dict) -> bytes:
     # pydantic doesn't sort keys reliably, so use orjson to serialize to json
     option = orjson.OPT_SORT_KEYS
-    json_string = orjson.dumps(instance_dict, default=JSONEncoder().default, option=option)
+    json_string = orjson.dumps(obj, default=JSONEncoder().default, option=option)
 
     return json_string
 

--- a/posthog/test/test_schema_helpers.py
+++ b/posthog/test/test_schema_helpers.py
@@ -71,6 +71,13 @@ class TestSchemaHelpers(TestCase):
         self.assertEqual(json.loads(to_json(q1)), {"kind": "TrendsQuery", "series": []})
         self.assertEqual(json.loads(to_json(q2)), {"kind": "TrendsQuery", "series": []})
 
+    def test_serializes_empty_and_missing_date_range_equally(self):
+        q1 = TrendsQuery(**base_trends)
+        q2 = TrendsQuery(**{**base_trends, "dateRange": {}})
+
+        self.assertEqual(json.loads(to_json(q1)), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(json.loads(to_json(q2)), {"kind": "TrendsQuery", "series": []})
+
     def test_serializes_series_without_frontend_only_props(self):
         query = TrendsQuery(**{**base_trends, "series": [EventsNode(name="$pageview", custom_name="My custom name")]})
 

--- a/posthog/test/test_schema_helpers.py
+++ b/posthog/test/test_schema_helpers.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 from parameterized import parameterized
 
@@ -19,7 +18,7 @@ from posthog.schema import (
     BreakdownAttributionType,
     TrendsQuery,
 )
-from posthog.schema_helpers import to_json
+from posthog.schema_helpers import to_dict
 
 
 base_trends: dict[str, Any] = {"series": []}
@@ -39,8 +38,8 @@ class TestSchemaHelpers(TestCase):
         q1 = EventPropertyFilter(key="abc", operator=PropertyOperator.gt)
         q2 = PersonPropertyFilter(key="abc", operator=PropertyOperator.gt)
 
-        self.assertNotEqual(to_json(q1), to_json(q2))
-        self.assertIn('"type":"event"', str(to_json(q1)))
+        self.assertNotEqual(to_dict(q1), to_dict(q2))
+        self.assertIn("'type': 'event'", str(to_dict(q1)))
 
     def test_serializes_to_same_json_for_default_value(self):
         """
@@ -53,70 +52,70 @@ class TestSchemaHelpers(TestCase):
         q2 = EventPropertyFilter(key="abc", operator=None)
         q3 = EventPropertyFilter(key="abc", operator=PropertyOperator.exact)
 
-        self.assertEqual(to_json(q1), to_json(q2))
-        self.assertEqual(to_json(q2), to_json(q3))
-        self.assertNotIn("operator", str(to_json(q1)))
+        self.assertEqual(to_dict(q1), to_dict(q2))
+        self.assertEqual(to_dict(q2), to_dict(q3))
+        self.assertNotIn("operator", str(to_dict(q1)))
 
     def test_serializes_empty_and_missing_insight_filter_equally(self):
         q1 = TrendsQuery(**base_trends)
         q2 = TrendsQuery(**{**base_trends, "trendsFilter": {}})
 
-        self.assertEqual(json.loads(to_json(q1)), {"kind": "TrendsQuery", "series": []})
-        self.assertEqual(json.loads(to_json(q2)), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(to_dict(q1), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(to_dict(q2), {"kind": "TrendsQuery", "series": []})
 
     def test_serializes_empty_and_missing_breakdown_filter_equally(self):
         q1 = TrendsQuery(**base_trends)
         q2 = TrendsQuery(**{**base_trends, "breakdownFilter": {}})
 
-        self.assertEqual(json.loads(to_json(q1)), {"kind": "TrendsQuery", "series": []})
-        self.assertEqual(json.loads(to_json(q2)), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(to_dict(q1), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(to_dict(q2), {"kind": "TrendsQuery", "series": []})
 
     def test_serializes_empty_and_missing_date_range_equally(self):
         q1 = TrendsQuery(**base_trends)
         q2 = TrendsQuery(**{**base_trends, "dateRange": {}})
 
-        self.assertEqual(json.loads(to_json(q1)), {"kind": "TrendsQuery", "series": []})
-        self.assertEqual(json.loads(to_json(q2)), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(to_dict(q1), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(to_dict(q2), {"kind": "TrendsQuery", "series": []})
 
     def test_serializes_series_without_frontend_only_props(self):
         query = TrendsQuery(**{**base_trends, "series": [EventsNode(name="$pageview", custom_name="My custom name")]})
 
-        result_dict = json.loads(to_json(query))
+        result_dict = to_dict(query)
 
         self.assertEqual(result_dict, {"kind": "TrendsQuery", "series": [{"name": "$pageview"}]})
 
     def test_serializes_insight_filter_without_frontend_only_props(self):
         query = TrendsQuery(**{**base_trends, "trendsFilter": {"showLegend": True}})
 
-        result_dict = json.loads(to_json(query))
+        result_dict = to_dict(query)
 
         self.assertEqual(result_dict, {"kind": "TrendsQuery", "series": []})
 
     def test_serializes_display_with_canonic_alternatives(self):
         # time series (gets removed as ActionsLineGraph is the default)
         query = TrendsQuery(**{**base_trends, "trendsFilter": {"display": "ActionsAreaGraph"}})
-        self.assertEqual(json.loads(to_json(query)), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(to_dict(query), {"kind": "TrendsQuery", "series": []})
 
         # cumulative time series
         query = TrendsQuery(**{**base_trends, "trendsFilter": {"display": "ActionsLineGraphCumulative"}})
         self.assertEqual(
-            json.loads(to_json(query)),
+            to_dict(query),
             {"kind": "TrendsQuery", "series": [], "trendsFilter": {"display": "ActionsLineGraphCumulative"}},
         )
 
         # total value
         query = TrendsQuery(**{**base_trends, "trendsFilter": {"display": "BoldNumber"}})
         self.assertEqual(
-            json.loads(to_json(query)),
+            to_dict(query),
             {"kind": "TrendsQuery", "series": [], "trendsFilter": {"display": "ActionsBarValue"}},
         )
 
     def _assert_filter(self, key: str, num_keys: int, q1: BaseModel, q2: BaseModel):
-        self.assertEqual(to_json(q1), to_json(q2))
+        self.assertEqual(to_dict(q1), to_dict(q2))
         if num_keys == 0:
-            self.assertEqual(key in json.loads(to_json(q1)), False)
+            self.assertEqual(key in to_dict(q1), False)
         else:
-            self.assertEqual(num_keys, len(json.loads(to_json(q1))[key].keys()))
+            self.assertEqual(num_keys, len(to_dict(q1)[key].keys()))
 
     @parameterized.expand(
         [

--- a/posthog/test/test_schema_helpers.py
+++ b/posthog/test/test_schema_helpers.py
@@ -13,7 +13,6 @@ from posthog.schema import (
     FunnelStepReference,
     FunnelsQuery,
     FunnelVizType,
-    FunnelLayout,
     PersonPropertyFilter,
     PropertyOperator,
     StepOrderValue,
@@ -82,7 +81,7 @@ class TestSchemaHelpers(TestCase):
             # general: missing filter
             (None, {}, 0),
             ({}, {"display": "ActionsLineGraph"}, 0),
-            ({"display": "ActionsAreaGraph"}, {"display": "ActionsAreaGraph"}, 1),
+            ({"display": "BoldNumber"}, {"display": "BoldNumber"}, 1),
         ]
     )
     def test_trends_filter(self, f1, f2, num_keys):
@@ -160,8 +159,12 @@ class TestSchemaHelpers(TestCase):
             # hidden_legend_breakdowns
             # ({}, {"hidden_legend_breakdowns": []}, 0),
             # layout
-            ({}, {"layout": FunnelLayout.vertical}, 0),
-            ({"layout": FunnelLayout.horizontal}, {"layout": FunnelLayout.horizontal}, 1),
+            ({}, {"breakdownAttributionType": BreakdownAttributionType.first_touch}, 0),
+            (
+                {"breakdownAttributionType": BreakdownAttributionType.last_touch},
+                {"breakdownAttributionType": BreakdownAttributionType.last_touch},
+                1,
+            ),
         ]
     )
     def test_funnels_filter(self, f1, f2, num_keys):
@@ -202,3 +205,10 @@ class TestSchemaHelpers(TestCase):
             json.loads(to_json(query)),
             {"kind": "TrendsQuery", "series": [], "trendsFilter": {"display": "ActionsBarValue"}},
         )
+
+    def test_serializes_empty_and_missing_filter_equally(self):
+        q1 = TrendsQuery(**base_trends)
+        q2 = TrendsQuery(**{**base_trends, "trendsFilter": {}})
+
+        self.assertEqual(json.loads(to_json(q1)), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(json.loads(to_json(q2)), {"kind": "TrendsQuery", "series": []})

--- a/posthog/test/test_schema_helpers.py
+++ b/posthog/test/test_schema_helpers.py
@@ -175,26 +175,30 @@ class TestSchemaHelpers(TestCase):
 
         result_dict = json.loads(to_json(query))
 
-        self.assertEqual(result_dict, {"series": [{"name": "$pageview"}]})
+        self.assertEqual(result_dict, {"kind": "TrendsQuery", "series": [{"name": "$pageview"}]})
 
     def test_removes_frontend_only_props_from_insight_filter(self):
         query = TrendsQuery(**{**base_trends, "trendsFilter": {"showLegend": True}})
 
         result_dict = json.loads(to_json(query))
 
-        self.assertEqual(result_dict, {"series": []})
+        self.assertEqual(result_dict, {"kind": "TrendsQuery", "series": []})
 
     def test_replaces_display_with_canonic_alternatie(self):
         # time series (gets removed as ActionsLineGraph is the default)
         query = TrendsQuery(**{**base_trends, "trendsFilter": {"display": "ActionsAreaGraph"}})
-        self.assertEqual(json.loads(to_json(query)), {"series": []})
+        self.assertEqual(json.loads(to_json(query)), {"kind": "TrendsQuery", "series": []})
 
         # cumulative time series
         query = TrendsQuery(**{**base_trends, "trendsFilter": {"display": "ActionsLineGraphCumulative"}})
         self.assertEqual(
-            json.loads(to_json(query)), {"series": [], "trendsFilter": {"display": "ActionsLineGraphCumulative"}}
+            json.loads(to_json(query)),
+            {"kind": "TrendsQuery", "series": [], "trendsFilter": {"display": "ActionsLineGraphCumulative"}},
         )
 
         # total value
         query = TrendsQuery(**{**base_trends, "trendsFilter": {"display": "BoldNumber"}})
-        self.assertEqual(json.loads(to_json(query)), {"series": [], "trendsFilter": {"display": "ActionsBarValue"}})
+        self.assertEqual(
+            json.loads(to_json(query)),
+            {"kind": "TrendsQuery", "series": [], "trendsFilter": {"display": "ActionsBarValue"}},
+        )


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/pull/22465

## Changes

This removes frontend-only settings from the cache key payload. I've also adapted the serializer to remove empty models, so the faux-defaults in the schema aren't necessary any more.

## How did you test this code?

Added tests