### PR TITLE
fix: Added missing queryset call to plugin viewsets

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -901,6 +901,7 @@ class LegacyPluginConfigViewSet(PluginConfigViewSet):
 
 class PipelineTransformationsViewSet(PluginViewSet):
     def safely_get_queryset(self, queryset):
+        queryset = super().safely_get_queryset(queryset)
         return queryset.filter(Q(capabilities__has_key="methods") & Q(capabilities__methods__contains=["processEvent"]))
 
 
@@ -913,6 +914,7 @@ class PipelineTransformationsConfigsViewSet(PluginConfigViewSet):
 
 class PipelineDestinationsViewSet(PluginViewSet):
     def safely_get_queryset(self, queryset):
+        queryset = super().safely_get_queryset(queryset)
         return queryset.filter(
             Q(capabilities__has_key="methods")
             & (Q(capabilities__methods__contains=["onEvent"]) | Q(capabilities__methods__contains=["composeWebhook"]))
@@ -932,6 +934,7 @@ class PipelineDestinationsConfigsViewSet(PluginConfigViewSet):
 
 class PipelineFrontendAppsViewSet(PluginViewSet):
     def safely_get_queryset(self, queryset):
+        queryset = super().safely_get_queryset(queryset)
         return queryset.exclude(Q(capabilities__has_key="methods") | Q(capabilities__has_key="scheduled_tasks"))
 
 
@@ -944,6 +947,7 @@ class PipelineFrontendAppsConfigsViewSet(PluginConfigViewSet):
 
 class PipelineImportAppsViewSet(PluginViewSet):
     def safely_get_queryset(self, queryset):
+        queryset = super().safely_get_queryset(queryset)
         # All the plugins, that are not on the other pages
         return queryset.filter(
             Q(Q(capabilities__has_key="scheduled_tasks") & ~Q(capabilities__scheduled_tasks=[]))


### PR DESCRIPTION
## Problem

The pluginviewset derivatives do their own filtering but don't call the parent as they should.

## Changes

* Fixes the calls to super

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
