### PR TITLE
fix(insights): Make fractional seconds optional when rendering tzlabel in DataTable

### DIFF
--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -73,7 +73,7 @@ export function renderColumn(
             } catch (e) {
                 // do nothing
             }
-            if (value.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}/)) {
+            if (value.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3,6})?Z$/)) {
                 return <TZLabel time={value} showSeconds />
             }
         }


### PR DESCRIPTION
## Problem

Fixes #22915

## Changes

The issue was identified in the date formatting logic, specifically in the regular expression used to match the date-time format. The regular expression only matched strings with fractional seconds. The fix involves updating the regular expression to optionally match fractional seconds.

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

Try this as SQL insight: `select '2024-06-19T09:15:04Z'`