### PR TITLE
fix: Set an upper bound on the number of (legacy) overrides processed in a single batch

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -848,7 +848,7 @@ export class DeferredPersonOverrideWorker {
             'processPendingOverrides',
             async () => {
                 status.debug('👥', 'Processing pending overrides...')
-                const overridesCount = await this.processPendingOverrides()
+                const overridesCount = await this.processPendingOverrides(5000)
                 ;(overridesCount > 0 ? status.info : status.debug)(
                     '👥',
                     `Processed ${overridesCount} pending overrides.`


### PR DESCRIPTION
## Problem

In the event that number of rows in the pending overrides table becomes very large, fetching all rows can eventually cause the override worker to OOM. The lack of a finite upper bound makes resource tuning running pods a moving target.

## Changes

Only processes up to 5000 overrides in a single batch.

## Does this work well for both Cloud and self-hosted?

Yes: overrides are not enabled in self-hosted/hobby, if I recall correctly — even though this is safe, it's shouldn't be applicable.

## How did you test this code?

👀 