### PR TITLE
fix: Do not retry on TemporalScheduleNotFoundError

### DIFF
--- a/posthog/temporal/batch_exports/backfill_batch_export.py
+++ b/posthog/temporal/batch_exports/backfill_batch_export.py
@@ -319,7 +319,9 @@ class BackfillBatchExportWorkflow(PostHogWorkflow):
             get_schedule_frequency,
             inputs.batch_export_id,
             start_to_close_timeout=dt.timedelta(minutes=1),
-            retry_policy=temporalio.common.RetryPolicy(maximum_attempts=0),
+            retry_policy=temporalio.common.RetryPolicy(
+                maximum_attempts=0, non_retryable_error_types=["TemporalScheduleNotFoundError"]
+            ),
         )
 
         # Temporal requires that we set a timeout.


### PR DESCRIPTION
## Problem

We shouldn't backfill a schedule that no longer exists. We'll raise an `TemporalScheduleNotFoundError` exception is that the case. However, we were not catching this error in the first `get_schedule_frequency` activity, which can cause it to fail and retry indefinitely.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
