### PR TITLE
feat(insights): add support for query based insights to insight icon

### DIFF
--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -297,6 +297,10 @@ export function isEmptyObject(candidate: unknown): boolean {
     return isObject(candidate) && Object.keys(candidate).length === 0
 }
 
+export function isNonEmptyObject(candidate: unknown): candidate is Record<string, unknown> {
+    return isObject(candidate) && !isEmptyObject(candidate)
+}
+
 // https://stackoverflow.com/questions/25421233/javascript-removing-undefined-fields-from-an-object
 export function objectClean<T extends Record<string | number | symbol, unknown>>(obj: T): T {
     const response = { ...obj }

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -45,7 +45,14 @@ import { urls } from 'scenes/urls'
 import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
 import { NodeKind } from '~/queries/schema'
 import { isInsightVizNode } from '~/queries/utils'
-import { ActivityScope, InsightModel, InsightType, LayoutView, SavedInsightsTabs } from '~/types'
+import {
+    ActivityScope,
+    InsightModel,
+    InsightType,
+    LayoutView,
+    QueryBasedInsightModel,
+    SavedInsightsTabs,
+} from '~/types'
 
 import { teamLogic } from '../teamLogic'
 import { INSIGHTS_PER_PAGE, savedInsightsLogic } from './savedInsightsLogic'
@@ -315,16 +322,26 @@ export const scene: SceneExport = {
     logic: savedInsightsLogic,
 }
 
-export function InsightIcon({ insight, className }: { insight: InsightModel; className?: string }): JSX.Element | null {
-    let insightType = insight?.filters?.insight || InsightType.TRENDS
-    if (!!insight.query && !isInsightVizNode(insight.query)) {
-        insightType = InsightType.JSON
+export function InsightIcon({
+    insight,
+    className,
+}: {
+    insight: InsightModel | QueryBasedInsightModel
+    className?: string
+}): JSX.Element | null {
+    let Icon: (props?: any) => JSX.Element | null = () => null
+
+    if ('filters' in insight && insight.filters != null) {
+        const insightType = insight.filters.insight || InsightType.TRENDS
+        const insightMetadata = INSIGHT_TYPES_METADATA[insightType]
+        Icon = insightMetadata && insightMetadata.icon
+    } else if ('query' in insight && insight.query != null) {
+        const insightType = isInsightVizNode(insight.query) ? insight.query.source.kind : insight.query.kind
+        const insightMetadata = QUERY_TYPES_METADATA[insightType]
+        Icon = insightMetadata && insightMetadata.icon
     }
-    const insightMetadata = INSIGHT_TYPES_METADATA[insightType]
-    if (insightMetadata && insightMetadata.icon) {
-        return <insightMetadata.icon className={className} />
-    }
-    return null
+
+    return Icon ? <Icon className={className} /> : null
 }
 
 export function NewInsightButton({ dataAttr }: NewInsightButtonProps): JSX.Element {

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -33,6 +33,7 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { PaginationControl, usePagination } from 'lib/lemon-ui/PaginationControl'
 import { SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
+import { isNonEmptyObject } from 'lib/utils'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { SavedInsightsEmptyState } from 'scenes/insights/EmptyStates'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
@@ -44,7 +45,7 @@ import { urls } from 'scenes/urls'
 
 import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
 import { NodeKind } from '~/queries/schema'
-import { isInsightVizNode } from '~/queries/utils'
+import { isNodeWithSource } from '~/queries/utils'
 import {
     ActivityScope,
     InsightModel,
@@ -331,12 +332,12 @@ export function InsightIcon({
 }): JSX.Element | null {
     let Icon: (props?: any) => JSX.Element | null = () => null
 
-    if ('filters' in insight && insight.filters != null) {
+    if ('filters' in insight && isNonEmptyObject(insight.filters)) {
         const insightType = insight.filters.insight || InsightType.TRENDS
         const insightMetadata = INSIGHT_TYPES_METADATA[insightType]
         Icon = insightMetadata && insightMetadata.icon
-    } else if ('query' in insight && insight.query != null) {
-        const insightType = isInsightVizNode(insight.query) ? insight.query.source.kind : insight.query.kind
+    } else if ('query' in insight && isNonEmptyObject(insight.query)) {
+        const insightType = isNodeWithSource(insight.query) ? insight.query.source.kind : insight.query.kind
         const insightMetadata = QUERY_TYPES_METADATA[insightType]
         Icon = insightMetadata && insightMetadata.icon
     }

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -2,6 +2,8 @@ import './SavedInsights.scss'
 
 import {
     IconBrackets,
+    IconCorrelationAnalysis,
+    IconCursor,
     IconFunnels,
     IconGraph,
     IconHogQL,
@@ -22,7 +24,7 @@ import { InsightCard } from 'lib/components/Cards/InsightCard'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { PageHeader } from 'lib/components/PageHeader'
 import { TZLabel } from 'lib/components/TZLabel'
-import { IconAction, IconEvent, IconGridView, IconListView, IconSelectEvents, IconTableChart } from 'lib/lemon-ui/icons'
+import { IconAction, IconGridView, IconListView, IconTableChart } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
@@ -166,13 +168,13 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
     [NodeKind.FunnelCorrelationQuery]: {
         name: 'Funnel Correlation',
         description: 'See which events or properties correlate to a funnel result',
-        icon: IconPerson,
+        icon: IconCorrelationAnalysis,
         inMenu: false,
     },
     [NodeKind.EventsNode]: {
         name: 'Events',
         description: 'List and explore events',
-        icon: IconSelectEvents,
+        icon: IconCursor,
         inMenu: true,
     },
     [NodeKind.ActionsNode]: {
@@ -189,8 +191,8 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
     },
     [NodeKind.EventsQuery]: {
         name: 'Events Query',
-        description: 'Hmmm, not every kind should be displayable I guess',
-        icon: IconEvent,
+        description: 'List and explore events',
+        icon: IconCursor,
         inMenu: true,
     },
     [NodeKind.PersonsNode]: {
@@ -262,7 +264,7 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
     [NodeKind.HogQLQuery]: {
         name: 'HogQL',
         description: 'Direct HogQL query',
-        icon: IconHogQL,
+        icon: IconBrackets,
         inMenu: true,
     },
     [NodeKind.HogQLMetadata]: {


### PR DESCRIPTION
## Problem

The `<InsightIcon />` component doesn't support query based "regular" insights and renders all of them as trends insights. All other insights are rendered as "brackets" icon.

## Changes

This PR adapts the component to use the icon from the query based metadata. Meaning "regular" insights work as before and other insights have the same icon they use elsewhere in the app. 

~Note: This means HogQL insights aren't rendered as "brackets" any more, but as a "table chart". While this is more consistent throughout the app, I kind of liked the icon from before.~ A couple of icons have been adapted, see screenshots:

### Before
<img width="1636" alt="Screenshot 2024-07-05 at 09 53 37" src="https://github.com/PostHog/posthog/assets/1851359/1f62bdf6-742a-4d00-a515-2aaaae1a4d69">

### After
<img width="1597" alt="Screenshot 2024-07-05 at 09 41 51" src="https://github.com/PostHog/posthog/assets/1851359/f8071a2f-e309-49b0-b234-0e034c458d6f">

## How did you test this code?

Locally, with :eyes: