### PR TITLE
fix: Fix bug that assumes that 2 months are 61 days apart

### DIFF
--- a/plugin-server/tests/main/ingestion-queues/session-recording/services/replay-events-ingester.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/services/replay-events-ingester.test.ts
@@ -46,7 +46,9 @@ describe('replay events ingester', () => {
     })
 
     test('does not ingest messages from a month in the future', async () => {
-        const twoMonthsFromNow = DateTime.utc().plus({ months: 2 })
+        const now = DateTime.utc()
+        const twoMonthsFromNow = now.plus({ months: 2 })
+        const expectedDaysFromNow = twoMonthsFromNow.diff(now, 'days').days
 
         await ingester.consume(makeIncomingMessage("mickey's fun house", twoMonthsFromNow.toMillis()))
 
@@ -67,7 +69,7 @@ describe('replay events ingester', () => {
         expect(details).toEqual(
             expect.objectContaining({
                 isValid: true,
-                daysFromNow: 61,
+                daysFromNow: expectedDaysFromNow,
                 timestamp: expectedTimestamp,
             })
         )


### PR DESCRIPTION
## Problem

CI fails ;)

## Changes

We have a test that assumes that 2 months in the future = 61 days in the future, which obviously becomes a problem on the first of July, i.e. today

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Fixed the test
