### PR TITLE
chore: restart celery on file change

### DIFF
--- a/bin/start-worker
+++ b/bin/start-worker
@@ -7,8 +7,8 @@ trap 'kill $(jobs -p)' EXIT
 source ./bin/celery-queues.env
 
 # start celery worker with heartbeat (-B)
-SKIP_ASYNC_MIGRATIONS_SETUP=0 CELERY_WORKER_QUEUES=$CELERY_WORKER_QUEUES celery -A posthog worker --without-heartbeat --without-mingle --pool=threads -Ofair -n node@%h &
-celery -A posthog beat -S redbeat.RedBeatScheduler &
+SKIP_ASYNC_MIGRATIONS_SETUP=0 CELERY_WORKER_QUEUES=$CELERY_WORKER_QUEUES pnpm chokidar "posthog/**/*.py" --initial --silent -c "celery -A posthog worker --without-heartbeat --without-mingle --pool=threads -Ofair -n node@%h" &
+pnpm chokidar "posthog/**/*.py" --initial --silent -c "celery -A posthog beat -S redbeat.RedBeatScheduler" &
 
 if [[ "$PLUGIN_SERVER_IDLE" != "1" && "$PLUGIN_SERVER_IDLE" != "true" ]]; then
   ./bin/plugin-server

--- a/package.json
+++ b/package.json
@@ -241,6 +241,7 @@
         "axe-core": "^4.4.3",
         "babel-loader": "^8.0.6",
         "babel-plugin-import": "^1.13.0",
+        "chokidar-cli": "^3.0.0",
         "concurrently": "^5.3.0",
         "css-loader": "^3.4.2",
         "cypress": "^13.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,6 +536,9 @@ devDependencies:
   babel-plugin-import:
     specifier: ^1.13.0
     version: 1.13.8
+  chokidar-cli:
+    specifier: ^3.0.0
+    version: 3.0.0
   concurrently:
     specifier: ^5.3.0
     version: 5.3.0
@@ -10054,6 +10057,17 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
+  /chokidar-cli@3.0.0:
+    resolution: {integrity: sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==}
+    engines: {node: '>= 8.10.0'}
+    hasBin: true
+    dependencies:
+      chokidar: 3.5.3
+      lodash.debounce: 4.0.8
+      lodash.throttle: 4.1.1
+      yargs: 13.3.2
+    dev: true
+
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -15499,6 +15513,10 @@ packages:
 
   /lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+    dev: true
+
+  /lodash.throttle@4.1.1:
+    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
     dev: true
 
   /lodash.truncate@4.4.2:


### PR DESCRIPTION
## Problem
- Celery doesn't auto restart when the backend code is changed
- Now that async queries are a thing, meaning that Celery is used to run the actual querying code, we end up with Celery running old versions of the codebase
- This sometimes causes me to go down a rabbit hole as to why my changes aren't working

## Changes
- Wrap the `celery` command in [chokidar](https://www.npmjs.com/package/chokidar) to restart when python files get updated
- I can't get this working from the launch.json config in VSCode - the debugger just won't attach due to us running a node process first, but, this is _good enough_ for now
