### PR TITLE
chore: prune unnecessary metrics from usage reports

### DIFF
--- a/posthog/tasks/test/__snapshots__/test_usage_report.ambr
+++ b/posthog/tasks/test/__snapshots__/test_usage_report.ambr
@@ -3,15 +3,6 @@
   '''
   
   SELECT team_id,
-         count(1) as count
-  FROM events
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.1
-  '''
-  
-  SELECT team_id,
          count(distinct toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid)) as count
   FROM events
   WHERE timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
@@ -22,169 +13,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.10
-  '''
-  
-  SELECT distinct_id as team,
-         sum(JSONExtractInt(properties, 'count')) as sum
-  FROM events
-  WHERE team_id = 2
-    AND event='local evaluation usage'
-    AND timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND has(['correct'], replaceRegexpAll(JSONExtractRaw(properties, 'token'), '^"|"$', ''))
-  GROUP BY team
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.11
-  '''
-  
-  SELECT distinct_id as team,
-         sum(JSONExtractInt(properties, 'count')) as sum
-  FROM events
-  WHERE team_id = 2
-    AND event='local evaluation usage'
-    AND timestamp between '2022-01-01 00:00:00' AND '2022-01-10 23:59:59'
-    AND has(['correct'], replaceRegexpAll(JSONExtractRaw(properties, 'token'), '^"|"$', ''))
-  GROUP BY team
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.12
-  '''
-  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
-       JSONExtractString(log_comment, 'query_type') as query_type,
-       JSONExtractString(log_comment, 'access_method') as access_method
-  SELECT team_id,
-         sum(read_bytes) as count
-  FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE (type = 'QueryFinish'
-         OR type = 'ExceptionWhileProcessing')
-    AND is_initial_query = 1
-    AND query_type IN (['hogql_query', 'HogQLQuery'])
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = ''
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.13
-  '''
-  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
-       JSONExtractString(log_comment, 'query_type') as query_type,
-       JSONExtractString(log_comment, 'access_method') as access_method
-  SELECT team_id,
-         sum(read_rows) as count
-  FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE (type = 'QueryFinish'
-         OR type = 'ExceptionWhileProcessing')
-    AND is_initial_query = 1
-    AND query_type IN (['hogql_query', 'HogQLQuery'])
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = ''
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.14
-  '''
-  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
-       JSONExtractString(log_comment, 'query_type') as query_type,
-       JSONExtractString(log_comment, 'access_method') as access_method
-  SELECT team_id,
-         sum(query_duration_ms) as count
-  FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE (type = 'QueryFinish'
-         OR type = 'ExceptionWhileProcessing')
-    AND is_initial_query = 1
-    AND query_type IN (['hogql_query', 'HogQLQuery'])
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = ''
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.15
-  '''
-  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
-       JSONExtractString(log_comment, 'query_type') as query_type,
-       JSONExtractString(log_comment, 'access_method') as access_method
-  SELECT team_id,
-         sum(read_bytes) as count
-  FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE (type = 'QueryFinish'
-         OR type = 'ExceptionWhileProcessing')
-    AND is_initial_query = 1
-    AND query_type IN (['hogql_query', 'HogQLQuery'])
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = 'personal_api_key'
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.16
-  '''
-  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
-       JSONExtractString(log_comment, 'query_type') as query_type,
-       JSONExtractString(log_comment, 'access_method') as access_method
-  SELECT team_id,
-         sum(read_rows) as count
-  FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE (type = 'QueryFinish'
-         OR type = 'ExceptionWhileProcessing')
-    AND is_initial_query = 1
-    AND query_type IN (['hogql_query', 'HogQLQuery'])
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = 'personal_api_key'
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.17
-  '''
-  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
-       JSONExtractString(log_comment, 'query_type') as query_type,
-       JSONExtractString(log_comment, 'access_method') as access_method
-  SELECT team_id,
-         sum(query_duration_ms) as count
-  FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE (type = 'QueryFinish'
-         OR type = 'ExceptionWhileProcessing')
-    AND is_initial_query = 1
-    AND query_type IN (['hogql_query', 'HogQLQuery'])
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = 'personal_api_key'
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.18
-  '''
-  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
-       JSONExtractString(log_comment, 'query_type') as query_type,
-       JSONExtractString(log_comment, 'access_method') as access_method
-  SELECT team_id,
-         sum(read_bytes) as count
-  FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE (type = 'QueryFinish'
-         OR type = 'ExceptionWhileProcessing')
-    AND is_initial_query = 1
-    AND query_type IN (['EventsQuery'])
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = ''
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.19
-  '''
-  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
-       JSONExtractString(log_comment, 'query_type') as query_type,
-       JSONExtractString(log_comment, 'access_method') as access_method
-  SELECT team_id,
-         sum(read_rows) as count
-  FROM clusterAllReplicas(posthog, system.query_log)
-  WHERE (type = 'QueryFinish'
-         OR type = 'ExceptionWhileProcessing')
-    AND is_initial_query = 1
-    AND query_type IN (['EventsQuery'])
-    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND access_method = ''
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.2
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.1
   '''
   
   SELECT team_id,
@@ -200,7 +29,92 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.20
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.10
+  '''
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_bytes) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['hogql_query', 'HogQLQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = 'personal_api_key'
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.11
+  '''
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_rows) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['hogql_query', 'HogQLQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = 'personal_api_key'
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.12
+  '''
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(query_duration_ms) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['hogql_query', 'HogQLQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = 'personal_api_key'
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.13
+  '''
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_bytes) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['EventsQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = ''
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.14
+  '''
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_rows) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['EventsQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = ''
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.15
   '''
   WITH JSONExtractInt(log_comment, 'team_id') as team_id,
        JSONExtractString(log_comment, 'query_type') as query_type,
@@ -217,7 +131,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.21
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.16
   '''
   WITH JSONExtractInt(log_comment, 'team_id') as team_id,
        JSONExtractString(log_comment, 'query_type') as query_type,
@@ -234,7 +148,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.22
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.17
   '''
   WITH JSONExtractInt(log_comment, 'team_id') as team_id,
        JSONExtractString(log_comment, 'query_type') as query_type,
@@ -251,7 +165,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.23
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.18
   '''
   WITH JSONExtractInt(log_comment, 'team_id') as team_id,
        JSONExtractString(log_comment, 'query_type') as query_type,
@@ -268,7 +182,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.24
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.19
   '''
   
   SELECT team_id,
@@ -279,18 +193,22 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.25
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.2
   '''
   
   SELECT team_id,
-         COUNT() as count
+         count(1) as count
   FROM events
-  WHERE event = 'survey sent'
-    AND timestamp between '2022-01-01 00:00:00' AND '2022-01-10 23:59:59'
+  WHERE timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND ($group_0 != ''
+         OR $group_1 != ''
+         OR $group_2 != ''
+         OR $group_3 != ''
+         OR $group_4 != '')
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.26
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.20
   '''
   
   SELECT team,
@@ -312,44 +230,6 @@
   '''
   
   SELECT team_id,
-         count(1) as count
-  FROM events
-  WHERE timestamp between '2022-01-01 00:00:00' AND '2022-01-10 23:59:59'
-    AND event != '$feature_flag_called'
-    AND event NOT IN ('survey sent',
-                      'survey shown',
-                      'survey dismissed')
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.4
-  '''
-  
-  SELECT team_id,
-         count(1) as count
-  FROM events
-  WHERE timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
-    AND ($group_0 != ''
-         OR $group_1 != ''
-         OR $group_2 != ''
-         OR $group_3 != ''
-         OR $group_4 != '')
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.5
-  '''
-  
-  SELECT team_id,
-         count(distinct session_id) as count
-  FROM session_replay_events
-  GROUP BY team_id
-  '''
-# ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.6
-  '''
-  
-  SELECT team_id,
          count(distinct session_id) as count
   FROM
     (SELECT any(team_id) as team_id,
@@ -366,7 +246,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.7
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.4
   '''
   
   SELECT team_id,
@@ -386,7 +266,7 @@
   GROUP BY team_id
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.8
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.5
   '''
   
   SELECT distinct_id as team,
@@ -399,16 +279,67 @@
   GROUP BY team
   '''
 # ---
-# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.9
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.6
   '''
   
   SELECT distinct_id as team,
          sum(JSONExtractInt(properties, 'count')) as sum
   FROM events
   WHERE team_id = 2
-    AND event='decide usage'
-    AND timestamp between '2022-01-01 00:00:00' AND '2022-01-10 23:59:59'
+    AND event='local evaluation usage'
+    AND timestamp between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
     AND has(['correct'], replaceRegexpAll(JSONExtractRaw(properties, 'token'), '^"|"$', ''))
   GROUP BY team
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.7
+  '''
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_bytes) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['hogql_query', 'HogQLQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = ''
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.8
+  '''
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(read_rows) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['hogql_query', 'HogQLQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = ''
+  GROUP BY team_id
+  '''
+# ---
+# name: TestFeatureFlagsUsageReport.test_usage_report_decide_requests.9
+  '''
+  WITH JSONExtractInt(log_comment, 'team_id') as team_id,
+       JSONExtractString(log_comment, 'query_type') as query_type,
+       JSONExtractString(log_comment, 'access_method') as access_method
+  SELECT team_id,
+         sum(query_duration_ms) as count
+  FROM clusterAllReplicas(posthog, system.query_log)
+  WHERE (type = 'QueryFinish'
+         OR type = 'ExceptionWhileProcessing')
+    AND is_initial_query = 1
+    AND query_type IN (['hogql_query', 'HogQLQuery'])
+    AND query_start_time between '2022-01-10 00:00:00' AND '2022-01-10 23:59:59'
+    AND access_method = ''
+  GROUP BY team_id
   '''
 # ---

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -409,13 +409,10 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     },
                     "plugins_enabled": {"Installed and enabled": 1},
                     "instance_tag": "none",
-                    "event_count_lifetime": 57,
                     "event_count_in_period": 24,
                     "enhanced_persons_event_count_in_period": 23,
-                    "event_count_in_month": 44,
                     "event_count_with_groups_in_period": 2,
                     "recording_count_in_period": 5,
-                    "recording_count_total": 16,
                     "mobile_recording_count_in_period": 0,
                     "group_types_total": 2,
                     "dashboard_count": 2,
@@ -424,14 +421,10 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "dashboard_tagged_count": 0,
                     "ff_count": 2,
                     "ff_active_count": 1,
-                    "decide_requests_count_in_month": 0,
                     "decide_requests_count_in_period": 0,
-                    "local_evaluation_requests_count_in_month": 0,
                     "local_evaluation_requests_count_in_period": 0,
-                    "billable_feature_flag_requests_count_in_month": 0,
                     "billable_feature_flag_requests_count_in_period": 0,
                     "survey_responses_count_in_period": 1,
-                    "survey_responses_count_in_month": 1,
                     "hogql_app_bytes_read": 0,
                     "hogql_app_rows_read": 0,
                     "hogql_app_duration_ms": 0,
@@ -453,13 +446,10 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "team_count": 2,
                     "teams": {
                         str(self.org_1_team_1.id): {
-                            "event_count_lifetime": 46,
                             "event_count_in_period": 14,
                             "enhanced_persons_event_count_in_period": 13,
-                            "event_count_in_month": 34,
                             "event_count_with_groups_in_period": 2,
                             "recording_count_in_period": 0,
-                            "recording_count_total": 0,
                             "mobile_recording_count_in_period": 0,
                             "group_types_total": 2,
                             "dashboard_count": 2,
@@ -468,14 +458,10 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                             "dashboard_tagged_count": 0,
                             "ff_count": 2,
                             "ff_active_count": 1,
-                            "decide_requests_count_in_month": 0,
                             "decide_requests_count_in_period": 0,
-                            "local_evaluation_requests_count_in_month": 0,
                             "local_evaluation_requests_count_in_period": 0,
-                            "billable_feature_flag_requests_count_in_month": 0,
                             "billable_feature_flag_requests_count_in_period": 0,
                             "survey_responses_count_in_period": 1,
-                            "survey_responses_count_in_month": 1,
                             "hogql_app_bytes_read": 0,
                             "hogql_app_rows_read": 0,
                             "hogql_app_duration_ms": 0,
@@ -491,13 +477,10 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                             "rows_synced_in_period": 0,
                         },
                         str(self.org_1_team_2.id): {
-                            "event_count_lifetime": 11,
                             "event_count_in_period": 10,
                             "enhanced_persons_event_count_in_period": 10,
-                            "event_count_in_month": 10,
                             "event_count_with_groups_in_period": 0,
                             "recording_count_in_period": 5,
-                            "recording_count_total": 16,
                             "mobile_recording_count_in_period": 0,
                             "group_types_total": 0,
                             "dashboard_count": 0,
@@ -506,14 +489,10 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                             "dashboard_tagged_count": 0,
                             "ff_count": 0,
                             "ff_active_count": 0,
-                            "decide_requests_count_in_month": 0,
                             "decide_requests_count_in_period": 0,
-                            "local_evaluation_requests_count_in_month": 0,
                             "local_evaluation_requests_count_in_period": 0,
-                            "billable_feature_flag_requests_count_in_month": 0,
                             "billable_feature_flag_requests_count_in_period": 0,
                             "survey_responses_count_in_period": 0,
-                            "survey_responses_count_in_month": 0,
                             "hogql_app_bytes_read": 0,
                             "hogql_app_rows_read": 0,
                             "hogql_app_duration_ms": 0,
@@ -552,13 +531,10 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     },
                     "plugins_enabled": {"Installed and enabled": 1},
                     "instance_tag": "none",
-                    "event_count_lifetime": 11,
                     "event_count_in_period": 10,
                     "enhanced_persons_event_count_in_period": 10,
-                    "event_count_in_month": 10,
                     "event_count_with_groups_in_period": 0,
                     "recording_count_in_period": 0,
-                    "recording_count_total": 0,
                     "mobile_recording_count_in_period": 0,
                     "group_types_total": 0,
                     "dashboard_count": 0,
@@ -567,14 +543,10 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "dashboard_tagged_count": 0,
                     "ff_count": 0,
                     "ff_active_count": 0,
-                    "decide_requests_count_in_month": 0,
                     "decide_requests_count_in_period": 0,
-                    "local_evaluation_requests_count_in_month": 0,
                     "local_evaluation_requests_count_in_period": 0,
-                    "billable_feature_flag_requests_count_in_month": 0,
                     "billable_feature_flag_requests_count_in_period": 0,
                     "survey_responses_count_in_period": 0,
-                    "survey_responses_count_in_month": 0,
                     "hogql_app_bytes_read": 0,
                     "hogql_app_rows_read": 0,
                     "hogql_app_duration_ms": 0,
@@ -596,13 +568,10 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                     "team_count": 1,
                     "teams": {
                         str(self.org_2_team_3.id): {
-                            "event_count_lifetime": 11,
                             "event_count_in_period": 10,
                             "enhanced_persons_event_count_in_period": 10,
-                            "event_count_in_month": 10,
                             "event_count_with_groups_in_period": 0,
                             "recording_count_in_period": 0,
-                            "recording_count_total": 0,
                             "mobile_recording_count_in_period": 0,
                             "group_types_total": 0,
                             "dashboard_count": 0,
@@ -611,14 +580,10 @@ class UsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesMixin
                             "dashboard_tagged_count": 0,
                             "ff_count": 0,
                             "ff_active_count": 0,
-                            "decide_requests_count_in_month": 0,
                             "decide_requests_count_in_period": 0,
-                            "local_evaluation_requests_count_in_month": 0,
                             "local_evaluation_requests_count_in_period": 0,
-                            "billable_feature_flag_requests_count_in_month": 0,
                             "billable_feature_flag_requests_count_in_period": 0,
                             "survey_responses_count_in_period": 0,
-                            "survey_responses_count_in_month": 0,
                             "hogql_app_bytes_read": 0,
                             "hogql_app_rows_read": 0,
                             "hogql_app_duration_ms": 0,
@@ -707,9 +672,7 @@ class ReplayUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTable
         all_reports = _get_all_usage_data_as_team_rows(period_start, period_end)
         report = _get_team_report(all_reports, self.team)
 
-        assert all_reports["teams_with_recording_count_total"] == {self.team.pk: 16}
         assert report.recording_count_in_period == 5
-        assert report.recording_count_total == 16
 
         assert report.mobile_recording_count_in_period == 0
 
@@ -721,10 +684,6 @@ class ReplayUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTable
 
         all_reports = _get_all_usage_data_as_team_rows(period_start, period_end)
         report = _get_team_report(all_reports, self.team)
-
-        # we don't split mobile recordings out of the total since that field is not used
-        assert all_reports["teams_with_recording_count_total"] == {self.team.pk: 18}
-        assert report.recording_count_total == 18
 
         # but we do split them out of the daily usage since that field is used
         assert report.recording_count_in_period == 5
@@ -853,28 +812,18 @@ class TestFeatureFlagsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickh
 
         assert org_1_report["organization_name"] == "Org 1"
         assert org_1_report["decide_requests_count_in_period"] == 11
-        assert org_1_report["decide_requests_count_in_month"] == 105
         assert org_1_report["billable_feature_flag_requests_count_in_period"] == 11
-        assert org_1_report["billable_feature_flag_requests_count_in_month"] == 105
         assert org_1_report["teams"]["3"]["decide_requests_count_in_period"] == 10
-        assert org_1_report["teams"]["3"]["decide_requests_count_in_month"] == 100
         assert org_1_report["teams"]["3"]["billable_feature_flag_requests_count_in_period"] == 10
-        assert org_1_report["teams"]["3"]["billable_feature_flag_requests_count_in_month"] == 100
         assert org_1_report["teams"]["4"]["decide_requests_count_in_period"] == 1
-        assert org_1_report["teams"]["4"]["decide_requests_count_in_month"] == 5
         assert org_1_report["teams"]["4"]["billable_feature_flag_requests_count_in_period"] == 1
-        assert org_1_report["teams"]["4"]["billable_feature_flag_requests_count_in_month"] == 5
 
         # because of wrong token, Org 2 has no decide counts.
         assert org_2_report["organization_name"] == "Org 2"
         assert org_2_report["decide_requests_count_in_period"] == 0
-        assert org_2_report["decide_requests_count_in_month"] == 0
-        assert org_2_report["billable_feature_flag_requests_count_in_month"] == 0
         assert org_2_report["billable_feature_flag_requests_count_in_period"] == 0
         assert org_2_report["teams"]["5"]["decide_requests_count_in_period"] == 0
-        assert org_2_report["teams"]["5"]["decide_requests_count_in_month"] == 0
         assert org_2_report["teams"]["5"]["billable_feature_flag_requests_count_in_period"] == 0
-        assert org_2_report["teams"]["5"]["billable_feature_flag_requests_count_in_month"] == 0
 
     @patch("posthog.tasks.usage_report.Client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
@@ -943,32 +892,20 @@ class TestFeatureFlagsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickh
 
         assert org_1_report["organization_name"] == "Org 1"
         assert org_1_report["local_evaluation_requests_count_in_period"] == 11
-        assert org_1_report["local_evaluation_requests_count_in_month"] == 105
         assert org_1_report["decide_requests_count_in_period"] == 0
-        assert org_1_report["decide_requests_count_in_month"] == 0
         assert org_1_report["billable_feature_flag_requests_count_in_period"] == 110
-        assert org_1_report["billable_feature_flag_requests_count_in_month"] == 1050
         assert org_1_report["teams"]["3"]["local_evaluation_requests_count_in_period"] == 10
-        assert org_1_report["teams"]["3"]["local_evaluation_requests_count_in_month"] == 100
         assert org_1_report["teams"]["4"]["local_evaluation_requests_count_in_period"] == 1
-        assert org_1_report["teams"]["4"]["local_evaluation_requests_count_in_month"] == 5
         assert org_1_report["teams"]["3"]["billable_feature_flag_requests_count_in_period"] == 100
-        assert org_1_report["teams"]["3"]["billable_feature_flag_requests_count_in_month"] == 1000
         assert org_1_report["teams"]["4"]["billable_feature_flag_requests_count_in_period"] == 10
-        assert org_1_report["teams"]["4"]["billable_feature_flag_requests_count_in_month"] == 50
 
         # because of wrong token, Org 2 has no decide counts.
         assert org_2_report["organization_name"] == "Org 2"
         assert org_2_report["local_evaluation_requests_count_in_period"] == 0
-        assert org_2_report["local_evaluation_requests_count_in_month"] == 0
         assert org_1_report["decide_requests_count_in_period"] == 0
-        assert org_1_report["decide_requests_count_in_month"] == 0
-        assert org_2_report["billable_feature_flag_requests_count_in_month"] == 0
         assert org_2_report["billable_feature_flag_requests_count_in_period"] == 0
         assert org_2_report["teams"]["5"]["local_evaluation_requests_count_in_period"] == 0
-        assert org_2_report["teams"]["5"]["local_evaluation_requests_count_in_month"] == 0
         assert org_2_report["teams"]["5"]["billable_feature_flag_requests_count_in_period"] == 0
-        assert org_2_report["teams"]["5"]["billable_feature_flag_requests_count_in_month"] == 0
 
 
 @freeze_time("2022-01-10T00:01:00Z")
@@ -1058,19 +995,13 @@ class TestSurveysUsageReport(ClickhouseDestroyTablesMixin, TestCase, ClickhouseT
 
         assert org_1_report["organization_name"] == "Org 1"
         assert org_1_report["survey_responses_count_in_period"] == 2
-        assert org_1_report["survey_responses_count_in_month"] == 10
         assert org_1_report["teams"]["3"]["survey_responses_count_in_period"] == 1
-        assert org_1_report["teams"]["3"]["survey_responses_count_in_month"] == 5
         assert org_1_report["teams"]["4"]["survey_responses_count_in_period"] == 1
-        assert org_1_report["teams"]["4"]["survey_responses_count_in_month"] == 5
 
         assert org_2_report["organization_name"] == "Org 2"
         assert org_2_report["decide_requests_count_in_period"] == 0
-        assert org_2_report["decide_requests_count_in_month"] == 0
         assert org_2_report["survey_responses_count_in_period"] == 1
-        assert org_2_report["survey_responses_count_in_month"] == 7
         assert org_2_report["teams"]["5"]["survey_responses_count_in_period"] == 1
-        assert org_2_report["teams"]["5"]["survey_responses_count_in_month"] == 7
 
     @patch("posthog.tasks.usage_report.Client")
     @patch("posthog.tasks.usage_report.send_report_to_billing_service")
@@ -1109,9 +1040,7 @@ class TestSurveysUsageReport(ClickhouseDestroyTablesMixin, TestCase, ClickhouseT
             _get_full_org_usage_report(all_reports[str(self.org_1.id)], get_instance_metadata(period))
         )
         assert report["organization_name"] == "Org 1"
-        assert report["survey_responses_count_in_month"] == 5
         assert report["event_count_in_period"] == 0
-        assert report["event_count_in_month"] == 0
 
 
 @freeze_time("2022-01-10T00:01:00Z")

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -71,23 +71,14 @@ USAGE_REPORT_TASK_KWARGS = {
 
 @dataclasses.dataclass
 class UsageReportCounters:
-    event_count_lifetime: int
     event_count_in_period: int
     enhanced_persons_event_count_in_period: int
-    event_count_in_month: int
     event_count_with_groups_in_period: int
-    # event_count_by_lib: Dict
-    # event_count_by_name: Dict
-
     # Recordings
     recording_count_in_period: int
-    recording_count_total: int
     mobile_recording_count_in_period: int
-
     # Persons and Groups
     group_types_total: int
-    # person_count_total: int
-    # person_count_in_period: int
     # Dashboards
     dashboard_count: int
     dashboard_template_count: int
@@ -97,11 +88,8 @@ class UsageReportCounters:
     ff_count: int
     ff_active_count: int
     decide_requests_count_in_period: int
-    decide_requests_count_in_month: int
     local_evaluation_requests_count_in_period: int
-    local_evaluation_requests_count_in_month: int
     billable_feature_flag_requests_count_in_period: int
-    billable_feature_flag_requests_count_in_month: int
     # HogQL
     hogql_app_bytes_read: int
     hogql_app_rows_read: int
@@ -118,7 +106,6 @@ class UsageReportCounters:
     event_explorer_api_duration_ms: int
     # Surveys
     survey_responses_count_in_period: int
-    survey_responses_count_in_month: int
     # Data Warehouse
     rows_synced_in_period: int
 
@@ -895,10 +882,14 @@ def _add_team_report_to_org_reports(
 
 def _get_all_org_reports(period_start: datetime, period_end: datetime) -> dict[str, OrgReport]:
     print("Getting all usage data...")  # noqa T201
+    time_now = datetime.now()
     all_data = _get_all_usage_data_as_team_rows(period_start, period_end)
+    print(f"Getting all usage data took {(datetime.now() - time_now).total_seconds()} seconds.")  # noqa T201
 
     print("Getting teams for usage reports...")  # noqa T201
+    time_now = datetime.now()
     teams = _get_teams_for_usage_reports()
+    print(f"Getting teams for usage reports took {(datetime.now() - time_now).total_seconds()} seconds.")  # noqa T201
 
     org_reports: dict[str, OrgReport] = {}
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1,16 +1,9 @@
 import dataclasses
 import os
 from collections import Counter
-from datetime import datetime
-from typing import (
-    Any,
-    Literal,
-    Optional,
-    TypedDict,
-    Union,
-    cast,
-)
 from collections.abc import Sequence
+from datetime import datetime
+from typing import Any, Literal, Optional, TypedDict, Union, cast
 
 import requests
 import structlog
@@ -378,21 +371,6 @@ def capture_event(
 
 @timed_log()
 @retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
-def get_teams_with_event_count_lifetime() -> list[tuple[int, int]]:
-    result = sync_execute(
-        """
-        SELECT team_id, count(1) as count
-        FROM events
-        GROUP BY team_id
-    """,
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
-    return result
-
-
-@timed_log()
-@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_billable_event_count_in_period(
     begin: datetime, end: datetime, count_distinct: bool = False
 ) -> list[tuple[int, int]]:
@@ -471,40 +449,6 @@ def get_teams_with_event_count_with_groups_in_period(begin: datetime, end: datet
 
 @timed_log()
 @retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
-def get_teams_with_event_count_by_lib(begin: datetime, end: datetime) -> list[tuple[int, str, int]]:
-    results = sync_execute(
-        """
-        SELECT team_id, JSONExtractString(properties, '$lib') as lib, COUNT(1) as count
-        FROM events
-        WHERE timestamp between %(begin)s AND %(end)s
-        GROUP BY lib, team_id
-    """,
-        {"begin": begin, "end": end},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
-    return results
-
-
-@timed_log()
-@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
-def get_teams_with_event_count_by_name(begin: datetime, end: datetime) -> list[tuple[int, str, int]]:
-    results = sync_execute(
-        """
-        SELECT team_id, event, COUNT(1) as count
-        FROM events
-        WHERE timestamp between %(begin)s AND %(end)s
-        GROUP BY event, team_id
-    """,
-        {"begin": begin, "end": end},
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
-    return results
-
-
-@timed_log()
-@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_recording_count_in_period(
     begin: datetime, end: datetime, snapshot_source: Literal["mobile", "web"] = "web"
 ) -> list[tuple[int, int]]:
@@ -538,21 +482,6 @@ def get_teams_with_recording_count_in_period(
         settings=CH_BILLING_SETTINGS,
     )
 
-    return result
-
-
-@timed_log()
-@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
-def get_teams_with_recording_count_total() -> list[tuple[int, int]]:
-    result = sync_execute(
-        """
-        SELECT team_id, count(distinct session_id) as count
-        FROM session_replay_events
-        GROUP BY team_id
-    """,
-        workload=Workload.OFFLINE,
-        settings=CH_BILLING_SETTINGS,
-    )
     return result
 
 
@@ -727,22 +656,15 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
     we count across all teams rather than doing it one by one
     """
     return {
-        "teams_with_event_count_lifetime": get_teams_with_event_count_lifetime(),
         "teams_with_event_count_in_period": get_teams_with_billable_event_count_in_period(
             period_start, period_end, count_distinct=True
         ),
         "teams_with_enhanced_persons_event_count_in_period": get_teams_with_billable_enhanced_persons_event_count_in_period(
             period_start, period_end, count_distinct=True
         ),
-        "teams_with_event_count_in_month": get_teams_with_billable_event_count_in_period(
-            period_start.replace(day=1), period_end
-        ),
         "teams_with_event_count_with_groups_in_period": get_teams_with_event_count_with_groups_in_period(
             period_start, period_end
         ),
-        # teams_with_event_count_by_lib=get_teams_with_event_count_by_lib(period_start, period_end),
-        # teams_with_event_count_by_name=get_teams_with_event_count_by_name(period_start, period_end),
-        "teams_with_recording_count_total": get_teams_with_recording_count_total(),
         "teams_with_recording_count_in_period": get_teams_with_recording_count_in_period(
             period_start, period_end, snapshot_source="web"
         ),
@@ -752,14 +674,8 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
         "teams_with_decide_requests_count_in_period": get_teams_with_feature_flag_requests_count_in_period(
             period_start, period_end, FlagRequestType.DECIDE
         ),
-        "teams_with_decide_requests_count_in_month": get_teams_with_feature_flag_requests_count_in_period(
-            period_start.replace(day=1), period_end, FlagRequestType.DECIDE
-        ),
         "teams_with_local_evaluation_requests_count_in_period": get_teams_with_feature_flag_requests_count_in_period(
             period_start, period_end, FlagRequestType.LOCAL_EVALUATION
-        ),
-        "teams_with_local_evaluation_requests_count_in_month": get_teams_with_feature_flag_requests_count_in_period(
-            period_start.replace(day=1), period_end, FlagRequestType.LOCAL_EVALUATION
         ),
         "teams_with_group_types_total": list(
             GroupTypeMapping.objects.values("team_id").annotate(total=Count("id")).order_by("team_id")
@@ -878,9 +794,6 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
         "teams_with_survey_responses_count_in_period": get_teams_with_survey_responses_count_in_period(
             period_start, period_end
         ),
-        "teams_with_survey_responses_count_in_month": get_teams_with_survey_responses_count_in_period(
-            period_start.replace(day=1), period_end
-        ),
         "teams_with_rows_synced_in_period": get_teams_with_rows_synced_in_period(period_start, period_end),
     }
 
@@ -906,34 +819,21 @@ def _get_teams_for_usage_reports() -> Sequence[Team]:
 
 
 def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounters:
-    decide_requests_count_in_month = all_data["teams_with_decide_requests_count_in_month"].get(team.id, 0)
     decide_requests_count_in_period = all_data["teams_with_decide_requests_count_in_period"].get(team.id, 0)
     local_evaluation_requests_count_in_period = all_data["teams_with_local_evaluation_requests_count_in_period"].get(
         team.id, 0
     )
-    local_evaluation_requests_count_in_month = all_data["teams_with_local_evaluation_requests_count_in_month"].get(
-        team.id, 0
-    )
     return UsageReportCounters(
-        event_count_lifetime=all_data["teams_with_event_count_lifetime"].get(team.id, 0),
         event_count_in_period=all_data["teams_with_event_count_in_period"].get(team.id, 0),
         enhanced_persons_event_count_in_period=all_data["teams_with_enhanced_persons_event_count_in_period"].get(
             team.id, 0
         ),
-        event_count_in_month=all_data["teams_with_event_count_in_month"].get(team.id, 0),
         event_count_with_groups_in_period=all_data["teams_with_event_count_with_groups_in_period"].get(team.id, 0),
-        # event_count_by_lib: Di all_data["teams_with_#"].get(team.id, 0),
-        # event_count_by_name: Di all_data["teams_with_#"].get(team.id, 0),
-        recording_count_total=all_data["teams_with_recording_count_total"].get(team.id, 0),
         recording_count_in_period=all_data["teams_with_recording_count_in_period"].get(team.id, 0),
         mobile_recording_count_in_period=all_data["teams_with_mobile_recording_count_in_period"].get(team.id, 0),
         group_types_total=all_data["teams_with_group_types_total"].get(team.id, 0),
         decide_requests_count_in_period=decide_requests_count_in_period,
-        decide_requests_count_in_month=decide_requests_count_in_month,
         local_evaluation_requests_count_in_period=local_evaluation_requests_count_in_period,
-        local_evaluation_requests_count_in_month=local_evaluation_requests_count_in_month,
-        billable_feature_flag_requests_count_in_month=decide_requests_count_in_month
-        + (local_evaluation_requests_count_in_month * 10),
         billable_feature_flag_requests_count_in_period=decide_requests_count_in_period
         + (local_evaluation_requests_count_in_period * 10),
         dashboard_count=all_data["teams_with_dashboard_count"].get(team.id, 0),
@@ -955,7 +855,6 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         event_explorer_api_rows_read=all_data["teams_with_event_explorer_api_rows_read"].get(team.id, 0),
         event_explorer_api_duration_ms=all_data["teams_with_event_explorer_api_duration_ms"].get(team.id, 0),
         survey_responses_count_in_period=all_data["teams_with_survey_responses_count_in_period"].get(team.id, 0),
-        survey_responses_count_in_month=all_data["teams_with_survey_responses_count_in_month"].get(team.id, 0),
         rows_synced_in_period=all_data["teams_with_rows_synced_in_period"].get(team.id, 0),
     )
 
@@ -995,8 +894,10 @@ def _add_team_report_to_org_reports(
 
 
 def _get_all_org_reports(period_start: datetime, period_end: datetime) -> dict[str, OrgReport]:
+    print("Getting all usage data...")  # noqa T201
     all_data = _get_all_usage_data_as_team_rows(period_start, period_end)
 
+    print("Getting teams for usage reports...")  # noqa T201
     teams = _get_teams_for_usage_reports()
 
     org_reports: dict[str, OrgReport] = {}


### PR DESCRIPTION
## Problem

Usage reports are failing in US. I think we need to batch them, but hoping this works as a quick fix to get them rolling again.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Prunes unnecessary metrics from usage reports.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
