### PR TITLE
fix: add ca-certs to livestream image

### DIFF
--- a/frontend/src/lib/utils/apiHost.ts
+++ b/frontend/src/lib/utils/apiHost.ts
@@ -14,6 +14,8 @@ export function liveEventsHostOrigin(): string | null {
         return 'https://live.us.posthog.com'
     } else if (appOrigin === 'https://eu.posthog.com') {
         return 'https://live.eu.posthog.com'
+    } else if (appOrigin === 'https://app.dev.posthog.dev') {
+        return 'https://live.dev.posthog.dev'
     }
     return 'http://localhost:8666'
 }

--- a/livestream/Dockerfile
+++ b/livestream/Dockerfile
@@ -21,4 +21,7 @@ RUN apt-get update && \
 
 FROM ubuntu
 COPY --from=builder /livestream /GeoLite2-City.mmdb /
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
+
 CMD ["/livestream"]


### PR DESCRIPTION
## Problem

ca-certs were missing for the livestream docker image

also add dev config so we can test it in dev

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
