### PR TITLE
fix: Correctly log records tracked

### DIFF
--- a/posthog/api/test/__snapshots__/test_properties_timeline.ambr
+++ b/posthog/api/test/__snapshots__/test_properties_timeline.ambr
@@ -446,7 +446,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', '')) AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -482,7 +482,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array("mat_pp_foo", "mat_pp_bar") AS relevant_property_values,
+                          array("mat_pp_bar", "mat_pp_foo") AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -522,7 +522,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', '')) AS relevant_property_values,
+                          array(replaceRegexpAll(JSONExtractRaw(person_properties, 'bar'), '^"|"$', ''), replaceRegexpAll(JSONExtractRaw(person_properties, 'foo'), '^"|"$', '')) AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (
@@ -558,7 +558,7 @@
                                                              ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS end_event_number
      FROM
        (SELECT timestamp, person_properties AS properties,
-                          array("mat_pp_foo", "mat_pp_bar") AS relevant_property_values,
+                          array("mat_pp_bar", "mat_pp_foo") AS relevant_property_values,
                           lagInFrame(relevant_property_values) OVER (
                                                                      ORDER BY timestamp ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS previous_relevant_property_values,
                                                                     row_number() OVER (

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -434,8 +434,8 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                 ):
                     logger.debug(
                         "Loading %s records of size %s bytes",
-                        local_results_file.records_since_last_reset,
-                        local_results_file.bytes_since_last_reset,
+                        records_since_last_flush,
+                        bytes_since_last_flush,
                     )
                     table = bigquery_stage_table if requires_merge else bigquery_table
 

--- a/posthog/temporal/tests/batch_exports/test_temporary_file.py
+++ b/posthog/temporal/tests/batch_exports/test_temporary_file.py
@@ -11,6 +11,7 @@ from posthog.temporal.batch_exports.temporary_file import (
     BatchExportTemporaryFile,
     CSVBatchExportWriter,
     JSONLBatchExportWriter,
+    LastInsertedAt,
     ParquetBatchExportWriter,
     json_dumps_bytes,
 )
@@ -222,7 +223,7 @@ TEST_RECORD_BATCHES = [
 async def test_jsonl_writer_writes_record_batches(record_batch):
     """Test record batches are written as valid JSONL."""
     in_memory_file_obj = io.BytesIO()
-    inserted_ats_seen = []
+    inserted_ats_seen: list[LastInsertedAt] = []
 
     async def store_in_memory_on_flush(
         batch_export_file, records_since_last_flush, bytes_since_last_flush, flush_counter, last_inserted_at, is_last

--- a/posthog/temporal/tests/batch_exports/test_temporary_file.py
+++ b/posthog/temporal/tests/batch_exports/test_temporary_file.py
@@ -227,6 +227,7 @@ async def test_jsonl_writer_writes_record_batches(record_batch):
     async def store_in_memory_on_flush(
         batch_export_file, records_since_last_flush, bytes_since_last_flush, flush_counter, last_inserted_at, is_last
     ):
+        assert writer.records_since_last_flush == record_batch.num_rows
         in_memory_file_obj.write(batch_export_file.read())
         inserted_ats_seen.append(last_inserted_at)
 
@@ -235,6 +236,8 @@ async def test_jsonl_writer_writes_record_batches(record_batch):
     record_batch = record_batch.sort_by("_inserted_at")
     async with writer.open_temporary_file():
         await writer.write_record_batch(record_batch)
+
+    assert writer.records_total == record_batch.num_rows
 
     lines = in_memory_file_obj.readlines()
     for index, line in enumerate(lines):


### PR DESCRIPTION
## Problem

We are not correctly logging number of records written. However, the tracking is working fine, we are just using the old API to get records written instead of the available argument in `flush_callable`.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Use the argument.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added an assertion to confirm we are tracking number of rows.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
