### PR TITLE
fix: Added missing var for test

### DIFF
--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -266,7 +266,7 @@ class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):
         # First add in the request information that should be added to the sql.
         # We check this to make sure it is not removed by the comment stripping
         with self.capture_select_queries() as sqls:
-            tag_queries(kind="request", id="1")
+            tag_queries(kind="request", id="1", user_id=self.user_id)
             sync_execute(
                 query="""
                     -- this request returns 1


### PR DESCRIPTION
## Problem

This test reliably fails on certain branches. I'm not sure why but it almost seems like a race condition related to some weird threading stuff. No idea if this is the right fix but adding in the user_id explicitly has the correct outcome.

## Changes

* Add the missing expected tag for the test

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
