### PR TITLE
chore: add ids to admin for qol when debugging/doing support

### DIFF
--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -13,6 +13,7 @@ class OrganizationAdmin(admin.ModelAdmin):
     show_full_result_count = False  # prevent count() queries to show the no of filtered results
     paginator = NoCountPaginator  # prevent count() queries and return a fix page count instead
     fields = [
+        "id",
         "name",
         "created_at",
         "updated_at",
@@ -24,7 +25,15 @@ class OrganizationAdmin(admin.ModelAdmin):
         "is_hipaa",
     ]
     inlines = [ProjectInline, TeamInline, OrganizationMemberInline]
-    readonly_fields = ["created_at", "updated_at", "billing_link_v2", "usage_posthog", "usage", "customer_trust_scores"]
+    readonly_fields = [
+        "id",
+        "created_at",
+        "updated_at",
+        "billing_link_v2",
+        "usage_posthog",
+        "usage",
+        "customer_trust_scores",
+    ]
     search_fields = ("name", "members__email", "team__api_token")
     list_display = (
         "id",

--- a/posthog/admin/admins/user_admin.py
+++ b/posthog/admin/admins/user_admin.py
@@ -38,6 +38,7 @@ class UserAdmin(DjangoUserAdmin):
             None,
             {
                 "fields": (
+                    "id",
                     "email",
                     "password",
                     "current_organization",
@@ -66,7 +67,7 @@ class UserAdmin(DjangoUserAdmin):
     list_filter = ("is_staff", "is_active", "groups")
     list_select_related = ("current_team", "current_organization")
     search_fields = ("email", "first_name", "last_name")
-    readonly_fields = ["current_team", "current_organization"]
+    readonly_fields = ["id", "current_team", "current_organization"]
     ordering = ("email",)
 
     def current_team_link(self, user: User):


### PR DESCRIPTION
When doing support/debugging it's a pain to pull user/org ids from the URL, this is a small QOL change. 