### PR TITLE
feat: shorten async query exponential backoff

### DIFF
--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -21,7 +21,7 @@ import {
     isTimeToSeeDataSessionsQuery,
 } from './utils'
 
-const QUERY_ASYNC_MAX_INTERVAL_SECONDS = 5
+const QUERY_ASYNC_MAX_INTERVAL_SECONDS = 3
 const QUERY_ASYNC_TOTAL_POLL_SECONDS = 10 * 60 + 6 // keep in sync with backend-side timeout (currently 10min) + a small buffer
 
 //get export context for a given query

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -87,7 +87,7 @@ export async function pollForResults(
 
     while (performance.now() - pollStart < QUERY_ASYNC_TOTAL_POLL_SECONDS * 1000) {
         await delay(currentDelay, methodOptions?.signal)
-        currentDelay = Math.min(currentDelay * 2, QUERY_ASYNC_MAX_INTERVAL_SECONDS * 1000)
+        currentDelay = Math.min(currentDelay * 1.25, QUERY_ASYNC_MAX_INTERVAL_SECONDS * 1000)
 
         try {
             const statusResponse = (await api.queryStatus.get(queryId, showProgress)).query_status


### PR DESCRIPTION
## Problem

The current 2x exponential backoff for async queries polls at the following intervals (total time elapsed).
In parentheses, I have put the longest amount of extra time a user has to wait, as a percentage of their query time.

0.3s
0.9s (200%)
2.1s (133%)
4.5s (114%)
9.3s (107%)
14.3s (54%)


The jump from 4.5s to 9.3s especially feels long. If the query completes in 4.5 seconds, a user has to keep waiting another 4.8 seconds, 107% longer.

## Changes

Convert to a 1.25x backoff and reducing max delay to 3 seconds.

This looks like 
0.3s
0.7s (125%)
1.1s (69%)
1.7s (51%)
2.5s (42%)
3.4s (37%)
4.5s (34%)
6.0s (32%)
7.7s (30%)
10.0s (29%)
12.8s (28%)
...
