### PR TITLE
fix: switch default sorting column

### DIFF
--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -249,7 +249,7 @@ export function DashboardsTable({
                 rowClassName={(record) => (record._highlight ? 'highlighted' : null)}
                 columns={columns}
                 loading={dashboardsLoading}
-                defaultSorting={{ columnKey: 'name', order: 1 }}
+                defaultSorting={{ columnKey: 'created_at', order: -1 }}
                 emptyState="No dashboards matching your filters!"
                 nouns={['dashboard', 'dashboards']}
             />

--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -50,7 +50,8 @@ export function DashboardsTable({
     hideActions,
 }: DashboardsTableProps): JSX.Element {
     const { unpinDashboard, pinDashboard } = useActions(dashboardsModel)
-    const { setFilters } = useActions(dashboardsLogic)
+    const { setFilters, tableSortingChanged } = useActions(dashboardsLogic)
+    const { tableSorting } = useValues(dashboardsLogic)
     const { hasAvailableFeature } = useValues(userLogic)
     const { currentTeam } = useValues(teamLogic)
     const { showDuplicateDashboardModal } = useActions(duplicateDashboardLogic)
@@ -249,7 +250,10 @@ export function DashboardsTable({
                 rowClassName={(record) => (record._highlight ? 'highlighted' : null)}
                 columns={columns}
                 loading={dashboardsLoading}
-                defaultSorting={{ columnKey: 'created_at', order: -1 }}
+                defaultSorting={tableSorting}
+                onSort={(newSorting) => {
+                    tableSortingChanged(newSorting)
+                }}
                 emptyState="No dashboards matching your filters!"
                 nouns={['dashboard', 'dashboards']}
             />

--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -251,9 +251,7 @@ export function DashboardsTable({
                 columns={columns}
                 loading={dashboardsLoading}
                 defaultSorting={tableSorting}
-                onSort={(newSorting) => {
-                    tableSortingChanged(newSorting)
-                }}
+                onSort={tableSortingChanged}
                 emptyState="No dashboards matching your filters!"
                 nouns={['dashboard', 'dashboards']}
             />

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -1,6 +1,7 @@
 import Fuse from 'fuse.js'
 import { actions, connect, kea, path, reducers, selectors } from 'kea'
 import { actionToUrl, router, urlToAction } from 'kea-router'
+import { Sorting } from 'lib/lemon-ui/LemonTable/sorting'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectClean } from 'lib/utils'
 import { userLogic } from 'scenes/userLogic'
@@ -14,6 +15,8 @@ export enum DashboardsTab {
     Dashboards = 'dashboards',
     Templates = 'templates',
 }
+
+const DEFAULT_SORTING = { columnKey: 'name', order: 1 }
 
 export interface DashboardsFilters {
     search: string
@@ -39,8 +42,18 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
         setFilters: (filters: Partial<DashboardsFilters>) => ({
             filters,
         }),
+        tableSortingChanged: (sorting: Sorting | null) => ({
+            sorting,
+        }),
     }),
     reducers({
+        tableSorting: [
+            DEFAULT_SORTING as Sorting,
+            { persist: true },
+            {
+                tableSortingChanged: (_, { sorting }) => sorting || DEFAULT_SORTING,
+            },
+        ],
         currentTab: [
             DashboardsTab.Dashboards as DashboardsTab,
             {

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -16,7 +16,7 @@ export enum DashboardsTab {
     Templates = 'templates',
 }
 
-const DEFAULT_SORTING = { columnKey: 'name', order: 1 }
+const DEFAULT_SORTING: Sorting = { columnKey: 'name', order: 1 }
 
 export interface DashboardsFilters {
     search: string
@@ -48,7 +48,7 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
     }),
     reducers({
         tableSorting: [
-            DEFAULT_SORTING as Sorting,
+            DEFAULT_SORTING,
             { persist: true },
             {
                 tableSortingChanged: (_, { sorting }) => sorting || DEFAULT_SORTING,


### PR DESCRIPTION
i _always_ change the sorting order when i load the dashboards page

let's save my last selection

this will save me seconds every year

![2024-06-26 13 56 02](https://github.com/PostHog/posthog/assets/984817/aab712cb-7f78-48ce-a673-0dc034ef263c)
