### PR TITLE
feat(web-analytics): Add session explorer to dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ plugin-transpiler/dist
 *-esbuild-meta.json
 *-esbuild-bundle-visualization.html
 .dlt
+*.db

--- a/frontend/src/scenes/web-analytics/SessionDebugger/SessionAttributionExplorerScene.tsx
+++ b/frontend/src/scenes/web-analytics/SessionDebugger/SessionAttributionExplorerScene.tsx
@@ -1,9 +1,12 @@
+import { IconCollapse, IconExpand } from '@posthog/icons'
 import { useActions, useValues } from 'kea'
 import { supportLogic } from 'lib/components/Support/supportLogic'
 import { IconFeedback } from 'lib/lemon-ui/icons'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import React from 'react'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 
@@ -23,13 +26,53 @@ export const scene: SceneExport = {
     logic: sessionAttributionExplorerLogic,
 }
 
-const ExampleUrlsCell: QueryContextColumnComponent = ({ value }: { value: unknown }): JSX.Element => {
-    const values = Array.isArray(value) ? value : [value]
+const ExpandableDataCell: QueryContextColumnComponent = ({ value }: { value: unknown }): JSX.Element => {
+    const [isExpanded, setIsExpanded] = React.useState(false)
+
+    if (value == null || (Array.isArray(value) && value.length === 0)) {
+        return (
+            <Tooltip title="NULL">
+                <span aria-hidden={true} className="cursor-default">
+                    —
+                </span>
+            </Tooltip>
+        )
+    }
+
+    if (!Array.isArray(value)) {
+        return <div>{value}</div>
+    }
+
     return (
-        <div>
-            {values.map((url) => (
-                <div key={url}>{url}</div>
-            ))}
+        <div className="flex flex-row">
+            <div>
+                <span>
+                    <LemonButton
+                        active={isExpanded}
+                        onClick={() => {
+                            setIsExpanded(!isExpanded)
+                        }}
+                        icon={isExpanded ? <IconCollapse /> : <IconExpand />}
+                        title={isExpanded ? 'Show less' : 'Show more'}
+                        size="small"
+                    />
+                </span>
+            </div>
+            <div className="flex flex-col items-center justify-center">
+                <div className="flex flex-1">
+                    {isExpanded ? (
+                        <ul className="flex-1 flex flex-col">
+                            {value.map((url) => (
+                                <li className="flex-1 mb-1 break-all" key={url}>
+                                    {url}
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        value[0]
+                    )}
+                </div>
+            </div>
         </div>
     )
 }
@@ -38,6 +81,7 @@ const queryContext: QueryContext = {
     columns: {
         channel_type: {
             title: 'Channel type',
+            render: ExpandableDataCell,
         },
         count: {
             title: 'Session count',
@@ -45,22 +89,27 @@ const queryContext: QueryContext = {
         },
         referring_domain: {
             title: 'Referring domain',
+            render: ExpandableDataCell,
         },
         utm_source: {
             title: 'UTM source',
+            render: ExpandableDataCell,
         },
         utm_medium: {
             title: 'UTM medium',
+            render: ExpandableDataCell,
         },
         utm_campaign: {
             title: 'UTM campaign',
+            render: ExpandableDataCell,
         },
         has_ad_id: {
-            title: 'Has ad ID',
+            title: 'Ad IDs',
+            render: ExpandableDataCell,
         },
         example_entry_urls: {
             title: 'Example entry URLs',
-            render: ExampleUrlsCell,
+            render: ExpandableDataCell,
         },
     },
 }

--- a/frontend/src/scenes/web-analytics/SessionDebugger/sessionAttributionExplorerLogic.ts
+++ b/frontend/src/scenes/web-analytics/SessionDebugger/sessionAttributionExplorerLogic.ts
@@ -63,7 +63,7 @@ SELECT
         if(isNotNull($entry_gad_source), 'gad_source', NULL)
         -- add more here if we add more ad ids
     ], ','), '') as "context.columns.has_ad_id",
-    topK(3)($entry_current_url) as "context.columns.example_entry_urls"
+    topK(10)($entry_current_url) as "context.columns.example_entry_urls"
 FROM sessions
 WHERE {filters}
 GROUP BY

--- a/frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx
@@ -1,9 +1,36 @@
+import { IconEllipsis, IconSearch } from '@posthog/icons'
+import { PageHeader } from 'lib/components/PageHeader'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
 import { SceneExport } from 'scenes/sceneTypes'
+import { urls } from 'scenes/urls'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 import { WebAnalyticsDashboard } from 'scenes/web-analytics/WebDashboard'
 
 export function WebAnalyticsScene(): JSX.Element {
-    return <WebAnalyticsDashboard />
+    return (
+        <>
+            <PageHeader
+                buttons={
+                    <>
+                        <LemonMenu
+                            items={[
+                                {
+                                    label: 'Session Attribution Explorer',
+                                    to: urls.sessionAttributionExplorer(),
+                                    icon: <IconSearch />,
+                                },
+                            ]}
+                        >
+                            <LemonButton icon={<IconEllipsis />} size="small" />
+                        </LemonMenu>
+                    </>
+                }
+            />
+
+            <WebAnalyticsDashboard />
+        </>
+    )
 }
 
 export const scene: SceneExport = {


### PR DESCRIPTION
## Problem

* Session explorer was not particularly findable, so add a better link from the web analytics dashboard
* Make the example URLs collapsible, in preparation for allowing users to change what they group by

## Changes

This can be expanded now:
<img width="1773" alt="Screenshot 2024-07-08 at 16 15 14" src="https://github.com/PostHog/posthog/assets/2056078/be580e91-5d8f-4a5e-8f4f-ccfdb340ef8e">
<img width="1777" alt="Screenshot 2024-07-08 at 16 15 10" src="https://github.com/PostHog/posthog/assets/2056078/ca7c142f-2bdc-4726-bb19-feca56284511">

There's a link up here now:
<img width="1780" alt="Screenshot 2024-07-08 at 16 16 07" src="https://github.com/PostHog/posthog/assets/2056078/cbd2dbfd-ccfc-4ae7-b99a-77b716729ef2">


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Manual testing, took screenshots
