### PR TITLE
fix: update org project pay gate copy

### DIFF
--- a/frontend/src/lib/components/PayGateMini/PayGateMini.tsx
+++ b/frontend/src/lib/components/PayGateMini/PayGateMini.tsx
@@ -211,10 +211,12 @@ const renderUsageLimitMessage = (
                 </p>
                 {featureInfo.key === AvailableFeature.ORGANIZATIONS_PROJECTS && !isAddonProduct ? (
                     <>
-                        <p>
-                            Please enter your credit card details by subscribing to any product (eg. Product analytics
-                            or Session replay) to create up to <b>{featureInfoOnNextPlan?.limit} projects</b>.
-                        </p>
+                        {featureInfoOnNextPlan?.limit && (
+                            <p>
+                                Please enter your credit card details to create up to{' '}
+                                <b>{featureInfoOnNextPlan?.limit} projects</b>.
+                            </p>
+                        )}
                         <p className="italic text-xs text-muted mb-4">
                             Need unlimited projects? Check out the{' '}
                             <Link to="/organization/billing?products=platform_and_support" onClick={handleCtaClick}>

--- a/frontend/src/lib/components/PayGateMini/payGateMiniLogic.tsx
+++ b/frontend/src/lib/components/PayGateMini/payGateMiniLogic.tsx
@@ -86,10 +86,13 @@ export const payGateMiniLogic = kea<payGateMiniLogicType>([
         ],
         nextPlanWithFeature: [
             (s) => [s.productWithFeature],
-            (productWithFeature) =>
-                productWithFeature?.plans.find(
-                    (plan) => plan.features?.some((f) => f.key === props.featureKey) && !plan.current_plan
-                ),
+            (productWithFeature) => {
+                const currentPlanIndex = productWithFeature?.plans.findIndex((plan) => plan.current_plan)
+                if (!currentPlanIndex) {
+                    return null
+                }
+                return productWithFeature?.plans[currentPlanIndex + 1]
+            },
         ],
         featureInfoOnNextPlan: [
             (s) => [s.nextPlanWithFeature],


### PR DESCRIPTION
## Problem

We had a customer report about the org projects pay gate having incorrect copy and not allowing them to create a new project when they should be able to. 

There were two issues:
- the feature override was overridden teams add-on limit - looking into this
- the copy was 1. outdated with subscribe to all products and 2. wrong because the `featureInfoOnNextPlan` had a bug in it. The bug was `nextPlanWithFeature`, which looked for the first plan that isn't the current one. But if you're on the paid plan, then it returns the free plan. 

## Changes

1. Fixed `nextPlanWithFeature`
2. Removed copy around `subscribing to any product`