### PR TITLE
fix(web-analytics): Make order by and group by match, and add LCP

### DIFF
--- a/posthog/clickhouse/migrations/0066_sessions_lcp.py
+++ b/posthog/clickhouse/migrations/0066_sessions_lcp.py
@@ -37,12 +37,14 @@ DROP COLUMN IF EXISTS autocapture_count
 
 def add_columns_to_required_tables(_):
     sync_execute(ADD_LCP_COLUMNS_BASE_SQL.format(table="raw_sessions", cluster=CLICKHOUSE_CLUSTER))
+    sync_execute(ADD_LCP_COLUMNS_BASE_SQL.format(table="writable_raw_sessions", cluster=CLICKHOUSE_CLUSTER))
     sync_execute(ADD_LCP_COLUMNS_BASE_SQL.format(table="sharded_raw_sessions", cluster=CLICKHOUSE_CLUSTER))
 
 
 def drop_columns_from_required_tables(_):
     for sql in [DROP_PAGEVIEW_COLUMN_BASE_SQL, DROP_SCREEN_COLUMN_BASE_SQL, DROP_AUTOCAPTURE_COLUMN_BASE_SQL]:
         sync_execute(sql.format(table="raw_sessions", cluster=CLICKHOUSE_CLUSTER))
+        sync_execute(sql.format(table="writable_raw_sessions", cluster=CLICKHOUSE_CLUSTER))
         sync_execute(sql.format(table="sharded_raw_sessions", cluster=CLICKHOUSE_CLUSTER))
 
 

--- a/posthog/clickhouse/migrations/0066_sessions_lcp.py
+++ b/posthog/clickhouse/migrations/0066_sessions_lcp.py
@@ -1,0 +1,58 @@
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.raw_sessions.sql import (
+    RAW_SESSIONS_TABLE_MV_SQL,
+    DROP_RAW_SESSION_MATERIALIZED_VIEW_SQL,
+    DROP_RAW_SESSION_VIEW_SQL,
+    RAW_SESSIONS_VIEW_SQL,
+)
+from posthog.settings import CLICKHOUSE_CLUSTER
+from infi.clickhouse_orm import migrations
+
+ADD_LCP_COLUMNS_BASE_SQL = """
+ALTER TABLE {table}
+ON CLUSTER {cluster}
+ADD COLUMN IF NOT EXISTS first_lcp AggregateFunction(argMin, Nullable(Float64), DateTime64(6, 'UTC'))
+"""
+
+
+DROP_PAGEVIEW_COLUMN_BASE_SQL = """
+ALTER TABLE {table}
+ON CLUSTER {cluster}
+DROP COLUMN IF EXISTS pageview_count
+"""
+
+DROP_SCREEN_COLUMN_BASE_SQL = """
+ALTER TABLE {table}
+ON CLUSTER {cluster}
+DROP COLUMN IF EXISTS screen_count
+"""
+
+DROP_AUTOCAPTURE_COLUMN_BASE_SQL = """
+ALTER TABLE {table}
+ON CLUSTER {cluster}
+DROP COLUMN IF EXISTS autocapture_count
+"""
+
+
+def add_columns_to_required_tables(_):
+    sync_execute(ADD_LCP_COLUMNS_BASE_SQL.format(table="raw_sessions", cluster=CLICKHOUSE_CLUSTER))
+    sync_execute(ADD_LCP_COLUMNS_BASE_SQL.format(table="sharded_raw_sessions", cluster=CLICKHOUSE_CLUSTER))
+
+
+def drop_columns_from_required_tables(_):
+    for sql in [DROP_PAGEVIEW_COLUMN_BASE_SQL, DROP_SCREEN_COLUMN_BASE_SQL, DROP_AUTOCAPTURE_COLUMN_BASE_SQL]:
+        sync_execute(sql.format(table="raw_sessions", cluster=CLICKHOUSE_CLUSTER))
+        sync_execute(sql.format(table="sharded_raw_sessions", cluster=CLICKHOUSE_CLUSTER))
+
+
+operations = [
+    # drop the MV and view, will prevent the underlying table from getting new events, so make sure that the time this is run is backfilled
+    run_sql_with_exceptions(DROP_RAW_SESSION_MATERIALIZED_VIEW_SQL),
+    run_sql_with_exceptions(DROP_RAW_SESSION_VIEW_SQL),
+    migrations.RunPython(add_columns_to_required_tables),
+    migrations.RunPython(drop_columns_from_required_tables),
+    # add the MV and view back
+    run_sql_with_exceptions(RAW_SESSIONS_TABLE_MV_SQL),
+    run_sql_with_exceptions(RAW_SESSIONS_VIEW_SQL),
+]

--- a/posthog/clickhouse/schema.py
+++ b/posthog/clickhouse/schema.py
@@ -89,6 +89,7 @@ from posthog.models.raw_sessions.sql import (
     DISTRIBUTED_RAW_SESSIONS_TABLE_SQL,
     WRITABLE_RAW_SESSIONS_TABLE_SQL,
     RAW_SESSIONS_TABLE_MV_SQL,
+    RAW_SESSIONS_VIEW_SQL,
 )
 from posthog.models.sessions.sql import (
     SESSIONS_TABLE_SQL,
@@ -201,7 +202,7 @@ CREATE_DICTIONARY_QUERIES = (PERSON_OVERRIDES_CREATE_DICTIONARY_SQL, CHANNEL_DEF
 
 CREATE_DATA_QUERIES = (CHANNEL_DEFINITION_DATA_SQL,)
 
-CREATE_VIEW_QUERIES = (SESSIONS_VIEW_SQL,)
+CREATE_VIEW_QUERIES = (SESSIONS_VIEW_SQL, RAW_SESSIONS_VIEW_SQL)
 
 build_query = lambda query: query if isinstance(query, str) else query()
 get_table_name = lambda query: re.findall(r"[\.\s]`?([a-z0-9_]+)`?\s+ON CLUSTER", build_query(query))[0]

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -1657,20 +1657,17 @@
       initial_ttclid AggregateFunction(argMin, String, DateTime64(6, 'UTC')),
   
       -- Count pageview, autocapture, and screen events for providing totals.
-      -- It's unclear if we can use the counts as they are not idempotent, and we had a bug on EU where events were
-      -- double-counted, so the counts were wrong. To get around this, also keep track of the unique uuids. This will be
-      -- slower and more expensive to store, but will be correct even if events are double-counted, so can be used to
-      -- verify correctness and as a backup. Ideally we will be able to delete the uniq columns in the future when we're
-      -- satisfied that counts are accurate.
-      pageview_count SimpleAggregateFunction(sum, Int64),
+      -- We use uniq on the event UUIDs so that inserting events can be idempotent. This is important as especially on EU
+      -- we don't reliably receive events exactly once.
       pageview_uniq AggregateFunction(uniq, Nullable(UUID)),
-      autocapture_count SimpleAggregateFunction(sum, Int64),
       autocapture_uniq AggregateFunction(uniq, Nullable(UUID)),
-      screen_count SimpleAggregateFunction(sum, Int64),
       screen_uniq AggregateFunction(uniq, Nullable(UUID)),
   
       -- replay
-      maybe_has_session_replay SimpleAggregateFunction(max, Bool) -- will be written False to by the events table mv and True to by the replay table mv
+      maybe_has_session_replay SimpleAggregateFunction(max, Bool), -- will be written False to by the events table mv and True to by the replay table mv
+  
+      -- web vitals
+      first_lcp AggregateFunction(argMin, Nullable(Float64), DateTime64(6, 'UTC'))
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_raw_sessions', cityHash64(session_id_v7))
   
   '''
@@ -1735,21 +1732,25 @@
       argMinState(JSONExtractString(properties, 'ttclid'), timestamp) as initial_ttclid,
   
       -- count
-      sumIf(1, event='$pageview') as pageview_count,
       uniqState(if(event='$pageview', uuid, NULL)) as pageview_uniq,
-      sumIf(1, event='$autocapture') as autocapture_count,
       uniqState(if(event='$autocapture', uuid, NULL)) as autocapture_uniq,
-      sumIf(1, event='$screen') as screen_count,
       uniqState(if(event='$screen', uuid, NULL)) as screen_uniq,
   
       -- replay
-      false as maybe_has_session_replay
+      false as maybe_has_session_replay,
+  
+      -- web vitals
+      argMinState(accurateCastOrNull(JSONExtractString(properties, '$web_vitals_LCP_value'), 'Float64'), timestamp) as first_lcp
   FROM posthog_test.sharded_events
   WHERE and(
       bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7, -- has a session id and is valid uuidv7
       toYYYYMMDD(timestamp) >= 0
   )
-  GROUP BY session_id_v7, team_id
+  GROUP BY
+      team_id,
+      toStartOfHour(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000))),
+      cityHash64(session_id_v7),
+      session_id_v7
   
   
   '''
@@ -2267,20 +2268,17 @@
       initial_ttclid AggregateFunction(argMin, String, DateTime64(6, 'UTC')),
   
       -- Count pageview, autocapture, and screen events for providing totals.
-      -- It's unclear if we can use the counts as they are not idempotent, and we had a bug on EU where events were
-      -- double-counted, so the counts were wrong. To get around this, also keep track of the unique uuids. This will be
-      -- slower and more expensive to store, but will be correct even if events are double-counted, so can be used to
-      -- verify correctness and as a backup. Ideally we will be able to delete the uniq columns in the future when we're
-      -- satisfied that counts are accurate.
-      pageview_count SimpleAggregateFunction(sum, Int64),
+      -- We use uniq on the event UUIDs so that inserting events can be idempotent. This is important as especially on EU
+      -- we don't reliably receive events exactly once.
       pageview_uniq AggregateFunction(uniq, Nullable(UUID)),
-      autocapture_count SimpleAggregateFunction(sum, Int64),
       autocapture_uniq AggregateFunction(uniq, Nullable(UUID)),
-      screen_count SimpleAggregateFunction(sum, Int64),
       screen_uniq AggregateFunction(uniq, Nullable(UUID)),
   
       -- replay
-      maybe_has_session_replay SimpleAggregateFunction(max, Bool) -- will be written False to by the events table mv and True to by the replay table mv
+      maybe_has_session_replay SimpleAggregateFunction(max, Bool), -- will be written False to by the events table mv and True to by the replay table mv
+  
+      -- web vitals
+      first_lcp AggregateFunction(argMin, Nullable(Float64), DateTime64(6, 'UTC'))
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.raw_sessions', '{replica}')
   
   PARTITION BY toYYYYMM(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000)))
@@ -2566,20 +2564,17 @@
       initial_ttclid AggregateFunction(argMin, String, DateTime64(6, 'UTC')),
   
       -- Count pageview, autocapture, and screen events for providing totals.
-      -- It's unclear if we can use the counts as they are not idempotent, and we had a bug on EU where events were
-      -- double-counted, so the counts were wrong. To get around this, also keep track of the unique uuids. This will be
-      -- slower and more expensive to store, but will be correct even if events are double-counted, so can be used to
-      -- verify correctness and as a backup. Ideally we will be able to delete the uniq columns in the future when we're
-      -- satisfied that counts are accurate.
-      pageview_count SimpleAggregateFunction(sum, Int64),
+      -- We use uniq on the event UUIDs so that inserting events can be idempotent. This is important as especially on EU
+      -- we don't reliably receive events exactly once.
       pageview_uniq AggregateFunction(uniq, Nullable(UUID)),
-      autocapture_count SimpleAggregateFunction(sum, Int64),
       autocapture_uniq AggregateFunction(uniq, Nullable(UUID)),
-      screen_count SimpleAggregateFunction(sum, Int64),
       screen_uniq AggregateFunction(uniq, Nullable(UUID)),
   
       -- replay
-      maybe_has_session_replay SimpleAggregateFunction(max, Bool) -- will be written False to by the events table mv and True to by the replay table mv
+      maybe_has_session_replay SimpleAggregateFunction(max, Bool), -- will be written False to by the events table mv and True to by the replay table mv
+  
+      -- web vitals
+      first_lcp AggregateFunction(argMin, Nullable(Float64), DateTime64(6, 'UTC'))
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_raw_sessions', cityHash64(session_id_v7))
   
   '''
@@ -3324,20 +3319,17 @@
       initial_ttclid AggregateFunction(argMin, String, DateTime64(6, 'UTC')),
   
       -- Count pageview, autocapture, and screen events for providing totals.
-      -- It's unclear if we can use the counts as they are not idempotent, and we had a bug on EU where events were
-      -- double-counted, so the counts were wrong. To get around this, also keep track of the unique uuids. This will be
-      -- slower and more expensive to store, but will be correct even if events are double-counted, so can be used to
-      -- verify correctness and as a backup. Ideally we will be able to delete the uniq columns in the future when we're
-      -- satisfied that counts are accurate.
-      pageview_count SimpleAggregateFunction(sum, Int64),
+      -- We use uniq on the event UUIDs so that inserting events can be idempotent. This is important as especially on EU
+      -- we don't reliably receive events exactly once.
       pageview_uniq AggregateFunction(uniq, Nullable(UUID)),
-      autocapture_count SimpleAggregateFunction(sum, Int64),
       autocapture_uniq AggregateFunction(uniq, Nullable(UUID)),
-      screen_count SimpleAggregateFunction(sum, Int64),
       screen_uniq AggregateFunction(uniq, Nullable(UUID)),
   
       -- replay
-      maybe_has_session_replay SimpleAggregateFunction(max, Bool) -- will be written False to by the events table mv and True to by the replay table mv
+      maybe_has_session_replay SimpleAggregateFunction(max, Bool), -- will be written False to by the events table mv and True to by the replay table mv
+  
+      -- web vitals
+      first_lcp AggregateFunction(argMin, Nullable(Float64), DateTime64(6, 'UTC'))
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.raw_sessions', '{replica}')
   
   PARTITION BY toYYYYMM(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000)))

--- a/posthog/hogql/database/schema/sessions_v2.py
+++ b/posthog/hogql/database/schema/sessions_v2.py
@@ -50,9 +50,9 @@ RAW_SESSIONS_FIELDS: dict[str, FieldOrTable] = {
     "initial_referring_domain": DatabaseField(name="initial_referring_domain"),
     "initial_gclid": DatabaseField(name="initial_gclid"),
     "initial_gad_source": DatabaseField(name="initial_gad_source"),
-    "pageview_count": IntegerDatabaseField(name="pageview_count"),
-    "autocapture_count": IntegerDatabaseField(name="autocapture_count"),
-    "screen_count": IntegerDatabaseField(name="screen_count"),
+    "pageview_uniq": IntegerDatabaseField(name="pageview_uniq"),
+    "autocapture_uniq": IntegerDatabaseField(name="autocapture_uniq"),
+    "screen_uniq": IntegerDatabaseField(name="screen_uniq"),
     "last_external_click_url": StringDatabaseField(name="last_external_click_url"),
     "first_lcp": FloatDatabaseField(name="first_lcp", nullable=True),
 }

--- a/posthog/hogql/database/schema/sessions_v2.py
+++ b/posthog/hogql/database/schema/sessions_v2.py
@@ -200,9 +200,9 @@ def select_from_sessions_table_v2(
         "$entry_referring_domain": arg_min_merge_nullable_string_field("initial_referring_domain"),
         "$entry_gclid": arg_min_merge_nullable_string_field("initial_gclid"),
         "$entry_gad_source": arg_min_merge_nullable_string_field("initial_gad_source"),
-        "$pageview_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "pageview_count"])]),
-        "$screen_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "screen_count"])]),
-        "$autocapture_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "autocapture_count"])]),
+        "$pageview_count": ast.Call(name="uniqMerge", args=[ast.Field(chain=[table_name, "pageview_uniq"])]),
+        "$screen_count": ast.Call(name="uniqMerge", args=[ast.Field(chain=[table_name, "screen_uniq"])]),
+        "$autocapture_count": ast.Call(name="uniqMerge", args=[ast.Field(chain=[table_name, "autocapture_uniq"])]),
         "$last_external_click_url": arg_max_merge_nullable_string_field("last_external_click_url"),
         "$first_lcp": arg_min_merge_field("first_lcp"),
     }
@@ -232,12 +232,11 @@ def select_from_sessions_table_v2(
         args=[aggregate_fields["$urls"]],
     )
 
-    bounce_pageview_count = aggregate_fields["$pageview_count"]
     aggregate_fields["$is_bounce"] = ast.Call(
         name="if",
         args=[
-            # if pageview_count is 0, return NULL so it doesn't contribute towards the bounce rate either way
-            ast.Call(name="equals", args=[bounce_pageview_count, ast.Constant(value=0)]),
+            # if pageview_count is 0, return NULL, so it doesn't contribute towards the bounce rate either way
+            ast.Call(name="equals", args=[aggregate_fields["$pageview_count"], ast.Constant(value=0)]),
             ast.Constant(value=None),
             ast.Call(
                 name="not",
@@ -246,7 +245,7 @@ def select_from_sessions_table_v2(
                         name="or",
                         args=[
                             # if > 1 pageview, not a bounce
-                            ast.Call(name="greater", args=[bounce_pageview_count, ast.Constant(value=1)]),
+                            ast.Call(name="greater", args=[aggregate_fields["$pageview_count"], ast.Constant(value=1)]),
                             # if > 0 autocapture events, not a bounce
                             ast.Call(
                                 name="greater", args=[aggregate_fields["$autocapture_count"], ast.Constant(value=0)]

--- a/posthog/hogql/database/schema/test/test_sessions_v2.py
+++ b/posthog/hogql/database/schema/test/test_sessions_v2.py
@@ -24,6 +24,28 @@ class TestSessionsV2(ClickhouseTestMixin, APIBaseTest):
             modifiers=modifiers,
         )
 
+    def test_session_view(self):
+        session_id = str(uuid7())
+
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="d1",
+            properties={"$current_url": "https://example.com", "$session_id": session_id},
+        )
+
+        response = self.__execute(
+            parse_select(
+                "select * from raw_sessions_v where session_id = {session_id}",
+                placeholders={"session_id": ast.Constant(value=session_id)},
+            ),
+        )
+
+        self.assertEqual(
+            len(response.results or []),
+            1,
+        )
+
     def test_select_star(self):
         session_id = str(uuid7())
 

--- a/posthog/hogql/database/schema/test/test_sessions_v2.py
+++ b/posthog/hogql/database/schema/test/test_sessions_v2.py
@@ -406,6 +406,7 @@ class TestGetLazySessionProperties(ClickhouseTestMixin, APIBaseTest):
                 "$entry_utm_medium",
                 "$entry_utm_source",
                 "$entry_utm_term",
+                "$first_lcp",
                 "$is_bounce",
                 "$last_external_click_url",
                 "$pageview_count",

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -931,6 +931,7 @@ HOGQL_AGGREGATIONS: dict[str, HogQLFunctionMeta] = {
     "kurtPopIf": HogQLFunctionMeta("kurtPopIf", 2, 2, aggregate=True),
     "uniq": HogQLFunctionMeta("uniq", 1, None, aggregate=True),
     "uniqIf": HogQLFunctionMeta("uniqIf", 2, None, aggregate=True),
+    "uniqMerge": HogQLFunctionMeta("uniqMerge", 1, None, aggregate=True),
     "uniqExact": HogQLFunctionMeta("uniqExact", 1, None, aggregate=True),
     "uniqExactIf": HogQLFunctionMeta("uniqExactIf", 2, None, aggregate=True),
     # "uniqCombined": HogQLFunctionMeta("uniqCombined", 1, 1, aggregate=True),

--- a/posthog/models/raw_sessions/sql.py
+++ b/posthog/models/raw_sessions/sql.py
@@ -436,7 +436,7 @@ SELECT
     session_id_v7,
     fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000)) as session_timestamp,
     team_id,
-    any(distinct_id) as distinct_id,
+    argMaxMerge(distinct_id) as distinct_id,
     min(min_timestamp) as min_timestamp,
     max(max_timestamp) as max_timestamp,
 

--- a/posthog/models/raw_sessions/sql.py
+++ b/posthog/models/raw_sessions/sql.py
@@ -333,7 +333,11 @@ WHERE and(
     bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7, -- has a session id and is valid uuidv7
     {INGEST_FROM_DATE}
 )
-GROUP BY session_id_v7, team_id
+GROUP BY
+    team_id,
+    toStartOfHour(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000))),
+    cityHash64(session_id_v7),
+    session_id_v7
 """.format(
         database=settings.CLICKHOUSE_DATABASE,
         current_url=source_url_column("$current_url"),
@@ -488,7 +492,11 @@ SELECT
 
     max(maybe_has_session_replay) as maybe_has_session_replay
 FROM {TABLE_BASE_NAME}
-GROUP BY session_id_v7, team_id
+GROUP BY
+    team_id,
+    toStartOfHour(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000))),
+    cityHash64(session_id_v7),
+    session_id_v7
 """
 )
 


### PR DESCRIPTION
## Problem

I doubt this was really affecting us, but it is usually a good idea to have the GROUP BY in the SELECT of a materialised view match the ORDER BY of the table. See https://den-crane.github.io/Everything_you_should_know_about_materialized_views_commented.pdf

## Changes

* Make these match.
* Fix a problem with the debug view and add a test for it
* Add LCP + a test
* Add a migration for all of the above

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Tests still pass, which tests the schema change. Added a test for the view
