### PR TITLE
chore(insights): Consolidate HogQL flags to `hogql-insights-preview`

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -167,14 +167,7 @@ export const FEATURE_FLAGS = {
     REDIRECT_SIGNUPS_TO_INSTANCE: 'redirect-signups-to-instance', // owner: @raquelmsmith
     APPS_AND_EXPORTS_UI: 'apps-and-exports-ui', // owner: @benjackwhite
     HOGQL_INSIGHTS: 'hogql-insights-preview', // owner: @mariusandra
-    HOGQL_INSIGHTS_LIFECYCLE: 'hogql-insights-lifecycle', // owner: @mariusandra
-    HOGQL_INSIGHTS_PATHS: 'hogql-insights-paths', // owner: @webjunkie
-    HOGQL_INSIGHTS_RETENTION: 'hogql-insights-retention', // owner: @webjunkie
-    HOGQL_INSIGHTS_TRENDS: 'hogql-insights-trends', // owner: @Gilbert09
-    HOGQL_INSIGHTS_STICKINESS: 'hogql-insights-stickiness', // owner: @Gilbert09
-    HOGQL_INSIGHTS_FUNNELS: 'hogql-insights-funnels', // owner: @thmsobrmlr
     HOGQL_INSIGHT_LIVE_COMPARE: 'hogql-insight-live-compare', // owner: @mariusandra
-    HOGQL_IN_INSIGHT_SERIALIZATION: 'hogql-in-insight-serialization', // owner: @Twixes
     BI_VIZ: 'bi_viz', // owner: @Gilbert09
     WEBHOOKS_DENYLIST: 'webhooks-denylist', // owner: #team-pipeline
     PERSONS_HOGQL_QUERY: 'persons-hogql-query', // owner: @mariusandra

--- a/frontend/src/queries/nodes/InsightViz/TrendsSeries.tsx
+++ b/frontend/src/queries/nodes/InsightViz/TrendsSeries.tsx
@@ -88,8 +88,7 @@ export function TrendsSeries(): JSX.Element | null {
                 mathAvailability={mathAvailability}
                 propertiesTaxonomicGroupTypes={propertiesTaxonomicGroupTypes}
                 actionsTaxonomicGroupTypes={
-                    featureFlags[FEATURE_FLAGS.DATA_WAREHOUSE] &&
-                    (featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS] || featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_TRENDS])
+                    featureFlags[FEATURE_FLAGS.DATA_WAREHOUSE] && featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS]
                         ? [
                               TaxonomicFilterGroupType.Events,
                               TaxonomicFilterGroupType.Actions,

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -29,9 +29,7 @@ import {
     isInsightQueryNode,
     isInsightVizNode,
     isLifecycleQuery,
-    isPathsQuery,
     isPersonsNode,
-    isRetentionQuery,
     isStickinessQuery,
     isTimeToSeeDataQuery,
     isTimeToSeeDataSessionsNode,
@@ -166,18 +164,6 @@ export async function query<N extends DataNode>(
     const allFlags = featureFlagLogic.findMounted()?.values.featureFlags ?? {}
 
     const hogQLInsightsFlagEnabled = Boolean(allFlags[FEATURE_FLAGS.HOGQL_INSIGHTS])
-    const hogQLInsightsLifecycleFlagEnabled =
-        hogQLInsightsFlagEnabled || Boolean(allFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_LIFECYCLE])
-    const hogQLInsightsPathsFlagEnabled =
-        hogQLInsightsFlagEnabled || Boolean(allFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_PATHS])
-    const hogQLInsightsRetentionFlagEnabled =
-        hogQLInsightsFlagEnabled || Boolean(allFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_RETENTION])
-    const hogQLInsightsTrendsFlagEnabled =
-        hogQLInsightsFlagEnabled || Boolean(allFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_TRENDS])
-    const hogQLInsightsStickinessFlagEnabled =
-        hogQLInsightsFlagEnabled || Boolean(allFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_STICKINESS])
-    const hogQLInsightsFunnelsFlagEnabled =
-        hogQLInsightsFlagEnabled || Boolean(allFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_FUNNELS])
     const hogQLInsightsLiveCompareEnabled = Boolean(allFlags[FEATURE_FLAGS.HOGQL_INSIGHT_LIVE_COMPARE])
 
     async function fetchLegacyUrl(): Promise<Record<string, any>> {
@@ -221,15 +207,7 @@ export async function query<N extends DataNode>(
                 methodOptions
             )
         } else if (isInsightQueryNode(queryNode) || (isActorsQuery(queryNode) && !!legacyUrl)) {
-            if (
-                (hogQLInsightsLifecycleFlagEnabled && isLifecycleQuery(queryNode)) ||
-                (hogQLInsightsPathsFlagEnabled &&
-                    (isPathsQuery(queryNode) || (isActorsQuery(queryNode) && !!legacyUrl))) ||
-                (hogQLInsightsRetentionFlagEnabled && isRetentionQuery(queryNode)) ||
-                (hogQLInsightsTrendsFlagEnabled && isTrendsQuery(queryNode)) ||
-                (hogQLInsightsStickinessFlagEnabled && isStickinessQuery(queryNode)) ||
-                (hogQLInsightsFunnelsFlagEnabled && isFunnelsQuery(queryNode))
-            ) {
+            if (hogQLInsightsFlagEnabled) {
                 if (hogQLInsightsLiveCompareEnabled) {
                     const legacyFunction = (): any => {
                         try {

--- a/frontend/src/scenes/insights/insightDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.test.ts
@@ -166,17 +166,9 @@ describe('insightDataLogic', () => {
             }).toMatchValues({ isHogQLInsight: false })
         })
 
-        it('returns true with generic flag enabled', () => {
+        it('returns true with flag enabled', () => {
             theFeatureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.HOGQL_INSIGHTS], {
                 [FEATURE_FLAGS.HOGQL_INSIGHTS]: true,
-            })
-
-            expectLogic(theInsightDataLogic).toMatchValues({ isHogQLInsight: true })
-        })
-
-        it('returns true with specific flag enabled', () => {
-            theFeatureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.HOGQL_INSIGHTS_TRENDS], {
-                [FEATURE_FLAGS.HOGQL_INSIGHTS_TRENDS]: true,
             })
 
             expectLogic(theInsightDataLogic).toMatchValues({ isHogQLInsight: true })

--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -15,15 +15,7 @@ import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeT
 import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { queryExportContext } from '~/queries/query'
 import { InsightNodeKind, InsightVizNode, Node, NodeKind } from '~/queries/schema'
-import {
-    isFunnelsQuery,
-    isInsightVizNode,
-    isLifecycleQuery,
-    isPathsQuery,
-    isRetentionQuery,
-    isStickinessQuery,
-    isTrendsQuery,
-} from '~/queries/utils'
+import { isInsightVizNode } from '~/queries/utils'
 import { ExportContext, FilterType, InsightLogicProps, InsightType } from '~/types'
 
 import type { insightDataLogicType } from './insightDataLogicType'
@@ -113,16 +105,7 @@ export const insightDataLogic = kea<insightDataLogicType>([
         isHogQLInsight: [
             (s) => [s.featureFlags, s.query],
             (featureFlags, query) => {
-                return (
-                    isInsightVizNode(query) &&
-                    (!!featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS] ||
-                        (isTrendsQuery(query.source) && !!featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_TRENDS]) ||
-                        (isFunnelsQuery(query.source) && !!featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_FUNNELS]) ||
-                        (isRetentionQuery(query.source) && !!featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_RETENTION]) ||
-                        (isPathsQuery(query.source) && !!featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_PATHS]) ||
-                        (isStickinessQuery(query.source) && !!featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_STICKINESS]) ||
-                        (isLifecycleQuery(query.source) && !!featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS_LIFECYCLE]))
-                )
+                return isInsightVizNode(query) && !!featureFlags[FEATURE_FLAGS.HOGQL_INSIGHTS]
             },
         ],
 

--- a/frontend/src/scenes/retention/retentionModalLogic.ts
+++ b/frontend/src/scenes/retention/retentionModalLogic.ts
@@ -67,11 +67,7 @@ export const retentionModalLogic = kea<retentionModalLogicType>([
         exploreUrl: [
             (s) => [s.actorsQuery, s.featureFlags],
             (actorsQuery, featureFlags): string | null => {
-                if (
-                    !actorsQuery ||
-                    (!featureFlags?.[FEATURE_FLAGS.HOGQL_INSIGHTS] &&
-                        !featureFlags?.[FEATURE_FLAGS.HOGQL_INSIGHTS_RETENTION])
-                ) {
+                if (!actorsQuery || !featureFlags?.[FEATURE_FLAGS.HOGQL_INSIGHTS]) {
                     return null
                 }
                 const query: DataTableNode = {

--- a/posthog/hogql_queries/legacy_compatibility/feature_flag.py
+++ b/posthog/hogql_queries/legacy_compatibility/feature_flag.py
@@ -8,7 +8,7 @@ def should_use_hogql_backend_in_insight_serialization(team: Team) -> bool:
         return settings.HOGQL_INSIGHTS_OVERRIDE
 
     return posthoganalytics.feature_enabled(
-        "hogql-in-insight-serialization",
+        "hogql-insights-preview",
         str(team.uuid),
         groups={
             "organization": str(team.organization_id),


### PR DESCRIPTION
## Problem

It's time to simplify things. We don't need these flags to be separate anymore:

- `hogql-in-insight-serialization`
- `hogql-insights-lifecycle`
- `hogql-insights-paths`
- `hogql-insights-retention`
- `hogql-insights-trends`
- `hogql-insights-funnels`

## Changes

> Where the Delete key has gone there will be nothing. Only `hogql-insights-preview` will remain.
