### PR TITLE
chore: more realtime data

### DIFF
--- a/posthog/session_recordings/realtime_snapshots.py
+++ b/posthog/session_recordings/realtime_snapshots.py
@@ -3,7 +3,7 @@ from time import sleep
 from typing import Optional
 
 import structlog
-from prometheus_client import Counter
+from prometheus_client import Counter, Histogram
 
 from posthog import settings
 from posthog.redis import get_client
@@ -20,6 +20,12 @@ PUBLISHED_REALTIME_SUBSCRIPTIONS_COUNTER = Counter(
 REALTIME_SUBSCRIPTIONS_LOADED_COUNTER = Counter(
     "realtime_snapshots_loaded_counter",
     "When the API is serving snapshot requests successfully loads snapshots from realtime channel.",
+    labelnames=["attempt_count"],
+)
+
+REALTIME_SUBSCRIPTIONS_DATA_LENGTH = Histogram(
+    "realtime_snapshots_data_length",
+    "The length of the data received from the realtime channel. It's ok for this to be zero _some times_ an increase in the rate of zero indicates a possible issue.",
     labelnames=["attempt_count"],
 )
 
@@ -91,6 +97,7 @@ def get_realtime_snapshots(team_id: str, session_id: str, attempt_count=0) -> Op
                     snapshots.append(line.decode("utf8"))
 
             REALTIME_SUBSCRIPTIONS_LOADED_COUNTER.labels(attempt_count=attempt_count).inc()
+            REALTIME_SUBSCRIPTIONS_DATA_LENGTH.labels(attempt_count=attempt_count).observe(len(snapshots))
             return snapshots
 
         return None


### PR DESCRIPTION
I didn't realise there was a problem in the EU until i impersonated a customer and couldn't load any recordings

as far as i can tell realtime source in the EU is consistently returning no data at the moment at least for one customer 🙈

let's graph the length of snapshot data realtime is returning... an increase of zeros indicates a possible issue 