### PR TITLE
feat: Reduce useless person updates

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -328,7 +328,7 @@ export class PersonState {
         })
         Object.entries(properties).map(([key, value]) => {
             if (personProperties[key] !== value) {
-                if (this.shouldUpdatePersonIfOnlyChange(key)) {
+                if (typeof personProperties[key] === 'undefined' || this.shouldUpdatePersonIfOnlyChange(key)) {
                     updated = true
                 }
                 metricsKeys.add(this.getMetricKey(key))

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -396,6 +396,7 @@ test('capture new person', async () => {
             properties: personInitialAndUTMProperties({
                 distinct_id: 2,
                 token: team.api_token,
+                x: 123,
                 utm_medium: 'instagram',
                 $current_url: 'https://test.com/pricing',
                 $browser_version: 80,
@@ -404,6 +405,9 @@ test('capture new person', async () => {
                     { tag_name: 'a', nth_child: 1, nth_of_type: 2, attr__class: 'btn btn-sm' },
                     { tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: '💻' },
                 ],
+                $set: {
+                    x: 123, // to make sure update happens
+                },
             }),
         } as any as PluginEvent,
         team.id,
@@ -417,6 +421,7 @@ test('capture new person', async () => {
     expect(persons.length).toEqual(1)
     expect(persons[0].version).toEqual(1)
     expectedProps = {
+        x: 123,
         $creator_event_uuid: uuid,
         $initial_browser: 'Chrome',
         $initial_browser_version: '95',
@@ -448,6 +453,7 @@ test('capture new person', async () => {
     expect(JSON.parse(chPeople2[0].properties)).toEqual(expectedProps)
 
     expect(events[1].properties.$set).toEqual({
+        x: 123,
         utm_medium: 'instagram',
         $browser: 'Firefox',
         $browser_version: 80,
@@ -492,6 +498,9 @@ test('capture new person', async () => {
                     { tag_name: 'a', nth_child: 1, nth_of_type: 2, attr__class: 'btn btn-sm' },
                     { tag_name: 'div', nth_child: 1, nth_of_type: 2, $el_text: '💻' },
                 ],
+                $set: {
+                    x: 123, // to make sure update happens
+                },
             }),
         } as any as PluginEvent,
         team.id,
@@ -508,6 +517,7 @@ test('capture new person', async () => {
     expect(persons[0].version).toEqual(1)
 
     expect(events[2].properties.$set).toEqual({
+        x: 123,
         $browser: 'Firefox',
         $current_url: 'https://test.com/pricing',
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Postgres can't be upscaled anymore and ingestion is being slowed down by useless person processing.

It's useless because we add these properties ourselves it's not something users asked for.

Furthermore some of them like $current_url change often, see [graph](https://grafana.prod-us.posthog.dev/explore?schemaVersion=1&panes=%7B%221t6%22:%7B%22datasource%22:%22victoriametrics%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22victoriametrics%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%28increase%28set_usage_in_non_person_events%5B5m%5D%29%2F5%29%22,%22instant%22:false,%22legendFormat%22:%22$set%20in%20the%20event%22,%22range%22:true,%22refId%22:%22A%22,%22interval%22:%22%22,%22hide%22:false%7D,%7B%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22victoriametrics%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%28increase%28event_processed_and_ingested%5B5m%5D%29%29%20%2F%205%22,%22instant%22:false,%22legendFormat%22:%22total%20events%20processed%22,%22range%22:true,%22refId%22:%22B%22,%22interval%22:%22%22,%22hide%22:false,%22useBackend%22:false,%22disableTextWrap%22:false,%22fullMetaSearch%22:false,%22includeNullMetadata%22:true%7D,%7B%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22victoriametrics%22%7D,%22editorMode%22:%22builder%22,%22expr%22:%22sum%20by%28key%29%20%28increase%28person_property_key_update_total%5B5m%5D%29%29%20%2F%205%22,%22instant%22:false,%22legendFormat%22:%22%7B%7Bkey%7D%7D%22,%22range%22:true,%22refId%22:%22C%22,%22interval%22:%22%22,%22hide%22:false,%22useBackend%22:false,%22disableTextWrap%22:false,%22fullMetaSearch%22:false,%22includeNullMetadata%22:true%7D%5D,%22range%22:%7B%22from%22:%221718200913792%22,%22to%22:%221718202367319%22%7D%7D%7D&orgId=1).


Using these lates properties in queries is rare, e.g. for $current_url https://metabase.prod-us.posthog.dev/question/772-current-url-usage-in-queries

What stays unchanged:
1. person events still update everything
1. any custom user property still always updates the person
1. initial properties on person always get updated
1. removing a property from person always gets removed
3. PoE properties mode (the default for new users and recommended for everyone) will still have the same values on events within a session

What will change:
1. if someone uses non-person events from posthog-js and backend events together and expects those backend events to have the latest person properties that we autoset from ingestion to show up in PoE properties for those backend events. TLDR: this is rare and we don't really care.
2. Person property value and PoE person join mode will have the latest property value from a person event (previously was from any event) for properties that we auto add (e.g. $geoip_ and $current_url). TLDR: this will have a reasonable value, just not the latest, we don't really care.

see more info for motivation: https://github.com/PostHog/product-internal/pull/612

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
