### PR TITLE
fix(billing UI): fix success color

### DIFF
--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -325,7 +325,7 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                     >
                         <div>
                             {currentPlan && (
-                                <h4 className={`${!upgradePlan ? 'text-success-dark' : 'text-warning-dark'}`}>
+                                <h4 className={`${!upgradePlan ? 'text-success' : 'text-warning-dark'}`}>
                                     You're on the {currentPlan.name} plan for {product.name}.
                                 </h4>
                             )}


### PR DESCRIPTION
## Problem
The success color has low contrast in the dark mode.

## Changes
Use `text-success` instead of `text-success-dark` for both dark and light modes.

|Before|After|
|----|----|
|<img width="526" alt="image" src="https://github.com/PostHog/posthog/assets/22996112/cdd38f57-87ef-42b5-b7f4-275daa7bf62e">|<img width="526" alt="image" src="https://github.com/PostHog/posthog/assets/22996112/31a4e413-706f-4fbe-af66-4650fa4cff65">|

|Before|After|
|----|----|
|<img width="525" alt="image" src="https://github.com/PostHog/posthog/assets/22996112/c087b9d4-1874-4d32-94df-4d9b2b55e9a0">|<img width="525" alt="image" src="https://github.com/PostHog/posthog/assets/22996112/78e95712-dd3a-47e8-9d99-ab5bfb2c0b33">|

## How did you test this code?
👀 
