### PR TITLE
chore: add arrayReduce method to HogQL

### DIFF
--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -325,7 +325,7 @@ HOGQL_CLICKHOUSE_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "arrayDistinct": HogQLFunctionMeta("arrayDistinct", 1, 1),
     "arrayEnumerateDense": HogQLFunctionMeta("arrayEnumerateDense", 1, 1),
     "arrayIntersect": HogQLFunctionMeta("arrayIntersect", 1, None),
-    # "arrayReduce": HogQLFunctionMeta("arrayReduce", 2,None),  # takes a "parametric function" as first arg, is that safe?
+    "arrayReduce": HogQLFunctionMeta("arrayReduce", 2, 2),
     # "arrayReduceInRanges": HogQLFunctionMeta("arrayReduceInRanges", 3,None),  # takes a "parametric function" as first arg, is that safe?
     "arrayReverse": HogQLFunctionMeta("arrayReverse", 1, 1),
     "arrayFilter": HogQLFunctionMeta("arrayFilter", 2, None),
@@ -1042,6 +1042,9 @@ FIRST_ARG_DATETIME_FUNCTIONS = (
     "hopStart",
     "hopEnd",
 )
+
+# Aggregation functions applied to array elements
+ALLOWED_PARAMETRIC_FUNCTIONS = "sumMap"
 
 
 def _find_function(name: str, functions: dict[str, HogQLFunctionMeta]) -> Optional[HogQLFunctionMeta]:

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -815,10 +815,12 @@ class _Printer(Visitor):
                 elif node.name == "arrayReduce":
                     reduceFuncArg = node.args[0]
                     if not isinstance(reduceFuncArg, ast.Constant):
-                        raise QueryError(f"Function 'arrayReduce' expects a constant as the first argument")
+                        raise QueryError(
+                            f"Function 'arrayReduce' expects an the name of an aggregate function as the first argument"
+                        )
                     if reduceFuncArg.value not in ALLOWED_PARAMETRIC_FUNCTIONS:
                         raise QueryError(
-                            f"Function 'arrayReduce' is not permitted to call the '{reduceFuncArg.value}' function"
+                            f"Function 'arrayReduce' is not permitted to aggregate the '{reduceFuncArg.value}' function"
                         )
                     args = [self.visit(arg) for arg in node.args]
                 else:

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -391,8 +391,12 @@ class TestPrinter(BaseTest):
             'The HogQL identifier "as%d" is not permitted as it contains the "%" character',
         )
         self._assert_expr_error(
+            "arrayReduce(abs(1), [])",
+            "Function 'arrayReduce' expects an the name of an aggregate function as the first argument",
+        )
+        self._assert_expr_error(
             "arrayReduce('topK', [])",
-            "Function 'arrayReduce' is not permitted to call the 'topK' function",
+            "Function 'arrayReduce' is not permitted to aggregate the 'topK' function",
         )
         self._assert_expr_error(
             "arrayReduce('sumMap', [], [])",

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -339,6 +339,7 @@ class TestPrinter(BaseTest):
             self._expr("toDecimal('3.14')", context), "accurateCastOrNull(%(hogql_val_6)s, %(hogql_val_7)s)"
         )
         self.assertEqual(self._expr("quantile(0.95)( event )"), "quantile(0.95)(events.event)")
+        self.assertEqual(self._expr("arrayReduce('sumMap', [])"), "arrayReduce(%(hogql_val_0)s, [])")
 
     def test_expr_parse_errors(self):
         self._assert_expr_error("", "Empty query")
@@ -388,6 +389,14 @@ class TestPrinter(BaseTest):
         self._assert_expr_error(
             "event as `as%d`",
             'The HogQL identifier "as%d" is not permitted as it contains the "%" character',
+        )
+        self._assert_expr_error(
+            "arrayReduce('topK', [])",
+            "Function 'arrayReduce' is not permitted to call the 'topK' function",
+        )
+        self._assert_expr_error(
+            "arrayReduce('sumMap', [], [])",
+            "Function 'arrayReduce' expects 2 arguments, found 3",
         )
 
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=True, PERSON_ON_EVENTS_V2_OVERRIDE=True)


### PR DESCRIPTION
## Problem

Prompted by https://github.com/PostHog/posthog/pull/23160/files#r1653456118

## Changes

- Limiting to two arguments (can actually accept an unbounded amount of arrays as arguments)
- Limit first argument of `arrayReduce` to a list of `ALLOWED_PARAMETRIC_FUNCTIONS` (only contains `sumMap` for now)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested error states & checks