### PR TITLE
fix(insights): Fix render column tzlabel regex

### DIFF
--- a/frontend/src/queries/nodes/DataTable/renderColumn.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumn.tsx
@@ -73,7 +73,7 @@ export function renderColumn(
             } catch (e) {
                 // do nothing
             }
-            if (value.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3,6})?Z$/)) {
+            if (value.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3,6})?(?:Z|[+-]\d{2}:\d{2})?$/)) {
                 return <TZLabel time={value} showSeconds />
             }
         }


### PR DESCRIPTION
## Problem

Regression in #23079 

Fixes #22915

## Changes

Adjust regex to make `Z` optional

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

Checked with other date formats