### PR TITLE
feat(insights): make 'all' and multi cohort work in trends actors

### DIFF
--- a/posthog/hogql_queries/insights/trends/breakdown.py
+++ b/posthog/hogql_queries/insights/trends/breakdown.py
@@ -30,7 +30,7 @@ class Breakdown:
     timings: HogQLTimings
     modifiers: HogQLQueryModifiers
     events_filter: ast.Expr
-    breakdown_values_override: Optional[list[str]]
+    breakdown_values_override: Optional[list[str | int]]
     limit_context: LimitContext
 
     def __init__(

--- a/posthog/hogql_queries/insights/trends/breakdown.py
+++ b/posthog/hogql_queries/insights/trends/breakdown.py
@@ -42,7 +42,7 @@ class Breakdown:
         timings: HogQLTimings,
         modifiers: HogQLQueryModifiers,
         events_filter: ast.Expr,
-        breakdown_values_override: Optional[list[str]] = None,
+        breakdown_values_override: Optional[list[str | int]] = None,
         limit_context: LimitContext = LimitContext.QUERY,
     ):
         self.team = team

--- a/posthog/hogql_queries/insights/trends/breakdown.py
+++ b/posthog/hogql_queries/insights/trends/breakdown.py
@@ -103,10 +103,16 @@ class Breakdown:
             and self.query.breakdownFilter.breakdown is not None
             and self.query.breakdownFilter.breakdown_type == "cohort"
         ):
-            if self.query.breakdownFilter.breakdown == "all":
+            breakdown = (
+                self.breakdown_values_override
+                if self.breakdown_values_override
+                else self.query.breakdownFilter.breakdown
+            )
+
+            if breakdown == "all":
                 return None
 
-            if isinstance(self.query.breakdownFilter.breakdown, list):
+            if isinstance(breakdown, list):
                 or_clause = ast.Or(
                     exprs=[
                         ast.CompareOperation(
@@ -114,12 +120,12 @@ class Breakdown:
                             op=ast.CompareOperationOp.InCohort,
                             right=ast.Constant(value=breakdown),
                         )
-                        for breakdown in self.query.breakdownFilter.breakdown
+                        for breakdown in breakdown
                     ]
                 )
-                if len(self.query.breakdownFilter.breakdown) > 1:
+                if len(breakdown) > 1:
                     return or_clause
-                elif len(self.query.breakdownFilter.breakdown) == 1:
+                elif len(breakdown) == 1:
                     return or_clause.exprs[0]
                 else:
                     return ast.Constant(value=True)
@@ -127,7 +133,7 @@ class Breakdown:
             return ast.CompareOperation(
                 left=ast.Field(chain=["person_id"]),
                 op=ast.CompareOperationOp.InCohort,
-                right=ast.Constant(value=self.query.breakdownFilter.breakdown),
+                right=ast.Constant(value=breakdown),
             )
 
         # No need to filter if we're showing the "other" bucket, as we need to look at all events anyway.

--- a/posthog/hogql_queries/insights/trends/test/test_trends_persons.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_persons.py
@@ -436,9 +436,6 @@ class TestTrendsPersons(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(get_distinct_id(result[2]), "person3")
         self.assertEqual(get_event_count(result[2]), 1)
 
-    def test_trends_all_cohort_breakdown_persons_auto(self):
-        self.trends_all_cohort_breakdown_persons("auto")
-
     def test_trends_all_cohort_breakdown_persons_subquery(self):
         self.trends_all_cohort_breakdown_persons("subquery")
 

--- a/posthog/hogql_queries/insights/trends/test/test_trends_persons.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_persons.py
@@ -372,7 +372,6 @@ class TestTrendsPersons(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(get_distinct_id(result[1]), "person3")
         self.assertEqual(get_event_count(result[1]), 1)
 
-    @skip("fails, as cohort breakdown value is seemingly ignored")
     def test_trends_multi_cohort_breakdown_persons(self):
         self._create_events()
         cohort1 = _create_cohort(
@@ -395,7 +394,7 @@ class TestTrendsPersons(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(len(result), 1)
         self.assertEqual(get_distinct_id(result[0]), "person1")
-        self.assertEqual(get_event_count(result[0]), 2)
+        self.assertEqual(get_event_count(result[0]), 3)
 
         result = self._get_actors(trends_query=source_query, day="2023-05-01", breakdown=cohort2.pk)
 

--- a/posthog/hogql_queries/insights/trends/test/test_trends_persons.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_persons.py
@@ -5,6 +5,7 @@ from django.test import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 
+from posthog.api.test.test_team import create_team
 from posthog.hogql_queries.actors_query_runner import ActorsQueryRunner
 from posthog.models import Team, Cohort, GroupTypeMapping
 from posthog.models.group.util import create_group
@@ -23,6 +24,7 @@ from posthog.schema import (
     PropertyMathType,
     TrendsFilter,
     TrendsQuery,
+    HogQLQueryModifiers,
 )
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person
 
@@ -48,6 +50,7 @@ def get_actors(
         series=series,
         status=status,
         includeRecordings=includeRecordings,
+        modifiers=trends_query.modifiers,
     )
     actors_query = ActorsQuery(
         source=insight_actors_query,
@@ -59,6 +62,7 @@ def get_actors(
             *(["matched_recordings"] if includeRecordings else []),
         ],
         orderBy=["event_count DESC"],
+        modifiers=trends_query.modifiers,
     )
     response = ActorsQueryRunner(query=actors_query, team=team).calculate()
     return response.results
@@ -188,6 +192,30 @@ class TestTrendsPersons(ClickhouseTestMixin, APIBaseTest):
             properties={"some_property": 20},
             team=self.team,
         )
+
+        other_team = create_team(self.team.organization)
+
+        _create_person(
+            team_id=other_team.pk,
+            distinct_ids=["person4"],
+            properties={"$geoip_country_code": "US"},
+        )
+
+        for i in range(6):
+            _create_event(
+                event="$pageview",
+                distinct_id="person4",
+                timestamp=f"2023-04-{30-i} 16:00",
+                properties={"some_property": 20},
+                team=other_team,
+            )
+            _create_event(
+                event="$pageview",
+                distinct_id="person4",
+                timestamp=f"2023-05-0{i+1} 16:00",
+                properties={"some_property": 20},
+                team=other_team,
+            )
 
     def test_trends_single_series_persons(self):
         self._create_events()
@@ -377,8 +405,7 @@ class TestTrendsPersons(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(get_distinct_id(result[1]), "person3")
         self.assertEqual(get_event_count(result[1]), 1)
 
-    @skip("fails, as 'all' cohort can't be resolved")
-    def test_trends_all_cohort_breakdown_persons(self):
+    def trends_all_cohort_breakdown_persons(self, inCohortVia: str):
         self._create_events()
         cohort1 = _create_cohort(
             team=self.team,
@@ -391,21 +418,35 @@ class TestTrendsPersons(ClickhouseTestMixin, APIBaseTest):
             breakdownFilter=BreakdownFilter(breakdown=[cohort1.pk, "all"], breakdown_type=BreakdownType.cohort),
         )
 
+        source_query.modifiers = HogQLQueryModifiers(inCohortVia=inCohortVia)
+
         result = self._get_actors(trends_query=source_query, day="2023-05-01", breakdown=cohort1.pk)
 
         self.assertEqual(len(result), 1)
         self.assertEqual(get_distinct_id(result[0]), "person1")
-        self.assertEqual(get_event_count(result[0]), 2)
+        self.assertEqual(get_event_count(result[0]), 3)
 
         result = self._get_actors(trends_query=source_query, day="2023-05-01", breakdown="all")
 
         self.assertEqual(len(result), 3)
         self.assertEqual(get_distinct_id(result[0]), "person1")
-        self.assertEqual(get_event_count(result[0]), 2)
+        self.assertEqual(get_event_count(result[0]), 3)
         self.assertEqual(get_distinct_id(result[1]), "person2")
         self.assertEqual(get_event_count(result[1]), 2)
         self.assertEqual(get_distinct_id(result[2]), "person3")
         self.assertEqual(get_event_count(result[2]), 1)
+
+    def test_trends_all_cohort_breakdown_persons_auto(self):
+        self.trends_all_cohort_breakdown_persons("auto")
+
+    def test_trends_all_cohort_breakdown_persons_subquery(self):
+        self.trends_all_cohort_breakdown_persons("subquery")
+
+    def test_trends_all_cohort_breakdown_persons_leftjoin(self):
+        self.trends_all_cohort_breakdown_persons("leftjoin")
+
+    def test_trends_all_cohort_breakdown_persons_leftjoin_conjoined(self):
+        self.trends_all_cohort_breakdown_persons("leftjoin_conjoined")
 
     def test_trends_math_weekly_active_persons(self):
         for i in range(17, 24):

--- a/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
@@ -360,7 +360,7 @@ class TrendsActorsQueryBuilder:
             timings=self.timings,
             modifiers=self.modifiers,
             events_filter=self._events_where_expr(with_breakdown_expr=False),
-            breakdown_values_override=[str(self.breakdown_value)] if self.breakdown_value is not None else None,
+            breakdown_values_override=[self.breakdown_value] if self.breakdown_value is not None else None,
             limit_context=self.limit_context,
         )
 

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -251,11 +251,9 @@ class TrendsQueryRunner(QueryRunner):
 
             for value in breakdown_values:
                 if self.query.breakdownFilter is not None and self.query.breakdownFilter.breakdown_type == "cohort":
-                    cohort_name = (
-                        "all users" if value == "all" or str(value) == "0" else Cohort.objects.get(pk=value).name
-                    )
-                    label = cohort_name
-                    value = value
+                    is_all = value == "all" or str(value) == "0"
+                    label = "all users" if is_all else Cohort.objects.get(pk=value).name
+                    value = "all" if is_all else value
                 elif value == BREAKDOWN_OTHER_STRING_LABEL:
                     label = BREAKDOWN_OTHER_DISPLAY
                 elif value == BREAKDOWN_NULL_STRING_LABEL:

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -160,7 +160,7 @@ class TrendsQueryRunner(QueryRunner):
             if self.query.breakdownFilter and self.query.breakdownFilter.breakdown_type == BreakdownType.cohort:
                 if self.query.breakdownFilter.breakdown in ("all", ["all"]) or breakdown_value == "all":
                     self.query.breakdownFilter = None
-                else:
+                elif isinstance(self.query.breakdownFilter.breakdown, list):
                     self.query.breakdownFilter.breakdown = [
                         x for x in self.query.breakdownFilter.breakdown if x != "all"
                     ]

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -63,6 +63,7 @@ from posthog.schema import (
     TrendsQueryResponse,
     HogQLQueryModifiers,
     DataWarehouseEventsModifier,
+    BreakdownType,
 )
 from posthog.warehouse.models import DataWarehouseTable
 from posthog.utils import format_label_date, multisort
@@ -156,6 +157,13 @@ class TrendsQueryRunner(QueryRunner):
         include_recordings: Optional[bool] = None,
     ) -> ast.SelectQuery | ast.SelectUnionQuery:
         with self.timings.measure("trends_to_actors_query"):
+            if self.query.breakdownFilter and self.query.breakdownFilter.breakdown_type == BreakdownType.cohort:
+                if self.query.breakdownFilter.breakdown in ("all", ["all"]) or breakdown_value == "all":
+                    self.query.breakdownFilter = None
+                else:
+                    self.query.breakdownFilter.breakdown = [
+                        x for x in self.query.breakdownFilter.breakdown if x != "all"
+                    ]
             query_builder = TrendsActorsQueryBuilder(
                 trends_query=self.query,
                 team=self.team,
@@ -165,7 +173,7 @@ class TrendsQueryRunner(QueryRunner):
                 # actors related args
                 time_frame=time_frame,
                 series_index=series_index,
-                breakdown_value=breakdown_value,
+                breakdown_value=breakdown_value if breakdown_value != "all" else None,
                 compare_value=compare_value,
                 include_recordings=include_recordings,
             )
@@ -243,7 +251,9 @@ class TrendsQueryRunner(QueryRunner):
 
             for value in breakdown_values:
                 if self.query.breakdownFilter is not None and self.query.breakdownFilter.breakdown_type == "cohort":
-                    cohort_name = "all users" if str(value) == "0" else Cohort.objects.get(pk=value).name
+                    cohort_name = (
+                        "all users" if value == "all" or str(value) == "0" else Cohort.objects.get(pk=value).name
+                    )
                     label = cohort_name
                     value = value
                 elif value == BREAKDOWN_OTHER_STRING_LABEL:


### PR DESCRIPTION
## Problem

As described here https://github.com/PostHog/posthog/pull/22132 we don't handle 'all' or multi cohorts in trend actors queries

## Changes

Update the code that generates the actors query from the trends query to get rid of the 'all' cohort.
[actors.webm](https://github.com/PostHog/posthog/assets/1855120/daef1b25-35ec-4b17-8df0-fcac4044eaf6)

I had [previous written a change](https://github.com/PostHog/posthog/compare/aspicer/cohort_all?expand=1) that actually adds support for `in cohort 'all'` to the language, but gave it a second thought and put this up instead. I didn't think the language really needed to support this if we could handle weird cases outside of it.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tests in python. Verifying that it works in dev.