### PR TITLE
feat: remove exceptions to ignore from decide

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -224,7 +224,6 @@ def get_decide(request: HttpRequest):
             response["autocaptureExceptions"] = (
                 {
                     "endpoint": "/e/",
-                    "errors_to_ignore": team.autocapture_exceptions_errors_to_ignore or [],
                 }
                 if team.autocapture_exceptions_opt_in
                 else False

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -369,31 +369,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         response = self._post_decide().json()
         self.assertEqual(
             response["autocaptureExceptions"],
-            {"errors_to_ignore": [], "endpoint": "/e/"},
-        )
-
-    def test_exception_autocapture_errors_to_ignore(self, *args):
-        # :TRICKY: Test for regression around caching
-        response = self._post_decide().json()
-        self.assertEqual(response["autocaptureExceptions"], False)
-
-        self._update_team({"autocapture_exceptions_opt_in": True})
-        self._update_team(
-            {
-                "autocapture_exceptions_errors_to_ignore": [
-                    "ResizeObserver loop limit exceeded",
-                    ".* bot .*",
-                ]
-            }
-        )
-
-        response = self._post_decide().json()
-        self.assertEqual(
-            response["autocaptureExceptions"],
-            {
-                "errors_to_ignore": ["ResizeObserver loop limit exceeded", ".* bot .*"],
-                "endpoint": "/e/",
-            },
+            {"endpoint": "/e/"},
         )
 
     def test_user_session_recording_opt_in_wildcard_domain(self, *args):
@@ -2719,7 +2695,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
         self.assertEqual(response["featureFlags"], {})
         self.assertEqual(
             response["autocaptureExceptions"],
-            {"errors_to_ignore": [], "endpoint": "/e/"},
+            {"endpoint": "/e/"},
         )
 
         # now database is down
@@ -2743,7 +2719,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
             self.assertEqual(response["capturePerformance"], True)
             self.assertEqual(
                 response["autocaptureExceptions"],
-                {"errors_to_ignore": [], "endpoint": "/e/"},
+                {"endpoint": "/e/"},
             )
             self.assertEqual(response["featureFlags"], {})
 


### PR DESCRIPTION
let's remove this before we release any of the SDK side of error tracking

the first version of testing this allowed us to instruct the SDK to drop events

we're 99.9999% for sure changing ingestion and its nicer to do this in ingestion, so we don't need to tell the SDK about it in decide