### PR TITLE
feat: block robots from seeing shared dashboards

### DIFF
--- a/posthog/views.py
+++ b/posthog/views.py
@@ -80,7 +80,9 @@ def stats(request):
 
 
 def robots_txt(request):
-    ROBOTS_TXT_CONTENT = "User-agent: *\nDisallow: /shared_dashboard/" if is_cloud() else "User-agent: *\nDisallow: /"
+    ROBOTS_TXT_CONTENT = (
+        "User-agent: *\nDisallow: /shared_dashboard/\nDisallow: /shared/" if True else "User-agent: *\nDisallow: /"
+    )
     return HttpResponse(ROBOTS_TXT_CONTENT, content_type="text/plain")
 
 

--- a/posthog/views.py
+++ b/posthog/views.py
@@ -81,7 +81,9 @@ def stats(request):
 
 def robots_txt(request):
     ROBOTS_TXT_CONTENT = (
-        "User-agent: *\nDisallow: /shared_dashboard/\nDisallow: /shared/" if True else "User-agent: *\nDisallow: /"
+        "User-agent: *\nDisallow: /shared_dashboard/\nDisallow: /shared/"
+        if is_cloud()
+        else "User-agent: *\nDisallow: /"
     )
     return HttpResponse(ROBOTS_TXT_CONTENT, content_type="text/plain")
 


### PR DESCRIPTION
A simple request from one of our users:
https://posthoghelp.zendesk.com/agent/tickets/15018 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/17219)

We don't let robots crawl /shared_dashboards but actually these live at /shared/

Add /shared/ to robots.txt