### PR TITLE
chore(admin): speed up page load for plugin & pluginconfig admin

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -655,26 +655,97 @@
 # ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_with_hogql_aggregation.1
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
+  /* user_id:0 request:_snapshot_ */
+  SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS value,
+         count(*) as count
+  FROM events e
+  WHERE team_id = 2
+    AND event IN ['$pageleave', '$pageview']
+    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC')
+  GROUP BY value
+  ORDER BY count DESC, value DESC
+  LIMIT 26
+  OFFSET 0
   '''
 # ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_with_hogql_aggregation.2
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
+  /* user_id:0 request:_snapshot_ */
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time,
+         prop
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner ,
+            prop
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time ,
+                               prop
+        FROM
+          (SELECT *,
+                  if(latest_0 <= latest_1
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
+                  if(isNotNull(latest_1)
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                  prop
+           FROM
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([['test'], ['control'], ['']], prop), prop, ['Other']) as prop
+              FROM
+                (SELECT *,
+                        if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
+                 FROM
+                   (SELECT e.timestamp as timestamp,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$account_id'), ''), 'null'), '^"|"$', '') as aggregation_target,
+                           pdi.person_id as person_id,
+                           if(event = '$pageview', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = '$pageleave', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS prop_basic,
+                           prop_basic as prop,
+                           argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
+                    FROM events e
+                    INNER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['$pageleave', '$pageview']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 2
+                      AND event IN ['$pageleave', '$pageview']
+                      AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                      AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC')
+                      AND (step_0 = 1
+                           OR step_1 = 1) )))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps,
+              prop
+     HAVING steps = max_steps)
+  GROUP BY prop
   '''
 # ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_with_hogql_aggregation.3

--- a/posthog/admin/admins/plugin_admin.py
+++ b/posthog/admin/admins/plugin_admin.py
@@ -1,4 +1,7 @@
 from django.contrib import admin
+from django.utils.html import format_html
+
+from posthog.models import Plugin
 
 
 class PluginAdmin(admin.ModelAdmin):
@@ -8,3 +11,53 @@ class PluginAdmin(admin.ModelAdmin):
     autocomplete_fields = ("organization",)
     search_fields = ("name",)
     ordering = ("-created_at",)
+
+    readonly_fields = ["id", "organization", "created_at", "updated_at", "is_stateless"]
+
+    fieldsets = [
+        (
+            None,
+            {
+                "fields": ["id", "organization", "created_at", "updated_at"],
+            },
+        ),
+        (
+            "Configuration",
+            {
+                "fields": ["is_global", "is_preinstalled", "is_stateless", "log_level"],
+            },
+        ),
+        (
+            "Metadata",
+            {
+                "fields": ["name", "description", "plugin_type", "url", "icon", "config_schema", "capabilities"],
+            },
+        ),
+        (
+            "Git update checks",
+            {
+                "classes": ["collapse"],
+                "fields": ["tag", "latest_tag", "latest_tag_checked_at"],
+            },
+        ),
+        (
+            "Deprecated metadata",
+            {
+                "classes": ["collapse"],
+                "fields": ["error", "from_json", "from_web", "source", "metrics", "public_jobs"],
+            },
+        ),
+        (
+            "Access control",
+            {
+                "fields": ["has_private_access"],
+            },
+        ),
+    ]
+
+    def organization_link(self, plugin: Plugin):
+        return format_html(
+            '<a href="/admin/posthog/organization/{}/change/">{}</a>',
+            plugin.organization.pk,
+            plugin.organization.name,
+        )

--- a/posthog/admin/admins/plugin_config_admin.py
+++ b/posthog/admin/admins/plugin_config_admin.py
@@ -7,7 +7,7 @@ from posthog.models import PluginConfig
 
 class PluginConfigAdmin(admin.ModelAdmin):
     list_select_related = ("plugin", "team")
-    list_display = ("id", "plugin_name", "team_name", "enabled")
+    list_display = ("id", "plugin_name", "team_name", "enabled", "deleted")
     list_display_links = ("id", "plugin_name")
     list_filter = (
         ("enabled", admin.BooleanFieldListFilter),
@@ -16,10 +16,45 @@ class PluginConfigAdmin(admin.ModelAdmin):
         ("plugin", admin.RelatedOnlyFieldListFilter),
         "plugin__is_global",
     )
-    list_select_related = ("team", "plugin")
     search_fields = ("team__name", "team__organization__name", "plugin__name")
     ordering = ("-created_at",)
+
     inlines = [PluginAttachmentInline]
+    readonly_fields = [
+        "id",
+        "plugin",
+        "team",
+        "created_at",
+        "updated_at",
+    ]
+
+    fieldsets = [
+        (
+            None,
+            {
+                "fields": ["id", "plugin", "team", "created_at", "updated_at"],
+            },
+        ),
+        (
+            "Common config",
+            {
+                "fields": ["enabled", "deleted", "order", "config"],
+            },
+        ),
+        (
+            "CDP",
+            {
+                "fields": ["filters"],
+            },
+        ),
+        (
+            "Frontend apps",
+            {
+                "classes": ["collapse"],
+                "fields": ["name", "description", "web_token"],
+            },
+        ),
+    ]
 
     def plugin_name(self, config: PluginConfig):
         return format_html(f"{config.plugin.name} ({config.plugin_id})")


### PR DESCRIPTION
## Problem

These pages take a dozen seconds to load on prod-us, I assume that the issue is the org and team dropdowns. We don't want to change these fields, so

## Changes

- mark the team, plugin, org foreign keys as read-only
- manually specify all fields in fieldsets for better readability + identify deprecated fields

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

works on my machine
