### PR TITLE
fix: event matching for set usage logging

### DIFF
--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -250,8 +250,8 @@ export function formPipelineEvent(message: Message): PipelineEvent {
     // Track $set usage in events that aren't known to use it, before ingestion adds anything there
     if (
         combinedEvent.properties &&
-        !(PERSON_EVENTS.has(combinedEvent.event)) &&
-        !(KNOWN_SET_EVENTS.has(combinedEvent.event)) &&
+        !PERSON_EVENTS.has(combinedEvent.event) &&
+        !KNOWN_SET_EVENTS.has(combinedEvent.event) &&
         ('$set' in combinedEvent.properties ||
             '$set_once' in combinedEvent.properties ||
             '$unset' in combinedEvent.properties)

--- a/plugin-server/src/utils/event.ts
+++ b/plugin-server/src/utils/event.ts
@@ -250,8 +250,8 @@ export function formPipelineEvent(message: Message): PipelineEvent {
     // Track $set usage in events that aren't known to use it, before ingestion adds anything there
     if (
         combinedEvent.properties &&
-        !(combinedEvent.event in PERSON_EVENTS) &&
-        !(combinedEvent.event in KNOWN_SET_EVENTS) &&
+        !(PERSON_EVENTS.has(combinedEvent.event)) &&
+        !(KNOWN_SET_EVENTS.has(combinedEvent.event)) &&
         ('$set' in combinedEvent.properties ||
             '$set_once' in combinedEvent.properties ||
             '$unset' in combinedEvent.properties)


### PR DESCRIPTION
## Problem

python vs typescript ... 🤦‍♀️ 

Interestingly that tells us 6/7 events don't have any `$set` before we run plugins add the auto props [graph](https://grafana.prod-us.posthog.dev/explore?schemaVersion=1&panes=%7B%221t6%22:%7B%22datasource%22:%22victoriametrics%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22victoriametrics%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%28increase%28set_usage_in_non_person_events%5B5m%5D%29%2F5%29%22,%22instant%22:false,%22legendFormat%22:%22$set%20in%20the%20event%22,%22range%22:true,%22refId%22:%22A%22,%22interval%22:%22%22,%22hide%22:false%7D,%7B%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22victoriametrics%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%28increase%28event_processed_and_ingested%5B5m%5D%29%29%20%2F%205%22,%22instant%22:false,%22legendFormat%22:%22total%20events%20processed%22,%22range%22:true,%22refId%22:%22B%22,%22interval%22:%22%22,%22hide%22:false,%22useBackend%22:false,%22disableTextWrap%22:false,%22fullMetaSearch%22:false,%22includeNullMetadata%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-2d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1) and we know that almost every event has them afterwards.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
