### PR TITLE
chore(plugin-server): move person kafka ack awaits to the batch-level…

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -754,20 +754,14 @@ export class DB {
             personUpdateVersionMismatchCounter.inc()
         }
 
-        const kafkaMessages = []
-        const message = generateKafkaPersonUpdateMessage(updatedPerson)
-        if (tx) {
-            kafkaMessages.push(message)
-        } else {
-            await this.kafkaProducer.queueMessage({ kafkaMessage: message, waitForAck: true })
-        }
+        const kafkaMessage = generateKafkaPersonUpdateMessage(updatedPerson)
 
         status.debug(
             '🧑‍🦰',
             `Updated person ${updatedPerson.uuid} of team ${updatedPerson.team_id} to version ${updatedPerson.version}.`
         )
 
-        return [updatedPerson, kafkaMessages]
+        return [updatedPerson, [kafkaMessage]]
     }
 
     public async deletePerson(person: InternalPerson, tx?: TransactionClient): Promise<ProducerRecord[]> {

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -10,13 +10,13 @@ export async function processPersonsStep(
     event: PluginEvent,
     timestamp: DateTime,
     processPerson: boolean
-): Promise<[PluginEvent, Person]> {
+): Promise<[PluginEvent, Person, Promise<void>]> {
     let overridesWriter: DeferredPersonOverrideWriter | undefined = undefined
     if (runner.poEEmbraceJoin) {
         overridesWriter = new DeferredPersonOverrideWriter(runner.hub.db.postgres)
     }
 
-    const person = await new PersonState(
+    const [person, kafkaAck] = await new PersonState(
         event,
         event.team_id,
         String(event.distinct_id),
@@ -27,5 +27,5 @@ export async function processPersonsStep(
         overridesWriter
     ).update()
 
-    return [event, person]
+    return [event, person, kafkaAck]
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -203,11 +203,12 @@ export class EventPipelineRunner {
             event.team_id
         )
 
-        const [postPersonEvent, person] = await this.runStep(
+        const [postPersonEvent, person, personKafkaAck] = await this.runStep(
             processPersonsStep,
             [this, normalizedEvent, timestamp, processPerson],
             event.team_id
         )
+        kafkaAcks.push(personKafkaAck)
 
         const preparedEvent = await this.runStep(
             prepareEventStep,


### PR DESCRIPTION
… await

## Problem

For Person merges and Person property updates we were still awaiting the Kafka ACKs deep in the code.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Pull Person-related ACK awaits into the existing toplevel `await`.

It's not pretty, but it follows the well established Ack pattern in the plugin-server. I think we may want to hide all of these Ack promises in some object (on the Hub...?) and await them at the top-level. I started down that path but everything was intertwined so much that I wasn't feel I was making progress.

Note that `createPerson` is still await produces, I will follow-up if we want, but this is getting noisy.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Existing

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
