### PR TITLE
fix: allow entering a custom value while property values load in insi…

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -128,7 +128,7 @@ export function PropertyValue({
             loading={options[propertyKey]?.status === 'loading'}
             value={formattedValues}
             mode={isMultiSelect ? 'multiple' : 'single'}
-            allowCustomValues={options[propertyKey] ? options[propertyKey].allowCustomValues : true}
+            allowCustomValues={options[propertyKey]?.allowCustomValues ?? true}
             onChange={(nextVal) => (isMultiSelect ? setValue(nextVal) : setValue(nextVal[0]))}
             onInputChange={onSearchTextChange}
             placeholder={placeholder}


### PR DESCRIPTION
## Problem

Fixes a regression that removed the ability to enter a value to PropertyFilter, forcing users to wait until property values are loaded, even if they know an exact value. It affects large customers when property values take some time to load. There was an additional loading state that I didn't find initially.

## Does this work well for both Cloud and self-hosted?

Yes