### PR TITLE
chore: bring back the migration check

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -177,19 +177,18 @@ jobs:
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
             # First running migrations from master, to simulate the real-world scenario
-            # Commented out to move to Python 3.11. Uncomment after deploy.
-            #            - name: Checkout master
-            #              uses: actions/checkout@v3
-            #              with:
-            #                  ref: master
-            #
-            #            - name: Install python dependencies for master
-            #              run: |
-            #                  uv pip install --system -r requirements.txt -r requirements-dev.txt
-            #
-            #            - name: Run migrations up to master
-            #              run: |
-            #                  python manage.py migrate
+            - name: Checkout master
+              uses: actions/checkout@v3
+              with:
+                  ref: master
+
+            - name: Install python dependencies for master
+              run: |
+                  uv pip install --system -r requirements.txt -r requirements-dev.txt
+
+            - name: Run migrations up to master
+              run: |
+                  python manage.py migrate
 
             # Now we can consider this PR's migrations
             - name: Checkout this PR
@@ -203,24 +202,22 @@ jobs:
               run: |
                   python manage.py migrate
 
-    # Commented out to move to Python 3.11. Uncomment after deploy.
-    #
-    #            - name: Check migrations
-    #              run: |
-    #                  python manage.py makemigrations --check --dry-run
-    #                  git fetch origin master
-    #                  # `git diff --name-only` returns a list of files that were changed - added OR deleted OR modified
-    #                  # With `--name-status` we get the same, but including a column for status, respectively: A, D, M
-    #                  # In this check we exclusively care about files that were
-    #                  # added (A) in posthog/migrations/. We also want to ignore
-    #                  # initial migrations (0001_*) as these are guaranteed to be
-    #                  # run on initial setup where there is no data.
-    #                  git diff --name-status origin/master..HEAD | grep "A\sposthog/migrations/" | awk '{print $2}' | grep -v migrations/0001_ | python manage.py test_migrations_are_safe
-    #
-    #            - name: Check CH migrations
-    #              run: |
-    #                  # Same as above, except now for CH looking at files that were added in posthog/clickhouse/migrations/
-    #                  git diff --name-status origin/master..HEAD | grep "A\sposthog/clickhouse/migrations/" | awk '{print $2}' |  python manage.py test_ch_migrations_are_safe
+            - name: Check migrations
+              run: |
+                  python manage.py makemigrations --check --dry-run
+                  git fetch origin master
+                  # `git diff --name-only` returns a list of files that were changed - added OR deleted OR modified
+                  # With `--name-status` we get the same, but including a column for status, respectively: A, D, M
+                  # In this check we exclusively care about files that were
+                  # added (A) in posthog/migrations/. We also want to ignore
+                  # initial migrations (0001_*) as these are guaranteed to be
+                  # run on initial setup where there is no data.
+                  git diff --name-status origin/master..HEAD | grep "A\sposthog/migrations/" | awk '{print $2}' | grep -v migrations/0001_ | python manage.py test_migrations_are_safe
+
+            - name: Check CH migrations
+              run: |
+                  # Same as above, except now for CH looking at files that were added in posthog/clickhouse/migrations/
+                  git diff --name-status origin/master..HEAD | grep "A\sposthog/clickhouse/migrations/" | awk '{print $2}' |  python manage.py test_ch_migrations_are_safe
 
     django:
         needs: changes


### PR DESCRIPTION
this was commented out for python 3.11

i guess we need to bring it back