### PR TITLE
fix: Ensure django is connected in batch export activities

### DIFF
--- a/posthog/models/test/test_user_scene_personalisation.py
+++ b/posthog/models/test/test_user_scene_personalisation.py
@@ -1,7 +1,7 @@
 import pytest
 from django import db
 
-from posthog.models import User, UserScenePersonalisation, Dashboard
+from posthog.models import Dashboard, User, UserScenePersonalisation
 from posthog.test.base import BaseTest
 
 


### PR DESCRIPTION
## Problem

Occasionally, we see temporal workers retry a lot while attempting to use a closed django connection. Sometimes, this can lead to a large delay to start a batch export as the ORM query to create a batch export run takes forever to get a connection to the database that works.

I don't think we are necessarily doing anything wrong, but rather suspect this could be a lack of proper transaction support in async django in combination with a pgbouncer running in transactional mode. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

~Call `ensure_connection` using `sync_to_async`.~
Wrap sync ORM calls in `database_sync_to_async`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Unfortunately, I can't really reproduce the issue.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
