### PR TITLE
fix: heartbeat less

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -387,11 +387,10 @@ export class SessionRecordingIngester {
                     statsKey: `recordingingester.handleEachBatch.consumeBatch`,
                     func: async () => {
                         if (this.config.SESSION_RECORDING_PARALLEL_CONSUMPTION) {
-                            await Promise.all(recordingMessages.map((x) => this.consume(x).then(heartbeat)))
+                            await Promise.all(recordingMessages.map((x) => this.consume(x)))
                         } else {
                             for (const message of recordingMessages) {
                                 await this.consume(message)
-                                heartbeat()
                             }
                         }
                     },

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -684,7 +684,7 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
                 await ingester.handleEachBatch(partitionMsgs1, heartbeat)
 
                 // NOTE: the number here can change as we change the code. Important is that it is called a number of times
-                expect(heartbeat).toBeCalledTimes(8)
+                expect(heartbeat).toBeCalledTimes(6)
             })
         })
     })


### PR DESCRIPTION
we have long timeouts on inactivity
but blobby heartbeats on every message
when scaled up
and under load 
this is a lot of heartbeating 
and the only thing it achieves is load on the broker