### PR TITLE
fix: temporary realtime warning page

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -804,9 +804,9 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
         ],
 
         snapshotsInvalid: [
-            (s, p) => [s.snapshotsByWindowId, s.fullyLoaded, p.sessionRecordingId],
-            (snapshotsByWindowId, fullyLoaded, sessionRecordingId): boolean => {
-                if (!fullyLoaded) {
+            (s, p) => [s.snapshotsByWindowId, s.fullyLoaded, s.start, p.sessionRecordingId],
+            (snapshotsByWindowId, fullyLoaded, start, sessionRecordingId): boolean => {
+                if (!fullyLoaded || !start) {
                     return false
                 }
 
@@ -835,7 +835,9 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                     })
                 }
 
-                return everyWindowMissingFullSnapshot
+                const minutesSinceRecording = start.diff(dayjs(), 'minute')
+
+                return everyWindowMissingFullSnapshot && minutesSinceRecording <= 5
             },
         ],
 


### PR DESCRIPTION
## Problem

Recordings will not play back without a full snapshot. They are often missing if the full snapshot is not ingested before some other data

## Changes

Add a warning to customers that the replay isn't quite ready yet (we cannot hide it from the list because the listing code does not know whether the snapshots exist in S3)

![Screenshot 2024-06-25 at 11 08 33](https://github.com/PostHog/posthog/assets/6685876/2d6a76f8-1a1f-49c7-846b-e081018ce96c)
