### PR TITLE
fix: allowed hostname check might need to decode the provided needle

### DIFF
--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -31,7 +31,6 @@ from rest_framework.response import Response
 from two_factor.forms import TOTPDeviceForm
 from two_factor.utils import default_device
 
-from posthog.api.decide import hostname_in_allowed_url_list
 from posthog.api.email_verification import EmailVerifier
 from posthog.api.organization import OrganizationSerializer
 from posthog.api.shared import OrganizationBasicSerializer, TeamBasicSerializer
@@ -39,6 +38,7 @@ from posthog.api.utils import (
     PublicIPOnlyHttpAdapter,
     raise_if_user_provided_url_unsafe,
     ClassicBehaviorBooleanFieldSerializer,
+    unparsed_hostname_in_allowed_url_list,
 )
 from posthog.auth import (
     PersonalAPIKeyAuthentication,
@@ -493,7 +493,7 @@ def redirect_to_site(request):
     if not app_url:
         return HttpResponse(status=404)
 
-    if not team or not hostname_in_allowed_url_list(team.app_urls, urllib.parse.urlparse(app_url).hostname):
+    if not team or not unparsed_hostname_in_allowed_url_list(team.app_urls, app_url):
         return HttpResponse(f"Can only redirect to a permitted domain.", status=403)
     request.user.temporary_token = secrets.token_urlsafe(32)
     request.user.save()

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -40,7 +40,7 @@ from posthog.api import (
     uploaded_media,
     user,
 )
-from posthog.api.decide import hostname_in_allowed_url_list
+from .api.utils import hostname_in_allowed_url_list
 from posthog.api.early_access_feature import early_access_features
 from posthog.api.survey import surveys
 from posthog.constants import PERMITTED_FORUM_DOMAINS


### PR DESCRIPTION
See https://posthoghelp.zendesk.com/agent/tickets/15418 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/18021)

If we sent an external redirect to a permitted domain but the browser encoded the URL so that `https://my-permitted-domain.com` became `http%3A%2F%2Fmy-permitted-domain.com` then we wouldn't manage to find it in the allow list

Adds an option to check against a decoded needle

---

other call sites into this already parse the hostname and then rely on that value so i haven't replaced all of the places, particularly in decide this is high-traffic enough that if the issue was happening there we'd already know about it