### PR TITLE
feat: Timeout row count if it takes longer than 1/12 of frequency

### DIFF
--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -354,14 +354,20 @@ async def start_batch_export_run(inputs: StartBatchExportRunInputs) -> tuple[Bat
         except asyncio.TimeoutError:
             count = None
 
-    if count is not None and count > 0:
+    if count is None:
+        logger.info(
+            "Batch export for range %s - %s will continue without a count of rows to export",
+            inputs.data_interval_start,
+            inputs.data_interval_end,
+        )
+    elif count > 0:
         logger.info(
             "Batch export for range %s - %s will export %s rows",
             inputs.data_interval_start,
             inputs.data_interval_end,
             count,
         )
-    elif count is not None:
+    else:
         logger.info(
             "Batch export for range %s - %s has no rows to export",
             inputs.data_interval_start,


### PR DESCRIPTION
## Problem

Turn row count into a best effort operation. This could have UI implications, but shouldn't impact _most_ users, as 1/12 of the frequency is enough time for most users, even those in 5 minute frequencies.

Row count in its current form is used for two reasons:
* Early return.
* UI metrics display.

I am considering completely phasing it out, but need to see how this would impact these two things first. Hence, why I opted for a timeout initially.

This should help cut down on time for those scenarios where count is slow, like when running unconstrained against a workflow event with significant and regular delays.
 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add a timeout to count in `start_batch_export_run`.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yup.
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Covered by current tests.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
