### PR TITLE
feat(cdp): Add a bunch more metrics counting for hog functions

### DIFF
--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -25,7 +25,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 preflightSchedules: true,
                 cdpProcessedEvents: true,
                 cdpFunctionCallbacks: true,
-                cdpOverflow: true,
+                cdpFunctionOverflow: true,
                 ...sharedCapabilities,
             }
         case PluginServerMode.ingestion:
@@ -101,9 +101,9 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 cdpFunctionCallbacks: true,
                 ...sharedCapabilities,
             }
-        case PluginServerMode.cdp_overflow:
+        case PluginServerMode.cdp_function_overflow:
             return {
-                cdpOverflow: true,
+                cdpFunctionOverflow: true,
                 ...sharedCapabilities,
             }
     }

--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -3,7 +3,7 @@ import { Counter, Histogram } from 'prom-client'
 
 import {
     KAFKA_CDP_FUNCTION_CALLBACKS,
-    KAFKA_CDP_OVERFLOW,
+    KAFKA_CDP_FUNCTION_OVERFLOW,
     KAFKA_EVENTS_JSON,
     KAFKA_LOG_ENTRIES,
 } from '../config/kafka-topics'
@@ -195,7 +195,7 @@ abstract class CdpConsumerBase {
                     if (functionState === HogWatcherState.overflowed) {
                         // TODO: _Maybe_ report to AppMetrics 2 when it is ready
                         this.messagesToProduce.push({
-                            topic: KAFKA_CDP_OVERFLOW,
+                            topic: KAFKA_CDP_FUNCTION_OVERFLOW,
                             value: {
                                 source: 'hog_function_callback',
                                 payload: item,
@@ -259,7 +259,7 @@ abstract class CdpConsumerBase {
                                 })
 
                                 this.messagesToProduce.push({
-                                    topic: KAFKA_CDP_OVERFLOW,
+                                    topic: KAFKA_CDP_FUNCTION_OVERFLOW,
                                     value: {
                                         source: 'event_invocations',
                                         payload: {
@@ -491,7 +491,7 @@ export class CdpFunctionCallbackConsumer extends CdpConsumerBase {
 
 export class CdpOverflowConsumer extends CdpConsumerBase {
     protected name = 'CdpOverflowConsumer'
-    protected topic = KAFKA_CDP_OVERFLOW
+    protected topic = KAFKA_CDP_FUNCTION_OVERFLOW
     protected consumerGroupId = 'cdp-overflow-consumer'
 
     public async _handleEachBatch(messages: Message[], heartbeat: () => void): Promise<void> {

--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -21,7 +21,7 @@ const MAX_LOG_LENGTH = 10000
 const DEFAULT_TIMEOUT_MS = 100
 
 const hogExecutionDuration = new Histogram({
-    name: 'hog_function_execution_duration_ms',
+    name: 'cdp_hog_function_execution_duration_ms',
     help: 'Processing time and success status of internal functions',
     // We have a timeout so we don't need to worry about much more than that
     buckets: [0, 10, 20, 50, 100, 200],

--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -71,7 +71,11 @@ export const addLog = (result: HogFunctionInvocationResult, level: HogFunctionLo
 export class HogExecutor {
     constructor(private hogFunctionManager: HogFunctionManager) {}
 
-    findMatchingFunctions(event: HogFunctionInvocationGlobals): HogFunctionType[] {
+    findMatchingFunctions(event: HogFunctionInvocationGlobals): {
+        total: number
+        matching: number
+        functions: HogFunctionType[]
+    } {
         const allFunctionsForTeam = this.hogFunctionManager.getTeamHogFunctions(event.project.id)
         const filtersGlobals = convertToHogFunctionFilterGlobal(event)
 
@@ -109,18 +113,18 @@ export class HogExecutor {
             return false
         })
 
-        if (!Object.keys(functions).length) {
-            return []
-        }
-
-        status.info(
+        status.debug(
             '🦔',
             `[HogExecutor] Found ${Object.keys(functions).length} matching functions out of ${
                 Object.keys(allFunctionsForTeam).length
             } for team`
         )
 
-        return functions
+        return {
+            total: allFunctionsForTeam.length,
+            matching: functions.length,
+            functions,
+        }
     }
 
     /**

--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -1,5 +1,6 @@
 import { convertHogToJS, convertJSToHog, exec, ExecResult, VMState } from '@posthog/hogvm'
 import { DateTime } from 'luxon'
+import { Histogram } from 'prom-client'
 
 import { status } from '../utils/status'
 import { UUIDT } from '../utils/utils'
@@ -18,6 +19,13 @@ const MAX_ASYNC_STEPS = 2
 const MAX_HOG_LOGS = 10
 const MAX_LOG_LENGTH = 10000
 const DEFAULT_TIMEOUT_MS = 100
+
+const hogExecutionDuration = new Histogram({
+    name: 'hog_function_execution_duration_ms',
+    help: 'Processing time and success status of internal functions',
+    // We have a timeout so we don't need to worry about much more than that
+    buckets: [0, 10, 20, 50, 100, 200],
+})
 
 export const formatInput = (bytecode: any, globals: HogFunctionInvocation['globals']): any => {
     // Similar to how we generate the bytecode by iterating over the values,
@@ -297,6 +305,7 @@ export class HogExecutor {
             }
 
             const duration = performance.now() - start
+            hogExecutionDuration.observe(duration)
 
             result.finished = execRes.finished
             result.timings.push({

--- a/plugin-server/src/config/kafka-topics.ts
+++ b/plugin-server/src/config/kafka-topics.ts
@@ -44,4 +44,4 @@ export const KAFKA_LOG_ENTRIES = `${prefix}log_entries${suffix}`
 
 // CDP topics
 export const KAFKA_CDP_FUNCTION_CALLBACKS = `${prefix}cdp_function_callbacks${suffix}`
-export const KAFKA_CDP_OVERFLOW = `${prefix}cdp_overflow${suffix}`
+export const KAFKA_CDP_FUNCTION_OVERFLOW = `${prefix}cdp_function_overflow${suffix}`

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -519,7 +519,7 @@ export async function startPluginsServer(
             }
         }
 
-        if (capabilities.cdpOverflow) {
+        if (capabilities.cdpFunctionOverflow) {
             ;[hub, closeHub] = hub ? [hub, closeHub] : await createHub(serverConfig, capabilities)
             const consumer = new CdpOverflowConsumer(hub)
             await consumer.start()

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -84,7 +84,7 @@ export enum PluginServerMode {
     person_overrides = 'person-overrides',
     cdp_processed_events = 'cdp-processed-events',
     cdp_function_callbacks = 'cdp-function-callbacks',
-    cdp_overflow = 'cdp-overflow',
+    cdp_function_overflow = 'cdp-function-overflow',
 }
 
 export const stringToPluginServerMode = Object.fromEntries(
@@ -320,7 +320,7 @@ export interface PluginServerCapabilities {
     sessionRecordingBlobOverflowIngestion?: boolean
     cdpProcessedEvents?: boolean
     cdpFunctionCallbacks?: boolean
-    cdpOverflow?: boolean
+    cdpFunctionOverflow?: boolean
     personOverrides?: boolean
     appManagementSingleton?: boolean
     preflightSchedules?: boolean // Used for instance health checks on hobby deploy, not useful on cloud

--- a/plugin-server/tests/cdp/hog-executor.test.ts
+++ b/plugin-server/tests/cdp/hog-executor.test.ts
@@ -63,7 +63,7 @@ describe('Hog Executor', () => {
 
         it('can parse incoming messages correctly', () => {
             const globals = createHogExecutionGlobals()
-            const results = executor.executeFunctions(globals, executor.findMatchingFunctions(globals))
+            const results = executor.executeFunctions(globals, executor.findMatchingFunctions(globals).functions)
             expect(results).toHaveLength(1)
             expect(results[0]).toMatchObject({
                 id: expect.any(String),
@@ -73,7 +73,7 @@ describe('Hog Executor', () => {
 
         it('collects logs from the function', () => {
             const globals = createHogExecutionGlobals()
-            const results = executor.executeFunctions(globals, executor.findMatchingFunctions(globals))
+            const results = executor.executeFunctions(globals, executor.findMatchingFunctions(globals).functions)
             expect(results[0].logs).toMatchObject([
                 {
                     team_id: 1,
@@ -106,7 +106,7 @@ describe('Hog Executor', () => {
 
         it('queues up an async function call', () => {
             const globals = createHogExecutionGlobals()
-            const results = executor.executeFunctions(globals, executor.findMatchingFunctions(globals))
+            const results = executor.executeFunctions(globals, executor.findMatchingFunctions(globals).functions)
             expect(results[0]).toMatchObject({
                 id: results[0].id,
                 globals: {
@@ -163,7 +163,7 @@ describe('Hog Executor', () => {
         it('executes the full function in a loop', () => {
             const logs: HogFunctionLogEntry[] = []
             const globals = createHogExecutionGlobals()
-            const results = executor.executeFunctions(globals, executor.findMatchingFunctions(globals))
+            const results = executor.executeFunctions(globals, executor.findMatchingFunctions(globals).functions)
             const splicedLogs = results[0].logs.splice(0, 100)
             logs.push(...splicedLogs)
 
@@ -221,7 +221,7 @@ describe('Hog Executor', () => {
 
             // Simulate the recusive loop
             const globals = createHogExecutionGlobals()
-            const results = executor.executeFunctions(globals, executor.findMatchingFunctions(globals))
+            const results = executor.executeFunctions(globals, executor.findMatchingFunctions(globals).functions)
             expect(results).toHaveLength(1)
 
             // Run the result one time simulating a successful fetch
@@ -254,7 +254,7 @@ describe('Hog Executor', () => {
             mockFunctionManager.getTeamHogFunctions.mockReturnValue([fn])
 
             const globals = createHogExecutionGlobals()
-            const results = executor.executeFunctions(globals, executor.findMatchingFunctions(globals))
+            const results = executor.executeFunctions(globals, executor.findMatchingFunctions(globals).functions)
             expect(results).toHaveLength(1)
             expect(results[0].error).toContain('Execution timed out after 0.1 seconds. Performed ')
 


### PR DESCRIPTION
## Problem

Starting to build up dashboards for alerting and such ([see here](https://grafana.prod-us.posthog.dev/d/adq1hh2c8q48wd/cdp?folderUid=adq1h6k7psf0gb&var-query0=&var-partition=$__all&var-Consumers=&var-consumers=$__all&from=now-3h&to=now&timezone=browser&var-consumer=$__all)) - lets count a bunch more things to do that

## Changes

* Count invocations with their outcome
* Count async responses with their outcome
* Adds histogram observer for function timings

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
