### PR TITLE
fix: schema build step after the python 3.11 migration

### DIFF
--- a/bin/build-schema-python.sh
+++ b/bin/build-schema-python.sh
@@ -34,4 +34,4 @@ fi
 # Remove this when https://github.com/koxudaxi/datamodel-code-generator/issues/1313 is resolved
 
 sed -i -e 's/str, Enum/StrEnum/g' posthog/schema.py
-sed -i 's/from enum import Enum/from enum import Enum, StrEnum/g' posthog/schema.py
+sed -i -e 's/from enum import Enum/from enum import Enum, StrEnum/g' posthog/schema.py


### PR DESCRIPTION
## Problem

Schema fails to build after migration to Python 3.11 on MacOS:

```bash
> bash bin/build-schema-python.sh

<string>:13: Deprecated: `experimental string processing` has been included in `preview` and deprecated. Use `preview` instead.
1 file reformatted
Found 378 errors (378 fixed, 0 remaining).
sed: 1: "posthog/schema.py": extra characters at the end of p command
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1
```

## Changes

- Added the `-e` parameter.
