### PR TITLE
fix(hogql): Fix query with visit_tuple

### DIFF
--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -416,6 +416,9 @@ class IsTimeOrIntervalConstantVisitor(Visitor[bool]):
     def visit_alias(self, node: ast.Alias) -> bool:
         return self.visit(node.expr)
 
+    def visit_tuple(self, node: ast.Tuple) -> bool:
+        return all(self.visit(arg) for arg in node.exprs)
+
 
 def is_simple_timestamp_field_expression(expr: ast.Expr, context: HogQLContext, tombstone_string: str) -> bool:
     return IsSimpleTimestampFieldExpressionVisitor(context, tombstone_string).visit(expr)
@@ -514,6 +517,9 @@ class IsSimpleTimestampFieldExpressionVisitor(Visitor[bool]):
             )
 
         return self.visit(node.expr)
+
+    def visit_tuple(self, node: ast.Tuple) -> bool:
+        return all(self.visit(arg) for arg in node.exprs)
 
 
 def rewrite_timestamp_field(expr: ast.Expr, context: HogQLContext) -> ast.Expr:


### PR DESCRIPTION
## Problem

https://posthog.sentry.io/issues/5461680694/
raised in
https://posthoghelp.zendesk.com/agent/tickets/14403 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/17847)

## Changes

add `visit_tuple`

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

test query 

```json
{
  "aggregation_group_type_index": null,
  "dateRange": {
    "date_from": "-7d",
    "date_to": null,
    "explicitDate": false
  },
  "filterTestAccounts": true,
  "kind": "RetentionQuery",
  "properties": [
    {
      "key": "$entry_current_url",
      "label": null,
      "operator": "regex",
      "type": "session",
      "value": "^https:\\/\\/www something here$"
    }
  ],
  "response": null,
  "retentionFilter": {
    "period": "Week",
    "retentionReference": "total",
    "retentionType": "retention_first_time",
    "returningEntity": null,
    "showMean": null,
    "targetEntity": null,
    "totalIntervals": 8
  },
  "samplingFactor": null
}
```