### PR TITLE
fix: Plugin permissions

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -327,8 +327,8 @@ class PluginViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if self.action == "retrieve":
             # NOTE: This is inefficient but it is such an edge case that it feels safer this way than
             # Modifying our underyling permissions system too much.
-            lookup_value = self.kwargs[self.lookup_field]
             try:
+                lookup_value = self.kwargs.get(self.lookup_field)
                 obj = Plugin.objects.get(pk=lookup_value)
                 if obj.is_global:
                     return [IsAuthenticated(), APIScopePermission(), PluginsAccessLevelPermission()]

--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -5,10 +5,6 @@ import subprocess
 from typing import Any, Optional, cast, Literal
 
 import requests
-from rest_framework.permissions import IsAuthenticated
-from posthog.permissions import (
-    APIScopePermission,
-)
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import UploadedFile

--- a/posthog/api/plugin_log_entry.py
+++ b/posthog/api/plugin_log_entry.py
@@ -5,7 +5,7 @@ from rest_framework import exceptions, viewsets
 from rest_framework.response import Response
 from rest_framework_dataclasses.serializers import DataclassSerializer
 
-from posthog.api.plugin import PluginOwnershipPermission, PluginsAccessLevelPermission
+from posthog.api.plugin import PluginsAccessLevelPermission
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.models.plugin import (
     PluginLogEntry,
@@ -22,7 +22,7 @@ class PluginLogEntrySerializer(DataclassSerializer):
 class PluginLogEntryViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object = "plugin"
     serializer_class = PluginLogEntrySerializer
-    permission_classes = [PluginsAccessLevelPermission, PluginOwnershipPermission]
+    permission_classes = [PluginsAccessLevelPermission]
 
     def list(self, request, *args, **kwargs):
         limit_raw = request.GET.get("limit")

--- a/posthog/api/test/__snapshots__/test_plugin.ambr
+++ b/posthog/api/test/__snapshots__/test_plugin.ambr
@@ -58,32 +58,7 @@
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.10
   '''
-  SELECT "posthog_plugin"."id",
-         "posthog_plugin"."organization_id",
-         "posthog_plugin"."plugin_type",
-         "posthog_plugin"."is_global",
-         "posthog_plugin"."is_preinstalled",
-         "posthog_plugin"."is_stateless",
-         "posthog_plugin"."name",
-         "posthog_plugin"."description",
-         "posthog_plugin"."url",
-         "posthog_plugin"."icon",
-         "posthog_plugin"."config_schema",
-         "posthog_plugin"."tag",
-         "posthog_plugin"."archive",
-         "posthog_plugin"."latest_tag",
-         "posthog_plugin"."latest_tag_checked_at",
-         "posthog_plugin"."capabilities",
-         "posthog_plugin"."metrics",
-         "posthog_plugin"."public_jobs",
-         "posthog_plugin"."error",
-         "posthog_plugin"."from_json",
-         "posthog_plugin"."from_web",
-         "posthog_plugin"."source",
-         "posthog_plugin"."created_at",
-         "posthog_plugin"."updated_at",
-         "posthog_plugin"."log_level",
-         "posthog_organization"."id",
+  SELECT "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
          "posthog_organization"."created_at",
@@ -101,111 +76,12 @@
          "posthog_organization"."setup_section_2_completed",
          "posthog_organization"."personalization",
          "posthog_organization"."domain_whitelist"
-  FROM "posthog_plugin"
-  INNER JOIN "posthog_organization" ON ("posthog_plugin"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         OR "posthog_plugin"."is_global"
-         OR "posthog_plugin"."id" IN
-           (SELECT U0."plugin_id"
-            FROM "posthog_pluginconfig" U0
-            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (NOT U0."deleted"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
-  LIMIT 100
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
   '''
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.11
-  '''
-  SELECT "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."is_active",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."pending_email",
-         "posthog_user"."temporary_token",
-         "posthog_user"."distinct_id",
-         "posthog_user"."is_email_verified",
-         "posthog_user"."has_seen_product_intro_for",
-         "posthog_user"."strapi_id",
-         "posthog_user"."theme_mode",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."hedgehog_config",
-         "posthog_user"."events_column_config",
-         "posthog_user"."email_opt_in"
-  FROM "posthog_user"
-  WHERE "posthog_user"."id" = 2
-  LIMIT 21
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.12
-  '''
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.13
-  '''
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.14
-  '''
-  SELECT 1 AS "a"
-  FROM "posthog_organizationmembership"
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 1
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.15
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_plugin"
@@ -219,7 +95,7 @@
                    AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
   '''
 # ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.16
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.12
   '''
   SELECT "posthog_plugin"."id",
          "posthog_plugin"."organization_id",
@@ -277,7 +153,7 @@
   LIMIT 100
   '''
 # ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.17
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.13
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -309,7 +185,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.18
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.14
   '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -334,7 +210,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.19
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.15
   '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -357,6 +233,112 @@
   FROM "posthog_organization"
   WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
   LIMIT 21
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.16
+  '''
+  SELECT 1 AS "a"
+  FROM "posthog_organizationmembership"
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
+  LIMIT 1
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.17
+  '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.18
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_plugin"
+  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         OR "posthog_plugin"."is_global"
+         OR "posthog_plugin"."id" IN
+           (SELECT U0."plugin_id"
+            FROM "posthog_pluginconfig" U0
+            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
+            WHERE (NOT U0."deleted"
+                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.19
+  '''
+  SELECT "posthog_plugin"."id",
+         "posthog_plugin"."organization_id",
+         "posthog_plugin"."plugin_type",
+         "posthog_plugin"."is_global",
+         "posthog_plugin"."is_preinstalled",
+         "posthog_plugin"."is_stateless",
+         "posthog_plugin"."name",
+         "posthog_plugin"."description",
+         "posthog_plugin"."url",
+         "posthog_plugin"."icon",
+         "posthog_plugin"."config_schema",
+         "posthog_plugin"."tag",
+         "posthog_plugin"."archive",
+         "posthog_plugin"."latest_tag",
+         "posthog_plugin"."latest_tag_checked_at",
+         "posthog_plugin"."capabilities",
+         "posthog_plugin"."metrics",
+         "posthog_plugin"."public_jobs",
+         "posthog_plugin"."error",
+         "posthog_plugin"."from_json",
+         "posthog_plugin"."from_web",
+         "posthog_plugin"."source",
+         "posthog_plugin"."created_at",
+         "posthog_plugin"."updated_at",
+         "posthog_plugin"."log_level",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_plugin"
+  INNER JOIN "posthog_organization" ON ("posthog_plugin"."organization_id" = "posthog_organization"."id")
+  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         OR "posthog_plugin"."is_global"
+         OR "posthog_plugin"."id" IN
+           (SELECT U0."plugin_id"
+            FROM "posthog_pluginconfig" U0
+            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
+            WHERE (NOT U0."deleted"
+                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
+  LIMIT 100
   '''
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.2
@@ -386,169 +368,6 @@
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.20
   '''
-  SELECT 1 AS "a"
-  FROM "posthog_organizationmembership"
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 1
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.21
-  '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_plugin"
-  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         OR "posthog_plugin"."is_global"
-         OR "posthog_plugin"."id" IN
-           (SELECT U0."plugin_id"
-            FROM "posthog_pluginconfig" U0
-            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (NOT U0."deleted"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.22
-  '''
-  SELECT "posthog_plugin"."id",
-         "posthog_plugin"."organization_id",
-         "posthog_plugin"."plugin_type",
-         "posthog_plugin"."is_global",
-         "posthog_plugin"."is_preinstalled",
-         "posthog_plugin"."is_stateless",
-         "posthog_plugin"."name",
-         "posthog_plugin"."description",
-         "posthog_plugin"."url",
-         "posthog_plugin"."icon",
-         "posthog_plugin"."config_schema",
-         "posthog_plugin"."tag",
-         "posthog_plugin"."archive",
-         "posthog_plugin"."latest_tag",
-         "posthog_plugin"."latest_tag_checked_at",
-         "posthog_plugin"."capabilities",
-         "posthog_plugin"."metrics",
-         "posthog_plugin"."public_jobs",
-         "posthog_plugin"."error",
-         "posthog_plugin"."from_json",
-         "posthog_plugin"."from_web",
-         "posthog_plugin"."source",
-         "posthog_plugin"."created_at",
-         "posthog_plugin"."updated_at",
-         "posthog_plugin"."log_level",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_plugin"
-  INNER JOIN "posthog_organization" ON ("posthog_plugin"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         OR "posthog_plugin"."is_global"
-         OR "posthog_plugin"."id" IN
-           (SELECT U0."plugin_id"
-            FROM "posthog_pluginconfig" U0
-            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (NOT U0."deleted"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
-  LIMIT 100
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.23
-  '''
-  SELECT "posthog_plugin"."id",
-         "posthog_plugin"."organization_id",
-         "posthog_plugin"."plugin_type",
-         "posthog_plugin"."is_global",
-         "posthog_plugin"."is_preinstalled",
-         "posthog_plugin"."is_stateless",
-         "posthog_plugin"."name",
-         "posthog_plugin"."description",
-         "posthog_plugin"."url",
-         "posthog_plugin"."icon",
-         "posthog_plugin"."config_schema",
-         "posthog_plugin"."tag",
-         "posthog_plugin"."archive",
-         "posthog_plugin"."latest_tag",
-         "posthog_plugin"."latest_tag_checked_at",
-         "posthog_plugin"."capabilities",
-         "posthog_plugin"."metrics",
-         "posthog_plugin"."public_jobs",
-         "posthog_plugin"."error",
-         "posthog_plugin"."from_json",
-         "posthog_plugin"."from_web",
-         "posthog_plugin"."source",
-         "posthog_plugin"."created_at",
-         "posthog_plugin"."updated_at",
-         "posthog_plugin"."log_level",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist",
-         "posthog_organization"."available_features"
-  FROM "posthog_plugin"
-  INNER JOIN "posthog_organization" ON ("posthog_plugin"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         OR "posthog_plugin"."is_global"
-         OR "posthog_plugin"."id" IN
-           (SELECT U0."plugin_id"
-            FROM "posthog_pluginconfig" U0
-            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (NOT U0."deleted"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
-  LIMIT 100
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.3
-  '''
-  SELECT 1 AS "a"
-  FROM "posthog_organizationmembership"
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 1
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.4
-  '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_plugin"
-  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         OR "posthog_plugin"."is_global"
-         OR "posthog_plugin"."id" IN
-           (SELECT U0."plugin_id"
-            FROM "posthog_pluginconfig" U0
-            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (NOT U0."deleted"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.5
-  '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
          "posthog_user"."last_login",
@@ -579,7 +398,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.6
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.21
   '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -601,6 +420,217 @@
          "posthog_organization"."domain_whitelist"
   FROM "posthog_organization"
   WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.22
+  '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.23
+  '''
+  SELECT 1 AS "a"
+  FROM "posthog_organizationmembership"
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
+  LIMIT 1
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.24
+  '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.25
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_plugin"
+  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         OR "posthog_plugin"."is_global"
+         OR "posthog_plugin"."id" IN
+           (SELECT U0."plugin_id"
+            FROM "posthog_pluginconfig" U0
+            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
+            WHERE (NOT U0."deleted"
+                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.26
+  '''
+  SELECT "posthog_plugin"."id",
+         "posthog_plugin"."organization_id",
+         "posthog_plugin"."plugin_type",
+         "posthog_plugin"."is_global",
+         "posthog_plugin"."is_preinstalled",
+         "posthog_plugin"."is_stateless",
+         "posthog_plugin"."name",
+         "posthog_plugin"."description",
+         "posthog_plugin"."url",
+         "posthog_plugin"."icon",
+         "posthog_plugin"."config_schema",
+         "posthog_plugin"."tag",
+         "posthog_plugin"."archive",
+         "posthog_plugin"."latest_tag",
+         "posthog_plugin"."latest_tag_checked_at",
+         "posthog_plugin"."capabilities",
+         "posthog_plugin"."metrics",
+         "posthog_plugin"."public_jobs",
+         "posthog_plugin"."error",
+         "posthog_plugin"."from_json",
+         "posthog_plugin"."from_web",
+         "posthog_plugin"."source",
+         "posthog_plugin"."created_at",
+         "posthog_plugin"."updated_at",
+         "posthog_plugin"."log_level",
+         "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_plugin"
+  INNER JOIN "posthog_organization" ON ("posthog_plugin"."organization_id" = "posthog_organization"."id")
+  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         OR "posthog_plugin"."is_global"
+         OR "posthog_plugin"."id" IN
+           (SELECT U0."plugin_id"
+            FROM "posthog_pluginconfig" U0
+            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
+            WHERE (NOT U0."deleted"
+                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
+  LIMIT 100
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.3
+  '''
+  SELECT 1 AS "a"
+  FROM "posthog_organizationmembership"
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
+  LIMIT 1
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.4
+  '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.5
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_plugin"
+  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         OR "posthog_plugin"."is_global"
+         OR "posthog_plugin"."id" IN
+           (SELECT U0."plugin_id"
+            FROM "posthog_pluginconfig" U0
+            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
+            WHERE (NOT U0."deleted"
+                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.6
+  '''
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."is_active",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."temporary_token",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."strapi_id",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."hedgehog_config",
+         "posthog_user"."events_column_config",
+         "posthog_user"."email_opt_in"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 2
   LIMIT 21
   '''
 # ---
@@ -631,24 +661,35 @@
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.8
   '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.9
+  '''
   SELECT 1 AS "a"
   FROM "posthog_organizationmembership"
   WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
          AND "posthog_organizationmembership"."user_id" = 2)
   LIMIT 1
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.9
-  '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_plugin"
-  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         OR "posthog_plugin"."is_global"
-         OR "posthog_plugin"."id" IN
-           (SELECT U0."plugin_id"
-            FROM "posthog_pluginconfig" U0
-            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (NOT U0."deleted"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
   '''
 # ---

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -15,12 +15,7 @@ from posthog.models import Plugin, PluginAttachment, PluginConfig, PluginSourceF
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.team.team import Team
 from posthog.models.user import User
-from posthog.plugins.access import (
-    can_configure_plugins,
-    can_globally_manage_plugins,
-    can_install_plugins,
-    can_view_plugins,
-)
+from posthog.plugins.access import can_configure_plugins, can_globally_manage_plugins, can_install_plugins
 from posthog.plugins.test.mock import mocked_plugin_requests_get
 from posthog.plugins.test.plugin_archives import (
     HELLO_WORLD_PLUGIN_GITHUB_ATTACHMENT_ZIP,
@@ -1717,12 +1712,10 @@ class TestPluginsAccessLevelAPI(APIBaseTest):
         result_root = can_globally_manage_plugins(self.organization)
         result_install = can_install_plugins(self.organization)
         result_config = can_configure_plugins(self.organization)
-        result_view = can_view_plugins(self.organization)
 
         self.assertTrue(result_root)
         self.assertTrue(result_install)
         self.assertTrue(result_config)
-        self.assertTrue(result_view)
 
     def test_install_check(self):
         self.organization.plugins_access_level = Organization.PluginsAccessLevel.INSTALL
@@ -1731,20 +1724,10 @@ class TestPluginsAccessLevelAPI(APIBaseTest):
         result_root = can_globally_manage_plugins(self.organization)
         result_install = can_install_plugins(self.organization)
         result_config = can_configure_plugins(self.organization)
-        result_view = can_view_plugins(self.organization)
 
         self.assertFalse(result_root)
         self.assertTrue(result_install)
         self.assertTrue(result_config)
-        self.assertTrue(result_view)
-
-    def test_install_check_but_different_specific_id(self):
-        self.organization.plugins_access_level = Organization.PluginsAccessLevel.INSTALL
-        self.organization.save()
-
-        result_install = can_install_plugins(self.organization, "5802AE1C-FA8E-4559-9D7A-3206E371A350")
-
-        self.assertFalse(result_install)
 
     def test_config_check(self):
         self.organization.plugins_access_level = Organization.PluginsAccessLevel.CONFIG
@@ -1753,12 +1736,10 @@ class TestPluginsAccessLevelAPI(APIBaseTest):
         result_root = can_globally_manage_plugins(self.organization)
         result_install = can_install_plugins(self.organization)
         result_config = can_configure_plugins(self.organization)
-        result_view = can_view_plugins(self.organization)
 
         self.assertFalse(result_root)
         self.assertFalse(result_install)
         self.assertTrue(result_config)
-        self.assertTrue(result_view)
 
     def test_config_check_with_id_str(self):
         self.organization.plugins_access_level = Organization.PluginsAccessLevel.CONFIG
@@ -1768,12 +1749,10 @@ class TestPluginsAccessLevelAPI(APIBaseTest):
         result_root = can_globally_manage_plugins(organization_id)
         result_install = can_install_plugins(organization_id)
         result_config = can_configure_plugins(organization_id)
-        result_view = can_view_plugins(organization_id)
 
         self.assertFalse(result_root)
         self.assertFalse(result_install)
         self.assertTrue(result_config)
-        self.assertTrue(result_view)
 
     def test_none_check(self):
         self.organization.plugins_access_level = Organization.PluginsAccessLevel.NONE
@@ -1782,20 +1761,16 @@ class TestPluginsAccessLevelAPI(APIBaseTest):
         result_root = can_globally_manage_plugins(self.organization)
         result_install = can_install_plugins(self.organization)
         result_config = can_configure_plugins(self.organization)
-        result_view = can_view_plugins(self.organization)
 
         self.assertFalse(result_root)
         self.assertFalse(result_install)
         self.assertFalse(result_config)
-        self.assertFalse(result_view)
 
     def test_no_org_check(self):
         result_root = can_globally_manage_plugins(None)
         result_install = can_install_plugins(None)
         result_config = can_configure_plugins(None)
-        result_view = can_view_plugins(None)
 
         self.assertFalse(result_root)
         self.assertFalse(result_install)
         self.assertFalse(result_config)
-        self.assertFalse(result_view)

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -945,22 +945,22 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
 
     @snapshot_postgres_queries
     def test_listing_plugins_is_not_nplus1(self, _mock_get, _mock_reload) -> None:
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             self._assert_number_of_when_listed_plugins(0)
 
         Plugin.objects.create(organization=self.organization)
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             self._assert_number_of_when_listed_plugins(1)
 
         Plugin.objects.create(organization=self.organization)
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             self._assert_number_of_when_listed_plugins(2)
 
         Plugin.objects.create(organization=self.organization)
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             self._assert_number_of_when_listed_plugins(3)
 
     def _assert_number_of_when_listed_plugins(self, expected_plugins_count: int) -> None:

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -168,7 +168,7 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
         User.objects.create_and_join(
             organization=other_org, email="test@test.com", password="123456", first_name="Test"
         )
-        # OrganizationMembership.objects.create(user=self.user, organization=other_org)
+        OrganizationMembership.objects.create(user=self.user, organization=other_org)
 
         repo_url = "https://github.com/PostHog/helloworldplugin"
         install_response = self.client.post(f"/api/organizations/{my_org.id}/plugins/", {"url": repo_url})

--- a/posthog/api/test/test_plugin.py
+++ b/posthog/api/test/test_plugin.py
@@ -943,6 +943,14 @@ class TestPluginAPI(APIBaseTest, QueryMatchingTest):
         response_this = self.client.get(f"/api/organizations/@current/plugins/{this_orgs_plugin.id}/")
         self.assertEqual(response_this.status_code, 200)
 
+    def test_can_access_global_plugin_even_if_not_in_org(self, mock_get, mock_reload):
+        other_org = Organization.objects.create(
+            name="Foo", plugins_access_level=Organization.PluginsAccessLevel.INSTALL
+        )
+        other_orgs_plugin = Plugin.objects.create(organization=other_org, is_global=True)
+        res = self.client.get(f"/api/organizations/@current/plugins/{other_orgs_plugin.id}/")
+        assert res.status_code == 200, res.json()
+
     @snapshot_postgres_queries
     def test_listing_plugins_is_not_nplus1(self, _mock_get, _mock_reload) -> None:
         with self.assertNumQueries(8):

--- a/posthog/plugins/access.py
+++ b/posthog/plugins/access.py
@@ -4,20 +4,8 @@ from uuid import UUID
 from posthog.models.organization import Organization
 
 
-def can_globally_manage_plugins(organization_or_id: Optional[Union[Organization, str, UUID]]) -> bool:
-    if organization_or_id is None:
-        return False
-    organization: Organization = (
-        organization_or_id
-        if isinstance(organization_or_id, Organization)
-        else Organization.objects.get(id=organization_or_id)
-    )
-    return organization.plugins_access_level >= Organization.PluginsAccessLevel.ROOT
-
-
-def can_install_plugins(
-    organization_or_id: Optional[Union[Organization, str, UUID]],
-    specific_organization_id: Optional[Union[str, UUID]] = None,
+def has_plugin_access_level(
+    organization_or_id: Optional[Union[Organization, str, UUID]], min_access_level: int
 ) -> bool:
     if organization_or_id is None:
         return False
@@ -26,28 +14,16 @@ def can_install_plugins(
         if isinstance(organization_or_id, Organization)
         else Organization.objects.get(id=organization_or_id)
     )
-    if specific_organization_id and str(organization.id) != str(specific_organization_id):
-        return False
-    return organization.plugins_access_level >= Organization.PluginsAccessLevel.INSTALL
+    return organization.plugins_access_level >= min_access_level
+
+
+def can_globally_manage_plugins(organization_or_id: Optional[Union[Organization, str, UUID]]) -> bool:
+    return has_plugin_access_level(organization_or_id, Organization.PluginsAccessLevel.ROOT)
+
+
+def can_install_plugins(organization_or_id: Optional[Union[Organization, str, UUID]]) -> bool:
+    return has_plugin_access_level(organization_or_id, Organization.PluginsAccessLevel.INSTALL)
 
 
 def can_configure_plugins(organization_or_id: Optional[Union[Organization, str, UUID]]) -> bool:
-    if organization_or_id is None:
-        return False
-    organization: Organization = (
-        organization_or_id
-        if isinstance(organization_or_id, Organization)
-        else Organization.objects.get(id=organization_or_id)
-    )
-    return organization.plugins_access_level >= Organization.PluginsAccessLevel.CONFIG
-
-
-def can_view_plugins(organization_or_id: Optional[Union[Organization, str, UUID]]) -> bool:
-    if organization_or_id is None:
-        return False
-    organization: Organization = (
-        organization_or_id
-        if isinstance(organization_or_id, Organization)
-        else Organization.objects.get(id=organization_or_id)
-    )
-    return organization.plugins_access_level > Organization.PluginsAccessLevel.NONE
+    return has_plugin_access_level(organization_or_id, Organization.PluginsAccessLevel.CONFIG)


### PR DESCRIPTION
## Problem

There was a lot going on in the plugins api that made reasoning on permissions hard. This refactors things to make it clearer and ensures you can always list and get things you need.

## Changes

* The queryset is simplified to always be plugins in your org, that are global, or used by plugin configs in your org
* The permissions are the same as always for general access
* We override the standard filters to allow listing global plugins
* We override the permissions _only_ for retrieve so that we can bypass the org membership check if the plugin is global

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
