### PR TITLE
fix: snapshot size fangling headroom reduction

### DIFF
--- a/posthog/session_recordings/session_recording_helpers.py
+++ b/posthog/session_recordings/session_recording_helpers.py
@@ -129,7 +129,7 @@ def preprocess_replay_events(
     if len(events) == 0:
         return
 
-    size_with_headroom = max_size_bytes * 0.95  # Leave 5% headroom
+    size_with_headroom = max_size_bytes * 0.90  # Leave 10% headroom
 
     distinct_id = events[0]["properties"]["distinct_id"]
     session_id = events[0]["properties"]["$session_id"]

--- a/posthog/session_recordings/test/test_session_recording_helpers.py
+++ b/posthog/session_recordings/test/test_session_recording_helpers.py
@@ -461,7 +461,7 @@ def test_new_ingestion_groups_using_snapshot_bytes_if_possible(raw_snapshot_even
         159,
     ]
 
-    space_with_headroom = math.ceil((106 + 1072 + 50) * 1.05)
+    space_with_headroom = math.ceil((106 + 1072 + 50) * 1.10)
     assert list(mock_capture_flow(events, max_size_bytes=space_with_headroom)[1]) == [
         {
             "event": "$snapshot_items",


### PR DESCRIPTION
in capture we try to split up recording data so that it fits into the kafka message size limit

we allow ourselves 0.95 of the SESSION_RECORDING_KAFKA_MAX_REQUEST_SIZE_BYTES setting

that is currently 10,485,760

so we allow 10,485,760*0.95 = 9,961,472

the first two rejected messages we sampled were 9.8 and 9.4MB as reported in S3 console, 10.3 and 9.9MB as reported on disk locally

one also could definitely have been split further

let's reduce the headroom to 0.9 or 9,437,184 and see if the splitting kicks in more effectively

