### PR TITLE
feat(session-replay): Make session replay support where clause extractor

### DIFF
--- a/posthog/hogql/database/schema/session_replay_events.py
+++ b/posthog/hogql/database/schema/session_replay_events.py
@@ -33,7 +33,6 @@ def join_replay_table_to_sessions_table(
     if not join_to_add.fields_accessed:
         raise ResolutionError("No fields requested from replay")
 
-    # TODO i think this should be fixed in the where_clause_extractor so that it grabs time bounds for us
     join_expr = ast.JoinExpr(table=select_from_sessions_table(join_to_add.fields_accessed, node, context))
     join_expr.join_type = "LEFT JOIN"
     join_expr.alias = join_to_add.to_table

--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -438,9 +438,9 @@ class IsSimpleTimestampFieldExpressionVisitor(Visitor[bool]):
         if node.type and isinstance(node.type, ast.FieldType):
             resolved_field = node.type.resolve_database_field(self.context)
             if resolved_field and isinstance(resolved_field, DatabaseField) and resolved_field:
-                return resolved_field.name in ["$start_timestamp", "min_timestamp", "timestamp"]
+                return resolved_field.name in ["$start_timestamp", "min_timestamp", "timestamp", "min_first_timestamp"]
         # no type information, so just use the name of the field
-        return node.chain[-1] in ["$start_timestamp", "min_timestamp", "timestamp"]
+        return node.chain[-1] in ["$start_timestamp", "min_timestamp", "timestamp", "min_first_timestamp"]
 
     def visit_arithmetic_operation(self, node: ast.ArithmeticOperation) -> bool:
         # only allow the min_timestamp field to be used on one side of the arithmetic operation
@@ -495,6 +495,7 @@ class IsSimpleTimestampFieldExpressionVisitor(Visitor[bool]):
     def visit_alias(self, node: ast.Alias) -> bool:
         from posthog.hogql.database.schema.events import EventsTable
         from posthog.hogql.database.schema.sessions import SessionsTable
+        from posthog.hogql.database.schema.session_replay_events import RawSessionReplayEventsTable
 
         if node.type and isinstance(node.type, ast.FieldAliasType):
             resolved_field = node.type.resolve_database_field(self.context)
@@ -504,13 +505,21 @@ class IsSimpleTimestampFieldExpressionVisitor(Visitor[bool]):
             if isinstance(table_type, ast.TableAliasType):
                 table_type = table_type.table_type
             return (
-                isinstance(table_type, ast.TableType)
-                and isinstance(table_type.table, EventsTable)
-                and resolved_field.name == "timestamp"
-            ) or (
-                isinstance(table_type, ast.LazyTableType)
-                and isinstance(table_type.table, SessionsTable)
-                and resolved_field.name == "$start_timestamp"
+                (
+                    isinstance(table_type, ast.TableType)
+                    and isinstance(table_type.table, EventsTable)
+                    and resolved_field.name == "timestamp"
+                )
+                or (
+                    isinstance(table_type, ast.LazyTableType)
+                    and isinstance(table_type.table, SessionsTable)
+                    and resolved_field.name == "$start_timestamp"
+                )
+                or (
+                    isinstance(table_type, ast.TableType)
+                    and isinstance(table_type.table, RawSessionReplayEventsTable)
+                    and resolved_field.name == "min_first_timestamp"
+                )
             )
 
         return self.visit(node.expr)
@@ -530,6 +539,7 @@ class RewriteTimestampFieldVisitor(CloningVisitor):
     def visit_field(self, node: ast.Field) -> ast.Field:
         from posthog.hogql.database.schema.events import EventsTable
         from posthog.hogql.database.schema.sessions import SessionsTable
+        from posthog.hogql.database.schema.session_replay_events import RawSessionReplayEventsTable
 
         if node.type and isinstance(node.type, ast.FieldType):
             resolved_field = node.type.resolve_database_field(self.context)
@@ -538,12 +548,14 @@ class RewriteTimestampFieldVisitor(CloningVisitor):
                 table_type = table_type.table_type
             table = table_type.table
             if resolved_field and isinstance(resolved_field, DatabaseField):
-                if (isinstance(table, EventsTable) and resolved_field.name == "timestamp") or (
-                    isinstance(table, SessionsTable) and resolved_field.name == "$start_timestamp"
+                if (
+                    (isinstance(table, EventsTable) and resolved_field.name == "timestamp")
+                    or (isinstance(table, SessionsTable) and resolved_field.name == "$start_timestamp")
+                    or (isinstance(table, RawSessionReplayEventsTable) and resolved_field.name == "min_first_timestamp")
                 ):
                     return ast.Field(chain=["raw_sessions", "min_timestamp"])
         # no type information, so just use the name of the field
-        if node.chain[-1] in ["$start_timestamp", "min_timestamp", "timestamp"]:
+        if node.chain[-1] in ["$start_timestamp", "min_timestamp", "timestamp", "min_first_timestamp"]:
             return ast.Field(chain=["raw_sessions", "min_timestamp"])
         return node
 


### PR DESCRIPTION
## Problem

Session replay doesn't have timestamp clause inlining when using session properties

## Changes

Make the where clause extractor support the raw session replay events table

<img width="1842" alt="Screenshot 2024-06-12 at 15 35 24" src="https://github.com/PostHog/posthog/assets/2056078/8f92d7e9-0833-40ac-8a04-f8f1f7be4814">


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added a test