### PR TITLE
fix(api): Always allow GET /users/@me with personal API key

### DIFF
--- a/posthog/api/test/test_personal_api_keys.py
+++ b/posthog/api/test/test_personal_api_keys.py
@@ -476,6 +476,12 @@ class TestPersonalAPIKeysWithOrganizationScopeAPIAuthentication(PersonalAPIKeysB
         response = self._do_request(f"/api/projects")
         assert response.status_code == status.HTTP_200_OK, response.json()
 
+    def test_allows_user_me_read_access(self):
+        # The /users/@me/ endpoint is not team-based, but it's useful as a way of checking whether the key works
+        # (e.g. in our Zapier integration), hence it's exempt from org/team scoping
+        response = self._do_request(f"/api/users/@me/")
+        assert response.status_code == status.HTTP_200_OK, response.json()
+
 
 class TestPersonalAPIKeysWithTeamScopeAPIAuthentication(PersonalAPIKeysBaseTest):
     def setUp(self):
@@ -510,3 +516,9 @@ class TestPersonalAPIKeysWithTeamScopeAPIAuthentication(PersonalAPIKeysBaseTest)
         assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
         assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
         response = self._do_request(f"/api/projects/{self.other_team.id}")
+
+    def test_allows_user_me_read_access(self):
+        # The /users/@me/ endpoint is not team-based, but it's useful as a way of checking whether the key works
+        # (e.g. in our Zapier integration), hence it's exempt from org/team scoping
+        response = self._do_request(f"/api/users/@me/")
+        assert response.status_code == status.HTTP_200_OK, response.json()

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -358,7 +358,7 @@ class APIScopePermission(BasePermission):
         request: Request,
         view: View,
     ) -> None:
-        if view.scope_object == "user":
+        if getattr(view, "scope_object", None) == "user":
             return  # The /api/users/@me/ endpoint is exempt from team and org scoping
 
         scoped_organizations = request.successful_authenticator.personal_api_key.scoped_organizations

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -353,12 +353,9 @@ class APIScopePermission(BasePermission):
 
         return True
 
-    def check_team_and_org_permissions(
-        self,
-        request: Request,
-        view: View,
-    ) -> None:
-        if getattr(view, "scope_object", None) == "user":
+    def check_team_and_org_permissions(self, request, view) -> None:
+        scope_object = self.get_scope_object(request, view)
+        if scope_object == "user":
             return  # The /api/users/@me/ endpoint is exempt from team and org scoping
 
         scoped_organizations = request.successful_authenticator.personal_api_key.scoped_organizations


### PR DESCRIPTION
## Problem

Zapier emailed me that a user reported being unable to connect their PostHog account in our Zapier integration, the cause being the PostHog API returning a server error. I went through the connection flow without an all-access key without issues, but then went for a project-scoped key, and that's when I saw the error: [POSTHOG-QGV](https://posthog.sentry.io/issues/4996601747/).
Project-scoped keys can't be used to get the user they belong to, but that's what the Zapier integration relies on to verify auth.

## Changes

I propose we just allow project-scoped keys to get the current user (interestingly organization-scoped ones already allow it). The user endpoint is anyway a scope of its own, so there doesn't seem to be a point to a blanket ban.

## How did you test this code?

Added a couple tests for the user endpoint being a special case.