### PR TITLE
feat: faster ingestion warnings

### DIFF
--- a/posthog/api/ingestion_warnings.py
+++ b/posthog/api/ingestion_warnings.py
@@ -17,11 +17,25 @@ class IngestionWarningsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         start_date = now() - timedelta(days=30)
         warning_events = sync_execute(
             """
-            SELECT type, timestamp, details
-            FROM ingestion_warnings
-            WHERE team_id = %(team_id)s
-              AND timestamp > %(start_date)s
-            ORDER BY timestamp DESC
+            SELECT
+                type,
+                count(details) as total_count,
+                arraySlice(groupArray((details, timestamp)), 1, 50) as top_50_recent_examples
+            FROM
+                (SELECT
+                    type,
+                    details,
+                    timestamp
+                 FROM
+                    ingestion_warnings
+                 WHERE
+                    team_id =  %(team_id)s
+                    AND timestamp > %(start_date)s
+                 ORDER BY
+                    type,
+                    timestamp DESC)
+            GROUP BY
+                type
         """,
             {
                 "team_id": self.team_id,
@@ -34,17 +48,19 @@ class IngestionWarningsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
 
 def _calculate_summaries(warning_events):
     summaries = {}
-    for warning_type, timestamp, details in warning_events:
-        details = json.loads(details)
-        if warning_type not in summaries:
-            summaries[warning_type] = {
-                "type": warning_type,
-                "lastSeen": timestamp,
-                "warnings": [],
-                "count": 0,
-            }
-
-        summaries[warning_type]["warnings"].append({"type": warning_type, "timestamp": timestamp, "details": details})
-        summaries[warning_type]["count"] += 1
+    for warning_type, count, examples in warning_events:
+        summaries[warning_type] = {
+            "type": warning_type,
+            "lastSeen": examples[0][1] if examples else None,
+            "warnings": [
+                {
+                    "type": warning_type,
+                    "timestamp": timestamp,
+                    "details": json.loads(details),
+                }
+                for details, timestamp in examples
+            ],
+            "count": count,
+        }
 
     return sorted(summaries.values(), key=lambda summary: summary["lastSeen"], reverse=True)

--- a/posthog/api/test/test_ingestion_warnings.py
+++ b/posthog/api/test/test_ingestion_warnings.py
@@ -31,7 +31,7 @@ def create_ingestion_warning(team_id: int, type: str, details: dict, timestamp: 
 class TestIngestionWarningsAPI(ClickhouseTestMixin, APIBaseTest):
     @freeze_time("2021-12-04T19:20:00Z")
     def test_ingestion_warnings_api(self):
-        a_lot_of_ingestion_warning_timestamps = []
+        a_lot_of_ingestion_warning_timestamps: list[str] = []
         # more than the number the front end will show
         # KLUDGE: it is 59 here so that timestamp creation can be naive
         for i in range(59):

--- a/posthog/api/test/test_ingestion_warnings.py
+++ b/posthog/api/test/test_ingestion_warnings.py
@@ -1,4 +1,5 @@
 import json
+from math import floor
 
 from freezegun.api import freeze_time
 from rest_framework import status
@@ -14,6 +15,7 @@ from posthog.utils import cast_timestamp_or_now
 
 def create_ingestion_warning(team_id: int, type: str, details: dict, timestamp: str, source=""):
     timestamp = cast_timestamp_or_now(timestamp)
+
     data = {
         "team_id": team_id,
         "type": type,
@@ -29,6 +31,22 @@ def create_ingestion_warning(team_id: int, type: str, details: dict, timestamp: 
 class TestIngestionWarningsAPI(ClickhouseTestMixin, APIBaseTest):
     @freeze_time("2021-12-04T19:20:00Z")
     def test_ingestion_warnings_api(self):
+        a_lot_of_ingestion_warning_timestamps = []
+        # more than the number the front end will show
+        # KLUDGE: it is 59 here so that timestamp creation can be naive
+        for i in range(59):
+            seconds = f"0{i}" if i < 10 else str(i)
+            minutes = floor(i / 10)
+            formatted_minutes = f"0{minutes}" if minutes < 10 else str(minutes)
+            timestamp = f"2021-12-04T13:{formatted_minutes}:{seconds}Z"
+            a_lot_of_ingestion_warning_timestamps.insert(0, timestamp)
+            create_ingestion_warning(
+                team_id=self.team.id,
+                type="replay_timestamp_too_far",
+                details={},
+                timestamp=timestamp,
+            )
+
         create_ingestion_warning(
             team_id=self.team.id,
             type="cannot_merge_already_identified",
@@ -69,10 +87,24 @@ class TestIngestionWarningsAPI(ClickhouseTestMixin, APIBaseTest):
 
         response = self.client.get(f"/api/projects/{self.team.pk}/ingestion_warnings")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(
-            response.json(),
-            {
+        assert (
+            response.json()
+            == {
                 "results": [
+                    {
+                        "count": 59,  # count is correct and not limited like the examples are
+                        "lastSeen": "2021-12-04T13:05:58Z",
+                        "type": "replay_timestamp_too_far",
+                        "warnings": [
+                            {
+                                "details": {},
+                                "timestamp": t,
+                                "type": "replay_timestamp_too_far",
+                                # even though there are very many warnings we limit the number of examples we send to the frontend
+                            }
+                            for t in a_lot_of_ingestion_warning_timestamps[:50]
+                        ],
+                    },
                     {
                         "type": "cannot_merge_already_identified",
                         "lastSeen": "2021-12-03T00:00:00Z",
@@ -108,5 +140,5 @@ class TestIngestionWarningsAPI(ClickhouseTestMixin, APIBaseTest):
                         "count": 1,
                     },
                 ]
-            },
+            }
         )


### PR DESCRIPTION
the ingestion warning page is basically unusable because there is no API-side paging

the query to load the data is pretty fast but

<img width="309" alt="Screenshot 2024-06-14 at 13 45 10" src="https://github.com/PostHog/posthog/assets/984817/341dfe6e-d046-4fad-a0ee-d7d02d88bee6">

we loop over the records to count them in python... then send them all over the wire

---

If you've got 509,000 ingestion warnings my guess is you'll never read them all

----

So, let's count in ClickHouse and return a limited number of examples

If someone really needs more than 50 examples we can add proper paging then

But I find myself not wanting to visit ingestion warnings so we should make this faster