### PR TITLE
fix(insights): Take queued tiles into account when blocking dashboard refresh button

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -655,7 +655,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
         itemsLoading: [
             (s) => [s.dashboardLoading, s.refreshStatus],
             (dashboardLoading, refreshStatus) => {
-                return dashboardLoading || Object.values(refreshStatus).some((s) => s.loading)
+                return dashboardLoading || Object.values(refreshStatus).some((s) => s.loading || s.queued)
             },
         ],
         isRefreshingQueued: [(s) => [s.refreshStatus], (refreshStatus) => (id: string) => !!refreshStatus[id]?.queued],


### PR DESCRIPTION
## Problem

The refresh button is enabled even when (async) queries are updating the tiles.

## Changes

Adjust condition

## How did you test this code?

👀 