### PR TITLE
fix: Move set usage tracking earlier

### DIFF
--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -1,7 +1,7 @@
 import { PluginEvent, PostHogEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
-import { setUsageInNonPersonEventsCounter } from 'main/ingestion-queues/metrics'
 import { Message } from 'node-rdkafka'
 
+import { setUsageInNonPersonEventsCounter } from '../main/ingestion-queues/metrics'
 import {
     ClickHouseEvent,
     GroupTypeToColumnIndex,

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -1,4 +1,5 @@
 import { PluginEvent, PostHogEvent, ProcessedPluginEvent } from '@posthog/plugin-scaffold'
+import { setUsageInNonPersonEventsCounter } from 'main/ingestion-queues/metrics'
 import { Message } from 'node-rdkafka'
 
 import {
@@ -16,6 +17,14 @@ import {
     clickHouseTimestampToDateTime,
     clickHouseTimestampToISO,
 } from './utils'
+
+const PERSON_EVENTS = new Set(['$set', '$identify', '$create_alias', '$merge_dangerously', '$groupidentify'])
+const KNOWN_SET_EVENTS = new Set([
+    '$feature_interaction',
+    '$feature_enrollment_update',
+    'survey dismissed',
+    'survey sent',
+])
 
 export function convertToOnEventPayload(event: PostIngestionEvent): ProcessedPluginEvent {
     return {
@@ -236,6 +245,19 @@ export function formPipelineEvent(message: Message): PipelineEvent {
     // TODO: inefficient to do this twice?
     const { data: dataStr, ...rawEvent } = JSON.parse(message.value!.toString())
     const combinedEvent = { ...JSON.parse(dataStr), ...rawEvent }
+
+    // Track $set usage in events that aren't known to use it, before ingestion adds anything there
+    if (
+        combinedEvent.properties &&
+        !(combinedEvent.event in PERSON_EVENTS) &&
+        !(combinedEvent.event in KNOWN_SET_EVENTS) &&
+        ('$set' in combinedEvent.properties ||
+            '$set_once' in combinedEvent.properties ||
+            '$unset' in combinedEvent.properties)
+    ) {
+        setUsageInNonPersonEventsCounter.inc()
+    }
+
     const event: PipelineEvent = normalizeEvent({
         ...combinedEvent,
         site_url: combinedEvent.site_url || null,

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -1,7 +1,7 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
 
-import { eventDroppedCounter, setUsageInNonPersonEventsCounter } from '../../../main/ingestion-queues/metrics'
+import { eventDroppedCounter } from '../../../main/ingestion-queues/metrics'
 import { runInSpan } from '../../../sentry'
 import { Hub, PipelineEvent } from '../../../types'
 import { DependencyUnavailableError } from '../../../utils/db/error'
@@ -24,14 +24,6 @@ import { pluginsProcessEventStep } from './pluginsProcessEventStep'
 import { populateTeamDataStep } from './populateTeamDataStep'
 import { prepareEventStep } from './prepareEventStep'
 import { processPersonsStep } from './processPersonsStep'
-
-const PERSON_EVENTS = new Set(['$set', '$identify', '$create_alias', '$merge_dangerously', '$groupidentify'])
-const KNOWN_SET_EVENTS = new Set([
-    '$feature_interaction',
-    '$feature_enrollment_update',
-    'survey dismissed',
-    'survey sent',
-])
 
 export type EventPipelineResult = {
     // Promises that the batch handler should await on before committing offsets,
@@ -199,16 +191,6 @@ export class EventPipelineRunner {
             )
 
             return this.registerLastStep('clientIngestionWarning', [event], kafkaAcks)
-        }
-
-        // Track $set usage in events that aren't known to use it, before plugins which add various $set props.
-        if (
-            event.properties &&
-            !(event.event in PERSON_EVENTS) &&
-            !(event.event in KNOWN_SET_EVENTS) &&
-            ('$set' in event.properties || '$set_once' in event.properties || '$unset' in event.properties)
-        ) {
-            setUsageInNonPersonEventsCounter.inc()
         }
 
         const processedEvent = await this.runStep(pluginsProcessEventStep, [this, event], event.team_id)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
I forgot about the normalization and didn't realize it happens that early
Original PR for motivation https://github.com/PostHog/posthog/pull/22755

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
