### PR TITLE
feat: add feature flag to not allow members to invite users

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activation/activationLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activation/activationLogic.ts
@@ -50,7 +50,7 @@ export const activationLogic = kea<activationLogicType>([
             membersLogic,
             ['memberCount'],
             inviteLogic,
-            ['invites'],
+            ['invites', 'isAllowToSendInvites'],
             savedInsightsLogic,
             ['insights'],
             dashboardsModel,
@@ -175,6 +175,7 @@ export const activationLogic = kea<activationLogicType>([
                 s.currentTeam,
                 s.memberCount,
                 s.invites,
+                s.isAllowToSendInvites,
                 s.insights,
                 s.rawDashboards,
                 s.customEventsCount,
@@ -185,6 +186,7 @@ export const activationLogic = kea<activationLogicType>([
                 currentTeam,
                 memberCount,
                 invites,
+                isAllowToSendInvites,
                 insights,
                 dashboards,
                 customEventsCount,
@@ -205,14 +207,16 @@ export const activationLogic = kea<activationLogicType>([
                             })
                             break
                         case ActivationTasks.InviteTeamMember:
-                            tasks.push({
-                                id: ActivationTasks.InviteTeamMember,
-                                name: 'Invite a team member',
-                                description: 'Everyone in your organization can benefit from PostHog',
-                                completed: memberCount > 1 || invites.length > 0,
-                                canSkip: true,
-                                skipped: skippedTasks.includes(ActivationTasks.InviteTeamMember),
-                            })
+                            if (isAllowToSendInvites.allowed) {
+                                tasks.push({
+                                    id: ActivationTasks.InviteTeamMember,
+                                    name: 'Invite a team member',
+                                    description: 'Everyone in your organization can benefit from PostHog',
+                                    completed: memberCount > 1 || invites.length > 0,
+                                    canSkip: true,
+                                    skipped: skippedTasks.includes(ActivationTasks.InviteTeamMember),
+                                })
+                            }
                             break
                         case ActivationTasks.CreateFirstInsight:
                             tasks.push({

--- a/frontend/src/layout/navigation/TopBar/AccountPopover.tsx
+++ b/frontend/src/layout/navigation/TopBar/AccountPopover.tsx
@@ -207,6 +207,7 @@ export function AccountPopoverOverlay(): JSX.Element {
     const { openSidePanel } = useActions(sidePanelStateLogic)
     const { preflight, isCloudOrDev, isCloud } = useValues(preflightLogic)
     const { closeAccountPopover } = useActions(navigationLogic)
+    const { isAllowToSendInvites } = useValues(inviteLogic)
 
     return (
         <>
@@ -226,7 +227,7 @@ export function AccountPopoverOverlay(): JSX.Element {
                         Billing
                     </LemonButton>
                 ) : null}
-                <InviteMembersButton />
+                {isAllowToSendInvites.allowed && <InviteMembersButton />}
             </AccountPopoverSection>
             {(otherOrganizations.length > 0 || preflight?.can_create_org) && (
                 <AccountPopoverSection title="Other organizations">

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -211,6 +211,7 @@ export const FEATURE_FLAGS = {
     SURVEYS_BRANCHING_LOGIC: 'surveys-branching-logic', // owner: @jurajmajerik #team-feature-success
     WEB_ANALYTICS_LIVE_USER_COUNT: 'web-analytics-live-user-count', // owner: @robbie-c
     SETTINGS_SESSION_TABLE_VERSION: 'settings-session-table-version', // owner: @robbie-c
+    OWNER_ADMIN_ORGANIZATION_INVITES_ONLY: 'owner-admin-organization-invites-only', // owner: @growth
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
+++ b/frontend/src/scenes/project-homepage/ProjectHomepage.tsx
@@ -37,6 +37,7 @@ export function ProjectHomepage(): JSX.Element {
     const { showSceneDashboardChoiceModal } = useActions(
         sceneDashboardChoiceModalLogic({ scene: Scene.ProjectHomepage })
     )
+    const { isAllowToSendInvites } = useValues(inviteLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     const headerButtons = (
@@ -52,15 +53,17 @@ export function ProjectHomepage(): JSX.Element {
             >
                 Customize homepage
             </LemonButton>
-            <LemonButton
-                data-attr="project-home-invite-team-members"
-                onClick={() => {
-                    showInviteModal()
-                }}
-                type="secondary"
-            >
-                Invite members
-            </LemonButton>
+            {isAllowToSendInvites.allowed && (
+                <LemonButton
+                    data-attr="project-home-invite-team-members"
+                    onClick={() => {
+                        showInviteModal()
+                    }}
+                    type="secondary"
+                >
+                    Invite members
+                </LemonButton>
+            )}
         </>
     )
 

--- a/frontend/src/scenes/settings/organization/InviteModal.tsx
+++ b/frontend/src/scenes/settings/organization/InviteModal.tsx
@@ -215,10 +215,17 @@ export function InviteTeamMatesComponent(): JSX.Element {
 export function InviteModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }): JSX.Element {
     const { user } = useValues(userLogic)
     const { preflight } = useValues(preflightLogic)
-    const { invitesToSend, canSubmit } = useValues(inviteLogic)
+    const { invitesToSend, canSubmit, isAllowToSendInvites } = useValues(inviteLogic)
     const { resetInviteRows, inviteTeamMembers } = useActions(inviteLogic)
 
     const validInvitesCount = invitesToSend.filter((invite) => invite.isValid && invite.target_email).length
+
+    let disabledReason = null
+    if (!isAllowToSendInvites.allowed) {
+        disabledReason = 'You need to be an Admin or Owner to send invites.'
+    } else if (!canSubmit) {
+        disabledReason = 'Make sure all fields are filled in correctly.'
+    }
 
     return (
         <div className="InviteModal">
@@ -265,7 +272,7 @@ export function InviteModal({ isOpen, onClose }: { isOpen: boolean; onClose: () 
                                 <LemonButton
                                     onClick={() => inviteTeamMembers()}
                                     type="primary"
-                                    disabled={!canSubmit}
+                                    disabledReason={disabledReason}
                                     data-attr="invite-team-member-submit"
                                 >
                                     {validInvitesCount

--- a/frontend/src/scenes/settings/organization/Invites.tsx
+++ b/frontend/src/scenes/settings/organization/Invites.tsx
@@ -57,7 +57,7 @@ function makeActionsComponent(
     }
 }
 export function Invites(): JSX.Element {
-    const { invites, invitesLoading } = useValues(inviteLogic)
+    const { invites, invitesLoading, isAllowToSendInvites } = useValues(inviteLogic)
     const { deleteInvite, showInviteModal } = useActions(inviteLogic)
     const { preflight } = useValues(preflightLogic)
 
@@ -121,7 +121,12 @@ export function Invites(): JSX.Element {
                 data-attr="invites-table"
                 emptyState="There are no outstanding invitations. You can invite another team member above."
             />
-            <LemonButton type="primary" onClick={showInviteModal} data-attr="invite-teammate-button">
+            <LemonButton
+                type="primary"
+                onClick={showInviteModal}
+                data-attr="invite-teammate-button"
+                disabledReason={isAllowToSendInvites.disabledReason}
+            >
                 Invite team member
             </LemonButton>
         </div>


### PR DESCRIPTION
## Changes

We've received feedback about how our invite permissions work. Right now any user can invite other users to their organization. We do limit the roles they can invite (only their role or lower) but not if they can send invites. Until we fully support RBAC (later this year) this will allow us to turn on a feature flag for users that request something like this.

This PR adds a `isAllowToSendInvites` value to the invite logic that returns an object with a bool if allowed and a disabled reason if not allowed. The selector will check for the feature flag (`owner-admin-organization-invites-only`), if not present, it will default to allowed. If it is present it will check the current users' org member level and only return allowed if they are an admin or owner.

I've updated all instances of where the invite modal can be opened. I've also updated the invite modal submit button just in case a user finds their way into the modal. 

Note: this is a frontend change only. Technically, they can still perform the functionality via the API.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
