### PR TITLE
fix(web-analytics): Fix backfill null array error

### DIFF
--- a/posthog/models/raw_sessions/sql.py
+++ b/posthog/models/raw_sessions/sql.py
@@ -170,7 +170,7 @@ SELECT
     timestamp AS max_timestamp,
 
     -- urls
-    [{current_url}] AS urls,
+    if({current_url} IS NOT NULL, [{current_url}], []) AS urls,
     initializeAggregation('argMinState', {current_url_string}, timestamp) as entry_url,
     initializeAggregation('argMaxState', {current_url_string}, timestamp) as end_url,
     initializeAggregation('argMaxState', {external_click_url}, timestamp) as last_external_click_url,


### PR DESCRIPTION
## Problem

I was planning to run the backfill script today but found a couple of problems I want to fix before I do so

## Changes

* Correctly wire up the team_id arg.
* Fix a type error that can occur when trying to insert a null url

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran the backfill script locally successfully
