### PR TITLE
fix: trends export with an applied formula

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -173,8 +173,9 @@ def _convert_response_to_csv_data(data: Any) -> Generator[Any, None, None]:
             # TRENDS LIKE
             for index, item in enumerate(results):
                 line = {"series": item.get("label", f"Series #{index + 1}")}
-                if item.get("action", {}).get("custom_name"):
-                    line["custom name"] = item.get("action").get("custom_name")
+                action = item.get("action")
+                if isinstance(action, dict) and action.get("custom_name"):
+                    line["custom name"] = action.get("custom_name")
                 if item.get("aggregated_value"):
                     line["total count"] = item.get("aggregated_value")
                 else:

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -593,3 +593,66 @@ class TestCSVExporter(APIBaseTest):
         first_split_parts = url.split("?")
         assert len(first_split_parts) == 2
         return {bits[0]: bits[1] for bits in [param.split("=") for param in first_split_parts[1].split("&")]}
+
+    @patch("posthog.hogql.constants.MAX_SELECT_RETURNED_ROWS", 10)
+    @patch("posthog.models.exported_asset.UUIDT")
+    def test_csv_exporter_trends_query_with_none_action(
+        self, mocked_uuidt: Any, MAX_SELECT_RETURNED_ROWS: int = 10
+    ) -> None:
+        _create_person(
+            distinct_ids=[f"user_1"],
+            team=self.team,
+        )
+
+        events_by_person = {
+            "user_1": [
+                {
+                    "event": "$pageview",
+                    "timestamp": datetime(2024, 3, 22, 13, 46),
+                },
+                {
+                    "event": "$pageview",
+                    "timestamp": datetime(2024, 3, 22, 13, 47),
+                },
+            ],
+        }
+        journeys_for(events_by_person, self.team)
+        flush_persons_and_events()
+
+        exported_asset = ExportedAsset(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.CSV,
+            export_context={
+                "source": {
+                    "kind": "TrendsQuery",
+                    "dateRange": {"date_to": "2024-03-22", "date_from": "2024-03-22"},
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "event": None,
+                            "name": "All events",
+                            "math": "dau",
+                        },
+                        {
+                            "kind": "EventsNode",
+                            "event": "$pageview",
+                            "name": "$pageview",
+                            "math": "dau",
+                        },
+                    ],
+                    "interval": "day",
+                    "trendsFilter": {"showLegend": True, "aggregationAxisFormat": "percentage", "formula": "(B/A)*100"},
+                }
+            },
+        )
+        exported_asset.save()
+        mocked_uuidt.return_value = "a-guid"
+
+        with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_EXPORTS_FOLDER="Test-Exports"):
+            csv_exporter.export_tabular(exported_asset)
+            content = object_storage.read(exported_asset.content_location)
+            lines = (content or "").strip().split("\r\n")
+            self.assertEqual(
+                lines,
+                ["series,22-Mar-2024", "Formula ((B/A)*100),100.0"],
+            )


### PR DESCRIPTION
## Problem

Fixed #23480 

## Changes

If the `action` field is defined in a dict and is `None`, the `get` method doesn't use a default value.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

I've added a test that catches this case.
