### PR TITLE
chore: Update pyproject.toml for Python 3.11

### DIFF
--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from django.core.cache import cache
 from flaky import flaky
 from rest_framework import status
@@ -1601,8 +1601,8 @@ class TestExperimentAuxiliaryEndpoints(ClickhouseTestMixin, APILicensedTest):
         explicit_datetime = parser.isoparse(target_filter["explicit_datetime"])
 
         self.assertTrue(
-            explicit_datetime <= datetime.now(timezone.utc) - timedelta(days=5)
-            and explicit_datetime >= datetime.now(timezone.utc) - timedelta(days=5, hours=1)
+            explicit_datetime <= datetime.now(UTC) - timedelta(days=5)
+            and explicit_datetime >= datetime.now(UTC) - timedelta(days=5, hours=1)
         )
 
         cohort_id = cohort["id"]

--- a/ee/session_recordings/session_summary/test/test_summarize_session.py
+++ b/ee/session_recordings/session_summary/test/test_summarize_session.py
@@ -1,4 +1,4 @@
-from datetime import timezone, datetime
+from datetime import datetime, UTC
 
 from dateutil.parser import isoparse
 
@@ -23,7 +23,7 @@ class TestSummarizeSessions(BaseTest):
                     ["$pageview", isoparse("2021-01-01T00:00:02Z")],
                 ],
             ),
-            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=UTC),
         )
         assert processed.columns == ["event", "milliseconds_since_start"]
         assert processed.results == [["$pageview", 0], ["$pageview", 1000], ["$pageview", 2000]]

--- a/ee/session_recordings/test/test_session_recording_extensions.py
+++ b/ee/session_recordings/test/test_session_recording_extensions.py
@@ -1,5 +1,5 @@
 import gzip
-from datetime import timedelta, datetime, timezone
+from datetime import timedelta, datetime, UTC
 from secrets import token_urlsafe
 from unittest.mock import patch, MagicMock
 from uuid import uuid4
@@ -84,7 +84,7 @@ class TestSessionRecordingExtensions(ClickhouseTestMixin, APIBaseTest):
 
     def test_persists_recording_from_blob_ingested_storage(self):
         with self.settings(OBJECT_STORAGE_SESSION_RECORDING_BLOB_INGESTION_FOLDER=TEST_BUCKET):
-            two_minutes_ago = (datetime.now() - timedelta(minutes=2)).replace(tzinfo=timezone.utc)
+            two_minutes_ago = (datetime.now() - timedelta(minutes=2)).replace(tzinfo=UTC)
 
             with freeze_time(two_minutes_ago):
                 session_id = f"test_persists_recording_from_blob_ingested_storage-s1-{uuid4()}"

--- a/ee/session_recordings/test/test_session_recording_playlist.py
+++ b/ee/session_recordings/test/test_session_recording_playlist.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from unittest import mock
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -187,7 +187,7 @@ class TestSessionRecordingPlaylist(APILicensedTest):
 
         session_one = f"test_fetch_playlist_recordings-session1-{uuid4()}"
         session_two = f"test_fetch_playlist_recordings-session2-{uuid4()}"
-        three_days_ago = (datetime.now() - timedelta(days=3)).replace(tzinfo=timezone.utc)
+        three_days_ago = (datetime.now() - timedelta(days=3)).replace(tzinfo=UTC)
 
         produce_replay_summary(
             team_id=self.team.id,
@@ -242,7 +242,7 @@ class TestSessionRecordingPlaylist(APILicensedTest):
 
         session_one = f"test_fetch_playlist_recordings-session1-{uuid4()}"
         session_two = f"test_fetch_playlist_recordings-session2-{uuid4()}"
-        three_days_ago = (datetime.now() - timedelta(days=3)).replace(tzinfo=timezone.utc)
+        three_days_ago = (datetime.now() - timedelta(days=3)).replace(tzinfo=UTC)
 
         for session_id in [session_one, session_two]:
             produce_replay_summary(

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -56,7 +56,7 @@ def generate_assets(
         # Wait for all assets to be exported
         tasks = [exporter.export_asset.si(asset.id) for asset in assets]
         # run them one after the other, so we don't exhaust celery workers
-        exports_expire = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(
+        exports_expire = datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(
             minutes=settings.PARALLEL_ASSET_GENERATION_MAX_TIMEOUT_MINUTES
         )
         parallel_job = chain(*tasks).apply_async(expires=exports_expire, retry=False)

--- a/posthog/api/app_metrics.py
+++ b/posthog/api/app_metrics.py
@@ -90,9 +90,7 @@ class AppMetricsViewSet(TeamAndOrgViewSetMixin, mixins.RetrieveModelMixin, views
         after = self.request.GET.get("date_from", "-30d")
         before = self.request.GET.get("date_to", None)
         after_datetime = relative_date_parse(after, self.team.timezone_info)
-        before_datetime = (
-            relative_date_parse(before, self.team.timezone_info) if before else dt.datetime.now(dt.timezone.utc)
-        )
+        before_datetime = relative_date_parse(before, self.team.timezone_info) if before else dt.datetime.now(dt.UTC)
         date_range = (after_datetime, before_datetime)
         runs = (
             BatchExportRun.objects.select_related("batch_export__destination")

--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -290,7 +290,7 @@ class PasswordResetSerializer(serializers.Serializer):
             user = None
 
         if user:
-            user.requested_password_reset_at = datetime.datetime.now(datetime.timezone.utc)
+            user.requested_password_reset_at = datetime.datetime.now(datetime.UTC)
             user.save()
             token = password_reset_token_generator.make_token(user)
             send_password_reset(user.id, token)

--- a/posthog/api/test/batch_exports/test_log_entry.py
+++ b/posthog/api/test/batch_exports/test_log_entry.py
@@ -38,7 +38,7 @@ def create_batch_export_log_entry(
             "log_source": "batch_exports",
             "log_source_id": batch_export_id,
             "instance_id": run_id,
-            "timestamp": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f"),
+            "timestamp": dt.datetime.now(dt.UTC).strftime("%Y-%m-%d %H:%M:%S.%f"),
             "level": level,
             "message": message,
         },
@@ -147,7 +147,7 @@ def test_log_level_filter(batch_export, team, level):
 
     results = []
     timeout = 10
-    start = dt.datetime.now(dt.timezone.utc)
+    start = dt.datetime.now(dt.UTC)
 
     while not results:
         results = fetch_batch_export_log_entries(
@@ -157,7 +157,7 @@ def test_log_level_filter(batch_export, team, level):
             after=dt.datetime(2023, 9, 22, 0, 59, 59),
             before=dt.datetime(2023, 9, 22, 1, 0, 1),
         )
-        if (dt.datetime.now(dt.timezone.utc) - start) > dt.timedelta(seconds=timeout):
+        if (dt.datetime.now(dt.UTC) - start) > dt.timedelta(seconds=timeout):
             break
 
     results.sort(key=lambda record: record.message)
@@ -195,7 +195,7 @@ def test_log_level_filter_with_lowercase(batch_export, team, level):
 
     results = []
     timeout = 10
-    start = dt.datetime.now(dt.timezone.utc)
+    start = dt.datetime.now(dt.UTC)
 
     while not results:
         results = fetch_batch_export_log_entries(
@@ -205,7 +205,7 @@ def test_log_level_filter_with_lowercase(batch_export, team, level):
             after=dt.datetime(2023, 9, 22, 0, 59, 59),
             before=dt.datetime(2023, 9, 22, 1, 0, 1),
         )
-        if (dt.datetime.now(dt.timezone.utc) - start) > dt.timedelta(seconds=timeout):
+        if (dt.datetime.now(dt.UTC) - start) > dt.timedelta(seconds=timeout):
             break
 
     results.sort(key=lambda record: record.message)

--- a/posthog/api/test/batch_exports/test_pause.py
+++ b/posthog/api/test/batch_exports/test_pause.py
@@ -397,8 +397,8 @@ def test_unpause_can_trigger_a_backfill(client: HttpClient):
 
         data = get_batch_export_ok(client, team.pk, batch_export_id)
         assert batch_export["last_updated_at"] < data["last_updated_at"]
-        start_at = dt.datetime.strptime(data["last_paused_at"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=dt.timezone.utc)
-        end_at = dt.datetime.strptime(data["last_updated_at"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=dt.timezone.utc)
+        start_at = dt.datetime.strptime(data["last_paused_at"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=dt.UTC)
+        end_at = dt.datetime.strptime(data["last_updated_at"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=dt.UTC)
         mock_backfill.assert_called_once_with(
             ANY,
             batch_export["id"],

--- a/posthog/api/test/batch_exports/test_update.py
+++ b/posthog/api/test/batch_exports/test_update.py
@@ -94,8 +94,8 @@ def test_can_put_config(client: HttpClient):
         new_schedule = describe_schedule(temporal, batch_export["id"])
         assert old_schedule.schedule.spec.intervals[0].every != new_schedule.schedule.spec.intervals[0].every
         assert new_schedule.schedule.spec.intervals[0].every == dt.timedelta(days=1)
-        assert new_schedule.schedule.spec.start_at == dt.datetime(2022, 7, 19, 0, 0, 0, tzinfo=dt.timezone.utc)
-        assert new_schedule.schedule.spec.end_at == dt.datetime(2023, 7, 20, 0, 0, 0, tzinfo=dt.timezone.utc)
+        assert new_schedule.schedule.spec.start_at == dt.datetime(2022, 7, 19, 0, 0, 0, tzinfo=dt.UTC)
+        assert new_schedule.schedule.spec.end_at == dt.datetime(2023, 7, 20, 0, 0, 0, tzinfo=dt.UTC)
 
         decoded_payload = async_to_sync(codec.decode)(new_schedule.schedule.action.args)
         args = json.loads(decoded_payload[0].data)

--- a/posthog/api/test/test_app_metrics.py
+++ b/posthog/api/test/test_app_metrics.py
@@ -116,7 +116,7 @@ class TestAppMetricsAPI(ClickhouseTestMixin, APIBaseTest):
 
         temporal = sync_connect()
 
-        now = dt.datetime(2021, 12, 5, 13, 23, 0, tzinfo=dt.timezone.utc)
+        now = dt.datetime(2021, 12, 5, 13, 23, 0, tzinfo=dt.UTC)
         with start_test_worker(temporal):
             response = create_batch_export_ok(
                 self.client,
@@ -213,7 +213,7 @@ class TestAppMetricsAPI(ClickhouseTestMixin, APIBaseTest):
         }
 
         temporal = sync_connect()
-        now = dt.datetime(2021, 12, 5, 13, 23, 0, tzinfo=dt.timezone.utc)
+        now = dt.datetime(2021, 12, 5, 13, 23, 0, tzinfo=dt.UTC)
 
         with start_test_worker(temporal):
             response = create_batch_export_ok(

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -13,7 +13,7 @@ import string
 import structlog
 import zlib
 from datetime import datetime, timedelta
-from datetime import timezone as tz
+from datetime import UTC
 from django.http import HttpResponse
 from django.test.client import MULTIPART_CONTENT, Client
 from django.utils import timezone
@@ -1305,7 +1305,7 @@ class TestCapture(BaseTest):
         # right time sent as sent_at to process_event
 
         sent_at = datetime.fromisoformat(arguments["sent_at"])
-        self.assertEqual(sent_at.tzinfo, tz.utc)
+        self.assertEqual(sent_at.tzinfo, UTC)
 
         timediff = sent_at.timestamp() - tomorrow_sent_at.timestamp()
         self.assertLess(abs(timediff), 1)

--- a/posthog/async_migrations/test/test_utils.py
+++ b/posthog/async_migrations/test/test_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from unittest.mock import patch
 
 import pytest
@@ -49,7 +49,7 @@ class TestUtils(AsyncMigrationBaseTest):
 
         sm.refresh_from_db()
         self.assertEqual(sm.status, MigrationStatus.Errored)
-        self.assertGreater(sm.finished_at, datetime.now(timezone.utc) - timedelta(hours=1))
+        self.assertGreater(sm.finished_at, datetime.now(UTC) - timedelta(hours=1))
         errors = AsyncMigrationError.objects.filter(async_migration=sm).order_by("created_at")
         self.assertEqual(errors.count(), 2)
         self.assertEqual(errors[0].description, "some error")
@@ -81,7 +81,7 @@ class TestUtils(AsyncMigrationBaseTest):
         sm.refresh_from_db()
 
         self.assertEqual(sm.status, MigrationStatus.CompletedSuccessfully)
-        self.assertGreater(sm.finished_at, datetime.now(timezone.utc) - timedelta(hours=1))
+        self.assertGreater(sm.finished_at, datetime.now(UTC) - timedelta(hours=1))
 
         self.assertEqual(sm.progress, 100)
         errors = AsyncMigrationError.objects.filter(async_migration=sm)

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -76,11 +76,11 @@ def validate_date_input(date_input: Any, team: Team | None = None) -> dt.datetim
 
     if parsed.tzinfo is None:
         if team:
-            parsed = parsed.replace(tzinfo=team.timezone_info).astimezone(dt.timezone.utc)
+            parsed = parsed.replace(tzinfo=team.timezone_info).astimezone(dt.UTC)
         else:
-            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+            parsed = parsed.replace(tzinfo=dt.UTC)
     else:
-        parsed = parsed.astimezone(dt.timezone.utc)
+        parsed = parsed.astimezone(dt.UTC)
 
     return parsed
 

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -257,7 +257,7 @@ def pause_batch_export(temporal: Client, batch_export_id: str, note: str | None 
         raise BatchExportServiceRPCError(f"BatchExport {batch_export_id} could not be paused") from exc
 
     batch_export.paused = True
-    batch_export.last_paused_at = dt.datetime.now(dt.timezone.utc)
+    batch_export.last_paused_at = dt.datetime.now(dt.UTC)
     batch_export.save()
 
     return True
@@ -285,7 +285,7 @@ async def apause_batch_export(temporal: Client, batch_export_id: str, note: str 
         raise BatchExportServiceRPCError(f"BatchExport {batch_export_id} could not be paused") from exc
 
     batch_export.paused = True
-    batch_export.last_paused_at = dt.datetime.now(dt.timezone.utc)
+    batch_export.last_paused_at = dt.datetime.now(dt.UTC)
     await batch_export.asave()
 
     return True

--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -154,7 +154,7 @@ def execute_process_query(
 
     query_status.error = True  # Assume error in case nothing below ends up working
 
-    pickup_time = datetime.datetime.now(datetime.timezone.utc)
+    pickup_time = datetime.datetime.now(datetime.UTC)
     if query_status.start_time:
         wait_duration = (pickup_time - query_status.start_time) / datetime.timedelta(seconds=1)
         QUERY_WAIT_TIME.labels(team=team_id).observe(wait_duration)
@@ -173,7 +173,7 @@ def execute_process_query(
         query_status.complete = True
         query_status.error = False
         query_status.results = results
-        query_status.end_time = datetime.datetime.now(datetime.timezone.utc)
+        query_status.end_time = datetime.datetime.now(datetime.UTC)
         query_status.expiration_time = query_status.end_time + datetime.timedelta(seconds=manager.STATUS_TTL_SECONDS)
         process_duration = (query_status.end_time - pickup_time) / datetime.timedelta(seconds=1)
         QUERY_PROCESS_TIME.labels(team=team_id).observe(process_duration)
@@ -232,7 +232,7 @@ def enqueue_process_query_task(
         return manager.get_query_status()
 
     # Immediately set status, so we don't have race with celery
-    query_status = QueryStatus(id=query_id, team_id=team.id, start_time=datetime.datetime.now(datetime.timezone.utc))
+    query_status = QueryStatus(id=query_id, team_id=team.id, start_time=datetime.datetime.now(datetime.UTC))
     manager.store_query_status(query_status)
 
     if _test_only_bypass_celery:

--- a/posthog/clickhouse/test/test_person_overrides.py
+++ b/posthog/clickhouse/test/test_person_overrides.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from time import sleep
 from typing import TypedDict
 from uuid import UUID, uuid4
@@ -124,7 +124,7 @@ def test_person_overrides_dict():
         "override_person_id": uuid4(),
         "merged_at": datetime.fromisoformat("2020-01-02T00:00:00+00:00"),
         "oldest_event": datetime.fromisoformat("2020-01-01T00:00:00+00:00"),
-        "created_at": datetime.now(timezone.utc),
+        "created_at": datetime.now(UTC),
         "version": 1,
     }
 

--- a/posthog/demo/matrix/models.py
+++ b/posthog/demo/matrix/models.py
@@ -106,9 +106,7 @@ class SimEvent:
     group4_created_at: Optional[dt.datetime] = None
 
     def __str__(self) -> str:
-        separator = (
-            "-" if self.timestamp < dt.datetime.now(dt.timezone.utc) else "+"
-        )  # Future events are denoted by a '+'
+        separator = "-" if self.timestamp < dt.datetime.now(dt.UTC) else "+"  # Future events are denoted by a '+'
         display = f"{self.timestamp} {separator} {self.event} # {self.distinct_id}"
         if current_url := self.properties.get("$current_url"):
             display += f" @ {current_url}"

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -1,4 +1,4 @@
-from datetime import timezone, datetime, date
+from datetime import datetime, date, UTC
 from typing import Optional, cast
 import pytest
 from django.test import override_settings
@@ -97,7 +97,7 @@ class TestResolver(BaseTest):
                 "SELECT 1, 'boo', true, 1.1232, null, {date}, {datetime}, {uuid}, {array}, {array12}, {tuple}",
                 placeholders={
                     "date": ast.Constant(value=date(2020, 1, 10)),
-                    "datetime": ast.Constant(value=datetime(2020, 1, 10, 0, 0, 0, tzinfo=timezone.utc)),
+                    "datetime": ast.Constant(value=datetime(2020, 1, 10, 0, 0, 0, tzinfo=UTC)),
                     "uuid": ast.Constant(value=UUID("00000000-0000-4000-8000-000000000000")),
                     "array": ast.Constant(value=[]),
                     "array12": ast.Constant(value=[1, 2]),

--- a/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_actors_query_builder.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from typing import Optional, cast
 
 from freezegun import freeze_time
@@ -70,7 +70,7 @@ class TestTrendsActorsQueryBuilder(BaseTest):
     def _get_utc_string(self, dt: datetime | None) -> str | None:
         if dt is None:
             return None
-        return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+        return dt.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%SZ")
 
     def test_time_frame(self):
         self.team.timezone = "Europe/Berlin"

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from enum import IntEnum
 from typing import Any, Generic, Optional, TypeVar, Union, cast, TypeGuard
 from zoneinfo import ZoneInfo
@@ -445,7 +445,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             elif execution_mode == ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE:
                 # We're allowed to calculate if the cache is older than 24 hours, but we'll do it asynchronously
                 assert isinstance(cached_response, CachedResponse)
-                if datetime.now(timezone.utc) - cached_response.last_refresh > EXTENDED_CACHE_AGE:
+                if datetime.now(UTC) - cached_response.last_refresh > EXTENDED_CACHE_AGE:
                     query_status_response = self.enqueue_async_calculation(cache_key=cache_key, user=user)
                     cached_response.query_status = query_status_response.query_status
                 return cached_response
@@ -490,8 +490,8 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         fresh_response_dict = {
             **self.calculate().model_dump(),
             "is_cached": False,
-            "last_refresh": datetime.now(timezone.utc),
-            "next_allowed_client_refresh": datetime.now(timezone.utc) + self._refresh_frequency(),
+            "last_refresh": datetime.now(UTC),
+            "next_allowed_client_refresh": datetime.now(UTC) + self._refresh_frequency(),
             "cache_key": cache_key,
             "timezone": self.team.timezone,
         }

--- a/posthog/jwt.py
+++ b/posthog/jwt.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from enum import Enum
 from typing import Any
 
@@ -23,7 +23,7 @@ def encode_jwt(payload: dict, expiry_delta: timedelta, audience: PosthogJwtAudie
     encoded_jwt = jwt.encode(
         {
             **payload,
-            "exp": datetime.now(tz=timezone.utc) + expiry_delta,
+            "exp": datetime.now(tz=UTC) + expiry_delta,
             "aud": audience.value,
         },
         settings.SECRET_KEY,

--- a/posthog/management/commands/create_batch_export_from_app.py
+++ b/posthog/management/commands/create_batch_export_from_app.py
@@ -116,7 +116,7 @@ class Command(BaseCommand):
 
         if options.get("backfill_batch_export", False) and dry_run is False:
             client = sync_connect()
-            end_at = dt.datetime.now(dt.timezone.utc)
+            end_at = dt.datetime.now(dt.UTC)
             start_at = end_at - (dt.timedelta(hours=1) if interval == "hour" else dt.timedelta(days=1))
             backfill_export(
                 client,

--- a/posthog/management/commands/generate_demo_data.py
+++ b/posthog/management/commands/generate_demo_data.py
@@ -65,7 +65,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         timer = monotonic()
         seed = options.get("seed") or secrets.token_hex(16)
-        now = options.get("now") or dt.datetime.now(dt.timezone.utc)
+        now = options.get("now") or dt.datetime.now(dt.UTC)
         existing_team_id = options.get("team_id")
         if (
             existing_team_id is not None

--- a/posthog/management/commands/migrate_team.py
+++ b/posthog/management/commands/migrate_team.py
@@ -254,7 +254,7 @@ def create_migration(
         raise CommandError("Didn't receive 'y', exiting")
     print()  # noqa: T201
 
-    now = dt.datetime.now(dt.timezone.utc)
+    now = dt.datetime.now(dt.UTC)
     # This is a precaution so we don't accidentally leave the export running indefinitely.
     end_at = now + dt.timedelta(days=end_days_from_now)
 
@@ -299,5 +299,5 @@ def parse_to_utc(date_str: str) -> dt.datetime:
         except ValueError:
             raise ValueError("Invalid date format. Expected 'YYYY-MM-DD' or 'YYYY-MM-DD HH:MM:SS'.")
 
-    utc_datetime = parsed_datetime.replace(tzinfo=dt.timezone.utc)
+    utc_datetime = parsed_datetime.replace(tzinfo=dt.UTC)
     return utc_datetime

--- a/posthog/management/commands/plugin_server_load_test.py
+++ b/posthog/management/commands/plugin_server_load_test.py
@@ -63,7 +63,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         seed = options.get("seed") or secrets.token_hex(16)
-        now = options.get("now") or dt.datetime.now(dt.timezone.utc)
+        now = options.get("now") or dt.datetime.now(dt.UTC)
 
         admin = KafkaAdminClient(bootstrap_servers=settings.KAFKA_HOSTS)
         consumer = KafkaConsumer(KAFKA_EVENTS_PLUGIN_INGESTION_TOPIC, bootstrap_servers=settings.KAFKA_HOSTS)

--- a/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
+++ b/posthog/management/commands/test/test_sync_persons_to_clickhouse.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from unittest import mock
 from uuid import UUID, uuid4
 
@@ -143,7 +143,7 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
         wraps=posthog.management.commands.sync_persons_to_clickhouse.raw_create_group_ch,
     )
     def test_group_sync(self, mocked_ch_call):
-        ts = datetime.now(timezone.utc)
+        ts = datetime.now(UTC)
         Group.objects.create(
             team_id=self.team.pk,
             group_type_index=2,
@@ -183,12 +183,12 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
             2,
             "group-key",
             {"a": 5},
-            timestamp=datetime.now(timezone.utc) - timedelta(hours=3),
+            timestamp=datetime.now(UTC) - timedelta(hours=3),
         )
         group.group_properties = {"a": 5, "b": 3}
         group.save()
 
-        ts_before = datetime.now(timezone.utc)
+        ts_before = datetime.now(UTC)
         run_group_sync(self.team.pk, live_run=True, sync=True)
         mocked_ch_call.assert_called_once()
 
@@ -213,7 +213,7 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
         )
         self.assertLessEqual(
             ch_group[4].strftime("%Y-%m-%d %H:%M:%S"),
-            datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+            datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S"),
         )
 
         # second time it's a no-op
@@ -225,7 +225,7 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
         wraps=posthog.management.commands.sync_persons_to_clickhouse.raw_create_group_ch,
     )
     def test_group_sync_multiple_entries(self, mocked_ch_call):
-        ts = datetime.now(timezone.utc)
+        ts = datetime.now(UTC)
         Group.objects.create(
             team_id=self.team.pk,
             group_type_index=2,
@@ -430,7 +430,7 @@ class TestSyncPersonsToClickHouse(BaseTest, ClickhouseTestMixin):
             group_type_index=2,
             group_key="group-key",
             group_properties={"a": 1234},
-            created_at=datetime.now(timezone.utc) - timedelta(hours=3),
+            created_at=datetime.now(UTC) - timedelta(hours=3),
             version=5,
         )
 

--- a/posthog/models/filters/stickiness_filter.py
+++ b/posthog/models/filters/stickiness_filter.py
@@ -72,7 +72,7 @@ class StickinessFilter(
         else:
             data = {"insight": INSIGHT_STICKINESS}
         super().__init__(data, request, **kwargs)
-        team: Optional["Team"] = kwargs.get("team", None)
+        team: Optional[Team] = kwargs.get("team", None)
         if not team:
             raise ValidationError("Team must be provided to stickiness filter")
         self.team = team

--- a/posthog/models/test/test_async_deletion_model.py
+++ b/posthog/models/test/test_async_deletion_model.py
@@ -65,7 +65,7 @@ class TestAsyncDeletion(ClickhouseTestMixin, ClickhouseDestroyTablesMixin, BaseT
 
     @snapshot_clickhouse_queries
     def test_mark_deletions_done_person(self):
-        base_datetime = dt.datetime(2024, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
+        base_datetime = dt.datetime(2024, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
 
         _create_event(
             event_uuid=uuid4(),
@@ -101,7 +101,7 @@ class TestAsyncDeletion(ClickhouseTestMixin, ClickhouseDestroyTablesMixin, BaseT
 
     @snapshot_clickhouse_queries
     def test_mark_deletions_done_person_when_not_done(self):
-        base_datetime = dt.datetime(2024, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
+        base_datetime = dt.datetime(2024, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
 
         _create_event(
             event_uuid=uuid4(),
@@ -226,7 +226,7 @@ class TestAsyncDeletion(ClickhouseTestMixin, ClickhouseDestroyTablesMixin, BaseT
 
     @snapshot_clickhouse_alter_queries
     def test_delete_person(self):
-        base_datetime = dt.datetime(2024, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
+        base_datetime = dt.datetime(2024, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
 
         # Event for person, created before AsyncDeletion, so it should be deleted
         _create_event(
@@ -264,7 +264,7 @@ class TestAsyncDeletion(ClickhouseTestMixin, ClickhouseDestroyTablesMixin, BaseT
 
     @snapshot_clickhouse_alter_queries
     def test_delete_person_unrelated(self):
-        base_datetime = dt.datetime(2024, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
+        base_datetime = dt.datetime(2024, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
 
         _create_event(
             event_uuid=uuid4(),

--- a/posthog/models/test/test_person_override_model.py
+++ b/posthog/models/test/test_person_override_model.py
@@ -48,7 +48,7 @@ def people(team):
 
 @pytest.fixture
 def oldest_event():
-    return dt.datetime.now(dt.timezone.utc)
+    return dt.datetime.now(dt.UTC)
 
 
 @pytest.mark.django_db(transaction=True)

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -1,7 +1,7 @@
 import os
 import time
 from contextlib import contextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from prometheus_client import Histogram
 import json
 from typing import Any, cast
@@ -430,7 +430,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 # Keys are like 1619712000-1619712060
                 blob_key = full_key.replace(blob_prefix.rstrip("/") + "/", "")
                 blob_key_base = blob_key.split(".")[0]  # Remove the extension if it exists
-                time_range = [datetime.fromtimestamp(int(x) / 1000, tz=timezone.utc) for x in blob_key_base.split("-")]
+                time_range = [datetime.fromtimestamp(int(x) / 1000, tz=UTC) for x in blob_key_base.split("-")]
 
                 sources.append(
                     {
@@ -446,7 +446,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             newest_timestamp = min(sources, key=lambda k: k["end_timestamp"])["end_timestamp"]
 
             if might_have_realtime:
-                might_have_realtime = oldest_timestamp + timedelta(hours=24) > datetime.now(timezone.utc)
+                might_have_realtime = oldest_timestamp + timedelta(hours=24) > datetime.now(UTC)
         if might_have_realtime:
             sources.append(
                 {

--- a/posthog/session_recordings/session_recording_helpers.py
+++ b/posthog/session_recordings/session_recording_helpers.py
@@ -2,7 +2,7 @@ import base64
 import gzip
 import json
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from typing import Any
 from collections.abc import Callable, Generator
 
@@ -268,7 +268,7 @@ def is_active_event(event: SessionRecordingEventSummary) -> bool:
 
 
 def parse_snapshot_timestamp(timestamp: int):
-    return datetime.fromtimestamp(timestamp / 1000, timezone.utc)
+    return datetime.fromtimestamp(timestamp / 1000, UTC)
 
 
 def convert_to_timestamp(source: str) -> int:

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1,7 +1,7 @@
 import json
 import time
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from unittest.mock import ANY, patch, MagicMock, call
 from urllib.parse import urlencode
 
@@ -395,7 +395,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             "distinct_id": "d1",
             "viewed": False,
             "recording_duration": 30,
-            "start_time": base_time.replace(tzinfo=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "start_time": base_time.replace(tzinfo=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "end_time": (base_time + relativedelta(seconds=30)).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "click_count": 0,
             "keypress_count": 0,

--- a/posthog/tasks/test/test_process_scheduled_changes.py
+++ b/posthog/tasks/test/test_process_scheduled_changes.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from posthog.models import ScheduledChange, FeatureFlag
 from posthog.test.base import APIBaseTest, QueryMatchingTest, snapshot_postgres_queries
 from posthog.tasks.process_scheduled_changes import process_scheduled_changes
@@ -21,7 +21,7 @@ class TestProcessScheduledChanges(APIBaseTest, QueryMatchingTest):
             record_id=feature_flag.id,
             model_name="FeatureFlag",
             payload={"operation": "update_status", "value": True},
-            scheduled_at=(datetime.now(timezone.utc) - timedelta(seconds=30)).isoformat(),
+            scheduled_at=(datetime.now(UTC) - timedelta(seconds=30)).isoformat(),
         )
 
         process_scheduled_changes()
@@ -55,7 +55,7 @@ class TestProcessScheduledChanges(APIBaseTest, QueryMatchingTest):
             record_id=feature_flag.id,
             model_name="FeatureFlag",
             payload=payload,
-            scheduled_at=(datetime.now(timezone.utc) - timedelta(seconds=30)),
+            scheduled_at=(datetime.now(UTC) - timedelta(seconds=30)),
         )
 
         process_scheduled_changes()
@@ -105,7 +105,7 @@ class TestProcessScheduledChanges(APIBaseTest, QueryMatchingTest):
             record_id=feature_flag.id,
             model_name="FeatureFlag",
             payload=payload,
-            scheduled_at=(datetime.now(timezone.utc) - timedelta(seconds=30)),
+            scheduled_at=(datetime.now(UTC) - timedelta(seconds=30)),
         )
 
         process_scheduled_changes()
@@ -131,7 +131,7 @@ class TestProcessScheduledChanges(APIBaseTest, QueryMatchingTest):
             record_id=feature_flag.id,
             model_name="FeatureFlag",
             payload=payload,
-            scheduled_at=(datetime.now(timezone.utc) - timedelta(seconds=30)),
+            scheduled_at=(datetime.now(UTC) - timedelta(seconds=30)),
         )
 
         process_scheduled_changes()
@@ -169,11 +169,11 @@ class TestProcessScheduledChanges(APIBaseTest, QueryMatchingTest):
                 "operation": "add_release_condition",
                 "value": {"groups": [change_past_condition], "multivariate": None, "payloads": {}},
             },
-            scheduled_at=(datetime.now(timezone.utc) - timedelta(hours=1)),
+            scheduled_at=(datetime.now(UTC) - timedelta(hours=1)),
         )
 
         # 2. Due in the past and already executed
-        change_past_executed_at = datetime.now(timezone.utc) - timedelta(hours=5)
+        change_past_executed_at = datetime.now(UTC) - timedelta(hours=5)
         change_past_executed = ScheduledChange.objects.create(
             team=self.team,
             record_id=feature_flag.id,
@@ -197,7 +197,7 @@ class TestProcessScheduledChanges(APIBaseTest, QueryMatchingTest):
                 "operation": "add_release_condition",
                 "value": {"groups": [change_due_now_condition], "multivariate": None, "payloads": {}},
             },
-            scheduled_at=datetime.now(timezone.utc),
+            scheduled_at=datetime.now(UTC),
         )
 
         # 4. Due in the future
@@ -206,7 +206,7 @@ class TestProcessScheduledChanges(APIBaseTest, QueryMatchingTest):
             record_id=feature_flag.id,
             model_name="FeatureFlag",
             payload={"operation": "update_status", "value": False},
-            scheduled_at=(datetime.now(timezone.utc) + timedelta(hours=1)),
+            scheduled_at=(datetime.now(UTC) + timedelta(hours=1)),
         )
 
         process_scheduled_changes()

--- a/posthog/temporal/batch_exports/backfill_batch_export.py
+++ b/posthog/temporal/batch_exports/backfill_batch_export.py
@@ -114,7 +114,7 @@ class BackfillScheduleInputs:
 def get_utcnow():
     """Return the current time in UTC. This function is only required for mocking during tests,
     because mocking the global datetime breaks Temporal."""
-    return dt.datetime.now(dt.timezone.utc)
+    return dt.datetime.now(dt.UTC)
 
 
 @temporalio.activity.defn

--- a/posthog/temporal/batch_exports/squash_person_overrides.py
+++ b/posthog/temporal/batch_exports/squash_person_overrides.py
@@ -5,7 +5,7 @@ import contextlib
 import json
 import typing
 from dataclasses import dataclass, field
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone, UTC
 
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
@@ -14,7 +14,7 @@ from posthog.temporal.batch_exports.base import PostHogWorkflow
 from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.heartbeat import Heartbeater
 
-EPOCH = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
+EPOCH = datetime(1970, 1, 1, 0, 0, tzinfo=UTC)
 
 
 CREATE_TABLE_PERSON_DISTINCT_ID_OVERRIDES_JOIN = """
@@ -174,7 +174,7 @@ MUTATIONS = {
 }
 
 
-def parse_clickhouse_timestamp(s: str, tzinfo: timezone = timezone.utc) -> datetime:
+def parse_clickhouse_timestamp(s: str, tzinfo: timezone = UTC) -> datetime:
     """Parse a timestamp from ClickHouse."""
     return datetime.strptime(s.strip(), "%Y-%m-%d %H:%M:%S.%f").replace(tzinfo=tzinfo)
 

--- a/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
+++ b/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
@@ -60,66 +60,66 @@ async def temporal_schedule(temporal_client, team):
     "start_at,end_at,step,expected",
     [
         (
-            dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc),
-            dt.datetime(2023, 1, 2, 0, 0, 0, tzinfo=dt.timezone.utc),
+            dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC),
+            dt.datetime(2023, 1, 2, 0, 0, 0, tzinfo=dt.UTC),
             dt.timedelta(days=1),
             [
                 (
-                    dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc),
-                    dt.datetime(2023, 1, 2, 0, 0, 0, tzinfo=dt.timezone.utc),
+                    dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC),
+                    dt.datetime(2023, 1, 2, 0, 0, 0, tzinfo=dt.UTC),
                 )
             ],
         ),
         (
-            dt.datetime(2023, 1, 1, 10, 0, 0, tzinfo=dt.timezone.utc),
-            dt.datetime(2023, 1, 1, 12, 20, 0, tzinfo=dt.timezone.utc),
+            dt.datetime(2023, 1, 1, 10, 0, 0, tzinfo=dt.UTC),
+            dt.datetime(2023, 1, 1, 12, 20, 0, tzinfo=dt.UTC),
             dt.timedelta(hours=1),
             [
                 (
-                    dt.datetime(2023, 1, 1, 10, 0, 0, tzinfo=dt.timezone.utc),
-                    dt.datetime(2023, 1, 1, 11, 0, 0, tzinfo=dt.timezone.utc),
+                    dt.datetime(2023, 1, 1, 10, 0, 0, tzinfo=dt.UTC),
+                    dt.datetime(2023, 1, 1, 11, 0, 0, tzinfo=dt.UTC),
                 ),
                 (
-                    dt.datetime(2023, 1, 1, 11, 0, 0, tzinfo=dt.timezone.utc),
-                    dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc),
+                    dt.datetime(2023, 1, 1, 11, 0, 0, tzinfo=dt.UTC),
+                    dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.UTC),
                 ),
             ],
         ),
         (
-            dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc),
-            dt.datetime(2023, 1, 2, 0, 0, 0, tzinfo=dt.timezone.utc),
+            dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC),
+            dt.datetime(2023, 1, 2, 0, 0, 0, tzinfo=dt.UTC),
             dt.timedelta(hours=12),
             [
                 (
-                    dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc),
-                    dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc),
+                    dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC),
+                    dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.UTC),
                 ),
                 (
-                    dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc),
-                    dt.datetime(2023, 1, 2, 0, 0, 0, tzinfo=dt.timezone.utc),
+                    dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.UTC),
+                    dt.datetime(2023, 1, 2, 0, 0, 0, tzinfo=dt.UTC),
                 ),
             ],
         ),
         (
-            dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc),
-            dt.datetime(2023, 1, 5, 0, 0, 0, tzinfo=dt.timezone.utc),
+            dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC),
+            dt.datetime(2023, 1, 5, 0, 0, 0, tzinfo=dt.UTC),
             dt.timedelta(days=1),
             [
                 (
-                    dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc),
-                    dt.datetime(2023, 1, 2, 0, 0, 0, tzinfo=dt.timezone.utc),
+                    dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC),
+                    dt.datetime(2023, 1, 2, 0, 0, 0, tzinfo=dt.UTC),
                 ),
                 (
-                    dt.datetime(2023, 1, 2, 0, 0, 0, tzinfo=dt.timezone.utc),
-                    dt.datetime(2023, 1, 3, 0, 0, 0, tzinfo=dt.timezone.utc),
+                    dt.datetime(2023, 1, 2, 0, 0, 0, tzinfo=dt.UTC),
+                    dt.datetime(2023, 1, 3, 0, 0, 0, tzinfo=dt.UTC),
                 ),
                 (
-                    dt.datetime(2023, 1, 3, 0, 0, 0, tzinfo=dt.timezone.utc),
-                    dt.datetime(2023, 1, 4, 0, 0, 0, tzinfo=dt.timezone.utc),
+                    dt.datetime(2023, 1, 3, 0, 0, 0, tzinfo=dt.UTC),
+                    dt.datetime(2023, 1, 4, 0, 0, 0, tzinfo=dt.UTC),
                 ),
                 (
-                    dt.datetime(2023, 1, 4, 0, 0, 0, tzinfo=dt.timezone.utc),
-                    dt.datetime(2023, 1, 5, 0, 0, 0, tzinfo=dt.timezone.utc),
+                    dt.datetime(2023, 1, 4, 0, 0, 0, tzinfo=dt.UTC),
+                    dt.datetime(2023, 1, 5, 0, 0, 0, tzinfo=dt.UTC),
                 ),
             ],
         ),
@@ -145,8 +145,8 @@ async def test_get_schedule_frequency(activity_environment, temporal_worker, tem
 @pytest.mark.django_db(transaction=True)
 async def test_backfill_schedule_activity(activity_environment, temporal_worker, temporal_client, temporal_schedule):
     """Test backfill_schedule activity schedules all backfill runs."""
-    start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
-    end_at = dt.datetime(2023, 1, 1, 0, 10, 0, tzinfo=dt.timezone.utc)
+    start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+    end_at = dt.datetime(2023, 1, 1, 0, 10, 0, tzinfo=dt.UTC)
 
     desc = await temporal_schedule.describe()
     inputs = BackfillScheduleInputs(
@@ -199,8 +199,8 @@ async def test_backfill_schedule_activity(activity_environment, temporal_worker,
 @pytest.mark.django_db(transaction=True)
 async def test_backfill_batch_export_workflow(temporal_worker, temporal_schedule, temporal_client, team):
     """Test BackfillBatchExportWorkflow executes all backfill runs and updates model."""
-    start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
-    end_at = dt.datetime(2023, 1, 1, 0, 10, 0, tzinfo=dt.timezone.utc)
+    start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+    end_at = dt.datetime(2023, 1, 1, 0, 10, 0, tzinfo=dt.UTC)
 
     desc = await temporal_schedule.describe()
 
@@ -275,9 +275,9 @@ async def test_backfill_batch_export_workflow_no_end_at(
     """Test BackfillBatchExportWorkflow executes all backfill runs and updates model."""
 
     # Note the mocked time here, we should stop backfilling at 8 minutes and unpause the job.
-    mock_utcnow.return_value = dt.datetime(2023, 1, 1, 0, 8, 12, tzinfo=dt.timezone.utc)
+    mock_utcnow.return_value = dt.datetime(2023, 1, 1, 0, 8, 12, tzinfo=dt.UTC)
 
-    start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
+    start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
     end_at = None
 
     desc = await temporal_schedule.describe()
@@ -356,8 +356,8 @@ async def test_backfill_batch_export_workflow_fails_when_schedule_deleted(
     temporal_worker, temporal_schedule, temporal_client, team
 ):
     """Test BackfillBatchExportWorkflow fails when its underlying Temporal Schedule is deleted."""
-    start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
-    end_at = dt.datetime(2023, 1, 1, 0, 10, 0, tzinfo=dt.timezone.utc)
+    start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+    end_at = dt.datetime(2023, 1, 1, 0, 10, 0, tzinfo=dt.UTC)
 
     desc = await temporal_schedule.describe()
 
@@ -398,8 +398,8 @@ async def test_backfill_batch_export_workflow_fails_when_schedule_deleted_after_
     In this test, in contrats to the previous one, we wait until we have started running some
     backfill runs before cancelling.
     """
-    start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
-    end_at = dt.datetime(2023, 1, 1, 0, 10, 0, tzinfo=dt.timezone.utc)
+    start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+    end_at = dt.datetime(2023, 1, 1, 0, 10, 0, tzinfo=dt.UTC)
 
     desc = await temporal_schedule.describe()
 
@@ -471,8 +471,8 @@ async def test_backfill_batch_export_workflow_is_cancelled_on_repeated_failures(
     temporal_worker, failing_s3_batch_export, temporal_client, ateam, clickhouse_client
 ):
     """Test BackfillBatchExportWorkflow will be cancelled on repeated failures."""
-    start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
-    end_at = dt.datetime(2023, 1, 1, 1, 0, 0, tzinfo=dt.timezone.utc)
+    start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+    end_at = dt.datetime(2023, 1, 1, 1, 0, 0, tzinfo=dt.UTC)
 
     # We need some data otherwise the S3 batch export will not fail as it short-circuits.
     for d in date_range(start_at, end_at, dt.timedelta(minutes=5)):

--- a/posthog/temporal/tests/batch_exports/test_batch_exports.py
+++ b/posthog/temporal/tests/batch_exports/test_batch_exports.py
@@ -189,9 +189,7 @@ def assert_records_match_events(records, events):
                 key in ("timestamp", "_inserted_at", "created_at")
                 and expected.get(key.removeprefix("_"), None) is not None
             ):
-                assert value == dt.datetime.fromisoformat(expected[key.removeprefix("_")]).replace(
-                    tzinfo=dt.timezone.utc
-                ), msg
+                assert value == dt.datetime.fromisoformat(expected[key.removeprefix("_")]).replace(tzinfo=dt.UTC), msg
             elif isinstance(expected[key], dict):
                 assert value == json.dumps(expected[key]), msg
             else:
@@ -437,7 +435,7 @@ async def test_iter_records_with_single_field_and_alias(clickhouse_client, field
 
         if isinstance(result, dt.datetime):
             # Event generation function returns datetimes as strings.
-            expected_value = dt.datetime.fromisoformat(expected_value).replace(tzinfo=dt.timezone.utc)
+            expected_value = dt.datetime.fromisoformat(expected_value).replace(tzinfo=dt.UTC)
 
         assert result == expected_value
 
@@ -536,16 +534,16 @@ async def test_iter_records_uses_extra_query_parameters(clickhouse_client):
             "hour",
             "2023-08-01T00:00:00+00:00",
             (
-                dt.datetime(2023, 7, 31, 23, 0, 0, tzinfo=dt.timezone.utc),
-                dt.datetime(2023, 8, 1, 0, 0, 0, tzinfo=dt.timezone.utc),
+                dt.datetime(2023, 7, 31, 23, 0, 0, tzinfo=dt.UTC),
+                dt.datetime(2023, 8, 1, 0, 0, 0, tzinfo=dt.UTC),
             ),
         ),
         (
             "day",
             "2023-08-01T00:00:00+00:00",
             (
-                dt.datetime(2023, 7, 31, 0, 0, 0, tzinfo=dt.timezone.utc),
-                dt.datetime(2023, 8, 1, 0, 0, 0, tzinfo=dt.timezone.utc),
+                dt.datetime(2023, 7, 31, 0, 0, 0, tzinfo=dt.UTC),
+                dt.datetime(2023, 8, 1, 0, 0, 0, tzinfo=dt.UTC),
             ),
         ),
     ],

--- a/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
@@ -48,7 +48,7 @@ SKIP_IF_MISSING_GOOGLE_APPLICATION_CREDENTIALS = pytest.mark.skipif(
 
 pytestmark = [SKIP_IF_MISSING_GOOGLE_APPLICATION_CREDENTIALS, pytest.mark.asyncio, pytest.mark.django_db]
 
-TEST_TIME = dt.datetime.now(dt.timezone.utc)
+TEST_TIME = dt.datetime.now(dt.UTC)
 
 
 def assert_clickhouse_records_in_bigquery(
@@ -133,7 +133,7 @@ def assert_clickhouse_records_in_bigquery(
                 if k in json_columns and v is not None:
                     expected_record[k] = json.loads(v)
                 elif isinstance(v, dt.datetime):
-                    expected_record[k] = v.replace(tzinfo=dt.timezone.utc)
+                    expected_record[k] = v.replace(tzinfo=dt.UTC)
                 else:
                     expected_record[k] = v
 
@@ -251,8 +251,8 @@ async def test_insert_into_bigquery_activity_inserts_data_into_bigquery_table(
     Once we have these events, we pass them to the assert_events_in_bigquery function to check
     that they appear in the expected BigQuery table.
     """
-    data_interval_start = dt.datetime(2023, 4, 20, 14, 0, 0, tzinfo=dt.timezone.utc)
-    data_interval_end = dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.timezone.utc)
+    data_interval_start = dt.datetime(2023, 4, 20, 14, 0, 0, tzinfo=dt.UTC)
+    data_interval_end = dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.UTC)
 
     # Generate a random team id integer. There's still a chance of a collision,
     # but it's very small.
@@ -312,7 +312,7 @@ async def test_insert_into_bigquery_activity_inserts_data_into_bigquery_table(
     with freeze_time(TEST_TIME) as frozen_time:
         await activity_environment.run(insert_into_bigquery_activity, insert_inputs)
 
-        ingested_timestamp = frozen_time().replace(tzinfo=dt.timezone.utc)
+        ingested_timestamp = frozen_time().replace(tzinfo=dt.UTC)
 
         assert_clickhouse_records_in_bigquery(
             bigquery_client=bigquery_client,
@@ -456,7 +456,7 @@ async def test_bigquery_export_workflow(
         assert run.status == "Completed"
         assert run.records_completed == 100
 
-        ingested_timestamp = frozen_time().replace(tzinfo=dt.timezone.utc)
+        ingested_timestamp = frozen_time().replace(tzinfo=dt.UTC)
         assert_clickhouse_records_in_bigquery(
             bigquery_client=bigquery_client,
             clickhouse_client=clickhouse_client,
@@ -692,7 +692,7 @@ async def test_bigquery_export_workflow_handles_cancellation(ateam, bigquery_bat
         ([{"test": 6.0}], [bigquery.SchemaField("test", "FLOAT64")]),
         ([{"test": True}], [bigquery.SchemaField("test", "BOOL")]),
         ([{"test": dt.datetime.now()}], [bigquery.SchemaField("test", "TIMESTAMP")]),
-        ([{"test": dt.datetime.now(tz=dt.timezone.utc)}], [bigquery.SchemaField("test", "TIMESTAMP")]),
+        ([{"test": dt.datetime.now(tz=dt.UTC)}], [bigquery.SchemaField("test", "TIMESTAMP")]),
         (
             [
                 {
@@ -702,7 +702,7 @@ async def test_bigquery_export_workflow_handles_cancellation(ateam, bigquery_bat
                     "test_float": 6.0,
                     "test_bool": False,
                     "test_timestamp": dt.datetime.now(),
-                    "test_timestamptz": dt.datetime.now(tz=dt.timezone.utc),
+                    "test_timestamptz": dt.datetime.now(tz=dt.UTC),
                 }
             ],
             [

--- a/posthog/temporal/tests/batch_exports/test_http_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_http_batch_export_workflow.py
@@ -99,7 +99,7 @@ async def assert_clickhouse_records_in_mock_server(
                 if k == "properties":
                     expected_record[k] = json.loads(v) if v else {}
                 elif isinstance(v, dt.datetime):
-                    expected_record[k] = v.replace(tzinfo=dt.timezone.utc).isoformat()
+                    expected_record[k] = v.replace(tzinfo=dt.UTC).isoformat()
                 else:
                     expected_record[k] = v
 
@@ -134,8 +134,8 @@ async def test_insert_into_http_activity_inserts_data_into_http_endpoint(
     * Are not duplicates of other events that are in the same batch.
     * Do not have an event name contained in the batch export's exclude_events.
     """
-    data_interval_start = dt.datetime(2023, 4, 20, 14, 0, 0, tzinfo=dt.timezone.utc)
-    data_interval_end = dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.timezone.utc)
+    data_interval_start = dt.datetime(2023, 4, 20, 14, 0, 0, tzinfo=dt.UTC)
+    data_interval_end = dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.UTC)
 
     # Generate a random team id integer. There's still a chance of a collision,
     # but it's very small.
@@ -211,8 +211,8 @@ async def test_insert_into_http_activity_throws_on_bad_http_status(
     clickhouse_client, activity_environment, http_config, exclude_events
 ):
     """Test that the insert_into_http_activity function throws on status >= 400"""
-    data_interval_start = dt.datetime(2023, 4, 20, 14, 0, 0, tzinfo=dt.timezone.utc)
-    data_interval_end = dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.timezone.utc)
+    data_interval_start = dt.datetime(2023, 4, 20, 14, 0, 0, tzinfo=dt.UTC)
+    data_interval_end = dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.UTC)
 
     # Generate a random team id integer. There's still a chance of a collision,
     # but it's very small.

--- a/posthog/temporal/tests/batch_exports/test_logger.py
+++ b/posthog/temporal/tests/batch_exports/test_logger.py
@@ -211,13 +211,13 @@ BATCH_EXPORT_ID = str(uuid.uuid4())
     "activity_environment",
     [
         ActivityInfo(
-            workflow_id=f"{BATCH_EXPORT_ID}-{dt.datetime.now(dt.timezone.utc)}",
+            workflow_id=f"{BATCH_EXPORT_ID}-{dt.datetime.now(dt.UTC)}",
             workflow_type="s3-export",
             workflow_run_id=str(uuid.uuid4()),
             attempt=random.randint(1, 10000),
         ),
         ActivityInfo(
-            workflow_id=f"{BATCH_EXPORT_ID}-Backfill-{dt.datetime.now(dt.timezone.utc)}",
+            workflow_id=f"{BATCH_EXPORT_ID}-Backfill-{dt.datetime.now(dt.UTC)}",
             workflow_type="backfill-batch-export",
             workflow_run_id=str(uuid.uuid4()),
             attempt=random.randint(1, 10000),
@@ -262,13 +262,13 @@ async def test_batch_exports_logger_binds_activity_context(
     "activity_environment",
     [
         ActivityInfo(
-            workflow_id=f"{BATCH_EXPORT_ID}-{dt.datetime.now(dt.timezone.utc)}",
+            workflow_id=f"{BATCH_EXPORT_ID}-{dt.datetime.now(dt.UTC)}",
             workflow_type="s3-export",
             workflow_run_id=str(uuid.uuid4()),
             attempt=random.randint(1, 10000),
         ),
         ActivityInfo(
-            workflow_id=f"{BATCH_EXPORT_ID}-Backfill-{dt.datetime.now(dt.timezone.utc)}",
+            workflow_id=f"{BATCH_EXPORT_ID}-Backfill-{dt.datetime.now(dt.UTC)}",
             workflow_type="backfill-batch-export",
             workflow_run_id=str(uuid.uuid4()),
             attempt=random.randint(1, 10000),
@@ -324,13 +324,13 @@ def log_entries_table():
     "activity_environment",
     [
         ActivityInfo(
-            workflow_id=f"{BATCH_EXPORT_ID}-{dt.datetime.now(dt.timezone.utc)}",
+            workflow_id=f"{BATCH_EXPORT_ID}-{dt.datetime.now(dt.UTC)}",
             workflow_type="s3-export",
             workflow_run_id=str(uuid.uuid4()),
             attempt=random.randint(1, 10000),
         ),
         ActivityInfo(
-            workflow_id=f"{BATCH_EXPORT_ID}-Backfill-{dt.datetime.now(dt.timezone.utc)}",
+            workflow_id=f"{BATCH_EXPORT_ID}-Backfill-{dt.datetime.now(dt.UTC)}",
             workflow_type="backfill-batch-export",
             workflow_run_id=str(uuid.uuid4()),
             attempt=random.randint(1, 10000),

--- a/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
@@ -117,7 +117,7 @@ async def assert_clickhouse_records_in_postgres(
                 if k in {"properties", "set", "set_once", "person_properties"} and v is not None:
                     expected_record[k] = json.loads(v)
                 elif isinstance(v, dt.datetime):
-                    expected_record[k] = v.replace(tzinfo=dt.timezone.utc)
+                    expected_record[k] = v.replace(tzinfo=dt.UTC)
                 else:
                     expected_record[k] = v
 
@@ -200,8 +200,8 @@ async def test_insert_into_postgres_activity_inserts_data_into_postgres_table(
     development postgres instance for testing. But we setup and manage our own database
     to avoid conflicting with PostHog itself.
     """
-    data_interval_start = dt.datetime(2023, 4, 20, 14, 0, 0, tzinfo=dt.timezone.utc)
-    data_interval_end = dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.timezone.utc)
+    data_interval_start = dt.datetime(2023, 4, 20, 14, 0, 0, tzinfo=dt.UTC)
+    data_interval_end = dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.UTC)
 
     # Generate a random team id integer. There's still a chance of a collision,
     # but it's very small.

--- a/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
@@ -130,7 +130,7 @@ async def assert_clickhouse_records_in_redshfit(
                         remove_escaped_whitespace_recursive(json.loads(v)), ensure_ascii=False
                     )
                 elif isinstance(v, dt.datetime):
-                    expected_record[k] = v.replace(tzinfo=dt.timezone.utc)  # type: ignore
+                    expected_record[k] = v.replace(tzinfo=dt.UTC)  # type: ignore
                 else:
                     expected_record[k] = v
 
@@ -242,8 +242,8 @@ async def test_insert_into_redshift_activity_inserts_data_into_redshift_table(
     Once we have these events, we pass them to the assert_events_in_redshift function to check
     that they appear in the expected Redshift table.
     """
-    data_interval_start = dt.datetime(2023, 4, 20, 14, 0, 0, tzinfo=dt.timezone.utc)
-    data_interval_end = dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.timezone.utc)
+    data_interval_start = dt.datetime(2023, 4, 20, 14, 0, 0, tzinfo=dt.UTC)
+    data_interval_end = dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.UTC)
 
     # Generate a random team id integer. There's still a chance of a collision,
     # but it's very small.

--- a/posthog/temporal/tests/batch_exports/test_run_updates.py
+++ b/posthog/temporal/tests/batch_exports/test_run_updates.py
@@ -85,8 +85,8 @@ async def test_start_batch_export_run(activity_environment, team, batch_export):
 
     We check if a 'BatchExportRun' is created after the activity runs.
     """
-    start = dt.datetime(2023, 4, 24, tzinfo=dt.timezone.utc)
-    end = dt.datetime(2023, 4, 25, tzinfo=dt.timezone.utc)
+    start = dt.datetime(2023, 4, 24, tzinfo=dt.UTC)
+    end = dt.datetime(2023, 4, 25, tzinfo=dt.UTC)
 
     inputs = StartBatchExportRunInputs(
         team_id=team.id,
@@ -110,8 +110,8 @@ async def test_start_batch_export_run(activity_environment, team, batch_export):
 @pytest.mark.asyncio
 async def test_finish_batch_export_run(activity_environment, team, batch_export):
     """Test the export_run_status activity."""
-    start = dt.datetime(2023, 4, 24, tzinfo=dt.timezone.utc)
-    end = dt.datetime(2023, 4, 25, tzinfo=dt.timezone.utc)
+    start = dt.datetime(2023, 4, 24, tzinfo=dt.UTC)
+    end = dt.datetime(2023, 4, 25, tzinfo=dt.UTC)
 
     inputs = StartBatchExportRunInputs(
         team_id=team.id,
@@ -145,8 +145,8 @@ async def test_finish_batch_export_run(activity_environment, team, batch_export)
 @pytest.mark.asyncio
 async def test_finish_batch_export_run_pauses_if_reaching_failure_threshold(activity_environment, team, batch_export):
     """Test if 'finish_batch_export_run' will pause a batch export upon reaching failure_threshold."""
-    start = dt.datetime(2023, 4, 24, tzinfo=dt.timezone.utc)
-    end = dt.datetime(2023, 4, 25, tzinfo=dt.timezone.utc)
+    start = dt.datetime(2023, 4, 24, tzinfo=dt.UTC)
+    end = dt.datetime(2023, 4, 25, tzinfo=dt.UTC)
 
     inputs = StartBatchExportRunInputs(
         team_id=team.id,
@@ -183,8 +183,8 @@ async def test_finish_batch_export_run_pauses_if_reaching_failure_threshold(acti
 @pytest.mark.asyncio
 async def test_finish_batch_export_run_never_pauses_with_small_check_window(activity_environment, team, batch_export):
     """Test if 'finish_batch_export_run' will never pause a batch export with a small check window."""
-    start = dt.datetime(2023, 4, 24, tzinfo=dt.timezone.utc)
-    end = dt.datetime(2023, 4, 25, tzinfo=dt.timezone.utc)
+    start = dt.datetime(2023, 4, 24, tzinfo=dt.UTC)
+    end = dt.datetime(2023, 4, 25, tzinfo=dt.UTC)
 
     inputs = StartBatchExportRunInputs(
         team_id=team.id,

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -286,8 +286,8 @@ async def test_insert_into_s3_activity_puts_data_into_s3(
     Once we have these events, we pass them to the assert_clickhouse_records_in_s3 function to check
     that they appear in the expected S3 bucket and key.
     """
-    data_interval_start = dt.datetime(2023, 4, 20, 14, 0, 0, tzinfo=dt.timezone.utc)
-    data_interval_end = dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.timezone.utc)
+    data_interval_start = dt.datetime(2023, 4, 20, 14, 0, 0, tzinfo=dt.UTC)
+    data_interval_end = dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.UTC)
 
     # Generate a random team id integer. There's still a chance of a collision,
     # but it's very small.

--- a/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
@@ -977,8 +977,8 @@ async def test_insert_into_snowflake_activity_inserts_data_into_snowflake_table(
     that they appear in the expected Snowflake table. This function runs against a real Snowflake
     instance, so the environment should be populated with the necessary credentials.
     """
-    data_interval_start = dt.datetime(2023, 4, 20, 14, 0, 0, tzinfo=dt.timezone.utc)
-    data_interval_end = dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.timezone.utc)
+    data_interval_start = dt.datetime(2023, 4, 20, 14, 0, 0, tzinfo=dt.UTC)
+    data_interval_end = dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.UTC)
 
     team_id = random.randint(1, 1000000)
     await generate_test_events_in_clickhouse(

--- a/posthog/temporal/tests/persons_on_events_squash/test_squash_person_overrides_workflow.py
+++ b/posthog/temporal/tests/persons_on_events_squash/test_squash_person_overrides_workflow.py
@@ -1,7 +1,7 @@
 import operator
 import random
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from typing import NamedTuple, TypedDict
 from uuid import UUID, uuid4
 
@@ -862,7 +862,7 @@ async def test_delete_person_overrides_mutation_within_grace_period(
     activity_environment, events_to_override, person_overrides_data, clickhouse_client
 ):
     """Test we do not delete person overrides if they are within the grace period."""
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     override_timestamp = int(now.timestamp())
     team_id, person_override = next(iter(person_overrides_data.items()))
     distinct_id, _ = next(iter(person_override))
@@ -914,7 +914,7 @@ async def test_delete_person_overrides_mutation_within_grace_period(
     assert int(row[0]) == not_deleted_person["team_id"]
     assert row[1] == not_deleted_person["distinct_id"]
     assert UUID(row[2]) == UUID(not_deleted_person["person_id"])
-    _timestamp = datetime.strptime(row[3], "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+    _timestamp = datetime.strptime(row[3], "%Y-%m-%d %H:%M:%S").replace(tzinfo=UTC)
     # _timestamp is up to second precision
     assert _timestamp == now.replace(microsecond=0)
 

--- a/posthog/temporal/tests/test_clickhouse.py
+++ b/posthog/temporal/tests/test_clickhouse.py
@@ -23,12 +23,12 @@ from posthog.temporal.common.clickhouse import encode_clickhouse_data
         (("; DROP TABLE events --",), b"('; DROP TABLE events --')"),
         (("'a'); DROP TABLE events --",), b"('\\'a\\'); DROP TABLE events --')"),
         (
-            dt.datetime(2023, 7, 14, 0, 0, 0, tzinfo=dt.timezone.utc),
+            dt.datetime(2023, 7, 14, 0, 0, 0, tzinfo=dt.UTC),
             b"toDateTime('2023-07-14 00:00:00', 'UTC')",
         ),
         (dt.datetime(2023, 7, 14, 0, 0, 0), b"toDateTime('2023-07-14 00:00:00')"),
         (
-            dt.datetime(2023, 7, 14, 0, 0, 0, 5555, tzinfo=dt.timezone.utc),
+            dt.datetime(2023, 7, 14, 0, 0, 0, 5555, tzinfo=dt.UTC),
             b"toDateTime64('2023-07-14 00:00:00.005555', 6, 'UTC')",
         ),
     ],

--- a/posthog/temporal/tests/utils/datetimes.py
+++ b/posthog/temporal/tests/utils/datetimes.py
@@ -16,4 +16,4 @@ def to_isoformat(d: str | None) -> str | None:
     """Parse a string and return it as default isoformatted."""
     if d is None:
         return None
-    return dt.datetime.fromisoformat(d).replace(tzinfo=dt.timezone.utc).isoformat()
+    return dt.datetime.fromisoformat(d).replace(tzinfo=dt.UTC).isoformat()

--- a/posthog/test/test_datetime.py
+++ b/posthog/test/test_datetime.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 
 from posthog.datetime import (
     start_of_hour,
@@ -23,7 +23,7 @@ def test_start_of_day():
 
 def test_end_of_day():
     assert end_of_day(datetime.fromisoformat("2023-02-08T12:05:23+00:00")) == datetime(
-        2023, 2, 8, 23, 59, 59, 999999, tzinfo=timezone.utc
+        2023, 2, 8, 23, 59, 59, 999999, tzinfo=UTC
     )
 
 

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1289,12 +1289,12 @@ async def wait_for_parallel_celery_group(task: Any, expires: Optional[datetime.d
     default_expires = datetime.timedelta(minutes=5)
 
     if not expires:
-        expires = datetime.datetime.now(tz=datetime.timezone.utc) + default_expires
+        expires = datetime.datetime.now(tz=datetime.UTC) + default_expires
 
     sleep_generator = sleep_time_generator()
 
     while not task.ready():
-        if datetime.datetime.now(tz=datetime.timezone.utc) > expires:
+        if datetime.datetime.now(tz=datetime.UTC) > expires:
             child_states = []
             child: AsyncResult
             children = task.children or []

--- a/posthog/warehouse/external_data_source/workspace.py
+++ b/posthog/warehouse/external_data_source/workspace.py
@@ -27,7 +27,7 @@ def get_or_create_workspace(team_id: int):
         workspace_id = create_workspace(team_id)
         team.external_data_workspace_id = workspace_id
         # start tracking from now
-        team.external_data_workspace_last_synced_at = datetime.datetime.now(datetime.timezone.utc)
+        team.external_data_workspace_last_synced_at = datetime.datetime.now(datetime.UTC)
         team.save()
 
     return team.external_data_workspace_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [tool.black]
 line-length = 120
-target-version = ['py310']
+target-version = ['py311']
 
 [tool.isort]
 profile = "black"

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -11,7 +11,7 @@
 
 -c requirements.txt
 
-ruff~=0.4.3
+ruff~=0.4.10
 mypy~=1.10.0
 mypy-baseline~=0.7.0
 mypy-extensions==1.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -288,8 +288,7 @@ ruamel-yaml==0.18.6
     # via prance
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-ruff==0.4.3
-    # via -r requirements-dev.in
+ruff==0.4.10
 six==1.16.0
     # via
     #   -c requirements.txt


### PR DESCRIPTION
## Problem

After Python 3.11 upgrade we can align ruff via pyproject.toml

## Changes

- upgrade
- run fixes

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

n/a