### PR TITLE
fix: don't drop meta events when message is too large

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -651,20 +651,24 @@ def replace_with_warning(event: dict[str, Any]) -> dict[str, Any] | None:
         if not isinstance(first_item, dict) or ("$window_id" not in first_item and "timestamp" not in first_item):
             return None
 
+        only_meta_events = [x for x in snapshot_items if isinstance(x, dict) and ("type" in x and x["type"] == 4)]
         return {
             **event,
             "properties": {
                 **properties,
                 "$snapshot_bytes": 0,
                 "$snapshot_items": [
-                    {
-                        "type": 5,
-                        "data": {
-                            "tag": "Message too large",
-                        },
-                        "$window_id": first_item.get("$window_id"),
-                        "timestamp": first_item.get("timestamp"),
-                    }
+                    *only_meta_events,
+                    *[
+                        {
+                            "type": 5,
+                            "data": {
+                                "tag": "Message too large",
+                            },
+                            "$window_id": first_item.get("$window_id"),
+                            "timestamp": first_item.get("timestamp"),
+                        }
+                    ],
                 ],
             },
         }

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -659,16 +659,14 @@ def replace_with_warning(event: dict[str, Any]) -> dict[str, Any] | None:
                 "$snapshot_bytes": 0,
                 "$snapshot_items": [
                     *only_meta_events,
-                    *[
-                        {
-                            "type": 5,
-                            "data": {
-                                "tag": "Message too large",
-                            },
-                            "$window_id": first_item.get("$window_id"),
-                            "timestamp": first_item.get("timestamp"),
-                        }
-                    ],
+                    {
+                        "type": 5,
+                        "data": {
+                            "tag": "Message too large",
+                        },
+                        "$window_id": first_item.get("$window_id"),
+                        "timestamp": first_item.get("timestamp"),
+                    },
                 ],
             },
         }

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -456,7 +456,13 @@ class TestCapture(BaseTest):
 
         response = self._send_august_2023_version_session_recording_event(
             event_data=[
-                {"type": 2, "data": {"lots": "of data"}, "$window_id": "the window id", "timestamp": 1234567890}
+                {
+                    "type": 4,
+                    "data": {"href": "https://keepme.io"},
+                    "$window_id": "the window id",
+                    "timestamp": 1234567890,
+                },
+                {"type": 2, "data": {"lots": "of data"}, "$window_id": "the window id", "timestamp": 1234567890},
             ]
         )
         assert response.status_code == 200
@@ -465,11 +471,17 @@ class TestCapture(BaseTest):
             snapshot_bytes=0,
             event_data=[
                 {
+                    "type": 4,
+                    "data": {"href": "https://keepme.io"},
+                    "$window_id": "the window id",
+                    "timestamp": 1234567890,
+                },
+                {
                     "type": 5,
                     "data": {"tag": "Message too large"},
                     "timestamp": 1234567890,
                     "$window_id": "the window id",
-                }
+                },
             ],
         )
         assert {


### PR DESCRIPTION
events are typed as `dict[str, Any]` so we can inspect the snapshot items we're about to replace and keep any meta events