### PR TITLE
refactor: Heartbeat constantly with heartbeater

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -38,7 +38,7 @@ from posthog.temporal.batch_exports.temporary_file import (
 )
 from posthog.temporal.batch_exports.utils import peek_first_and_rewind
 from posthog.temporal.common.clickhouse import get_client
-from posthog.temporal.common.heartbeat import Heartbeatter
+from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import bind_temporal_worker_logger
 from posthog.temporal.common.utils import (
     BatchExportHeartbeatDetails,
@@ -263,7 +263,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
 
         asyncio.create_task(worker_shutdown_handler())
 
-        async with Heartbeatter() as heartbeatter:
+        async with Heartbeater() as heartbeater:
             with bigquery_client(inputs) as bq_client:
                 with BatchExportTemporaryFile() as jsonl_file:
                     rows_exported = get_rows_exported_metric()
@@ -336,7 +336,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                                 await flush_to_bigquery(bigquery_table, schema)
 
                                 last_inserted_at = inserted_at.isoformat()
-                                heartbeatter.details = (str(last_inserted_at),)
+                                heartbeater.details = (str(last_inserted_at),)
 
                                 jsonl_file.reset()
 
@@ -344,7 +344,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                         await flush_to_bigquery(bigquery_table, schema)
 
                         last_inserted_at = inserted_at.isoformat()
-                        heartbeatter.details = (str(last_inserted_at),)
+                        heartbeater.details = (str(last_inserted_at),)
 
                         jsonl_file.reset()
 

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -46,7 +46,7 @@ from posthog.temporal.batch_exports.temporary_file import (
 )
 from posthog.temporal.batch_exports.utils import peek_first_and_rewind, try_set_batch_export_run_to_running
 from posthog.temporal.common.clickhouse import get_client
-from posthog.temporal.common.heartbeat import Heartbeatter
+from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import bind_temporal_worker_logger
 
 
@@ -462,7 +462,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
             extra_query_parameters=query_parameters,
         )
 
-        async with Heartbeatter() as heartbeatter:
+        async with Heartbeater() as heartbeater:
             async with s3_upload as s3_upload:
 
                 async def flush_to_s3(
@@ -484,7 +484,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
                     rows_exported.add(records_since_last_flush)
                     bytes_exported.add(bytes_since_last_flush)
 
-                    heartbeatter.details = (str(last_inserted_at), s3_upload.to_state())
+                    heartbeater.details = (str(last_inserted_at), s3_upload.to_state())
 
                 first_record_batch, record_iterator = peek_first_and_rewind(record_iterator)
                 first_record_batch = cast_record_batch_json_columns(first_record_batch)

--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -12,7 +12,7 @@ from temporalio.common import RetryPolicy
 
 from posthog.temporal.batch_exports.base import PostHogWorkflow
 from posthog.temporal.common.clickhouse import get_client
-from posthog.temporal.common.heartbeat import Heartbeatter
+from posthog.temporal.common.heartbeat import Heartbeater
 
 EPOCH = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
 
@@ -243,7 +243,7 @@ async def optimize_person_distinct_id_overrides(dry_run: bool) -> None:
         activity.logger.debug("Optimize query: %s", optimize_query)
         return
 
-    async with Heartbeatter():
+    async with Heartbeater():
         async with get_client(mutations_sync=2) as clickhouse_client:
             await clickhouse_client.execute_query(
                 optimize_query.format(database=settings.CLICKHOUSE_DATABASE, cluster=settings.CLICKHOUSE_CLUSTER)
@@ -292,7 +292,7 @@ async def create_table(inputs: TableActivityInputs) -> None:
         activity.logger.debug("Query: %s", create_table_query)
         return
 
-    async with Heartbeatter():
+    async with Heartbeater():
         async with get_client() as clickhouse_client:
             await clickhouse_client.execute_query(create_table_query, query_parameters=inputs.query_parameters)
 
@@ -321,7 +321,7 @@ async def drop_table(inputs: TableActivityInputs) -> None:
         activity.logger.debug("Query: %s", drop_table_query)
         return
 
-    async with Heartbeatter():
+    async with Heartbeater():
         async with get_client() as clickhouse_client:
             await clickhouse_client.execute_query(drop_table_query)
 
@@ -554,7 +554,7 @@ async def wait_for_mutation(inputs: MutationActivityInputs) -> None:
         database=settings.CLICKHOUSE_DATABASE,
         cluster=settings.CLICKHOUSE_CLUSTER,
     )
-    async with Heartbeatter():
+    async with Heartbeater():
         async with get_client() as clickhouse_client:
             prepared_submit_query = clickhouse_client.prepare_query(submit_query, inputs.query_parameters)
             query_command = parse_mutation_command(prepared_submit_query)

--- a/posthog/temporal/common/heartbeat.py
+++ b/posthog/temporal/common/heartbeat.py
@@ -4,7 +4,7 @@ import typing
 from temporalio import activity
 
 
-class Heartbeatter:
+class Heartbeater:
     """Regular heartbeatting during Temporal activity execution.
 
     This class manages two heartbeat tasks via a context manager:

--- a/posthog/temporal/common/utils.py
+++ b/posthog/temporal/common/utils.py
@@ -1,8 +1,8 @@
 import collections.abc
+import abc
 import dataclasses
 import datetime as dt
 import typing
-import abc
 
 
 class EmptyHeartbeatError(Exception):
@@ -138,7 +138,7 @@ async def should_resume_from_activity_heartbeat(
         # Ideally, any new exceptions should be added to the previous blocks after the first time and we will never land here.
         heartbeat_details = None
         received = False
-        logger.exception("Did not receive details from previous activity Excecution due to an unexpected error")
+        logger.exception("Did not receive details from previous activity Execution due to an unexpected error")
 
     else:
         received = True

--- a/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
@@ -516,7 +516,7 @@ async def test_bigquery_export_workflow_handles_insert_activity_errors(ateam, bi
     assert len(runs) == 1
 
     run = runs[0]
-    assert run.status == "FailedRetryable"
+    assert run.status == "Failed"
     assert run.latest_error == "ValueError: A useful error message"
 
 


### PR DESCRIPTION
## Problem

BigQuery batch exports will occasionally time out. This is because we don't heartbeat constantly, but only do it at set moments (after finishing uploading a chunk). So, if an upload takes longer than usual, we miss the heartbeat timeout.
 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Wrap BigQuery batch export execution in `Heartbeater`.
Also rename `Heartbeatter` to `Heartbeater` as even though it's not a standard word, "beater" takes only one t.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Ran bigquery tests, all pass with the exception of a test that triggers an error that is now non-retryable. Fixed this in commit https://github.com/PostHog/posthog/pull/22701/commits/aa0658767f114589f2e50e19ba9472e471e7a657
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
