### PR TITLE
feat(web-analytics): Add missing limit_context to query runners

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -264,31 +264,62 @@ def get_query_runner(
             team=team,
             timings=timings,
             modifiers=modifiers,
+            limit_context=limit_context,
         )
     if kind == "WebOverviewQuery":
         use_session_table = get_from_dict_or_attr(query, "useSessionsTable")
         if use_session_table:
             from .web_analytics.web_overview import WebOverviewQueryRunner
 
-            return WebOverviewQueryRunner(query=query, team=team, timings=timings, modifiers=modifiers)
+            return WebOverviewQueryRunner(
+                query=query,
+                team=team,
+                timings=timings,
+                modifiers=modifiers,
+                limit_context=limit_context,
+            )
         else:
             from .web_analytics.web_overview_legacy import LegacyWebOverviewQueryRunner
 
-            return LegacyWebOverviewQueryRunner(query=query, team=team, timings=timings, modifiers=modifiers)
+            return LegacyWebOverviewQueryRunner(
+                query=query,
+                team=team,
+                timings=timings,
+                modifiers=modifiers,
+                limit_context=limit_context,
+            )
     if kind == "WebTopClicksQuery":
         from .web_analytics.top_clicks import WebTopClicksQueryRunner
 
-        return WebTopClicksQueryRunner(query=query, team=team, timings=timings, modifiers=modifiers)
+        return WebTopClicksQueryRunner(
+            query=query,
+            team=team,
+            timings=timings,
+            modifiers=modifiers,
+            limit_context=limit_context,
+        )
     if kind == "WebStatsTableQuery":
         use_session_table = get_from_dict_or_attr(query, "useSessionsTable")
         if use_session_table:
             from .web_analytics.stats_table import WebStatsTableQueryRunner
 
-            return WebStatsTableQueryRunner(query=query, team=team, timings=timings, modifiers=modifiers)
+            return WebStatsTableQueryRunner(
+                query=query,
+                team=team,
+                timings=timings,
+                modifiers=modifiers,
+                limit_context=limit_context,
+            )
         else:
             from .web_analytics.stats_table_legacy import LegacyWebStatsTableQueryRunner
 
-            return LegacyWebStatsTableQueryRunner(query=query, team=team, timings=timings, modifiers=modifiers)
+            return LegacyWebStatsTableQueryRunner(
+                query=query,
+                team=team,
+                timings=timings,
+                modifiers=modifiers,
+                limit_context=limit_context,
+            )
 
     raise ValueError(f"Can't get a runner for an unknown query kind: {kind}")
 


### PR DESCRIPTION
## Problem

We're just missing some plumbing, see https://posthog.slack.com/archives/C05LJK1N3CP/p1718035203834449

## Changes

Add plumbing

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tests still pass, web analytics dashboard loads locally
