### PR TITLE
fix: blobby internal kafka queueing

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -182,8 +182,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_WATCHER_MIN_OBSERVATIONS: 3,
         CDP_WATCHER_OVERFLOW_RATING_THRESHOLD: 0.8,
         CDP_WATCHER_DISABLED_RATING_THRESHOLD: 0.5,
-
-        SESSION_RECORDING_KAFKA_CONSUMPTION_STATS_INTERVAL_MS: undefined,
     }
 }
 

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -182,6 +182,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_WATCHER_MIN_OBSERVATIONS: 3,
         CDP_WATCHER_OVERFLOW_RATING_THRESHOLD: 0.8,
         CDP_WATCHER_DISABLED_RATING_THRESHOLD: 0.5,
+
+        SESSION_RECORDING_KAFKA_CONSUMPTION_STATS_INTERVAL_MS: undefined,
     }
 }
 

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -148,6 +148,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_KAFKA_SECURITY_PROTOCOL: undefined,
         SESSION_RECORDING_KAFKA_BATCH_SIZE: 500,
         SESSION_RECORDING_KAFKA_QUEUE_SIZE: 1500,
+        // if not set we'll use the plugin server default value
+        SESSION_RECORDING_KAFKA_QUEUE_SIZE_KB: undefined,
 
         SESSION_RECORDING_LOCAL_DIRECTORY: '.tmp/sessions',
         // NOTE: 10 minutes

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -72,7 +72,6 @@ export const startBatchConsumer = async ({
     callEachBatchWhenEmpty = false,
     debug,
     queuedMaxMessagesKBytes = 102400,
-    statsIntervalMs,
 }: {
     connectionConfig: GlobalConfig
     groupId: string
@@ -92,7 +91,6 @@ export const startBatchConsumer = async ({
     callEachBatchWhenEmpty?: boolean
     debug?: string
     queuedMaxMessagesKBytes?: number
-    statsIntervalMs?: number
 }): Promise<BatchConsumer> => {
     // Starts consuming from `topic` in batches of `fetchBatchSize` messages,
     // with consumer group id `groupId`. We use `connectionConfig` to connect
@@ -161,7 +159,6 @@ export const startBatchConsumer = async ({
         'partition.assignment.strategy': 'cooperative-sticky',
         rebalance_cb: true,
         offset_commit_cb: true,
-        'statistics.interval.ms': statsIntervalMs,
     }
 
     if (debug) {

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -72,6 +72,7 @@ export const startBatchConsumer = async ({
     callEachBatchWhenEmpty = false,
     debug,
     queuedMaxMessagesKBytes = 102400,
+    statsIntervalMs,
 }: {
     connectionConfig: GlobalConfig
     groupId: string
@@ -91,6 +92,7 @@ export const startBatchConsumer = async ({
     callEachBatchWhenEmpty?: boolean
     debug?: string
     queuedMaxMessagesKBytes?: number
+    statsIntervalMs?: number
 }): Promise<BatchConsumer> => {
     // Starts consuming from `topic` in batches of `fetchBatchSize` messages,
     // with consumer group id `groupId`. We use `connectionConfig` to connect
@@ -159,6 +161,7 @@ export const startBatchConsumer = async ({
         'partition.assignment.strategy': 'cooperative-sticky',
         rebalance_cb: true,
         offset_commit_cb: true,
+        'statistics.interval.ms': statsIntervalMs,
     }
 
     if (debug) {

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -71,6 +71,7 @@ export const startBatchConsumer = async ({
     queuedMinMessages = 100000,
     callEachBatchWhenEmpty = false,
     debug,
+    queuedMaxMessagesKBytes = 102400,
 }: {
     connectionConfig: GlobalConfig
     groupId: string
@@ -89,6 +90,7 @@ export const startBatchConsumer = async ({
     queuedMinMessages?: number
     callEachBatchWhenEmpty?: boolean
     debug?: string
+    queuedMaxMessagesKBytes?: number
 }): Promise<BatchConsumer> => {
     // Starts consuming from `topic` in batches of `fetchBatchSize` messages,
     // with consumer group id `groupId`. We use `connectionConfig` to connect
@@ -138,7 +140,7 @@ export const startBatchConsumer = async ({
         // https://github.com/confluentinc/librdkafka/blob/e75de5be191b6b8e9602efc969f4af64071550de/CONFIGURATION.md?plain=1#L118
         // Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue
         'queued.min.messages': queuedMinMessages, // 100000 is the default
-        'queued.max.messages.kbytes': 102400, // 1048576 is the default, we go smaller to reduce mem usage.
+        'queued.max.messages.kbytes': queuedMaxMessagesKBytes, // 1048576 is the default, we go smaller to reduce mem usage.
         // Use cooperative-sticky rebalancing strategy, which is the
         // [default](https://kafka.apache.org/documentation/#consumerconfigs_partition.assignment.strategy)
         // in the Java Kafka Client. There its actually

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -333,6 +333,8 @@ export class SessionRecordingIngester {
     }
 
     public async handleEachBatch(messages: Message[], heartbeat: () => void): Promise<void> {
+        heartbeat()
+
         if (messages.length !== 0) {
             status.info('🔁', `blob_ingester_consumer - handling batch`, {
                 size: messages.length,
@@ -509,7 +511,6 @@ export class SessionRecordingIngester {
             },
             callEachBatchWhenEmpty: true, // Useful as we will still want to account for flushing sessions
             debug: this.config.SESSION_RECORDING_KAFKA_DEBUG,
-            statsIntervalMs: this.config.SESSION_RECORDING_KAFKA_CONSUMPTION_STATS_INTERVAL_MS,
         })
 
         this.batchConsumer.consumer.on('event.stats', (stats) => {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -509,7 +509,7 @@ export class SessionRecordingIngester {
             },
             callEachBatchWhenEmpty: true, // Useful as we will still want to account for flushing sessions
             debug: this.config.SESSION_RECORDING_KAFKA_DEBUG,
-            statsIntervalMs: this.config.KAFKA_CONSUMPTION_STATS_INTERVAL_MS,
+            statsIntervalMs: this.config.SESSION_RECORDING_KAFKA_CONSUMPTION_STATS_INTERVAL_MS,
         })
 
         this.batchConsumer.consumer.on('event.stats', (stats) => {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -492,11 +492,16 @@ export class SessionRecordingIngester {
             // we only use 9 or 10MB but there's no reason to limit this 🤷️
             consumerMaxBytes: this.config.KAFKA_CONSUMPTION_MAX_BYTES,
             consumerMaxBytesPerPartition: this.config.KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION,
-            // our messages are very big, so we don't want to buffer too many
+            // our messages are very big, so we don't want to queue too many
             queuedMinMessages: this.config.SESSION_RECORDING_KAFKA_QUEUE_SIZE,
+            // we'll anyway never queue more than the value set here
+            // since we have large messages we'll need this to be a reasonable multiple
+            // of the likely message size times the fetchBatchSize
+            // or we'll always hit the batch timeout
+            queuedMaxMessagesKBytes: this.config.SESSION_RECORDING_KAFKA_QUEUE_SIZE_KB,
+            fetchBatchSize: this.config.SESSION_RECORDING_KAFKA_BATCH_SIZE,
             consumerMaxWaitMs: this.config.KAFKA_CONSUMPTION_MAX_WAIT_MS,
             consumerErrorBackoffMs: this.config.KAFKA_CONSUMPTION_ERROR_BACKOFF_MS,
-            fetchBatchSize: this.config.SESSION_RECORDING_KAFKA_BATCH_SIZE,
             batchingTimeoutMs: this.config.KAFKA_CONSUMPTION_BATCHING_TIMEOUT_MS,
             topicCreationTimeoutMs: this.config.KAFKA_TOPIC_CREATION_TIMEOUT_MS,
             eachBatch: async (messages, { heartbeat }) => {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -509,8 +509,13 @@ export class SessionRecordingIngester {
             },
             callEachBatchWhenEmpty: true, // Useful as we will still want to account for flushing sessions
             debug: this.config.SESSION_RECORDING_KAFKA_DEBUG,
+            statsIntervalMs: this.config.KAFKA_CONSUMPTION_STATS_INTERVAL_MS,
         })
 
+        this.batchConsumer.consumer.on('event.stats', (stats) => {
+            const statsJson = JSON.parse(stats.message) // Example field, actual field may differ
+            status.info('🪵', 'consumer stats', statsJson)
+        })
         this.totalNumPartitions = (await getPartitionsForTopic(this.connectedBatchConsumer, this.topic)).length
 
         addSentryBreadcrumbsEventListeners(this.batchConsumer.consumer)

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -513,10 +513,6 @@ export class SessionRecordingIngester {
             debug: this.config.SESSION_RECORDING_KAFKA_DEBUG,
         })
 
-        this.batchConsumer.consumer.on('event.stats', (stats) => {
-            const statsJson = JSON.parse(stats.message) // Example field, actual field may differ
-            status.info('🪵', 'consumer stats', statsJson)
-        })
         this.totalNumPartitions = (await getPartitionsForTopic(this.connectedBatchConsumer, this.topic)).length
 
         addSentryBreadcrumbsEventListeners(this.batchConsumer.consumer)

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -266,9 +266,6 @@ export interface PluginsServerConfig extends CdpConfig {
 
     POSTHOG_SESSION_RECORDING_REDIS_HOST: string | undefined
     POSTHOG_SESSION_RECORDING_REDIS_PORT: number | undefined
-
-    // can be set to emit kafka statistics, a callback needs to be set to handle the stats
-    SESSION_RECORDING_KAFKA_CONSUMPTION_STATS_INTERVAL_MS: number | undefined
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -260,6 +260,7 @@ export interface PluginsServerConfig extends CdpConfig {
     SESSION_RECORDING_KAFKA_SECURITY_PROTOCOL: KafkaSecurityProtocol | undefined
     SESSION_RECORDING_KAFKA_BATCH_SIZE: number
     SESSION_RECORDING_KAFKA_QUEUE_SIZE: number
+    SESSION_RECORDING_KAFKA_QUEUE_SIZE_KB: number | undefined
     SESSION_RECORDING_KAFKA_DEBUG: string | undefined
     SESSION_RECORDING_MAX_PARALLEL_FLUSHES: number
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -266,6 +266,9 @@ export interface PluginsServerConfig extends CdpConfig {
 
     POSTHOG_SESSION_RECORDING_REDIS_HOST: string | undefined
     POSTHOG_SESSION_RECORDING_REDIS_PORT: number | undefined
+
+    // can be set to emit kafka statistics, a callback needs to be set to handle the stats
+    SESSION_RECORDING_KAFKA_CONSUMPTION_STATS_INTERVAL_MS: number | undefined
 }
 
 export interface Hub extends PluginsServerConfig {

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -684,7 +684,7 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
                 await ingester.handleEachBatch(partitionMsgs1, heartbeat)
 
                 // NOTE: the number here can change as we change the code. Important is that it is called a number of times
-                expect(heartbeat).toBeCalledTimes(7)
+                expect(heartbeat).toBeCalledTimes(8)
             })
         })
     })


### PR DESCRIPTION
i'd like to experiment with this value.

why? 

good question

blobby messages can be up to 10MB
they are frequently very large regardless

kafka consumer will try to fetch into an internal queue up to the provided queue size (for us ~1600 depending on incident/mood) and limited by max queue kb

max queue kb in plugin server is always 102,400 kilobytes (down from a (commented) default of 1,048,576)

we then try to read a batch of messages from the queue, blobby tries to read 400 at the moment
and waits for the batch timeout of 30 seconds

---

so i believe we're telling blobby to queue 1600 messages but only up to 100MB
it might only be able to queue 10 messages within a 100MB limit
we then say "go get 400 messages (or as many as you can get in 30 seconds)
it sits for 30 seconds 
and then processes the ten it managed to load

----

it's hard to see if this is true because in amongst the very large messages will be very small ones.

so we can load 400 at a time _sometimes_

---

at the moment we're struggling to recover from an incident and I'd like to be able to play
