### PR TITLE
chore(plugin-server): drop non-lazy personless mode

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -137,7 +137,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         RUSTY_HOOK_ROLLOUT_PERCENTAGE: 0,
         RUSTY_HOOK_URL: '',
         CAPTURE_CONFIG_REDIS_HOST: null,
-        LAZY_PERSON_CREATION_TEAMS: '',
 
         STARTUP_PROFILE_DURATION_SECONDS: 300, // 5 minutes
         STARTUP_PROFILE_CPU: false,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -212,7 +212,6 @@ export interface PluginsServerConfig {
     SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
     PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
     CAPTURE_CONFIG_REDIS_HOST: string | null // Redis cluster to use to coordinate with capture (overflow, routing)
-    LAZY_PERSON_CREATION_TEAMS: string
 
     // dump profiles to disk, covering the first N seconds of runtime
     STARTUP_PROFILE_DURATION_SECONDS: number
@@ -299,7 +298,6 @@ export interface Hub extends PluginsServerConfig {
     pluginConfigsToSkipElementsParsing: ValueMatcher<number>
     poeEmbraceJoinForTeams: ValueMatcher<number>
     poeWritesExcludeTeams: ValueMatcher<number>
-    lazyPersonCreationTeams: ValueMatcher<number>
     // lookups
     eventsToDropByToken: Map<string, string[]>
 }

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -204,7 +204,6 @@ export async function createHub(
         pluginConfigsToSkipElementsParsing: buildIntegerMatcher(process.env.SKIP_ELEMENTS_PARSING_PLUGINS, true),
         poeEmbraceJoinForTeams: buildIntegerMatcher(process.env.POE_EMBRACE_JOIN_FOR_TEAMS, true),
         poeWritesExcludeTeams: buildIntegerMatcher(process.env.POE_WRITES_EXCLUDE_TEAMS, false),
-        lazyPersonCreationTeams: buildIntegerMatcher(process.env.LAZY_PERSON_CREATION_TEAMS, true),
         eventsToDropByToken: createEventsToDropByToken(process.env.DROP_EVENTS_BY_TOKEN_DISTINCT_ID),
     }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/processPersonsStep.ts
@@ -23,7 +23,6 @@ export async function processPersonsStep(
         timestamp,
         processPerson,
         runner.hub.db,
-        runner.hub.lazyPersonCreationTeams(event.team_id),
         overridesWriter
     ).update()
 

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -92,7 +92,6 @@ export class PersonState {
         private timestamp: DateTime,
         private processPerson: boolean, // $process_person_profile flag from the event
         private db: DB,
-        private lazyPersonCreation: boolean,
         private personOverrideWriter?: DeferredPersonOverrideWriter
     ) {
         this.eventProperties = event.properties!
@@ -104,50 +103,39 @@ export class PersonState {
 
     async update(): Promise<[Person, Promise<void>]> {
         if (!this.processPerson) {
-            if (this.lazyPersonCreation) {
-                const existingPerson = await this.db.fetchPerson(this.teamId, this.distinctId, { useReadReplica: true })
-                if (existingPerson) {
-                    const person = existingPerson as Person
-
-                    // Ensure person properties don't propagate elsewhere, such as onto the event itself.
-                    person.properties = {}
-
-                    if (this.timestamp > person.created_at.plus({ minutes: 1 })) {
-                        // See documentation on the field.
-                        //
-                        // Note that we account for timestamp vs person creation time (with a little
-                        // padding for good measure) to account for ingestion lag. It's possible for
-                        // events to be processed after person creation even if they were sent prior
-                        // to person creation, and the user did nothing wrong in that case.
-                        person.force_upgrade = true
-                    }
-
-                    return [person, Promise.resolve()]
-                }
-
-                // We need a value from the `person_created_column` in ClickHouse. This should be
-                // hidden from users for events without a real person, anyway. It's slightly offset
-                // from the 0 date (by 5 seconds) in order to assist in debugging by being
-                // harmlessly distinct from Unix UTC "0".
-                const createdAt = DateTime.utc(1970, 1, 1, 0, 0, 5)
-
-                const fakePerson: Person = {
-                    team_id: this.teamId,
-                    properties: {},
-                    uuid: uuidFromDistinctId(this.teamId, this.distinctId),
-                    created_at: createdAt,
-                }
-                return [fakePerson, Promise.resolve()]
-            } else {
-                // We don't need to handle any properties for `processPerson=false` events, so we can
-                // short circuit by just finding or creating a person and returning early.
-                const [person, _] = await promiseRetry(() => this.createOrGetPerson(), 'get_person_personless')
+            const existingPerson = await this.db.fetchPerson(this.teamId, this.distinctId, { useReadReplica: true })
+            if (existingPerson) {
+                const person = existingPerson as Person
 
                 // Ensure person properties don't propagate elsewhere, such as onto the event itself.
                 person.properties = {}
 
+                if (this.timestamp > person.created_at.plus({ minutes: 1 })) {
+                    // See documentation on the field.
+                    //
+                    // Note that we account for timestamp vs person creation time (with a little
+                    // padding for good measure) to account for ingestion lag. It's possible for
+                    // events to be processed after person creation even if they were sent prior
+                    // to person creation, and the user did nothing wrong in that case.
+                    person.force_upgrade = true
+                }
+
                 return [person, Promise.resolve()]
             }
+
+            // We need a value from the `person_created_column` in ClickHouse. This should be
+            // hidden from users for events without a real person, anyway. It's slightly offset
+            // from the 0 date (by 5 seconds) in order to assist in debugging by being
+            // harmlessly distinct from Unix UTC "0".
+            const createdAt = DateTime.utc(1970, 1, 1, 0, 0, 5)
+
+            const fakePerson: Person = {
+                team_id: this.teamId,
+                properties: {},
+                uuid: uuidFromDistinctId(this.teamId, this.distinctId),
+                created_at: createdAt,
+            }
+            return [fakePerson, Promise.resolve()]
         }
 
         const [person, identifyOrAliasKafkaAck]: [InternalPerson | undefined, Promise<void>] =
@@ -419,8 +407,9 @@ export class PersonState {
         // Overrides are only created when the version is > 0, see:
         //   https://github.com/PostHog/posthog/blob/92e17ce307a577c4233d4ab252eebc6c2207a5ee/posthog/models/person/sql.py#L269-L287
         //
-        // With the addition of optional person processing, we are now rolling out a change to
-        // lazily create `posthog_persondistinctid` and `posthog_person` rows. This means that:
+        // With the addition of optional person processing, we are no longer creating
+        // `posthog_persondistinctid` and `posthog_person` rows when $process_person_profile=false.
+        // This means that:
         // 1. At merge time, it's possible this `distinct_id` and its deterministically generated
         //    `person.uuid` has already been used for events in ClickHouse, but they have no
         //    corresponding rows in the `posthog_persondistinctid` or `posthog_person` tables
@@ -429,10 +418,7 @@ export class PersonState {
         //    `distinct_id` even though we're just now INSERT-ing it into Postgres/ClickHouse. We do
         //    this by starting with `version=1`, as if we had just deleted the old user and were
         //    updating the `distinct_id` row as part of the merge
-        let addDistinctIdVersion = 0
-        if (this.lazyPersonCreation) {
-            addDistinctIdVersion = 1
-        }
+        const addDistinctIdVersion = 1
 
         if (otherPerson && !mergeIntoPerson) {
             await this.db.addDistinctId(otherPerson, mergeIntoDistinctId, addDistinctIdVersion)


### PR DESCRIPTION
… await## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Lazy person creation is 100% rolled out, these branches just add noise.

## Changes

Drop the non-lazy personless code paths.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Existing
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
