### PR TITLE
fix(eslint): lint cypress files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -293,7 +293,7 @@ module.exports = {
     },
     overrides: [
         {
-            files: ['**/test/**/*', '**/*.test.*', '**/*.cy.ts'],
+            files: ['**/test/**/*', '**/*.test.*'],
             env: {
                 ...env,
                 node: true,
@@ -317,7 +317,25 @@ module.exports = {
                 // but it's helpful sometimes
                 'jest/no-export': 'off',
                 // also helpful sometimes, but not always
-                'jest/no-conditional-expect': 'warn'
+                'jest/no-conditional-expect': 'warn',
+            },
+        },
+        {
+            files: ['**/*.cy.ts'],
+            env: {
+                ...env,
+                node: true,
+                'jest/globals': true,
+            },
+            "plugins": ["jest"],
+            "extends": ["plugin:jest/recommended"],
+            globals: {
+                ...globals,
+                given: 'readonly',
+            },
+            rules: {
+                // don't complain about unknown expect statements
+                'jest/valid-expect': 'off'
             },
         },
         {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -335,7 +335,9 @@ module.exports = {
             },
             rules: {
                 // don't complain about unknown expect statements
-                'jest/valid-expect': 'off'
+                'jest/valid-expect': 'off',
+                // don't warn about missing expect
+                'jest/expect-expect': 'off'
             },
         },
         {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ const globals = {
 }
 
 module.exports = {
-    ignorePatterns: ['node_modules', 'plugin-server', 'cypress'],
+    ignorePatterns: ['node_modules', 'plugin-server'],
     env,
     settings: {
         react: {
@@ -293,7 +293,7 @@ module.exports = {
     },
     overrides: [
         {
-            files: ['**/test/**/*', '**/*.test.*'],
+            files: ['**/test/**/*', '**/*.test.*', '**/*.cy.ts'],
             env: {
                 ...env,
                 node: true,

--- a/cypress/e2e/alerts.cy.ts
+++ b/cypress/e2e/alerts.cy.ts
@@ -1,5 +1,5 @@
-import { createInsight, insight, savedInsights } from '../productAnalytics'
 import { decideResponse } from '../fixtures/api/decide'
+import { createInsight } from '../productAnalytics'
 
 describe('Alerts', () => {
     it('Should allow create and delete an alert', () => {

--- a/cypress/e2e/billingUpgradeCTA.cy.ts
+++ b/cypress/e2e/billingUpgradeCTA.cy.ts
@@ -1,6 +1,3 @@
-import { decideResponse } from '../fixtures/api/decide'
-import * as fflate from 'fflate'
-
 // Mainly testing to make sure events are fired as expected
 
 describe('Billing Upgrade CTA', () => {

--- a/cypress/e2e/dashboard-deletion.ts
+++ b/cypress/e2e/dashboard-deletion.ts
@@ -1,6 +1,7 @@
 import { urls } from 'scenes/urls'
-import { randomString } from '../support/random'
+
 import { dashboard, dashboards, insight, savedInsights } from '../productAnalytics'
+import { randomString } from '../support/random'
 
 describe('deleting dashboards', () => {
     it('can delete dashboard without deleting the insights', () => {

--- a/cypress/e2e/dashboard-duplication.ts
+++ b/cypress/e2e/dashboard-duplication.ts
@@ -1,6 +1,7 @@
-import { randomString } from '../support/random'
 import { urls } from 'scenes/urls'
+
 import { dashboard, dashboards, duplicateDashboardFromMenu, savedInsights } from '../productAnalytics'
+import { randomString } from '../support/random'
 
 describe('duplicating dashboards', () => {
     let dashboardName, insightName, expectedCopiedDashboardName, expectedCopiedInsightName

--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -1,6 +1,5 @@
+import { dashboard, dashboards, insight } from '../productAnalytics'
 import { randomString } from '../support/random'
-import { insight, dashboards, dashboard } from '../productAnalytics'
-import { urls } from 'scenes/urls'
 
 describe('Dashboard', () => {
     beforeEach(() => {

--- a/cypress/e2e/events.cy.ts
+++ b/cypress/e2e/events.cy.ts
@@ -1,5 +1,3 @@
-import { dayjs } from 'lib/dayjs'
-
 const interceptPropertyDefinitions = (): void => {
     cy.intercept('/api/event/values/?key=%24browser').as('getBrowserValues')
 

--- a/cypress/e2e/experiments.cy.ts
+++ b/cypress/e2e/experiments.cy.ts
@@ -67,7 +67,7 @@ describe('Experiments', () => {
         cy.get('[data-attr="save-experiment"]').first().click()
     })
 
-    const createExperimentInNewUi = () => {
+    const createExperimentInNewUi = (): void => {
         cy.intercept('**/decide/*', (req) =>
             req.reply(
                 decideResponse({

--- a/cypress/e2e/insights-duplication.cy.ts
+++ b/cypress/e2e/insights-duplication.cy.ts
@@ -1,6 +1,7 @@
 import { urls } from 'scenes/urls'
+
+import { createInsight, savedInsights } from '../productAnalytics'
 import { randomString } from '../support/random'
-import { savedInsights, createInsight } from '../productAnalytics'
 
 // For tests related to trends please check trendsElements.js
 describe('Insights', () => {

--- a/cypress/e2e/insights-navigation-open-directly.cy.ts
+++ b/cypress/e2e/insights-navigation-open-directly.cy.ts
@@ -1,4 +1,5 @@
 import { urls } from 'scenes/urls'
+
 import { insight } from '../productAnalytics'
 
 const hogQLQuery = `select event,

--- a/cypress/e2e/insights-navigation-open-sql-insight-first.cy.ts
+++ b/cypress/e2e/insights-navigation-open-sql-insight-first.cy.ts
@@ -1,4 +1,5 @@
 import { urls } from 'scenes/urls'
+
 import { insight } from '../productAnalytics'
 
 const hogQLQuery = `select event,

--- a/cypress/e2e/insights-navigation.cy.ts
+++ b/cypress/e2e/insights-navigation.cy.ts
@@ -1,6 +1,7 @@
 import { urls } from 'scenes/urls'
-import { randomString } from '../support/random'
+
 import { insight } from '../productAnalytics'
+import { randomString } from '../support/random'
 
 const hogQLQuery = `select event,
           count()

--- a/cypress/e2e/insights-unsaved-confirmation.cy.ts
+++ b/cypress/e2e/insights-unsaved-confirmation.cy.ts
@@ -1,5 +1,5 @@
-import { randomString } from '../support/random'
 import { insight } from '../productAnalytics'
+import { randomString } from '../support/random'
 
 // For tests related to trends please check trendsElements.js
 describe('Insights', () => {

--- a/cypress/e2e/insights.cy.ts
+++ b/cypress/e2e/insights.cy.ts
@@ -1,4 +1,5 @@
 import { urls } from 'scenes/urls'
+
 import { createInsight, insight, savedInsights } from '../productAnalytics'
 import { randomString } from '../support/random'
 

--- a/cypress/e2e/signup.cy.ts
+++ b/cypress/e2e/signup.cy.ts
@@ -95,7 +95,7 @@ describe('Signup', () => {
         cy.get('[data-attr=signup-name]').type('Alice Bob').should('have.value', 'Alice Bob')
         cy.get('[data-attr=signup-submit]').click()
 
-        cy.wait('@signupRequest').then((interception) => {
+        cy.wait('@signupRequest').then(() => {
             cy.get('.LemonBanner').should('contain', 'There is already an account with this email address.')
         })
 

--- a/cypress/e2e/surveys.cy.ts
+++ b/cypress/e2e/surveys.cy.ts
@@ -21,7 +21,7 @@ describe('Surveys', () => {
 
         // save
         //get 2nd element matching the selector
-        cy.get('[data-attr="save-survey"]').eq(1).click()
+        cy.get('[data-attr="save-survey"]').eq(0).click()
         cy.get('[data-attr=success-toast]').contains('created').should('exist')
 
         // back to surveys
@@ -104,7 +104,7 @@ describe('Surveys', () => {
         cy.get('[data-attr=success-toast]').contains('created').should('exist')
 
         // check preview release conditions
-        cy.contains('Release conditions summary').should('exist')
+        cy.contains('Display conditions summary').should('exist')
         cy.get('.FeatureConditionCard').should('exist').should('contain.text', 'is_demo equals true')
         cy.get('.FeatureConditionCard').should('contain.text', 'Rolled out to 100% of users in this set.')
 
@@ -135,11 +135,11 @@ describe('Surveys', () => {
         cy.contains('Remove all user properties').click()
 
         // save
-        cy.get('[data-attr="save-survey"]').eq(1).click()
+        cy.get('[data-attr="save-survey"]').eq(0).click()
 
         // check preview release conditions
         cy.get('.LemonTabs').contains('Overview').click()
-        cy.contains('Release conditions summary').should('exist')
+        cy.contains('Display conditions summary').should('exist')
         cy.get('.FeatureConditionCard').should('not.exist')
 
         // delete survey
@@ -201,7 +201,7 @@ describe('Surveys', () => {
         cy.get('button[data-attr="launch-survey"]').should('have.text', 'Launch')
 
         // check if targetting criteria is copied
-        cy.contains('Release conditions summary').should('exist')
+        cy.contains('Display conditions summary').should('exist')
         cy.get('.FeatureConditionCard').should('exist').should('contain.text', 'is_demo equals true')
         cy.get('.FeatureConditionCard').should('contain.text', 'Rolled out to 100% of users in this set.')
 

--- a/cypress/e2e/surveys.cy.ts
+++ b/cypress/e2e/surveys.cy.ts
@@ -227,7 +227,7 @@ describe('Surveys', () => {
             .should('exist')
     })
 
-    it.only('can set responses limit', () => {
+    it('can set responses limit', () => {
         cy.get('h1').should('contain', 'Surveys')
         cy.get('[data-attr=new-survey]').click()
         cy.get('[data-attr=new-blank-survey]').click()

--- a/cypress/e2e/systemStatus.cy.ts
+++ b/cypress/e2e/systemStatus.cy.ts
@@ -1,5 +1,3 @@
-import { urls } from 'scenes/urls'
-
 describe('System Status', () => {
     it('System Status loaded', () => {
         cy.location('pathname').should('eq', '/project/1/insights')

--- a/cypress/productAnalytics/index.ts
+++ b/cypress/productAnalytics/index.ts
@@ -169,7 +169,7 @@ export const dashboard = {
         cy.get('[data-attr=insight-save-button]').contains('Save & add to dashboard').click()
         cy.wait('@postInsight')
     },
-    addPropertyFilter(type: string = 'Browser', value: string = 'Chrome'): void {
+    addPropertyFilter(type: string, value: string = 'Chrome'): void {
         cy.get('.PropertyFilterButton').should('have.length', 0)
         cy.get('[data-attr="property-filter-0"]').click()
         cy.get('[data-attr="taxonomic-filter-searchfield"]').click().type('Browser').wait(1000)

--- a/cypress/support/accessibility.ts
+++ b/cypress/support/accessibility.ts
@@ -1,9 +1,7 @@
 import { Options } from 'cypress-axe'
 
 export const reportA11y = (options: Options, tag: string, skipFailures = true): void => {
-    if (typeof tag !== undefined) {
-        tag += '-'
-    }
+    tag += '-'
 
     // reports on A11y failures without failing the tests
     cy.checkA11y(

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,8 +1,10 @@
 import 'givens/setup'
 import './commands'
 import 'cypress-axe'
-import { decideResponse } from '../fixtures/api/decide'
+
 import { urls } from 'scenes/urls'
+
+import { decideResponse } from '../fixtures/api/decide'
 
 try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "prettier": "prettier --write \"./**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}\"",
         "prettier:check": "prettier --check \"frontend/**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}\"",
         "typescript:check": "tsc --noEmit && echo \"No errors reported by tsc.\"",
-        "lint:js": "eslint frontend/src",
+        "lint:js": "eslint frontend/src cypress",
         "lint:css": "stylelint \"frontend/**/*.{css,scss}\"",
         "format:backend": "ruff .",
         "format:frontend": "pnpm lint:js --fix && pnpm lint:css --fix && pnpm prettier",


### PR DESCRIPTION
## Changes
Context: https://posthog.slack.com/archives/C0113360FFV/p1720447504686709

We want to include cypress files in the pre-commit check to enforce this rule: https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-focused-tests.md

The `cypress` folder was previously part of `ignorePatterns`, not sure why, I guess @thmsobrmlr knows?