### PR TITLE
fix: Move more workloads to Offline cluster

### DIFF
--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -32,7 +32,7 @@ def execute_hogql_query(
     query_type: str = "hogql_query",
     filters: Optional[HogQLFilters] = None,
     placeholders: Optional[dict[str, ast.Expr]] = None,
-    workload: Workload = Workload.ONLINE,
+    workload: Workload = Workload.DEFAULT,
     settings: Optional[HogQLGlobalSettings] = None,
     modifiers: Optional[HogQLQueryModifiers] = None,
     limit_context: Optional[LimitContext] = LimitContext.QUERY,

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -8,7 +8,6 @@ from django.utils.timezone import now
 
 from posthog.api.element import ElementSerializer
 from posthog.api.utils import get_pk_or_uuid
-from posthog.clickhouse.client.connection import Workload
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr, parse_order_expr
 from posthog.hogql.property import action_to_expr, has_aggregation, property_to_expr
@@ -189,7 +188,6 @@ class EventsQueryRunner(QueryRunner):
         query_result = self.paginator.execute_hogql_query(
             query=self.to_query(),
             team=self.team,
-            workload=Workload.ONLINE,
             query_type="EventsQuery",
             timings=self.timings,
             modifiers=self.modifiers,

--- a/posthog/hogql_queries/hogql_query_runner.py
+++ b/posthog/hogql_queries/hogql_query_runner.py
@@ -2,7 +2,6 @@ from datetime import timedelta
 from typing import Optional, cast
 from collections.abc import Callable
 
-from posthog.clickhouse.client.connection import Workload
 from posthog.hogql import ast
 from posthog.hogql.filters import replace_filters
 from posthog.hogql.parser import parse_select
@@ -60,7 +59,6 @@ class HogQLQueryRunner(QueryRunner):
             filters=self.query.filters,
             modifiers=self.query.modifiers or self.modifiers,
             team=self.team,
-            workload=Workload.ONLINE,
             timings=self.timings,
             limit_context=self.limit_context,
         )

--- a/posthog/hogql_queries/sessions_timeline_query_runner.py
+++ b/posthog/hogql_queries/sessions_timeline_query_runner.py
@@ -4,7 +4,6 @@ from typing import cast
 from posthog.api.element import ElementSerializer
 
 
-from posthog.clickhouse.client.connection import Workload
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
@@ -138,7 +137,6 @@ class SessionsTimelineQueryRunner(QueryRunner):
         query_result = execute_hogql_query(
             query=self.to_query(),
             team=self.team,
-            workload=Workload.ONLINE,
             query_type="SessionsTimelineQuery",
             timings=self.timings,
             modifiers=self.modifiers,

--- a/posthog/models/feature_flag/user_blast_radius.py
+++ b/posthog/models/feature_flag/user_blast_radius.py
@@ -8,6 +8,7 @@ from posthog.models.filters import Filter
 from posthog.models.property import GroupTypeIndex
 from posthog.models.team.team import Team
 from posthog.queries.base import relative_date_parse_for_feature_flag_matching
+from posthog.clickhouse.client.connection import Workload
 
 
 def replace_proxy_properties(team: Team, feature_flag_condition: dict):
@@ -58,6 +59,7 @@ def get_user_blast_radius(
                 )
             """,
                 groups_query_params,
+                workload=Workload.OFFLINE,  # These queries can be massive, and don't block creation of feature flags
             )[0][0]
         else:
             total_affected_count = team.groups_seen_so_far(group_type_index)


### PR DESCRIPTION
## Problem

Follow up on #22691, turns out we explicitly overrode a couple of queries with workload which meant the queries didn't actually move 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
