### PR TITLE
feat: show filters on group page

### DIFF
--- a/frontend/src/scenes/error-tracking/ErrorTrackingFilters.tsx
+++ b/frontend/src/scenes/error-tracking/ErrorTrackingFilters.tsx
@@ -1,0 +1,109 @@
+import { LemonSelect } from '@posthog/lemon-ui'
+import { useActions, useValues } from 'kea'
+import { DateFilter } from 'lib/components/DateFilter/DateFilter'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
+import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
+import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
+
+import { AnyPropertyFilter } from '~/types'
+
+import { errorTrackingLogic } from './errorTrackingLogic'
+import { errorTrackingSceneLogic } from './errorTrackingSceneLogic'
+
+export const ErrorTrackingFilters = ({ showOrder = true }: { showOrder?: boolean }): JSX.Element => {
+    const { dateRange, filterGroup, filterTestAccounts } = useValues(errorTrackingLogic)
+    const { setDateRange, setFilterGroup, setFilterTestAccounts } = useActions(errorTrackingLogic)
+    const { order } = useValues(errorTrackingSceneLogic)
+    const { setOrder } = useActions(errorTrackingSceneLogic)
+
+    return (
+        <UniversalFilters
+            rootKey="session-recordings"
+            group={filterGroup}
+            taxonomicGroupTypes={[TaxonomicFilterGroupType.PersonProperties, TaxonomicFilterGroupType.Cohorts]}
+            onChange={(filterGroup) => {
+                setFilterGroup(filterGroup)
+            }}
+        >
+            <div className="divide-y bg-bg-light rounded border">
+                <div className="flex flex-1 items-center space-x-2 px-2 py-1.5">
+                    <RecordingsUniversalFilterGroup />
+                    <UniversalFilters.AddFilterButton type="secondary" size="small" />
+                </div>
+                <div className="flex space-x-1 justify-between px-2 py-1.5">
+                    <div className="flex space-x-1">
+                        <DateFilter
+                            dateFrom={dateRange.date_from}
+                            dateTo={dateRange.date_to}
+                            onChange={(changedDateFrom, changedDateTo) => {
+                                setDateRange({ date_from: changedDateFrom, date_to: changedDateTo })
+                            }}
+                            size="small"
+                        />
+                        {showOrder && (
+                            <LemonSelect
+                                onSelect={setOrder}
+                                onChange={setOrder}
+                                value={order}
+                                options={[
+                                    {
+                                        value: 'last_seen',
+                                        label: 'Last seen',
+                                    },
+                                    {
+                                        value: 'first_seen',
+                                        label: 'First seen',
+                                    },
+                                    {
+                                        value: 'unique_occurrences',
+                                        label: 'Occurrences',
+                                    },
+                                    {
+                                        value: 'unique_users',
+                                        label: 'Users',
+                                    },
+                                    {
+                                        value: 'unique_sessions',
+                                        label: 'Sessions',
+                                    },
+                                ]}
+                                size="small"
+                            />
+                        )}
+                    </div>
+                    <div>
+                        <TestAccountFilter
+                            filters={{ filter_test_accounts: filterTestAccounts }}
+                            onChange={({ filter_test_accounts }) => {
+                                setFilterTestAccounts(filter_test_accounts || false)
+                            }}
+                            size="small"
+                        />
+                    </div>
+                </div>
+            </div>
+        </UniversalFilters>
+    )
+}
+
+const RecordingsUniversalFilterGroup = (): JSX.Element => {
+    const { filterGroup } = useValues(universalFiltersLogic)
+    const { replaceGroupValue, removeGroupValue } = useActions(universalFiltersLogic)
+
+    const values = filterGroup.values as AnyPropertyFilter[]
+
+    return (
+        <>
+            {values.map((filter, index) => (
+                <UniversalFilters.Value
+                    key={index}
+                    index={index}
+                    filter={filter}
+                    onRemove={() => removeGroupValue(index)}
+                    onChange={(value) => replaceGroupValue(index, value)}
+                />
+            ))}
+        </>
+    )
+}

--- a/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
+++ b/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
@@ -1,20 +1,16 @@
-import { LemonSelect } from '@posthog/lemon-ui'
-import { useActions, useValues } from 'kea'
-import { DateFilter } from 'lib/components/DateFilter/DateFilter'
-import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
-import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
+import { useValues } from 'kea'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
-import { TestAccountFilter } from 'scenes/insights/filters/TestAccountFilter'
+import { useMemo } from 'react'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { Query } from '~/queries/Query/Query'
-import { NodeKind } from '~/queries/schema'
 import { QueryContext, QueryContextColumnComponent } from '~/queries/types'
-import { AnyPropertyFilter } from '~/types'
 
+import { ErrorTrackingFilters } from './ErrorTrackingFilters'
+import { errorTrackingLogic } from './errorTrackingLogic'
 import { errorTrackingSceneLogic } from './errorTrackingSceneLogic'
+import { errorTrackingQuery } from './queries'
 
 export const scene: SceneExport = {
     component: ErrorTrackingScene,
@@ -22,7 +18,13 @@ export const scene: SceneExport = {
 }
 
 export function ErrorTrackingScene(): JSX.Element {
-    const { dateRange, order, filterTestAccounts, filterGroup } = useValues(errorTrackingSceneLogic)
+    const { order } = useValues(errorTrackingSceneLogic)
+    const { dateRange, filterTestAccounts, filterGroup } = useValues(errorTrackingLogic)
+
+    const query = useMemo(
+        () => errorTrackingQuery({ order, dateRange, filterTestAccounts, filterGroup }),
+        [order, dateRange, filterTestAccounts, filterGroup]
+    )
 
     const context: QueryContext = {
         columns: {
@@ -36,39 +38,8 @@ export function ErrorTrackingScene(): JSX.Element {
 
     return (
         <div className="space-y-4">
-            <Filters />
-            <Query
-                query={{
-                    kind: NodeKind.DataTableNode,
-                    source: {
-                        kind: NodeKind.EventsQuery,
-                        select: [
-                            'any(properties) -- Error',
-                            'properties.$exception_type',
-                            'count() as unique_occurrences -- Occurrences',
-                            'count(distinct $session_id) as unique_sessions -- Sessions',
-                            'count(distinct distinct_id) as unique_users -- Users',
-                            'max(timestamp) as last_seen',
-                            'min(timestamp) as first_seen',
-                        ],
-                        event: '$exception',
-                        orderBy: [order],
-                        after: dateRange.date_from,
-                        before: dateRange.date_to,
-                        filterTestAccounts,
-                        properties: filterGroup.values,
-                    },
-                    hiddenColumns: [
-                        'properties.$exception_type',
-                        'first_value(properties)',
-                        'max(timestamp) as last_seen',
-                        'min(timestamp) as first_seen',
-                    ],
-                    showActions: false,
-                    showTimings: false,
-                }}
-                context={context}
-            />
+            <ErrorTrackingFilters />
+            <Query query={query} context={context} />
         </div>
     )
 }
@@ -83,98 +54,5 @@ const CustomGroupTitleColumn: QueryContextColumnComponent = (props) => {
             description={<div className="line-clamp-1">{properties.$exception_message}</div>}
             to={urls.errorTrackingGroup(properties.$exception_type)}
         />
-    )
-}
-
-const Filters = (): JSX.Element => {
-    const { dateRange, order, filterGroup, filterTestAccounts } = useValues(errorTrackingSceneLogic)
-    const { setDateRange, setOrder, setFilterGroup, setFilterTestAccounts } = useActions(errorTrackingSceneLogic)
-
-    return (
-        <UniversalFilters
-            rootKey="session-recordings"
-            group={filterGroup}
-            taxonomicGroupTypes={[TaxonomicFilterGroupType.PersonProperties, TaxonomicFilterGroupType.Cohorts]}
-            onChange={(filterGroup) => {
-                setFilterGroup(filterGroup)
-            }}
-        >
-            <div className="divide-y bg-bg-light rounded border">
-                <div className="flex space-x-1 justify-between px-2 py-1.5">
-                    <div className="flex space-x-1">
-                        <DateFilter
-                            dateFrom={dateRange.date_from}
-                            dateTo={dateRange.date_to}
-                            onChange={(changedDateFrom, changedDateTo) => {
-                                setDateRange({ date_from: changedDateFrom, date_to: changedDateTo })
-                            }}
-                            size="small"
-                        />
-                        <LemonSelect
-                            onSelect={setOrder}
-                            onChange={setOrder}
-                            value={order}
-                            options={[
-                                {
-                                    value: 'last_seen',
-                                    label: 'Last seen',
-                                },
-                                {
-                                    value: 'first_seen',
-                                    label: 'First seen',
-                                },
-                                {
-                                    value: 'unique_occurrences',
-                                    label: 'Occurrences',
-                                },
-                                {
-                                    value: 'unique_users',
-                                    label: 'Users',
-                                },
-                                {
-                                    value: 'unique_sessions',
-                                    label: 'Sessions',
-                                },
-                            ]}
-                            size="small"
-                        />
-                    </div>
-                    <div>
-                        <TestAccountFilter
-                            filters={{ filter_test_accounts: filterTestAccounts }}
-                            onChange={({ filter_test_accounts }) => {
-                                setFilterTestAccounts(filter_test_accounts || false)
-                            }}
-                            size="small"
-                        />
-                    </div>
-                </div>
-                <div className="flex flex-1 items-center space-x-2 px-2 py-1.5">
-                    <RecordingsUniversalFilterGroup />
-                    <UniversalFilters.AddFilterButton type="secondary" size="small" />
-                </div>
-            </div>
-        </UniversalFilters>
-    )
-}
-
-const RecordingsUniversalFilterGroup = (): JSX.Element => {
-    const { filterGroup } = useValues(universalFiltersLogic)
-    const { replaceGroupValue, removeGroupValue } = useActions(universalFiltersLogic)
-
-    const values = filterGroup.values as AnyPropertyFilter[]
-
-    return (
-        <>
-            {values.map((filter, index) => (
-                <UniversalFilters.Value
-                    key={index}
-                    index={index}
-                    filter={filter}
-                    onRemove={() => removeGroupValue(index)}
-                    onChange={(value) => replaceGroupValue(index, value)}
-                />
-            ))}
-        </>
     )
 }

--- a/frontend/src/scenes/error-tracking/errorTrackingLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingLogic.ts
@@ -1,0 +1,48 @@
+import { actions, kea, path, reducers } from 'kea'
+import { UniversalFiltersGroup } from 'lib/components/UniversalFilters/UniversalFilters'
+
+import { DateRange, ErrorTrackingOrder } from '~/queries/schema'
+import { FilterLogicalOperator } from '~/types'
+
+import type { errorTrackingLogicType } from './errorTrackingLogicType'
+
+export const errorTrackingLogic = kea<errorTrackingLogicType>([
+    path(['scenes', 'error-tracking', 'errorTrackingLogic']),
+
+    actions({
+        setDateRange: (dateRange: DateRange) => ({ dateRange }),
+        setOrder: (order: ErrorTrackingOrder) => ({ order }),
+        setFilterGroup: (filterGroup: UniversalFiltersGroup) => ({ filterGroup }),
+        setFilterTestAccounts: (filterTestAccounts: boolean) => ({ filterTestAccounts }),
+    }),
+    reducers({
+        dateRange: [
+            { date_from: '-7d', date_to: null } as DateRange,
+            { persist: true },
+            {
+                setDateRange: (_, { dateRange }) => dateRange,
+            },
+        ],
+        order: [
+            'last_seen' as ErrorTrackingOrder,
+            { persist: true },
+            {
+                setOrder: (_, { order }) => order,
+            },
+        ],
+        filterGroup: [
+            { type: FilterLogicalOperator.And, values: [] } as UniversalFiltersGroup,
+            { persist: true },
+            {
+                setFilterGroup: (_, { filterGroup }) => filterGroup,
+            },
+        ],
+        filterTestAccounts: [
+            false as boolean,
+            { persist: true },
+            {
+                setFilterTestAccounts: (_, { filterTestAccounts }) => filterTestAccounts,
+            },
+        ],
+    }),
+])

--- a/frontend/src/scenes/error-tracking/errorTrackingSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingSceneLogic.ts
@@ -1,8 +1,6 @@
 import { actions, kea, path, reducers } from 'kea'
-import { UniversalFiltersGroup } from 'lib/components/UniversalFilters/UniversalFilters'
 
-import { DateRange, ErrorTrackingOrder } from '~/queries/schema'
-import { FilterLogicalOperator } from '~/types'
+import { ErrorTrackingOrder } from '~/queries/schema'
 
 import type { errorTrackingSceneLogicType } from './errorTrackingSceneLogicType'
 
@@ -10,34 +8,14 @@ export const errorTrackingSceneLogic = kea<errorTrackingSceneLogicType>([
     path(['scenes', 'error-tracking', 'errorTrackingSceneLogic']),
 
     actions({
-        setDateRange: (dateRange: DateRange) => ({ dateRange }),
         setOrder: (order: ErrorTrackingOrder) => ({ order }),
-        setFilterGroup: (filterGroup: UniversalFiltersGroup) => ({ filterGroup }),
-        setFilterTestAccounts: (filterTestAccounts: boolean) => ({ filterTestAccounts }),
     }),
     reducers({
-        dateRange: [
-            { date_from: '-7d', date_to: null } as DateRange,
-            {
-                setDateRange: (_, { dateRange }) => dateRange,
-            },
-        ],
         order: [
             'last_seen' as ErrorTrackingOrder,
+            { persist: true },
             {
                 setOrder: (_, { order }) => order,
-            },
-        ],
-        filterGroup: [
-            { type: FilterLogicalOperator.And, values: [] } as UniversalFiltersGroup,
-            {
-                setFilterGroup: (_, { filterGroup }) => filterGroup,
-            },
-        ],
-        filterTestAccounts: [
-            false as boolean,
-            {
-                setFilterTestAccounts: (_, { filterTestAccounts }) => filterTestAccounts,
             },
         ],
     }),

--- a/frontend/src/scenes/error-tracking/queries.ts
+++ b/frontend/src/scenes/error-tracking/queries.ts
@@ -1,0 +1,81 @@
+import { UniversalFiltersGroup } from 'lib/components/UniversalFilters/UniversalFilters'
+
+import { DataTableNode, DateRange, ErrorTrackingOrder, EventsQuery, NodeKind } from '~/queries/schema'
+import { AnyPropertyFilter } from '~/types'
+
+export const errorTrackingQuery = ({
+    order,
+    dateRange,
+    filterTestAccounts,
+    filterGroup,
+}: {
+    order: ErrorTrackingOrder
+    dateRange: DateRange
+    filterTestAccounts: boolean
+    filterGroup: UniversalFiltersGroup
+}): DataTableNode => {
+    return {
+        kind: NodeKind.DataTableNode,
+        source: {
+            kind: NodeKind.EventsQuery,
+            select: [
+                'any(properties) -- Error',
+                'properties.$exception_type',
+                'count() as unique_occurrences -- Occurrences',
+                'count(distinct $session_id) as unique_sessions -- Sessions',
+                'count(distinct distinct_id) as unique_users -- Users',
+                'max(timestamp) as last_seen',
+                'min(timestamp) as first_seen',
+            ],
+            orderBy: [order],
+            ...defaultProperties({ dateRange, filterTestAccounts, filterGroup }),
+        },
+        hiddenColumns: [
+            'properties.$exception_type',
+            'first_value(properties)',
+            'max(timestamp) as last_seen',
+            'min(timestamp) as first_seen',
+        ],
+        showActions: false,
+        showTimings: false,
+    }
+}
+
+export const errorTrackingGroupQuery = ({
+    group,
+    dateRange,
+    filterTestAccounts,
+    filterGroup,
+}: {
+    group: string
+    dateRange: DateRange
+    filterTestAccounts: boolean
+    filterGroup: UniversalFiltersGroup
+}): EventsQuery => {
+    return {
+        kind: NodeKind.EventsQuery,
+        select: ['properties', 'timestamp', 'person'],
+        where: [`properties.$exception_type = '${group}'`],
+        ...defaultProperties({ dateRange, filterTestAccounts, filterGroup }),
+    }
+}
+
+const defaultProperties = ({
+    dateRange,
+    filterTestAccounts,
+    filterGroup,
+}: {
+    dateRange: DateRange
+    filterTestAccounts: boolean
+    filterGroup: UniversalFiltersGroup
+}): Pick<EventsQuery, 'event' | 'after' | 'before' | 'filterTestAccounts' | 'properties'> => {
+    const properties = filterGroup.values as AnyPropertyFilter[]
+
+    return {
+        event: '$exception',
+        after: dateRange.date_from || undefined,
+        before: dateRange.date_to || undefined,
+        filterTestAccounts,
+        properties,
+    }
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1006,15 +1006,6 @@ export type ErrorCluster = {
 }
 export type ErrorClusterResponse = ErrorCluster[] | null
 
-export type ErrorTrackingGroup = {
-    id: string
-    title: string
-    description: string
-    occurrences: number
-    uniqueSessions: number
-    uniqueUsers: number
-}
-
 export type EntityType = 'actions' | 'events' | 'data_warehouse' | 'new_entity'
 
 export interface Entity {


### PR DESCRIPTION
## Problem

We do not persist filters from the index page to the group

## Changes

- Given the filters are all property filters let's carry them over. Now you will only see a subset of exceptions ( / events) returned on the group page
- Rewrite the group logic as an `EventsQuery` to remove the raw hogql from the frontend

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Not yet