### PR TITLE
feat(web-analytics): Add live stats logic

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -210,6 +210,7 @@ export const FEATURE_FLAGS = {
     ERROR_TRACKING: 'error-tracking', // owner: #team-replay
     SETTINGS_BOUNCE_RATE_PAGE_VIEW_MODE: 'settings-bounce-rate-page-view-mode', // owner: @robbie-c
     SURVEYS_BRANCHING_LOGIC: 'surveys-branching-logic', // owner: @jurajmajerik #team-feature-success
+    WEB_ANALYTICS_LIVE_USER_COUNT: 'web-analytics-live-user-count', // owner: @robbie-c
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
@@ -1,0 +1,30 @@
+import { IconLive } from '@posthog/icons'
+import { useValues } from 'kea'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils'
+import { teamLogic } from 'scenes/teamLogic'
+import { liveEventsTableLogic } from 'scenes/web-analytics/liveWebAnalyticsLogic'
+
+export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {
+    const { liveUserCount, liveUserUpdatedSecondsAgo } = useValues(liveEventsTableLogic)
+    const { currentTeam } = useValues(teamLogic)
+
+    if (liveUserCount == null || liveUserUpdatedSecondsAgo == null) {
+        return null
+    }
+
+    const inTeamString = currentTeam ? ` in ${currentTeam.name}` : ''
+    const tooltip = `${humanFriendlyNumber(
+        liveUserCount
+    )} users are online${inTeamString} (updated ${liveUserUpdatedSecondsAgo} seconds ago)`
+
+    return (
+        <div className="flex-row">
+            <Tooltip title={tooltip}>
+                <span>
+                    <IconLive /> {humanFriendlyLargeNumber(liveUserCount)} currently online
+                </span>
+            </Tooltip>
+        </div>
+    )
+}

--- a/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
@@ -33,6 +33,7 @@ export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {
                     <IconLive /> <strong>{humanFriendlyLargeNumber(liveUserCount)}</strong> currently online
                 </span>
             </Tooltip>
+            <div className="bg-border h-px w-full mt-2" />
         </div>
     )
 }

--- a/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
@@ -9,14 +9,22 @@ export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {
     const { liveUserCount, liveUserUpdatedSecondsAgo } = useValues(liveEventsTableLogic)
     const { currentTeam } = useValues(teamLogic)
 
-    if (liveUserCount == null || liveUserUpdatedSecondsAgo == null) {
+    if (liveUserCount == null) {
+        // No data yet, or feature flag disabled
         return null
     }
 
+    const usersOnlineString = `${humanFriendlyNumber(liveUserCount)} ${
+        liveUserCount === 1 ? 'user is' : 'users are'
+    } online`
     const inTeamString = currentTeam ? ` in ${currentTeam.name}` : ''
-    const tooltip = `${humanFriendlyNumber(
-        liveUserCount
-    )} users are online${inTeamString} (updated ${liveUserUpdatedSecondsAgo} seconds ago)`
+    const updatedAgoString =
+        liveUserUpdatedSecondsAgo === 0
+            ? ' (updated just now)'
+            : liveUserUpdatedSecondsAgo == null
+            ? ''
+            : ` (updated ${liveUserUpdatedSecondsAgo} seconds ago)`
+    const tooltip = `${usersOnlineString}${inTeamString}${updatedAgoString}`
 
     return (
         <div className="flex-row">

--- a/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsLiveUserCount.tsx
@@ -22,7 +22,7 @@ export const WebAnalyticsLiveUserCount = (): JSX.Element | null => {
         <div className="flex-row">
             <Tooltip title={tooltip}>
                 <span>
-                    <IconLive /> {humanFriendlyLargeNumber(liveUserCount)} currently online
+                    <IconLive /> <strong>{humanFriendlyLargeNumber(liveUserCount)}</strong> currently online
                 </span>
             </Tooltip>
         </div>

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -28,6 +28,8 @@ import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollec
 import { ReloadAll } from '~/queries/nodes/DataNode/Reload'
 import { QuerySchema } from '~/queries/schema'
 
+import { WebAnalyticsLiveUserCount } from './WebAnalyticsLiveUserCount'
+
 const Filters = (): JSX.Element => {
     const {
         webAnalyticsFilters,
@@ -319,6 +321,7 @@ export const WebAnalyticsDashboard = (): JSX.Element => {
                 <WebAnalyticsModal />
                 <WebAnalyticsNotice />
                 <div className="WebAnalyticsDashboard w-full flex flex-col">
+                    <WebAnalyticsLiveUserCount />
                     <Filters />
                     <WebAnalyticsHealthCheck />
                     <Tiles />

--- a/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
@@ -15,35 +15,34 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
     }),
     actions(() => ({
         pollStats: true,
-        setStats: ({ stats, now }: { stats: StatsResponse; now: Date }) => ({ stats, now }),
+        setLiveUserCount: ({ liveUserCount, now }: { liveUserCount: number; now: Date }) => ({
+            liveUserCount,
+            now,
+        }),
         setNow: ({ now }: { now: Date }) => ({ now }),
     })),
     reducers({
-        stats: [
-            null as StatsResponse | null,
+        liveUserCount: [
+            null as number | null,
             {
-                setStats: (_, { stats }) => stats,
+                setLiveUserCount: (_, { liveUserCount }) => liveUserCount,
             },
         ],
         statsUpdatedTime: [
             null as Date | null,
             {
-                setStats: (_, { now }) => now,
+                setNumUsersOnProduct: (_, { now }) => now,
             },
         ],
         now: [
             null as Date | null,
             {
                 setNow: (_, { now }) => now,
-                setStats: (_, { now }) => now,
+                setLiveUserCount: (_, { now }) => now,
             },
         ],
     }),
     selectors({
-        liveUserCount: [
-            (s) => [s.stats],
-            (stats: StatsResponse | null) => (stats?.users_on_product ? stats.users_on_product : null),
-        ],
         liveUserUpdatedSecondsAgo: [
             (s) => [s.statsUpdatedTime, s.now],
             (statsUpdatedTime: Date | null, now: Date | null) => {
@@ -71,8 +70,9 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
                         Authorization: `Bearer ${values.currentTeam.live_events_token}`,
                     },
                 })
-                const data = await response.json()
-                actions.setStats({ stats: data, now: new Date() })
+                const data: StatsResponse = await response.json()
+                const liveUserCount = data.users_on_product || 0 // returns undefined if there are no users
+                actions.setLiveUserCount({ liveUserCount, now: new Date() })
             } catch (error) {
                 console.error('Failed to poll stats:', error)
             }

--- a/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
@@ -1,21 +1,58 @@
-import { actions, connect, events, kea, listeners, path, reducers } from 'kea'
+import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { liveEventsHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
+import type { liveEventsTableLogicType } from './liveWebAnalyticsLogicType'
+export interface StatsResponse {
+    users_on_product?: number
+}
 export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
     path(['scenes', 'activity', 'live-events', 'liveEventsTableLogic']),
     connect({
-        values: [teamLogic, ['currentTeam']],
+        values: [teamLogic, ['currentTeam'], featureFlagLogic, ['featureFlags']],
     }),
     actions(() => ({
         pollStats: true,
-        setStats: (stats) => ({ stats }),
+        setStats: ({ stats, now }: { stats: StatsResponse; now: Date }) => ({ stats, now }),
+        setNow: ({ now }: { now: Date }) => ({ now }),
     })),
     reducers({
         stats: [
-            { users_on_product: null },
+            null as StatsResponse | null,
             {
                 setStats: (_, { stats }) => stats,
+            },
+        ],
+        statsUpdatedTime: [
+            null as Date | null,
+            {
+                setStats: (_, { now }) => now,
+            },
+        ],
+        now: [
+            null as Date | null,
+            {
+                setNow: (_, { now }) => now,
+                setStats: (_, { now }) => now,
+            },
+        ],
+    }),
+    selectors({
+        liveUserCount: [(s) => [s.stats], (stats) => (stats?.users_on_product ? stats.users_on_product : null)],
+        liveUserUpdatedSecondsAgo: [
+            (s) => [s.statsUpdatedTime, s.now],
+            (statsUpdatedTime, now) => {
+                if (!statsUpdatedTime || !now) {
+                    return null
+                }
+                const seconds = Math.ceil((now.getTime() - statsUpdatedTime.getTime()) / 1000)
+                if (seconds < 0 || seconds >= 300) {
+                    // this should only happen if we have a bug, but be defensive and don't show anything surprising if there is a bug
+                    return null
+                }
+                return seconds
             },
         ],
     }),
@@ -32,21 +69,31 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
                     },
                 })
                 const data = await response.json()
-                actions.setStats(data)
+                actions.setStats({ stats: data, now: new Date() })
             } catch (error) {
                 console.error('Failed to poll stats:', error)
             }
         },
     })),
-    events(({ actions, cache }) => ({
+    events(({ actions, cache, values }) => ({
         afterMount: () => {
-            cache.statsInterval = setInterval(() => {
+            if (values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LIVE_USER_COUNT]) {
+                actions.setNow({ now: new Date() })
                 actions.pollStats()
-            }, 1500)
+
+                cache.statsInterval = setInterval(() => {
+                    actions.pollStats()
+                }, 30000)
+
+                cache.nowInterval = setInterval(() => {
+                    actions.setNow({ now: new Date() })
+                }, 500)
+            }
         },
         beforeUnmount: () => {
             if (cache.statsInterval) {
                 clearInterval(cache.statsInterval)
+                cache.statsInterval = null
             }
         },
     })),

--- a/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
@@ -1,0 +1,53 @@
+import { actions, connect, events, kea, listeners, path, reducers } from 'kea'
+import { liveEventsHostOrigin } from 'lib/utils/apiHost'
+import { teamLogic } from 'scenes/teamLogic'
+
+export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
+    path(['scenes', 'activity', 'live-events', 'liveEventsTableLogic']),
+    connect({
+        values: [teamLogic, ['currentTeam']],
+    }),
+    actions(() => ({
+        pollStats: true,
+        setStats: (stats) => ({ stats }),
+    })),
+    reducers({
+        stats: [
+            { users_on_product: null },
+            {
+                setStats: (_, { stats }) => stats,
+            },
+        ],
+    }),
+    listeners(({ actions, values }) => ({
+        pollStats: async () => {
+            try {
+                if (!values.currentTeam) {
+                    return
+                }
+
+                const response = await fetch(`${liveEventsHostOrigin()}/stats`, {
+                    headers: {
+                        Authorization: `Bearer ${values.currentTeam.live_events_token}`,
+                    },
+                })
+                const data = await response.json()
+                actions.setStats(data)
+            } catch (error) {
+                console.error('Failed to poll stats:', error)
+            }
+        },
+    })),
+    events(({ actions, cache }) => ({
+        afterMount: () => {
+            cache.statsInterval = setInterval(() => {
+                actions.pollStats()
+            }, 1500)
+        },
+        beforeUnmount: () => {
+            if (cache.statsInterval) {
+                clearInterval(cache.statsInterval)
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
@@ -31,7 +31,7 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
         statsUpdatedTime: [
             null as Date | null,
             {
-                setNumUsersOnProduct: (_, { now }) => now,
+                setLiveUserCount: (_, { now }) => now,
             },
         ],
         now: [

--- a/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/liveWebAnalyticsLogic.tsx
@@ -40,10 +40,13 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
         ],
     }),
     selectors({
-        liveUserCount: [(s) => [s.stats], (stats) => (stats?.users_on_product ? stats.users_on_product : null)],
+        liveUserCount: [
+            (s) => [s.stats],
+            (stats: StatsResponse | null) => (stats?.users_on_product ? stats.users_on_product : null),
+        ],
         liveUserUpdatedSecondsAgo: [
             (s) => [s.statsUpdatedTime, s.now],
-            (statsUpdatedTime, now) => {
+            (statsUpdatedTime: Date | null, now: Date | null) => {
                 if (!statsUpdatedTime || !now) {
                     return null
                 }


### PR DESCRIPTION
## Problem

The live users count service can show currently online users - and we're not doing anything with that :)

## Changes

Add a count for how many users are live in the project.

In page header:

<img width="1356" alt="Screenshot 2024-06-25 at 19 21 52" src="https://github.com/PostHog/posthog/assets/2056078/24f5b5e0-ef3c-49e2-bfb6-ca2cfd57093e">

~~Normal view:~~ (placement is no longer here, it's in the header)

<img width="475" alt="Screenshot 2024-06-25 at 16 36 34" src="https://github.com/PostHog/posthog/assets/2056078/00de14b2-e3a6-4787-a6a1-514defd8b37e">

~~Tooltip:~~ (the tooltip still looks like this, but the placement is now in the header)

<img width="491" alt="Screenshot 2024-06-25 at 16 36 51" src="https://github.com/PostHog/posthog/assets/2056078/a7cf7889-5053-4c74-ae71-d80e45ac24ff">

## Does this work well for both Cloud and self-hosted?

It's currently behind a feature flag, I'm not sure we support running this service in live-hosting yet

## How did you test this code?
Currently can't test this locally as I can't run the service locally, so had to mock the request. It's behind a FF so we'll dogfood before releasing