### PR TITLE
fix(hog): metadata UnboundLocalError

### DIFF
--- a/posthog/hogql/metadata.py
+++ b/posthog/hogql/metadata.py
@@ -46,7 +46,6 @@ def get_hogql_metadata(
                 enable_select_queries=True,
                 debug=query.debug or False,
             )
-
             select_ast = parse_select(query.select)
             if query.filters:
                 select_ast = replace_filters(select_ast, query.filters, team)
@@ -57,14 +56,14 @@ def get_hogql_metadata(
                 context=context,
                 dialect="clickhouse",
             )
+            response.warnings = context.warnings
+            response.notices = context.notices
+            response.errors = context.errors
         elif isinstance(query.program, str):
             program = parse_program(query.program)
             create_bytecode(program, supported_functions={"fetch"}, args=[])
         else:
             raise ValueError("Either expr or select must be provided")
-        response.warnings = context.warnings
-        response.notices = context.notices
-        response.errors = context.errors
         response.isValid = len(response.errors) == 0
     except Exception as e:
         response.isValid = False


### PR DESCRIPTION
## Problem

![2024-06-24 10 45 53](https://github.com/PostHog/posthog/assets/53387/9bb45afb-70f4-4982-83ea-f8c7e8466d69)

## Changes

I'm not sure why this didn't trigger an error locally... but fixed now. I thought it may be a Python 3.10 vs 3.11 thing, but it also works fine with 3.11 locally 🤷 

## How did you test this code?

Testing in production as it's "works on my machine" (TM)