### PR TITLE
chore: add a rate limit for usage reports to billing

### DIFF
--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -274,7 +274,7 @@ def get_org_owner_or_first_user(organization_id: str) -> Optional[User]:
     return user
 
 
-@shared_task(**USAGE_REPORT_TASK_KWARGS, max_retries=3)
+@shared_task(**USAGE_REPORT_TASK_KWARGS, max_retries=3, rate_limit="5/s")
 def send_report_to_billing_service(org_id: str, report: dict[str, Any]) -> None:
     if not settings.EE_AVAILABLE:
         return


### PR DESCRIPTION
## Problem

We're seeing an issue with billing's ability to handle these requests. It looks like the issue is with connections to redis. This will limit the requests to billing so that it has a chance to process them all.  