### PR TITLE
feat: Added heatmaps opt in check to processing

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -600,7 +600,7 @@ export interface Team {
     api_token: string
     slack_incoming_webhook: string | null
     session_recording_opt_in: boolean
-    heatmaps_opt_in: boolean
+    heatmaps_opt_in: boolean | null
     ingested_event: boolean
     person_display_name_properties: string[] | null
     test_account_filters:

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -600,6 +600,7 @@ export interface Team {
     api_token: string
     slack_incoming_webhook: string | null
     session_recording_opt_in: boolean
+    heatmaps_opt_in: boolean
     ingested_event: boolean
     person_display_name_properties: string[] | null
     test_account_filters:

--- a/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
@@ -29,8 +29,6 @@ export async function extractHeatmapDataStep(
     let acks: Promise<void>[] = []
 
     try {
-        // Team lookup is cached, but will fail if PG is unavailable and the key expired.
-        // We should retry processing this event.
         const team = await runner.hub.teamManager.fetchTeam(teamId)
 
         if (team?.heatmaps_opt_in !== false) {

--- a/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
@@ -31,8 +31,6 @@ export async function extractHeatmapDataStep(
     try {
         const team = await runner.hub.teamManager.fetchTeam(teamId)
 
-        console.log('team', team?.heatmaps_opt_in)
-
         if (team?.heatmaps_opt_in !== false) {
             const heatmapEvents = extractScrollDepthHeatmapData(event) ?? []
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
@@ -20,7 +20,7 @@ type HeatmapDataItem = {
 
 type HeatmapData = Record<string, HeatmapDataItem[]>
 
-export function extractHeatmapDataStep(
+export async function extractHeatmapDataStep(
     runner: EventPipelineRunner,
     event: PreIngestionEvent
 ): Promise<[PreIngestionEvent, Promise<void>[]]> {
@@ -29,17 +29,23 @@ export function extractHeatmapDataStep(
     let acks: Promise<void>[] = []
 
     try {
-        const heatmapEvents = extractScrollDepthHeatmapData(event) ?? []
+        // Team lookup is cached, but will fail if PG is unavailable and the key expired.
+        // We should retry processing this event.
+        const team = await runner.hub.teamManager.fetchTeam(teamId)
 
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        acks = heatmapEvents.map((rawEvent) => {
-            return runner.hub.kafkaProducer.produce({
-                topic: runner.hub.CLICKHOUSE_HEATMAPS_KAFKA_TOPIC,
-                key: eventUuid,
-                value: Buffer.from(JSON.stringify(rawEvent)),
-                waitForAck: true,
+        if (team?.heatmaps_opt_in !== false) {
+            const heatmapEvents = extractScrollDepthHeatmapData(event) ?? []
+
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            acks = heatmapEvents.map((rawEvent) => {
+                return runner.hub.kafkaProducer.produce({
+                    topic: runner.hub.CLICKHOUSE_HEATMAPS_KAFKA_TOPIC,
+                    key: eventUuid,
+                    value: Buffer.from(JSON.stringify(rawEvent)),
+                    waitForAck: true,
+                })
             })
-        })
+        }
     } catch (e) {
         acks.push(
             captureIngestionWarning(runner.hub.kafkaProducer, teamId, 'invalid_heatmap_data', {
@@ -51,7 +57,7 @@ export function extractHeatmapDataStep(
     // We don't want to ingest this data to the events table
     delete event.properties['$heatmap_data']
 
-    return Promise.resolve([event, acks])
+    return [event, acks]
 }
 
 function replacePathInUrl(url: string, newPath: string): string {

--- a/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/extractHeatmapDataStep.ts
@@ -31,6 +31,8 @@ export async function extractHeatmapDataStep(
     try {
         const team = await runner.hub.teamManager.fetchTeam(teamId)
 
+        console.log('team', team?.heatmaps_opt_in)
+
         if (team?.heatmaps_opt_in !== false) {
             const heatmapEvents = extractScrollDepthHeatmapData(event) ?? []
 

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -155,6 +155,7 @@ export async function fetchTeam(client: PostgresRouter, teamId: Team['id']): Pro
                 api_token,
                 slack_incoming_webhook,
                 session_recording_opt_in,
+                heatmaps_opt_in,
                 ingested_event,
                 person_display_name_properties,
                 test_account_filters
@@ -180,6 +181,7 @@ export async function fetchTeamByToken(client: PostgresRouter, token: string): P
                 api_token,
                 slack_incoming_webhook,
                 session_recording_opt_in,
+                heatmaps_opt_in,
                 ingested_event,
                 test_account_filters
             FROM posthog_team

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -999,6 +999,7 @@ describe('DB', () => {
                 name: 'TEST PROJECT',
                 organization_id: organizationId,
                 session_recording_opt_in: true,
+                heatmaps_opt_in: null,
                 slack_incoming_webhook: null,
                 uuid: expect.any(String),
                 person_display_name_properties: [],
@@ -1026,6 +1027,7 @@ describe('DB', () => {
                 name: 'TEST PROJECT',
                 organization_id: organizationId,
                 session_recording_opt_in: true,
+                heatmaps_opt_in: null,
                 slack_incoming_webhook: null,
                 uuid: expect.any(String),
                 test_account_filters: {} as any, // NOTE: Test insertion data gets set as an object weirdly

--- a/plugin-server/tests/worker/ingestion/event-pipeline/extractHeatmapDataStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/extractHeatmapDataStep.test.ts
@@ -216,7 +216,6 @@ describe('extractHeatmapDataStep()', () => {
     it('drops if the associated team has explicit opt out', async () => {
         runner.hub.teamManager.fetchTeam = jest.fn(() => Promise.resolve({ heatmaps_opt_in: false }))
         const response = await extractHeatmapDataStep(runner, event)
-        const response = await extractHeatmapDataStep(runner, event)
         expect(response[0]).toEqual(event)
         expect(response[0].properties.$heatmap_data).toBeUndefined()
         expect(response[1]).toHaveLength(0)

--- a/plugin-server/tests/worker/ingestion/event-pipeline/extractHeatmapDataStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/extractHeatmapDataStep.test.ts
@@ -132,6 +132,7 @@ describe('extractHeatmapDataStep()', () => {
             hub: {
                 kafkaProducer: {
                     produce: jest.fn((e) => Promise.resolve(e)),
+                    queueMessage: jest.fn((e) => Promise.resolve(e)),
                 },
                 teamManager: {
                     fetchTeam: jest.fn(() => Promise.resolve({ heatmaps_opt_in: true })),

--- a/plugin-server/tests/worker/ingestion/event-pipeline/extractHeatmapDataStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/extractHeatmapDataStep.test.ts
@@ -133,6 +133,9 @@ describe('extractHeatmapDataStep()', () => {
                 kafkaProducer: {
                     produce: jest.fn((e) => Promise.resolve(e)),
                 },
+                teamManager: {
+                    fetchTeam: jest.fn(() => Promise.resolve({ heatmaps_opt_in: true })),
+                },
             },
             nextStep: (...args: any[]) => args,
         }
@@ -207,6 +210,12 @@ describe('extractHeatmapDataStep()', () => {
               "y": 14,
             }
         `)
+    })
+
+    it.only('drops if the associated team has explicit opt out', async () => {
+        runner.hub.teamManager.fetchTeam = jest.fn(() => Promise.resolve({ heatmaps_opt_in: false }))
+        const response = await extractHeatmapDataStep(runner, event)
+        expect(response).toEqual([event, []])
     })
 
     describe('validation', () => {

--- a/plugin-server/tests/worker/ingestion/event-pipeline/extractHeatmapDataStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/extractHeatmapDataStep.test.ts
@@ -216,7 +216,11 @@ describe('extractHeatmapDataStep()', () => {
     it('drops if the associated team has explicit opt out', async () => {
         runner.hub.teamManager.fetchTeam = jest.fn(() => Promise.resolve({ heatmaps_opt_in: false }))
         const response = await extractHeatmapDataStep(runner, event)
-        expect(response).toEqual([event, []])
+        const response = await extractHeatmapDataStep(runner, event)
+        expect(response[0]).toEqual(event)
+        expect(response[0].properties.$heatmap_data).toBeUndefined()
+        expect(response[1]).toHaveLength(0)
+        expect(runner.hub.kafkaProducer.produce).toBeCalledTimes(0)
     })
 
     describe('validation', () => {

--- a/plugin-server/tests/worker/ingestion/event-pipeline/extractHeatmapDataStep.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/extractHeatmapDataStep.test.ts
@@ -212,7 +212,7 @@ describe('extractHeatmapDataStep()', () => {
         `)
     })
 
-    it.only('drops if the associated team has explicit opt out', async () => {
+    it('drops if the associated team has explicit opt out', async () => {
         runner.hub.teamManager.fetchTeam = jest.fn(() => Promise.resolve({ heatmaps_opt_in: false }))
         const response = await extractHeatmapDataStep(runner, event)
         expect(response).toEqual([event, []])

--- a/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
+++ b/plugin-server/tests/worker/ingestion/event-pipeline/runner.test.ts
@@ -91,6 +91,8 @@ describe('EventPipelineRunner', () => {
 
     beforeEach(() => {
         hub = {
+            kafkaProducer: { queueMessage: jest.fn() },
+            teamManager: { fetchTeam: jest.fn(() => {}) },
             db: {
                 kafkaProducer: { queueMessage: jest.fn() },
                 fetchPerson: jest.fn(),


### PR DESCRIPTION
## Problem

We shouldn't process heatmap data where it is explicitly off in the team setting

## Changes

* Adds it to the team manager and checks it before processing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
