### PR TITLE
fix(surveys): fix bad survey value destructuring

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -1204,7 +1204,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 recurring_survey_iteration_count: survey.iteration_count == undefined ? 0 : survey.iteration_count,
                 recurring_survey_iteration_interval:
                     survey.iteration_frequency_days == undefined ? 0 : survey.iteration_frequency_days,
-                shuffle_questions_enabled: !!survey.appearance.shuffleQuestions,
+                shuffle_questions_enabled: !!survey.appearance?.shuffleQuestions,
                 shuffle_question_options_enabled_count: questionsWithShuffledOptions.length,
             })
         },
@@ -1267,7 +1267,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 recurring_survey_iteration_count: survey.iteration_count == undefined ? 0 : survey.iteration_count,
                 recurring_survey_iteration_interval:
                     survey.iteration_frequency_days == undefined ? 0 : survey.iteration_frequency_days,
-                shuffle_questions_enabled: !!survey.appearance.shuffleQuestions,
+                shuffle_questions_enabled: !!survey.appearance?.shuffleQuestions,
                 shuffle_question_options_enabled_count: questionsWithShuffledOptions.length,
             })
         },

--- a/frontend/src/scenes/surveys/QuestionBranchingInput.tsx
+++ b/frontend/src/scenes/surveys/QuestionBranchingInput.tsx
@@ -46,7 +46,7 @@ export function QuestionBranchingInput({
                             setQuestionBranchingType(questionIndex, type, specificQuestionIndex)
                         }
 
-                        if (survey.appearance?.shuffleQuestions) {
+                        if (survey.appearance && survey.appearance.shuffleQuestions) {
                             LemonDialog.open({
                                 title: 'Your survey has question shuffling enabled',
                                 description: (

--- a/frontend/src/scenes/surveys/QuestionBranchingInput.tsx
+++ b/frontend/src/scenes/surveys/QuestionBranchingInput.tsx
@@ -46,7 +46,7 @@ export function QuestionBranchingInput({
                             setQuestionBranchingType(questionIndex, type, specificQuestionIndex)
                         }
 
-                        if (survey.appearance.shuffleQuestions) {
+                        if (survey.appearance?.shuffleQuestions) {
                             LemonDialog.open({
                                 title: 'Your survey has question shuffling enabled',
                                 description: (
@@ -81,7 +81,7 @@ export function QuestionBranchingInput({
                               ]
                             : []),
                         {
-                            label: survey.appearance.displayThankYouMessage ? 'Confirmation message' : 'End',
+                            label: survey.appearance?.displayThankYouMessage ? 'Confirmation message' : 'End',
                             value: SurveyQuestionBranchingType.End,
                         },
                         ...(hasResponseBasedBranching

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -67,7 +67,7 @@ export default function SurveyEdit(): JSX.Element {
         useValues(surveysLogic)
     const { featureFlags } = useValues(enabledFeaturesLogic)
     const sortedItemIds = survey.questions.map((_, idx) => idx.toString())
-    const { thankYouMessageDescriptionContentType } = survey.appearance
+    const { thankYouMessageDescriptionContentType = null } = survey.appearance ?? {}
     const surveysRecurringScheduleDisabledReason = surveysRecurringScheduleAvailable
         ? undefined
         : 'Subscribe to surveys for repeating surveys over a duration of time'

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -153,7 +153,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                 question.description
                             const editingThankYouMessage =
                                 defaultSurveyFieldValues[question.type].appearance.thankYouMessageHeader !==
-                                survey.appearance.thankYouMessageHeader
+                                survey.appearance?.thankYouMessageHeader
                             setDefaultForQuestionType(
                                 index,
                                 newType,
@@ -373,7 +373,9 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                 <LemonField name="buttonText" label="Button text">
                     <LemonInput
                         value={
-                            question.buttonText === undefined ? survey.appearance.submitButtonText : question.buttonText
+                            question.buttonText === undefined
+                                ? survey.appearance?.submitButtonText
+                                : question.buttonText
                         }
                     />
                 </LemonField>

--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -374,7 +374,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                     <LemonInput
                         value={
                             question.buttonText === undefined
-                                ? survey.appearance?.submitButtonText
+                                ? survey.appearance?.submitButtonText ?? 'Submit'
                                 : question.buttonText
                         }
                     />

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -651,7 +651,7 @@ export const surveyLogic = kea<surveyLogicType>([
                         ? state.questions[idx].description
                         : defaultSurveyFieldValues[type].questions[0].description
                     const thankYouMessageHeader = isEditingThankYouMessage
-                        ? state.appearance.thankYouMessageHeader
+                        ? state.appearance?.thankYouMessageHeader
                         : defaultSurveyFieldValues[type].appearance.thankYouMessageHeader
                     const newQuestions = [...state.questions]
                     newQuestions[idx] = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2606,7 +2606,7 @@ export interface Survey {
             }[]
         } | null
     } | null
-    appearance: SurveyAppearance
+    appearance: SurveyAppearance | null
     questions: (BasicSurveyQuestion | LinkSurveyQuestion | RatingSurveyQuestion | MultipleSurveyQuestion)[]
     created_at: string
     created_by: UserBasicType | null


### PR DESCRIPTION
## Problem

We had [a support ticket](https://posthoghelp.zendesk.com/agent/tickets/15166) where a user was using APIs to create our surveys and had a `null` SurveyAppearance field.   `posthog-js` accepted those types fine but for some reason the `posthog` types weren't synced up with it.  When I added this field a few weeks ago I didn't double-check that the types were synced.  Leads to an error like this

![image](https://github.com/PostHog/posthog/assets/4853149/0c09a36f-176f-4262-8507-f51812b92a96)

¡que feo!

## Changes

Fix the type and destructure it correctly.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

 Manually tested, works great.
