### PR TITLE
fix(insights): Fix trends actors query not using series properties with actions

### DIFF
--- a/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
@@ -244,10 +244,11 @@ class TrendsActorsQueryBuilder:
                     )
                 )
 
-            if self.entity.properties is not None and self.entity.properties != []:
-                conditions.append(property_to_expr(self.entity.properties, self.team))
         else:
             raise ValueError(f"Invalid entity kind {self.entity.kind}")
+
+        if self.entity.properties is not None and self.entity.properties != []:
+            conditions.append(property_to_expr(self.entity.properties, self.team))
 
         return conditions
 


### PR DESCRIPTION
## Problem

Fixes #22978

## Changes

Move `entity.properties` conditions check

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

Use debug query

```
{
  "kind": "DataTableNode",
  "source": {
    "kind": "ActorsQuery",
    "source": {
      "kind": "InsightActorsQuery",
      "source": {
        "kind": "TrendsQuery",
        "filterTestAccounts": false,
        "series": [
          {
            "kind": "ActionsNode",
            "id": "1",
            "name": "Interacted with file",
            "properties": [
              {
                "key": "$feature/signup-page-4.0",
                "value": "is_not_set",
                "operator": "is_not_set",
                "type": "event"
              }
            ],
            "math": "dau"
          }
        ],
        "interval": "day",
        "trendsFilter": {
          "display": "BoldNumber"
        },
        "dateRange": {
          "date_from": "-1233d",
          "date_to": ""
        },
        "properties": {
          "type": "AND",
          "values": [
            {
              "type": "AND",
              "values": [
                {
                  "key": "id",
                  "value": 2,
                  "type": "cohort"
                }
              ]
            }
          ]
        }
      },
      "includeRecordings": true
    },
    "orderBy": [
      "event_count DESC, actor_id DESC"
    ],
    "search": ""
  },
  "full": true
}
```
