### PR TITLE
fix(properties): avoid adding empty property filters

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/propertyGroupFilterLogic.ts
+++ b/frontend/src/queries/nodes/InsightViz/PropertyGroupFilters/propertyGroupFilterLogic.ts
@@ -4,7 +4,7 @@ import { objectsEqual } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 import { StickinessQuery, TrendsQuery } from '~/queries/schema'
-import { EmptyPropertyFilter, FilterLogicalOperator, PropertyGroupFilter } from '~/types'
+import { FilterLogicalOperator, PropertyGroupFilter } from '~/types'
 
 import type { propertyGroupFilterLogicType } from './propertyGroupFilterLogicType'
 
@@ -48,15 +48,12 @@ export const propertyGroupFilterLogic = kea<propertyGroupFilterLogicType>([
                             values: [
                                 {
                                     type: FilterLogicalOperator.And,
-                                    values: [{} as EmptyPropertyFilter],
+                                    values: [],
                                 },
                             ],
                         }
                     }
-                    const filterGroups = [
-                        ...state.values,
-                        { type: FilterLogicalOperator.And, values: [{} as EmptyPropertyFilter] },
-                    ]
+                    const filterGroups = [...state.values, { type: FilterLogicalOperator.And, values: [] }]
 
                     return { ...state, values: filterGroups }
                 },


### PR DESCRIPTION
## Problem

Insights land in a state with invalid property filters.

Repro:
1. Go to a new insight
2. Switch the outermost properties filter toggle from AND to OR and back to AND
3. Save the insight
-> See faulty filter

## Changes

Does not add the empty property filter, avoiding the issue

## How did you test this code?

The empty property filter should have been there for _something_, all keeps working for me though