### PR TITLE
refactor(insights): query based `allEventNames` selector

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownPopover.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownPopover.tsx
@@ -3,6 +3,7 @@ import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterGroupType, TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
 import { Popover } from 'lib/lemon-ui/Popover/Popover'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 import { groupsModel } from '~/models/groupsModel'
 
@@ -15,7 +16,8 @@ type TaxonomicBreakdownPopoverProps = {
 }
 
 export const TaxonomicBreakdownPopover = ({ open, setOpen, children }: TaxonomicBreakdownPopoverProps): JSX.Element => {
-    const { allEventNames } = useValues(insightLogic)
+    const { insightProps } = useValues(insightLogic)
+    const { allEventNames } = useValues(insightVizDataLogic(insightProps))
     const { groupsTaxonomicTypes } = useValues(groupsModel)
     const { taxonomicBreakdownType, includeSessions } = useValues(taxonomicBreakdownFilterLogic)
 

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -6,7 +6,7 @@ import api from 'lib/api'
 import { TriggerExportProps } from 'lib/components/ExportButton/exporter'
 import { DashboardPrivilegeLevel } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
-import { getEventNamesForAction, objectsEqual, toParams } from 'lib/utils'
+import { objectsEqual, toParams } from 'lib/utils'
 import { eventUsageLogic, InsightEventSource } from 'lib/utils/eventUsageLogic'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import {
@@ -26,7 +26,6 @@ import { mathsLogic } from 'scenes/trends/mathsLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-import { actionsModel } from '~/models/actionsModel'
 import { cohortsModel } from '~/models/cohortsModel'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { groupsModel } from '~/models/groupsModel'
@@ -36,15 +35,7 @@ import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
 import { queryExportContext } from '~/queries/query'
 import { InsightVizNode } from '~/queries/schema'
 import { isInsightVizNode } from '~/queries/utils'
-import {
-    ActionType,
-    FilterType,
-    InsightLogicProps,
-    InsightModel,
-    InsightShortId,
-    ItemMode,
-    SetInsightOptions,
-} from '~/types'
+import { FilterType, InsightLogicProps, InsightModel, InsightShortId, ItemMode, SetInsightOptions } from '~/types'
 
 import { teamLogic } from '../teamLogic'
 import type { insightLogicType } from './insightLogicType'
@@ -381,21 +372,6 @@ export const insightLogic = kea<insightLogicType>([
                     (insight.description || '') !== (savedInsight.description || '') ||
                     !objectsEqual(insight.tags || [], savedInsight.tags || [])
                 )
-            },
-        ],
-        allEventNames: [
-            (s) => [s.filters, actionsModel.selectors.actions],
-            (filters, actions: ActionType[]) => {
-                const allEvents = [
-                    ...(filters.events || []).map((e) => e.id),
-                    ...(filters.actions || []).flatMap((action) => getEventNamesForAction(action.id, actions)),
-                ]
-                // Has one "all events" event.
-                if (allEvents.some((e) => e === null)) {
-                    return []
-                }
-                // remove duplicates and empty events
-                return Array.from(new Set(allEvents.filter((a): a is string => !!a)))
             },
         ],
         filtersKnown: [

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -14,7 +14,9 @@ import { sceneLogic } from 'scenes/sceneLogic'
 import { filterTestAccountsDefaultsLogic } from 'scenes/settings/project/filterTestAccountDefaultsLogic'
 import { BASE_MATH_DEFINITIONS } from 'scenes/trends/mathsLogic'
 
+import { actionsModel } from '~/models/actionsModel'
 import { queryNodeToFilter, seriesNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
+import { getAllEventNames } from '~/queries/nodes/InsightViz/utils'
 import {
     BreakdownFilter,
     CompareFilter,
@@ -357,6 +359,12 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
                     ...seriesNodeToFilter(rest),
                 })),
             }),
+        ],
+
+        // all events used in the insight (useful for fetching only relevant property definitions)
+        allEventNames: [
+            (s) => [s.querySource, actionsModel.selectors.actions],
+            (querySource, actions) => getAllEventNames(querySource, actions),
         ],
     }),
 

--- a/frontend/src/scenes/insights/insightVizDataLogic.ts
+++ b/frontend/src/scenes/insights/insightVizDataLogic.ts
@@ -364,7 +364,7 @@ export const insightVizDataLogic = kea<insightVizDataLogicType>([
         // all events used in the insight (useful for fetching only relevant property definitions)
         allEventNames: [
             (s) => [s.querySource, actionsModel.selectors.actions],
-            (querySource, actions) => getAllEventNames(querySource, actions),
+            (querySource, actions) => (querySource ? getAllEventNames(querySource, actions) : []),
         ],
     }),
 


### PR DESCRIPTION
## Problem

The `allEventNames` selector relies on `filters`, which we want to remove.

## Changes

Makes the selector based on queries (using an existing method that was refactored).

## How did you test this code?

Checked that the relevant event names are sent (when adding a breakdown) in the networking panel