### PR TITLE
feat(web-analytics): Add option behind FF to switch to V2 web analytics

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -211,7 +211,7 @@ export const FEATURE_FLAGS = {
     SETTINGS_BOUNCE_RATE_PAGE_VIEW_MODE: 'settings-bounce-rate-page-view-mode', // owner: @robbie-c
     SURVEYS_BRANCHING_LOGIC: 'surveys-branching-logic', // owner: @jurajmajerik #team-feature-success
     WEB_ANALYTICS_LIVE_USER_COUNT: 'web-analytics-live-user-count', // owner: @robbie-c
-    SETTINGS_SESSION_V2: 'web-analytics-live-user-count', // owner: @robbie-c
+    SETTINGS_SESSION_TABLE_VERSION: 'settings-session-table-version', // owner: @robbie-c
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -211,6 +211,7 @@ export const FEATURE_FLAGS = {
     SETTINGS_BOUNCE_RATE_PAGE_VIEW_MODE: 'settings-bounce-rate-page-view-mode', // owner: @robbie-c
     SURVEYS_BRANCHING_LOGIC: 'surveys-branching-logic', // owner: @jurajmajerik #team-feature-success
     WEB_ANALYTICS_LIVE_USER_COUNT: 'web-analytics-live-user-count', // owner: @robbie-c
+    SETTINGS_SESSION_V2: 'web-analytics-live-user-count', // owner: @robbie-c
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -394,6 +394,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportPoEModeUpdated: (mode: string) => ({ mode }),
         reportPersonsJoinModeUpdated: (mode: string) => ({ mode }),
         reportBounceRatePageViewModeUpdated: (mode: string) => ({ mode }),
+        reportSessionTableVersionUpdated: (version: string) => ({ version }),
         reportPropertySelectOpened: true,
         reportCreatedDashboardFromModal: true,
         reportSavedInsightToDashboard: true,
@@ -808,6 +809,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         },
         reportBounceRatePageViewModeUpdated: async ({ mode }) => {
             posthog.capture('bounce rate page view mode updated', { mode })
+        },
+        reportSessionTableVersionUpdated: async ({ version }) => {
+            posthog.capture('session table version updated', { version })
         },
         reportInsightFilterRemoved: async ({ index }) => {
             posthog.capture('local filter removed', { index })

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -1,6 +1,7 @@
 import { BounceRatePageViewModeSetting } from 'scenes/settings/project/BounceRatePageViewMode'
 import { PersonsJoinMode } from 'scenes/settings/project/PersonsJoinMode'
 import { PersonsOnEvents } from 'scenes/settings/project/PersonsOnEvents'
+import { SessionsTableVersion } from 'scenes/settings/project/SessionsTableVersion'
 
 import { Invites } from './organization/Invites'
 import { Members } from './organization/Members'
@@ -166,6 +167,12 @@ export const SettingsMap: SettingSection[] = [
                 title: 'Bounce rate page view mode',
                 component: <BounceRatePageViewModeSetting />,
                 flag: 'SETTINGS_BOUNCE_RATE_PAGE_VIEW_MODE',
+            },
+            {
+                id: 'session-table-version',
+                title: 'Sessions Table Version',
+                component: <SessionsTableVersion />,
+                flag: 'SETTINGS_SESSION_TABLE_VERSION',
             },
         ],
     },

--- a/frontend/src/scenes/settings/project/SessionsTableVersion.tsx
+++ b/frontend/src/scenes/settings/project/SessionsTableVersion.tsx
@@ -1,0 +1,75 @@
+import { useActions, useValues } from 'kea'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonRadio, LemonRadioOption } from 'lib/lemon-ui/LemonRadio'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import { useState } from 'react'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { HogQLQueryModifiers } from '~/queries/schema'
+
+type SessionTableVersion = NonNullable<HogQLQueryModifiers['sessionTableVersion']>
+
+const bounceRatePageViewModeOptions: LemonRadioOption<SessionTableVersion>[] = [
+    {
+        value: 'auto',
+        label: (
+            <>
+                <div>Auto</div>
+            </>
+        ),
+    },
+    {
+        value: 'v1',
+        label: (
+            <>
+                <div>Version 1</div>
+            </>
+        ),
+    },
+    {
+        value: 'v2',
+        label: (
+            <>
+                <div>Version 2</div>
+            </>
+        ),
+    },
+]
+
+export function SessionsTableVersion(): JSX.Element {
+    const { updateCurrentTeam } = useActions(teamLogic)
+    const { currentTeam } = useValues(teamLogic)
+    const { reportSessionTableVersionUpdated } = useActions(eventUsageLogic)
+
+    const savedSessionTableVersion =
+        currentTeam?.modifiers?.sessionTableVersion ?? currentTeam?.default_modifiers?.sessionTableVersion ?? 'auto'
+    const [sessionTableVersion, setSessionTableVersion] = useState<SessionTableVersion>(savedSessionTableVersion)
+
+    const handleChange = (version: SessionTableVersion): void => {
+        updateCurrentTeam({ modifiers: { ...currentTeam?.modifiers, sessionTableVersion: version } })
+        reportSessionTableVersionUpdated(version)
+    }
+
+    return (
+        <>
+            <p>
+                Choose which version of the session table to use. V2 is faster, but requires uuidv7 session ids. Use
+                auto unless you know what you're doing.
+            </p>
+            <LemonRadio
+                value={sessionTableVersion}
+                onChange={setSessionTableVersion}
+                options={bounceRatePageViewModeOptions}
+            />
+            <div className="mt-4">
+                <LemonButton
+                    type="primary"
+                    onClick={() => handleChange(sessionTableVersion)}
+                    disabledReason={sessionTableVersion === savedSessionTableVersion ? 'No changes to save' : undefined}
+                >
+                    Save
+                </LemonButton>
+            </div>
+        </>
+    )
+}

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -82,6 +82,7 @@ export type SettingId =
     | 'hedgehog-mode'
     | 'persons-join-mode'
     | 'bounce-rate-page-view-mode'
+    | 'session-table-version'
 
 type FeatureFlagKey = keyof typeof FEATURE_FLAGS
 

--- a/posthog/hogql/modifiers.py
+++ b/posthog/hogql/modifiers.py
@@ -52,8 +52,8 @@ def set_default_modifier_values(modifiers: HogQLQueryModifiers, team: "Team"):
     if modifiers.bounceRatePageViewMode is None:
         modifiers.bounceRatePageViewMode = BounceRatePageViewMode.COUNT_PAGEVIEWS
 
-    if modifiers.sessionTableVersion is None or modifiers.sessionTableVersion == SessionTableVersion.AUTO:
-        modifiers.sessionTableVersion = SessionTableVersion.V1
+    if modifiers.sessionTableVersion is None:
+        modifiers.sessionTableVersion = SessionTableVersion.AUTO
 
 
 def set_default_in_cohort_via(modifiers: HogQLQueryModifiers) -> HogQLQueryModifiers:

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -90,7 +90,7 @@ class TestQueryRunner(BaseTest):
                     "optimizeJoinedFilters": False,
                     "personsOnEventsMode": "disabled",
                     "bounceRatePageViewMode": "count_pageviews",
-                    "sessionTableVersion": "v1",
+                    "sessionTableVersion": "auto",
                 },
                 "limit_context": "query",
                 "query": {"kind": "TestQuery", "some_attr": "bla"},
@@ -109,7 +109,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_19dbcf2dbe2bd72239f37007f2eb6224")
+        self.assertEqual(cache_key, "cache_c4e20e19f3cad552478257f71f80b52f")
 
     def test_cache_key_runner_subclass(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -123,7 +123,7 @@ class TestQueryRunner(BaseTest):
         runner = TestSubclassQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_325bbd17cd27dd556d765984ba993da0")
+        self.assertEqual(cache_key, "cache_db0fcd4797812983cbf9df57cd9f3032")
 
     def test_cache_key_different_timezone(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -134,7 +134,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_c1d666350117520920dbc3cc9286195c")
+        self.assertEqual(cache_key, "cache_8c92e69a656cc68522e5b48a7304b97d")
 
     @mock.patch("django.db.transaction.on_commit")
     def test_cache_response(self, mock_on_commit):


### PR DESCRIPTION
Note: this will invalidated the query cache, so my plan is to merge this outside of peak times, e.g. at the start of the work day tomorrow

## Problem

We don't have a way of switching people to the v2 table. It's backfilled for team 2 and I want to start dogfooding :)

## Changes

Add a setting behind a FF to change the sessions table version

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Changed the setting locally, checked that the clickhouse that was actually run matched the expected version
