### PR TITLE
feat: Timestamp-based backfills for batch exports

### DIFF
--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -73,6 +73,12 @@ def validate_date_input(date_input: Any) -> dt.datetime:
         parsed = dt.datetime.fromisoformat(date_input.replace("Z", "+00:00"))
     except (TypeError, ValueError):
         raise ValidationError(f"Input {date_input} is not a valid ISO formatted datetime.")
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    else:
+        parsed = parsed.astimezone(dt.timezone.utc)
+
     return parsed
 
 

--- a/posthog/batch_exports/models.py
+++ b/posthog/batch_exports/models.py
@@ -310,6 +310,5 @@ class BatchExportBackfill(UUIDModel):
     @property
     def workflow_id(self) -> str:
         """Return the Workflow id that corresponds to this BatchExportBackfill model."""
-        start_at = self.start_at.strftime("%Y-%m-%dT%H:%M:%S")
-        end_at = self.end_at and self.end_at.strftime("%Y-%m-%dT%H:%M:%S")
-        return f"{self.batch_export.id}-Backfill-{start_at}-{end_at}"
+        end_at = self.end_at and self.end_at.isoformat()
+        return f"{self.batch_export.id}-Backfill-{self.start_at.isoformat()}-{end_at}"

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -343,6 +343,9 @@ def disable_and_delete_export(instance: BatchExport):
 
     instance.deleted = True
 
+    for backfill in running_backfills_for_batch_export(instance.id):
+        async_to_sync(cancel_running_batch_export_backfill)(temporal, backfill)
+
     try:
         batch_export_delete_schedule(temporal, str(instance.pk))
     except BatchExportServiceScheduleNotFound as e:
@@ -352,9 +355,6 @@ def disable_and_delete_export(instance: BatchExport):
         )
 
     instance.save()
-
-    for backfill in running_backfills_for_batch_export(instance.id):
-        async_to_sync(cancel_running_batch_export_backfill)(temporal, backfill)
 
 
 def batch_export_delete_schedule(temporal: Client, schedule_id: str) -> None:

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -391,7 +391,7 @@ class BackfillBatchExportInputs:
     start_at: str
     end_at: str | None
     buffer_limit: int = 1
-    wait_delay: float = 5.0
+    start_delay: float = 1.0
 
 
 def backfill_export(

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -57,6 +57,7 @@ class BatchExportSchema(typing.TypedDict):
 class BatchExportsInputsProtocol(typing.Protocol):
     team_id: int
     batch_export_schema: BatchExportSchema | None = None
+    is_backfill: bool = False
 
 
 @dataclass
@@ -92,6 +93,7 @@ class S3BatchExportInputs:
     batch_export_schema: BatchExportSchema | None = None
     endpoint_url: str | None = None
     file_format: str = "JSONLines"
+    is_backfill: bool = False
 
 
 @dataclass
@@ -113,6 +115,7 @@ class SnowflakeBatchExportInputs:
     exclude_events: list[str] | None = None
     include_events: list[str] | None = None
     batch_export_schema: BatchExportSchema | None = None
+    is_backfill: bool = False
 
 
 @dataclass
@@ -134,6 +137,7 @@ class PostgresBatchExportInputs:
     exclude_events: list[str] | None = None
     include_events: list[str] | None = None
     batch_export_schema: BatchExportSchema | None = None
+    is_backfill: bool = False
 
 
 @dataclass
@@ -162,6 +166,7 @@ class BigQueryBatchExportInputs:
     include_events: list[str] | None = None
     use_json_type: bool = False
     batch_export_schema: BatchExportSchema | None = None
+    is_backfill: bool = False
 
 
 @dataclass
@@ -177,6 +182,7 @@ class HttpBatchExportInputs:
     exclude_events: list[str] | None = None
     include_events: list[str] | None = None
     batch_export_schema: BatchExportSchema | None = None
+    is_backfill: bool = False
 
 
 @dataclass
@@ -188,6 +194,7 @@ class NoOpInputs:
     interval: str = "hour"
     arg: str = ""
     batch_export_schema: BatchExportSchema | None = None
+    is_backfill: bool = False
 
 
 DESTINATION_WORKFLOWS = {

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -443,13 +443,6 @@ def backfill_export(
 @async_to_sync
 async def start_backfill_batch_export_workflow(temporal: Client, inputs: BackfillBatchExportInputs) -> str:
     """Async call to start a BackfillBatchExportWorkflow."""
-    handle = temporal.get_schedule_handle(inputs.batch_export_id)
-    description = await handle.describe()
-
-    if description.schedule.spec.jitter is not None and inputs.end_at is not None:
-        # Adjust end_at to account for jitter if present.
-        inputs.end_at = (dt.datetime.fromisoformat(inputs.end_at) + description.schedule.spec.jitter).isoformat()
-
     workflow_id = f"{inputs.batch_export_id}-Backfill-{inputs.start_at}-{inputs.end_at}"
     await temporal.start_workflow(
         "backfill-batch-export",

--- a/posthog/temporal/batch_exports/backfill_batch_export.py
+++ b/posthog/temporal/batch_exports/backfill_batch_export.py
@@ -191,6 +191,7 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
         ]
 
         args = await client.data_converter.decode(schedule_action.args)
+        args[0]["is_backfill"] = True
 
         workflow_handle = await client.start_workflow(
             schedule_action.workflow,

--- a/posthog/temporal/batch_exports/backfill_batch_export.py
+++ b/posthog/temporal/batch_exports/backfill_batch_export.py
@@ -37,11 +37,8 @@ class HeartbeatDetails(typing.NamedTuple):
     """Details sent over in a Temporal Activity heartbeat."""
 
     schedule_id: str
-    start_at: str
-    # Note that this `end_at` is not optional, because heartbeats details describe the last concrete
-    # period of time we were waiting to backfill, and not the entire backfill job itself.
-    end_at: str
-    wait_start_at: str
+    workflow_id: str
+    last_batch_data_interval_end: str
 
     def make_activity_heartbeat_while_running(
         self, function_to_run: collections.abc.Callable, heartbeat_every: dt.timedelta
@@ -111,8 +108,7 @@ class BackfillScheduleInputs:
     start_at: str
     end_at: str | None
     frequency_seconds: float
-    buffer_limit: int = 1
-    wait_delay: float = 5.0
+    start_delay: float = 1.0
 
 
 def get_utcnow():
@@ -125,7 +121,7 @@ def get_utcnow():
 async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
     """Temporal Activity to backfill a Temporal Schedule.
 
-    The backfill is broken up into batches of inputs.buffer_limit size. After a backfill batch is
+    The backfill is broken up into batches of 1. After a backfill batch is
     requested, we wait for it to be done before continuing with the next.
 
     This activity heartbeats while waiting to allow cancelling an ongoing backfill.
@@ -151,27 +147,29 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
         # Let's not double-backfill and instead wait for any outstanding runs.
         last_activity_details = HeartbeatDetails(*details[0])
 
+        workflow_handle = client.get_workflow_handle(last_activity_details.workflow_id)
         details = HeartbeatDetails(
             schedule_id=inputs.schedule_id,
-            start_at=last_activity_details.start_at,
-            end_at=last_activity_details.end_at,
-            wait_start_at=last_activity_details.wait_start_at,
+            workflow_id=workflow_handle.id,
+            last_batch_data_interval_end=last_activity_details.last_batch_data_interval_end,
         )
 
-        await wait_for_schedule_backfill_in_range_with_heartbeat(details, client, heartbeat_timeout, inputs.wait_delay)
+        await wait_for_workflow_with_heartbeat(details, workflow_handle, heartbeat_timeout)
 
         # Update start_at to resume from the end of the period we just waited for
-        start_at = dt.datetime.fromisoformat(last_activity_details.end_at)
+        start_at = dt.datetime.fromisoformat(last_activity_details.last_batch_data_interval_end)
 
-    handle = client.get_schedule_handle(inputs.schedule_id)
+    schedule_handle = client.get_schedule_handle(inputs.schedule_id)
 
-    description = await handle.describe()
-    jitter = description.schedule.spec.jitter
+    description = await schedule_handle.describe()
 
     frequency = dt.timedelta(seconds=inputs.frequency_seconds)
-    full_backfill_range = backfill_range(start_at, end_at, frequency * inputs.buffer_limit)
+    full_backfill_range = backfill_range(start_at, end_at, frequency)
 
-    for backfill_start_at, backfill_end_at in full_backfill_range:
+    for _, backfill_end_at in full_backfill_range:
+        if await check_temporal_schedule_exists(client, description.id) is False:
+            raise TemporalScheduleNotFoundError(description.id)
+
         utcnow = get_utcnow()
 
         if end_at is None and backfill_end_at >= utcnow:
@@ -180,110 +178,63 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
             await sync_to_async(unpause_batch_export)(client, inputs.schedule_id)
             return
 
-        if jitter is not None:
-            backfill_end_at = backfill_end_at + jitter
+        schedule_action: temporalio.client.ScheduleActionStartWorkflow = description.schedule.action
 
-        backfill = temporalio.client.ScheduleBackfill(
-            start_at=backfill_start_at,
-            end_at=backfill_end_at,
-            overlap=temporalio.client.ScheduleOverlapPolicy.ALLOW_ALL,
+        search_attributes = [
+            temporalio.common.SearchAttributePair(
+                key=temporalio.common.SearchAttributeKey.for_text("TemporalScheduledById"), value=description.id
+            ),
+            temporalio.common.SearchAttributePair(
+                key=temporalio.common.SearchAttributeKey.for_datetime("TemporalScheduledStartTime"),
+                value=backfill_end_at,
+            ),
+        ]
+
+        args = await client.data_converter.decode(schedule_action.args)
+
+        workflow_handle = await client.start_workflow(
+            schedule_action.workflow,
+            *args,
+            id=f"{description.id}-{backfill_end_at:%Y-%m-%dT%H:%M:%S}Z",
+            task_queue=schedule_action.task_queue,
+            run_timeout=schedule_action.run_timeout,
+            task_timeout=schedule_action.task_timeout,
+            id_reuse_policy=temporalio.common.WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+            search_attributes=temporalio.common.TypedSearchAttributes(search_attributes=search_attributes),
         )
-        await handle.backfill(backfill)
-
         details = HeartbeatDetails(
             schedule_id=inputs.schedule_id,
-            start_at=backfill_start_at.isoformat(),
-            end_at=backfill_end_at.isoformat(),
-            wait_start_at=utcnow.isoformat(),
+            workflow_id=workflow_handle.id,
+            last_batch_data_interval_end=backfill_end_at.isoformat(),
         )
+        temporalio.activity.heartbeat(details)
 
-        await wait_for_schedule_backfill_in_range_with_heartbeat(details, client, heartbeat_timeout, inputs.wait_delay)
+        await wait_for_workflow_with_heartbeat(details, workflow_handle, heartbeat_timeout, inputs.start_delay)
 
 
-async def wait_for_schedule_backfill_in_range_with_heartbeat(
+async def wait_for_workflow_with_heartbeat(
     heartbeat_details: HeartbeatDetails,
-    client: temporalio.client.Client,
+    workflow_handle: temporalio.client.WorkflowHandle,
     heartbeat_timeout: dt.timedelta | None = None,
-    wait_delay: float = 5.0,
+    start_delay: float = 0.0,
 ):
     """Decide if heartbeating is required while waiting for a backfill in range to finish."""
     if heartbeat_timeout:
         wait_func = heartbeat_details.make_activity_heartbeat_while_running(
-            wait_for_schedule_backfill_in_range, heartbeat_every=dt.timedelta(seconds=1)
+            workflow_handle.result, heartbeat_every=dt.timedelta(seconds=1)
         )
     else:
-        wait_func = wait_for_schedule_backfill_in_range
+        wait_func = workflow_handle.result
 
-    await wait_func(
-        client,
-        heartbeat_details.schedule_id,
-        dt.datetime.fromisoformat(heartbeat_details.start_at),
-        dt.datetime.fromisoformat(heartbeat_details.end_at),
-        dt.datetime.fromisoformat(heartbeat_details.wait_start_at),
-        wait_delay,
-    )
+    await asyncio.sleep(start_delay)
 
-
-async def wait_for_schedule_backfill_in_range(
-    client: temporalio.client.Client,
-    schedule_id: str,
-    start_at: dt.datetime,
-    end_at: dt.datetime,
-    now: dt.datetime,
-    wait_delay: float = 5.0,
-) -> None:
-    """Wait for a Temporal Schedule backfill in a date range to be finished.
-
-    We can use the TemporalScheduledById and the TemporalScheduledStartTime to identify the Workflow executions
-    runs that fall under this Temporal Schedule's backfill. However, there could be regularly scheduled runs returned
-    by a query on just these two fields. So, we take the 'now' argument to provide a lower bound for the Workflow
-    execution start time, assuming that backfill runs will have started recently after 'now' whereas regularly
-    scheduled runs happened sometime in the past, before 'now'. This should hold true for historical backfills,
-    but the heuristic fails for "future backfills", which should not be allowed.
-
-    Raises:
-         TemporalScheduleNotFoundError: If we detect the Temporal Schedule we are waiting on doesn't exist.
-    """
-    if await check_temporal_schedule_exists(client, schedule_id) is False:
-        raise TemporalScheduleNotFoundError(schedule_id)
-
-    query = (
-        f'TemporalScheduledById="{schedule_id}" '
-        f'AND TemporalScheduledStartTime >= "{start_at.isoformat()}" '
-        f'AND TemporalScheduledStartTime <= "{end_at.isoformat()}" '
-        f'AND StartTime >= "{now.isoformat()}"'
-    )
-
-    workflows = [workflow async for workflow in client.list_workflows(query=query)]
-
-    if workflows and check_workflow_executions_not_running(workflows) is True:
-        return
-
-    done = False
-    while not done:
-        await asyncio.sleep(wait_delay)
-
-        if await check_temporal_schedule_exists(client, schedule_id) is False:
-            raise TemporalScheduleNotFoundError(schedule_id)
-
-        workflows = [workflow async for workflow in client.list_workflows(query=query)]
-
-        if not workflows:
-            # Backfill hasn't started yet.
-            continue
-
-        if check_workflow_executions_not_running(workflows) is False:
-            continue
-
-        done = True
-
-
-def check_workflow_executions_not_running(workflow_executions: list[temporalio.client.WorkflowExecution]) -> bool:
-    """Check if a list of Worflow Executions has any still running."""
-    return all(
-        workflow_execution.status != temporalio.client.WorkflowExecutionStatus.RUNNING
-        for workflow_execution in workflow_executions
-    )
+    try:
+        await wait_func()
+    except temporalio.client.WorkflowFailureError:
+        # `WorkflowFailureError` includes cancellations, terminations, timeouts, and errors.
+        # Common errors should be handled by the workflow itself (i.e. by retrying an activity).
+        # TODO: Log anyways if we land here.
+        pass
 
 
 async def check_temporal_schedule_exists(client: temporalio.client.Client, schedule_id: str) -> bool:
@@ -387,8 +338,7 @@ class BackfillBatchExportWorkflow(PostHogWorkflow):
             start_at=inputs.start_at,
             end_at=inputs.end_at,
             frequency_seconds=frequency_seconds,
-            buffer_limit=inputs.buffer_limit,
-            wait_delay=inputs.wait_delay,
+            start_delay=inputs.start_delay,
         )
         try:
             await temporalio.workflow.execute_activity(

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -60,8 +60,8 @@ AND timestamp < toDateTime64({data_interval_end}, 6, 'UTC') + INTERVAL 1 DAY
 )
 
 
-def get_timestamp_predicates_for_team(team_id: int) -> str:
-    if str(team_id) in settings.UNCONSTRAINED_TIMESTAMP_TEAM_IDS:
+def get_timestamp_predicates_for_team(team_id: int, is_backfill: bool = False) -> str:
+    if str(team_id) in settings.UNCONSTRAINED_TIMESTAMP_TEAM_IDS or is_backfill:
         return ""
     else:
         return TIMESTAMP_PREDICATES.substitute(
@@ -76,6 +76,7 @@ async def get_rows_count(
     interval_end: str,
     exclude_events: collections.abc.Iterable[str] | None = None,
     include_events: collections.abc.Iterable[str] | None = None,
+    is_backfill: bool = False,
 ) -> int:
     """Return a count of rows to be batch exported."""
     data_interval_start_ch = dt.datetime.fromisoformat(interval_start).strftime("%Y-%m-%d %H:%M:%S")
@@ -95,14 +96,18 @@ async def get_rows_count(
         include_events_statement = ""
         events_to_include_tuple = ()
 
-    timestamp_predicates = get_timestamp_predicates_for_team(team_id)
+    if is_backfill:
+        timestamp_field = "timestamp"
+    else:
+        timestamp_field = "COALESCE(inserted_at, _timestamp)"
+    timestamp_predicates = get_timestamp_predicates_for_team(team_id, is_backfill)
 
     query = SELECT_QUERY_TEMPLATE.substitute(
         fields="count(DISTINCT event, cityHash64(distinct_id), cityHash64(uuid)) as count",
         order_by="",
         format="",
         distinct="",
-        timestamp_field="COALESCE(inserted_at, _timestamp)",
+        timestamp_field=timestamp_field,
         timestamp=timestamp_predicates,
         exclude_events=exclude_events_statement,
         include_events=include_events_statement,
@@ -161,6 +166,7 @@ def iter_records(
     include_events: collections.abc.Iterable[str] | None = None,
     fields: list[BatchExportField] | None = None,
     extra_query_parameters: dict[str, typing.Any] | None = None,
+    is_backfill: bool = False,
 ) -> RecordsGenerator:
     """Iterate over Arrow batch records for a batch export.
 
@@ -195,7 +201,11 @@ def iter_records(
         include_events_statement = ""
         events_to_include_tuple = ()
 
-    timestamp_predicates = timestamp_predicates = get_timestamp_predicates_for_team(team_id)
+    if is_backfill:
+        timestamp_field = "timestamp"
+    else:
+        timestamp_field = "COALESCE(inserted_at, _timestamp)"
+    timestamp_predicates = get_timestamp_predicates_for_team(team_id, is_backfill)
 
     if fields is None:
         query_fields = ",".join(f"{field['expression']} AS {field['alias']}" for field in default_fields())
@@ -212,7 +222,7 @@ def iter_records(
         order_by="ORDER BY COALESCE(inserted_at, _timestamp)",
         format="FORMAT ArrowStream",
         distinct="DISTINCT ON (event, cityHash64(distinct_id), cityHash64(uuid))",
-        timestamp_field="COALESCE(inserted_at, _timestamp)",
+        timestamp_field=timestamp_field,
         timestamp=timestamp_predicates,
         exclude_events=exclude_events_statement,
         include_events=include_events_statement,

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -323,6 +323,7 @@ class StartBatchExportRunInputs:
     data_interval_end: str
     exclude_events: list[str] | None = None
     include_events: list[str] | None = None
+    is_backfill: bool = False
 
 
 RecordsTotalCount = int | None
@@ -360,6 +361,7 @@ async def start_batch_export_run(inputs: StartBatchExportRunInputs) -> tuple[Bat
                     interval_end=inputs.data_interval_end,
                     exclude_events=inputs.exclude_events,
                     include_events=inputs.include_events,
+                    is_backfill=inputs.is_backfill,
                 ),
                 timeout=(delta / 12).total_seconds(),
             )

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -38,9 +38,9 @@ SELECT_QUERY_TEMPLATE = Template(
     $fields
     FROM events
     WHERE
-        COALESCE(inserted_at, _timestamp) >= toDateTime64({data_interval_start}, 6, 'UTC')
-        AND COALESCE(inserted_at, _timestamp) < toDateTime64({data_interval_end}, 6, 'UTC')
-        AND team_id = {team_id}
+        team_id = {team_id}
+        AND $timestamp_field >= toDateTime64({data_interval_start}, 6, 'UTC')
+        AND $timestamp_field < toDateTime64({data_interval_end}, 6, 'UTC')
         $timestamp
         $exclude_events
         $include_events
@@ -102,6 +102,7 @@ async def get_rows_count(
         order_by="",
         format="",
         distinct="",
+        timestamp_field="COALESCE(inserted_at, _timestamp)",
         timestamp=timestamp_predicates,
         exclude_events=exclude_events_statement,
         include_events=include_events_statement,
@@ -211,6 +212,7 @@ def iter_records(
         order_by="ORDER BY COALESCE(inserted_at, _timestamp)",
         format="FORMAT ArrowStream",
         distinct="DISTINCT ON (event, cityHash64(distinct_id), cityHash64(uuid))",
+        timestamp_field="COALESCE(inserted_at, _timestamp)",
         timestamp=timestamp_predicates,
         exclude_events=exclude_events_statement,
         include_events=include_events_statement,
@@ -462,6 +464,7 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
             check_window=inputs.failure_check_window,
             failure_threshold=inputs.failure_threshold,
         )
+
         if not is_over_failure_threshold:
             return
 

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -152,6 +152,7 @@ class BigQueryInsertInputs:
     use_json_type: bool = False
     batch_export_schema: BatchExportSchema | None = None
     run_id: str | None = None
+    is_backfill: bool = False
 
 
 @contextlib.contextmanager
@@ -243,6 +244,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
             include_events=inputs.include_events,
             fields=fields,
             extra_query_parameters=query_parameters,
+            is_backfill=inputs.is_backfill,
         )
 
         bigquery_table = None
@@ -377,6 +379,7 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
             data_interval_end=data_interval_end.isoformat(),
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
+            is_backfill=inputs.is_backfill,
         )
         run_id, records_total_count = await workflow.execute_activity(
             start_batch_export_run,
@@ -427,6 +430,7 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
             use_json_type=inputs.use_json_type,
             batch_export_schema=inputs.batch_export_schema,
             run_id=run_id,
+            is_backfill=inputs.is_backfill,
         )
 
         await execute_batch_export_insert_activity(

--- a/posthog/temporal/batch_exports/http_batch_export.py
+++ b/posthog/temporal/batch_exports/http_batch_export.py
@@ -106,6 +106,7 @@ class HttpInsertInputs:
     include_events: list[str] | None = None
     run_id: str | None = None
     batch_export_schema: BatchExportSchema | None = None
+    is_backfill: bool = False
 
 
 async def maybe_resume_from_heartbeat(inputs: HttpInsertInputs) -> str:
@@ -191,6 +192,7 @@ async def insert_into_http_activity(inputs: HttpInsertInputs) -> RecordsComplete
             include_events=inputs.include_events,
             fields=fields,
             extra_query_parameters=None,
+            is_backfill=inputs.is_backfill,
         )
 
         last_uploaded_timestamp: str | None = None
@@ -324,6 +326,7 @@ class HttpBatchExportWorkflow(PostHogWorkflow):
             data_interval_end=data_interval_end.isoformat(),
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
+            is_backfill=inputs.is_backfill,
         )
         run_id, records_total_count = await workflow.execute_activity(
             start_batch_export_run,
@@ -368,6 +371,7 @@ class HttpBatchExportWorkflow(PostHogWorkflow):
             include_events=inputs.include_events,
             batch_export_schema=inputs.batch_export_schema,
             run_id=run_id,
+            is_backfill=inputs.is_backfill,
         )
 
         await execute_batch_export_insert_activity(

--- a/posthog/temporal/batch_exports/noop.py
+++ b/posthog/temporal/batch_exports/noop.py
@@ -13,6 +13,7 @@ from posthog.temporal.batch_exports.base import PostHogWorkflow
 @dataclass
 class NoopActivityArgs:
     arg: str
+    is_backfill: bool = False
 
 
 @activity.defn
@@ -39,7 +40,7 @@ class NoOpWorkflow(PostHogWorkflow):
         workflow.logger.info(f"Running workflow with parameter {inputs.arg}")
         result = await workflow.execute_activity(
             noop_activity,
-            NoopActivityArgs(inputs.arg),
+            NoopActivityArgs(inputs.arg, inputs.is_backfill),
             start_to_close_timeout=timedelta(seconds=60),
             schedule_to_close_timeout=timedelta(minutes=5),
         )

--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -239,6 +239,7 @@ class PostgresInsertInputs:
     include_events: list[str] | None = None
     batch_export_schema: BatchExportSchema | None = None
     run_id: str | None = None
+    is_backfill: bool = False
 
 
 @activity.defn
@@ -277,6 +278,7 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs) -> Records
             include_events=inputs.include_events,
             fields=fields,
             extra_query_parameters=query_parameters,
+            is_backfill=inputs.is_backfill,
         )
 
         if inputs.batch_export_schema is None:
@@ -384,6 +386,7 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
             data_interval_end=data_interval_end.isoformat(),
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
+            is_backfill=inputs.is_backfill,
         )
         run_id, records_total_count = await workflow.execute_activity(
             start_batch_export_run,

--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -319,6 +319,7 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs) -> Records
             include_events=inputs.include_events,
             fields=fields,
             extra_query_parameters=query_parameters,
+            is_backfill=inputs.is_backfill,
         )
 
         known_super_columns = ["properties", "set", "set_once", "person_properties"]
@@ -413,6 +414,7 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
             data_interval_end=data_interval_end.isoformat(),
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
+            is_backfill=inputs.is_backfill,
         )
         run_id, records_total_count = await workflow.execute_activity(
             start_batch_export_run,
@@ -464,6 +466,7 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
             properties_data_type=inputs.properties_data_type,
             batch_export_schema=inputs.batch_export_schema,
             run_id=run_id,
+            is_backfill=inputs.is_backfill,
         )
 
         await execute_batch_export_insert_activity(

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -342,6 +342,7 @@ class S3InsertInputs:
     # TODO: In Python 3.11, this could be a enum.StrEnum.
     file_format: str = "JSONLines"
     run_id: str | None = None
+    is_backfill: bool = False
 
 
 async def initialize_and_resume_multipart_upload(inputs: S3InsertInputs) -> tuple[S3MultiPartUpload, str]:
@@ -460,6 +461,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
             include_events=inputs.include_events,
             fields=fields,
             extra_query_parameters=query_parameters,
+            is_backfill=inputs.is_backfill,
         )
 
         async with Heartbeatter() as heartbeatter:
@@ -630,6 +632,7 @@ class S3BatchExportWorkflow(PostHogWorkflow):
             data_interval_end=data_interval_end.isoformat(),
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
+            is_backfill=inputs.is_backfill,
         )
         run_id, records_total_count = await workflow.execute_activity(
             start_batch_export_run,
@@ -682,6 +685,7 @@ class S3BatchExportWorkflow(PostHogWorkflow):
             batch_export_schema=inputs.batch_export_schema,
             file_format=inputs.file_format,
             run_id=run_id,
+            is_backfill=inputs.is_backfill,
         )
 
         await execute_batch_export_insert_activity(

--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -116,6 +116,7 @@ class SnowflakeInsertInputs:
     include_events: list[str] | None = None
     batch_export_schema: BatchExportSchema | None = None
     run_id: str | None = None
+    is_backfill: bool = False
 
 
 def use_namespace(connection: SnowflakeConnection, database: str, schema: str) -> None:
@@ -465,6 +466,7 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs) -> Recor
             include_events=inputs.include_events,
             fields=fields,
             extra_query_parameters=query_parameters,
+            is_backfill=inputs.is_backfill,
         )
 
         known_variant_columns = ["properties", "people_set", "people_set_once", "person_properties"]
@@ -576,6 +578,7 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
             data_interval_end=data_interval_end.isoformat(),
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
+            is_backfill=inputs.is_backfill,
         )
         run_id, records_total_count = await workflow.execute_activity(
             start_batch_export_run,
@@ -626,6 +629,7 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
             include_events=inputs.include_events,
             batch_export_schema=inputs.batch_export_schema,
             run_id=run_id,
+            is_backfill=inputs.is_backfill,
         )
 
         await execute_batch_export_insert_activity(

--- a/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
+++ b/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime as dt
 import uuid
 from unittest import mock
@@ -20,7 +21,6 @@ from posthog.temporal.batch_exports.backfill_batch_export import (
     backfill_range,
     backfill_schedule,
     get_schedule_frequency,
-    wait_for_schedule_backfill_in_range,
 )
 from posthog.temporal.tests.utils.datetimes import date_range
 from posthog.temporal.tests.utils.events import (
@@ -143,7 +143,7 @@ async def test_get_schedule_frequency(activity_environment, temporal_worker, tem
 
 
 @pytest.mark.django_db(transaction=True)
-async def test_backfill_schedule_activity(activity_environment, temporal_worker, temporal_schedule):
+async def test_backfill_schedule_activity(activity_environment, temporal_worker, temporal_client, temporal_schedule):
     """Test backfill_schedule activity schedules all backfill runs."""
     start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
     end_at = dt.datetime(2023, 1, 1, 0, 10, 0, tzinfo=dt.timezone.utc)
@@ -153,18 +153,29 @@ async def test_backfill_schedule_activity(activity_environment, temporal_worker,
         schedule_id=desc.id,
         start_at=start_at.isoformat(),
         end_at=end_at.isoformat(),
-        buffer_limit=2,
-        wait_delay=1.0,
+        start_delay=1.0,
         frequency_seconds=desc.schedule.spec.intervals[0].every.total_seconds(),
     )
 
     await activity_environment.run(backfill_schedule, inputs)
 
-    desc = await temporal_schedule.describe()
-    result = desc.info.num_actions
-    expected = 10
+    query = f'TemporalScheduledById="{desc.id}"'
+    workflows = []
 
-    assert result >= expected
+    timeout = 20
+    waited = 0
+    expected = 10
+    while len(workflows) < expected:
+        # It can take a few seconds for workflows to be query-able
+        waited += 1
+        if waited > timeout:
+            raise TimeoutError("Timed-out waiting for workflows to be query-able")
+
+        await asyncio.sleep(1)
+
+        workflows = [workflow async for workflow in temporal_client.list_workflows(query=query)]
+
+    assert len(workflows) == expected
 
 
 @pytest.mark.django_db(transaction=True)
@@ -181,8 +192,7 @@ async def test_backfill_batch_export_workflow(temporal_worker, temporal_schedule
         batch_export_id=desc.id,
         start_at=start_at.isoformat(),
         end_at=end_at.isoformat(),
-        buffer_limit=2,
-        wait_delay=1.0,
+        start_delay=1.0,
     )
 
     handle = await temporal_client.start_workflow(
@@ -195,11 +205,23 @@ async def test_backfill_batch_export_workflow(temporal_worker, temporal_schedule
     )
     await handle.result()
 
-    desc = await temporal_schedule.describe()
-    result = desc.info.num_actions
-    expected = 10
+    query = f'TemporalScheduledById="{desc.id}"'
+    workflows = []
 
-    assert result == expected
+    timeout = 20
+    waited = 0
+    expected = 10
+    while len(workflows) < expected:
+        # It can take a few seconds for workflows to be query-able
+        waited += 1
+        if waited > timeout:
+            raise TimeoutError("Timed-out waiting for workflows to be query-able")
+
+        await asyncio.sleep(1)
+
+        workflows = [workflow async for workflow in temporal_client.list_workflows(query=query)]
+
+    assert len(workflows) == expected
 
     backfills = await afetch_batch_export_backfills(batch_export_id=desc.id)
 
@@ -230,8 +252,7 @@ async def test_backfill_batch_export_workflow_no_end_at(
         batch_export_id=desc.id,
         start_at=start_at.isoformat(),
         end_at=end_at,
-        buffer_limit=2,
-        wait_delay=0.1,
+        start_delay=0.1,
     )
 
     batch_export = await afetch_batch_export(desc.id)
@@ -247,11 +268,23 @@ async def test_backfill_batch_export_workflow_no_end_at(
     )
     await handle.result()
 
-    desc = await temporal_schedule.describe()
-    result = desc.info.num_actions
-    expected = 8
+    query = f'TemporalScheduledById="{desc.id}"'
+    workflows = []
 
-    assert result == expected
+    timeout = 20
+    waited = 0
+    expected = 8
+    while len(workflows) < expected:
+        # It can take a few seconds for workflows to be query-able
+        waited += 1
+        if waited > timeout:
+            raise TimeoutError("Timed-out waiting for workflows to be query-able")
+
+        await asyncio.sleep(1)
+
+        workflows = [workflow async for workflow in temporal_client.list_workflows(query=query)]
+
+    assert len(workflows) == expected
 
     backfills = await afetch_batch_export_backfills(batch_export_id=desc.id)
 
@@ -280,8 +313,7 @@ async def test_backfill_batch_export_workflow_fails_when_schedule_deleted(
         batch_export_id=desc.id,
         start_at=start_at.isoformat(),
         end_at=end_at.isoformat(),
-        buffer_limit=1,
-        wait_delay=2.0,
+        start_delay=2.0,
     )
 
     handle = await temporal_client.start_workflow(
@@ -314,7 +346,6 @@ async def test_backfill_batch_export_workflow_fails_when_schedule_deleted_after_
     """
     start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
     end_at = dt.datetime(2023, 1, 1, 0, 10, 0, tzinfo=dt.timezone.utc)
-    now = dt.datetime.now(dt.timezone.utc)
 
     desc = await temporal_schedule.describe()
 
@@ -324,8 +355,7 @@ async def test_backfill_batch_export_workflow_fails_when_schedule_deleted_after_
         batch_export_id=desc.id,
         start_at=start_at.isoformat(),
         end_at=end_at.isoformat(),
-        buffer_limit=1,
-        wait_delay=2.0,
+        start_delay=2.0,
     )
 
     handle = await temporal_client.start_workflow(
@@ -336,19 +366,6 @@ async def test_backfill_batch_export_workflow_fails_when_schedule_deleted_after_
         execution_timeout=dt.timedelta(seconds=20),
         retry_policy=temporalio.common.RetryPolicy(maximum_attempts=1),
     )
-    await wait_for_schedule_backfill_in_range(
-        client=temporal_client,
-        schedule_id=desc.id,
-        start_at=start_at,
-        end_at=dt.datetime(2023, 1, 1, 0, 1, 0, tzinfo=dt.timezone.utc),
-        now=now,
-        wait_delay=1.0,
-    )
-
-    desc = await temporal_schedule.describe()
-    result = desc.info.num_actions
-
-    assert result >= 1
 
     await temporal_schedule.delete()
 
@@ -419,8 +436,7 @@ async def test_backfill_batch_export_workflow_is_cancelled_on_repeated_failures(
         batch_export_id=str(failing_s3_batch_export.id),
         start_at=start_at.isoformat(),
         end_at=end_at.isoformat(),
-        buffer_limit=2,
-        wait_delay=1.0,
+        start_delay=2.0,
     )
 
     # Need to recreate the specific ID the app would use when triggering a backfill
@@ -441,7 +457,7 @@ async def test_backfill_batch_export_workflow_is_cancelled_on_repeated_failures(
         await handle.result()
 
     err = exc_info.value
-    assert isinstance(err.__cause__, temporalio.exceptions.CancelledError)
+    assert isinstance(err.__cause__, temporalio.exceptions.CancelledError), err.__cause__
 
     await sync_to_async(failing_s3_batch_export.refresh_from_db)()
     assert failing_s3_batch_export.paused is True

--- a/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
+++ b/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
@@ -494,8 +494,8 @@ async def test_backfill_batch_export_workflow_is_cancelled_on_repeated_failures(
     )
 
     # Need to recreate the specific ID the app would use when triggering a backfill
-    start_at_str = start_at.strftime("%Y-%m-%dT%H:%M:%S")
-    end_at_str = end_at.strftime("%Y-%m-%dT%H:%M:%S")
+    start_at_str = start_at.isoformat()
+    end_at_str = end_at.isoformat()
     backfill_id = f"{failing_s3_batch_export.id}-Backfill-{start_at_str}-{end_at_str}"
 
     handle = await temporal_client.start_workflow(

--- a/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
+++ b/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
@@ -160,7 +160,7 @@ async def test_backfill_schedule_activity(activity_environment, temporal_worker,
     await activity_environment.run(backfill_schedule, inputs)
 
     query = f'TemporalScheduledById="{desc.id}"'
-    workflows = []
+    workflows: list[temporalio.client.WorkflowExecution] = []
 
     timeout = 20
     waited = 0
@@ -224,7 +224,7 @@ async def test_backfill_batch_export_workflow(temporal_worker, temporal_schedule
     await handle.result()
 
     query = f'TemporalScheduledById="{desc.id}"'
-    workflows = []
+    workflows: list[temporalio.client.WorkflowExecution] = []
 
     timeout = 20
     waited = 0
@@ -305,7 +305,7 @@ async def test_backfill_batch_export_workflow_no_end_at(
     await handle.result()
 
     query = f'TemporalScheduledById="{desc.id}"'
-    workflows = []
+    workflows: list[temporalio.client.WorkflowExecution] = []
 
     timeout = 20
     waited = 0

--- a/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
+++ b/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
@@ -177,6 +177,24 @@ async def test_backfill_schedule_activity(activity_environment, temporal_worker,
 
     assert len(workflows) == expected
 
+    for workflow in workflows:
+        handle = temporal_client.get_workflow_handle(workflow.id)
+        history = await handle.fetch_history()
+
+        for event in history.events:
+            if event.event_type == 1:
+                # 1 is EVENT_TYPE_WORKFLOW_EXECUTION_STARTED
+                args = await workflow.data_converter.decode(
+                    event.workflow_execution_started_event_attributes.input.payloads
+                )
+                assert args[0]["is_backfill"] is True
+            elif event.event_type == 10:
+                # 10 is EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
+                args = await workflow.data_converter.decode(
+                    event.activity_task_scheduled_event_attributes.input.payloads
+                )
+                assert args[0]["is_backfill"] is True
+
 
 @pytest.mark.django_db(transaction=True)
 async def test_backfill_batch_export_workflow(temporal_worker, temporal_schedule, temporal_client, team):
@@ -222,6 +240,24 @@ async def test_backfill_batch_export_workflow(temporal_worker, temporal_schedule
         workflows = [workflow async for workflow in temporal_client.list_workflows(query=query)]
 
     assert len(workflows) == expected
+
+    for workflow in workflows:
+        handle = temporal_client.get_workflow_handle(workflow.id)
+        history = await handle.fetch_history()
+
+        for event in history.events:
+            if event.event_type == 1:
+                # 1 is EVENT_TYPE_WORKFLOW_EXECUTION_STARTED
+                args = await workflow.data_converter.decode(
+                    event.workflow_execution_started_event_attributes.input.payloads
+                )
+                assert args[0]["is_backfill"] is True
+            elif event.event_type == 10:
+                # 10 is EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
+                args = await workflow.data_converter.decode(
+                    event.activity_task_scheduled_event_attributes.input.payloads
+                )
+                assert args[0]["is_backfill"] is True
 
     backfills = await afetch_batch_export_backfills(batch_export_id=desc.id)
 
@@ -285,6 +321,24 @@ async def test_backfill_batch_export_workflow_no_end_at(
         workflows = [workflow async for workflow in temporal_client.list_workflows(query=query)]
 
     assert len(workflows) == expected
+
+    for workflow in workflows:
+        handle = temporal_client.get_workflow_handle(workflow.id)
+        history = await handle.fetch_history()
+
+        for event in history.events:
+            if event.event_type == 1:
+                # 1 is EVENT_TYPE_WORKFLOW_EXECUTION_STARTED
+                args = await workflow.data_converter.decode(
+                    event.workflow_execution_started_event_attributes.input.payloads
+                )
+                assert args[0]["is_backfill"] is True
+            elif event.event_type == 10:
+                # 10 is EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
+                args = await workflow.data_converter.decode(
+                    event.activity_task_scheduled_event_attributes.input.payloads
+                )
+                assert args[0]["is_backfill"] is True
 
     backfills = await afetch_batch_export_backfills(batch_export_id=desc.id)
 

--- a/posthog/temporal/tests/test_encryption_codec.py
+++ b/posthog/temporal/tests/test_encryption_codec.py
@@ -50,6 +50,7 @@ async def test_payloads_are_encrypted():
         arg=input_str,
         batch_export_id="123",
         team_id=1,
+        is_backfill=False,
     )
 
     # The no-op Workflow can only produce a limited set of results, so we'll check if the events match any of these.
@@ -57,7 +58,7 @@ async def test_payloads_are_encrypted():
     # input to the workflow (inputs).
     expected_results = (
         no_op_result_str,
-        {"arg": input_str},
+        {"arg": input_str, "is_backfill": False},
         dataclasses.asdict(inputs),
     )
 


### PR DESCRIPTION
## Problem

Using `inserted_at` causes a lot of confusion with users. The field has a place for ongoing exports, as it allows us to include new events that have an old timestamp, up to a certain range. This is critical when dealing with pipeline lag, as otherwise an ongoing export would miss data.

Although it is our best alternative for ongoing exports, I don't think that is the case for historical exports. Users know when they have sent all their data, and historical exports tend to cover a period that has already settled in our database. So, we don't need `inserted_at` to avoid missing events in-flight. Moreover, users tend to create historical exports based on `timestamp`, as we do not communicate the `inserted_at` field with them. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* In backfill workflows, do not use the backfill API anymore, but instead call `start_workflow`. This is a requirement for the point below.
* Pass a new `is_backfill` input when calling a workflow from a backfill workflow.
* When receiving `is_backfill`, `get_rows_count` and `iter_records` will use `timestamp` as the field to set the export bounds.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Extended backfill tests.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
