### PR TITLE
chore: turn on new blobby setting for our team

### DIFF
--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1947,7 +1947,7 @@ class TestCapture(BaseTest):
             self._send_august_2023_version_session_recording_event(event_data=None)
 
             session_recording_producer_singleton_mock.assert_called_with(
-                compression_type="gzip",
+                compression_type=None,
                 kafka_hosts=[
                     "another-server:9092",
                     "a-fourth.server:9092",

--- a/posthog/settings/session_replay.py
+++ b/posthog/settings/session_replay.py
@@ -40,4 +40,4 @@ REPLAY_MESSAGE_TOO_LARGE_SAMPLE_BUCKET = get_from_env(
 #
 # gzip is the current default in production
 # TODO we can clean this up once we've tested the new gzip-in-capture compression and don't need a setting
-SESSION_RECORDING_KAFKA_COMPRESSION = get_from_env("SESSION_RECORDING_KAFKA_COMPRESSION", "gzip")
+SESSION_RECORDING_KAFKA_COMPRESSION = get_from_env("SESSION_RECORDING_KAFKA_COMPRESSION", "gzip-in-capture")


### PR DESCRIPTION
i'm manually testing this but any deploys will reset it

once i'm sure this doesn't break all ingestion for our team, let's turn it on, so we can assess its effect