### PR TITLE
chore: convert label to json to handle empties

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -124,7 +124,7 @@ jobs:
                         "release": "ingestion",
                         "commit": ${{ toJson(github.event.head_commit) }},
                         "repository": ${{ toJson(github.repository) }},
-                        "labels": ${{ steps.labels.outputs.labels }}
+                        "labels": ${{ toJson(steps.labels.outputs.labels) }}
                       }
 
             - name: Check for changes that affect batch exports temporal worker


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

When labels are empty it breaks the json used by the cloud deployment.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
