### PR TITLE
Fix secret key error

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -185,6 +185,7 @@ services:
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
         environment:
             SENTRY_DSN: $SENTRY_DSN
+            SECRET_KEY: $POSTHOG_SECRET
             SITE_URL: https://$DOMAIN
         depends_on:
             - db


### PR DESCRIPTION
## Problem

Without this, the container endlessly crashes complaining that it has the default secret key. Fixes https://github.com/PostHog/posthog/issues/23589.

## Changes

Included secret key in the django worker

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Works locally for me

## How did you test this code?

Ran posthog on my machine
