### PR TITLE
fix(data-warehouse): test prefetch

### DIFF
--- a/posthog/temporal/tests/external_data/test_external_data_job.py
+++ b/posthog/temporal/tests/external_data/test_external_data_job.py
@@ -283,7 +283,9 @@ async def test_run_stripe_job(activity_environment, team, minio_client, **kwargs
             schema=customer_schema,
         )
 
-        new_job = await sync_to_async(ExternalDataJob.objects.filter(id=new_job.id).prefetch_related("pipeline").get)()
+        new_job = await sync_to_async(
+            ExternalDataJob.objects.filter(id=new_job.id).prefetch_related("pipeline").prefetch_related("schema").get
+        )()
 
         inputs = ImportDataActivityInputs(
             team_id=team.id,
@@ -438,7 +440,9 @@ async def test_run_stripe_job_cancelled(activity_environment, team, minio_client
             schema=customer_schema,
         )
 
-        new_job = await sync_to_async(ExternalDataJob.objects.filter(id=new_job.id).prefetch_related("pipeline").get)()
+        new_job = await sync_to_async(
+            ExternalDataJob.objects.filter(id=new_job.id).prefetch_related("pipeline").prefetch_related("schema").get
+        )()
 
         inputs = ImportDataActivityInputs(
             team_id=team.id,
@@ -522,7 +526,9 @@ async def test_run_stripe_job_row_count_update(activity_environment, team, minio
             schema=customer_schema,
         )
 
-        new_job = await sync_to_async(ExternalDataJob.objects.filter(id=new_job.id).prefetch_related("pipeline").get)()
+        new_job = await sync_to_async(
+            ExternalDataJob.objects.filter(id=new_job.id).prefetch_related("pipeline").prefetch_related("schema").get
+        )()
 
         inputs = ImportDataActivityInputs(
             team_id=team.id,
@@ -688,7 +694,9 @@ async def test_run_postgres_job(
             schema=posthog_test_schema,
         )
 
-        new_job = await sync_to_async(ExternalDataJob.objects.filter(id=new_job.id).prefetch_related("pipeline").get)()
+        new_job = await sync_to_async(
+            ExternalDataJob.objects.filter(id=new_job.id).prefetch_related("pipeline").prefetch_related("schema").get
+        )()
 
         inputs = ImportDataActivityInputs(
             team_id=team.id, run_id=str(new_job.pk), source_id=new_source.pk, schema_id=posthog_test_schema.id


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

- tests failing because schema wasn't prefetched

## Changes

- make sure schema is prefetched otherwise will break in async logic

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
