### PR TITLE
chore(data-warehouse): Validate join key is a field node

### DIFF
--- a/posthog/warehouse/api/test/test_view_link.py
+++ b/posthog/warehouse/api/test/test_view_link.py
@@ -42,6 +42,19 @@ class TestViewLinkQuery(APIBaseTest):
         )
         self.assertEqual(response.status_code, 400, response.content)
 
+    def test_create_saved_query_join_key_function(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/warehouse_view_links/",
+            {
+                "source_table_name": "events",
+                "joining_table_name": "persons",
+                "source_table_key": "upper(uuid)",
+                "joining_table_key": "id",
+                "field_name": "some_field",
+            },
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+
     def test_delete(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/warehouse_view_links/",

--- a/posthog/warehouse/api/view_link.py
+++ b/posthog/warehouse/api/view_link.py
@@ -4,7 +4,9 @@ from rest_framework import filters, serializers, viewsets
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
+from posthog.hogql.ast import Field
 from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.parser import parse_expr
 from posthog.warehouse.models import DataWarehouseJoin
 
 
@@ -66,6 +68,10 @@ class ViewLinkSerializer(serializers.ModelSerializer):
             database.get_table(table)
         except Exception:
             raise serializers.ValidationError(f"Invalid table: {table}")
+
+        node = parse_expr(join_key)
+        if not isinstance(node, Field):
+            raise serializers.ValidationError(f"Join key {join_key} must be a table field - no function calls allowed")
 
         return
 


### PR DESCRIPTION
## Problem
- We don't allow join keys that aren't a pure `ast.Field` node to be used as join keys when linking tables together
- But, we still allow you to set them as a `ast.Call`

## Changes
- Validate the join key, ensuring its a `ast.Field` node

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tests