### PR TITLE
fix: allow transparent canvases

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
@@ -163,7 +163,8 @@ export const CanvasReplayerPlugin = (events: eventWithTime[]): ReplayPlugin => {
                         img.src = url
                     }
                 },
-                'image/jpeg',
+                // ensures transparency is possible
+                'image/webp',
                 0.5
             )
         }


### PR DESCRIPTION
## Problem

Closes https://posthoghelp.zendesk.com/agent/tickets/15379 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/17724)

## Changes

- Use an image format that supports transparency
- Add a comment because I've changed this one too many times (probably just twice)