### PR TITLE
feat: add api_token to livestream jwt claims

### DIFF
--- a/.github/workflows/livestream-docker-image.yml
+++ b/.github/workflows/livestream-docker-image.yml
@@ -58,31 +58,31 @@ jobs:
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
 
-    # deploy:
-    #   runs-on: ubuntu-latest
-    #   needs: build
-    #   steps:
-    #   - name: get deployer token
-    #     id: deployer
-    #     uses: getsentry/action-github-app-token@v3
-    #     with:
-    #         app_id: ${{ secrets.DEPLOYER_APP_ID }}
-    #         private_key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
+    deploy:
+        runs-on: ubuntu-latest
+        needs: build
+        steps:
+            - name: get deployer token
+              id: deployer
+              uses: getsentry/action-github-app-token@v3
+              with:
+                  app_id: ${{ secrets.DEPLOYER_APP_ID }}
+                  private_key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
 
-    #   - name: Trigger livestream deployment
-    #     uses: peter-evans/repository-dispatch@v3
-    #     with:
-    #         token: ${{ steps.deployer.outputs.token }}
-    #         repository: PostHog/charts
-    #         event-type: commit_state_update
-    #         client-payload: |
-    #             {
-    #               "values": {
-    #                 "image": {
-    #                   "sha": "${{ needs.build.outputs.sha }}"
-    #                 }
-    #               },
-    #               "release": "livestream",
-    #               "commit": ${{ toJson(github.event.head_commit) }},
-    #               "repository": ${{ toJson(github.repository) }}
-    #             }
+            - name: Trigger livestream deployment
+              uses: peter-evans/repository-dispatch@v3
+              with:
+                  token: ${{ steps.deployer.outputs.token }}
+                  repository: PostHog/charts
+                  event-type: commit_state_update
+                  client-payload: |
+                      {
+                        "values": {
+                          "image": {
+                            "sha": "${{ needs.build.outputs.sha }}"
+                          }
+                        },
+                        "release": "livestream",
+                        "commit": ${{ toJson(github.event.head_commit) }},
+                        "repository": ${{ toJson(github.repository) }}
+                      }

--- a/livestream/configs.go
+++ b/livestream/configs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/viper"
@@ -23,4 +24,10 @@ func loadConfigs() {
 		fmt.Println("Config file changed:", e.Name)
 	})
 	viper.WatchConfig()
+
+	viper.SetEnvPrefix("livestream") // will be uppercased automatically
+	replacer := strings.NewReplacer(".", "_")
+	viper.SetEnvKeyReplacer(replacer)
+	viper.BindEnv("jwt.secret")   // read from LIVESTREAM_JWT_SECRET
+	viper.BindEnv("postgres.url") // read from LIVESTREAM_POSTGRES_URL
 }

--- a/livestream/jwt.go
+++ b/livestream/jwt.go
@@ -31,7 +31,7 @@ func decodeAuthToken(authHeader string) (jwt.MapClaims, error) {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		// Here you should specify the secret used to sign your JWTs.
-		return []byte(viper.GetString("jwt.token")), nil
+		return []byte(viper.GetString("jwt.secret")), nil
 	})
 
 	if err != nil {

--- a/livestream/main.go
+++ b/livestream/main.go
@@ -264,9 +264,5 @@ func main() {
 		}
 	})
 
-	if !isProd {
-		e.Logger.Fatal(e.Start(":8080"))
-	} else {
-		e.Logger.Fatal(e.StartAutoTLS(":443"))
-	}
+	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -199,7 +199,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
 
     def get_live_events_token(self, team: Team) -> Optional[str]:
         return encode_jwt(
-            {"team_id": team.id},
+            {"team_id": team.id, "api_token": team.api_token},
             timedelta(days=7),
             PosthogJwtAudience.LIVESTREAM,
         )


### PR DESCRIPTION
## Problem

currently livestream has a dependency on postgres, but this is literally only used to fetch the api_token for a team.

include the token with jwt claim so we can kill this dependency

also:
- removed tls (when we deploy to k8s we don't need this)
- allow jwt.secret to be set from env var

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
