### PR TITLE
fix: important changes n+1

### DIFF
--- a/posthog/api/activity_log.py
+++ b/posthog/api/activity_log.py
@@ -180,11 +180,13 @@ class ActivityLogViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, mixins
                 .values_list("item_id", flat=True)
             )
 
-            last_read_date = NotificationViewed.objects.filter(user=user).first()
+            last_read_date = (
+                NotificationViewed.objects.filter(user=user).values_list("last_viewed_activity_date", flat=True).first()
+            )
             last_read_filter = ""
 
             if last_read_date and params.get("unread") == "true":
-                last_read_filter = f"AND created_at > '{last_read_date.last_viewed_activity_date.isoformat()}'"
+                last_read_filter = f"AND created_at > '{last_read_date.isoformat()}'"
 
         with timer("query_for_candidate_ids"):
             # before we filter to include only the important changes,
@@ -252,9 +254,7 @@ class ActivityLogViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, mixins
             )
 
             if last_read_date and params.get("unread") == "true":
-                other_peoples_changes = other_peoples_changes.filter(
-                    created_at__gt=last_read_date.last_viewed_activity_date
-                )
+                other_peoples_changes = other_peoples_changes.filter(created_at__gt=last_read_date)
 
         with timer("query_for_data"):
             page_of_data = other_peoples_changes[:10]
@@ -268,7 +268,7 @@ class ActivityLogViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, mixins
             status=status.HTTP_200_OK,
             data={
                 "results": serialized_data,
-                "last_read": last_read_date.last_viewed_activity_date if last_read_date else None,
+                "last_read": last_read_date if last_read_date else None,
             },
         )
 


### PR DESCRIPTION
see https://posthog.sentry.io/issues/4367709669/?notification_uuid=0b79d54e-a1e6-49af-af32-88565b6b88a3&project=1899813&referrer=weekly_report

i couldn't actually figure out how to recreate this in a test
but since the n+1 trace shows us looping notifiction_viewed -> user
and we don't need the notification_viewed__user relation 
we can skip loading the user entirely (which might fix this)