### PR TITLE
fix(actions): display more than 100 actions

### DIFF
--- a/ee/api/test/test_action.py
+++ b/ee/api/test/test_action.py
@@ -79,7 +79,7 @@ class TestActionApi(APIBaseTest):
 
         # django_session + user + team  + look up if rate limit is enabled (cached after first lookup)
         # + organizationmembership + organization + action + taggeditem
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(8):
             response = self.client.get(f"/api/projects/{self.team.id}/actions")
         self.assertEqual(response.json()["results"][0]["tags"][0], "tag")
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/posthog/api/test/__snapshots__/test_action.ambr
+++ b/posthog/api/test/__snapshots__/test_action.ambr
@@ -88,63 +88,6 @@
 # ---
 # name: TestActionApi.test_listing_actions_is_not_nplus1.10
   '''
-  SELECT "posthog_action"."id",
-         "posthog_action"."name",
-         "posthog_action"."team_id",
-         "posthog_action"."description",
-         "posthog_action"."created_at",
-         "posthog_action"."created_by_id",
-         "posthog_action"."deleted",
-         "posthog_action"."post_to_slack",
-         "posthog_action"."slack_message_format",
-         "posthog_action"."updated_at",
-         "posthog_action"."bytecode",
-         "posthog_action"."bytecode_error",
-         "posthog_action"."steps_json",
-         "posthog_action"."is_calculating",
-         "posthog_action"."last_calculated_at",
-         COUNT("posthog_action_events"."event_id") AS "count",
-         "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."pending_email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."is_email_verified",
-         "posthog_user"."requested_password_reset_at",
-         "posthog_user"."has_seen_product_intro_for",
-         "posthog_user"."strapi_id",
-         "posthog_user"."theme_mode",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."hedgehog_config",
-         "posthog_user"."events_column_config",
-         "posthog_user"."email_opt_in"
-  FROM "posthog_action"
-  LEFT OUTER JOIN "posthog_action_events" ON ("posthog_action"."id" = "posthog_action_events"."action_id")
-  LEFT OUTER JOIN "posthog_user" ON ("posthog_action"."created_by_id" = "posthog_user"."id")
-  WHERE (NOT "posthog_action"."deleted"
-         AND "posthog_action"."team_id" = 2
-         AND "posthog_action"."team_id" = 2)
-  GROUP BY "posthog_action"."id",
-           "posthog_user"."id"
-  ORDER BY "posthog_action"."last_calculated_at" DESC,
-           "posthog_action"."name" ASC
-  LIMIT 100
-  '''
-# ---
-# name: TestActionApi.test_listing_actions_is_not_nplus1.11
-  '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
          "posthog_user"."last_login",
@@ -175,7 +118,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestActionApi.test_listing_actions_is_not_nplus1.12
+# name: TestActionApi.test_listing_actions_is_not_nplus1.11
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -230,7 +173,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestActionApi.test_listing_actions_is_not_nplus1.13
+# name: TestActionApi.test_listing_actions_is_not_nplus1.12
   '''
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
@@ -261,7 +204,7 @@
   WHERE "posthog_organizationmembership"."user_id" = 2
   '''
 # ---
-# name: TestActionApi.test_listing_actions_is_not_nplus1.14
+# name: TestActionApi.test_listing_actions_is_not_nplus1.13
   '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -284,6 +227,62 @@
   FROM "posthog_organization"
   WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
   LIMIT 21
+  '''
+# ---
+# name: TestActionApi.test_listing_actions_is_not_nplus1.14
+  '''
+  SELECT "posthog_action"."id",
+         "posthog_action"."name",
+         "posthog_action"."team_id",
+         "posthog_action"."description",
+         "posthog_action"."created_at",
+         "posthog_action"."created_by_id",
+         "posthog_action"."deleted",
+         "posthog_action"."post_to_slack",
+         "posthog_action"."slack_message_format",
+         "posthog_action"."updated_at",
+         "posthog_action"."bytecode",
+         "posthog_action"."bytecode_error",
+         "posthog_action"."steps_json",
+         "posthog_action"."is_calculating",
+         "posthog_action"."last_calculated_at",
+         COUNT("posthog_action_events"."event_id") AS "count",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."requested_password_reset_at",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."strapi_id",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."hedgehog_config",
+         "posthog_user"."events_column_config",
+         "posthog_user"."email_opt_in"
+  FROM "posthog_action"
+  LEFT OUTER JOIN "posthog_action_events" ON ("posthog_action"."id" = "posthog_action_events"."action_id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_action"."created_by_id" = "posthog_user"."id")
+  WHERE (NOT "posthog_action"."deleted"
+         AND "posthog_action"."team_id" = 2
+         AND "posthog_action"."team_id" = 2)
+  GROUP BY "posthog_action"."id",
+           "posthog_user"."id"
+  ORDER BY "posthog_action"."last_calculated_at" DESC,
+           "posthog_action"."name" ASC
   '''
 # ---
 # name: TestActionApi.test_listing_actions_is_not_nplus1.15
@@ -414,15 +413,58 @@
 # ---
 # name: TestActionApi.test_listing_actions_is_not_nplus1.4
   '''
-  SELECT COUNT(*)
-  FROM
-    (SELECT "posthog_action"."id" AS "col1"
-     FROM "posthog_action"
-     LEFT OUTER JOIN "posthog_action_events" ON ("posthog_action"."id" = "posthog_action_events"."action_id")
-     WHERE (NOT "posthog_action"."deleted"
-            AND "posthog_action"."team_id" = 2
-            AND "posthog_action"."team_id" = 2)
-     GROUP BY 1) subquery
+  SELECT "posthog_action"."id",
+         "posthog_action"."name",
+         "posthog_action"."team_id",
+         "posthog_action"."description",
+         "posthog_action"."created_at",
+         "posthog_action"."created_by_id",
+         "posthog_action"."deleted",
+         "posthog_action"."post_to_slack",
+         "posthog_action"."slack_message_format",
+         "posthog_action"."updated_at",
+         "posthog_action"."bytecode",
+         "posthog_action"."bytecode_error",
+         "posthog_action"."steps_json",
+         "posthog_action"."is_calculating",
+         "posthog_action"."last_calculated_at",
+         COUNT("posthog_action_events"."event_id") AS "count",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."requested_password_reset_at",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."strapi_id",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."hedgehog_config",
+         "posthog_user"."events_column_config",
+         "posthog_user"."email_opt_in"
+  FROM "posthog_action"
+  LEFT OUTER JOIN "posthog_action_events" ON ("posthog_action"."id" = "posthog_action_events"."action_id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_action"."created_by_id" = "posthog_user"."id")
+  WHERE (NOT "posthog_action"."deleted"
+         AND "posthog_action"."team_id" = 2
+         AND "posthog_action"."team_id" = 2)
+  GROUP BY "posthog_action"."id",
+           "posthog_user"."id"
+  ORDER BY "posthog_action"."last_calculated_at" DESC,
+           "posthog_action"."name" ASC
   '''
 # ---
 # name: TestActionApi.test_listing_actions_is_not_nplus1.5
@@ -570,14 +612,57 @@
 # ---
 # name: TestActionApi.test_listing_actions_is_not_nplus1.9
   '''
-  SELECT COUNT(*)
-  FROM
-    (SELECT "posthog_action"."id" AS "col1"
-     FROM "posthog_action"
-     LEFT OUTER JOIN "posthog_action_events" ON ("posthog_action"."id" = "posthog_action_events"."action_id")
-     WHERE (NOT "posthog_action"."deleted"
-            AND "posthog_action"."team_id" = 2
-            AND "posthog_action"."team_id" = 2)
-     GROUP BY 1) subquery
+  SELECT "posthog_action"."id",
+         "posthog_action"."name",
+         "posthog_action"."team_id",
+         "posthog_action"."description",
+         "posthog_action"."created_at",
+         "posthog_action"."created_by_id",
+         "posthog_action"."deleted",
+         "posthog_action"."post_to_slack",
+         "posthog_action"."slack_message_format",
+         "posthog_action"."updated_at",
+         "posthog_action"."bytecode",
+         "posthog_action"."bytecode_error",
+         "posthog_action"."steps_json",
+         "posthog_action"."is_calculating",
+         "posthog_action"."last_calculated_at",
+         COUNT("posthog_action_events"."event_id") AS "count",
+         "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."requested_password_reset_at",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."strapi_id",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."hedgehog_config",
+         "posthog_user"."events_column_config",
+         "posthog_user"."email_opt_in"
+  FROM "posthog_action"
+  LEFT OUTER JOIN "posthog_action_events" ON ("posthog_action"."id" = "posthog_action_events"."action_id")
+  LEFT OUTER JOIN "posthog_user" ON ("posthog_action"."created_by_id" = "posthog_user"."id")
+  WHERE (NOT "posthog_action"."deleted"
+         AND "posthog_action"."team_id" = 2
+         AND "posthog_action"."team_id" = 2)
+  GROUP BY "posthog_action"."id",
+           "posthog_user"."id"
+  ORDER BY "posthog_action"."last_calculated_at" DESC,
+           "posthog_action"."name" ASC
   '''
 # ---

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -221,7 +221,7 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         )
 
         # test queries
-        with self.assertNumQueries(FuzzyInt(7, 8)):
+        with self.assertNumQueries(FuzzyInt(6, 8)):
             # Django session,  user,  team,  org membership, instance setting,  org,
             # count, action
             self.client.get(f"/api/projects/{self.team.id}/actions/")

--- a/posthog/api/test/test_action.py
+++ b/posthog/api/test/test_action.py
@@ -330,7 +330,7 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             created_by=User.objects.create_and_join(self.organization, "a", ""),
         )
 
-        with self.assertNumQueries(7), snapshot_postgres_queries_context(self):
+        with self.assertNumQueries(6), snapshot_postgres_queries_context(self):
             self.client.get(f"/api/projects/{self.team.id}/actions/")
 
         Action.objects.create(
@@ -339,7 +339,7 @@ class TestActionApi(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             created_by=User.objects.create_and_join(self.organization, "b", ""),
         )
 
-        with self.assertNumQueries(7), snapshot_postgres_queries_context(self):
+        with self.assertNumQueries(6), snapshot_postgres_queries_context(self):
             self.client.get(f"/api/projects/{self.team.id}/actions/")
 
     def test_get_tags_on_non_ee_returns_empty_list(self):


### PR DESCRIPTION
## Problem

We're displaying only up to 100 actions on the actions page and in the taxonomic filter.

## Changes

This reverts [a change](https://github.com/PostHog/posthog/pull/22056/files#r1592091637) that added pagination to the actions endpoint. Using said pagination frontend side would be better, but by simply adding `endpoint: combineUrl('api/projects/${teamId}/actions').url` [here](https://github.com/PostHog/posthog/blob/5d2639606c8743659833091bc422a988476c5588/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx#L205), broke the search. Thus opting for a hotfix.

## How did you test this code?

Tested locally with > 200 actions