### PR TITLE
feat(insights): Move dashboard tile async load out of feature flag

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1022,13 +1022,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 const queryId = `${dashboardQueryId}::${uuid()}`
                 const queryStartTime = performance.now()
                 const apiUrl = `api/projects/${values.currentTeamId}/insights/${insight.id}/?${toParams({
-                    refresh: values.featureFlags[FEATURE_FLAGS.HOGQL_DASHBOARD_ASYNC]
-                        ? hardRefreshWithoutCache
-                            ? 'force_async'
-                            : 'async'
-                        : hardRefreshWithoutCache
-                        ? 'force_blocking'
-                        : 'blocking',
+                    refresh: hardRefreshWithoutCache ? 'force_async' : 'async',
                     from_dashboard: dashboardId, // needed to load insight in correct context
                     client_query_id: queryId,
                     session_id: currentSessionId(),


### PR DESCRIPTION
## Problem

We added async loading for whole dashboards and also for tiles behind a feature flag. But actually we can roll out async tiles right away since it doesn't cause any more load.

## Changes

Adjust condition

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

Just changing condition. Tested already.