### PR TITLE
fix(insights): Prevent requesting refreshes of shared dashboards and insights

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -582,6 +582,9 @@ class InsightSerializer(InsightBasicSerializer, UserPermissionsSerializerMixin):
                     and execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE
                 ):
                     execution_mode = ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE
+                elif self.context.get("is_shared", False) and execution_mode == ExecutionMode.CALCULATE_BLOCKING_ALWAYS:
+                    # On shared insights, we don't give the ability to refresh at will
+                    execution_mode = ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE
 
                 return calculate_for_query_based_insight(
                     insight,

--- a/posthog/api/test/__snapshots__/test_properties_timeline.ambr
+++ b/posthog/api/test/__snapshots__/test_properties_timeline.ambr
@@ -446,7 +446,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', '')) AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -482,7 +482,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array("mat_pp_foo", "mat_pp_bar") AS relevant_property_values,
+                          array("mat_pp_bar", "mat_pp_foo") AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -522,7 +522,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', '')) AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -558,7 +558,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array("mat_pp_foo", "mat_pp_bar") AS relevant_property_values,
+                          array("mat_pp_bar", "mat_pp_foo") AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -15,7 +15,9 @@ from posthog.hogql.query import execute_hogql_query
 from rest_framework import status
 from parameterized import parameterized
 
+from posthog import settings
 from posthog.api.test.dashboards import DashboardAPI
+from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import (
     Cohort,
     Dashboard,
@@ -280,6 +282,45 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertIsNotNone(insight_on_dashboard.get("filters_hash", None))
 
         self.assertNotEqual(insight_in_isolation["filters_hash"], insight_on_dashboard["filters_hash"])
+
+    def test_get_insight_in_shared_context(self) -> None:
+        filter_dict = {
+            "events": [{"id": "$pageview"}],
+            "properties": [{"key": "$browser", "value": "Mac OS X"}],
+        }
+
+        dashboard_id, _ = self.dashboard_api.create_dashboard(
+            {"name": "the dashboard", "filters": {"date_from": "-180d"}}
+        )
+
+        insight_id, _ = self.dashboard_api.create_insight(
+            {"filters": filter_dict, "name": "insight", "dashboards": [dashboard_id]}
+        )
+        sharing_config = SharingConfiguration.objects.create(team=self.team, insight_id=insight_id, enabled=True)
+
+        valid_url = f"{settings.SITE_URL}/shared/{sharing_config.access_token}"
+
+        with patch(
+            "posthog.caching.calculate_results.calculate_for_query_based_insight"
+        ) as calculate_for_query_based_insight:
+            self.client.get(valid_url)
+            calculate_for_query_based_insight.assert_called_once_with(
+                mock.ANY,
+                dashboard=mock.ANY,
+                execution_mode=ExecutionMode.CACHE_ONLY_NEVER_CALCULATE,
+                user=mock.ANY,
+            )
+
+        with patch(
+            "posthog.caching.calculate_results.calculate_for_query_based_insight"
+        ) as calculate_for_query_based_insight:
+            self.client.get(valid_url, data={"refresh": True})
+            calculate_for_query_based_insight.assert_called_once_with(
+                mock.ANY,
+                dashboard=mock.ANY,
+                execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
+                user=mock.ANY,
+            )
 
     def test_get_insight_by_short_id(self) -> None:
         filter_dict = {"events": [{"id": "$pageview"}]}


### PR DESCRIPTION
## Problem

I found that people can do `refresh=True` on shared insights and dashboards... While they will get fresh results, this always calculates and makes the insight end up being slow.

## Changes

Put in a safeguard 🚧

If stale, it will recalculate asynchronously. This won't show up on the shard insight however for now, you'd have to refresh.
I investigated the frontend logics if we might add polling, but would put this in a follow up since the logics are again complex 🫠 
