### PR TITLE
chore(hogql): add cache payload method for better visibility

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -450,7 +450,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         }
 
     def get_cache_key(self) -> str:
-        return generate_cache_key(f"query_{to_json(self.get_cache_payload())}")
+        return generate_cache_key(f"query_{bytes.decode(to_json(self.get_cache_payload()))}")
 
     @abstractmethod
     def _is_stale(self, cached_result_package):

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -26,6 +26,8 @@ class TestQuery(BaseModel):
 
 
 class TestQueryRunner(BaseTest):
+    maxDiff = None
+
     def setup_test_query_runner_class(self):
         """Setup required methods and attributes of the abstract base class."""
 
@@ -90,7 +92,7 @@ class TestQueryRunner(BaseTest):
                     "personsOnEventsMode": "disabled",
                 },
                 "limit_context": "query",
-                "query": {"some_attr": "bla"},
+                "query": {"kind": "TestQuery", "some_attr": "bla"},
                 "query_runner": "TestQueryRunner",
                 "team_id": 42,
                 "timezone": "UTC",

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -106,7 +106,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_9ec4601658411f9463234bf079d8f5b6")
+        self.assertEqual(cache_key, "cache_7d24771ea5182ac75c9e3eb793935ca2")
 
     def test_cache_key_runner_subclass(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -120,7 +120,7 @@ class TestQueryRunner(BaseTest):
         runner = TestSubclassQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_73b92e9e9263aec396fcbf8e296037c5")
+        self.assertEqual(cache_key, "cache_b40c7f719decbcc00d26d2ced2f09ed7")
 
     def test_cache_key_different_timezone(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -131,7 +131,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_426bf3a1a0a1d8eb3073c65028f3b485")
+        self.assertEqual(cache_key, "cache_0e0767a9656f2871ce6caede66d1cf15")
 
     def test_cache_response(self):
         TestQueryRunner = self.setup_test_query_runner_class()

--- a/posthog/schema_helpers.py
+++ b/posthog/schema_helpers.py
@@ -15,7 +15,7 @@ from posthog.schema import (
 from posthog.types import InsightQueryNode
 
 
-def to_json(query: BaseModel) -> bytes:
+def to_dict(query: BaseModel) -> dict:
     klass: Any = type(query)
 
     class ExtendedQuery(klass):
@@ -95,9 +95,13 @@ def to_json(query: BaseModel) -> bytes:
     # generate a dict from the pydantic model
     instance_dict = query.model_dump(exclude_none=True, exclude_defaults=True)
 
+    return instance_dict
+
+
+def to_json(obj: dict) -> bytes:
     # pydantic doesn't sort keys reliably, so use orjson to serialize to json
     option = orjson.OPT_SORT_KEYS
-    json_string = orjson.dumps(instance_dict, default=JSONEncoder().default, option=option)
+    json_string = orjson.dumps(obj, default=JSONEncoder().default, option=option)
 
     return json_string
 

--- a/posthog/test/test_schema_helpers.py
+++ b/posthog/test/test_schema_helpers.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 from parameterized import parameterized
 
@@ -19,7 +18,7 @@ from posthog.schema import (
     BreakdownAttributionType,
     TrendsQuery,
 )
-from posthog.schema_helpers import to_json
+from posthog.schema_helpers import to_dict
 
 
 base_trends: dict[str, Any] = {"series": []}
@@ -39,8 +38,8 @@ class TestSchemaHelpers(TestCase):
         q1 = EventPropertyFilter(key="abc", operator=PropertyOperator.gt)
         q2 = PersonPropertyFilter(key="abc", operator=PropertyOperator.gt)
 
-        self.assertNotEqual(to_json(q1), to_json(q2))
-        self.assertIn('"type":"event"', str(to_json(q1)))
+        self.assertNotEqual(to_dict(q1), to_dict(q2))
+        self.assertIn("'type': 'event'", str(to_dict(q1)))
 
     def test_serializes_to_same_json_for_default_value(self):
         """
@@ -53,70 +52,70 @@ class TestSchemaHelpers(TestCase):
         q2 = EventPropertyFilter(key="abc", operator=None)
         q3 = EventPropertyFilter(key="abc", operator=PropertyOperator.exact)
 
-        self.assertEqual(to_json(q1), to_json(q2))
-        self.assertEqual(to_json(q2), to_json(q3))
-        self.assertNotIn("operator", str(to_json(q1)))
+        self.assertEqual(to_dict(q1), to_dict(q2))
+        self.assertEqual(to_dict(q2), to_dict(q3))
+        self.assertNotIn("operator", str(to_dict(q1)))
 
     def test_serializes_empty_and_missing_insight_filter_equally(self):
         q1 = TrendsQuery(**base_trends)
         q2 = TrendsQuery(**{**base_trends, "trendsFilter": {}})
 
-        self.assertEqual(json.loads(to_json(q1)), {"kind": "TrendsQuery", "series": []})
-        self.assertEqual(json.loads(to_json(q2)), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(to_dict(q1), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(to_dict(q2), {"kind": "TrendsQuery", "series": []})
 
     def test_serializes_empty_and_missing_breakdown_filter_equally(self):
         q1 = TrendsQuery(**base_trends)
         q2 = TrendsQuery(**{**base_trends, "breakdownFilter": {}})
 
-        self.assertEqual(json.loads(to_json(q1)), {"kind": "TrendsQuery", "series": []})
-        self.assertEqual(json.loads(to_json(q2)), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(to_dict(q1), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(to_dict(q2), {"kind": "TrendsQuery", "series": []})
 
     def test_serializes_empty_and_missing_date_range_equally(self):
         q1 = TrendsQuery(**base_trends)
         q2 = TrendsQuery(**{**base_trends, "dateRange": {}})
 
-        self.assertEqual(json.loads(to_json(q1)), {"kind": "TrendsQuery", "series": []})
-        self.assertEqual(json.loads(to_json(q2)), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(to_dict(q1), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(to_dict(q2), {"kind": "TrendsQuery", "series": []})
 
     def test_serializes_series_without_frontend_only_props(self):
         query = TrendsQuery(**{**base_trends, "series": [EventsNode(name="$pageview", custom_name="My custom name")]})
 
-        result_dict = json.loads(to_json(query))
+        result_dict = to_dict(query)
 
         self.assertEqual(result_dict, {"kind": "TrendsQuery", "series": [{"name": "$pageview"}]})
 
     def test_serializes_insight_filter_without_frontend_only_props(self):
         query = TrendsQuery(**{**base_trends, "trendsFilter": {"showLegend": True}})
 
-        result_dict = json.loads(to_json(query))
+        result_dict = to_dict(query)
 
         self.assertEqual(result_dict, {"kind": "TrendsQuery", "series": []})
 
     def test_serializes_display_with_canonic_alternatives(self):
         # time series (gets removed as ActionsLineGraph is the default)
         query = TrendsQuery(**{**base_trends, "trendsFilter": {"display": "ActionsAreaGraph"}})
-        self.assertEqual(json.loads(to_json(query)), {"kind": "TrendsQuery", "series": []})
+        self.assertEqual(to_dict(query), {"kind": "TrendsQuery", "series": []})
 
         # cumulative time series
         query = TrendsQuery(**{**base_trends, "trendsFilter": {"display": "ActionsLineGraphCumulative"}})
         self.assertEqual(
-            json.loads(to_json(query)),
+            to_dict(query),
             {"kind": "TrendsQuery", "series": [], "trendsFilter": {"display": "ActionsLineGraphCumulative"}},
         )
 
         # total value
         query = TrendsQuery(**{**base_trends, "trendsFilter": {"display": "BoldNumber"}})
         self.assertEqual(
-            json.loads(to_json(query)),
+            to_dict(query),
             {"kind": "TrendsQuery", "series": [], "trendsFilter": {"display": "ActionsBarValue"}},
         )
 
     def _assert_filter(self, key: str, num_keys: int, q1: BaseModel, q2: BaseModel):
-        self.assertEqual(to_json(q1), to_json(q2))
+        self.assertEqual(to_dict(q1), to_dict(q2))
         if num_keys == 0:
-            self.assertEqual(key in json.loads(to_json(q1)), False)
+            self.assertEqual(key in to_dict(q1), False)
         else:
-            self.assertEqual(num_keys, len(json.loads(to_json(q1))[key].keys()))
+            self.assertEqual(num_keys, len(to_dict(q1)[key].keys()))
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

It's not clear what causes the `cache_key` to change, see e.g. https://posthog.slack.com/archives/C0113360FFV/p1717084465028049.

## Changes

This PR adds a test for the cache payload, so that it is more easily understandable why the cache key has changed. 

Note: This is a stacked PR and will go in with the two above it in the stack, so we only invalidate the cache once.

## How did you test this code?

Added tests