### PR TITLE
fix: exception group query

### DIFF
--- a/frontend/src/scenes/error-tracking/errorTrackingGroupSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingGroupSceneLogic.ts
@@ -44,7 +44,7 @@ export const errorTrackingGroupSceneLogic = kea<errorTrackingGroupSceneLogicType
                         kind: NodeKind.HogQLQuery,
                         query: hogql`SELECT properties
                                 FROM events e
-                                WHERE event = '$exception' AND properties.$exception_type = '${props.id}'`,
+                                WHERE event = '$exception' AND properties.$exception_type = ${props.id}`,
                     }
                     const res = await api.query(query)
                     return res.results.map((r) => JSON.parse(r[0]))


### PR DESCRIPTION
## Problem

`hogql` wraps inputs in quotes without me needing to

## Changes

2nd time I've made this mistake 🤦 