### PR TITLE
fix(insights): use UInt8 instead of Boolean for conditions in funnels

### DIFF
--- a/posthog/api/test/__snapshots__/test_properties_timeline.ambr
+++ b/posthog/api/test/__snapshots__/test_properties_timeline.ambr
@@ -446,7 +446,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', '')) AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -482,7 +482,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array("mat_pp_foo", "mat_pp_bar") AS relevant_property_values,
+                          array("mat_pp_bar", "mat_pp_foo") AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -522,7 +522,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', '')) AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -558,7 +558,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array("mat_pp_foo", "mat_pp_bar") AS relevant_property_values,
+                          array("mat_pp_bar", "mat_pp_foo") AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (

--- a/posthog/hogql_queries/insights/funnels/base.py
+++ b/posthog/hogql_queries/insights/funnels/base.py
@@ -580,7 +580,7 @@ class FunnelBase(ABC):
             raise NotImplementedError("DataWarehouseNode is not supported in funnels")
         elif entity.event is None:
             # all events
-            event_expr = ast.Constant(value=True)
+            event_expr = ast.Constant(value=1)
         else:
             # event
             event_expr = parse_expr("event = {event}", {"event": ast.Constant(value=entity.event)})

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel.py
@@ -3742,9 +3742,9 @@ FROM
         (SELECT
             e.timestamp AS timestamp,
             person_id AS aggregation_target,
-            if(true, 1, 0) AS step_0,
+            if(1, 1, 0) AS step_0,
             if(equals(step_0, 1), timestamp, NULL) AS latest_0,
-            if(true, 1, 0) AS step_1,
+            if(1, 1, 0) AS step_1,
             if(equals(step_1, 1), timestamp, NULL) AS latest_1
         FROM
             events AS e
@@ -3802,9 +3802,9 @@ FROM
                 (SELECT
                     e.timestamp AS timestamp,
                     person_id AS aggregation_target,
-                    if(true, 1, 0) AS step_0,
+                    if(1, 1, 0) AS step_0,
                     if(equals(step_0, 1), timestamp, NULL) AS latest_0,
-                    if(true, 1, 0) AS step_1,
+                    if(1, 1, 0) AS step_1,
                     if(equals(step_1, 1), timestamp, NULL) AS latest_1
                 FROM
                     events AS e
@@ -3873,9 +3873,9 @@ FROM
                     (SELECT
                         e.timestamp AS timestamp,
                         person_id AS aggregation_target,
-                        if(true, 1, 0) AS step_0,
+                        if(1, 1, 0) AS step_0,
                         if(equals(step_0, 1), timestamp, NULL) AS latest_0,
-                        if(true, 1, 0) AS step_1,
+                        if(1, 1, 0) AS step_1,
                         if(equals(step_1, 1), timestamp, NULL) AS latest_1
                     FROM
                         events AS e


### PR DESCRIPTION
## Problem

Fixed #23436 

## Changes

Replace Boolean with UInt8 in funnel insights making the new Clickhouse analyzer stop complaining.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unit tests and manual testing on the user's query.

## Additional context

Sentry: https://posthog.sentry.io/issues/5562321439/