### PR TITLE
perf: Move all celery workloads to offline cluster

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -88,8 +88,16 @@ def sync_execute(
         except ModuleNotFoundError:  # when we run plugin server tests it tries to run above, ignore
             pass
 
-    # When someone uses an API key, always put their query to the offline cluster
-    if workload == Workload.DEFAULT and get_query_tag_value("access_method") == "personal_api_key":
+    if workload == Workload.DEFAULT and (
+        # When someone uses an API key, always put their query to the offline cluster
+        get_query_tag_value("access_method") == "personal_api_key"
+        or
+        # Execute all celery tasks not directly set to be online on the offline cluster
+        (
+            get_query_tag_value("kind") == "celery"
+            and get_query_tag_value("id") != "posthog.tasks.tasks.process_query_task"
+        )
+    ):
         workload = Workload.OFFLINE
 
     with get_pool(workload, team_id, readonly).get_client() as client:


### PR DESCRIPTION
## Problem

A lot of queries, like cohort calculation, cache filling, were happening on the online cluster, needlessly crowding out real time queries.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
