### PR TITLE
fix: if a hedegehog falls in the woods

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -106,6 +106,23 @@ class TestUserAPI(APIBaseTest):
             ],
         )
 
+    def test_hedgehog_config_is_unset(self):
+        self.user.hedgehog_config = None
+        self.user.save()
+
+        response = self.client.get(f"/api/users/@me/hedgehog_config/")
+        assert response.status_code == status.HTTP_200_OK
+        # the front end assumes it will _always_ get JSON
+        assert response.json() == {}
+
+    def test_hedgehog_config_is_set(self):
+        self.user.hedgehog_config = {"a bag": "of data"}
+        self.user.save()
+
+        response = self.client.get(f"/api/users/@me/hedgehog_config/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"a bag": "of data"}
+
     def test_can_only_list_yourself(self):
         """
         At this moment only the current user can be retrieved from this endpoint.

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -473,7 +473,7 @@ class UserViewSet(
     def hedgehog_config(self, request, **kwargs):
         instance = self.get_object()
         if request.method == "GET":
-            return Response(instance.hedgehog_config)
+            return Response(instance.hedgehog_config or {})
         else:
             instance.hedgehog_config = request.data
             instance.save()


### PR DESCRIPTION
hedgehog config on a user can be null but we always expect valid JSON and the API wasn't returning json when there was no hedgehog config

generating a console error 

well, not any more!

(fixes https://github.com/PostHog/posthog-js/issues/1220)