### PR TITLE
feat: change language on person profile popup

### DIFF
--- a/frontend/src/scenes/persons/PersonPreview.tsx
+++ b/frontend/src/scenes/persons/PersonPreview.tsx
@@ -32,11 +32,11 @@ export function PersonPreview(props: PersonPreviewProps): JSX.Element | null {
     if (!person) {
         return (
             <div className="p-2 max-w-160">
-                <h4>Person profile not found</h4>
+                <h4>No profile associated with this ID</h4>
                 <p>
-                    The Person may have been deleted.
-                    <br />
-                    Alternatively, the events for this user may have had Person Profiles disabled.
+                    Person profiles allow you to see a detailed view of a Person's user properties, track users across
+                    devices, and more. To create person profiles, see{' '}
+                    <Link to="https://posthog.com/docs/data/persons#capturing-person-profiles">here.</Link>
                 </p>
             </div>
         )


### PR DESCRIPTION
## Problem

The person profile popup focused on persons having been deleted, but now the overwhelmingly common use-case will be because they are using personless events. So make it focus on that.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Updates the copy.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Ya

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
