### PR TITLE
feat(queries): Mark CHQueryErrorNoCommonType as user safe

### DIFF
--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -399,7 +399,7 @@ CLICKHOUSE_ERROR_CODE_LOOKUP: dict[int, ErrorCodeMeta] = {
     383: ErrorCodeMeta("CANNOT_APPLY_CATBOOST_MODEL"),
     384: ErrorCodeMeta("PART_IS_TEMPORARILY_LOCKED"),
     385: ErrorCodeMeta("MULTIPLE_STREAMS_REQUIRED"),
-    386: ErrorCodeMeta("NO_COMMON_TYPE"),
+    386: ErrorCodeMeta("NO_COMMON_TYPE", user_safe=True),
     387: ErrorCodeMeta("DICTIONARY_ALREADY_EXISTS"),
     388: ErrorCodeMeta("CANNOT_ASSIGN_OPTIMIZE"),
     389: ErrorCodeMeta("INSERT_WAS_DEDUPLICATED"),


### PR DESCRIPTION
## Problem

Property types don't seem to align and we can at least expose this error, it should be safe.

See https://posthog.sentry.io/issues/5543531757/?project=1899813

## Changes

Mark user safe
