### PR TITLE
fix: Add aliases to batch export tables

### DIFF
--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -46,7 +46,7 @@ FROM
         team_id={team_id},
         interval_start={interval_start},
         interval_end={interval_end}
-    )
+    ) AS persons
 FORMAT ArrowStream
 """
 
@@ -61,7 +61,7 @@ FROM
         interval_end={interval_end},
         include_events={include_events}::Array(String),
         exclude_events={exclude_events}::Array(String)
-    )
+    ) AS events
 FORMAT ArrowStream
 """)
 
@@ -76,7 +76,7 @@ FROM
         interval_end={interval_end},
         include_events={include_events}::Array(String),
         exclude_events={exclude_events}::Array(String)
-    )
+    ) AS events
 FORMAT ArrowStream
 """)
 
@@ -90,7 +90,7 @@ FROM
         interval_end={interval_end},
         include_events={include_events}::Array(String),
         exclude_events={exclude_events}::Array(String)
-    )
+    ) AS events
 FORMAT ArrowStream
 """)
 


### PR DESCRIPTION
## Problem

HogQL parser returns fully qualified fields, but new batch export views don't have the same names as source tables.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Use an alias on each of the views that matches the source tables (`events`, `persons`).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
