### PR TITLE
perf: Extend timeout for cohort calculation query

### DIFF
--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -324,7 +324,10 @@ def recalculate_cohortpeople(
             "team_id": cohort.team_id,
             "new_version": pending_version,
         },
-        settings={"optimize_on_insert": 0},
+        settings={
+            "max_execution_time": 240,
+            "optimize_on_insert": 0,
+        },
         workload=Workload.OFFLINE,
     )
 


### PR DESCRIPTION
## Problem

These queries can get quite slow, and we're seeing the occasional timeout exceeded (159) and estimated timeout exceeded (160) error for them. These are on the offline cluster so we can give them a longer leash to take a bit more time.

Speeding these up is possible but likely not really practical until the queries are migrated to HogQL. This should help keep things moving along until that happens.

## Changes

Doubles the existing timeout to 240, [which is likely enough to address many/most of the issues based on the logged execution time estimates](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjo0MiwibmF0aXZlIjp7InRlbXBsYXRlLXRhZ3MiOnsic25pcHBldDogUXVlcnkgUGVyZm9ybWFuY2UgLSBFeHRyYWN0IENvbW1vbiBMb2cgQ29tbWVudCBEYXRhIjp7InR5cGUiOiJzbmlwcGV0IiwibmFtZSI6InNuaXBwZXQ6IFF1ZXJ5IFBlcmZvcm1hbmNlIC0gRXh0cmFjdCBDb21tb24gTG9nIENvbW1lbnQgRGF0YSIsImlkIjoiMTA4NWQxMmQtZjNlOS00ODIzLTkwNTMtNGJjZjIzYzJhYjM5Iiwic25pcHBldC1uYW1lIjoiUXVlcnkgUGVyZm9ybWFuY2UgLSBFeHRyYWN0IENvbW1vbiBMb2cgQ29tbWVudCBEYXRhIiwiZGlzcGxheS1uYW1lIjoiU25pcHBldDogUXVlcnkgUGVyZm9ybWFuY2UgRXh0cmFjdCBDb21tb24gTG9nIENvbW1lbnQgRGF0YSIsInNuaXBwZXQtaWQiOjd9LCJzbmlwcGV0OiBRdWVyeSBQZXJmb3JtYW5jZTogUXVlcnkgVHlwZSI6eyJ0eXBlIjoic25pcHBldCIsIm5hbWUiOiJzbmlwcGV0OiBRdWVyeSBQZXJmb3JtYW5jZTogUXVlcnkgVHlwZSIsImlkIjoiMDBkN2FjMDAtYjRkYS00NDU3LTk1NjQtOWIzOTJjNjVkODU5Iiwic25pcHBldC1uYW1lIjoiUXVlcnkgUGVyZm9ybWFuY2U6IFF1ZXJ5IFR5cGUiLCJkaXNwbGF5LW5hbWUiOiJTbmlwcGV0OiBRdWVyeSBQZXJmb3JtYW5jZTogUXVlcnkgVHlwZSIsInNuaXBwZXQtaWQiOjR9LCJzbmlwcGV0OiBRdWVyeSBQZXJmb3JtYW5jZTogSGlnaCBQcmlvcml0eSBUZWFtIElEcyI6eyJ0eXBlIjoic25pcHBldCIsIm5hbWUiOiJzbmlwcGV0OiBRdWVyeSBQZXJmb3JtYW5jZTogSGlnaCBQcmlvcml0eSBUZWFtIElEcyIsImlkIjoiZDJiMGU2ZDYtODg0Zi00YjRlLTg3NTEtZmNkYTg5ZjBmNGNlIiwic25pcHBldC1uYW1lIjoiUXVlcnkgUGVyZm9ybWFuY2U6IEhpZ2ggUHJpb3JpdHkgVGVhbSBJRHMiLCJkaXNwbGF5LW5hbWUiOiJTbmlwcGV0OiBRdWVyeSBQZXJmb3JtYW5jZTogSGlnaCBQcmlvcml0eSBUZWFtIElEcyIsInNuaXBwZXQtaWQiOjF9fSwicXVlcnkiOiJ3aXRoIHt7c25pcHBldDogUXVlcnkgUGVyZm9ybWFuY2UgLSBFeHRyYWN0IENvbW1vbiBMb2cgQ29tbWVudCBEYXRhfX0gYXMgbGNcbmZyb20gY2x1c3RlckFsbFJlcGxpY2FzKHBvc3Rob2csIHN5c3RlbSwgcXVlcnlfbG9nKVxuc2VsZWN0XG4gICAgdG9GbG9hdDMyT3JOdWxsKHJlZ2V4cEV4dHJhY3QoZXhjZXB0aW9uLCAnRXN0aW1hdGVkIHF1ZXJ5IGV4ZWN1dGlvbiB0aW1lIFxcKChbXFxkLl0rKSBzZWNvbmRzXFwpJywgMSkpIGFzIGVzdGltYXRlZF9leGVjdXRpb25fdGltZSxcbiAgICBsYy4ndGVhbV9pZCcgYXMgdGVhbV9pZCxcbiAgICB0ZWFtX2lkIGluIHt7c25pcHBldDogUXVlcnkgUGVyZm9ybWFuY2U6IEhpZ2ggUHJpb3JpdHkgVGVhbSBJRHN9fSBhcyBpc19oaWdoX3ByaW9yaXR5LFxuICAgICpcbndoZXJlICAgIFxuICAgIGV2ZW50X3RpbWUgYmV0d2VlbiBub3coKSAtIGludGVydmFsICc3MiBob3VycycgYW5kIG5vdygpXG4gICAgYW5kIGlzX2luaXRpYWxfcXVlcnlcbiAgICBhbmQgZXhjZXB0aW9uX2NvZGUgaW4gKDE1OSwgMTYwKVxuICAgIGFuZCB7e3NuaXBwZXQ6IFF1ZXJ5IFBlcmZvcm1hbmNlOiBRdWVyeSBUeXBlfX0gPSAncG9zdGhvZy50YXNrcy5jYWxjdWxhdGVfY29ob3J0LmNhbGN1bGF0ZV9jb2hvcnRfY2gnXG5vcmRlciBieSBxdWVyeV9zdGFydF90aW1lIn0sInR5cGUiOiJuYXRpdmUifSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnsidGFibGUuY29sdW1uX2Zvcm1hdHRpbmciOlt7ImNvbHVtbnMiOlsiZXN0aW1hdGVkX2V4ZWN1dGlvbl90aW1lIl0sInR5cGUiOiJzaW5nbGUiLCJvcGVyYXRvciI6Ij4iLCJ2YWx1ZSI6MjQwLCJjb2xvciI6IiNFRjhDOEMiLCJoaWdobGlnaHRfcm93Ijp0cnVlLCJpZCI6MH1dfX0=).[^1]

## Does this work well for both Cloud and self-hosted?

Yep, it should.

## How did you test this code?

n/a

[^1]:  Note: strangely, some of the queries that are logged as extreme outliers in the previous link with large hundreds to thousands of seconds execution estimates aren't what we'd expect to be the expensive query ([the one updated here](https://github.com/PostHog/posthog/blob/f41e6b899f008c50f5606619a735042ca7106852/posthog/models/cohort/util.py#L318-L332)) but actually the `get_cohort_size` call executed [before](https://github.com/PostHog/posthog/blob/f41e6b899f008c50f5606619a735042ca7106852/posthog/models/cohort/util.py#L302) or [after](https://github.com/PostHog/posthog/blob/f41e6b899f008c50f5606619a735042ca7106852/posthog/models/cohort/util.py#L334) the bulk of the task has been completed. I suspect these are just bad estimates (similar queries run for me just fine) but that might be worth looking into separately.