### PR TITLE
feat: use new state deployment for posthog cloud

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -83,17 +83,22 @@ jobs:
                   token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Trigger PostHog Cloud deployment from Charts
-              uses: mvasigh/dispatch-action@main
+              uses: peter-evans/repository-dispatch@v3
               with:
                   token: ${{ steps.deployer.outputs.token }}
-                  repo: charts
-                  owner: PostHog
-                  event_type: posthog_deploy
-                  message: |
+                  repository: PostHog/charts
+                  event-type: commit_state_update
+                  client-payload: |
                       {
-                        "image_tag": "${{ steps.build.outputs.digest }}",
-                        "context": ${{ toJson(github) }},
-                        "github_labels": ${{ toJson(steps.labels.outputs.labels) }}
+                        "values": {
+                          "image": {
+                            "sha": "${{ steps.build.outputs.digest }}"
+                          }
+                        },
+                        "release": "posthog",
+                        "commit": ${{ toJson(github.event.head_commit) }},
+                        "repository": ${{ toJson(github.repository) }},
+                        "labels": ${{ steps.labels.outputs.labels }}
                       }
 
             - name: Check for changes in plugins directory


### PR DESCRIPTION
## Problem
see #23007 and #22668 , moving from doing hacky `helm get` calls and env vars to get the image tag to storing in a yaml file in posthog/charts

once https://github.com/PostHog/charts/pull/1343 is merged everything will be in place to support this (uploading assets)

this should make it significantly easier to do fast rollbacks

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
