### PR TITLE
feat(hog): Changed timeouts to milliseconds and timedelta for python

### DIFF
--- a/hogvm/python/cli.py
+++ b/hogvm/python/cli.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import sys
 import json
 from .execute import execute_bytecode
@@ -18,6 +19,6 @@ with open(filename) as file:
     code = file.read()
     code = json.loads(code)
 
-response = execute_bytecode(code, globals=None, timeout=5, team=None, debug=debug)
+response = execute_bytecode(code, globals=None, timeout=timedelta(seconds=5), team=None, debug=debug)
 for line in response.stdout:
     print(line)  # noqa: T201

--- a/hogvm/python/execute.py
+++ b/hogvm/python/execute.py
@@ -61,8 +61,8 @@ def execute_bytecode(
         return BytecodeResult(result=None, stdout=stdout, bytecode=bytecode)
 
     def check_timeout():
-        if time.time() - start_time > timeout.seconds and not debug:
-            raise HogVMException(f"Execution timed out after {timeout.seconds} seconds. Performed {ops} ops.")
+        if time.time() - start_time > timeout.total_seconds() and not debug:
+            raise HogVMException(f"Execution timed out after {timeout.total_seconds()} seconds. Performed {ops} ops.")
 
     while True:
         ops += 1

--- a/hogvm/python/execute.py
+++ b/hogvm/python/execute.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import re
 import time
 from copy import deepcopy
@@ -26,7 +27,7 @@ def execute_bytecode(
     bytecode: list[Any],
     globals: Optional[dict[str, Any]] = None,
     functions: Optional[dict[str, Callable[..., Any]]] = None,
-    timeout=5,
+    timeout=timedelta(seconds=5),
     team: Optional["Team"] = None,
     debug=False,
 ) -> BytecodeResult:
@@ -60,8 +61,8 @@ def execute_bytecode(
         return BytecodeResult(result=None, stdout=stdout, bytecode=bytecode)
 
     def check_timeout():
-        if time.time() - start_time > timeout and not debug:
-            raise HogVMException(f"Execution timed out after {timeout} seconds. Performed {ops} ops.")
+        if time.time() - start_time > timeout.seconds and not debug:
+            raise HogVMException(f"Execution timed out after {timeout.seconds} seconds. Performed {ops} ops.")
 
     while True:
         ops += 1

--- a/hogvm/typescript/package.json
+++ b/hogvm/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/hogvm",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "description": "PostHog Hog Virtual Machine",
     "types": "dist/index.d.ts",
     "main": "dist/index.js",

--- a/posthog/hogql/bytecode.py
+++ b/posthog/hogql/bytecode.py
@@ -1,4 +1,5 @@
 import dataclasses
+from datetime import timedelta
 from typing import Any, Optional, cast, TYPE_CHECKING
 from collections.abc import Callable
 
@@ -388,7 +389,7 @@ def execute_hog(
     team: Optional["Team"] = None,
     globals: Optional[dict[str, Any]] = None,
     functions: Optional[dict[str, Callable[..., Any]]] = None,
-    timeout=10,
+    timeout=timedelta(seconds=10),
 ) -> BytecodeResult:
     source_code = source_code.strip()
     if source_code.count("\n") == 0:


### PR DESCRIPTION
## Problem

The Hog timeouts were defaulting to seconds which caught me out. Given that these functions should be fast, a milliseconds default feels safer

## Changes

* Changes the TS one to milliseconds with comments
* Changes python to a timedelta which is more pythonic

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
