### PR TITLE
chore: Clarify `PERSISTED_FEATURE_FLAGS` mechanics

### DIFF
--- a/posthog/settings/feature_flags.py
+++ b/posthog/settings/feature_flags.py
@@ -2,14 +2,13 @@ import os
 
 from posthog.settings.utils import get_list
 
-# These flags will be force-enabled on the frontend
-# The features here are released, but the flags are just not yet removed from the code
+# The features here are released on the frontend, but the flags are just not yet removed from the code
+# WARNING: ONLY the frontend has feature flag overrides. Flags on the backend will NOT be affected by this setting
 PERSISTED_FEATURE_FLAGS = [
     *get_list(os.getenv("PERSISTED_FEATURE_FLAGS", "")),
     "simplify-actions",
     "historical-exports-v2",
     "ingestion-warnings-enabled",
-    "hogql-in-insight-serialization",
     "persons-hogql-query",
     "datanode-concurrency-limit",
     "session-table-property-filters",


### PR DESCRIPTION
## Changes

The `PERSISTED_FEATURE_FLAGS` setting only applies to flags on the frontend – no effect on the backend. This led to some problems recently (#22651). Let's clarify the comment on the setting.