### PR TITLE
fix: Always reload hog function on change

### DIFF
--- a/plugin-server/src/cdp/hog-function-manager.ts
+++ b/plugin-server/src/cdp/hog-function-manager.ts
@@ -24,11 +24,7 @@ export class HogFunctionManager {
         this.pubSub = new PubSub(this.serverConfig, {
             'reload-hog-function': async (message) => {
                 const { hogFunctionId, teamId } = JSON.parse(message)
-                // TODO: Change to only if already loaded
-
-                if (this.cache[teamId]?.[hogFunctionId]) {
-                    await this.reloadHogFunction(teamId, hogFunctionId)
-                }
+                await this.reloadHogFunction(teamId, hogFunctionId)
             },
         })
     }
@@ -72,8 +68,8 @@ export class HogFunctionManager {
     }
 
     public async reloadHogFunction(teamId: Team['id'], id: HogFunctionType['id']): Promise<void> {
+        status.info('🍿', `Reloading hog function ${id} from DB`)
         const item = await fetchHogFunction(this.postgres, id)
-
         if (item) {
             this.cache[teamId][id] = item
         } else {


### PR DESCRIPTION
## Problem

I was only doing it if cached but thats not right - we may as well always reload it.

## Changes

* Always reload the function and log a message so we can debug it 
* Also batch parallelizes the workload

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
