### PR TITLE
chore: retain URL filters on page reload

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -803,8 +803,6 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
             const params: Params = objectClean({
                 ...router.values.searchParams,
                 filters: values.filters ?? undefined,
-                simpleFilters: values.simpleFilters ?? undefined,
-                advancedFilters: values.advancedFilters ?? undefined,
                 sessionRecordingId: values.selectedRecordingId ?? undefined,
             })
 
@@ -813,6 +811,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
 
         return {
             setSelectedRecordingId: () => buildURL(false),
+            setUniversalFilters: () => buildURL(true),
             setAdvancedFilters: () => buildURL(true),
             setSimpleFilters: () => buildURL(true),
             resetFilters: () => buildURL(true),
@@ -842,6 +841,12 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                     actions.setUniversalFilters(
                         convertLegacyFiltersToUniversalFilters(params.simpleFilters, params.advancedFilters)
                     )
+                }
+            } else if (params.filters && !equal(params.filters, values.filters)) {
+                if (values.useUniversalFiltering) {
+                    actions.setUniversalFilters(params.filters)
+                } else {
+                    actions.setAdvancedFilters(convertUniversalFiltersToLegacyFilters(params.filters))
                 }
             }
         }

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -803,6 +803,8 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
             const params: Params = objectClean({
                 ...router.values.searchParams,
                 filters: values.filters ?? undefined,
+                simpleFilters: values.simpleFilters ?? undefined,
+                advancedFilters: values.advancedFilters ?? undefined,
                 sessionRecordingId: values.selectedRecordingId ?? undefined,
             })
 
@@ -843,11 +845,8 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                     )
                 }
             } else if (params.filters && !equal(params.filters, values.filters)) {
-                if (values.useUniversalFiltering) {
-                    actions.setUniversalFilters(params.filters)
-                } else {
-                    actions.setAdvancedFilters(convertUniversalFiltersToLegacyFilters(params.filters))
-                }
+                actions.setUniversalFilters(params.filters)
+                actions.setAdvancedFilters(convertUniversalFiltersToLegacyFilters(params.filters))
             }
         }
         return {


### PR DESCRIPTION
## Problem

We were not passing the universal filters through in the URL 

## Changes

- Add `actionToUrl` listener when using universal filters
- Convert universal filter params to the legacy filters if the flag is disabled


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Reloaded the page and filters persisted