### PR TITLE
fix(product-analytics): Fix debug clickhouse queries on localhost

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -80,6 +80,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                 data.query,
                 execution_mode=execution_mode,
                 query_id=client_query_id,
+                user=request.user,
             )
             if isinstance(result, BaseModel):
                 result = result.model_dump(by_alias=True)


### PR DESCRIPTION
## Problem

Most insights did not appear in "debug clickhouse queries". See thread https://posthog.slack.com/archives/C02E3BKC78F/p1717774317087499

## Changes

Pass the user

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Locally on web analytics dashboard, refreshed the page and some queries were there 

<img width="1294" alt="Screenshot 2024-06-07 at 18 10 53" src="https://github.com/PostHog/posthog/assets/2056078/e1a3fd47-eea6-4dbd-b10d-f3c2b8fbd802">
