### PR TITLE
fix(insights): Adjust shared insight mode to blocking

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -584,7 +584,7 @@ class InsightSerializer(InsightBasicSerializer, UserPermissionsSerializerMixin):
                     execution_mode = ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE
                 elif self.context.get("is_shared", False) and execution_mode == ExecutionMode.CALCULATE_BLOCKING_ALWAYS:
                     # On shared insights, we don't give the ability to refresh at will
-                    execution_mode = ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE
+                    execution_mode = ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
 
                 return calculate_for_query_based_insight(
                     insight,

--- a/posthog/api/test/test_insight.py
+++ b/posthog/api/test/test_insight.py
@@ -318,7 +318,7 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             calculate_for_query_based_insight.assert_called_once_with(
                 mock.ANY,
                 dashboard=mock.ANY,
-                execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
+                execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
                 user=mock.ANY,
             )
 


### PR DESCRIPTION
## Problem

Added a safeguard in #23249 but this calculates in the background and customer is wondering about outdated insight.

Until we add polling there (pending logic refactorings) we can just make it blocking.

## Changes

Make blocking as request with `refresh=true` but just basically now use recent cache.

