### PR TITLE
fix: fix bad parsing of pr info for fetching labels

### DIFF
--- a/.github/actions/get-pr-labels/action.yml
+++ b/.github/actions/get-pr-labels/action.yml
@@ -24,18 +24,22 @@ runs:
           shell: bash
           if: steps.pr-info.outputs.data
           id: extract-pr
+          continue-on-error: true
           run: |
               echo "PR_NUMBER=$(cat | jq -r '.[-1].number' <<EOF
-                ${{ steps.pr-info.outputs.data }}
+                ${{ toJSON(fromJSON(steps.pr-info.outputs.data)) }}
               EOF
               )" >> $GITHUB_OUTPUT
 
         - name: Fetch PR Labels
           shell: bash
-          if: steps.extract-pr.outputs.PR_NUMBER
           id: labels
           run: |
               PR_NUMBER=${{ steps.extract-pr.outputs.PR_NUMBER }}
+              if [ -z "${PR_NUMBER}" ] || [ "${PR_NUMBER}" = "null" ]; then
+                echo labels="[]" >> $GITHUB_OUTPUT
+                exit 0
+              fi
               LABELS=$(curl \
                 -H "Authorization: Bearer ${{ inputs.token }}" \
                 -H "Accept: application/vnd.github.v3+json" \


### PR DESCRIPTION
## Problem

TODO: REMOVE TEST CALL IN WORKFLOW BEFORE MERGING

parsing PR response was failing if there were `\` in the PR body
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
