### PR TITLE
chore: metric for batch insight caching state updates

### DIFF
--- a/posthog/caching/insight_caching_state.py
+++ b/posthog/caching/insight_caching_state.py
@@ -29,6 +29,11 @@ TARGET_CACHE_AGE_COUNTER = Counter(
     labelnames=["target_cache_age"],
 )
 
+INSIGHT_CACHING_STATES_UPSERTED_COUNT = Counter(
+    "insight_cache_state_upserted_count",
+    "Count of insight caching states upserted, this is the success signal",
+)
+
 
 # :TODO: Make these configurable
 class TargetCacheAge(Enum):
@@ -278,3 +283,4 @@ def _execute_insert(states: list[Optional[InsightCachingState]]):
     with connection.cursor() as cursor:
         query = INSERT_INSIGHT_CACHING_STATES_QUERY.format(values=", ".join(values))
         cursor.execute(query, params=params)
+        INSIGHT_CACHING_STATES_UPSERTED_COUNT.inc(cursor.rowcount)


### PR DESCRIPTION
the batch insight cache state update job logs nothing... so i can't see if it's working

let's emit the number of items upserted