### PR TITLE
feat: move session replay pinned persistence to its own queue

### DIFF
--- a/ee/session_recordings/persistence_tasks.py
+++ b/ee/session_recordings/persistence_tasks.py
@@ -3,12 +3,20 @@ from datetime import timedelta
 import structlog
 from celery import shared_task
 from django.utils import timezone
+from prometheus_client import Counter
 
 from ee.session_recordings.session_recording_extensions import persist_recording
 from posthog.session_recordings.models.session_recording import SessionRecording
 from posthog.tasks.utils import CeleryQueue
 
 logger = structlog.get_logger(__name__)
+
+REPLAY_NEEDS_PERSISTENCE_COUNTER = Counter(
+    "snapshot_persist_persistence_task_queued",
+    "Count of session recordings that need to be persisted",
+    # we normally avoid team label but not all teams pin recordings so there shouldn't be _too_ many labels here
+    labelnames=["team_id"],
+)
 
 
 @shared_task(
@@ -30,4 +38,5 @@ def persist_finished_recordings() -> None:
     logger.info("Persisting finished recordings", count=finished_recordings.count())
 
     for recording in finished_recordings:
+        REPLAY_NEEDS_PERSISTENCE_COUNTER.labels(team_id=recording.team_id).inc()
         persist_single_recording.delay(recording.session_id, recording.team_id)

--- a/ee/session_recordings/persistence_tasks.py
+++ b/ee/session_recordings/persistence_tasks.py
@@ -6,16 +6,23 @@ from django.utils import timezone
 
 from ee.session_recordings.session_recording_extensions import persist_recording
 from posthog.session_recordings.models.session_recording import SessionRecording
+from posthog.tasks.utils import CeleryQueue
 
 logger = structlog.get_logger(__name__)
 
 
-@shared_task(ignore_result=True)
+@shared_task(
+    ignore_result=True,
+    queue=CeleryQueue.SESSION_REPLAY_PERSISTENCE.value,
+)
 def persist_single_recording(id: str, team_id: int) -> None:
     persist_recording(id, team_id)
 
 
-@shared_task(ignore_result=True)
+@shared_task(
+    ignore_result=True,
+    queue=CeleryQueue.SESSION_REPLAY_PERSISTENCE.value,
+)
 def persist_finished_recordings() -> None:
     one_day_old = timezone.now() - timedelta(hours=24)
     finished_recordings = SessionRecording.objects.filter(created_at__lte=one_day_old, object_storage_path=None)

--- a/ee/session_recordings/session_recording_extensions.py
+++ b/ee/session_recordings/session_recording_extensions.py
@@ -6,7 +6,7 @@ from typing import Optional, cast
 
 import structlog
 from django.utils import timezone
-from prometheus_client import Histogram
+from prometheus_client import Histogram, Counter
 from sentry_sdk import capture_exception, capture_message
 
 from posthog import settings
@@ -19,8 +19,22 @@ logger = structlog.get_logger(__name__)
 
 SNAPSHOT_PERSIST_TIME_HISTOGRAM = Histogram(
     "snapshot_persist_time_seconds",
-    "We persist recording snapshots from S3 or from ClickHouse, how long does that take?",
-    labelnames=["source"],
+    "We persist recording snapshots from S3, how long does that take?",
+)
+
+SNAPSHOT_PERSIST_SUCCESS_COUNTER = Counter(
+    "snapshot_persist_success",
+    "Count of session recordings that were successfully persisted",
+)
+
+SNAPSHOT_PERSIST_FAILURE_COUNTER = Counter(
+    "snapshot_persist_failure",
+    "Count of session recordings that failed to be persisted",
+)
+
+SNAPSHOT_PERSIST_TOO_YOUNG_COUNTER = Counter(
+    "snapshot_persist_too_young",
+    "Count of session recordings that were too young to be persisted",
 )
 
 MINIMUM_AGE_FOR_RECORDING = timedelta(hours=24)
@@ -98,19 +112,21 @@ def persist_recording(recording_id: str, team_id: int) -> None:
             recording_id=recording_id,
             team_id=team_id,
         )
+        SNAPSHOT_PERSIST_TOO_YOUNG_COUNTER.inc()
         recording.save()
         return
 
     target_prefix = recording.build_object_storage_path("2023-08-01")
     source_prefix = recording.build_blob_ingestion_storage_path()
     # if snapshots are already in blob storage, then we can just copy the files between buckets
-    with SNAPSHOT_PERSIST_TIME_HISTOGRAM.labels(source="S3").time():
+    with SNAPSHOT_PERSIST_TIME_HISTOGRAM.time():
         copied_count = object_storage.copy_objects(source_prefix, target_prefix)
 
     if copied_count > 0:
         recording.storage_version = "2023-08-01"
         recording.object_storage_path = target_prefix
         recording.save()
+        SNAPSHOT_PERSIST_SUCCESS_COUNTER.inc()
         logger.info(
             "Persisting recording: done!",
             recording_id=recording_id,
@@ -119,6 +135,7 @@ def persist_recording(recording_id: str, team_id: int) -> None:
         )
         return
     else:
+        SNAPSHOT_PERSIST_FAILURE_COUNTER.inc()
         logger.error(
             "No snapshots found to copy in S3 when persisting a recording",
             recording_id=recording_id,

--- a/posthog/tasks/utils.py
+++ b/posthog/tasks/utils.py
@@ -36,3 +36,4 @@ class CeleryQueue(Enum):
     SUBSCRIPTION_DELIVERY = "subscription_delivery"
     USAGE_REPORTS = "usage_reports"
     SESSION_REPLAY_EMBEDDINGS = "session_replay_embeddings"
+    SESSION_REPLAY_PERSISTENCE = "session_replay_persistence"


### PR DESCRIPTION
pairs with https://github.com/PostHog/charts/pull/1300

we don't want pinned replay persistence to cause celery queue depth alerts