### PR TITLE
add iframe to allowed tags in api/survey.py

### DIFF
--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -517,6 +517,7 @@ def nh3_clean_with_allow_list(to_clean: str):
             "hgroup",
             "hr",
             "i",
+            "iframe",
             "img",
             "ins",
             "kbd",


### PR DESCRIPTION
in order to embed video in surveys for "in-app onboarding" type flows.

## Problem

Can embed iframe videos in preview mode, but we sanitize them in live mode. If this is workable without obvious security issues, would be great to have for our internal use in engaging users a bit better with surveys.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## How did you test this code?
