### PR TITLE
chore: always set filters

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -845,7 +845,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                     )
                 }
             }
-            if (params.filters && !equal(params.filters, values.filters)) {
+            if (values.useUniversalFiltering && params.filters && !equal(params.filters, values.filters)) {
                 actions.setUniversalFilters(params.filters)
                 actions.setAdvancedFilters(convertUniversalFiltersToLegacyFilters(params.filters))
             }

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -844,7 +844,8 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                         convertLegacyFiltersToUniversalFilters(params.simpleFilters, params.advancedFilters)
                     )
                 }
-            } else if (params.filters && !equal(params.filters, values.filters)) {
+            }
+            if (params.filters && !equal(params.filters, values.filters)) {
                 actions.setUniversalFilters(params.filters)
                 actions.setAdvancedFilters(convertUniversalFiltersToLegacyFilters(params.filters))
             }


### PR DESCRIPTION
## Problem

We're using an if / else when we should always be setting the universal filters if the flag is enabled

## Changes

Pull condition of out `else if` and into a new `if` statement