### PR TITLE
fix: Try to set transaction to read-write 

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -167,6 +167,8 @@ class PostgreSQLClient:
 
         async with self.connection.transaction():
             async with self.connection.cursor() as cursor:
+                await cursor.execute("SET TRANSACTION READ WRITE")
+
                 await cursor.execute(
                     sql.SQL(base_query).format(
                         pkey=primary_key_clause if primary_key else sql.SQL(""),
@@ -201,6 +203,8 @@ class PostgreSQLClient:
 
         async with self.connection.transaction():
             async with self.connection.cursor() as cursor:
+                await cursor.execute("SET TRANSACTION READ WRITE")
+
                 await cursor.execute(sql.SQL(base_query).format(table=table_identifier))
 
     @contextlib.asynccontextmanager
@@ -305,6 +309,8 @@ class PostgreSQLClient:
             async with self.connection.cursor() as cursor:
                 if schema:
                     await cursor.execute(sql.SQL("SET search_path TO {schema}").format(schema=sql.Identifier(schema)))
+                await cursor.execute("SET TRANSACTION READ WRITE")
+
                 await cursor.execute(merge_query)
 
     async def copy_tsv_to_postgres(
@@ -328,6 +334,8 @@ class PostgreSQLClient:
             async with self.connection.cursor() as cursor:
                 if schema:
                     await cursor.execute(sql.SQL("SET search_path TO {schema}").format(schema=sql.Identifier(schema)))
+
+                await cursor.execute("SET TRANSACTION READ WRITE")
 
                 async with cursor.copy(
                     # TODO: Switch to binary encoding as CSV has a million edge cases.


### PR DESCRIPTION
## Problem

By default, transactions may be set to read-only by postgresql admins.
However, batch exports does require write on several operations. Let's
try to use the `SET TRANSACTION` command to set the mode to `READ WRITE`
in those scenarios.

This way, postgresql admins may keep their defaults, and we can still
run batch exports.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
