### PR TITLE
chore: log more

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -662,8 +662,10 @@ def replace_with_warning(
         only_meta_events = [x for x in snapshot_items if isinstance(x, dict) and ("type" in x and x["type"] == 4)]
 
         kafka_size = "unknown"
+        size_difference = "unknown"
         try:
-            kafka_size = mstle.args[0].split(" ")[3]
+            kafka_size = int(mstle.args[0].split(" ")[3])
+            size_difference = kafka_size - posthog_size_calculation
         except:
             pass
 
@@ -692,6 +694,7 @@ def replace_with_warning(
                                 "kafka_size": kafka_size,
                                 "posthog_calculation": posthog_size_calculation,
                                 "lib_version": lib_version,
+                                "size_difference": size_difference,
                             },
                         },
                         "$window_id": first_item.get("$window_id"),

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -21,7 +21,7 @@ from sentry_sdk import configure_scope
 from sentry_sdk.api import capture_exception, start_span
 from statshog.defaults.django import statsd
 from token_bucket import Limiter, MemoryStorage
-from typing import Any, Optional
+from typing import Any, Optional, Literal
 
 from ee.billing.quota_limiting import QuotaLimitingCaches
 from posthog.api.utils import get_data, get_token, safe_clickhouse_string
@@ -661,8 +661,8 @@ def replace_with_warning(
 
         only_meta_events = [x for x in snapshot_items if isinstance(x, dict) and ("type" in x and x["type"] == 4)]
 
-        kafka_size = "unknown"
-        size_difference = "unknown"
+        kafka_size: int | None = None
+        size_difference: int | Literal["unknown"] = "unknown"
         try:
             kafka_size = int(mstle.args[0].split(" ")[3])
             size_difference = kafka_size - posthog_size_calculation

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -497,7 +497,7 @@ class TestCapture(BaseTest):
                 },
                 {"type": 2, "data": {"lots": "of data"}, "$window_id": "the window id", "timestamp": 1234567890},
             ],
-            query_params="lib_version=1.2.3",
+            query_params="ver=1.2.3",
         )
 
         assert response.status_code == 200
@@ -519,7 +519,7 @@ class TestCapture(BaseTest):
                             "error": "[Error 10] MessageSizeTooLargeError: Message size too large",
                             "error_message": "MESSAGE_SIZE_TOO_LARGE",
                             "kafka_size": None,  # none here because we're not really throwing MessageSizeTooLargeError
-                            "lib_version": "unknown",
+                            "lib_version": "1.2.3",
                             "posthog_calculation": 425,
                             "size_difference": "unknown",
                         },

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -496,8 +496,10 @@ class TestCapture(BaseTest):
                     "timestamp": 1234567890,
                 },
                 {"type": 2, "data": {"lots": "of data"}, "$window_id": "the window id", "timestamp": 1234567890},
-            ]
+            ],
+            query_params="lib_version=1.2.3",
         )
+
         assert response.status_code == 200
 
         expected_data = make_processed_recording_event(
@@ -511,7 +513,17 @@ class TestCapture(BaseTest):
                 },
                 {
                     "type": 5,
-                    "data": {"tag": "Message too large"},
+                    "data": {
+                        "tag": "Message too large",
+                        "payload": {
+                            "error": "[Error 10] MessageSizeTooLargeError: Message size too large",
+                            "error_message": "MESSAGE_SIZE_TOO_LARGE",
+                            "kafka_size": None,  # none here because we're not really throwing MessageSizeTooLargeError
+                            "lib_version": "unknown",
+                            "posthog_calculation": 425,
+                            "size_difference": "unknown",
+                        },
+                    },
                     "timestamp": 1234567890,
                     "$window_id": "the window id",
                 },
@@ -2230,7 +2242,7 @@ class TestCapture(BaseTest):
                     },
                 ],
             )
-            sample_replay_data_to_object_storage(event, random_number, "the-team-token")
+            sample_replay_data_to_object_storage(event, random_number, "the-team-token", "1.2.3")
             contents = object_storage.read("token-the-team-token-session_id-abcdefgh.json", bucket=TEST_SAMPLES_BUCKET)
             assert contents == json.dumps(event)
 
@@ -2262,7 +2274,7 @@ class TestCapture(BaseTest):
                     },
                 ],
             )
-            sample_replay_data_to_object_storage(event, random_number, "another-team-token")
+            sample_replay_data_to_object_storage(event, random_number, "another-team-token", "1.2.3")
 
             with pytest.raises(ObjectStorageError):
                 object_storage.read("token-another-team-token-session_id-abcdefgh.json", bucket=TEST_SAMPLES_BUCKET)


### PR DESCRIPTION
we're still not catching message size too large errors 

let's improve the logging when we do catch them 

so i can investigate them betterer

<img width="902" alt="Screenshot 2024-07-04 at 12 38 28" src="https://github.com/PostHog/posthog/assets/984817/8eb7e41f-3157-49ef-baee-c32896d91a4c">
