### PR TITLE
test(insights): mute updateInsight error in tests

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -9,6 +9,7 @@ import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
@@ -563,7 +564,9 @@ describe('insightLogic', () => {
                 cachedInsight: insight,
             })
             theEmptyFiltersLogic.mount()
+            silenceKeaLoadersErrors()
         })
+        afterEach(resumeKeaLoadersErrors)
 
         it('does not call the api on update when empty filters and no query', async () => {
             await expectLogic(theEmptyFiltersLogic, () => {


### PR DESCRIPTION
## Problem

An error is polluting test run logs, especially on CI:

```
  console.error
    {
      error: Error: Will not override empty filters in updateInsight.
          at updateInsight (/Users/thomas/Posthog/posthog/frontend/src/scenes/insights/insightLogic.ts:121:1)
          at newListeners.<computed> (/Users/thomas/Posthog/posthog/node_modules/.pnpm/kea-loaders@3.0.0_kea@3.1.5/node_modules/kea-loaders/src/index.ts:144:30)
          at /Users/thomas/Posthog/posthog/node_modules/.pnpm/kea@3.1.5_react@18.2.0/node_modules/kea/lib/index.cjs.js:1245:24
          at Object.dispatch (/Users/thomas/Posthog/posthog/node_modules/.pnpm/kea@3.1.5_react@18.2.0/node_modules/kea/lib/index.cjs.js:1980:19)
          at Object.logic.actions.<computed> [as updateInsight] (/Users/thomas/Posthog/posthog/node_modules/.pnpm/kea@3.1.5_react@18.2.0/node_modules/kea/lib/index.cjs.js:1367:28)
          at /Users/thomas/Posthog/posthog/frontend/src/scenes/insights/insightLogic.test.ts:570:1
          at syncInit (/Users/thomas/Posthog/posthog/node_modules/.pnpm/kea-test-utils@0.2.4_kea@3.1.5/node_modules/kea-test-utils/src/expect.ts:26:24)
          at expectLogic (/Users/thomas/Posthog/posthog/node_modules/.pnpm/kea-test-utils@0.2.4_kea@3.1.5/node_modules/kea-test-utils/src/expect.ts:34:23)
          at Object.<anonymous> (/Users/thomas/Posthog/posthog/frontend/src/scenes/insights/insightLogic.test.ts:569:1)
          at Promise.then.completed (/Users/thomas/Posthog/posthog/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:298:28)
          at new Promise (<anonymous>)
          at callAsyncCircusFn (/Users/thomas/Posthog/posthog/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/utils.js:231:10)
          at _callCircusTest (/Users/thomas/Posthog/posthog/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:316:40)
          at async _runTest (/Users/thomas/Posthog/posthog/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:252:3)
          at async _runTestsForDescribeBlock (/Users/thomas/Posthog/posthog/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:126:9)
          at async _runTestsForDescribeBlock (/Users/thomas/Posthog/posthog/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)
          at async _runTestsForDescribeBlock (/Users/thomas/Posthog/posthog/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:121:9)
          at async run (/Users/thomas/Posthog/posthog/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/run.js:71:3)
          at async runAndTransformResultsToJestFormat (/Users/thomas/Posthog/posthog/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
          at async jestAdapter (/Users/thomas/Posthog/posthog/node_modules/.pnpm/jest-circus@29.7.0/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
          at async runTestInternal (/Users/thomas/Posthog/posthog/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:367:16)
          at async runTest (/Users/thomas/Posthog/posthog/node_modules/.pnpm/jest-runner@29.7.0/node_modules/jest-runner/build/runTest.js:444:34),
      reducerKey: 'legacyInsight',
      actionKey: 'updateInsight'
    }
```
## Changes

Ignores it

## How did you test this code?

Running tests before and after