### PR TITLE
chore(data-warehouse): adjust time

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -322,9 +322,10 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         name="Invalid web replays count",
     )
 
-    # Every 30 minutes try to retrieve and calculate total rows synced in period
+    # Every 20 minutes try to retrieve and calculate total rows synced in period
+
     sender.add_periodic_task(
-        crontab(minute="*/30"),
+        crontab(minute="*/20"),
         calculate_external_data_rows_synced.s(),
         name="calculate external data rows synced",
     )

--- a/posthog/tasks/warehouse.py
+++ b/posthog/tasks/warehouse.py
@@ -19,13 +19,13 @@ logger = structlog.get_logger(__name__)
 MONTHLY_LIMIT = 500_000_000
 
 # TODO: adjust to whenever billing officially starts
-DEFAULT_DATE_TIME = datetime.datetime(2024, 7, 31, tzinfo=datetime.timezone.utc)
+DEFAULT_DATE_TIME = datetime.datetime(2024, 6, 1, tzinfo=datetime.timezone.utc)
 
 
 @app.task(ignore_result=True)
 def capture_external_data_rows_synced() -> None:
     for team in Team.objects.select_related("organization").exclude(
-        Q(organization__for_internal_metrics=True) | Q(is_demo=True) | Q(external_data_workspace_id__isnull=True)
+        Q(organization__for_internal_metrics=True) | Q(is_demo=True)
     ):
         capture_workspace_rows_synced_by_team.delay(team.pk)
 


### PR DESCRIPTION
## Problem

- the default date is set in the future

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- make default date set to june 1st so data starts flowing

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
