### PR TITLE
feat(surveys): added close button text customization feature

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -358,7 +358,10 @@ export default function SurveyEdit(): JSX.Element {
                                                                                   textPlaceholder="ex: We really appreciate it."
                                                                               />
                                                                           </LemonField.Pure>
-                                                                          <LemonField.Pure className="mt-2" label="Button text">
+                                                                          <LemonField.Pure
+                                                                              className="mt-2"
+                                                                              label="Button text"
+                                                                          >
                                                                               <LemonInput
                                                                                   value={
                                                                                       survey.appearance

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -358,6 +358,22 @@ export default function SurveyEdit(): JSX.Element {
                                                                                   textPlaceholder="ex: We really appreciate it."
                                                                               />
                                                                           </LemonField.Pure>
+                                                                          <LemonField.Pure label="Button text">
+                                                                              <LemonInput
+                                                                                  value={
+                                                                                      survey.appearance
+                                                                                          .thankYouMessageCloseButtonText
+                                                                                  }
+                                                                                  onChange={(val) =>
+                                                                                      setSurveyValue('appearance', {
+                                                                                          ...survey.appearance,
+                                                                                          thankYouMessageCloseButtonText:
+                                                                                              val,
+                                                                                      })
+                                                                                  }
+                                                                                  placeholder="ex: Close"
+                                                                              />
+                                                                          </LemonField.Pure>
                                                                           <LemonField.Pure className="mt-2">
                                                                               <LemonCheckbox
                                                                                   checked={

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -371,7 +371,7 @@ export default function SurveyEdit(): JSX.Element {
                                                                                               val,
                                                                                       })
                                                                                   }
-                                                                                  placeholder="ex: Close"
+                                                                                  placeholder="example: Close"
                                                                               />
                                                                           </LemonField.Pure>
                                                                           <LemonField.Pure className="mt-2">

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -358,7 +358,7 @@ export default function SurveyEdit(): JSX.Element {
                                                                                   textPlaceholder="ex: We really appreciate it."
                                                                               />
                                                                           </LemonField.Pure>
-                                                                          <LemonField.Pure label="Button text">
+                                                                          <LemonField.Pure className="mt-2" label="Button text">
                                                                               <LemonInput
                                                                                   value={
                                                                                       survey.appearance

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2650,6 +2650,7 @@ export interface SurveyAppearance {
     thankYouMessageHeader?: string
     thankYouMessageDescription?: string
     thankYouMessageDescriptionContentType?: SurveyQuestionDescriptionContentType
+    thankYouMessageCloseButtonText?: string
     autoDisappear?: boolean
     position?: string
     shuffleQuestions?: boolean

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,8 +260,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0(postcss@8.4.31)
   posthog-js:
-    specifier: 1.144.2
-    version: 1.144.2
+    specifier: file:../posthog-js
+    version: file:../posthog-js
   posthog-js-lite:
     specifier: 3.0.0
     version: 3.0.0
@@ -17706,14 +17706,6 @@ packages:
     resolution: {integrity: sha512-dyajjnfzZD1tht4N7p7iwf7nBnR1MjVaVu+MKr+7gBgA39bn28wizCIJZztZPtHy4PY0YwtSGgwfBCuG/hnHgA==}
     dev: false
 
-  /posthog-js@1.144.2:
-    resolution: {integrity: sha512-Kgq8/bJvrTbDDsfSqAURIiYdkJ5tPegR2JC6pqIeoFjnTx/Rrq0j4n3vDW7K1nCapBch7G5gTZdaK7O6t+rI9A==}
-    dependencies:
-      fflate: 0.4.8
-      preact: 10.22.1
-      web-vitals: 4.2.1
-    dev: false
-
   /potpack@2.0.0:
     resolution: {integrity: sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==}
     dev: false
@@ -22096,4 +22088,13 @@ packages:
 
   /zxcvbn@4.4.2:
     resolution: {integrity: sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==}
+    dev: false
+
+  file:../posthog-js:
+    resolution: {directory: ../posthog-js, type: directory}
+    name: posthog-js
+    dependencies:
+      fflate: 0.4.8
+      preact: 10.22.1
+      web-vitals: 4.2.1
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,8 +260,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0(postcss@8.4.31)
   posthog-js:
-    specifier: file:../posthog-js
-    version: file:../posthog-js
+    specifier: 1.144.2
+    version: 1.144.2
   posthog-js-lite:
     specifier: 3.0.0
     version: 3.0.0
@@ -17706,6 +17706,14 @@ packages:
     resolution: {integrity: sha512-dyajjnfzZD1tht4N7p7iwf7nBnR1MjVaVu+MKr+7gBgA39bn28wizCIJZztZPtHy4PY0YwtSGgwfBCuG/hnHgA==}
     dev: false
 
+  /posthog-js@1.144.2:
+    resolution: {integrity: sha512-Kgq8/bJvrTbDDsfSqAURIiYdkJ5tPegR2JC6pqIeoFjnTx/Rrq0j4n3vDW7K1nCapBch7G5gTZdaK7O6t+rI9A==}
+    dependencies:
+      fflate: 0.4.8
+      preact: 10.22.1
+      web-vitals: 4.2.1
+    dev: false
+
   /potpack@2.0.0:
     resolution: {integrity: sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==}
     dev: false
@@ -22088,13 +22096,4 @@ packages:
 
   /zxcvbn@4.4.2:
     resolution: {integrity: sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==}
-    dev: false
-
-  file:../posthog-js:
-    resolution: {directory: ../posthog-js, type: directory}
-    name: posthog-js
-    dependencies:
-      fflate: 0.4.8
-      preact: 10.22.1
-      web-vitals: 4.2.1
     dev: false


### PR DESCRIPTION
Ships with https://github.com/PostHog/posthog-js/pull/1288

Closes the last task in https://github.com/PostHog/posthog/issues/20851

## Changes

### Before

Not customizable

<img width="1007" alt="image" src="https://github.com/PostHog/posthog-js/assets/4853149/76ed261e-7c68-40c9-ac66-e9f2776b8605">

### After

![2024-07-05 15 50 11](https://github.com/PostHog/posthog-js/assets/4853149/c8658dae-63c7-4c7b-a418-d6c22bec25bf)

## Checklist

Manually tested it, looks solid.  Low-risk (it's an optional field)/easy change, just needed to make sure that the types lined up.