### PR TITLE
fix(data-warehouse): wrong operator

### DIFF
--- a/posthog/tasks/warehouse.py
+++ b/posthog/tasks/warehouse.py
@@ -57,7 +57,7 @@ def check_synced_row_limits_of_team(team_id: int) -> None:
     ]
     total_rows_synced = sum(rows_synced_list)
 
-    if team_id in limited_teams_rows_synced or total_rows_synced < MONTHLY_LIMIT:
+    if team_id in limited_teams_rows_synced or total_rows_synced > MONTHLY_LIMIT:
         running_jobs = ExternalDataJob.objects.filter(team_id=team_id, status=ExternalDataJob.Status.RUNNING)
         for job in running_jobs:
             try:


### PR DESCRIPTION
## Problem

- last commit to keep the limit checking in flipped the operator

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- restore operator

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
