### PR TITLE
chore(admin): Expose team UUID

### DIFF
--- a/posthog/admin/admins/team_admin.py
+++ b/posthog/admin/admins/team_admin.py
@@ -21,6 +21,7 @@ class TeamAdmin(admin.ModelAdmin):
     list_select_related = ("organization", "project")
     search_fields = (
         "id",
+        "uuid",
         "name",
         "organization__id",
         "organization__name",
@@ -28,7 +29,15 @@ class TeamAdmin(admin.ModelAdmin):
         "project__name",
         "api_token",
     )
-    readonly_fields = ["id", "organization", "primary_dashboard", "test_account_filters", "created_at", "updated_at"]
+    readonly_fields = [
+        "id",
+        "uuid",
+        "organization",
+        "primary_dashboard",
+        "test_account_filters",
+        "created_at",
+        "updated_at",
+    ]
     autocomplete_fields = ["project"]
 
     inlines = [GroupTypeMappingInline, ActionInline]
@@ -36,7 +45,7 @@ class TeamAdmin(admin.ModelAdmin):
         (
             None,
             {
-                "fields": ["name", "organization", "project"],
+                "fields": ["name", "id", "uuid", "organization", "project"],
             },
         ),
         (


### PR DESCRIPTION
## Problem

I was yesterday updating [a flag](https://posthog.slack.com/archives/C0368RPHLQH/p1718224523221989?thread_ts=1718094093.885929&cid=C0368RPHLQH) rolled out to projects based on their UUID (presumably because UUIDs are unique even across regions). It was kind of a pain, because I had to go to Metabase the obtain the UUIDs of projects – this is nowhere in Django admin.
 
## Changes

Simple, added the UUID to the list of fields shown.