### PR TITLE
fix: allow x-highlight-request tracing header

### DIFF
--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1565,6 +1565,10 @@ class TestCapture(BaseTest):
                 "gcp",
                 ["x-cloud-trace-context"],
             ),
+            (
+                "highlight",
+                ["x-highlight-request"],
+            ),
         ]
     )
     def test_cors_allows_tracing_headers(self, _: str, path: str, headers: list[str]) -> None:

--- a/posthog/utils_cors.py
+++ b/posthog/utils_cors.py
@@ -8,6 +8,7 @@ CORS_ALLOWED_TRACING_HEADERS = (
     "x-cloud-trace-context",
     "Sentry-Trace",
     "Baggage",
+    "x-highlight-request",
 )
 
 


### PR DESCRIPTION
Sometimes tracing headers cause CORS issues and we put them in an allowlist

I saw this one cause the issue

So, i put it in the allow list