### PR TITLE
even even safer

### DIFF
--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1908,6 +1908,8 @@ class TestCapture(BaseTest):
                     "lib_version",
                     "unknown",
                 ),
+                # by default, we want to signal that the producer should compress
+                ("compression_in_capture", "False"),
             ]
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
@@ -1924,6 +1926,7 @@ class TestCapture(BaseTest):
                     "lib_version",
                     "1.123.4",
                 ),
+                ("compression_in_capture", "False"),
             ]
 
     @patch("posthog.kafka_client.client.SessionRecordingKafkaProducer")
@@ -1940,6 +1943,8 @@ class TestCapture(BaseTest):
             ],
             SESSION_RECORDING_KAFKA_SECURITY_PROTOCOL="SSL",
             SESSION_RECORDING_KAFKA_MAX_REQUEST_SIZE_BYTES=1234,
+            # will always compress in the producer
+            REPLAY_COMPRESS_IN_CAPTURE_SAMPLE_RATE=0,
         ):
             # avoid logs from being printed because the mock is None
             session_recording_producer_singleton_mock.return_value = KafkaProducer()
@@ -2005,7 +2010,8 @@ class TestCapture(BaseTest):
                 "another-server:9092",
                 "a-fourth.server:9092",
             ],
-            SESSION_RECORDING_KAFKA_COMPRESSION="gzip-in-capture",
+            # will always compress in capture
+            REPLAY_COMPRESS_IN_CAPTURE_SAMPLE_RATE=1,
         ):
             session_recording_producer_factory_mock.return_value = session_recording_kafka_producer()
 

--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -205,12 +205,12 @@ KafkaProducer = SingletonDecorator(_KafkaProducer)
 SessionRecordingKafkaProducer = SingletonDecorator(_KafkaProducer)
 
 
-def session_recording_kafka_producer() -> _KafkaProducer:
+def session_recording_kafka_producer(already_compressed: bool = True) -> _KafkaProducer:
     return SessionRecordingKafkaProducer(
         kafka_hosts=settings.SESSION_RECORDING_KAFKA_HOSTS,
         kafka_security_protocol=settings.SESSION_RECORDING_KAFKA_SECURITY_PROTOCOL,
         max_request_size=settings.SESSION_RECORDING_KAFKA_MAX_REQUEST_SIZE_BYTES,
-        compression_type="gzip",
+        compression_type="gzip" if not already_compressed else None,
     )
 
 

--- a/posthog/settings/session_replay.py
+++ b/posthog/settings/session_replay.py
@@ -32,12 +32,8 @@ REPLAY_MESSAGE_TOO_LARGE_SAMPLE_BUCKET = get_from_env(
     "REPLAY_MESSAGE_TOO_LARGE_SAMPLE_BUCKET", "posthog-cloud-prod-us-east-1-k8s-replay-samples"
 )
 
-# NB if you want to set a compression you need to install it... the producer compresses not kafka
-# accepts
-# * None - no compression
-# * gzip - gzip compression by the kafka producer (auto decompressed by the consumer in blobby)
-# * gzip-in-capture - gzip in compression in the capture service (manually decompressed by the consumer in blobby)
-#
-# gzip is the current default in production
-# TODO we can clean this up once we've tested the new gzip-in-capture compression and don't need a setting
-SESSION_RECORDING_KAFKA_COMPRESSION = get_from_env("SESSION_RECORDING_KAFKA_COMPRESSION", "gzip")
+# we want to compress messages before passing them to the kafka producer
+# because it checks message size limits before compressing
+# messages should always be compressed so if the message is not "manually" compressed in capture
+# then the producer should compress it
+REPLAY_COMPRESS_IN_CAPTURE_SAMPLE_RATE = get_from_env("REPLAY_COMPRESS_IN_CAPTURE_SAMPLE_RATE", 0, type_cast=float)


### PR DESCRIPTION
ok, last attempt did not pan out because of a logic error we turned off all compression instead of only using new compression on team 2

that was not fun

"new compression" == "manually" compressing each message instead of letting the kafka producer decide when to compress

this instead locks new compression to our team and to a sample rate - so even for our team only a percentage of traffic uses new compression

when choosing new compression we add a header to the message 
if the header is present then we don't compress in the kafka producer
otherwise we do compress

----

i'm still not convinced though, it might be nicer to peak the message and check if it's compressed 🤔 