### PR TITLE
fix: force reconnection of db connection in proxy temporal jobs

### DIFF
--- a/posthog/temporal/proxy_service/common.py
+++ b/posthog/temporal/proxy_service/common.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import grpc.aio
 import uuid
 from django.conf import settings
+from django.db import connection
 
 from temporalio import activity
 
@@ -43,6 +44,7 @@ async def update_proxy_record(inputs: UpdateProxyRecordInputs):
 
     @sync_to_async
     def update_record(proxy_record_id):
+        connection.connect()
         pr = ProxyRecord.objects.get(id=proxy_record_id)
         pr.status = inputs.status
         pr.save()

--- a/posthog/temporal/proxy_service/create.py
+++ b/posthog/temporal/proxy_service/create.py
@@ -5,6 +5,7 @@ import dns.resolver
 import grpc.aio
 import json
 import uuid
+from django.db import connection
 
 from temporalio import activity, workflow
 import temporalio.common
@@ -62,6 +63,7 @@ async def wait_for_dns_records(inputs: WaitForDNSRecordsInputs):
 
     @sync_to_async
     def record_exists(proxy_record_id) -> bool:
+        connection.connect()
         pr = ProxyRecord.objects.filter(id=proxy_record_id)
         return len(pr) > 0
 
@@ -97,6 +99,7 @@ async def create_managed_proxy(inputs: CreateManagedProxyInputs):
 
     @sync_to_async
     def record_exists(proxy_record_id) -> bool:
+        connection.connect()
         pr = ProxyRecord.objects.filter(id=proxy_record_id)
         return len(pr) > 0
 

--- a/posthog/temporal/proxy_service/delete.py
+++ b/posthog/temporal/proxy_service/delete.py
@@ -4,6 +4,7 @@ import datetime as dt
 import grpc.aio
 import json
 import uuid
+from django.db import connection
 
 from temporalio import activity, workflow
 import temporalio.common
@@ -49,6 +50,7 @@ async def delete_proxy_record(inputs: DeleteProxyRecordInputs):
 
     @sync_to_async
     def delete_record(proxy_record_id):
+        connection.connect()
         pr = ProxyRecord.objects.get(id=proxy_record_id)
         pr.delete()
 


### PR DESCRIPTION
## Problem

we were getting intermittent "connection is closed" errors

forcing the connection to connect before db operations should fix this (and is a noop if connection is already connected)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
