### PR TITLE
fix: use keyboard navigation in toolbar

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonMenu/useKeyboardNavigation.ts
+++ b/frontend/src/lib/lemon-ui/LemonMenu/useKeyboardNavigation.ts
@@ -42,12 +42,12 @@ export function useKeyboardNavigation<R extends HTMLElement = HTMLElement, I ext
 
         referenceRef.current?.addEventListener('keydown', handleKeyDown)
         for (const item of itemsRef.current) {
-            item.current?.addEventListener('keydown', handleKeyDown)
+            item?.current?.addEventListener('keydown', handleKeyDown)
         }
         return () => {
             referenceRef.current?.removeEventListener('keydown', handleKeyDown)
             for (const item of itemsRef.current) {
-                item.current?.removeEventListener('keydown', handleKeyDown)
+                item?.current?.removeEventListener('keydown', handleKeyDown)
             }
         }
     }, [focusedItemIndex, itemCount])


### PR DESCRIPTION
<img width="621" alt="Screenshot 2024-06-07 at 09 50 38" src="https://github.com/PostHog/posthog/assets/984817/d51f976a-326b-47db-87f6-3a0364b5bc8f">

lemon menu is throwing an error and killing the toolbar on a customer's site
the itemsRef is an array of undefineds and then we treat them as not undefined
protect ourselves against that

see https://posthoghelp.zendesk.com/agent/tickets/14418 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/16387)