### PR TITLE
fix: Use DISTINCT ON for batch exports query

### DIFF
--- a/posthog/api/test/__snapshots__/test_properties_timeline.ambr
+++ b/posthog/api/test/__snapshots__/test_properties_timeline.ambr
@@ -446,7 +446,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', '')) AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -482,7 +482,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array("mat_pp_foo", "mat_pp_bar") AS relevant_property_values,
+                          array("mat_pp_bar", "mat_pp_foo") AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -522,7 +522,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', '')) AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -558,7 +558,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array("mat_pp_foo", "mat_pp_bar") AS relevant_property_values,
+                          array("mat_pp_bar", "mat_pp_foo") AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (

--- a/posthog/api/test/__snapshots__/test_properties_timeline.ambr
+++ b/posthog/api/test/__snapshots__/test_properties_timeline.ambr
@@ -446,7 +446,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', '')) AS relevant_property_values,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -482,7 +482,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array("mat_pp_bar", "mat_pp_foo") AS relevant_property_values,
+                          array("mat_pp_foo", "mat_pp_bar") AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -522,7 +522,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', '')) AS relevant_property_values,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -558,7 +558,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array("mat_pp_bar", "mat_pp_foo") AS relevant_property_values,
+                          array("mat_pp_foo", "mat_pp_bar") AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (

--- a/posthog/batch_exports/sql.py
+++ b/posthog/batch_exports/sql.py
@@ -1,5 +1,7 @@
-CREATE_PERSONS_BATCH_EXPORT_VIEW = """
-CREATE OR REPLACE VIEW persons_batch_export AS (
+from django.conf import settings
+
+CREATE_PERSONS_BATCH_EXPORT_VIEW = f"""
+CREATE OR REPLACE VIEW persons_batch_export ON CLUSTER {settings.CLICKHOUSE_CLUSTER} AS (
     SELECT
         pd.team_id AS team_id,
         pd.distinct_id AS distinct_id,
@@ -17,7 +19,7 @@ CREATE OR REPLACE VIEW persons_batch_export AS (
         FROM
             person_distinct_id2
         WHERE
-            team_id = {team_id:Int64}
+            team_id = {{team_id:Int64}}
         GROUP BY
             team_id,
             distinct_id
@@ -25,17 +27,17 @@ CREATE OR REPLACE VIEW persons_batch_export AS (
     INNER JOIN
         person p ON p.id = pd.person_id AND p.team_id = pd.team_id
     WHERE
-        pd.team_id = {team_id:Int64}
-        AND p.team_id = {team_id:Int64}
-        AND pd._timestamp >= {interval_start:DateTime64}
-        AND pd._timestamp < {interval_end:DateTime64}
+        pd.team_id = {{team_id:Int64}}
+        AND p.team_id = {{team_id:Int64}}
+        AND pd._timestamp >= {{interval_start:DateTime64}}
+        AND pd._timestamp < {{interval_end:DateTime64}}
     ORDER BY
         _inserted_at
 )
 """
 
-CREATE_EVENTS_BATCH_EXPORT_VIEW = """
-CREATE OR REPLACE VIEW events_batch_export AS (
+CREATE_EVENTS_BATCH_EXPORT_VIEW = f"""
+CREATE OR REPLACE VIEW events_batch_export ON CLUSTER {settings.CLICKHOUSE_CLUSTER} AS (
     SELECT DISTINCT ON (team_id, event, cityHash64(events.distinct_id), cityHash64(events.uuid))
         team_id AS team_id,
         timestamp AS timestamp,
@@ -53,22 +55,22 @@ CREATE OR REPLACE VIEW events_batch_export AS (
     FROM
         events
     PREWHERE
-        events.inserted_at >= {interval_start:DateTime64}
-        AND events.inserted_at < {interval_end:DateTime64}
+        events.inserted_at >= {{interval_start:DateTime64}}
+        AND events.inserted_at < {{interval_end:DateTime64}}
     WHERE
-        team_id = {team_id:Int64}
-        AND events.timestamp >= {interval_start:DateTime64} - INTERVAL {lookback_days:Int32} DAY
-        AND events.timestamp < {interval_end:DateTime64} + INTERVAL 1 DAY
-        AND (length({include_events:Array(String)}) = 0 OR event IN {include_events:Array(String)})
-        AND (length({exclude_events:Array(String)}) = 0 OR event NOT IN {exclude_events:Array(String)})
+        team_id = {{team_id:Int64}}
+        AND events.timestamp >= {{interval_start:DateTime64}} - INTERVAL {{lookback_days:Int32}} DAY
+        AND events.timestamp < {{interval_end:DateTime64}} + INTERVAL 1 DAY
+        AND (length({{include_events:Array(String)}}) = 0 OR event IN {{include_events:Array(String)}})
+        AND (length({{exclude_events:Array(String)}}) = 0 OR event NOT IN {{exclude_events:Array(String)}})
     ORDER BY
         _inserted_at, event
     SETTINGS optimize_aggregation_in_order=1
 )
 """
 
-CREATE_EVENTS_BATCH_EXPORT_VIEW_UNBOUNDED = """
-CREATE OR REPLACE VIEW events_batch_export_unbounded AS (
+CREATE_EVENTS_BATCH_EXPORT_VIEW_UNBOUNDED = f"""
+CREATE OR REPLACE VIEW events_batch_export_unbounded ON CLUSTER {settings.CLICKHOUSE_CLUSTER} AS (
     SELECT DISTINCT ON (team_id, event, cityHash64(events.distinct_id), cityHash64(events.uuid))
         team_id AS team_id,
         timestamp AS timestamp,
@@ -86,20 +88,20 @@ CREATE OR REPLACE VIEW events_batch_export_unbounded AS (
     FROM
         events
     PREWHERE
-        events.inserted_at >= {interval_start:DateTime64}
-        AND events.inserted_at < {interval_end:DateTime64}
+        events.inserted_at >= {{interval_start:DateTime64}}
+        AND events.inserted_at < {{interval_end:DateTime64}}
     WHERE
-        team_id = {team_id:Int64}
-        AND (length({include_events:Array(String)}) = 0 OR event IN {include_events:Array(String)})
-        AND (length({exclude_events:Array(String)}) = 0 OR event NOT IN {exclude_events:Array(String)})
+        team_id = {{team_id:Int64}}
+        AND (length({{include_events:Array(String)}}) = 0 OR event IN {{include_events:Array(String)}})
+        AND (length({{exclude_events:Array(String)}}) = 0 OR event NOT IN {{exclude_events:Array(String)}})
     ORDER BY
         _inserted_at, event
     SETTINGS optimize_aggregation_in_order=1
 )
 """
 
-CREATE_EVENTS_BATCH_EXPORT_VIEW_BACKFILL = """
-CREATE OR REPLACE VIEW events_batch_export_backfill AS (
+CREATE_EVENTS_BATCH_EXPORT_VIEW_BACKFILL = f"""
+CREATE OR REPLACE VIEW events_batch_export_backfill ON CLUSTER {settings.CLICKHOUSE_CLUSTER} AS (
     SELECT DISTINCT ON (team_id, event, cityHash64(events.distinct_id), cityHash64(events.uuid))
         team_id AS team_id,
         timestamp AS timestamp,
@@ -117,11 +119,11 @@ CREATE OR REPLACE VIEW events_batch_export_backfill AS (
     FROM
         events
     WHERE
-        team_id = {team_id:Int64}
-        AND events.timestamp >= {interval_start:DateTime64}
-        AND events.timestamp < {interval_end:DateTime64}
-        AND (length({include_events:Array(String)}) = 0 OR event IN {include_events:Array(String)})
-        AND (length({exclude_events:Array(String)}) = 0 OR event NOT IN {exclude_events:Array(String)})
+        team_id = {{team_id:Int64}}
+        AND events.timestamp >= {{interval_start:DateTime64}}
+        AND events.timestamp < {{interval_end:DateTime64}}
+        AND (length({{include_events:Array(String)}}) = 0 OR event IN {{include_events:Array(String)}})
+        AND (length({{exclude_events:Array(String)}}) = 0 OR event NOT IN {{exclude_events:Array(String)}})
     ORDER BY
         _inserted_at, event
     SETTINGS optimize_aggregation_in_order=1

--- a/posthog/batch_exports/sql.py
+++ b/posthog/batch_exports/sql.py
@@ -36,18 +36,18 @@ CREATE OR REPLACE VIEW persons_batch_export AS (
 
 CREATE_EVENTS_BATCH_EXPORT_VIEW = """
 CREATE OR REPLACE VIEW events_batch_export AS (
-    SELECT
+    SELECT DISTINCT ON (team_id, event, cityHash64(events.distinct_id), cityHash64(events.uuid))
         team_id AS team_id,
-        min(timestamp) AS timestamp,
+        timestamp AS timestamp,
         event AS event,
-        any(distinct_id) AS distinct_id,
-        any(toString(uuid)) AS uuid,
-        min(COALESCE(inserted_at, _timestamp)) AS _inserted_at,
-        any(created_at) AS created_at,
-        any(elements_chain) AS elements_chain,
-        any(toString(person_id)) AS person_id,
-        any(nullIf(properties, '')) AS properties,
-        any(nullIf(person_properties, '')) AS person_properties,
+        distinct_id AS distinct_id,
+        toString(uuid) AS uuid,
+        COALESCE(inserted_at, _timestamp) AS _inserted_at,
+        created_at AS created_at,
+        elements_chain AS elements_chain,
+        toString(person_id) AS person_id,
+        nullIf(properties, '') AS properties,
+        nullIf(person_properties, '') AS person_properties,
         nullIf(JSONExtractString(properties, '$set'), '') AS set,
         nullIf(JSONExtractString(properties, '$set_once'), '') AS set_once
     FROM
@@ -61,8 +61,6 @@ CREATE OR REPLACE VIEW events_batch_export AS (
         AND events.timestamp < {interval_end:DateTime64} + INTERVAL 1 DAY
         AND (length({include_events:Array(String)}) = 0 OR event IN {include_events:Array(String)})
         AND (length({exclude_events:Array(String)}) = 0 OR event NOT IN {exclude_events:Array(String)})
-    GROUP BY
-        team_id, toDate(events.timestamp), event, cityHash64(events.distinct_id), cityHash64(events.uuid)
     ORDER BY
         _inserted_at, event
     SETTINGS optimize_aggregation_in_order=1
@@ -71,18 +69,18 @@ CREATE OR REPLACE VIEW events_batch_export AS (
 
 CREATE_EVENTS_BATCH_EXPORT_VIEW_UNBOUNDED = """
 CREATE OR REPLACE VIEW events_batch_export_unbounded AS (
-    SELECT
+    SELECT DISTINCT ON (team_id, event, cityHash64(events.distinct_id), cityHash64(events.uuid))
         team_id AS team_id,
-        min(timestamp) AS timestamp,
+        timestamp AS timestamp,
         event AS event,
-        any(distinct_id) AS distinct_id,
-        any(toString(uuid)) AS uuid,
-        min(COALESCE(inserted_at, _timestamp)) AS _inserted_at,
-        any(created_at) AS created_at,
-        any(elements_chain) AS elements_chain,
-        any(toString(person_id)) AS person_id,
-        any(nullIf(properties, '')) AS properties,
-        any(nullIf(person_properties, '')) AS person_properties,
+        distinct_id AS distinct_id,
+        toString(uuid) AS uuid,
+        COALESCE(inserted_at, _timestamp) AS _inserted_at,
+        created_at AS created_at,
+        elements_chain AS elements_chain,
+        toString(person_id) AS person_id,
+        nullIf(properties, '') AS properties,
+        nullIf(person_properties, '') AS person_properties,
         nullIf(JSONExtractString(properties, '$set'), '') AS set,
         nullIf(JSONExtractString(properties, '$set_once'), '') AS set_once
     FROM
@@ -94,8 +92,6 @@ CREATE OR REPLACE VIEW events_batch_export_unbounded AS (
         team_id = {team_id:Int64}
         AND (length({include_events:Array(String)}) = 0 OR event IN {include_events:Array(String)})
         AND (length({exclude_events:Array(String)}) = 0 OR event NOT IN {exclude_events:Array(String)})
-    GROUP BY
-        team_id, toDate(events.timestamp), event, cityHash64(events.distinct_id), cityHash64(events.uuid)
     ORDER BY
         _inserted_at, event
     SETTINGS optimize_aggregation_in_order=1
@@ -104,18 +100,18 @@ CREATE OR REPLACE VIEW events_batch_export_unbounded AS (
 
 CREATE_EVENTS_BATCH_EXPORT_VIEW_BACKFILL = """
 CREATE OR REPLACE VIEW events_batch_export_backfill AS (
-    SELECT
+    SELECT DISTINCT ON (team_id, event, cityHash64(events.distinct_id), cityHash64(events.uuid))
         team_id AS team_id,
-        min(timestamp) AS timestamp,
+        timestamp AS timestamp,
         event AS event,
-        any(distinct_id) AS distinct_id,
-        any(toString(uuid)) AS uuid,
-        min(COALESCE(inserted_at, _timestamp)) AS _inserted_at,
-        any(created_at) AS created_at,
-        any(elements_chain) AS elements_chain,
-        any(toString(person_id)) AS person_id,
-        any(nullIf(properties, '')) AS properties,
-        any(nullIf(person_properties, '')) AS person_properties,
+        distinct_id AS distinct_id,
+        toString(uuid) AS uuid,
+        COALESCE(inserted_at, _timestamp) AS _inserted_at,
+        created_at AS created_at,
+        elements_chain AS elements_chain,
+        toString(person_id) AS person_id,
+        nullIf(properties, '') AS properties,
+        nullIf(person_properties, '') AS person_properties,
         nullIf(JSONExtractString(properties, '$set'), '') AS set,
         nullIf(JSONExtractString(properties, '$set_once'), '') AS set_once
     FROM
@@ -126,8 +122,6 @@ CREATE OR REPLACE VIEW events_batch_export_backfill AS (
         AND events.timestamp < {interval_end:DateTime64}
         AND (length({include_events:Array(String)}) = 0 OR event IN {include_events:Array(String)})
         AND (length({exclude_events:Array(String)}) = 0 OR event NOT IN {exclude_events:Array(String)})
-    GROUP BY
-        team_id, toDate(events.timestamp), event, cityHash64(events.distinct_id), cityHash64(events.uuid)
     ORDER BY
         _inserted_at, event
     SETTINGS optimize_aggregation_in_order=1

--- a/posthog/clickhouse/migrations/0065_update_batch_exports_views.py
+++ b/posthog/clickhouse/migrations/0065_update_batch_exports_views.py
@@ -1,0 +1,17 @@
+from posthog.batch_exports.sql import (
+    CREATE_EVENTS_BATCH_EXPORT_VIEW,
+    CREATE_EVENTS_BATCH_EXPORT_VIEW_BACKFILL,
+    CREATE_EVENTS_BATCH_EXPORT_VIEW_UNBOUNDED,
+    CREATE_PERSONS_BATCH_EXPORT_VIEW,
+)
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+operations = map(
+    run_sql_with_exceptions,
+    [
+        CREATE_PERSONS_BATCH_EXPORT_VIEW,
+        CREATE_EVENTS_BATCH_EXPORT_VIEW,
+        CREATE_EVENTS_BATCH_EXPORT_VIEW_UNBOUNDED,
+        CREATE_EVENTS_BATCH_EXPORT_VIEW_BACKFILL,
+    ],
+)


### PR DESCRIPTION
## Problem

When using `GROUP BY` clickhouse doesn't yield batches of `max_block_size`, so this can cause us to exceed Arrow's String type size on very large exports. Until ClickHouse supports Arrow's `LargeString` or allows us to control the batch size, we should switch back to `DISTINCT ON` to allow us to use `max_block_size` to control the batch size.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Updated migration, but will likely have to run this manually, or create a new migration.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
