### PR TITLE
fix: Hog Function clearing / resetting logic

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/pipelineHogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/pipelineHogFunctionConfigurationLogic.tsx
@@ -110,7 +110,7 @@ export const pipelineHogFunctionConfigurationLogic = kea<pipelineHogFunctionConf
         upsertHogFunction: (configuration: HogFunctionConfigurationType) => ({ configuration }),
         duplicate: true,
         duplicateFromTemplate: true,
-        resetToTemplate: (keepInputValues: boolean) => ({ keepInputValues }),
+        resetToTemplate: true,
     }),
     reducers({
         showSource: [

--- a/frontend/src/scenes/pipeline/hogfunctions/pipelineHogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/pipelineHogFunctionConfigurationLogic.tsx
@@ -110,7 +110,7 @@ export const pipelineHogFunctionConfigurationLogic = kea<pipelineHogFunctionConf
         upsertHogFunction: (configuration: HogFunctionConfigurationType) => ({ configuration }),
         duplicate: true,
         duplicateFromTemplate: true,
-        resetToTemplate: true,
+        resetToTemplate: (keepInputValues: boolean) => ({ keepInputValues }),
     }),
     reducers({
         showSource: [
@@ -191,6 +191,31 @@ export const pipelineHogFunctionConfigurationLogic = kea<pipelineHogFunctionConf
         },
     })),
     selectors(() => ({
+        defaultFormState: [
+            (s) => [s.template, s.hogFunction],
+            (template, hogFunction): HogFunctionConfigurationType => {
+                if (template) {
+                    // Fill defaults from template
+                    const inputs = {}
+
+                    template!.inputs_schema?.forEach((schema) => {
+                        if (schema.default) {
+                            inputs[schema.key] = { value: schema.default }
+                        }
+                    })
+
+                    return {
+                        ...template,
+                        inputs,
+                        enabled: false,
+                    }
+                } else if (hogFunction) {
+                    return hogFunction
+                }
+                return {} as HogFunctionConfigurationType
+            },
+        ],
+
         loading: [
             (s) => [s.hogFunctionLoading, s.templateLoading],
             (hogFunctionLoading, templateLoading) => hogFunctionLoading || templateLoading,
@@ -236,24 +261,9 @@ export const pipelineHogFunctionConfigurationLogic = kea<pipelineHogFunctionConf
     })),
 
     listeners(({ actions, values, cache, props }) => ({
-        loadTemplateSuccess: ({ template }) => {
-            // Fill defaults from template
-            const inputs = {}
-
-            template!.inputs_schema?.forEach((schema) => {
-                if (schema.default) {
-                    inputs[schema.key] = { value: schema.default }
-                }
-            })
-
-            actions.resetForm({
-                ...template!,
-                inputs,
-                enabled: false,
-            })
-        },
-        loadHogFunctionSuccess: ({ hogFunction }) => actions.resetForm(hogFunction!),
-        upsertHogFunctionSuccess: ({ hogFunction }) => actions.resetForm(hogFunction),
+        loadTemplateSuccess: () => actions.resetForm(),
+        loadHogFunctionSuccess: () => actions.resetForm(),
+        upsertHogFunctionSuccess: () => actions.resetForm(),
 
         upsertHogFunctionFailure: ({ errorObject }) => {
             const maybeValidationError = errorObject.data
@@ -279,11 +289,9 @@ export const pipelineHogFunctionConfigurationLogic = kea<pipelineHogFunctionConf
             }
         },
 
-        resetForm: ({ configuration }) => {
-            const savedValue = configuration
+        resetForm: () => {
             actions.resetConfiguration({
-                ...savedValue,
-                inputs: savedValue?.inputs ?? {},
+                ...values.defaultFormState,
                 ...(cache.configFromUrl || {}),
             })
         },
@@ -331,8 +339,23 @@ export const pipelineHogFunctionConfigurationLogic = kea<pipelineHogFunctionConf
         },
         resetToTemplate: async () => {
             if (values.hogFunction?.template) {
-                actions.resetForm({
+                const template = values.hogFunction.template
+                // Fill defaults from template
+                const inputs = {}
+
+                template.inputs_schema?.forEach((schema) => {
+                    if (schema.default) {
+                        inputs[schema.key] = { value: schema.default }
+                    }
+                })
+
+                actions.setConfigurationValues({
                     ...values.hogFunction.template,
+                    filters: values.configuration.filters ?? template.filters,
+                    // Keep some existing things
+                    name: values.configuration.name,
+                    description: values.configuration.description,
+                    inputs,
                     enabled: false,
                 })
             }

--- a/frontend/src/scenes/pipeline/hogfunctions/pipelineHogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/pipelineHogFunctionConfigurationLogic.tsx
@@ -198,7 +198,7 @@ export const pipelineHogFunctionConfigurationLogic = kea<pipelineHogFunctionConf
                     // Fill defaults from template
                     const inputs = {}
 
-                    template!.inputs_schema?.forEach((schema) => {
+                    template.inputs_schema?.forEach((schema) => {
                         if (schema.default) {
                             inputs[schema.key] = { value: schema.default }
                         }

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -3,6 +3,7 @@ import express from 'express'
 
 import { GroupTypeToColumnIndex, Hub } from '../types'
 import { status } from '../utils/status'
+import { delay } from '../utils/utils'
 import { AsyncFunctionExecutor } from './async-function-executor'
 import { addLog, HogExecutor } from './hog-executor'
 import { HogFunctionManager } from './hog-function-manager'
@@ -77,7 +78,7 @@ export class CdpApi {
             }
 
             // Hacky - wait for a little to give a chance for the state to change
-            await new Promise((resolve) => setTimeout(resolve, 100))
+            await delay(100)
 
             res.json(await this.hogWatcher.fetchWatcher(id))
         }


### PR DESCRIPTION
## Problem

There was a bug in the resetting that would nuke the form alltogether.

## Changes

* This fixes it with a selector for the default state so that we are always resetting to the right state.


|Before|After|
|----|----|
| ![2024-06-26 17 34 52](https://github.com/PostHog/posthog/assets/2536520/96678140-b8c1-48b1-9912-d5bca99c5fef) | ![2024-06-26 17 33 56](https://github.com/PostHog/posthog/assets/2536520/88e36312-92d1-4b32-b39e-af193e61bcc9) |

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
