### PR TITLE
feat: turn on optimizing joins in replay by flag

### DIFF
--- a/ee/session_recordings/queries/test/test_session_recording_list_from_filters.py
+++ b/ee/session_recordings/queries/test/test_session_recording_list_from_filters.py
@@ -157,7 +157,9 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
                     ]
                 },
             )
-            session_recording_list_instance = SessionRecordingListFromFilters(filter=filter, team=self.team)
+            session_recording_list_instance = SessionRecordingListFromFilters(
+                filter=filter, team=self.team, hogql_query_modifiers=None
+            )
             [generated_query, query_params] = session_recording_list_instance.get_query()
             assert query_params == {
                 "clamped_to_storage_ttl": mock.ANY,
@@ -258,7 +260,7 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
             )
 
             session_recording_list_instance = SessionRecordingListFromFilters(
-                filter=match_everyone_filter, team=self.team
+                filter=match_everyone_filter, team=self.team, hogql_query_modifiers=None
             )
             (session_recordings, _) = session_recording_list_instance.run()
 
@@ -278,7 +280,9 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
                 },
             )
 
-            session_recording_list_instance = SessionRecordingListFromFilters(filter=match_bla_filter, team=self.team)
+            session_recording_list_instance = SessionRecordingListFromFilters(
+                filter=match_bla_filter, team=self.team, hogql_query_modifiers=None
+            )
             (session_recordings, _) = session_recording_list_instance.run()
 
             assert len(session_recordings) == 1
@@ -342,6 +346,8 @@ class TestClickhouseSessionRecordingsListFromSessionReplay(ClickhouseTestMixin, 
             self._add_replay_with_pageview(session_id_three, three_user_ids[2])
 
             filter = SessionRecordingsFilter(team=self.team, data={"person_uuid": str(p.uuid)})
-            session_recording_list_instance = SessionRecordingListFromFilters(filter=filter, team=self.team)
+            session_recording_list_instance = SessionRecordingListFromFilters(
+                filter=filter, team=self.team, hogql_query_modifiers=None
+            )
             (session_recordings, _) = session_recording_list_instance.run()
             assert sorted([r["session_id"] for r in session_recordings]) == sorted([session_id_two, session_id_one])

--- a/posthog/session_recordings/queries/session_recording_list_from_filters.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_filters.py
@@ -1,4 +1,4 @@
-from typing import Any, NamedTuple, cast
+from typing import Any, NamedTuple, cast, Optional
 from datetime import datetime, timedelta
 
 from posthog.hogql import ast
@@ -80,7 +80,7 @@ class SessionRecordingListFromFilters:
         self,
         team: Team,
         filter: SessionRecordingsFilter,
-        hogql_query_modifers: HogQLQueryModifiers | None,
+        hogql_query_modifiers: Optional[HogQLQueryModifiers],
         **_,
     ):
         self._team = team
@@ -88,7 +88,7 @@ class SessionRecordingListFromFilters:
         self._paginator = HogQLHasMorePaginator(
             limit=filter.limit or self.SESSION_RECORDINGS_DEFAULT_LIMIT, offset=filter.offset or 0
         )
-        self._hogql_query_modifiers = hogql_query_modifers
+        self._hogql_query_modifiers = hogql_query_modifiers
 
     @property
     def ttl_days(self):

--- a/posthog/session_recordings/queries/session_recording_list_from_filters.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_filters.py
@@ -9,7 +9,7 @@ from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.models import Team
 from posthog.models.filters.session_recordings_filter import SessionRecordingsFilter
 from posthog.models.filters.mixins.utils import cached_property
-from posthog.schema import QueryTiming
+from posthog.schema import QueryTiming, HogQLQueryModifiers
 from posthog.session_recordings.queries.session_replay_events import ttl_days
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS
 
@@ -80,6 +80,7 @@ class SessionRecordingListFromFilters:
         self,
         team: Team,
         filter: SessionRecordingsFilter,
+        hogql_query_modifers: HogQLQueryModifiers | None,
         **_,
     ):
         self._team = team
@@ -87,6 +88,7 @@ class SessionRecordingListFromFilters:
         self._paginator = HogQLHasMorePaginator(
             limit=filter.limit or self.SESSION_RECORDINGS_DEFAULT_LIMIT, offset=filter.offset or 0
         )
+        self._hogql_query_modifiers = hogql_query_modifers
 
     @property
     def ttl_days(self):
@@ -108,6 +110,7 @@ class SessionRecordingListFromFilters:
             team=self._team,
             # TODO - should we have our own query type 🤷
             query_type="hogql_query",
+            modifiers=self._hogql_query_modifiers,
         )
 
         return SessionRecordingQueryResult(

--- a/posthog/session_recordings/queries/test/test_session_recording_list_from_filters.py
+++ b/posthog/session_recordings/queries/test/test_session_recording_list_from_filters.py
@@ -80,7 +80,9 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
 
     def _filter_recordings_by(self, recordings_filter: dict) -> SessionRecordingQueryResult:
         the_filter = SessionRecordingsFilter(team=self.team, data=recordings_filter)
-        session_recording_list_instance = SessionRecordingListFromFilters(filter=the_filter, team=self.team)
+        session_recording_list_instance = SessionRecordingListFromFilters(
+            filter=the_filter, team=self.team, hogql_query_modifiers=None
+        )
         return session_recording_list_instance.run()
 
     @property

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -778,7 +778,7 @@ def list_recordings(
             modifier_overrides = flags_n_bags["featureFlagPayloads"][FLAG_KEY]
 
             if modifier_overrides:
-                modifiers.optimizeJoinedFilters = modifier_overrides.get("optimizeJoinedFilters", None)
+                modifiers.optimizeJoinedFilters = json.loads(modifier_overrides).get("optimizeJoinedFilters", None)
 
             with timer("load_recordings_from_hogql"):
                 (ch_session_recordings, more_recordings_available, hogql_timings) = SessionRecordingListFromFilters(

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -782,7 +782,7 @@ def list_recordings(
 
             with timer("load_recordings_from_hogql"):
                 (ch_session_recordings, more_recordings_available, hogql_timings) = SessionRecordingListFromFilters(
-                    filter=filter, team=team, hogql_query_modifers=modifiers
+                    filter=filter, team=team, hogql_query_modifiers=modifiers
                 ).run()
         else:
             # Only go to clickhouse if we still have remaining specified IDs, or we are not specifying IDs


### PR DESCRIPTION
hogql now has `optimizeJoinedFilters`
we want to turn this on but be able to opt organizations in or out
this adds the code to do that based on a flag
the flag uses a payload since we can then overtime add more of the possible modifiers to it