### PR TITLE
fix(hogql): c++ parser line numbers

### DIFF
--- a/hogql_parser/parser.cpp
+++ b/hogql_parser/parser.cpp
@@ -2566,11 +2566,11 @@ class HogQLErrorListener : public antlr4::BaseErrorListener {
   size_t getPosition(size_t line, size_t column) {
     size_t linePosition = 0;
     for (size_t i = 0; i < line - 1; i++) {
-      size_t increment = input.find("\n", linePosition) + 1;
-      if (increment == string::npos) {
+      size_t endOfLine = input.find("\n", linePosition);
+      if (endOfLine == string::npos) {
         return string::npos;
       }
-      linePosition += increment;
+      linePosition = endOfLine + 1;
     }
     return linePosition + column;
   }


### PR DESCRIPTION
## Problem

The C++ parser returned incorrect positions for errors

## Changes

Fixes the logic.

![2024-06-21 12 25 17](https://github.com/PostHog/posthog/assets/53387/06ef609f-84ff-40ec-9948-81e93c0ef67b)


## How did you test this code?

Errors started to show up locally in the right places:

## TODO:

I'll wait for https://github.com/PostHog/posthog/pull/23100 to be merged, then release a new version with the parser from this PR.