### PR TITLE
feat(insights): Support unary minus and plus in formulas

### DIFF
--- a/posthog/hogql_queries/utils/formula_ast.py
+++ b/posthog/hogql_queries/utils/formula_ast.py
@@ -63,7 +63,7 @@ class FormulaAST:
                 return -operand
             elif isinstance(unary_op, ast.UAdd):
                 return operand
-            raise ValueError(f"Operator {op.__class__.__name__} not supported")
+            raise ValueError(f"Operator {unary_op.__class__.__name__} not supported")
 
         elif isinstance(node, ast.Num):
             return node.n

--- a/posthog/hogql_queries/utils/formula_ast.py
+++ b/posthog/hogql_queries/utils/formula_ast.py
@@ -49,13 +49,21 @@ class FormulaAST:
             left = self._evaluate(node.left, const_map)
             op = node.op
             right = self._evaluate(node.right, const_map)
-
             try:
                 return self.op_map[type(op)](left, right)
             except ZeroDivisionError:
                 return 0
             except KeyError:
                 raise ValueError(f"Operator {op.__class__.__name__} not supported")
+
+        elif isinstance(node, ast.UnaryOp):
+            operand = self._evaluate(node.operand, const_map)
+            unary_op = node.op
+            if isinstance(unary_op, ast.USub):
+                return -operand
+            elif isinstance(unary_op, ast.UAdd):
+                return operand
+            raise ValueError(f"Operator {op.__class__.__name__} not supported")
 
         elif isinstance(node, ast.Num):
             return node.n

--- a/posthog/hogql_queries/utils/test/test_formula_ast.py
+++ b/posthog/hogql_queries/utils/test/test_formula_ast.py
@@ -56,3 +56,13 @@ class TestFormulaAST(APIBaseTest):
         formula = self._get_formula_ast()
         response = formula.call("a+b")
         self.assertListEqual([2, 4, 6, 8], response)
+
+    def test_unary_minus(self):
+        formula = self._get_formula_ast()
+        response = formula.call("-A")
+        self.assertListEqual([-1, -2, -3, -4], response)
+
+    def test_unary_plus(self):
+        formula = self._get_formula_ast()
+        response = formula.call("+A")
+        self.assertListEqual([1, 2, 3, 4], response)


### PR DESCRIPTION
## Problem

When doing manual QA on https://github.com/PostHog/posthog/pull/22995, I noticed we don't support formulas that look like this : `-A` – because unary operators weren't supported.
 
## Changes

Just added support while doing QA on that other PR, and with a couple tests added here I think we can simply ship it.