### PR TITLE
fix: pipeline 3000 creation plugin get access

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -5,10 +5,6 @@ import subprocess
 from typing import Any, Optional, cast, Literal
 
 import requests
-from rest_framework.permissions import IsAuthenticated
-from posthog.permissions import (
-    APIScopePermission,
-)
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import UploadedFile

--- a/posthog/api/plugin_log_entry.py
+++ b/posthog/api/plugin_log_entry.py
@@ -5,7 +5,7 @@ from rest_framework import exceptions, viewsets
 from rest_framework.response import Response
 from rest_framework_dataclasses.serializers import DataclassSerializer
 
-from posthog.api.plugin import PluginOwnershipPermission, PluginsAccessLevelPermission
+from posthog.api.plugin import PluginsAccessLevelPermission
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.models.plugin import (
     PluginLogEntry,
@@ -22,7 +22,7 @@ class PluginLogEntrySerializer(DataclassSerializer):
 class PluginLogEntryViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object = "plugin"
     serializer_class = PluginLogEntrySerializer
-    permission_classes = [PluginsAccessLevelPermission, PluginOwnershipPermission]
+    permission_classes = [PluginsAccessLevelPermission]
 
     def list(self, request, *args, **kwargs):
         limit_raw = request.GET.get("limit")

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -15,12 +15,7 @@ from posthog.models import Plugin, PluginAttachment, PluginConfig, PluginSourceF
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.team.team import Team
 from posthog.models.user import User
-from posthog.plugins.access import (
-    can_configure_plugins,
-    can_globally_manage_plugins,
-    can_install_plugins,
-    can_view_plugins,
-)
+from posthog.plugins.access import can_configure_plugins, can_globally_manage_plugins, can_install_plugins
 from posthog.plugins.test.mock import mocked_plugin_requests_get
 from posthog.plugins.test.plugin_archives import (
     HELLO_WORLD_PLUGIN_GITHUB_ATTACHMENT_ZIP,
@@ -1717,12 +1712,10 @@ class TestPluginsAccessLevelAPI(APIBaseTest):
         result_root = can_globally_manage_plugins(self.organization)
         result_install = can_install_plugins(self.organization)
         result_config = can_configure_plugins(self.organization)
-        result_view = can_view_plugins(self.organization)
 
         self.assertTrue(result_root)
         self.assertTrue(result_install)
         self.assertTrue(result_config)
-        self.assertTrue(result_view)
 
     def test_install_check(self):
         self.organization.plugins_access_level = Organization.PluginsAccessLevel.INSTALL
@@ -1731,20 +1724,10 @@ class TestPluginsAccessLevelAPI(APIBaseTest):
         result_root = can_globally_manage_plugins(self.organization)
         result_install = can_install_plugins(self.organization)
         result_config = can_configure_plugins(self.organization)
-        result_view = can_view_plugins(self.organization)
 
         self.assertFalse(result_root)
         self.assertTrue(result_install)
         self.assertTrue(result_config)
-        self.assertTrue(result_view)
-
-    def test_install_check_but_different_specific_id(self):
-        self.organization.plugins_access_level = Organization.PluginsAccessLevel.INSTALL
-        self.organization.save()
-
-        result_install = can_install_plugins(self.organization, "5802AE1C-FA8E-4559-9D7A-3206E371A350")
-
-        self.assertFalse(result_install)
 
     def test_config_check(self):
         self.organization.plugins_access_level = Organization.PluginsAccessLevel.CONFIG
@@ -1753,12 +1736,10 @@ class TestPluginsAccessLevelAPI(APIBaseTest):
         result_root = can_globally_manage_plugins(self.organization)
         result_install = can_install_plugins(self.organization)
         result_config = can_configure_plugins(self.organization)
-        result_view = can_view_plugins(self.organization)
 
         self.assertFalse(result_root)
         self.assertFalse(result_install)
         self.assertTrue(result_config)
-        self.assertTrue(result_view)
 
     def test_config_check_with_id_str(self):
         self.organization.plugins_access_level = Organization.PluginsAccessLevel.CONFIG
@@ -1768,12 +1749,10 @@ class TestPluginsAccessLevelAPI(APIBaseTest):
         result_root = can_globally_manage_plugins(organization_id)
         result_install = can_install_plugins(organization_id)
         result_config = can_configure_plugins(organization_id)
-        result_view = can_view_plugins(organization_id)
 
         self.assertFalse(result_root)
         self.assertFalse(result_install)
         self.assertTrue(result_config)
-        self.assertTrue(result_view)
 
     def test_none_check(self):
         self.organization.plugins_access_level = Organization.PluginsAccessLevel.NONE
@@ -1782,20 +1761,16 @@ class TestPluginsAccessLevelAPI(APIBaseTest):
         result_root = can_globally_manage_plugins(self.organization)
         result_install = can_install_plugins(self.organization)
         result_config = can_configure_plugins(self.organization)
-        result_view = can_view_plugins(self.organization)
 
         self.assertFalse(result_root)
         self.assertFalse(result_install)
         self.assertFalse(result_config)
-        self.assertFalse(result_view)
 
     def test_no_org_check(self):
         result_root = can_globally_manage_plugins(None)
         result_install = can_install_plugins(None)
         result_config = can_configure_plugins(None)
-        result_view = can_view_plugins(None)
 
         self.assertFalse(result_root)
         self.assertFalse(result_install)
         self.assertFalse(result_config)
-        self.assertFalse(result_view)

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -168,7 +168,7 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
         User.objects.create_and_join(
             organization=other_org, email="test@test.com", password="123456", first_name="Test"
         )
-        # OrganizationMembership.objects.create(user=self.user, organization=other_org)
+        OrganizationMembership.objects.create(user=self.user, organization=other_org)
 
         repo_url = "https://github.com/PostHog/helloworldplugin"
         install_response = self.client.post(f"/api/organizations/{my_org.id}/plugins/", {"url": repo_url})

--- a/posthog/plugins/access.py
+++ b/posthog/plugins/access.py
@@ -4,20 +4,8 @@ from uuid import UUID
 from posthog.models.organization import Organization
 
 
-def can_globally_manage_plugins(organization_or_id: Optional[Union[Organization, str, UUID]]) -> bool:
-    if organization_or_id is None:
-        return False
-    organization: Organization = (
-        organization_or_id
-        if isinstance(organization_or_id, Organization)
-        else Organization.objects.get(id=organization_or_id)
-    )
-    return organization.plugins_access_level >= Organization.PluginsAccessLevel.ROOT
-
-
-def can_install_plugins(
-    organization_or_id: Optional[Union[Organization, str, UUID]],
-    specific_organization_id: Optional[Union[str, UUID]] = None,
+def has_plugin_access_level(
+    organization_or_id: Optional[Union[Organization, str, UUID]], min_access_level: int
 ) -> bool:
     if organization_or_id is None:
         return False
@@ -26,28 +14,16 @@ def can_install_plugins(
         if isinstance(organization_or_id, Organization)
         else Organization.objects.get(id=organization_or_id)
     )
-    if specific_organization_id and str(organization.id) != str(specific_organization_id):
-        return False
-    return organization.plugins_access_level >= Organization.PluginsAccessLevel.INSTALL
+    return organization.plugins_access_level >= min_access_level
+
+
+def can_globally_manage_plugins(organization_or_id: Optional[Union[Organization, str, UUID]]) -> bool:
+    return has_plugin_access_level(organization_or_id, Organization.PluginsAccessLevel.ROOT)
+
+
+def can_install_plugins(organization_or_id: Optional[Union[Organization, str, UUID]]) -> bool:
+    return has_plugin_access_level(organization_or_id, Organization.PluginsAccessLevel.INSTALL)
 
 
 def can_configure_plugins(organization_or_id: Optional[Union[Organization, str, UUID]]) -> bool:
-    if organization_or_id is None:
-        return False
-    organization: Organization = (
-        organization_or_id
-        if isinstance(organization_or_id, Organization)
-        else Organization.objects.get(id=organization_or_id)
-    )
-    return organization.plugins_access_level >= Organization.PluginsAccessLevel.CONFIG
-
-
-def can_view_plugins(organization_or_id: Optional[Union[Organization, str, UUID]]) -> bool:
-    if organization_or_id is None:
-        return False
-    organization: Organization = (
-        organization_or_id
-        if isinstance(organization_or_id, Organization)
-        else Organization.objects.get(id=organization_or_id)
-    )
-    return organization.plugins_access_level > Organization.PluginsAccessLevel.NONE
+    return has_plugin_access_level(organization_or_id, Organization.PluginsAccessLevel.CONFIG)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
https://posthog.slack.com/archives/C0428JHABK2/p1717506873711699

I was able to list, but not look at a single plugin

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

extended unittest + created a plugin locally that was owned by a different organization, before the PR got 403, after 200 (http://localhost:8000/api/organizations/@current/plugins/4)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
