### PR TITLE
chore: add a data attr

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSegmentedButton/LemonSegmentedButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSegmentedButton/LemonSegmentedButton.tsx
@@ -23,6 +23,7 @@ export interface LemonSegmentedButtonProps<T extends React.Key> {
     size?: LemonButtonProps['size']
     className?: string
     fullWidth?: boolean
+    'data-attr'?: string
 }
 
 interface LemonSegmentedButtonCSSProperties extends React.CSSProperties {
@@ -38,6 +39,7 @@ export function LemonSegmentedButton<T extends React.Key>({
     size,
     fullWidth,
     className,
+    'data-attr': dataAttr,
 }: LemonSegmentedButtonProps<T>): JSX.Element {
     const { containerRef, selectionRef, sliderWidth, sliderOffset, transitioning } = useSliderPositioning<
         HTMLDivElement,
@@ -60,6 +62,7 @@ export function LemonSegmentedButton<T extends React.Key>({
                 } as LemonSegmentedButtonCSSProperties
             }
             ref={containerRef}
+            data-attr={dataAttr}
         >
             {sliderWidth > 0 && (
                 <div

--- a/frontend/src/lib/lemon-ui/LemonSegmentedButton/LemonSegmentedButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSegmentedButton/LemonSegmentedButton.tsx
@@ -23,7 +23,6 @@ export interface LemonSegmentedButtonProps<T extends React.Key> {
     size?: LemonButtonProps['size']
     className?: string
     fullWidth?: boolean
-    'data-attr'?: string
 }
 
 interface LemonSegmentedButtonCSSProperties extends React.CSSProperties {
@@ -39,7 +38,6 @@ export function LemonSegmentedButton<T extends React.Key>({
     size,
     fullWidth,
     className,
-    'data-attr': dataAttr,
 }: LemonSegmentedButtonProps<T>): JSX.Element {
     const { containerRef, selectionRef, sliderWidth, sliderOffset, transitioning } = useSliderPositioning<
         HTMLDivElement,
@@ -62,7 +60,6 @@ export function LemonSegmentedButton<T extends React.Key>({
                 } as LemonSegmentedButtonCSSProperties
             }
             ref={containerRef}
-            data-attr={dataAttr}
         >
             {sliderWidth > 0 && (
                 <div

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -220,6 +220,7 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
                                 <PlayerPersonMeta />
 
                                 <LemonSegmentedButton
+                                    data-attr="session-recording-player-view-choice"
                                     size="xsmall"
                                     value={playerView}
                                     onChange={setPlayerView}

--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -180,9 +180,15 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
         )
     }
 
-    const viewOptions: LemonSegmentedButtonOption<PlaybackViewType>[] = [{ value: 'playback', label: 'Playback' }]
+    const viewOptions: LemonSegmentedButtonOption<PlaybackViewType>[] = [
+        { value: 'playback', label: 'Playback', 'data-attr': 'session-recording-player-view-choice-playback' },
+    ]
     if (!noInspector) {
-        viewOptions.push({ value: 'inspector', label: 'Inspector' })
+        viewOptions.push({
+            value: 'inspector',
+            label: 'Inspector',
+            'data-attr': 'session-recording-player-view-choice-inspector',
+        })
     }
     if (allowWaterfallView) {
         viewOptions.push({
@@ -193,6 +199,7 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
                     <LemonTag type="success">New</LemonTag>
                 </div>
             ),
+            'data-attr': 'session-recording-player-view-choice-waterfall',
         })
     }
 
@@ -220,7 +227,6 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
                                 <PlayerPersonMeta />
 
                                 <LemonSegmentedButton
-                                    data-attr="session-recording-player-view-choice"
                                     size="xsmall"
                                     value={playerView}
                                     onChange={setPlayerView}


### PR DESCRIPTION
surprisingly hard to pick out an action for these buttons using autocapture

turns out lemon segmented button didn't support data attrs... - because you should add the data attr to the child buttons

so this PR adds them