### PR TITLE
feat: include org id when creating new tickets

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -405,6 +405,10 @@ export const supportLogic = kea<supportLogicType>([
                             value: posthog.get_distinct_id(),
                         },
                         {
+                            id: 27031528411291,
+                            value: userLogic?.values?.user?.organization?.id ?? '',
+                        },
+                        {
                             id: 26073267652251,
                             value: values.hasAvailableFeature(AvailableFeature.PRIORITY_SUPPORT)
                                 ? 'priority_support'


### PR DESCRIPTION
## Problem

This will allow us to find all tickets from a specific organization.

field in zendesk https://posthoghelp.zendesk.com/admin/objects-rules/tickets/ticket-fields/27031528411291

related ticket https://github.com/PostHog/posthog/issues/23365