### PR TITLE
fix: consider soft deleted when syncing caching state

### DIFF
--- a/posthog/caching/insight_caching_state.py
+++ b/posthog/caching/insight_caching_state.py
@@ -90,13 +90,15 @@ def insight_can_be_cached(insight: Optional[Insight]) -> bool:
 
 def sync_insight_cache_states():
     lazy_loader = LazyLoader()
-    insights = Insight.objects.all().prefetch_related("team", "sharingconfiguration_set").order_by("pk")
+    insights = (
+        Insight.objects_including_soft_deleted.all().prefetch_related("team", "sharingconfiguration_set").order_by("pk")
+    )
     for page_of_insights in _iterate_large_queryset(insights, 1000):
         batch = [upsert(insight.team, insight, lazy_loader, execute=False) for insight in page_of_insights]
         _execute_insert(batch)
 
     tiles = (
-        DashboardTile.objects.all()
+        DashboardTile.objects_including_soft_deleted.all()
         .filter(insight__isnull=False)
         .prefetch_related(
             "dashboard",

--- a/posthog/caching/test/test_insight_caching_state.py
+++ b/posthog/caching/test/test_insight_caching_state.py
@@ -470,7 +470,9 @@ def test_insight_cache_states_when_deleted_insight(team: Team, user: User):
 
     # periodic sync sets to no caching
     sync_insight_cache_states()
-    assert InsightCachingState.objects.filter(team=team, insight_id=insight.id).first().target_cache_age_seconds is None
+    single_match = InsightCachingState.objects.filter(team=team, insight_id=insight.id).first()
+    assert single_match is not None
+    assert single_match.target_cache_age_seconds is None
 
 
 class TestLazyLoader(BaseTest):


### PR DESCRIPTION
when we stopped including soft deleted in insights and dashboard tiles unless explicitly requested we stopped setting their insight caching state to "no cache"
so constantly churn retrying them