### PR TITLE
chore: log error if need be

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -276,8 +276,8 @@ def invalid_web_replays() -> None:
                 )
                 count = results[0][i]
                 gauge.set(count)
-    except:
-        pass
+    except Exception as e:
+        logger.error("Failed to run invalid web replays task", error=e, inc_exc_info=True)
 
 
 KNOWN_CELERY_TASK_IDENTIFIERS = {


### PR DESCRIPTION
follow-up to #23169

that code runs locally but isn't being reported in production 🤷 

this logs if there's an error in that task 
and incidentally restarts the worker pods in case that's all that's the problem