### PR TITLE
feat: warn when messages were dropped

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -1,6 +1,6 @@
 import './PlayerMeta.scss'
 
-import { LemonSelect, LemonSelectOption, Link } from '@posthog/lemon-ui'
+import { LemonBanner, LemonSelect, LemonSelectOption, Link } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
@@ -56,6 +56,25 @@ function URLOrScreen({ lastUrl }: { lastUrl: string | undefined }): JSX.Element 
             </span>
         </span>
     )
+}
+
+function PlayerWarningsRow(): JSX.Element | null {
+    const { messageTooLargeWarnings } = useValues(sessionRecordingPlayerLogic)
+    return messageTooLargeWarnings.length ? (
+        <div>
+            <LemonBanner
+                type="error"
+                action={{
+                    children: 'Learn more',
+                    to: 'https://posthog.com/docs/session-replay/troubleshooting#message-too-large-warning',
+                    targetBlank: true,
+                }}
+            >
+                This session recording had {messageTooLargeWarnings.length} messages that were too large to be captured.{' '}
+                This will mean playback is not 100% accurate.{' '}
+            </LemonBanner>
+        </div>
+    ) : null
 }
 
 export function PlayerMeta(): JSX.Element {
@@ -189,6 +208,7 @@ export function PlayerMeta(): JSX.Element {
                     <div className={clsx('flex-1', isSmallPlayer ? 'min-w-[1rem]' : 'min-w-[5rem]')} />
                     {resolutionView}
                 </div>
+                <PlayerWarningsRow />
             </div>
         </DraggableToNotebook>
     )

--- a/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMeta.tsx
@@ -70,8 +70,8 @@ function PlayerWarningsRow(): JSX.Element | null {
                     targetBlank: true,
                 }}
             >
-                This session recording had {messageTooLargeWarnings.length} messages that were too large to be captured.{' '}
-                This will mean playback is not 100% accurate.{' '}
+                This session recording had recording data that was too large and could not be captured. This will mean
+                playback is not 100% accurate.{' '}
             </LemonBanner>
         </div>
     ) : null

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -1,5 +1,5 @@
 import posthogEE from '@posthog/ee/exports'
-import { EventType, eventWithTime } from '@rrweb/types'
+import { customEvent, EventType, eventWithTime } from '@rrweb/types'
 import { captureException } from '@sentry/react'
 import {
     actions,
@@ -886,8 +886,8 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
 
         customRRWebEvents: [
             (s) => [s.snapshots],
-            (snapshots): eventWithTime[] => {
-                return snapshots.filter((snapshot) => snapshot.type === EventType.Custom)
+            (snapshots): customEvent[] => {
+                return snapshots.filter((snapshot) => snapshot.type === EventType.Custom).map((x) => x as customEvent)
             },
         ],
     })),

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -883,6 +883,13 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                 })
             },
         ],
+
+        customRRWebEvents: [
+            (s) => [s.snapshots],
+            (snapshots): eventWithTime[] => {
+                return snapshots.filter((snapshot) => snapshot.type === EventType.Custom)
+            },
+        ],
     })),
     afterMount(({ cache }) => {
         resetTimingsCache(cache)

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1,4 +1,5 @@
 import { lemonToast } from '@posthog/lemon-ui'
+import { customEvent } from '@rrweb/types'
 import { captureException } from '@sentry/react'
 import {
     actions,
@@ -469,7 +470,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
 
         messageTooLargeWarnings: [
             (s) => [s.customRRWebEvents],
-            (customRRWebEvents) => {
+            (customRRWebEvents: customEvent[]) => {
                 return customRRWebEvents.filter((event) => event.data.tag === 'Message too large')
             },
         ],

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -179,7 +179,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         setIsFullScreen: (isFullScreen: boolean) => ({ isFullScreen }),
         skipPlayerForward: (rrWebPlayerTime: number, skip: number) => ({ rrWebPlayerTime, skip }),
         incrementClickCount: true,
-        // the error is emitted from code we don't control in rrweb so we can't guarantee it's really an Error
+        // the error is emitted from code we don't control in rrweb, so we can't guarantee it's really an Error
         playerErrorSeen: (error: any) => ({ error }),
         fingerprintReported: (fingerprint: string) => ({ fingerprint }),
     }),
@@ -470,7 +470,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         messageTooLargeWarnings: [
             (s) => [s.customRRWebEvents],
             (customRRWebEvents) => {
-                return customRRWebEvents.filter((event) => event.data.payload.tag === 'Message too large')
+                return customRRWebEvents.filter((event) => event.data.tag === 'Message too large')
             },
         ],
     }),

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -107,6 +107,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 'sessionPlayerMetaData',
                 'sessionPlayerMetaDataLoading',
                 'createExportJSON',
+                'customRRWebEvents',
             ],
             playerSettingsLogic,
             ['speed', 'skipInactivitySetting'],
@@ -463,6 +464,13 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                     }
                     return null
                 }
+            },
+        ],
+
+        messageTooLargeWarnings: [
+            (s) => [s.customRRWebEvents],
+            (customRRWebEvents) => {
+                return customRRWebEvents.filter((event) => event.data.payload.tag === 'Message too large')
             },
         ],
     }),


### PR DESCRIPTION
We now record custom events within a recording when we have to drop messages because they were too large for Kafka

So we can show an error to folk when they view the recordings

(in this view we report 0 dropped messages but that's only so i could get the screenshot, really we don't show it if there are 0)

<img width="952" alt="Screenshot 2024-06-28 at 13 53 12" src="https://github.com/PostHog/posthog/assets/984817/0e9a11c0-a661-4417-9397-f28224d5d081">
