### PR TITLE
fix(insights): time to convert funnel should ingore a breakdown filter

### DIFF
--- a/posthog/hogql_queries/insights/funnels/base.py
+++ b/posthog/hogql_queries/insights/funnels/base.py
@@ -3,7 +3,6 @@ from functools import cached_property
 from typing import Any, Optional, Union, cast
 import uuid
 from posthog.clickhouse.materialized_columns.column import ColumnName
-from posthog.constants import FunnelVizType
 from posthog.hogql import ast
 from posthog.hogql.constants import get_breakdown_limit_for_context
 from posthog.hogql.parser import parse_expr, parse_select
@@ -28,6 +27,7 @@ from posthog.schema import (
     EventsNode,
     FunnelExclusionActionsNode,
     FunnelTimeToConvertResults,
+    FunnelVizType,
 )
 from posthog.types import EntityNode, ExclusionEntityNode
 from rest_framework.exceptions import ValidationError


### PR DESCRIPTION
## Problem

Closes #23489.

A funnel with the `time_to_convert` visualization type doesn't support a breakdown filter.

<img width="1207" alt="Screenshot 2024-07-05 at 16 15 03" src="https://github.com/PostHog/posthog/assets/13541795/7dcd397e-18a9-4267-90d2-f8bbfd8a2540">

However, it's possible to set the breakdown following these steps:
1. Open a "Conversion steps" funnel
2. Set a breakdown
3. Select the "Time to Convert" funnel type
4. Query cannot resolve a field, which is #23489.

## Changes

I've added a condition to check the funnel type.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

An additional test was added to catch this case.