### PR TITLE
fix(web-analytics): Make channel type comparison case-insensitive

### DIFF
--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -68,6 +68,12 @@ def create_channel_type_expr(
             args=[ast.Call(name="nullIf", args=[expr, ast.Constant(value="")]), ast.Constant(value="null")],
         )
 
+    def wrap_with_lower(expr: ast.Expr) -> ast.Expr:
+        return ast.Call(
+            name="lower",
+            args=[expr],
+        )
+
     # This logic is referenced in our docs https://posthog.com/docs/data/channel-type, be sure to update both if you
     # update either.
     return parse_expr(
@@ -131,9 +137,9 @@ multiIf(
 )""",
         start=None,
         placeholders={
-            "campaign": wrap_with_null_if_empty(campaign),
-            "medium": wrap_with_null_if_empty(medium),
-            "source": wrap_with_null_if_empty(source),
+            "campaign": wrap_with_lower(wrap_with_null_if_empty(campaign)),
+            "medium": wrap_with_lower(wrap_with_null_if_empty(medium)),
+            "source": wrap_with_lower(wrap_with_null_if_empty(source)),
             "referring_domain": referring_domain,
             "gclid": wrap_with_null_if_empty(gclid),
             "gad_source": wrap_with_null_if_empty(gad_source),

--- a/posthog/hogql/database/schema/test/test_channel_type.py
+++ b/posthog/hogql/database/schema/test/test_channel_type.py
@@ -549,3 +549,19 @@ class TestChannelType(ClickhouseTestMixin, APIBaseTest):
     #             "https://l.facebook.com/",
     #         ),
     #     )
+
+    def test_zendesk_ticket_14945(self):
+        # see https://posthoghelp.zendesk.com/agent/tickets/14945
+        self.assertEqual(
+            "Paid Social",
+            self._get_session_channel_type(
+                {
+                    "utm_source": "Facebook",
+                    "utm_medium": "Paid",
+                    "utm_campaign": "Foo",
+                    "referring_domain": "l.facebook.com",
+                    "gclid": "",
+                    "gad_source": "",
+                }
+            ),
+        )

--- a/posthog/hogql/database/schema/test/test_channel_type.py
+++ b/posthog/hogql/database/schema/test/test_channel_type.py
@@ -552,6 +552,10 @@ class TestChannelType(ClickhouseTestMixin, APIBaseTest):
 
     def test_zendesk_ticket_14945(self):
         # see https://posthoghelp.zendesk.com/agent/tickets/14945
+
+        # In this ticket, a customer's paid social traffic was incorrect tagged as organic social, because we
+        # didn't recognise the word "Paid" with an uppercase 'P' as a paid source. Really, this should have
+        # been case-insensitive, and that is what the fix was.
         self.assertEqual(
             "Paid Social",
             self._get_session_channel_type(


### PR DESCRIPTION
## Problem

See https://posthoghelp.zendesk.com/agent/tickets/14945 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/23244)

## Changes

Make the channel type comparisons and lookups case-insensitive when dealing with utm_source, utm_medium and utm_campaign

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added a test