### PR TITLE
feat(web-analytics): Fix group by, remove date range

### DIFF
--- a/posthog/clickhouse/migrations/0066_sessions_group_by.py
+++ b/posthog/clickhouse/migrations/0066_sessions_group_by.py
@@ -1,0 +1,6 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.raw_sessions.sql import RAW_SESSION_TABLE_UPDATE_SQL
+
+operations = [
+    run_sql_with_exceptions(RAW_SESSION_TABLE_UPDATE_SQL),
+]

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -1745,11 +1745,12 @@
       -- replay
       false as maybe_has_session_replay
   FROM posthog_test.sharded_events
-  WHERE and(
-      bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7, -- has a session id and is valid uuidv7
-      toYYYYMMDD(timestamp) >= 0
-  )
-  GROUP BY session_id_v7, team_id
+  WHERE bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7 -- has a session id and is valid uuidv7)
+  GROUP BY
+      team_id,
+      toStartOfHour(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000))),
+      cityHash64(session_id_v7),
+      session_id_v7
   
   
   '''

--- a/posthog/models/raw_sessions/sql.py
+++ b/posthog/models/raw_sessions/sql.py
@@ -5,13 +5,6 @@ from posthog.clickhouse.table_engines import (
     ReplicationScheme,
     AggregatingMergeTree,
 )
-from posthog.settings import TEST
-
-# the date of the day after this PR will be merged, this allows us to run the backfill script on complete days
-# with a condition like toYYYYMMDD(timestamp) < X
-INGEST_FROM_DATE = "toYYYYMMDD(timestamp) >= 20240626"
-if TEST:
-    INGEST_FROM_DATE = "toYYYYMMDD(timestamp) >= 0"
 
 TABLE_BASE_NAME = "raw_sessions"
 RAW_SESSIONS_DATA_TABLE = lambda: f"sharded_{TABLE_BASE_NAME}"
@@ -329,11 +322,12 @@ SELECT
     -- replay
     false as maybe_has_session_replay
 FROM {database}.sharded_events
-WHERE and(
-    bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7, -- has a session id and is valid uuidv7
-    {INGEST_FROM_DATE}
-)
-GROUP BY session_id_v7, team_id
+WHERE bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7 -- has a session id and is valid uuidv7)
+GROUP BY
+    team_id,
+    toStartOfHour(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000))),
+    cityHash64(session_id_v7),
+    session_id_v7
 """.format(
         database=settings.CLICKHOUSE_DATABASE,
         current_url=source_url_column("$current_url"),
@@ -370,7 +364,6 @@ GROUP BY session_id_v7, team_id
         mc_cid=source_string_column("mc_cid"),
         igshid=source_string_column("igshid"),
         ttclid=source_string_column("ttclid"),
-        INGEST_FROM_DATE=INGEST_FROM_DATE,
     )
 )
 


### PR DESCRIPTION
## Problem

The sessions v2 table group by doesn't match the order by. This isn't likely to be causing problems but does go against best practice so fix it.

Additionally, we no longer need the date range condition

## Changes
* Change group by to match order by in sessions table v2
* Remove date range condition

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Relies on existing tests passing