### PR TITLE
fix(plugin-server): fix conflict case in addPersonlessDistinctId

### DIFF
--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -284,6 +284,23 @@ describe('DB', () => {
         return selectResult.rows[0]
     }
 
+    test('addPersonlessDistinctId', async () => {
+        const team = await getFirstTeam(hub)
+        await db.addPersonlessDistinctId(team.id, 'addPersonlessDistinctId')
+
+        // This will conflict, but shouldn't throw an error
+        await db.addPersonlessDistinctId(team.id, 'addPersonlessDistinctId')
+
+        const result = await db.postgres.query(
+            PostgresUse.COMMON_WRITE,
+            'SELECT id FROM posthog_personlessdistinctid WHERE team_id = $1 AND distinct_id = $2',
+            [team.id, 'addPersonlessDistinctId'],
+            'addPersonlessDistinctId'
+        )
+
+        expect(result.rows.length).toEqual(1)
+    })
+
     describe('createPerson', () => {
         let team: Team
         const uuid = new UUIDT().toString()


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Didn't realize `ON CONFLICT ... DO NOTHING` doesn't return the `RETURNING` on a conflict... annoying.

## Changes

Fix by doing followup `SELECT`, this should be ~rare because we have an LRU cache to tell us if we can skip trying the insert.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
Added test