### PR TITLE
fix: Fix FieldAliasType.resolve_database_field not implemented

### DIFF
--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -501,7 +501,11 @@ class IsSimpleTimestampFieldExpressionVisitor(Visitor[bool]):
         from posthog.hogql.database.schema.session_replay_events import RawSessionReplayEventsTable
 
         if node.type and isinstance(node.type, ast.FieldAliasType):
-            resolved_field = node.type.resolve_database_field(self.context)
+            try:
+                resolved_field = node.type.resolve_database_field(self.context)
+            except NotImplementedError:
+                return False
+
             table_type = node.type.resolve_table_type(self.context)
             if not table_type:
                 return False


### PR DESCRIPTION
## Problem

Fixes #23185

Unclear how we run into this, cannot reproduce locally.

See Sentry for more:

Sentry Issue: [POSTHOG-1C24](https://posthog.sentry.io/issues/5485460318/?referrer=github_integration)

```
NotImplementedError: FieldAliasType.resolve_database_field not implemented
(43 additional frame(s) were not displayed)
...
  File "posthog/hogql/visitor.py", line 32, in visit
    raise e
  File "posthog/hogql/visitor.py", line 27, in visit
    return node.accept(self)
  File "posthog/hogql/base.py", line 32, in accept
    return visit(self)
  File "posthog/hogql/database/schema/util/where_clause_extractor.py", line 504, in visit_alias
    resolved_field = node.type.resolve_database_field(self.context)
  File "posthog/hogql/ast.py", line 115, in resolve_database_field
    raise NotImplementedError("FieldAliasType.resolve_database_field not implemented")
```

## Changes

Try to catch and return somehow.

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

Not sure