### PR TITLE
chore(hogql): Added corr clickhouse func

### DIFF
--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -292,6 +292,7 @@ HOGQL_CLICKHOUSE_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     ),
     "multiplyDecimal": HogQLFunctionMeta("multiplyDecimal", 2, 3),
     "divideDecimal": HogQLFunctionMeta("divideDecimal", 2, 3),
+    "corr": HogQLFunctionMeta("corr", 2, 2),
     # arrays and strings common
     "empty": HogQLFunctionMeta("empty", 1, 1),
     "notEmpty": HogQLFunctionMeta("notEmpty", 1, 1),

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -292,7 +292,6 @@ HOGQL_CLICKHOUSE_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     ),
     "multiplyDecimal": HogQLFunctionMeta("multiplyDecimal", 2, 3),
     "divideDecimal": HogQLFunctionMeta("divideDecimal", 2, 3),
-    "corr": HogQLFunctionMeta("corr", 2, 2),
     # arrays and strings common
     "empty": HogQLFunctionMeta("empty", 1, 1),
     "notEmpty": HogQLFunctionMeta("notEmpty", 1, 1),
@@ -855,6 +854,7 @@ HOGQL_AGGREGATIONS: dict[str, HogQLFunctionMeta] = {
     "covarPopIf": HogQLFunctionMeta("covarPopIf", 3, 3, aggregate=True),
     "covarSamp": HogQLFunctionMeta("covarSamp", 2, 2, aggregate=True),
     "covarSampIf": HogQLFunctionMeta("covarSampIf", 3, 3, aggregate=True),
+    "corr": HogQLFunctionMeta("corr", 2, 2, aggregate=True),
     # ClickHouse-specific aggregate functions
     "anyHeavy": HogQLFunctionMeta("anyHeavy", 1, 1, aggregate=True),
     "anyHeavyIf": HogQLFunctionMeta("anyHeavyIf", 2, 2, aggregate=True),


### PR DESCRIPTION
## Problem
[Annika wants to use `corr(..)`](https://posthog.slack.com/archives/C019RAX2XBN/p1718109072226909)

## Changes
Annika gets `corr(...)`

## Does this work well for both Cloud and self-hosted?
Probably

## How did you test this code?
👀 

<img width="1178" alt="image" src="https://github.com/PostHog/posthog/assets/1459269/362cfb36-7dae-49c2-a0a5-09a0701bca7b">
