### PR TITLE
fix: prevent canvas error

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
@@ -74,8 +74,10 @@ export const CanvasReplayerPlugin = (events: eventWithTime[]): ReplayPlugin => {
                     return
                 }
 
-                target.width = source.clientWidth
-                target.height = source.clientHeight
+                if (source) {
+                    target.width = source.clientWidth
+                    target.height = source.clientHeight
+                }
 
                 await canvasMutation({
                     event: e,


### PR DESCRIPTION
## Problem

Investigating https://posthoghelp.zendesk.com/agent/tickets/14769 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/17976) I noticed a recording was throwing a console error if the `source` is missing

## Changes

Given this just resizes the `target` (to account for the canvas changing size during a recording) we can just skip if the source can no longer be found.

Ideally the source would never be `null` but it is in this case so why not protect against it. I believe https://github.com/PostHog/posthog-js/pull/1241 (released in v1.139.1) should improve the null cases

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Errors disappeared locally