### PR TITLE
fix(data-warehouse): restore folder path logic

### DIFF
--- a/posthog/warehouse/models/external_data_job.py
+++ b/posthog/warehouse/models/external_data_job.py
@@ -3,7 +3,6 @@ from django.db.models import Prefetch
 from django.conf import settings
 from posthog.models.team import Team
 from posthog.models.utils import CreatedMetaFields, UUIDModel, sane_repr
-from posthog.settings import TEST
 from posthog.warehouse.s3 import get_s3_client
 from uuid import UUID
 from posthog.warehouse.util import database_sync_to_async
@@ -33,14 +32,12 @@ class ExternalDataJob(CreatedMetaFields, UUIDModel):
 
     @property
     def folder_path(self) -> str:
-        return f"team_{self.team_id}_{self.pipeline.source_type}_{str(self.schema_id)}".lower().replace("-", "_")
+        if self.schema and self.schema.is_incremental:
+            return f"team_{self.team_id}_{self.pipeline.source_type}_{str(self.schema.pk)}".lower().replace("-", "_")
+
+        return f"team_{self.team_id}_{self.pipeline.source_type}_{str(self.pk)}".lower().replace("-", "_")
 
     def url_pattern_by_schema(self, schema: str) -> str:
-        if TEST:
-            return (
-                f"http://{settings.AIRBYTE_BUCKET_DOMAIN}/test-pipeline/{self.folder_path}/{schema.lower()}/*.parquet"
-            )
-
         return f"https://{settings.AIRBYTE_BUCKET_DOMAIN}/dlt/{self.folder_path}/{schema.lower()}/*.parquet"
 
     def delete_data_in_bucket(self) -> None:

--- a/posthog/warehouse/models/external_data_job.py
+++ b/posthog/warehouse/models/external_data_job.py
@@ -3,6 +3,7 @@ from django.db.models import Prefetch
 from django.conf import settings
 from posthog.models.team import Team
 from posthog.models.utils import CreatedMetaFields, UUIDModel, sane_repr
+from posthog.settings import TEST
 from posthog.warehouse.s3 import get_s3_client
 from uuid import UUID
 from posthog.warehouse.util import database_sync_to_async
@@ -38,6 +39,11 @@ class ExternalDataJob(CreatedMetaFields, UUIDModel):
         return f"team_{self.team_id}_{self.pipeline.source_type}_{str(self.pk)}".lower().replace("-", "_")
 
     def url_pattern_by_schema(self, schema: str) -> str:
+        if TEST:
+            return (
+                f"http://{settings.AIRBYTE_BUCKET_DOMAIN}/test-pipeline/{self.folder_path}/{schema.lower()}/*.parquet"
+            )
+
         return f"https://{settings.AIRBYTE_BUCKET_DOMAIN}/dlt/{self.folder_path}/{schema.lower()}/*.parquet"
 
     def delete_data_in_bucket(self) -> None:


### PR DESCRIPTION
## Problem

- folder path is causing duplicate data

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- revert folder path logic

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
