### PR TITLE
fix(data-warehouse): add username option to sshtunnel key pair

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -168,6 +168,13 @@ export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
                                 value: 'keypair',
                                 fields: [
                                     {
+                                        name: 'username',
+                                        label: 'Tunnel username',
+                                        type: 'text',
+                                        required: false,
+                                        placeholder: 'User1',
+                                    },
+                                    {
                                         name: 'private_key',
                                         label: 'Tunnel private key',
                                         type: 'textarea',

--- a/posthog/warehouse/models/ssh_tunnel.py
+++ b/posthog/warehouse/models/ssh_tunnel.py
@@ -119,6 +119,7 @@ class SSHTunnel:
         else:
             return SSHTunnelForwarder(
                 (self.host, int(self.port)),
+                ssh_username=self.username,
                 ssh_pkey=self.parse_private_key(),
                 ssh_private_key_password=self.passphrase,
                 remote_bind_address=(remote_host, remote_port),


### PR DESCRIPTION
## Problem

- key option doesn't have username
- https://posthoghelp.zendesk.com/agent/tickets/14729 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/16986)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- be able to pass a username for the server if using key pair

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
