### PR TITLE
fix: Quote all fields in bigquery

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -214,7 +214,7 @@ class BigQueryClient(bigquery.Client):
         for n, field in enumerate(merge_key):
             if n > 0:
                 merge_condition += " AND "
-            merge_condition += f"final.{field.name} = stage.{field.name}"
+            merge_condition += f"final.`{field.name}` = stage.`{field.name}`"
 
         update_clause = ""
         values = ""
@@ -225,9 +225,9 @@ class BigQueryClient(bigquery.Client):
                 values += ", "
                 field_names += ", "
 
-            update_clause += f"final.{field.name} = stage.{field.name}"
-            field_names += field.name
-            values += f"stage.{field.name}"
+            update_clause += f"final.`{field.name}` = stage.`{field.name}`"
+            field_names += f"`{field.name}`"
+            values += f"stage.`{field.name}`"
 
         merge_query = f"""
         MERGE `{final_table.full_table_id.replace(":", ".", 1)}` final


### PR DESCRIPTION
## Problem

To avoid issues in the future, let's escape quote all fields in this query.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
