### PR TITLE
feat: add a launch compound for posthog with local billing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
     "configurations": [
         {
             "name": "Frontend",
-            "command": "npm start",
+            "command": "pnpm start",
             "request": "launch",
             "type": "node-terminal",
             "cwd": "${workspaceFolder}",
@@ -231,6 +231,22 @@
             "stopAll": true,
             "presentation": {
                 "order": 1,
+                "group": "compound"
+            }
+        },
+        {
+            "name": "PostHog (local billing)",
+            "configurations": [
+                "Backend (with local billing)",
+                "Celery Threaded Pool",
+                "Celery Redbeat Scheduler",
+                "Frontend",
+                "Plugin Server",
+                "Temporal Worker"
+            ],
+            "stopAll": true,
+            "presentation": {
+                "order": 2,
                 "group": "compound"
             }
         }


### PR DESCRIPTION
## Problem

I got tired of starting all the services individually, which I would need to do because I need to run PostHog with local billing. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds a launch compound that uses local billing! Just select this one in the debug toolbar:

<img width="456" alt="Code 2024-07-02 10 04 34" src="https://github.com/PostHog/posthog/assets/18598166/e93a9351-7f90-4aa2-b274-dbeb3a813a46">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

N/A

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

It works.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
