### PR TITLE
refactor(insights): make save as use query based insight

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -164,7 +164,8 @@ export const FEATURE_FLAGS = {
     PRODUCT_SPECIFIC_ONBOARDING: 'product-specific-onboarding', // owner: @raquelmsmith
     REDIRECT_SIGNUPS_TO_INSTANCE: 'redirect-signups-to-instance', // owner: @raquelmsmith
     APPS_AND_EXPORTS_UI: 'apps-and-exports-ui', // owner: @benjackwhite
-    HOGQL_DASHBOARD_CARDS: 'hogql-dashboard-cards', // owner: @thmsobrmlr
+    QUERY_BASED_DASHBOARD_CARDS: 'query-based-dashboard-cards', // owner: @thmsobrmlr
+    QUERY_BASED_INSIGHTS_SAVING: 'query-based-insights-saving', // owner: @thmsobrmlr
     HOGQL_DASHBOARD_ASYNC: 'hogql-dashboard-async', // owner: @webjunkie
     WEBHOOKS_DENYLIST: 'webhooks-denylist', // owner: #team-pipeline
     PERSONS_HOGQL_QUERY: 'persons-hogql-query', // owner: @mariusandra

--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -105,7 +105,7 @@ export const insightDataLogic = kea<insightDataLogicType>([
     selectors({
         useQueryDashboardCards: [
             (s) => [s.featureFlags],
-            (featureFlags) => !!featureFlags[FEATURE_FLAGS.HOGQL_DASHBOARD_CARDS],
+            (featureFlags) => !!featureFlags[FEATURE_FLAGS.QUERY_BASED_DASHBOARD_CARDS],
         ],
 
         query: [

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -339,6 +339,7 @@ describe('insightLogic', () => {
                     .toMatchValues({
                         legacyInsight: insight,
                         queryBasedInsight: {
+                            short_id: Insight42,
                             query: {
                                 kind: 'InsightVizNode',
                                 source: {

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -752,7 +752,6 @@ describe('insightLogic', () => {
                     `api/projects/${MOCK_TEAM_ID}/insights/`,
                     {
                         derived_name: 'DataTableNode query',
-                        filters: {},
                         query: {
                             kind: 'DataTableNode',
                         },

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -309,7 +309,6 @@ describe('insightLogic', () => {
                             short_id: Insight42,
                             query: { kind: NodeKind.TimeToSeeDataSessionsQuery },
                         }),
-                        legacyFilters: {},
                     })
                     .delay(1)
                     // do not override the insight if querying with different filters
@@ -339,10 +338,24 @@ describe('insightLogic', () => {
                 await expectLogic(logic)
                     .toMatchValues({
                         legacyInsight: insight,
-                        legacyFilters: partial({
-                            events: [partial({ id: 3 })],
-                            properties: [partial({ value: 'a' })],
-                        }),
+                        queryBasedInsight: {
+                            query: {
+                                kind: 'InsightVizNode',
+                                source: {
+                                    kind: 'TrendsQuery',
+                                    properties: {
+                                        type: 'AND',
+                                        values: [
+                                            {
+                                                type: 'AND',
+                                                values: [partial({ value: 'a' })],
+                                            },
+                                        ],
+                                    },
+                                    series: [partial({ event: 3 })],
+                                },
+                            },
+                        },
                     })
                     .delay(1)
                     .toNotHaveDispatchedActions(['setFilters', 'updateInsight'])
@@ -539,7 +552,6 @@ describe('insightLogic', () => {
             .toDispatchActions(savedInsightsLogic, ['loadInsights'])
             .toMatchValues({
                 savedInsight: partial({ filters: partial({ insight: InsightType.FUNNELS }) }),
-                legacyFilters: partial({ insight: InsightType.FUNNELS }),
                 legacyInsight: partial({ id: 12, short_id: Insight12, name: 'New Insight (copy)' }),
                 queryBasedInsight: partial({ id: 12, short_id: Insight12, name: 'New Insight (copy)' }),
                 insightChanged: false,

--- a/frontend/src/scenes/insights/insightLogic.ts
+++ b/frontend/src/scenes/insights/insightLogic.ts
@@ -362,10 +362,19 @@ export const insightLogic = kea<insightLogicType>([
     listeners(({ actions, values }) => ({
         saveInsight: async ({ redirectToViewMode }) => {
             const insightNumericId =
-                values.legacyInsight.id ||
-                (values.legacyInsight.short_id ? await getInsightId(values.legacyInsight.short_id) : undefined)
-            const { name, description, favorited, filters, query, deleted, dashboards, tags } = values.legacyInsight
+                values.queryBasedInsight.id ||
+                (values.queryBasedInsight.short_id ? await getInsightId(values.queryBasedInsight.short_id) : undefined)
+            const { name, description, favorited, deleted, dashboards, tags } = values.legacyInsight
+
             let savedInsight: InsightModel
+            let filters
+            let query
+
+            if (!values.queryBasedInsightSaving && isInsightVizNode(values.queryBasedInsight.query)) {
+                filters = queryNodeToFilter(values.queryBasedInsight.query.source)
+            } else {
+                query = values.queryBasedInsight.query
+            }
 
             try {
                 // We don't want to send ALL the insight properties back to the API, so only grabbing fields that might have changed
@@ -375,7 +384,7 @@ export const insightLogic = kea<insightLogicType>([
                     description,
                     favorited,
                     filters,
-                    query: query ? query : null,
+                    query,
                     deleted,
                     saved: true,
                     dashboards,


### PR DESCRIPTION
## Problem

The "Save as" functionality was using `legacyFilters` to determine the insight to be copied.

## Changes

- Derives `filters` from the query based insight.
- Opts out of the conversion with a feature flag (~regular saves and updates will be added to the flag eventually~ regular saves and updates also support the feature flag).

## How did you test this code?

Created a new insight, edited filters and use the "save as" functionality