### PR TITLE
feat: add a launch config for local billing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,6 +42,33 @@
             }
         },
         {
+            "name": "Backend (with local billing)",
+            "consoleName": "Backend",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/manage.py",
+            "args": ["runserver"],
+            "django": true,
+            "env": {
+                "PYTHONUNBUFFERED": "1",
+                "DJANGO_SETTINGS_MODULE": "posthog.settings",
+                "DEBUG": "1",
+                "CLICKHOUSE_SECURE": "False",
+                "KAFKA_HOSTS": "localhost",
+                "DATABASE_URL": "postgres://posthog:posthog@localhost:5432/posthog",
+                "SKIP_SERVICE_VERSION_REQUIREMENTS": "1",
+                "PRINT_SQL": "1",
+                "BILLING_SERVICE_URL": "http://localhost:8100/",
+                "CLOUD_DEPLOYMENT": "dev"
+            },
+            "console": "integratedTerminal",
+            "python": "${workspaceFolder}/env/bin/python",
+            "cwd": "${workspaceFolder}",
+            "presentation": {
+                "group": "main"
+            }
+        },
+        {
             "name": "Celery Threaded Pool",
             "consoleName": "Celery Threaded Pool",
             "type": "debugpy",


### PR DESCRIPTION
## Problem

I'm tired of always changing my launch.json file to use a local billing URL and then having to make sure I don't commit it. Time for a specific launch config :) 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds a new launch config for the backend with local billing.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

It works.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
