### PR TITLE
chore: updating activation endpoint to be activate

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -87,7 +87,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         return self.list(request, *args, **kwargs)
 
-    class ActivationSerializer(serializers.Serializer):
+    class ActivateSerializer(serializers.Serializer):
         plan = serializers.CharField(required=False)
         products = serializers.CharField(
             required=False
@@ -110,11 +110,11 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             return data
 
     @action(methods=["GET"], detail=False)
-    def activation(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+    def activate(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         license = get_cached_instance_license()
         organization = self._get_org_required()
 
-        serializer = self.ActivationSerializer(data=request.GET)
+        serializer = self.ActivateSerializer(data=request.GET)
         serializer.is_valid(raise_exception=True)
 
         redirect_path = serializer.validated_data.get("redirect_path", "organization/billing")
@@ -122,7 +122,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             redirect_path = redirect_path[1:]
 
         redirect_uri = f"{settings.SITE_URL or request.headers.get('Host')}/{redirect_path}"
-        url = f"{BILLING_SERVICE_URL}/activation?redirect_uri={redirect_uri}&organization_name={organization.name}"
+        url = f"{BILLING_SERVICE_URL}/activate?redirect_uri={redirect_uri}&organization_name={organization.name}"
 
         products = serializer.validated_data.get("products")
         url = f"{url}&products={products}"
@@ -132,6 +132,11 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             url = f"{url}&token={billing_service_token}"
 
         return redirect(url)
+
+    # This is deprecated and should be removed in the future in favor of 'activate'
+    @action(methods=["GET"], detail=False)
+    def activation(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+        return self.activate(request, *args, **kwargs)
 
     class DeactivateSerializer(serializers.Serializer):
         products = serializers.CharField()

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -109,8 +109,18 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
             return data
 
+    # This is deprecated and should be removed in the future in favor of 'activate'
+    @action(methods=["GET"], detail=False)
+    def activation(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+        return self.activate(request, *args, **kwargs)
+
     @action(methods=["GET"], detail=False)
     def activate(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+        return self.activate(request, *args, **kwargs)
+
+    # A viewset action cannot call another action directly so this is in place until
+    # the 'activation' endpoint is removed. Once removed, this method can move to the 'activate' action
+    def handle_activate(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         license = get_cached_instance_license()
         organization = self._get_org_required()
 
@@ -132,11 +142,6 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             url = f"{url}&token={billing_service_token}"
 
         return redirect(url)
-
-    # This is deprecated and should be removed in the future in favor of 'activate'
-    @action(methods=["GET"], detail=False)
-    def activation(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
-        return self.activate(request, *args, **kwargs)
 
     class DeactivateSerializer(serializers.Serializer):
         products = serializers.CharField()

--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -112,11 +112,11 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     # This is deprecated and should be removed in the future in favor of 'activate'
     @action(methods=["GET"], detail=False)
     def activation(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
-        return self.activate(request, *args, **kwargs)
+        return self.handle_activate(request, *args, **kwargs)
 
     @action(methods=["GET"], detail=False)
     def activate(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
-        return self.activate(request, *args, **kwargs)
+        return self.handle_activate(request, *args, **kwargs)
 
     # A viewset action cannot call another action directly so this is in place until
     # the 'activation' endpoint is removed. Once removed, this method can move to the 'activate' action

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -971,21 +971,33 @@ class TestBillingAPI(APILicensedTest):
         assert self.organization.customer_trust_scores == {"recordings": 0, "events": 15, "rows_synced": 0}
 
 
-class TestActivationBillingAPI(APILicensedTest):
-    def test_activation_success(self):
+class TestActivateBillingAPI(APILicensedTest):
+    def test_activate_success(self):
+        url = "/api/billing-v2/activate"
+        data = {"products": "product_1:plan_1,product_2:plan_2", "redirect_path": "custom/path"}
+
+        response = self.client.get(url, data=data)
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+
+        self.assertIn("/activate", response.url)
+        self.assertIn("products=product_1:plan_1,product_2:plan_2", response.url)
+        url_pattern = r"redirect_uri=http://[^/]+/custom/path"
+        self.assertRegex(response.url, url_pattern)
+
+    def test_deprecated_activation_success(self):
         url = "/api/billing-v2/activation"
         data = {"products": "product_1:plan_1,product_2:plan_2", "redirect_path": "custom/path"}
 
         response = self.client.get(url, data=data)
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
 
-        self.assertIn("/activation", response.url)
+        self.assertIn("/activate", response.url)
         self.assertIn("products=product_1:plan_1,product_2:plan_2", response.url)
         url_pattern = r"redirect_uri=http://[^/]+/custom/path"
         self.assertRegex(response.url, url_pattern)
 
-    def test_activation_with_default_redirect_path(self):
-        url = "/api/billing-v2/activation"
+    def test_activate_with_default_redirect_path(self):
+        url = "/api/billing-v2/activate"
         data = {
             "products": "product_1:plan_1,product_2:plan_2",
         }
@@ -997,16 +1009,16 @@ class TestActivationBillingAPI(APILicensedTest):
         url_pattern = r"redirect_uri=http://[^/]+/organization/billing"
         self.assertRegex(response.url, url_pattern)
 
-    def test_activation_failure(self):
-        url = "/api/billing-v2/activation"
+    def test_activate_failure(self):
+        url = "/api/billing-v2/activate"
         data = {"none": "nothing"}
 
         response = self.client.get(url, data)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_activation_with_plan_error(self):
-        url = "/api/billing-v2/activation"
+    def test_activate_with_plan_error(self):
+        url = "/api/billing-v2/activate"
         data = {"plan": "plan"}
 
         response = self.client.get(url, data)


### PR DESCRIPTION
## Changes

Following up on the PR in billing (https://github.com/PostHog/billing/pull/670), we're updating the `/activation` to be /`activate`. This PR adds `/activate` while still supporting `/activation`, so it's backward compatibility and will not affect existing users. We can remove `/activation` in the future when we're confident it's not being used. 

This is only changing the backend. There will be one more follow up PR to change things for the frontend. 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

no

## How did you test this code?

existing tests + new unit test for `/activation` still working + tested manually
