### PR TITLE
chore: Bump max memory usage for batch exports

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -27,6 +27,7 @@ OVERRIDE_TIMESTAMP_TEAM_IDS: dict[int, int] = dict(
 )
 
 CLICKHOUSE_MAX_EXECUTION_TIME: int = get_from_env("CLICKHOUSE_MAX_EXECUTION_TIME", 0, type_cast=int)
+CLICKHOUSE_MAX_MEMORY_USAGE: int = get_from_env("CLICKHOUSE_MAX_MEMORY_USAGE", 0, type_cast=int)
 CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT: int = get_from_env("CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT", 10000, type_cast=int)
 # Comma separated list of overrides in the format "team_id:block_size"
 CLICKHOUSE_MAX_BLOCK_SIZE_OVERRIDES: dict[int, int] = dict(

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -27,7 +27,7 @@ OVERRIDE_TIMESTAMP_TEAM_IDS: dict[int, int] = dict(
 )
 
 CLICKHOUSE_MAX_EXECUTION_TIME: int = get_from_env("CLICKHOUSE_MAX_EXECUTION_TIME", 0, type_cast=int)
-CLICKHOUSE_MAX_MEMORY_USAGE: int = get_from_env("CLICKHOUSE_MAX_MEMORY_USAGE", 100*1000*1000*1000, type_cast=int)
+CLICKHOUSE_MAX_MEMORY_USAGE: int = get_from_env("CLICKHOUSE_MAX_MEMORY_USAGE", 100 * 1000 * 1000 * 1000, type_cast=int)
 CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT: int = get_from_env("CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT", 10000, type_cast=int)
 # Comma separated list of overrides in the format "team_id:block_size"
 CLICKHOUSE_MAX_BLOCK_SIZE_OVERRIDES: dict[int, int] = dict(

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -27,7 +27,7 @@ OVERRIDE_TIMESTAMP_TEAM_IDS: dict[int, int] = dict(
 )
 
 CLICKHOUSE_MAX_EXECUTION_TIME: int = get_from_env("CLICKHOUSE_MAX_EXECUTION_TIME", 0, type_cast=int)
-CLICKHOUSE_MAX_MEMORY_USAGE: int = get_from_env("CLICKHOUSE_MAX_MEMORY_USAGE", 0, type_cast=int)
+CLICKHOUSE_MAX_MEMORY_USAGE: int = get_from_env("CLICKHOUSE_MAX_MEMORY_USAGE", 100*1000*1000*1000, type_cast=int)
 CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT: int = get_from_env("CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT", 10000, type_cast=int)
 # Comma separated list of overrides in the format "team_id:block_size"
 CLICKHOUSE_MAX_BLOCK_SIZE_OVERRIDES: dict[int, int] = dict(

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -417,6 +417,7 @@ async def get_client(
                 password=settings.CLICKHOUSE_PASSWORD,
                 database=settings.CLICKHOUSE_DATABASE,
                 max_execution_time=settings.CLICKHOUSE_MAX_EXECUTION_TIME,
+                max_memory_usage=settings.CLICKHOUSE_MAX_MEMORY_USAGE,
                 max_block_size=max_block_size,
                 output_format_arrow_string_as_string="true",
                 **kwargs,


### PR DESCRIPTION
## Problem

Some batch exports are running out of memory. 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Make `max_memory_usage` configurable, and set the default to unlimited.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

The change is similar to how we set `max_execution_time`, so this should work fine without specific testing. Batch exports unit tests will catch any simple errors.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
