### PR TITLE
fix(experiments): Prevent HogQL-only PoE modes breaking legacy insights

### DIFF
--- a/ee/clickhouse/queries/groups_join_query.py
+++ b/ee/clickhouse/queries/groups_join_query.py
@@ -8,7 +8,7 @@ from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.models.filters.utils import GroupTypeIndex
 from posthog.models.property.util import parse_prop_grouped_clauses
 from posthog.models.team.team import groups_on_events_querying_enabled
-from posthog.queries.util import PersonPropertiesMode
+from posthog.queries.util import PersonPropertiesMode, alias_poe_mode_for_legacy
 from posthog.schema import PersonsOnEventsMode
 
 
@@ -33,7 +33,7 @@ class GroupsJoinQuery:
         self._team_id = team_id
         self._column_optimizer = column_optimizer or EnterpriseColumnOptimizer(self._filter, self._team_id)
         self._join_key = join_key
-        self._person_on_events_mode = person_on_events_mode
+        self._person_on_events_mode = alias_poe_mode_for_legacy(person_on_events_mode)
 
     def get_join_query(self) -> tuple[str, dict]:
         join_queries, params = [], {}

--- a/posthog/queries/breakdown_props.py
+++ b/posthog/queries/breakdown_props.py
@@ -36,7 +36,7 @@ from posthog.queries.trends.sql import (
     HISTOGRAM_ELEMENTS_ARRAY_OF_KEY_SQL,
     TOP_ELEMENTS_ARRAY_OF_KEY_SQL,
 )
-from posthog.queries.util import PersonPropertiesMode
+from posthog.queries.util import PersonPropertiesMode, alias_poe_mode_for_legacy
 
 ALL_USERS_COHORT_ID = 0
 
@@ -86,7 +86,9 @@ def get_breakdown_prop_values(
     sessions_join_params: dict = {}
 
     null_person_filter = (
-        f"AND notEmpty(e.person_id)" if team.person_on_events_mode != PersonsOnEventsMode.DISABLED else ""
+        f"AND notEmpty(e.person_id)"
+        if alias_poe_mode_for_legacy(team.person_on_events_mode) != PersonsOnEventsMode.DISABLED
+        else ""
     )
 
     if person_properties_mode == PersonPropertiesMode.DIRECT_ON_EVENTS:

--- a/posthog/queries/event_query/event_query.py
+++ b/posthog/queries/event_query/event_query.py
@@ -20,7 +20,7 @@ from posthog.queries.person_query import PersonQuery
 from posthog.queries.query_date_range import QueryDateRange
 from posthog.schema import PersonsOnEventsMode
 from posthog.session_recordings.queries.session_query import SessionQuery
-from posthog.queries.util import PersonPropertiesMode
+from posthog.queries.util import PersonPropertiesMode, alias_poe_mode_for_legacy
 from posthog.queries.person_on_events_v2_sql import PERSON_DISTINCT_ID_OVERRIDES_JOIN_SQL
 
 
@@ -88,7 +88,7 @@ class EventQuery(metaclass=ABCMeta):
         self._should_join_persons = should_join_persons
         self._should_join_sessions = should_join_sessions
         self._extra_fields = extra_fields
-        self._person_on_events_mode = person_on_events_mode
+        self._person_on_events_mode = alias_poe_mode_for_legacy(person_on_events_mode)
 
         # Guards against a ClickHouse bug involving multiple joins against the same table with the same column name.
         # This issue manifests for us with formulas, where on queries A and B we join events against itself

--- a/posthog/queries/funnels/base.py
+++ b/posthog/queries/funnels/base.py
@@ -32,7 +32,7 @@ from posthog.queries.breakdown_props import (
 )
 from posthog.queries.funnels.funnel_event_query import FunnelEventQuery
 from posthog.queries.insight import insight_sync_execute
-from posthog.queries.util import correct_result_for_sampling, get_person_properties_mode
+from posthog.queries.util import alias_poe_mode_for_legacy, correct_result_for_sampling, get_person_properties_mode
 from posthog.schema import PersonsOnEventsMode
 from posthog.utils import relative_date_parse, generate_short_id
 
@@ -730,7 +730,7 @@ class ClickhouseFunnelBase(ABC):
 
         self.params.update({"breakdown": self._filter.breakdown})
         if self._filter.breakdown_type == "person":
-            if self._team.person_on_events_mode != PersonsOnEventsMode.DISABLED:
+            if alias_poe_mode_for_legacy(self._team.person_on_events_mode) != PersonsOnEventsMode.DISABLED:
                 basic_prop_selector, basic_prop_params = get_single_or_multi_property_string_expr(
                     self._filter.breakdown,
                     table="events",
@@ -760,7 +760,10 @@ class ClickhouseFunnelBase(ABC):
             # :TRICKY: We only support string breakdown for group properties
             assert isinstance(self._filter.breakdown, str)
 
-            if self._team.person_on_events_mode != PersonsOnEventsMode.DISABLED and groups_on_events_querying_enabled():
+            if (
+                alias_poe_mode_for_legacy(self._team.person_on_events_mode) != PersonsOnEventsMode.DISABLED
+                and groups_on_events_querying_enabled()
+            ):
                 properties_field = f"group{self._filter.breakdown_group_type_index}_properties"
                 expression, _ = get_property_string_expr(
                     table="events",

--- a/posthog/queries/groups_join_query/groups_join_query.py
+++ b/posthog/queries/groups_join_query/groups_join_query.py
@@ -5,6 +5,7 @@ from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.retention_filter import RetentionFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
 from posthog.queries.column_optimizer.column_optimizer import ColumnOptimizer
+from posthog.queries.util import alias_poe_mode_for_legacy
 from posthog.schema import PersonsOnEventsMode
 
 
@@ -29,7 +30,7 @@ class GroupsJoinQuery:
         self._team_id = team_id
         self._column_optimizer = column_optimizer or ColumnOptimizer(self._filter, self._team_id)
         self._join_key = join_key
-        self._person_on_events_mode = person_on_events_mode
+        self._person_on_events_mode = alias_poe_mode_for_legacy(person_on_events_mode)
 
     def get_join_query(self) -> tuple[str, dict]:
         return "", {}

--- a/posthog/queries/trends/breakdown.py
+++ b/posthog/queries/trends/breakdown.py
@@ -74,6 +74,7 @@ from posthog.queries.trends.util import (
     process_math,
 )
 from posthog.queries.util import (
+    alias_poe_mode_for_legacy,
     get_interval_func_ch,
     get_person_properties_mode,
     get_start_of_interval_sql,
@@ -108,7 +109,7 @@ class TrendsBreakdown:
         self.params: dict[str, Any] = {"team_id": team.pk}
         self.column_optimizer = column_optimizer or ColumnOptimizer(self.filter, self.team_id)
         self.add_person_urls = add_person_urls
-        self.person_on_events_mode = person_on_events_mode
+        self.person_on_events_mode = alias_poe_mode_for_legacy(person_on_events_mode)
         if person_on_events_mode == PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS:
             self._person_id_alias = f"if(notEmpty({self.PERSON_ID_OVERRIDES_TABLE_ALIAS}.distinct_id), {self.PERSON_ID_OVERRIDES_TABLE_ALIAS}.person_id, {self.EVENT_TABLE_ALIAS}.person_id)"
         elif person_on_events_mode == PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS:

--- a/posthog/queries/util.py
+++ b/posthog/queries/util.py
@@ -41,16 +41,10 @@ class PersonPropertiesMode(Enum):
 
 
 def alias_poe_mode_for_legacy(persons_on_events_mode: PersonsOnEventsMode) -> PersonsOnEventsMode:
-    # Person distinct ID overrides aren't implemented in legacy insights, so we alias to a non-overrides mode
     if persons_on_events_mode == PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED:
-        # PERSON_ID_OVERRIDE_PROPERTIES_JOINED is functionally equivalent to DISABLED
+        # PERSON_ID_OVERRIDE_PROPERTIES_JOINED is not implemented in legacy insights
+        # It's functionally the same as DISABLED, just slower - hence aliasing to DISABLED
         return PersonsOnEventsMode.DISABLED
-    if persons_on_events_mode == PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS:
-        # PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS has the same person properties semantics as
-        # PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS, although the latter (which we have to alias to) is less accurate.
-        # Specifically, with neither overrides not a join with persons, unique user counts are inflated,
-        # while conversions undercounted
-        return PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS
     return persons_on_events_mode
 
 


### PR DESCRIPTION
## Problem

We've recently [rolled out to all projects](https://us.posthog.com/project/2/feature_flags/41997) a significant optimization of user counts, called `PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED`. It works great in HogQL-based insights, but experiments still use the legacy engine, which doesn't support the new mode. Cue confused SQL queries and occasional errors. Some [context in Slack](https://posthog.slack.com/archives/C0368RPHLQH/p1718106386484109).

## Changes

This is simple: I added an `alias_poe_mode_for_legacy` function that always returns a mode _without_ overrides, searched for all instances of `PersonsOnEventsMode.DISABLED` in legacy insights, and made sure `person_on_events_mode` is wrapped in `alias_poe_mode_for_legacy()` in each of these places.