### PR TITLE
fix(hogql): pass parameter and use logic directly

### DIFF
--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -2,7 +2,7 @@ import { Monaco } from '@monaco-editor/react'
 import { IconInfo, IconMagicWand } from '@posthog/icons'
 import { LemonInput, Link } from '@posthog/lemon-ui'
 import clsx from 'clsx'
-import { useActions, useMountedLogic, useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
@@ -52,18 +52,17 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
         monaco,
     }
     const logic = hogQLQueryEditorLogic(hogQLQueryEditorLogicProps)
-    const { queryInput, hasErrors, error, prompt, aiAvailable, promptError, promptLoading, isValidView } =
-        useValues(logic)
+    const { queryInput, prompt, aiAvailable, promptError, promptLoading } = useValues(logic)
     const { setQueryInput, saveQuery, setPrompt, draftFromPrompt, saveAsView } = useActions(logic)
 
     const codeEditorKey = `hogQLQueryEditor/${key}`
     const codeEditorLogicProps = {
         key: codeEditorKey,
         query: queryInput,
-        language: 'hogql',
+        language: 'hogQL',
         metadataFilters: props.query.filters,
     }
-    useMountedLogic(codeEditorLogic(codeEditorLogicProps))
+    const { hasErrors, error, isValidView } = useValues(codeEditorLogic(codeEditorLogicProps))
 
     // Using useRef, not useState, as we don't want to reload the component when this changes.
     const monacoDisposables = useRef([] as IDisposable[])

--- a/frontend/src/queries/nodes/HogQLQuery/hogQLQueryEditorLogic.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/hogQLQueryEditorLogic.tsx
@@ -44,7 +44,7 @@ export const hogQLQueryEditorLogic = kea<hogQLQueryEditorLogicType>([
             codeEditorLogic({
                 key: `hogQLQueryEditor/${key}`,
                 query: props.query.query,
-                language: 'hogql',
+                language: 'hogQL',
                 metadataFilters: props.query.filters,
                 metadataSource: props.metadataSource,
             }),

--- a/frontend/src/queries/nodes/HogQLQuery/hogQLQueryEditorLogic.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/hogQLQueryEditorLogic.tsx
@@ -4,7 +4,6 @@ import { actions, connect, kea, key, listeners, path, props, propsChanged, reduc
 import { combineUrl } from 'kea-router'
 import api from 'lib/api'
 import { LemonField } from 'lib/lemon-ui/LemonField'
-import { codeEditorLogic } from 'lib/monaco/codeEditorLogic'
 // Note: we can only import types and not values from monaco-editor, because otherwise some Monaco code breaks
 // auto reload in development. Specifically, on this line:
 // `export const suggestWidgetStatusbarMenu = new MenuId('suggestWidgetStatusBar')`
@@ -39,19 +38,9 @@ export const hogQLQueryEditorLogic = kea<hogQLQueryEditorLogicType>([
             actions.setQueryInput(props.query.query)
         }
     }),
-    connect((props: HogQLQueryEditorLogicProps) => ({
-        values: [
-            codeEditorLogic({
-                key: `hogQLQueryEditor/${key}`,
-                query: props.query.query,
-                language: 'hogQL',
-                metadataFilters: props.query.filters,
-                metadataSource: props.metadataSource,
-            }),
-            ['hasErrors', 'error', 'isValidView'],
-        ],
+    connect({
         actions: [dataWarehouseViewsLogic, ['createDataWarehouseSavedQuery']],
-    })),
+    }),
     actions({
         saveQuery: true,
         setQueryInput: (queryInput: string) => ({ queryInput }),


### PR DESCRIPTION
## Problem

- hogql and hogQL mix up caused props to keep changing
- the fields from codeEditorLogic were not being updated

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- use right value
- use logic directly

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
