### PR TITLE
refactor(insights): query based `renameInsight`

### DIFF
--- a/frontend/src/layout/navigation-3000/sidebars/insights.ts
+++ b/frontend/src/layout/navigation-3000/sidebars/insights.ts
@@ -2,7 +2,7 @@ import { afterMount, connect, kea, listeners, path, reducers, selectors } from '
 import { subscriptions } from 'kea-subscriptions'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { insightsApi } from 'scenes/insights/utils/api'
 import { INSIGHTS_PER_PAGE, savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -101,10 +101,14 @@ export const insightsSidebarLogic = kea<insightsSidebarLogicType>([
                                         },
                                         {
                                             onClick: () => {
-                                                void deleteWithUndo({
-                                                    object: legacyInsight,
+                                                void deleteInsightWithUndo({
+                                                    object: insight,
                                                     endpoint: `projects/${currentTeamId}/insights`,
                                                     callback: actions.loadInsights,
+                                                    options: {
+                                                        writeAsQuery: values.queryBasedInsightSaving,
+                                                        readAsQuery: true,
+                                                    },
                                                 })
                                             },
                                             status: 'danger',

--- a/frontend/src/layout/navigation-3000/sidebars/insights.ts
+++ b/frontend/src/layout/navigation-3000/sidebars/insights.ts
@@ -1,6 +1,7 @@
 import { afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { subscriptions } from 'kea-subscriptions'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { insightsApi } from 'scenes/insights/utils/api'
 import { INSIGHTS_PER_PAGE, savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
@@ -28,6 +29,8 @@ export const insightsSidebarLogic = kea<insightsSidebarLogicType>([
             ['activeScene', 'sceneParams'],
             navigation3000Logic,
             ['searchTerm'],
+            featureFlagLogic,
+            ['featureFlags'],
         ],
         actions: [savedInsightsLogic, ['loadInsights', 'setSavedInsightsFilters', 'duplicateInsight']],
     })),

--- a/frontend/src/layout/navigation-3000/sidebars/insights.ts
+++ b/frontend/src/layout/navigation-3000/sidebars/insights.ts
@@ -112,7 +112,8 @@ export const insightsSidebarLogic = kea<insightsSidebarLogicType>([
                             ],
                             onRename: async (newName) => {
                                 const updatedItem = await insightsApi.update(
-                                    { ...insight, name: newName },
+                                    insight.id,
+                                    { name: newName },
                                     { writeAsQuery: values.queryBasedInsightSaving, readAsQuery: false }
                                 )
                                 insightsModel.actions.renameInsightSuccess(updatedItem)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -899,8 +899,8 @@ const api = {
         async create(data: any): Promise<InsightModel> {
             return await new ApiRequest().insights().create({ data })
         },
-        async update(data: any): Promise<InsightModel> {
-            return await new ApiRequest().insights().update({ data })
+        async update(id: number, data: any): Promise<InsightModel> {
+            return await new ApiRequest().insight(id).update({ data })
         },
     },
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -899,6 +899,9 @@ const api = {
         async create(data: any): Promise<InsightModel> {
             return await new ApiRequest().insights().create({ data })
         },
+        async update(data: any): Promise<InsightModel> {
+            return await new ApiRequest().insights().update({ data })
+        },
     },
 
     featureFlags: {

--- a/frontend/src/lib/utils/deleteWithUndo.tsx
+++ b/frontend/src/lib/utils/deleteWithUndo.tsx
@@ -1,5 +1,8 @@
 import { lemonToast } from '@posthog/lemon-ui'
 import api from 'lib/api'
+import { getInsightModel, InsightsApiOptions } from 'scenes/insights/utils/api'
+
+import { QueryBasedInsightModel } from '~/types'
 
 export async function deleteWithUndo<T extends Record<string, any>>({
     undo = false,
@@ -28,6 +31,42 @@ export async function deleteWithUndo<T extends Record<string, any>>({
                 : {
                       label: 'Undo',
                       action: () => deleteWithUndo({ undo: true, ...props }),
+                  },
+        }
+    )
+}
+
+/** Temporary duplicate of the function above that handles saving and restoring insights with filters
+ * when given a query based insight */
+export async function deleteInsightWithUndo({
+    undo = false,
+    options,
+    ...props
+}: {
+    undo?: boolean
+    endpoint: string
+    object: QueryBasedInsightModel
+    idField?: keyof QueryBasedInsightModel
+    callback?: (undo: boolean, object: QueryBasedInsightModel) => void
+    options: InsightsApiOptions<true>
+}): Promise<void> {
+    await api.update(`api/${props.endpoint}/${props.object[props.idField || 'id']}`, {
+        ...getInsightModel(props.object, options.writeAsQuery),
+        deleted: !undo,
+    })
+    props.callback?.(undo, props.object)
+    lemonToast[undo ? 'success' : 'info'](
+        <>
+            <b>{props.object.name || <i>{props.object.derived_name || 'Unnamed'}</i>}</b> has been{' '}
+            {undo ? 'restored' : 'deleted'}
+        </>,
+        {
+            toastId: `delete-item-${props.object.id}-${undo}`,
+            button: undo
+                ? undefined
+                : {
+                      label: 'Undo',
+                      action: () => deleteInsightWithUndo({ undo: true, options, ...props }),
                   },
         }
     )

--- a/frontend/src/models/insightsModel.tsx
+++ b/frontend/src/models/insightsModel.tsx
@@ -1,6 +1,5 @@
 import { LemonDialog, LemonInput } from '@posthog/lemon-ui'
 import { actions, connect, kea, listeners, path, selectors } from 'kea'
-import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
@@ -46,9 +45,9 @@ export const insightsModel = kea<insightsModelType>([
                     insightName: (name) => (!name ? 'You must enter a name' : undefined),
                 },
                 onSubmit: async ({ insightName }) => {
-                    const updatedItem = await api.update(
-                        `api/projects/${teamLogic.values.currentTeamId}/insights/${item.id}`,
-                        { name: insightName }
+                    const updatedItem = await insightsApi.update(
+                        { ...item, name: insightName },
+                        { writeAsQuery: values.queryBasedInsightSaving, readAsQuery: false }
                     )
                     lemonToast.success(
                         <>

--- a/frontend/src/models/insightsModel.tsx
+++ b/frontend/src/models/insightsModel.tsx
@@ -46,7 +46,8 @@ export const insightsModel = kea<insightsModelType>([
                 },
                 onSubmit: async ({ insightName }) => {
                     const updatedItem = await insightsApi.update(
-                        { ...item, name: insightName },
+                        item.id,
+                        { name: insightName },
                         { writeAsQuery: values.queryBasedInsightSaving, readAsQuery: false }
                     )
                     lemonToast.success(

--- a/frontend/src/models/insightsModel.tsx
+++ b/frontend/src/models/insightsModel.tsx
@@ -16,7 +16,7 @@ export const insightsModel = kea<insightsModelType>([
     path(['models', 'insightsModel']),
     connect({ values: [featureFlagLogic, ['featureFlags']], logic: [teamLogic] }),
     actions(() => ({
-        renameInsight: (item: InsightModel) => ({ item }),
+        renameInsight: (item: QueryBasedInsightModel) => ({ item }),
         renameInsightSuccess: (item: InsightModel) => ({ item }),
         //TODO this duplicates the insight but not the dashboard tile (e.g. if duplicated from dashboard you lose tile color
         duplicateInsight: (item: QueryBasedInsightModel) => ({ item }),

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -148,7 +148,7 @@ export function DashboardItems(): JSX.Element {
                                     updateColor={(color) => updateTileColor(tile.id, color)}
                                     ribbonColor={tile.color}
                                     refresh={() => refreshAllDashboardItems({ tiles: [tile], action: 'refresh' })}
-                                    rename={() => renameInsight(legacyInsight)}
+                                    rename={() => renameInsight(insight)}
                                     duplicate={() => duplicateInsight(insight)}
                                     showDetailsControls={placement != DashboardPlacement.Export}
                                     placement={placement}

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -14,7 +14,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
-import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { useState } from 'react'
 import { NewDashboardModal } from 'scenes/dashboard/NewDashboardModal'
 import { insightCommandLogic } from 'scenes/insights/insightCommandLogic'
@@ -41,7 +41,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
         insightProps,
         canEditInsight,
         queryBasedInsight: insight,
-        legacyInsight,
+        queryBasedInsightSaving,
         insightChanged,
         insightSaving,
         hasDashboardItemId,
@@ -216,12 +216,16 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                             <LemonButton
                                                 status="danger"
                                                 onClick={() =>
-                                                    void deleteWithUndo({
-                                                        object: legacyInsight,
+                                                    void deleteInsightWithUndo({
+                                                        object: insight,
                                                         endpoint: `projects/${currentTeamId}/insights`,
                                                         callback: () => {
                                                             loadInsights()
                                                             push(urls.savedInsights())
+                                                        },
+                                                        options: {
+                                                            writeAsQuery: queryBasedInsightSaving,
+                                                            readAsQuery: true,
                                                         },
                                                     })
                                                 }

--- a/frontend/src/scenes/insights/utils/api.ts
+++ b/frontend/src/scenes/insights/utils/api.ts
@@ -4,40 +4,53 @@ import { getInsightFilterOrQueryForPersistance } from '~/queries/nodes/InsightQu
 import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
 import { InsightModel, QueryBasedInsightModel } from '~/types'
 
+type InsightsApiOptions<Flag> = {
+    writeAsQuery: boolean
+    readAsQuery: Flag
+}
+
 type ReturnedInsightModelByFlag<Flag extends boolean> = Flag extends true ? QueryBasedInsightModel : InsightModel
 
+function getInsightModel<Flag extends boolean>(
+    insight: QueryBasedInsightModel,
+    asQuery: Flag
+): ReturnedInsightModelByFlag<Flag> {
+    return {
+        ...insight,
+        ...getInsightFilterOrQueryForPersistance(insight, asQuery),
+    } as ReturnedInsightModelByFlag<Flag>
+}
+
 export const insightsApi = {
+    async _perform<Flag extends boolean>(
+        method: 'create' | 'update',
+        insight: QueryBasedInsightModel,
+        options: InsightsApiOptions<Flag>
+    ): Promise<ReturnedInsightModelByFlag<Flag>> {
+        const { writeAsQuery, readAsQuery } = options
+
+        const data = getInsightModel(insight, writeAsQuery)
+        const legacyInsight = await api.insights[method](data)
+
+        const response = readAsQuery ? getQueryBasedInsightModel(legacyInsight) : legacyInsight
+        return response as ReturnedInsightModelByFlag<Flag>
+    },
     async create<Flag extends boolean>(
         insight: QueryBasedInsightModel,
-        options: {
-            writeAsQuery: boolean
-            readAsQuery: Flag
-        }
+        options: InsightsApiOptions<Flag>
     ): Promise<ReturnedInsightModelByFlag<Flag>> {
-        const data = {
-            ...insight,
-            ...getInsightFilterOrQueryForPersistance(insight, options.writeAsQuery),
-        }
-        const legacyInsight: InsightModel = await api.insights.create(data)
-        return (
-            options.readAsQuery ? getQueryBasedInsightModel(legacyInsight) : legacyInsight
-        ) as ReturnedInsightModelByFlag<Flag>
+        return this._perform('create', insight, options)
+    },
+    async update<Flag extends boolean>(
+        insight: QueryBasedInsightModel,
+        options: InsightsApiOptions<Flag>
+    ): Promise<ReturnedInsightModelByFlag<Flag>> {
+        return this._perform('update', insight, options)
     },
     async duplicate<Flag extends boolean>(
         insight: QueryBasedInsightModel,
-        options: {
-            writeAsQuery: boolean
-            readAsQuery: Flag
-        }
+        options: InsightsApiOptions<Flag>
     ): Promise<ReturnedInsightModelByFlag<Flag>> {
-        const data = {
-            ...insight,
-            ...getInsightFilterOrQueryForPersistance(insight, options.writeAsQuery),
-            name: insight.name ? `${insight.name} (copy)` : insight.name,
-        }
-        const legacyInsight: InsightModel = await api.insights.create(data)
-        return (
-            options.readAsQuery ? getQueryBasedInsightModel(legacyInsight) : legacyInsight
-        ) as ReturnedInsightModelByFlag<Flag>
+        return this.create({ ...insight, name: insight.name ? `${insight.name} (copy)` : insight.name }, options)
     },
 }

--- a/frontend/src/scenes/insights/utils/api.ts
+++ b/frontend/src/scenes/insights/utils/api.ts
@@ -4,14 +4,14 @@ import { getInsightFilterOrQueryForPersistance } from '~/queries/nodes/InsightQu
 import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
 import { InsightModel, QueryBasedInsightModel } from '~/types'
 
-type InsightsApiOptions<Flag> = {
+export type InsightsApiOptions<Flag> = {
     writeAsQuery: boolean
     readAsQuery: Flag
 }
 
 type ReturnedInsightModelByFlag<Flag extends boolean> = Flag extends true ? QueryBasedInsightModel : InsightModel
 
-function getInsightModel<Flag extends boolean>(
+export function getInsightModel<Flag extends boolean>(
     insight: QueryBasedInsightModel,
     asQuery: Flag
 ): ReturnedInsightModelByFlag<Flag> {

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -391,7 +391,7 @@ function SavedInsightsGrid(): JSX.Element {
                         <InsightCard
                             key={insight.short_id}
                             insight={{ ...legacyInsight }}
-                            rename={() => renameInsight(legacyInsight)}
+                            rename={() => renameInsight(insight)}
                             duplicate={() => duplicateInsight(insight)}
                             deleteWithUndo={async () =>
                                 await deleteWithUndo({

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -34,7 +34,7 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { PaginationControl, usePagination } from 'lib/lemon-ui/PaginationControl'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
-import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { SavedInsightsEmptyState } from 'scenes/insights/EmptyStates'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -377,7 +377,7 @@ export function NewInsightButton({ dataAttr }: NewInsightButtonProps): JSX.Eleme
 
 function SavedInsightsGrid(): JSX.Element {
     const { loadInsights, renameInsight, duplicateInsight } = useActions(savedInsightsLogic)
-    const { insights, insightsLoading, pagination } = useValues(savedInsightsLogic)
+    const { insights, insightsLoading, pagination, queryBasedInsightSaving } = useValues(savedInsightsLogic)
     const { currentTeamId } = useValues(teamLogic)
 
     const paginationState = usePagination(insights?.results || [], pagination)
@@ -394,10 +394,14 @@ function SavedInsightsGrid(): JSX.Element {
                             rename={() => renameInsight(insight)}
                             duplicate={() => duplicateInsight(insight)}
                             deleteWithUndo={async () =>
-                                await deleteWithUndo({
-                                    object: legacyInsight,
+                                await deleteInsightWithUndo({
+                                    object: insight,
                                     endpoint: `projects/${currentTeamId}/insights`,
                                     callback: loadInsights,
+                                    options: {
+                                        writeAsQuery: queryBasedInsightSaving,
+                                        readAsQuery: true,
+                                    },
                                 })
                             }
                             placement="SavedInsightGrid"
@@ -419,7 +423,8 @@ function SavedInsightsGrid(): JSX.Element {
 export function SavedInsights(): JSX.Element {
     const { loadInsights, updateFavoritedInsight, renameInsight, duplicateInsight, setSavedInsightsFilters } =
         useActions(savedInsightsLogic)
-    const { insights, count, insightsLoading, filters, sorting, pagination } = useValues(savedInsightsLogic)
+    const { insights, count, insightsLoading, filters, sorting, pagination, queryBasedInsightSaving } =
+        useValues(savedInsightsLogic)
     const { hasTagging } = useValues(organizationLogic)
     const { currentTeamId } = useValues(teamLogic)
     const summarizeInsight = useSummarizeInsight()
@@ -534,10 +539,14 @@ export function SavedInsights(): JSX.Element {
                                 <LemonButton
                                     status="danger"
                                     onClick={() =>
-                                        void deleteWithUndo({
-                                            object: legacyInsight,
+                                        void deleteInsightWithUndo({
+                                            object: insight,
                                             endpoint: `projects/${currentTeamId}/insights`,
                                             callback: loadInsights,
+                                            options: {
+                                                writeAsQuery: queryBasedInsightSaving,
+                                                readAsQuery: true,
+                                            },
                                         })
                                     }
                                     data-attr={`insight-item-${insight.short_id}-dropdown-remove`}

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -517,7 +517,7 @@ export function SavedInsights(): JSX.Element {
                                     Edit
                                 </LemonButton>
                                 <LemonButton
-                                    onClick={() => renameInsight(legacyInsight)}
+                                    onClick={() => renameInsight(insight)}
                                     data-attr={`insight-item-${insight.short_id}-dropdown-rename`}
                                     fullWidth
                                 >

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -76,7 +76,7 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
             debounce: boolean = true
         ) => ({ filters, merge, debounce }),
         updateFavoritedInsight: (insight: QueryBasedInsightModel, favorited: boolean) => ({ insight, favorited }),
-        renameInsight: (insight: InsightModel) => ({ insight }),
+        renameInsight: (insight: QueryBasedInsightModel) => ({ insight }),
         duplicateInsight: (insight: QueryBasedInsightModel, redirectToInsight = false) => ({
             insight,
             redirectToInsight,


### PR DESCRIPTION
## Problem

We want to have only query based insights frontend side, but we still need to send them to the backend with `filters`. The bigger goal of the coming PRs is to adapt all instances where we send insights to the backend for persistance with a wrapper function, so that the frontend can happily live with query based insights only.

## Changes

This PR lets all instances of `renameInsight` take a query based insight and conditionally:
- sends it with `filters` or `query` to the backend, based on a feature flag
- returns it with `filters` or `query`, based on a boolean value -> work is in progress to set this to `true` everywhere

## How did you test this code?

- [x] Renamed an insight on a dashboard 
- [x] ... on the insights page (list view)
- [x] ~... on the insights page (card view)~
- [x] ... on the insight page
