### PR TITLE
fix(data-warehouse): Dont pass password if its not set

### DIFF
--- a/posthog/warehouse/models/ssh_tunnel.py
+++ b/posthog/warehouse/models/ssh_tunnel.py
@@ -21,9 +21,9 @@ def from_private_key(file_obj: IO[str], passphrase: str | None = None) -> PKey:
     except ValueError:
         key = crypto_serialization.load_pem_private_key(  # type: ignore
             file_bytes,
-            password=password,
+            password=password if passphrase is not None else None,
         )
-        if password:
+        if passphrase:
             encryption_algorithm = crypto_serialization.BestAvailableEncryption(password)
         else:
             encryption_algorithm = crypto_serialization.NoEncryption()


### PR DESCRIPTION
## Problem
- For unencrypted keys, we pass an empty byte value to the underlying key library, which makes it think a passphrase for the key is passed in, causing the key parsing to fail

## Changes
- If no passphrase is given, then pass `None` to the underlying library

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested locally 