### PR TITLE
chore: add backfill_personless_distinct_ids command

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -655,26 +655,97 @@
 # ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_with_hogql_aggregation.1
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
+  /* user_id:0 request:_snapshot_ */
+  SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS value,
+         count(*) as count
+  FROM events e
+  WHERE team_id = 2
+    AND event IN ['$pageleave', '$pageview']
+    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC')
+  GROUP BY value
+  ORDER BY count DESC, value DESC
+  LIMIT 26
+  OFFSET 0
   '''
 # ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_with_hogql_aggregation.2
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
+  /* user_id:0 request:_snapshot_ */
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time,
+         prop
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner ,
+            prop
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time ,
+                               prop
+        FROM
+          (SELECT *,
+                  if(latest_0 <= latest_1
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
+                  if(isNotNull(latest_1)
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                  prop
+           FROM
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([['test'], ['control'], ['']], prop), prop, ['Other']) as prop
+              FROM
+                (SELECT *,
+                        if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
+                 FROM
+                   (SELECT e.timestamp as timestamp,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$account_id'), ''), 'null'), '^"|"$', '') as aggregation_target,
+                           pdi.person_id as person_id,
+                           if(event = '$pageview', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = '$pageleave', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS prop_basic,
+                           prop_basic as prop,
+                           argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['$pageleave', '$pageview']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event IN ['$pageleave', '$pageview']
+                      AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                      AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC')
+                      AND (step_0 = 1
+                           OR step_1 = 1) )))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps,
+              prop
+     HAVING steps = max_steps)
+  GROUP BY prop
   '''
 # ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_with_hogql_aggregation.3

--- a/posthog/management/commands/backfill_personless_distinct_ids.py
+++ b/posthog/management/commands/backfill_personless_distinct_ids.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from collections.abc import Sequence
+
+import structlog
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connection, transaction
+
+from posthog.clickhouse.client.execute import sync_execute as ch_execute
+from posthog.models.team.team import Team
+
+
+logger = structlog.get_logger(__name__)
+
+
+def batch_insert_personless_distinct_ids(data, batch_size=1000):
+    query = """
+    INSERT INTO posthog_personlessdistinctid (team_id, distinct_id, is_merged, created_at)
+    VALUES %s
+    ON CONFLICT (team_id, distinct_id) DO NOTHING
+    """
+
+    def chunks(lst, n):
+        for i in range(0, len(lst), n):
+            yield lst[i : i + n]
+
+    for batch in chunks(data, batch_size):
+        with transaction.atomic():
+            with connection.cursor() as cursor:
+                values = ",".join(
+                    cursor.mogrify("(%s, %s, false, now())", (team_id, distinct_id)) for team_id, distinct_id in batch
+                )
+                full_query = query % values
+
+                start = time.time()
+                cursor.execute(full_query)
+                logger.info("Inserted %r records in %r seconds", len(batch), time.time() - start)
+
+
+@dataclass
+class BackfillTeam:
+    team_id: int
+
+    def execute(self, dry_run: bool = False) -> None:
+        logger.info("Starting %r...", self)
+
+        query = """
+        SELECT team_id, distinct_id
+        FROM events
+        WHERE timestamp >= '2024-04-30'
+              AND timestamp < '2024-07-02'
+              AND person_mode = 'propertyless'
+              AND team_id = %(team_id)s
+        GROUP BY team_id, distinct_id
+        """
+
+        parameters = {
+            "team_id": self.team_id,
+        }
+
+        settings = {"max_execution_time": 300}
+
+        if dry_run:
+            [(count,)] = ch_execute(f"SELECT count() FROM ({query})", parameters, settings=settings)
+            logger.info("%r would have inserted %r records.", self, count)
+        else:
+            distinct_ids = ch_execute(query, parameters, settings=settings)
+            batch_insert_personless_distinct_ids(distinct_ids)
+            logger.info("Completed %r!", self)
+
+
+@dataclass
+class BackfillShard:
+    shard_count: int
+    shard_num: int
+
+    def execute(self, dry_run: bool = False) -> None:
+        logger.info("Starting %r...", self)
+
+        query = """
+        SELECT team_id, distinct_id
+        FROM events
+        WHERE timestamp >= '2024-04-30'
+              AND timestamp < '2024-07-02'
+              AND person_mode = 'propertyless'
+              AND team_id %% %(shard_count)s = %(shard_num)s
+        GROUP BY team_id, distinct_id
+        """
+
+        parameters = {
+            "shard_count": self.shard_count,
+            "shard_num": self.shard_num,
+        }
+
+        settings = {"max_execution_time": 300}
+
+        if dry_run:
+            [(count,)] = ch_execute(f"SELECT count() FROM ({query})", parameters, settings=settings)
+            logger.info("%r would have inserted %r records.", self, count)
+        else:
+            distinct_ids = ch_execute(query, parameters, settings=settings)
+            batch_insert_personless_distinct_ids(distinct_ids)
+            logger.info("Completed %r!", self)
+
+
+class Command(BaseCommand):
+    help = "Backfill posthog_personlessdistinctid records."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--team-id",
+            required=False,
+            type=int,
+            dest="team_id_list",
+            action="append",
+            help="team(s) to backfill",
+        )
+        parser.add_argument(
+            "--shard-count",
+            required=False,
+            type=int,
+            dest="shard_count",
+            action="store",
+            help="number of shards",
+        )
+        parser.add_argument(
+            "--shard-num",
+            required=False,
+            type=int,
+            dest="shard_num",
+            action="store",
+            help="shard number to backfill",
+        )
+        parser.add_argument(
+            "--live-run", action="store_true", help="actually execute INSERT queries (default is dry-run)"
+        )
+
+    def handle(
+        self,
+        *,
+        live_run: bool,
+        team_id_list: Sequence[int] | None,
+        shard_count: int | None,
+        shard_num: int | None,
+        **options,
+    ):
+        logger.setLevel(logging.INFO)
+
+        if shard_count is not None and shard_num is not None:
+            logger.info("Starting backfill for shard %s/%s...", shard_num, shard_count)
+            BackfillShard(shard_count, shard_num).execute(dry_run=not live_run)
+        elif team_id_list is not None:
+            team_ids = set(team_id_list)
+            existing_team_ids = set(Team.objects.filter(id__in=team_ids).values_list("id", flat=True))
+            if existing_team_ids != team_ids:
+                raise CommandError(f"Teams with ids {team_ids - existing_team_ids!r} do not exist")
+
+            logger.info("Starting backfill for %s teams...", len(team_ids))
+            for team_id in team_ids:
+                BackfillTeam(team_id).execute(dry_run=not live_run)
+        else:
+            raise CommandError("Either --team-id or --shard-count and --shard-num must be specified")


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We need to backfill the `posthog_personlessdistinctid` PG table from CH.

## Changes

Add management command.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes.

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
Test locally, and ran incrementally for team 2 (looks good)