### PR TITLE
feat: update loading bar to pull in queries from query log

### DIFF
--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -81,9 +81,10 @@ class QueryStatusManager:
 
         return json.loads(byte_results) if byte_results is not None else {}
 
-    def update_clickhouse_query_progress(self, initial_query_id, clickhouse_query_progress):
+    def update_clickhouse_query_progresses(self, clickhouse_query_progresses):
         clickhouse_query_progress_dict = self._get_clickhouse_query_progress_dict()
-        clickhouse_query_progress_dict[initial_query_id] = clickhouse_query_progress
+        for clickhouse_query_progress in clickhouse_query_progresses:
+            clickhouse_query_progress_dict[clickhouse_query_progress["query_id"]] = clickhouse_query_progress
         self._store_clickhouse_query_progress_dict(clickhouse_query_progress_dict)
 
     def has_results(self):

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -68,7 +68,7 @@ class TestQueryStatusManager(SimpleTestCase):
         self.manager._store_clickhouse_query_progress_dict(query_status)
         self.assertEqual(self.manager.get_query_status(True), self.query_status)
 
-    def test_update_clickhouse_query_progress(self):
+    def test_update_clickhouse_query_progresses(self):
         self.manager.store_query_status(self.query_status)
 
         query_id_1 = f"{self.team_id}_{self.query_id}_1"
@@ -80,13 +80,16 @@ class TestQueryStatusManager(SimpleTestCase):
         }
 
         self.manager._store_clickhouse_query_progress_dict(query_progress_dict)
-        self.manager.update_clickhouse_query_progress(
-            query_id_2,
-            {**ZERO_PROGRESS, "bytes_read": 10},
-        )
-        self.manager.update_clickhouse_query_progress(
-            query_id_3,
-            {**ZERO_PROGRESS, "bytes_read": 20},
+        self.manager.update_clickhouse_query_progresses(
+            [
+                {
+                    **ZERO_PROGRESS,
+                    "bytes_read": 10,
+                    "initial_query_id": query_id_2,
+                    "query_id": query_id_2,
+                },
+                {**ZERO_PROGRESS, "bytes_read": 20, "initial_query_id": query_id_2, "query_id": query_id_3},
+            ]
         )
 
         self.query_status.query_progress = ClickhouseQueryProgress(**{**ZERO_PROGRESS, "bytes_read": 31})

--- a/posthog/tasks/poll_query_performance.py
+++ b/posthog/tasks/poll_query_performance.py
@@ -1,8 +1,10 @@
+from itertools import groupby
 from typing import Optional
 
 from structlog import get_logger
 
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.client.execute_async import QueryStatusManager
 from posthog.utils import UUID_REGEX
 import re
@@ -21,39 +23,60 @@ def query_manager_from_initial_query_id(initial_query_id: str) -> Optional[Query
     return QueryStatusManager(query_id, team_id)
 
 
-def poll_query_performance() -> None:
-    CLICKHOUSE_SQL = """
-    SELECT
-        initial_query_id,
-        read_rows,
-        read_bytes,
-        total_rows_approx,
-        elapsed,
-        ProfileEvents['OSCPUVirtualTimeMicroseconds'] as OSCPUVirtualTimeMicroseconds
-    FROM clusterAllReplicas(posthog, system.processes)
-    WHERE is_initial_query
-    """
-    try:
-        results = sync_execute(CLICKHOUSE_SQL)
+def get_query_results() -> list[any]:
+    SYSTEM_PROCESSES_SQL = r"""
+        SELECT
+            initial_query_id,
+            read_rows,
+            read_bytes,
+            total_rows_approx,
+            elapsed,
+            ProfileEvents['OSCPUVirtualTimeMicroseconds'] as OSCPUVirtualTimeMicroseconds,
+            query_id
+        FROM clusterAllReplicas(posthog, system.processes)
+        WHERE initial_query_id REGEXP '\d+_[0-9a-f]{8}-'
+        UNION ALL SELECT
+            initial_query_id,
+            read_rows,
+            read_bytes,
+            read_rows as total_rows_approx,
+            query_duration_ms / 1000 as elapsed,
+            ProfileEvents['OSCPUVirtualTimeMicroseconds'] as OSCPUVirtualTimeMicroseconds,
+            query_id
+        FROM clusterAllReplicas(posthog, system.query_log)
+        WHERE initial_query_id REGEXP '\d+_[0-9a-f]{8}-'
+        AND type = 'QueryFinish'
+        AND event_time > subtractSeconds(now(), 10)
+        """
+    raw_results = sync_execute(SYSTEM_PROCESSES_SQL, workload=Workload.ONLINE)
 
-        noNaNInt = lambda num: 0 if math.isnan(num) else int(num)
+    noNaNInt = lambda num: 0 if math.isnan(num) else int(num)
 
-        all_query_progresses = {
-            result[0]: {
-                "bytes_read": noNaNInt(result[2]),
-                "rows_read": noNaNInt(result[1]),
-                "estimated_rows_total": noNaNInt(result[3]),
-                "time_elapsed": noNaNInt(result[4]),
-                "active_cpu_time": noNaNInt(result[5]),
-            }
-            for result in results
+    return [
+        {
+            "initial_query_id": result[0],
+            "query_id": result[6],
+            "bytes_read": noNaNInt(result[2]),
+            "rows_read": noNaNInt(result[1]),
+            "estimated_rows_total": noNaNInt(result[3]),
+            "time_elapsed": noNaNInt(result[4]),
+            "active_cpu_time": noNaNInt(result[5]),
         }
-        for initial_query_id, new_clickhouse_query_progress in all_query_progresses.items():
+        for result in raw_results
+    ]
+
+
+def poll_query_performance() -> None:
+    try:
+        results = get_query_results()
+
+        key_func = lambda x: x["initial_query_id"]
+        results.sort(key=key_func)
+        for initial_query_id, results_group in groupby(results, key=key_func):
             manager = query_manager_from_initial_query_id(initial_query_id)
             if manager is None:
                 continue
-
-            manager.update_clickhouse_query_progress(initial_query_id, new_clickhouse_query_progress)
+            manager.update_clickhouse_query_progresses(list(results_group))
 
     except Exception as e:
         logger.error("Clickhouse Status Check Failed", error=e)

--- a/posthog/tasks/poll_query_performance.py
+++ b/posthog/tasks/poll_query_performance.py
@@ -1,5 +1,5 @@
 from itertools import groupby
-from typing import Optional
+from typing import Optional, Any
 
 from structlog import get_logger
 
@@ -23,7 +23,7 @@ def query_manager_from_initial_query_id(initial_query_id: str) -> Optional[Query
     return QueryStatusManager(query_id, team_id)
 
 
-def get_query_results() -> list[any]:
+def get_query_results() -> list[Any]:
     SYSTEM_PROCESSES_SQL = r"""
         SELECT
             initial_query_id,

--- a/posthog/tasks/test/test_poll_query_performance.py
+++ b/posthog/tasks/test/test_poll_query_performance.py
@@ -27,7 +27,7 @@ class TestPollQueryPerformance(SimpleTestCase):
         time_elapsed = 4.301284
         millisecond_cpu_time = 3321332424
         mock_sync_execute.return_value = [
-            ("None_None_tHrh4Ox9", 0, 0, 0, 0.002112, 0),
+            ("None_None_tHrh4Ox9", 0, 0, 0, 0.002112, 0, "query_id"),
             (
                 "12345_550e8400-e29b-41d4-a716-446655440000_eO290UUI",
                 rows_read,
@@ -35,6 +35,7 @@ class TestPollQueryPerformance(SimpleTestCase):
                 total_rows_approx,
                 time_elapsed,
                 millisecond_cpu_time,
+                "550e8400-e29b-41d4-a716-446655440001",
             ),
         ]
         mock_manager = mock_QueryStatusManager.return_value
@@ -43,15 +44,18 @@ class TestPollQueryPerformance(SimpleTestCase):
 
         mock_sync_execute.assert_called_once()
         mock_QueryStatusManager.assert_called_once_with("550e8400-e29b-41d4-a716-446655440000", 12345)
-        mock_manager.update_clickhouse_query_progress.assert_called_once_with(
-            "12345_550e8400-e29b-41d4-a716-446655440000_eO290UUI",
-            {
-                "bytes_read": bytes_read,
-                "rows_read": rows_read,
-                "estimated_rows_total": total_rows_approx,
-                "time_elapsed": int(time_elapsed),
-                "active_cpu_time": millisecond_cpu_time,
-            },
+        mock_manager.update_clickhouse_query_progresses.assert_called_once_with(
+            [
+                {
+                    "initial_query_id": "12345_550e8400-e29b-41d4-a716-446655440000_eO290UUI",
+                    "query_id": "550e8400-e29b-41d4-a716-446655440001",
+                    "bytes_read": bytes_read,
+                    "rows_read": rows_read,
+                    "estimated_rows_total": total_rows_approx,
+                    "time_elapsed": int(time_elapsed),
+                    "active_cpu_time": millisecond_cpu_time,
+                },
+            ]
         )
 
 


### PR DESCRIPTION
## Problem

For some queries (especially funnels), progress is not properly shown. When I tested this on prod, it seemed like the `system.processes` table never shows anything but 0 for bytes or rows.

## Changes
Remedy this by querying the last 10 seconds of the query_log as well as the system.processes table. Short running queries that system.processes can't pick up will show up here. system.processes is still used for long running queries.

Also force these queries to be run on the online cluster (where async queries are run)

## Testing
Unit tested. Tested locally (can set the clickhouse docker container to only be allowed 0.1 cpus, and then queries take so long to finish you can see the progress come in) `docker container update --cpus .1 0970985ec67a`

The SQL we run is as follows:
```
  SELECT
      initial_query_id,
      read_rows,
      read_bytes,
      total_rows_approx,
      elapsed,
      ProfileEvents['OSCPUVirtualTimeMicroseconds'] as OSCPUVirtualTimeMicroseconds,
      query_id
  FROM clusterAllReplicas(posthog, system.processes)
  WHERE initial_query_id REGEXP '\d+_[0-9a-f]{8}-'
  UNION ALL SELECT
      initial_query_id,
      read_rows,
      read_bytes,
      read_rows as total_rows_approx,
      query_duration_ms / 1000 as elapsed,
      ProfileEvents['OSCPUVirtualTimeMicroseconds'] as OSCPUVirtualTimeMicroseconds,
      query_id
  FROM clusterAllReplicas(posthog, system.query_log)
  WHERE initial_query_id REGEXP '\d+_[0-9a-f]{8}-'
  AND type = 'QueryFinish'
  AND event_time > subtractSeconds(now(), 10)
