### PR TITLE
fix: small improvements for subscribe to all products

### DIFF
--- a/frontend/src/scenes/billing/AllProductsPlanComparison.tsx
+++ b/frontend/src/scenes/billing/AllProductsPlanComparison.tsx
@@ -273,7 +273,7 @@ export const AllProductsPlanComparison = ({
                             <React.Fragment key={`inclusion-only-product-features-${includedProduct.type}`}>
                                 <tr className="border-b">
                                     {/* Inclusion product title row */}
-                                    <th colSpan={3} className="bg-side justify-left rounded text-left mb-2 py-6">
+                                    <th colSpan={3} className="justify-left rounded text-left mb-2 py-6">
                                         <div className="flex items-center gap-x-2 my-2">
                                             {getProductIcon(includedProduct.name, includedProduct.icon_key, 'text-2xl')}
                                             <Tooltip title={includedProduct.description}>

--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -136,7 +136,9 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                                 >
                                                     Learn how to reduce your bill
                                                 </LemonButton>
-                                                {featureFlags[FEATURE_FLAGS.SUBSCRIBE_TO_ALL_PRODUCTS] !== 'test' &&
+                                                {(featureFlags[FEATURE_FLAGS.SUBSCRIBE_TO_ALL_PRODUCTS] !== 'test' ||
+                                                    (featureFlags[FEATURE_FLAGS.SUBSCRIBE_TO_ALL_PRODUCTS] === 'test' &&
+                                                        billing?.subscription_level === 'custom')) &&
                                                     (product.plans?.length > 0 ? (
                                                         <LemonButton
                                                             fullWidth


### PR DESCRIPTION
## Changes

- Make sure the unsubscribe button is show for users that have the flag but are on a customer plan map
- Improve the plans comparison table header bg color with the rest of the table

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
