### PR TITLE
fix(multi project flags): remove flag id from URL when switching projects

### DIFF
--- a/frontend/src/layout/navigation/ProjectSwitcher.tsx
+++ b/frontend/src/layout/navigation/ProjectSwitcher.tsx
@@ -5,7 +5,7 @@ import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonSnack } from 'lib/lemon-ui/LemonSnack/LemonSnack'
-import { removeProjectIdIfPresent } from 'lib/utils/router-utils'
+import { removeFlagIdIfPresent, removeProjectIdIfPresent } from 'lib/utils/router-utils'
 import { useMemo } from 'react'
 import { organizationLogic } from 'scenes/organizationLogic'
 import { isAuthenticatedTeam, teamLogic } from 'scenes/teamLogic'
@@ -91,7 +91,8 @@ function OtherProjectButton({ team }: { team: TeamBasicType; onClickInside?: () 
         // project switch lands on something like insight/abc that won't exist.
         // On the other hand, if we remove the ID, it could be that someone opens a page, realizes they're in the wrong project
         // and after switching is on a different page than before.
-        const route = removeProjectIdIfPresent(location.pathname)
+        let route = removeProjectIdIfPresent(location.pathname)
+        route = removeFlagIdIfPresent(route)
         return urls.project(team.id, route)
     }, [location.pathname])
 

--- a/frontend/src/lib/utils/router-utils.ts
+++ b/frontend/src/lib/utils/router-utils.ts
@@ -46,6 +46,13 @@ export function removeProjectIdIfPresent(path: string): string {
     return path
 }
 
+export function removeFlagIdIfPresent(path: string): string {
+    if (path.match(/^\/feature_flags\/\d+/)) {
+        return path.replace(/(feature_flags).*$/, '$1/')
+    }
+    return path
+}
+
 export function addProjectIdIfMissing(path: string, teamId?: TeamType['id']): string {
     return isPathWithoutProjectId(removeProjectIdIfPresent(path))
         ? removeProjectIdIfPresent(path)


### PR DESCRIPTION
## Problem
Reported in https://posthog.slack.com/archives/C011L071P8U/p1719829017752699

When switching projects while on a feature flag URL, the flag ID stays in the URL, causing a 404 error.

## Changes
Remove flag ID from the URL when switching projects.

## How did you test this code?
👀 