### PR TITLE
feat(ingestion): add kill switch for alpha heatmaps feature

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -137,6 +137,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         RUSTY_HOOK_ROLLOUT_PERCENTAGE: 0,
         RUSTY_HOOK_URL: '',
         CAPTURE_CONFIG_REDIS_HOST: null,
+        HEATMAPS_PROCESSING_ENABLED: true,
 
         STARTUP_PROFILE_DURATION_SECONDS: 300, // 5 minutes
         STARTUP_PROFILE_CPU: false,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -226,6 +226,7 @@ export interface PluginsServerConfig extends CdpConfig {
     SKIP_UPDATE_EVENT_AND_PROPERTIES_STEP: boolean
     PIPELINE_STEP_STALLED_LOG_TIMEOUT: number
     CAPTURE_CONFIG_REDIS_HOST: string | null // Redis cluster to use to coordinate with capture (overflow, routing)
+    HEATMAPS_PROCESSING_ENABLED: boolean
 
     // dump profiles to disk, covering the first N seconds of runtime
     STARTUP_PROFILE_DURATION_SECONDS: number

--- a/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
@@ -29,17 +29,19 @@ export function extractHeatmapDataStep(
     let acks: Promise<void>[] = []
 
     try {
-        const heatmapEvents = extractScrollDepthHeatmapData(event) ?? []
+        if (runner.hub.HEATMAPS_PROCESSING_ENABLED) {
+            const heatmapEvents = extractScrollDepthHeatmapData(event) ?? []
 
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        acks = heatmapEvents.map((rawEvent) => {
-            return runner.hub.kafkaProducer.produce({
-                topic: runner.hub.CLICKHOUSE_HEATMAPS_KAFKA_TOPIC,
-                key: eventUuid,
-                value: Buffer.from(JSON.stringify(rawEvent)),
-                waitForAck: true,
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            acks = heatmapEvents.map((rawEvent) => {
+                return runner.hub.kafkaProducer.produce({
+                    topic: runner.hub.CLICKHOUSE_HEATMAPS_KAFKA_TOPIC,
+                    key: eventUuid,
+                    value: Buffer.from(JSON.stringify(rawEvent)),
+                    waitForAck: true,
+                })
             })
-        })
+        }
     } catch (e) {
         acks.push(
             captureIngestionWarning(runner.hub.kafkaProducer, teamId, 'invalid_heatmap_data', {

--- a/plugin-server/tests/worker/ingestion/event-pipeline/extractHeatmapDataStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/extractHeatmapDataStep.test.ts
@@ -130,12 +130,22 @@ describe('extractHeatmapDataStep()', () => {
         event = cloneObject(preIngestionEvent)
         runner = {
             hub: {
+                HEATMAPS_PROCESSING_ENABLED: true,
                 kafkaProducer: {
                     produce: jest.fn((e) => Promise.resolve(e)),
                 },
             },
             nextStep: (...args: any[]) => args,
         }
+    })
+
+    it('drops the $heatmap_data if processing disabled', async () => {
+        runner.hub.HEATMAPS_PROCESSING_ENABLED = false
+        const response = await extractHeatmapDataStep(runner, event)
+        expect(response[0]).toEqual(event)
+        expect(response[0].properties.$heatmap_data).toBeUndefined() // Should still be removed from event
+        expect(response[1]).toHaveLength(0)
+        expect(runner.hub.kafkaProducer.produce).toBeCalledTimes(0) // No message to kafka
     })
 
     it('parses and ingests correct $heatmap_data', async () => {


### PR DESCRIPTION
## Problem

The heatmap features shows an event amplification behaviour that puts a high load on Kafka. As all experimental features, we should be able to turn it off to avoid incidents.

We can phase that option out when more granular config is implemented, by checking the team's PG config like blobby does.

## Changes

- Add a `HEATMAPS_PROCESSING_ENABLED` envvar, default to true
- When set to false, strip the heatmap data from the event, but don't write to Kafka

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Unit tests
