### PR TITLE
chore(livestream): Ignore invalid IP address errors

### DIFF
--- a/livestream/kafka.go
+++ b/livestream/kafka.go
@@ -116,7 +116,7 @@ func (c *KafkaConsumer) Consume() {
 
 		if ipStr != "" {
 			phEvent.Lat, phEvent.Lng, err = c.geolocator.Lookup(ipStr)
-			if err != nil {
+			if err != nil && err.Error() != "invalid IP address" { // An invalid IP address is not an error on our side
 				sentry.CaptureException(err)
 			}
 		}


### PR DESCRIPTION
# Problem

We're racking up a lot of useless invalid IP address errors. ([Sentry](https://posthog.sentry.io/issues/5512465904/?project=4507460997283840&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=0&utc=true))

## Changes

There might be `Lookup()` errors we want to capture, but "invalid IP address" is unlikely to be a problem on our side, so let's ignore it.