### PR TITLE
fix: add ph-no-capture to api token modal

### DIFF
--- a/frontend/src/lib/components/CodeSnippet/CodeSnippet.tsx
+++ b/frontend/src/lib/components/CodeSnippet/CodeSnippet.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx'
 import { useValues } from 'kea'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
-import { CSSProperties, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter'
 import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash'
 import dart from 'react-syntax-highlighter/dist/esm/languages/prism/dart'
@@ -81,7 +81,7 @@ export interface CodeSnippetProps {
     wrap?: boolean
     compact?: boolean
     actions?: JSX.Element
-    style?: CSSProperties
+    className?: string
     /** What is being copied. @example 'link' */
     thing?: string
     /** If set, the snippet becomes expandable when there's more than this number of lines. */
@@ -93,7 +93,7 @@ export function CodeSnippet({
     language = Language.Text,
     wrap = false,
     compact = false,
-    style,
+    className,
     actions,
     thing = 'snippet',
     maxLinesWithoutExpansion,
@@ -120,8 +120,7 @@ export function CodeSnippet({
     }
 
     return (
-        // eslint-disable-next-line react/forbid-dom-props
-        <div className={clsx('CodeSnippet', compact && 'CodeSnippet--compact')} style={style}>
+        <div className={clsx('CodeSnippet', compact && 'CodeSnippet--compact', className)}>
             <div className="CodeSnippet__actions">
                 {actions}
                 <LemonButton

--- a/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
+++ b/frontend/src/lib/components/CommandPalette/DebugCHQueries.tsx
@@ -153,7 +153,7 @@ function DebugCHQueries(): JSX.Element {
                                         language={Language.SQL}
                                         thing="query"
                                         maxLinesWithoutExpansion={10}
-                                        style={{ fontSize: 12, maxWidth: '60vw' }}
+                                        className="text-sm max-w-[60vw]"
                                     >
                                         {item.query}
                                     </CodeSnippet>
@@ -263,7 +263,7 @@ function DebugCHQueries(): JSX.Element {
                                             language={Language.JSON}
                                             maxLinesWithoutExpansion={0}
                                             key={item.query_id}
-                                            style={{ fontSize: 12, marginBottom: '0.25rem' }}
+                                            className="text-sm mb-2"
                                         >
                                             {JSON.stringify(event, null, 2)}
                                         </CodeSnippet>

--- a/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
+++ b/frontend/src/scenes/data-warehouse/ViewLinkModal.tsx
@@ -184,7 +184,7 @@ export function ViewLinkForm(): JSX.Element {
                             </div>
                         </div>
                         <div className="mt-4 flex w-full">
-                            <CodeSnippet style={{ width: '100%' }} language={Language.SQL}>
+                            <CodeSnippet className="w-full" language={Language.SQL}>
                                 {sqlCodeSnippet}
                             </CodeSnippet>
                         </div>

--- a/frontend/src/scenes/settings/user/personalAPIKeysLogic.tsx
+++ b/frontend/src/scenes/settings/user/personalAPIKeysLogic.tsx
@@ -306,7 +306,9 @@ export const personalAPIKeysLogic = kea<personalAPIKeysLogicType>([
                     <>
                         <p className="mb-4">You can now use key "{key.label}" for authentication:</p>
 
-                        <CodeSnippet thing="personal API key">{value}</CodeSnippet>
+                        <CodeSnippet className="ph-no-capture" thing="personal API key">
+                            {value}
+                        </CodeSnippet>
 
                         <LemonBanner type="warning" className="mt-4">
                             For security reasons the value above <em>will never be shown again</em>.


### PR DESCRIPTION
## Problem

this has the potential to capture sensitive information, so don't

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
