### PR TITLE
fix(data-warehouse): Fix getting ssh enabled var

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/create_job_model.py
+++ b/posthog/temporal/data_imports/workflow_activities/create_job_model.py
@@ -46,7 +46,7 @@ async def create_external_data_job_model_activity(inputs: CreateExternalDataJobM
         database = source.job_inputs.get("database")
         db_schema = source.job_inputs.get("schema")
 
-        using_ssh_tunnel = source.job_inputs.get("ssh_tunnel_enabled")
+        using_ssh_tunnel = str(source.job_inputs.get("ssh_tunnel_enabled", False)) == "True"
         ssh_tunnel_host = source.job_inputs.get("ssh_tunnel_host")
         ssh_tunnel_port = source.job_inputs.get("ssh_tunnel_port")
         ssh_tunnel_auth_type = source.job_inputs.get("ssh_tunnel_auth_type")


### PR DESCRIPTION
## Problem
- postgres syncs are breaking due to how we get the job inputs - causing us to mistakenly enable ssh tunnels
- Job inputs always return strings, and so we need to check it equates to the string `"True"` before enabling SSH tunnels

## Changes
Parse the job inputs correctly
