### PR TITLE
refactor(insights): query based `intervalUnit`

### DIFF
--- a/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.test.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.test.ts
@@ -125,9 +125,7 @@ function useInsightMocks(interval: string = 'day', timezone: string = 'UTC'): vo
         result: {},
         id: MOCK_INSIGHT_NUMERIC_ID,
         short_id: MOCK_INSIGHT_SHORT_ID,
-        filters: {
-            interval,
-        },
+        filters: { insight: 'TRENDS', interval },
         timezone,
     }
     useMocks({

--- a/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
+++ b/frontend/src/lib/components/AnnotationsOverlay/annotationsOverlayLogic.ts
@@ -3,6 +3,7 @@ import { actions, connect, kea, key, listeners, path, props, reducers, selectors
 import { Dayjs, dayjsLocalToTimezone } from 'lib/dayjs'
 import { groupBy } from 'lib/utils'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { AnnotationDataWithoutInsight, annotationsModel } from '~/models/annotationsModel'
@@ -39,7 +40,9 @@ export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
     connect(() => ({
         values: [
             insightLogic,
-            ['intervalUnit', 'insightId'],
+            ['insightId'],
+            insightVizDataLogic,
+            ['interval'],
             annotationsModel,
             ['annotations', 'annotationsLoading'],
             teamLogic,
@@ -92,6 +95,7 @@ export const annotationsOverlayLogic = kea<annotationsOverlayLogicType>([
         },
     })),
     selectors({
+        intervalUnit: [(s) => [s.interval], (interval) => interval || 'day'],
         pointsPerTick: [
             (_, p) => [p.ticks],
             (ticks): number => {

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -405,7 +405,6 @@ export const insightLogic = kea<insightLogicType>([
                 return 'insight' in (filters ?? {})
             },
         ],
-        intervalUnit: [(s) => [s.filters], (filters) => filters?.interval || 'day'],
         exporterResourceParams: [
             (s) => [s.filters, s.currentTeamId, s.insight],
             (


### PR DESCRIPTION
## Problem

The `intervalUnit` selector relies on `filters`, which we want to remove.

## Changes

Uses a query based alternative.

## How did you test this code?

Didn't