### PR TITLE
fix(web-analytics): Fix searching for session properties with multiple words in the search term

### DIFF
--- a/posthog/hogql/database/schema/sessions.py
+++ b/posthog/hogql/database/schema/sessions.py
@@ -1,3 +1,4 @@
+import re
 from typing import cast, Optional, TYPE_CHECKING
 
 from posthog.hogql import ast
@@ -311,6 +312,15 @@ def get_lazy_session_table_properties(search: Optional[str]):
             return PropertyType.Boolean
         return PropertyType.String
 
+    search_words = re.findall(r"\w+", search.lower()) if search else None
+
+    def is_match(field_name: str) -> bool:
+        if field_name in hidden_fields:
+            return False
+        if not search_words:
+            return True
+        return all(word in field_name.lower() for word in search_words)
+
     results = [
         {
             "id": field_name,
@@ -322,7 +332,7 @@ def get_lazy_session_table_properties(search: Optional[str]):
             "tags": [],
         }
         for field_name, field_definition in LAZY_SESSIONS_FIELDS.items()
-        if (not search or search.lower() in field_name.lower()) and field_name not in hidden_fields
+        if is_match(field_name)
     ]
     return results
 


### PR DESCRIPTION

## Problem

Bug reported by @andyvan-ph https://posthog.slack.com/archives/C02E3BKC78F/p1717407480798329

## Changes

Split the search term into words, and make sure that each word is in the returned property. Roughly matches how event properties are handled

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added tests, ran locally:
<img width="989" alt="Screenshot 2024-06-03 at 12 11 06" src="https://github.com/PostHog/posthog/assets/2056078/244b444a-bd2c-4d78-8585-416f8cd74b61">
