### PR TITLE
fix(insights): fix histogram breakdown formatting

### DIFF
--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -212,7 +212,11 @@ export function formatBreakdownLabel(
     cohorts: CohortType[] | undefined,
     formatPropertyValueForDisplay: FormatPropertyValueForDisplayFunction | undefined
 ): string {
-    if (breakdownFilter?.breakdown_histogram_bin_count != null && typeof breakdown_value === 'string') {
+    if (
+        breakdownFilter?.breakdown_histogram_bin_count != null &&
+        typeof breakdown_value === 'string' &&
+        breakdown_value.length > 0
+    ) {
         // replace nan with null
         const bucketValues = breakdown_value.replace(/\bnan\b/g, 'null')
         const [bucketStart, bucketEnd] = JSON.parse(bucketValues)


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0368RPHLQH/p1718278292100159

Fixes #22941
Fixes POSTHOG-1C2E

## Changes

Does not try to parse empty strings

## How did you test this code?

Locally