### PR TITLE
fix(vscode): remove celery beat from compound launcher

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -165,14 +165,7 @@
     "compounds": [
         {
             "name": "PostHog",
-            "configurations": [
-                "Backend",
-                "Celery Threaded Pool",
-                "Celery Redbeat Scheduler",
-                "Frontend",
-                "Plugin Server",
-                "Temporal Worker"
-            ],
+            "configurations": ["Backend", "Celery Threaded Pool", "Frontend", "Plugin Server", "Temporal Worker"],
             "stopAll": true,
             "presentation": {
                 "order": 1,
@@ -184,7 +177,6 @@
             "configurations": [
                 "Backend (with local billing)",
                 "Celery Threaded Pool",
-                "Celery Redbeat Scheduler",
                 "Frontend",
                 "Plugin Server",
                 "Temporal Worker"


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/23402 removed the "Celery Redbeat Scheduler" launch configuration, but didn't remove it from the compound launchers (breaking them).

## Changes

This PR removes them.

Note: We had been using the integrated beat before, but this was causing race conditions with async queries. I don't see them right now, so let's keep it as is for now (better to have less things running; just for context).

## How did you test this code?

Launched the compound