### PR TITLE
fix: error ordering

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2882,7 +2882,7 @@
             "type": "string"
         },
         "ErrorTrackingOrder": {
-            "enum": ["last_seen", "first_seen", "unique_occurrences", "unique_users", "unique_sessions"],
+            "enum": ["last_seen", "first_seen", "occurrences", "users", "sessions"],
             "type": "string"
         },
         "EventDefinition": {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1187,7 +1187,7 @@ export interface WebTopClicksQueryResponse extends AnalyticsQueryResponseBase<un
 
 export type CachedWebTopClicksQueryResponse = CachedQueryResponse<WebTopClicksQueryResponse>
 
-export type ErrorTrackingOrder = 'last_seen' | 'first_seen' | 'unique_occurrences' | 'unique_users' | 'unique_sessions'
+export type ErrorTrackingOrder = 'last_seen' | 'first_seen' | 'occurrences' | 'users' | 'sessions'
 
 export enum WebStatsBreakdown {
     Page = 'Page',

--- a/frontend/src/scenes/error-tracking/ErrorTrackingFilters.tsx
+++ b/frontend/src/scenes/error-tracking/ErrorTrackingFilters.tsx
@@ -56,15 +56,15 @@ export const ErrorTrackingFilters = ({ showOrder = true }: { showOrder?: boolean
                                         label: 'First seen',
                                     },
                                     {
-                                        value: 'unique_occurrences',
+                                        value: 'occurrences',
                                         label: 'Occurrences',
                                     },
                                     {
-                                        value: 'unique_users',
+                                        value: 'users',
                                         label: 'Users',
                                     },
                                     {
-                                        value: 'unique_sessions',
+                                        value: 'sessions',
                                         label: 'Sessions',
                                     },
                                 ]}

--- a/frontend/src/scenes/error-tracking/errorTrackingLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingLogic.ts
@@ -2,7 +2,7 @@ import type { LemonSegmentedButtonOption } from '@posthog/lemon-ui'
 import { actions, kea, listeners, path, reducers } from 'kea'
 import { UniversalFiltersGroup } from 'lib/components/UniversalFilters/UniversalFilters'
 
-import { DateRange, ErrorTrackingOrder } from '~/queries/schema'
+import { DateRange } from '~/queries/schema'
 import { FilterLogicalOperator } from '~/types'
 
 import type { errorTrackingLogicType } from './errorTrackingLogicType'
@@ -31,7 +31,6 @@ export const errorTrackingLogic = kea<errorTrackingLogicType>([
 
     actions({
         setDateRange: (dateRange: DateRange) => ({ dateRange }),
-        setOrder: (order: ErrorTrackingOrder) => ({ order }),
         setFilterGroup: (filterGroup: UniversalFiltersGroup) => ({ filterGroup }),
         setFilterTestAccounts: (filterTestAccounts: boolean) => ({ filterTestAccounts }),
         setSparklineSelectedPeriod: (period: string | null) => ({ period }),
@@ -43,13 +42,6 @@ export const errorTrackingLogic = kea<errorTrackingLogicType>([
             { persist: true },
             {
                 setDateRange: (_, { dateRange }) => dateRange,
-            },
-        ],
-        order: [
-            'last_seen' as ErrorTrackingOrder,
-            { persist: true },
-            {
-                setOrder: (_, { order }) => order,
             },
         ],
         filterGroup: [

--- a/frontend/src/scenes/error-tracking/queries.ts
+++ b/frontend/src/scenes/error-tracking/queries.ts
@@ -73,12 +73,14 @@ export const errorTrackingQuery = ({
         columns.splice(2, 0, 'context.columns.volume')
     }
 
+    const orderDirection = order === 'first_seen' ? 'ASC' : 'DESC'
+
     return {
         kind: NodeKind.DataTableNode,
         source: {
             kind: NodeKind.EventsQuery,
             select: select,
-            orderBy: [order],
+            orderBy: [`${order} ${orderDirection}`],
             ...defaultProperties({ dateRange, filterTestAccounts, filterGroup }),
         },
         hiddenColumns: ['properties.$exception_type', 'last_seen', 'first_seen'],

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -339,9 +339,9 @@ class EntityType(StrEnum):
 class ErrorTrackingOrder(StrEnum):
     LAST_SEEN = "last_seen"
     FIRST_SEEN = "first_seen"
-    UNIQUE_OCCURRENCES = "unique_occurrences"
-    UNIQUE_USERS = "unique_users"
-    UNIQUE_SESSIONS = "unique_sessions"
+    OCCURRENCES = "occurrences"
+    USERS = "users"
+    SESSIONS = "sessions"
 
 
 class EventDefinition(BaseModel):


### PR DESCRIPTION
## Problem

The ordering columns have been renamed to what they should be in the UI, the order did not comply with the new aliases

## Changes

- Remove duplicate ordering on logic
- Rename columns
- Correctly order the `first_seen` as ascending