### PR TITLE
fix(exports): Fix insight cache warming for dashboard tile export

### DIFF
--- a/posthog/tasks/exports/image_exporter.py
+++ b/posthog/tasks/exports/image_exporter.py
@@ -191,6 +191,7 @@ def export_image(exported_asset: ExportedAsset) -> None:
                     process_query_dict(
                         exported_asset.team,
                         exported_asset.insight.query,
+                        dashboard_filters_json=exported_asset.dashboard.filters if exported_asset.dashboard else None,
                         limit_context=LimitContext.QUERY_ASYNC,
                         execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
                     )


### PR DESCRIPTION
## Problem

We request a calculation but the cache key is off due to the missing dashboard filters.

## Changes

Take the dashboard filters into account.

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

Tested export with wiped cache from dashboard and from insight directly.