### PR TITLE
fix: writing to known bucket

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -689,8 +689,8 @@ def sample_replay_data_to_object_storage(event: dict[str, Any], random_number: f
     try:
         sample_rate = settings.REPLAY_MESSAGE_TOO_LARGE_SAMPLE_RATE
         if 0 < random_number < sample_rate <= 0.01:
-            object_key = f"session_id/{event.get('properties', {}).get('$session_id', 'unknown')}.json"
-            object_storage.write(object_key, json.dumps(event), bucket=settings.REPLAY_MESSAGE_TOO_LARGE_SAMPLE_BUCKET)
+            object_key = f"{settings.REPLAY_MESSAGES_TOO_LARGE_SAMPLES_PREFIX}/session_id/{event.get('properties', {}).get('$session_id', 'unknown')}.json"
+            object_storage.write(object_key, json.dumps(event))
     except Exception as ex:
         with sentry_sdk.push_scope() as scope:
             scope.set_tag("capture-pathway", "replay")

--- a/posthog/settings/session_replay.py
+++ b/posthog/settings/session_replay.py
@@ -28,6 +28,6 @@ REPLAY_EMBEDDINGS_CLUSTERING_DBSCAN_MIN_SAMPLES = get_from_env(
 )
 
 REPLAY_MESSAGE_TOO_LARGE_SAMPLE_RATE = get_from_env("REPLAY_MESSAGE_TOO_LARGE_SAMPLE_RATE", 0, type_cast=float)
-REPLAY_MESSAGE_TOO_LARGE_SAMPLE_BUCKET = get_from_env(
-    "REPLAY_MESSAGE_TOO_LARGE_SAMPLE_BUCKET", "posthog-cloud-prod-us-east-1-k8s-replay-samples"
+REPLAY_MESSAGES_TOO_LARGE_SAMPLES_PREFIX = get_from_env(
+    "REPLAY_MESSAGES_TOO_LARGE_SAMPLES_PREFIX", "replay_messages_too_large_samples"
 )


### PR DESCRIPTION
I'm still getting failures writing to the new bucket

see https://posthog.sentry.io/issues/5563154715/?project=1899813&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+sdk.name%3Asentry.python.django+capture-pathway%3Areplay&referrer=issue-stream&statsPeriod=24h&stream_index=1

this writes to a prefix in the existing bucket instead (these are only temporary samples so I don't want to spend too much more time on this 🫠)