### PR TITLE
fix: Heartbeating for all exports and other fixes

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -8,6 +8,7 @@ from asgiref.sync import sync_to_async
 from celery import shared_task
 from django.conf import settings
 from django.utils import timezone
+from structlog.typing import FilteringBoundLogger
 
 from posthog.batch_exports.models import BatchExportRun
 from posthog.cloud_utils import is_cloud
@@ -162,7 +163,7 @@ def send_fatal_plugin_error(
 @shared_task(**EMAIL_TASK_KWARGS)
 async def send_batch_export_run_failure(
     batch_export_run_id: str,
-    logger,
+    logger: FilteringBoundLogger,
 ) -> None:
     is_email_available_result = await sync_to_async(is_email_available)(with_absolute_urls=True)
     if not is_email_available_result:

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -465,7 +465,7 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
         from posthog.tasks.email import send_batch_export_run_failure
 
         try:
-            await send_batch_export_run_failure(inputs.id)
+            await send_batch_export_run_failure(inputs.id, logger)
         except Exception:
             logger.exception("Failure email notification could not be sent")
 

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -69,6 +69,15 @@ def get_timestamp_predicates_for_team(team_id: int, is_backfill: bool = False) -
         )
 
 
+def get_timestamp_field(is_backfill: bool) -> str:
+    """Return the field to use for timestamp bounds."""
+    if is_backfill:
+        timestamp_field = "timestamp"
+    else:
+        timestamp_field = "COALESCE(inserted_at, _timestamp)"
+    return timestamp_field
+
+
 async def get_rows_count(
     client: ClickHouseClient,
     team_id: int,
@@ -96,10 +105,7 @@ async def get_rows_count(
         include_events_statement = ""
         events_to_include_tuple = ()
 
-    if is_backfill:
-        timestamp_field = "timestamp"
-    else:
-        timestamp_field = "COALESCE(inserted_at, _timestamp)"
+    timestamp_field = get_timestamp_field(is_backfill)
     timestamp_predicates = get_timestamp_predicates_for_team(team_id, is_backfill)
 
     query = SELECT_QUERY_TEMPLATE.substitute(
@@ -201,10 +207,7 @@ def iter_records(
         include_events_statement = ""
         events_to_include_tuple = ()
 
-    if is_backfill:
-        timestamp_field = "timestamp"
-    else:
-        timestamp_field = "COALESCE(inserted_at, _timestamp)"
+    timestamp_field = get_timestamp_field(is_backfill)
     timestamp_predicates = get_timestamp_predicates_for_team(team_id, is_backfill)
 
     if fields is None:

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -464,11 +464,6 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
 
         from posthog.tasks.email import send_batch_export_run_failure
 
-        if batch_export_run.status == BatchExportRun.Status.FAILED:
-            from posthog.tasks.email import send_batch_export_run_failure
-
-        from posthog.tasks.email import send_batch_export_run_failure
-
         try:
             await send_batch_export_run_failure(inputs.id)
         except Exception:

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -465,7 +465,7 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
         from posthog.tasks.email import send_batch_export_run_failure
 
         try:
-            await send_batch_export_run_failure(inputs.id, logger)
+            await send_batch_export_run_failure(inputs.id)
         except Exception:
             logger.exception("Failure email notification could not be sent")
 

--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -40,6 +40,7 @@ from posthog.temporal.batch_exports.temporary_file import (
 )
 from posthog.temporal.batch_exports.utils import peek_first_and_rewind, try_set_batch_export_run_to_running
 from posthog.temporal.common.clickhouse import get_client
+from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import bind_temporal_worker_logger
 
 
@@ -255,107 +256,108 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs) -> Records
         inputs.table_name,
     )
 
-    await try_set_batch_export_run_to_running(run_id=inputs.run_id, logger=logger)
+    async with Heartbeater():
+        await try_set_batch_export_run_to_running(run_id=inputs.run_id, logger=logger)
 
-    async with get_client(team_id=inputs.team_id) as client:
-        if not await client.is_alive():
-            raise ConnectionError("Cannot establish connection to ClickHouse")
+        async with get_client(team_id=inputs.team_id) as client:
+            if not await client.is_alive():
+                raise ConnectionError("Cannot establish connection to ClickHouse")
 
-        if inputs.batch_export_schema is None:
-            fields = postgres_default_fields()
-            query_parameters = None
+            if inputs.batch_export_schema is None:
+                fields = postgres_default_fields()
+                query_parameters = None
 
-        else:
-            fields = inputs.batch_export_schema["fields"]
-            query_parameters = inputs.batch_export_schema["values"]
+            else:
+                fields = inputs.batch_export_schema["fields"]
+                query_parameters = inputs.batch_export_schema["values"]
 
-        record_iterator = iter_records(
-            client=client,
-            team_id=inputs.team_id,
-            interval_start=inputs.data_interval_start,
-            interval_end=inputs.data_interval_end,
-            exclude_events=inputs.exclude_events,
-            include_events=inputs.include_events,
-            fields=fields,
-            extra_query_parameters=query_parameters,
-            is_backfill=inputs.is_backfill,
-        )
-
-        if inputs.batch_export_schema is None:
-            table_fields = [
-                ("uuid", "VARCHAR(200)"),
-                ("event", "VARCHAR(200)"),
-                ("properties", "JSONB"),
-                ("elements", "JSONB"),
-                ("set", "JSONB"),
-                ("set_once", "JSONB"),
-                ("distinct_id", "VARCHAR(200)"),
-                ("team_id", "INTEGER"),
-                ("ip", "VARCHAR(200)"),
-                ("site_url", "VARCHAR(200)"),
-                ("timestamp", "TIMESTAMP WITH TIME ZONE"),
-            ]
-
-        else:
-            first_record, record_iterator = peek_first_and_rewind(record_iterator)
-
-            column_names = [column for column in first_record.schema.names if column != "_inserted_at"]
-            record_schema = first_record.select(column_names).schema
-            table_fields = get_postgres_fields_from_record_schema(
-                record_schema, known_json_columns=["properties", "set", "set_once", "person_properties"]
+            record_iterator = iter_records(
+                client=client,
+                team_id=inputs.team_id,
+                interval_start=inputs.data_interval_start,
+                interval_end=inputs.data_interval_end,
+                exclude_events=inputs.exclude_events,
+                include_events=inputs.include_events,
+                fields=fields,
+                extra_query_parameters=query_parameters,
+                is_backfill=inputs.is_backfill,
             )
 
-        async with postgres_connection(inputs) as connection:
-            await create_table_in_postgres(
-                connection,
-                schema=inputs.schema,
-                table_name=inputs.table_name,
-                fields=table_fields,
-            )
+            if inputs.batch_export_schema is None:
+                table_fields = [
+                    ("uuid", "VARCHAR(200)"),
+                    ("event", "VARCHAR(200)"),
+                    ("properties", "JSONB"),
+                    ("elements", "JSONB"),
+                    ("set", "JSONB"),
+                    ("set_once", "JSONB"),
+                    ("distinct_id", "VARCHAR(200)"),
+                    ("team_id", "INTEGER"),
+                    ("ip", "VARCHAR(200)"),
+                    ("site_url", "VARCHAR(200)"),
+                    ("timestamp", "TIMESTAMP WITH TIME ZONE"),
+                ]
 
-        schema_columns = [field[0] for field in table_fields]
+            else:
+                first_record, record_iterator = peek_first_and_rewind(record_iterator)
 
-        rows_exported = get_rows_exported_metric()
-        bytes_exported = get_bytes_exported_metric()
+                column_names = [column for column in first_record.schema.names if column != "_inserted_at"]
+                record_schema = first_record.select(column_names).schema
+                table_fields = get_postgres_fields_from_record_schema(
+                    record_schema, known_json_columns=["properties", "set", "set_once", "person_properties"]
+                )
 
-        with BatchExportTemporaryFile() as pg_file:
             async with postgres_connection(inputs) as connection:
+                await create_table_in_postgres(
+                    connection,
+                    schema=inputs.schema,
+                    table_name=inputs.table_name,
+                    fields=table_fields,
+                )
 
-                async def flush_to_postgres():
-                    logger.debug(
-                        "Copying %s records of size %s bytes",
-                        pg_file.records_since_last_reset,
-                        pg_file.bytes_since_last_reset,
-                    )
-                    await copy_tsv_to_postgres(
-                        pg_file,
-                        connection,
-                        inputs.schema,
-                        inputs.table_name,
-                        schema_columns,
-                    )
-                    rows_exported.add(pg_file.records_since_last_reset)
-                    bytes_exported.add(pg_file.bytes_since_last_reset)
+            schema_columns = [field[0] for field in table_fields]
 
-                for record_batch in record_iterator:
-                    for result in record_batch.select(schema_columns).to_pylist():
-                        row = result
+            rows_exported = get_rows_exported_metric()
+            bytes_exported = get_bytes_exported_metric()
 
-                        if "elements" in row and inputs.batch_export_schema is None:
-                            row["elements"] = json.dumps(row["elements"])
+            with BatchExportTemporaryFile() as pg_file:
+                async with postgres_connection(inputs) as connection:
 
-                        pg_file.write_records_to_tsv(
-                            [row], fieldnames=schema_columns, quoting=csv.QUOTE_MINIMAL, escapechar=None
+                    async def flush_to_postgres():
+                        logger.debug(
+                            "Copying %s records of size %s bytes",
+                            pg_file.records_since_last_reset,
+                            pg_file.bytes_since_last_reset,
                         )
+                        await copy_tsv_to_postgres(
+                            pg_file,
+                            connection,
+                            inputs.schema,
+                            inputs.table_name,
+                            schema_columns,
+                        )
+                        rows_exported.add(pg_file.records_since_last_reset)
+                        bytes_exported.add(pg_file.bytes_since_last_reset)
 
-                        if pg_file.tell() > settings.BATCH_EXPORT_POSTGRES_UPLOAD_CHUNK_SIZE_BYTES:
-                            await flush_to_postgres()
-                            pg_file.reset()
+                    for record_batch in record_iterator:
+                        for result in record_batch.select(schema_columns).to_pylist():
+                            row = result
 
-                if pg_file.tell() > 0:
-                    await flush_to_postgres()
+                            if "elements" in row and inputs.batch_export_schema is None:
+                                row["elements"] = json.dumps(row["elements"])
 
-            return pg_file.records_total
+                            pg_file.write_records_to_tsv(
+                                [row], fieldnames=schema_columns, quoting=csv.QUOTE_MINIMAL, escapechar=None
+                            )
+
+                            if pg_file.tell() > settings.BATCH_EXPORT_POSTGRES_UPLOAD_CHUNK_SIZE_BYTES:
+                                await flush_to_postgres()
+                                pg_file.reset()
+
+                    if pg_file.tell() > 0:
+                        await flush_to_postgres()
+
+                return pg_file.records_total
 
 
 @workflow.defn(name="postgres-export")
@@ -455,6 +457,4 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
                 "NotNullViolation",
             ],
             finish_inputs=finish_inputs,
-            # Disable heartbeat timeout until we add heartbeat support.
-            heartbeat_timeout_seconds=None,
         )

--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -32,8 +32,9 @@ from posthog.temporal.batch_exports.postgres_batch_export import (
     create_table_in_postgres,
     postgres_connection,
 )
-from posthog.temporal.batch_exports.utils import peek_first_and_rewind
+from posthog.temporal.batch_exports.utils import peek_first_and_rewind, try_set_batch_export_run_to_running
 from posthog.temporal.common.clickhouse import get_client
+from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import bind_temporal_worker_logger
 
 
@@ -298,92 +299,95 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs) -> Records
         inputs.table_name,
     )
 
-    async with get_client(team_id=inputs.team_id) as client:
-        if not await client.is_alive():
-            raise ConnectionError("Cannot establish connection to ClickHouse")
+    async with Heartbeater():
+        await try_set_batch_export_run_to_running(run_id=inputs.run_id, logger=logger)
 
-        if inputs.batch_export_schema is None:
-            fields = redshift_default_fields()
-            query_parameters = None
+        async with get_client(team_id=inputs.team_id) as client:
+            if not await client.is_alive():
+                raise ConnectionError("Cannot establish connection to ClickHouse")
 
-        else:
-            fields = inputs.batch_export_schema["fields"]
-            query_parameters = inputs.batch_export_schema["values"]
+            if inputs.batch_export_schema is None:
+                fields = redshift_default_fields()
+                query_parameters = None
 
-        record_iterator = iter_records(
-            client=client,
-            team_id=inputs.team_id,
-            interval_start=inputs.data_interval_start,
-            interval_end=inputs.data_interval_end,
-            exclude_events=inputs.exclude_events,
-            include_events=inputs.include_events,
-            fields=fields,
-            extra_query_parameters=query_parameters,
-            is_backfill=inputs.is_backfill,
-        )
+            else:
+                fields = inputs.batch_export_schema["fields"]
+                query_parameters = inputs.batch_export_schema["values"]
 
-        known_super_columns = ["properties", "set", "set_once", "person_properties"]
-
-        if inputs.properties_data_type != "varchar":
-            properties_type = "SUPER"
-        else:
-            properties_type = "VARCHAR(65535)"
-
-        if inputs.batch_export_schema is None:
-            table_fields = [
-                ("uuid", "VARCHAR(200)"),
-                ("event", "VARCHAR(200)"),
-                ("properties", properties_type),
-                ("elements", "VARCHAR(65535)"),
-                ("set", properties_type),
-                ("set_once", properties_type),
-                ("distinct_id", "VARCHAR(200)"),
-                ("team_id", "INTEGER"),
-                ("ip", "VARCHAR(200)"),
-                ("site_url", "VARCHAR(200)"),
-                ("timestamp", "TIMESTAMP WITH TIME ZONE"),
-            ]
-        else:
-            first_record, record_iterator = peek_first_and_rewind(record_iterator)
-
-            column_names = [column for column in first_record.schema.names if column != "_inserted_at"]
-            record_schema = first_record.select(column_names).schema
-            table_fields = get_redshift_fields_from_record_schema(
-                record_schema, known_super_columns=known_super_columns
+            record_iterator = iter_records(
+                client=client,
+                team_id=inputs.team_id,
+                interval_start=inputs.data_interval_start,
+                interval_end=inputs.data_interval_end,
+                exclude_events=inputs.exclude_events,
+                include_events=inputs.include_events,
+                fields=fields,
+                extra_query_parameters=query_parameters,
+                is_backfill=inputs.is_backfill,
             )
 
-        async with redshift_connection(inputs) as connection:
-            await create_table_in_postgres(
-                connection,
-                schema=inputs.schema,
-                table_name=inputs.table_name,
-                fields=table_fields,
-            )
+            known_super_columns = ["properties", "set", "set_once", "person_properties"]
 
-        schema_columns = {field[0] for field in table_fields}
+            if inputs.properties_data_type != "varchar":
+                properties_type = "SUPER"
+            else:
+                properties_type = "VARCHAR(65535)"
 
-        def map_to_record(row: dict) -> dict:
-            """Map row to a record to insert to Redshift."""
-            record = {k: v for k, v in row.items() if k in schema_columns}
+            if inputs.batch_export_schema is None:
+                table_fields = [
+                    ("uuid", "VARCHAR(200)"),
+                    ("event", "VARCHAR(200)"),
+                    ("properties", properties_type),
+                    ("elements", "VARCHAR(65535)"),
+                    ("set", properties_type),
+                    ("set_once", properties_type),
+                    ("distinct_id", "VARCHAR(200)"),
+                    ("team_id", "INTEGER"),
+                    ("ip", "VARCHAR(200)"),
+                    ("site_url", "VARCHAR(200)"),
+                    ("timestamp", "TIMESTAMP WITH TIME ZONE"),
+                ]
+            else:
+                first_record, record_iterator = peek_first_and_rewind(record_iterator)
 
-            for column in known_super_columns:
-                if record.get(column, None) is not None:
-                    # TODO: We should be able to save a json.loads here.
-                    record[column] = json.dumps(
-                        remove_escaped_whitespace_recursive(json.loads(record[column])), ensure_ascii=False
-                    )
+                column_names = [column for column in first_record.schema.names if column != "_inserted_at"]
+                record_schema = first_record.select(column_names).schema
+                table_fields = get_redshift_fields_from_record_schema(
+                    record_schema, known_super_columns=known_super_columns
+                )
 
-            return record
+            async with redshift_connection(inputs) as connection:
+                await create_table_in_postgres(
+                    connection,
+                    schema=inputs.schema,
+                    table_name=inputs.table_name,
+                    fields=table_fields,
+                )
 
-        async with postgres_connection(inputs) as connection:
-            records_completed = await insert_records_to_redshift(
-                (map_to_record(record) for record_batch in record_iterator for record in record_batch.to_pylist()),
-                connection,
-                inputs.schema,
-                inputs.table_name,
-            )
+            schema_columns = {field[0] for field in table_fields}
 
-        return records_completed
+            def map_to_record(row: dict) -> dict:
+                """Map row to a record to insert to Redshift."""
+                record = {k: v for k, v in row.items() if k in schema_columns}
+
+                for column in known_super_columns:
+                    if record.get(column, None) is not None:
+                        # TODO: We should be able to save a json.loads here.
+                        record[column] = json.dumps(
+                            remove_escaped_whitespace_recursive(json.loads(record[column])), ensure_ascii=False
+                        )
+
+                return record
+
+            async with postgres_connection(inputs) as connection:
+                records_completed = await insert_records_to_redshift(
+                    (map_to_record(record) for record_batch in record_iterator for record in record_batch.to_pylist()),
+                    connection,
+                    inputs.schema,
+                    inputs.table_name,
+                )
+
+            return records_completed
 
 
 @workflow.defn(name="redshift-export")
@@ -483,6 +487,4 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
                 "InsufficientPrivilege",
             ],
             finish_inputs=finish_inputs,
-            # Disable heartbeat timeout until we add heartbeat support.
-            heartbeat_timeout_seconds=None,
         )

--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -39,8 +39,9 @@ from posthog.temporal.batch_exports.metrics import (
 from posthog.temporal.batch_exports.temporary_file import (
     BatchExportTemporaryFile,
 )
-from posthog.temporal.batch_exports.utils import peek_first_and_rewind
+from posthog.temporal.batch_exports.utils import peek_first_and_rewind, try_set_batch_export_run_to_running
 from posthog.temporal.common.clickhouse import get_client
+from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import bind_temporal_worker_logger
 from posthog.temporal.common.utils import (
     BatchExportHeartbeatDetails,
@@ -412,142 +413,133 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs) -> Recor
         inputs.table_name,
     )
 
-    should_resume, details = await should_resume_from_activity_heartbeat(activity, SnowflakeHeartbeatDetails, logger)
+    async with Heartbeater() as heartbeater:
+        await try_set_batch_export_run_to_running(run_id=inputs.run_id, logger=logger)
 
-    if should_resume is True and details is not None:
-        data_interval_start = details.last_inserted_at.isoformat()
-        last_inserted_at = details.last_inserted_at
-        file_no = details.file_no
-    else:
-        data_interval_start = inputs.data_interval_start
-        last_inserted_at = None
-        file_no = 0
-
-    async with get_client(team_id=inputs.team_id) as client:
-        if not await client.is_alive():
-            raise ConnectionError("Cannot establish connection to ClickHouse")
-
-        rows_exported = get_rows_exported_metric()
-        bytes_exported = get_bytes_exported_metric()
-
-        async def flush_to_snowflake(
-            connection: SnowflakeConnection,
-            file: BatchExportTemporaryFile,
-            table_name: str,
-            file_no: int,
-            last: bool = False,
-        ):
-            logger.info(
-                "Putting %sfile %s containing %s records with size %s bytes",
-                "last " if last else "",
-                file_no,
-                file.records_since_last_reset,
-                file.bytes_since_last_reset,
-            )
-
-            await put_file_to_snowflake_table(connection, file, table_name, file_no)
-            rows_exported.add(file.records_since_last_reset)
-            bytes_exported.add(file.bytes_since_last_reset)
-
-        if inputs.batch_export_schema is None:
-            fields = snowflake_default_fields()
-            query_parameters = None
-
-        else:
-            fields = inputs.batch_export_schema["fields"]
-            query_parameters = inputs.batch_export_schema["values"]
-
-        record_iterator = iter_records(
-            client=client,
-            team_id=inputs.team_id,
-            interval_start=data_interval_start,
-            interval_end=inputs.data_interval_end,
-            exclude_events=inputs.exclude_events,
-            include_events=inputs.include_events,
-            fields=fields,
-            extra_query_parameters=query_parameters,
-            is_backfill=inputs.is_backfill,
+        should_resume, details = await should_resume_from_activity_heartbeat(
+            activity, SnowflakeHeartbeatDetails, logger
         )
 
-        known_variant_columns = ["properties", "people_set", "people_set_once", "person_properties"]
-        if inputs.batch_export_schema is None:
-            table_fields = [
-                ("uuid", "STRING"),
-                ("event", "STRING"),
-                ("properties", "VARIANT"),
-                ("elements", "VARIANT"),
-                ("people_set", "VARIANT"),
-                ("people_set_once", "VARIANT"),
-                ("distinct_id", "STRING"),
-                ("team_id", "INTEGER"),
-                ("ip", "STRING"),
-                ("site_url", "STRING"),
-                ("timestamp", "TIMESTAMP"),
-            ]
-
+        if should_resume is True and details is not None:
+            data_interval_start = details.last_inserted_at.isoformat()
+            last_inserted_at = details.last_inserted_at
+            file_no = details.file_no
         else:
-            first_record, record_iterator = peek_first_and_rewind(record_iterator)
+            data_interval_start = inputs.data_interval_start
+            last_inserted_at = None
+            file_no = 0
 
-            column_names = [column for column in first_record.schema.names if column != "_inserted_at"]
-            record_schema = first_record.select(column_names).schema
-            table_fields = get_snowflake_fields_from_record_schema(
-                record_schema,
-                known_variant_columns=known_variant_columns,
+        async with get_client(team_id=inputs.team_id) as client:
+            if not await client.is_alive():
+                raise ConnectionError("Cannot establish connection to ClickHouse")
+
+            rows_exported = get_rows_exported_metric()
+            bytes_exported = get_bytes_exported_metric()
+
+            async def flush_to_snowflake(
+                connection: SnowflakeConnection,
+                file: BatchExportTemporaryFile,
+                table_name: str,
+                file_no: int,
+                last: bool = False,
+            ):
+                logger.info(
+                    "Putting %sfile %s containing %s records with size %s bytes",
+                    "last " if last else "",
+                    file_no,
+                    file.records_since_last_reset,
+                    file.bytes_since_last_reset,
+                )
+
+                await put_file_to_snowflake_table(connection, file, table_name, file_no)
+                rows_exported.add(file.records_since_last_reset)
+                bytes_exported.add(file.bytes_since_last_reset)
+
+            if inputs.batch_export_schema is None:
+                fields = snowflake_default_fields()
+                query_parameters = None
+
+            else:
+                fields = inputs.batch_export_schema["fields"]
+                query_parameters = inputs.batch_export_schema["values"]
+
+            record_iterator = iter_records(
+                client=client,
+                team_id=inputs.team_id,
+                interval_start=data_interval_start,
+                interval_end=inputs.data_interval_end,
+                exclude_events=inputs.exclude_events,
+                include_events=inputs.include_events,
+                fields=fields,
+                extra_query_parameters=query_parameters,
+                is_backfill=inputs.is_backfill,
             )
 
-        with snowflake_connection(inputs) as connection:
-            await create_table_in_snowflake(connection, inputs.table_name, table_fields)
+            known_variant_columns = ["properties", "people_set", "people_set_once", "person_properties"]
+            if inputs.batch_export_schema is None:
+                table_fields = [
+                    ("uuid", "STRING"),
+                    ("event", "STRING"),
+                    ("properties", "VARIANT"),
+                    ("elements", "VARIANT"),
+                    ("people_set", "VARIANT"),
+                    ("people_set_once", "VARIANT"),
+                    ("distinct_id", "STRING"),
+                    ("team_id", "INTEGER"),
+                    ("ip", "STRING"),
+                    ("site_url", "STRING"),
+                    ("timestamp", "TIMESTAMP"),
+                ]
 
-            async def worker_shutdown_handler():
-                """Handle the Worker shutting down by heart-beating our latest status."""
-                await activity.wait_for_worker_shutdown()
-                logger.bind(last_inserted_at=last_inserted_at, file_no=file_no).debug("Worker shutting down!")
+            else:
+                first_record, record_iterator = peek_first_and_rewind(record_iterator)
 
-                if last_inserted_at is None:
-                    # Don't heartbeat if worker shuts down before we could even send anything
-                    # Just start from the beginning again.
-                    return
+                column_names = [column for column in first_record.schema.names if column != "_inserted_at"]
+                record_schema = first_record.select(column_names).schema
+                table_fields = get_snowflake_fields_from_record_schema(
+                    record_schema,
+                    known_variant_columns=known_variant_columns,
+                )
 
-                activity.heartbeat(str(last_inserted_at), file_no)
+            with snowflake_connection(inputs) as connection:
+                await create_table_in_snowflake(connection, inputs.table_name, table_fields)
 
-            asyncio.create_task(worker_shutdown_handler())
+                record_columns = [field[0] for field in table_fields] + ["_inserted_at"]
+                record = None
+                inserted_at = None
 
-            record_columns = [field[0] for field in table_fields] + ["_inserted_at"]
-            record = None
-            inserted_at = None
+                with BatchExportTemporaryFile() as local_results_file:
+                    for record_batch in record_iterator:
+                        for record in record_batch.select(record_columns).to_pylist():
+                            inserted_at = record.pop("_inserted_at")
 
-            with BatchExportTemporaryFile() as local_results_file:
-                for record_batch in record_iterator:
-                    for record in record_batch.select(record_columns).to_pylist():
-                        inserted_at = record.pop("_inserted_at")
+                            for variant_column in known_variant_columns:
+                                if (json_str := record.get(variant_column, None)) is not None:
+                                    record[variant_column] = json.loads(json_str)
 
-                        for variant_column in known_variant_columns:
-                            if (json_str := record.get(variant_column, None)) is not None:
-                                record[variant_column] = json.loads(json_str)
+                            local_results_file.write_records_to_jsonl([record])
 
-                        local_results_file.write_records_to_jsonl([record])
+                            if local_results_file.tell() > settings.BATCH_EXPORT_SNOWFLAKE_UPLOAD_CHUNK_SIZE_BYTES:
+                                await flush_to_snowflake(connection, local_results_file, inputs.table_name, file_no)
 
-                        if local_results_file.tell() > settings.BATCH_EXPORT_SNOWFLAKE_UPLOAD_CHUNK_SIZE_BYTES:
-                            await flush_to_snowflake(connection, local_results_file, inputs.table_name, file_no)
+                                last_inserted_at = inserted_at
+                                file_no += 1
 
-                            last_inserted_at = inserted_at
-                            file_no += 1
+                                heartbeater.details = (str(last_inserted_at), file_no)
 
-                            activity.heartbeat(str(last_inserted_at), file_no)
+                                local_results_file.reset()
 
-                            local_results_file.reset()
+                    if local_results_file.tell() > 0 and record is not None and inserted_at is not None:
+                        await flush_to_snowflake(connection, local_results_file, inputs.table_name, file_no, last=True)
 
-                if local_results_file.tell() > 0 and record is not None and inserted_at is not None:
-                    await flush_to_snowflake(connection, local_results_file, inputs.table_name, file_no, last=True)
+                        last_inserted_at = inserted_at
+                        file_no += 1
 
-                    last_inserted_at = inserted_at
-                    file_no += 1
+                        heartbeater.details = (str(last_inserted_at), file_no)
 
-                    activity.heartbeat(str(last_inserted_at), file_no)
+                await copy_loaded_files_to_snowflake_table(connection, inputs.table_name)
 
-            await copy_loaded_files_to_snowflake_table(connection, inputs.table_name)
-
-        return local_results_file.records_total
+            return local_results_file.records_total
 
 
 @workflow.defn(name="snowflake-export")


### PR DESCRIPTION
## Problem

This PR tackles a few small fixes for batch exports. The seemingly large line count is because of shifting levels of nesting, not much code has changed

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* All batch exports now use `Heartbeater` to heartbeat during all their execution.
  * This requires nesting some blocks of code, hence the seemingly large line diff count.
* Backfill batch export now waits before starting a new workflow and in the event of failure.
  * This is to give the cancellation call some time to go through, if any call exists.
* Email task now logs a bunch. Trying to debug an issue with emails not going out.
* Removed some redundant statements.
* Abstracted a block into a function.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
