### PR TITLE
chore: disable clickmaps by default

### DIFF
--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -116,7 +116,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
             },
         ],
         clickmapsEnabled: [
-            true,
+            false,
             { persist: true },
             {
                 toggleClickmapsEnabled: (state, { enabled }) => (enabled === undefined ? !state : enabled),


### PR DESCRIPTION
## Problem

Prompted by customer confusion in https://posthoghelp.zendesk.com/agent/tickets/15356 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/18012)

## Changes

- You don't actually see that heatmaps & clickmaps both exist when expanded
- We should limit things to enable heatmaps only by default

Should we only ever allow one at a time - use a LemonSegmentedButton for either clickmaps or heatmaps?