### PR TITLE
chore: persist player preferences

### DIFF
--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
@@ -22,7 +22,7 @@ export enum TimestampFormat {
     Device = 'device',
 }
 
-enum InspectorStacking {
+export enum InspectorStacking {
     Vertical = 'vertical',
     Horizontal = 'horizontal',
 }

--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
@@ -22,6 +22,17 @@ export enum TimestampFormat {
     Device = 'device',
 }
 
+enum InspectorStacking {
+    Vertical = 'vertical',
+    Horizontal = 'horizontal',
+}
+
+export enum PlaybackViewMode {
+    Playback = 'playback',
+    Inspector = 'inspector',
+    Waterfall = 'waterfall',
+}
+
 const MiniFilters: SharedListMiniFilter[] = [
     {
         tab: SessionRecordingPlayerTab.ALL,
@@ -191,6 +202,8 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
         setPrefersAdvancedFilters: (prefersAdvancedFilters: boolean) => ({ prefersAdvancedFilters }),
         setQuickFilterProperties: (properties: string[]) => ({ properties }),
         setTimestampFormat: (format: TimestampFormat) => ({ format }),
+        setPreferredInspectorStacking: (stacking: InspectorStacking) => ({ stacking }),
+        setPlaybackViewMode: (mode: PlaybackViewMode) => ({ mode }),
     }),
     connect({
         values: [teamLogic, ['currentTeam']],
@@ -203,6 +216,20 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
             },
             {
                 setShowFilters: (_, { showFilters }) => showFilters,
+            },
+        ],
+        preferredInspectorStacking: [
+            InspectorStacking.Horizontal as InspectorStacking,
+            { persist: true },
+            {
+                setPreferredInspectorStacking: (_, { stacking }) => stacking,
+            },
+        ],
+        playbackViewMode: [
+            PlaybackViewMode.Playback as PlaybackViewMode,
+            { persist: true },
+            {
+                setPlaybackViewMode: (_, { mode }) => mode,
             },
         ],
         prefersAdvancedFilters: [


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/23063

## Changes

Retain the playback mode & inspector preferences


![config-retained](https://github.com/PostHog/posthog/assets/6685876/9f6c2d8e-b595-457c-9997-3df39707c7b9)
(View is setup as before after each page refresh)