### PR TITLE
fix(plugin-server): use tx for create person step of merge

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -641,7 +641,8 @@ export class DB {
         isUserId: number | null,
         isIdentified: boolean,
         uuid: string,
-        distinctIds?: { distinctId: string; version?: number }[]
+        distinctIds?: { distinctId: string; version?: number }[],
+        tx?: TransactionClient
     ): Promise<InternalPerson> {
         distinctIds ||= []
 
@@ -653,7 +654,7 @@ export class DB {
         const personVersion = 0
 
         const { rows } = await this.postgres.query<RawPerson>(
-            PostgresUse.COMMON_WRITE,
+            tx ?? PostgresUse.COMMON_WRITE,
             `WITH inserted_person AS (
                     INSERT INTO posthog_person (
                         created_at, properties, properties_last_updated_at,

--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -256,7 +256,8 @@ export class PersonState {
         isUserId: number | null,
         isIdentified: boolean,
         creatorEventUuid: string,
-        distinctIds: { distinctId: string; version?: number }[]
+        distinctIds: { distinctId: string; version?: number }[],
+        tx?: TransactionClient
     ): Promise<InternalPerson> {
         if (distinctIds.length < 1) {
             throw new Error('at least 1 distinctId is required in `createPerson`')
@@ -284,7 +285,8 @@ export class PersonState {
             isUserId,
             isIdentified,
             uuid,
-            distinctIds
+            distinctIds,
+            tx
         )
     }
 
@@ -617,7 +619,8 @@ export class PersonState {
                             [
                                 { distinctId: distinctId1, version: distinctId1Version },
                                 { distinctId: distinctId2, version: distinctId2Version },
-                            ]
+                            ],
+                            tx
                         ),
                         Promise.resolve(),
                     ]

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1764,7 +1764,8 @@ describe('when handling $identify', () => {
         // completing before continuing with the first identify.
         const originalCreatePerson = hub.db.createPerson.bind(hub.db)
         const createPersonMock = jest.fn(async (...args) => {
-            const result = await originalCreatePerson(...args)
+            // We need to slice off the txn arg, or else we conflict with the `identify` below.
+            const result = await originalCreatePerson(...args.slice(0, -1))
 
             if (createPersonMock.mock.calls.length === 1) {
                 // On second invocation, make another identify call


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
`createPerson` in the merge wasn't using the outer txn.

## Changes

Use same txn as the personless Distinct ID writes.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
Existing, more to come