### PR TITLE
fix: flat sample key wil be easier to manage

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -689,7 +689,7 @@ def sample_replay_data_to_object_storage(event: dict[str, Any], random_number: f
     try:
         sample_rate = settings.REPLAY_MESSAGE_TOO_LARGE_SAMPLE_RATE
         if 0 < random_number < sample_rate <= 0.01:
-            object_key = f"token/{token}/session_id/{event.get('properties', {}).get('$session_id', 'unknown')}.json"
+            object_key = f"token-{token}-session_id-{event.get('properties', {}).get('$session_id', 'unknown')}.json"
             object_storage.write(object_key, json.dumps(event), bucket=settings.REPLAY_MESSAGE_TOO_LARGE_SAMPLE_BUCKET)
     except Exception as ex:
         with sentry_sdk.push_scope() as scope:

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -2231,7 +2231,7 @@ class TestCapture(BaseTest):
                 ],
             )
             sample_replay_data_to_object_storage(event, random_number, "the-team-token")
-            contents = object_storage.read("token/the-team-token/session_id/abcdefgh.json", bucket=TEST_SAMPLES_BUCKET)
+            contents = object_storage.read("token-the-team-token-session_id-abcdefgh.json", bucket=TEST_SAMPLES_BUCKET)
             assert contents == json.dumps(event)
 
     @parameterized.expand(
@@ -2265,4 +2265,4 @@ class TestCapture(BaseTest):
             sample_replay_data_to_object_storage(event, random_number, "another-team-token")
 
             with pytest.raises(ObjectStorageError):
-                object_storage.read("token/another-team-token/session_id/abcdefgh.json", bucket=TEST_SAMPLES_BUCKET)
+                object_storage.read("token-another-team-token-session_id-abcdefgh.json", bucket=TEST_SAMPLES_BUCKET)


### PR DESCRIPTION
i copied the structure we store session replay in since i thought it would be familiar

but...

it just means i can't see what has arrived when and i have to delete the samples so i can see what is new

no bueno

let's turn them into a flat list