### PR TITLE
feat(plugin-server): only write personless overrides when necessary

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -529,12 +529,12 @@ export class PersonState {
                 'mergeDistinctIds-OneExists',
                 async (tx) => {
                     // See comment above about `distinctIdVersion`
-                    const _insertedDistinctId = await this.db.addPersonlessDistinctIdForMerge(
+                    const insertedDistinctId = await this.db.addPersonlessDistinctIdForMerge(
                         this.teamId,
                         distinctIdToAdd,
                         tx
                     )
-                    const distinctIdVersion = 1 // TODO: Once `posthog_personlessdistinctid` is backfilled: insertedDistinctId ? 0 : 1
+                    const distinctIdVersion = insertedDistinctId ? 0 : 1
 
                     await this.db.addDistinctId(existingPerson, distinctIdToAdd, distinctIdVersion, tx)
                     return [existingPerson, Promise.resolve()]
@@ -584,7 +584,7 @@ export class PersonState {
                     // whether we can optimize away an override by doing a swap, or whether we
                     // need to actually write an override. (But mostly we're being verbose for
                     // documentation purposes)
-                    let distinctId2Version = 1 // TODO: Once `posthog_personlessdistinctid` is backfilled, this should be = 0
+                    let distinctId2Version = 0
                     if (insertedDistinctId1 && insertedDistinctId2) {
                         // We were the first to insert both (neither was used for Personless), so we
                         // can use either as the primary Person UUID and create no overrides.

--- a/plugin-server/tests/worker/ingestion/person-state.test.ts
+++ b/plugin-server/tests/worker/ingestion/person-state.test.ts
@@ -278,19 +278,9 @@ describe('PersonState.update()', () => {
                 ])
             )
 
-            // old2 does have an override, because we are temporarily writing out unnecessary
-            // overrides while we backfill `posthog_personlessdistinctid`
+            // old2 has no override, because it wasn't in posthog_personlessdistinctid
             const chOverridesOld = await fetchOverridesForDistinctId('old2')
-            expect(chOverridesOld.length).toEqual(1)
-            expect(chOverridesOld).toEqual(
-                expect.arrayContaining([
-                    expect.objectContaining({
-                        distinct_id: 'old2',
-                        person_id: oldUserUuid,
-                        version: 1,
-                    }),
-                ])
-            )
+            expect(chOverridesOld.length).toEqual(0)
         })
 
         it('force_upgrade works', async () => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
*After we've backfilled it*, we want to take advantage of `posthog_personlessdistinctid` to write out overrides only when they are necessary.

## Changes

Optimize override writes.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Existing