### PR TITLE
feat(billing): support initial billing limit for data warehouse

### DIFF
--- a/frontend/src/scenes/billing/BillingLimit.tsx
+++ b/frontend/src/scenes/billing/BillingLimit.tsx
@@ -12,12 +12,15 @@ import { billingProductLogic } from './billingProductLogic'
 export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JSX.Element | null => {
     const limitInputRef = useRef<HTMLInputElement | null>(null)
     const { billing, billingLoading } = useValues(billingLogic)
-    const { isEditingBillingLimit, customLimitUsd } = useValues(
+    const { isEditingBillingLimit, customLimitUsd, currentAndUpgradePlans } = useValues(
         billingProductLogic({ product, billingLimitInputRef: limitInputRef })
     )
     const { setIsEditingBillingLimit, setBillingLimitInput, submitBillingLimitInput } = useActions(
         billingProductLogic({ product })
     )
+
+    const initialBillingLimit = currentAndUpgradePlans?.currentPlan?.initial_billing_limit
+    const usingInitialBillingLimit = customLimitUsd === initialBillingLimit
 
     if (billing?.billing_period?.interval !== 'month' || !product.subscribed) {
         return null
@@ -32,12 +35,22 @@ export const BillingLimit = ({ product }: { product: BillingProductV2Type }): JS
                         <div className="flex items-center justify-center gap-1">
                             {customLimitUsd ? (
                                 <>
-                                    <Tooltip title="Set a billing limit to control your recurring costs. Some features may stop working if your usage exceeds your limit.">
-                                        <span>
-                                            You have a <b>${customLimitUsd}</b> billing limit set for{' '}
-                                            {product?.name?.toLowerCase()}.
-                                        </span>
-                                    </Tooltip>
+                                    {usingInitialBillingLimit ? (
+                                        <Tooltip title="Initial limits protect you from accidentally incurring large unexpected charges. Some features may stop working and data may be dropped if your usage exceeds your limit.">
+                                            <span>
+                                                This product has a default initial billing limit of{' '}
+                                                <b>${initialBillingLimit}</b>.
+                                            </span>
+                                        </Tooltip>
+                                    ) : (
+                                        <Tooltip title="Set a billing limit to control your recurring costs. Some features may stop working and data may be dropped if your usage exceeds your limit.">
+                                            <span>
+                                                You have a <b>${customLimitUsd}</b> billing limit set for{' '}
+                                                {product?.name?.toLowerCase()}.
+                                            </span>
+                                        </Tooltip>
+                                    )}
+
                                     <LemonButton
                                         onClick={() => setIsEditingBillingLimit(true)}
                                         status="danger"

--- a/frontend/src/scenes/billing/InitialBillingLimitNotice.tsx
+++ b/frontend/src/scenes/billing/InitialBillingLimitNotice.tsx
@@ -1,0 +1,41 @@
+import { useValues } from 'kea'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { urls } from 'scenes/urls'
+
+import { BillingProductV2Type, ProductKey } from '~/types'
+
+import { billingLogic } from './billingLogic'
+import { billingProductLogic } from './billingProductLogic'
+
+const InitialBillingLimitNoticeContents = ({ product }: { product: BillingProductV2Type }): JSX.Element | null => {
+    const { currentAndUpgradePlans, customLimitUsd } = useValues(billingProductLogic({ product }))
+    const initialBillingLimit = currentAndUpgradePlans?.currentPlan?.initial_billing_limit
+    const isUsingInitialBillingLimit = currentAndUpgradePlans?.currentPlan?.initial_billing_limit == customLimitUsd
+
+    return isUsingInitialBillingLimit ? (
+        <LemonBanner
+            type="info"
+            className="my-4"
+            action={{
+                type: 'primary',
+                children: 'Change limit',
+                to: urls.organizationBilling([product.type as ProductKey]),
+            }}
+            dismissKey={`initial-billing-limit-notice-${product.type}`}
+        >
+            <p className="flex-1 min-w-full sm:min-w-0">
+                Default initial billing limit of <b className="text-primary">${initialBillingLimit}</b> active.
+            </p>
+            <p className="font-normal">
+                This protects you from accidentally incurring large unexpected charges. Some features may stop working
+                and data may be dropped if your usage exceeds your limit.
+            </p>
+        </LemonBanner>
+    ) : null
+}
+
+export const InitialBillingLimitNotice = ({ product_key }: { product_key: ProductKey }): JSX.Element | null => {
+    const { billing } = useValues(billingLogic)
+    const product = billing?.products.find((p) => p.type === product_key)
+    return product ? <InitialBillingLimitNoticeContents product={product} /> : null
+}

--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -288,41 +288,14 @@ export const billingProductLogic = kea<billingProductLogicType>([
         },
         setScrollToProductKey: ({ scrollToProductKey }) => {
             if (scrollToProductKey && scrollToProductKey === props.product.type) {
-                const { currentPlan } = values.currentAndUpgradePlans
-
-                if (currentPlan?.initial_billing_limit) {
-                    actions.setProductSpecificAlert({
-                        status: 'warning',
-                        title: 'Billing Limit Automatically Applied',
-                        pathName: '/organization/billing',
-                        dismissKey: `auto-apply-billing-limit-${props.product.type}`,
-                        message: `To protect your costs and ours, we've automatically applied a $${currentPlan?.initial_billing_limit} billing limit for ${props.product.name}.`,
-                        action: {
-                            onClick: () => {
-                                actions.setIsEditingBillingLimit(true)
-                                setTimeout(() => {
-                                    if (props.billingLimitInputRef?.current) {
-                                        props.billingLimitInputRef?.current.focus()
-                                        props.billingLimitInputRef?.current.scrollIntoView({
-                                            behavior: 'smooth',
-                                            block: 'nearest',
-                                        })
-                                    }
-                                }, 0)
-                            },
-                            children: 'Update billing limit',
-                        },
-                    })
-                } else {
-                    setTimeout(() => {
-                        if (props.productRef?.current) {
-                            props.productRef?.current.scrollIntoView({
-                                behavior: 'smooth',
-                                block: 'center',
-                            })
-                        }
-                    }, 0)
-                }
+                setTimeout(() => {
+                    if (props.productRef?.current) {
+                        props.productRef?.current.scrollIntoView({
+                            behavior: 'smooth',
+                            block: 'center',
+                        })
+                    }
+                }, 0)
             }
         },
         initiateProductUpgrade: ({ plan, product, redirectPath }) => {

--- a/frontend/src/scenes/data-warehouse/DataWarehouseInitialBillingLimitNotice.tsx
+++ b/frontend/src/scenes/data-warehouse/DataWarehouseInitialBillingLimitNotice.tsx
@@ -1,0 +1,15 @@
+import { useValues } from 'kea'
+import { InitialBillingLimitNotice } from 'scenes/billing/InitialBillingLimitNotice'
+
+import { ProductKey } from '~/types'
+
+import { dataWarehouseSettingsLogic } from './settings/dataWarehouseSettingsLogic'
+
+export const DataWarehouseInitialBillingLimitNotice = (): JSX.Element | null => {
+    const { dataWarehouseSources, selfManagedTables } = useValues(dataWarehouseSettingsLogic)
+
+    const hasSources =
+        (dataWarehouseSources?.results && dataWarehouseSources?.results.length > 0) || selfManagedTables?.length > 0
+
+    return hasSources ? <InitialBillingLimitNotice product_key={ProductKey.DATA_WAREHOUSE} /> : null
+}

--- a/frontend/src/scenes/data-warehouse/external/DataWarehouseExternalScene.tsx
+++ b/frontend/src/scenes/data-warehouse/external/DataWarehouseExternalScene.tsx
@@ -11,6 +11,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { DataWarehouseBetaNotice } from '../DataWarehouseBetaNotice'
+import { DataWarehouseInitialBillingLimitNotice } from '../DataWarehouseInitialBillingLimitNotice'
 import { dataWarehouseSceneLogic } from './dataWarehouseSceneLogic'
 import { DataWarehouseTables } from './DataWarehouseTables'
 
@@ -73,6 +74,7 @@ export function DataWarehouseExternalScene(): JSX.Element {
                 }
             />
             <DataWarehouseBetaNotice />
+            <DataWarehouseInitialBillingLimitNotice />
             <BindLogic logic={insightSceneLogic} props={{}}>
                 <DataWarehouseTables />
             </BindLogic>

--- a/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
+++ b/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
@@ -7,6 +7,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { ManualLinkSourceType, SourceConfig } from '~/types'
 
 import { DataWarehouseBetaNotice } from '../DataWarehouseBetaNotice'
+import { DataWarehouseInitialBillingLimitNotice } from '../DataWarehouseInitialBillingLimitNotice'
 import PostgresSchemaForm from '../external/forms/PostgresSchemaForm'
 import SourceForm from '../external/forms/SourceForm'
 import { SyncProgressStep } from '../external/forms/SyncProgressStep'
@@ -73,6 +74,7 @@ export function NewSourceWizard(): JSX.Element {
                 }
             />
             <DataWarehouseBetaNotice />
+            <DataWarehouseInitialBillingLimitNotice />
             <>
                 <h3>{modalTitle}</h3>
                 <p>{modalCaption}</p>

--- a/frontend/src/scenes/data-warehouse/settings/DataWarehouseSettingsScene.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/DataWarehouseSettingsScene.tsx
@@ -8,6 +8,7 @@ import { urls } from 'scenes/urls'
 import { DataWarehouseSettingsTab } from '~/types'
 
 import { DataWarehouseBetaNotice } from '../DataWarehouseBetaNotice'
+import { DataWarehouseInitialBillingLimitNotice } from '../DataWarehouseInitialBillingLimitNotice'
 import { DataWarehouseManagedSourcesTable } from './DataWarehouseManagedSourcesTable'
 import { DataWarehouseSelfManagedSourcesTable } from './DataWarehouseSelfManagedSourcesTable'
 import { dataWarehouseSettingsLogic, humanFriendlyDataWarehouseSettingsTabName } from './dataWarehouseSettingsLogic'
@@ -46,6 +47,7 @@ export function DataWarehouseSettingsScene(): JSX.Element {
                 }
             />
             <DataWarehouseBetaNotice />
+            <DataWarehouseInitialBillingLimitNotice />
             <LemonTabs
                 activeKey={currentTab}
                 onChange={(tab) => router.actions.push(urls.dataWarehouseSettings(tab as DataWarehouseSettingsTab))}

--- a/frontend/src/scenes/onboarding/OnboardingBillingStep.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingBillingStep.tsx
@@ -1,5 +1,5 @@
 import { IconCheckCircle } from '@posthog/icons'
-import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+import { LemonButton } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { BillingUpgradeCTA } from 'lib/components/BillingUpgradeCTA'
 import { StarHog } from 'lib/components/hedgehogs'
@@ -33,7 +33,6 @@ export const OnboardingBillingStep = ({
     const { currentAndUpgradePlans } = useValues(billingProductLogic({ product }))
     const { reportBillingUpgradeClicked } = useActions(eventUsageLogic)
     const plan = currentAndUpgradePlans?.upgradePlan
-    const currentPlan = currentAndUpgradePlans?.currentPlan
 
     const [showPlanComp, setShowPlanComp] = useState(false)
 
@@ -92,15 +91,6 @@ export const OnboardingBillingStep = ({
                             >
                                 {showPlanComp ? 'Hide' : 'Show'} plans
                             </LemonButton>
-                            {currentPlan?.initial_billing_limit && (
-                                <div className="mt-2">
-                                    <LemonBanner type="info">
-                                        To protect your costs and ours, this product has an initial billing limit of $
-                                        {currentPlan.initial_billing_limit}. You can change or remove this limit on the
-                                        Billing page.
-                                    </LemonBanner>
-                                </div>
-                            )}
                         </div>
                     )}
 


### PR DESCRIPTION
## Problem

We are setting an initial billing limit of $500 for data warehouse users just in case they decide to sync a very large database without realizing it. This limit shows up on the billing page, so users should know why it's there, and also be alerted that it exists when they set up their first sync.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

1. Tells users on billing page if it's an initial limit and why it's there
![Arc 2024-07-01 15 19 17](https://github.com/PostHog/posthog/assets/18598166/60d18e85-496a-4b77-9c92-f474ca314296)

2. Alerts users about initial limit after setting up their first sync. 
    - Shows persistently until cleared with the X 
    - only if the current billing limit matches the initial limit
    - only if they have more than 1 source set up (no sense in telling them if they haven't set something up)
![Arc 2024-07-01 19 18 36](https://github.com/PostHog/posthog/assets/18598166/cb50208a-e3b9-43b3-8941-47bb52cffc49)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Shouldn't impact self-hosted as they can't have billing limits set

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
