### PR TITLE
refactor(insights): query based `deleteWithUndo`

### DIFF
--- a/frontend/src/layout/navigation-3000/sidebars/insights.ts
+++ b/frontend/src/layout/navigation-3000/sidebars/insights.ts
@@ -2,7 +2,7 @@ import { afterMount, connect, kea, listeners, path, reducers, selectors } from '
 import { subscriptions } from 'kea-subscriptions'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { insightsApi } from 'scenes/insights/utils/api'
 import { INSIGHTS_PER_PAGE, savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
@@ -101,10 +101,14 @@ export const insightsSidebarLogic = kea<insightsSidebarLogicType>([
                                         },
                                         {
                                             onClick: () => {
-                                                void deleteWithUndo({
-                                                    object: legacyInsight,
+                                                void deleteInsightWithUndo({
+                                                    object: insight,
                                                     endpoint: `projects/${currentTeamId}/insights`,
                                                     callback: actions.loadInsights,
+                                                    options: {
+                                                        writeAsQuery: values.queryBasedInsightSaving,
+                                                        readAsQuery: true,
+                                                    },
                                                 })
                                             },
                                             status: 'danger',

--- a/frontend/src/lib/utils/deleteWithUndo.tsx
+++ b/frontend/src/lib/utils/deleteWithUndo.tsx
@@ -1,5 +1,8 @@
 import { lemonToast } from '@posthog/lemon-ui'
 import api from 'lib/api'
+import { getInsightModel, InsightsApiOptions } from 'scenes/insights/utils/api'
+
+import { QueryBasedInsightModel } from '~/types'
 
 export async function deleteWithUndo<T extends Record<string, any>>({
     undo = false,
@@ -28,6 +31,42 @@ export async function deleteWithUndo<T extends Record<string, any>>({
                 : {
                       label: 'Undo',
                       action: () => deleteWithUndo({ undo: true, ...props }),
+                  },
+        }
+    )
+}
+
+/** Temporary duplicate of the function above that handles saving and restoring insights with filters
+ * when given a query based insight */
+export async function deleteInsightWithUndo({
+    undo = false,
+    options,
+    ...props
+}: {
+    undo?: boolean
+    endpoint: string
+    object: QueryBasedInsightModel
+    idField?: keyof QueryBasedInsightModel
+    callback?: (undo: boolean, object: QueryBasedInsightModel) => void
+    options: InsightsApiOptions<true>
+}): Promise<void> {
+    await api.update(`api/${props.endpoint}/${props.object[props.idField || 'id']}`, {
+        ...getInsightModel(props.object, options.writeAsQuery),
+        deleted: !undo,
+    })
+    props.callback?.(undo, props.object)
+    lemonToast[undo ? 'success' : 'info'](
+        <>
+            <b>{props.object.name || <i>{props.object.derived_name || 'Unnamed'}</i>}</b> has been{' '}
+            {undo ? 'restored' : 'deleted'}
+        </>,
+        {
+            toastId: `delete-item-${props.object.id}-${undo}`,
+            button: undo
+                ? undefined
+                : {
+                      label: 'Undo',
+                      action: () => deleteInsightWithUndo({ undo: true, options, ...props }),
                   },
         }
     )

--- a/frontend/src/models/insightsModel.tsx
+++ b/frontend/src/models/insightsModel.tsx
@@ -7,7 +7,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightsApi } from 'scenes/insights/utils/api'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { QueryBasedInsightModel } from '~/types'
+import { InsightModel, QueryBasedInsightModel } from '~/types'
 
 import type { insightsModelType } from './insightsModelType'
 
@@ -16,7 +16,7 @@ export const insightsModel = kea<insightsModelType>([
     connect({ values: [featureFlagLogic, ['featureFlags']], logic: [teamLogic] }),
     actions(() => ({
         renameInsight: (item: QueryBasedInsightModel) => ({ item }),
-        renameInsightSuccess: (item: QueryBasedInsightModel) => ({ item }),
+        renameInsightSuccess: (item: InsightModel) => ({ item }),
         //TODO this duplicates the insight but not the dashboard tile (e.g. if duplicated from dashboard you lose tile color
         duplicateInsight: (item: QueryBasedInsightModel) => ({ item }),
         duplicateInsightSuccess: (item: QueryBasedInsightModel) => ({ item }),

--- a/frontend/src/models/insightsModel.tsx
+++ b/frontend/src/models/insightsModel.tsx
@@ -7,7 +7,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightsApi } from 'scenes/insights/utils/api'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { InsightModel, QueryBasedInsightModel } from '~/types'
+import { QueryBasedInsightModel } from '~/types'
 
 import type { insightsModelType } from './insightsModelType'
 
@@ -16,7 +16,7 @@ export const insightsModel = kea<insightsModelType>([
     connect({ values: [featureFlagLogic, ['featureFlags']], logic: [teamLogic] }),
     actions(() => ({
         renameInsight: (item: QueryBasedInsightModel) => ({ item }),
-        renameInsightSuccess: (item: InsightModel) => ({ item }),
+        renameInsightSuccess: (item: QueryBasedInsightModel) => ({ item }),
         //TODO this duplicates the insight but not the dashboard tile (e.g. if duplicated from dashboard you lose tile color
         duplicateInsight: (item: QueryBasedInsightModel) => ({ item }),
         duplicateInsightSuccess: (item: QueryBasedInsightModel) => ({ item }),

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -14,7 +14,7 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
-import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { useState } from 'react'
 import { NewDashboardModal } from 'scenes/dashboard/NewDashboardModal'
 import { insightCommandLogic } from 'scenes/insights/insightCommandLogic'
@@ -41,7 +41,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
         insightProps,
         canEditInsight,
         queryBasedInsight: insight,
-        legacyInsight,
+        queryBasedInsightSaving,
         insightChanged,
         insightSaving,
         hasDashboardItemId,
@@ -216,12 +216,16 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                             <LemonButton
                                                 status="danger"
                                                 onClick={() =>
-                                                    void deleteWithUndo({
-                                                        object: legacyInsight,
+                                                    void deleteInsightWithUndo({
+                                                        object: insight,
                                                         endpoint: `projects/${currentTeamId}/insights`,
                                                         callback: () => {
                                                             loadInsights()
                                                             push(urls.savedInsights())
+                                                        },
+                                                        options: {
+                                                            writeAsQuery: queryBasedInsightSaving,
+                                                            readAsQuery: true,
                                                         },
                                                     })
                                                 }

--- a/frontend/src/scenes/insights/utils/api.ts
+++ b/frontend/src/scenes/insights/utils/api.ts
@@ -4,14 +4,14 @@ import { getInsightFilterOrQueryForPersistance } from '~/queries/nodes/InsightQu
 import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
 import { InsightModel, QueryBasedInsightModel } from '~/types'
 
-type InsightsApiOptions<Flag> = {
+export type InsightsApiOptions<Flag> = {
     writeAsQuery: boolean
     readAsQuery: Flag
 }
 
 type ReturnedInsightModelByFlag<Flag extends boolean> = Flag extends true ? QueryBasedInsightModel : InsightModel
 
-function getInsightModel<Flag extends boolean>(
+export function getInsightModel<Flag extends boolean>(
     insight: QueryBasedInsightModel,
     asQuery: Flag
 ): ReturnedInsightModelByFlag<Flag> {

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -34,7 +34,7 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { PaginationControl, usePagination } from 'lib/lemon-ui/PaginationControl'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
-import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { deleteInsightWithUndo, deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { SavedInsightsEmptyState } from 'scenes/insights/EmptyStates'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -376,7 +376,7 @@ export function NewInsightButton({ dataAttr }: NewInsightButtonProps): JSX.Eleme
 }
 
 function SavedInsightsGrid(): JSX.Element {
-    const { loadInsights, renameInsight, duplicateInsight } = useActions(savedInsightsLogic)
+    const { loadInsights, renameInsight, duplicateInsight, queryBasedInsightSaving } = useActions(savedInsightsLogic)
     const { insights, insightsLoading, pagination } = useValues(savedInsightsLogic)
     const { currentTeamId } = useValues(teamLogic)
 
@@ -394,10 +394,14 @@ function SavedInsightsGrid(): JSX.Element {
                             rename={() => renameInsight(insight)}
                             duplicate={() => duplicateInsight(insight)}
                             deleteWithUndo={async () =>
-                                await deleteWithUndo({
-                                    object: legacyInsight,
+                                await deleteInsightWithUndo({
+                                    object: insight,
                                     endpoint: `projects/${currentTeamId}/insights`,
                                     callback: loadInsights,
+                                    options: {
+                                        writeAsQuery: queryBasedInsightSaving,
+                                        readAsQuery: true,
+                                    },
                                 })
                             }
                             placement="SavedInsightGrid"

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -34,7 +34,7 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { PaginationControl, usePagination } from 'lib/lemon-ui/PaginationControl'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
-import { deleteInsightWithUndo, deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { SavedInsightsEmptyState } from 'scenes/insights/EmptyStates'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -423,7 +423,8 @@ function SavedInsightsGrid(): JSX.Element {
 export function SavedInsights(): JSX.Element {
     const { loadInsights, updateFavoritedInsight, renameInsight, duplicateInsight, setSavedInsightsFilters } =
         useActions(savedInsightsLogic)
-    const { insights, count, insightsLoading, filters, sorting, pagination } = useValues(savedInsightsLogic)
+    const { insights, count, insightsLoading, filters, sorting, pagination, queryBasedInsightSaving } =
+        useValues(savedInsightsLogic)
     const { hasTagging } = useValues(organizationLogic)
     const { currentTeamId } = useValues(teamLogic)
     const summarizeInsight = useSummarizeInsight()
@@ -538,10 +539,14 @@ export function SavedInsights(): JSX.Element {
                                 <LemonButton
                                     status="danger"
                                     onClick={() =>
-                                        void deleteWithUndo({
-                                            object: legacyInsight,
+                                        void deleteInsightWithUndo({
+                                            object: insight,
                                             endpoint: `projects/${currentTeamId}/insights`,
                                             callback: loadInsights,
+                                            options: {
+                                                writeAsQuery: queryBasedInsightSaving,
+                                                readAsQuery: true,
+                                            },
                                         })
                                     }
                                     data-attr={`insight-item-${insight.short_id}-dropdown-remove`}

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -376,8 +376,8 @@ export function NewInsightButton({ dataAttr }: NewInsightButtonProps): JSX.Eleme
 }
 
 function SavedInsightsGrid(): JSX.Element {
-    const { loadInsights, renameInsight, duplicateInsight, queryBasedInsightSaving } = useActions(savedInsightsLogic)
-    const { insights, insightsLoading, pagination } = useValues(savedInsightsLogic)
+    const { loadInsights, renameInsight, duplicateInsight } = useActions(savedInsightsLogic)
+    const { insights, insightsLoading, pagination, queryBasedInsightSaving } = useValues(savedInsightsLogic)
     const { currentTeamId } = useValues(teamLogic)
 
     const paginationState = usePagination(insights?.results || [], pagination)


### PR DESCRIPTION
## Problem

We want to have only query based insights frontend side, but we still need to send them to the backend with `filters`. The bigger goal of the coming PRs is to adapt all instances where we send insights to the backend for persistance with a wrapper function, so that the frontend can happily live with query based insights only.

## Changes

This PR replaces all instances of `deleteWithUndo` for insights with a `deleteInsightWithUndo` that take a query based insight and conditionally restores it with filters.

## How did you test this code?

With flag disabled:
- [x] Deleted (and restored!) an insight on the insights page (list view)
- [x] ~... on the insights page (card view)~ no button for that
- [x] ... on the insight page

With flag enabled:
- [x] Deleted (and restored!) an insight on the insights page (list view)
- [x] ~... on the insights page (card view)~ no button for that
- [x] ... on the insight page

