### PR TITLE
chore: Upgraded clickhouse driver

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ boto3==1.28.16
 brotli==1.1.0
 celery==5.3.4
 celery-redbeat==2.1.1
-clickhouse-driver==0.2.6
+clickhouse-driver==0.2.7
 clickhouse-pool==0.5.3
 cryptography==37.0.2
 dj-database-url==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -109,7 +109,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
-clickhouse-driver==0.2.6
+clickhouse-driver==0.2.7
     # via
     #   -r requirements.in
     #   clickhouse-pool


### PR DESCRIPTION
## Changes
- Upgrades the clickhouse-driver pip package
- Follow on from https://github.com/PostHog/charts/pull/1286

### Plan:
Disable Clickhouse verify param everywhere
**Why?** Because I want to update our clickhouse-driver pip package to the [latest version](https://github.com/mymarilyn/clickhouse-driver/blob/master/CHANGELOG.md?rgh-link-date=2024-06-05T17%3A02%3A42Z) to get https://github.com/mymarilyn/clickhouse-driver/issues/400 into our codebase
**Why do we need to disable verify for this?** It turns out, prior to clickhouse-driver@0.2.7, the driver never actually verified the TLS certificates of the connections. Starting from 0.2.7, this is fixed and certification validation occurs. Enabling verification will break prod for us as seen in a recent incident (see #inc-2024-04-10-querying-down-on-eu-after-ch-driver-upgrade or [here](https://posthog.slack.com/archives/C06U4G1FPK3/p1712784280682419))
Right now, the verify param gets injected into the connection [here in the posthog app](https://github.com/PostHog/posthog/blob/tom/snowflake-sw/posthog/clickhouse/client/connection.py?rgh-link-date=2024-06-05T17%3A02%3A42Z#L64)
The plan is to get this in - disable the verify param, and then upgrade the clickhouse-driver package afterwards