### PR TITLE
chore: Add `query-async` to `PERSISTED_FEATURE_FLAGS`

### DIFF
--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -14,4 +14,5 @@ PERSISTED_FEATURE_FLAGS = [
     "persons-hogql-query",
     "datanode-concurrency-limit",
     "session-table-property-filters",
+    "query-async",
 ]


### PR DESCRIPTION
## Problem

Looks like it's time to roll async queries out everywhere.

## Changes

This enforces rollout of `query-async` on both Cloud and hobby.