### PR TITLE
fix: use legacy filters when matching events

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -13,7 +13,10 @@ import {
     performanceEventDataLogic,
 } from 'scenes/session-recordings/apm/performanceEventDataLogic'
 import { playerSettingsLogic } from 'scenes/session-recordings/player/playerSettingsLogic'
-import { MatchingEventsMatchType } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
+import {
+    convertUniversalFiltersToLegacyFilters,
+    MatchingEventsMatchType,
+} from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
 
 import {
     MatchedRecordingEvent,
@@ -241,7 +244,10 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                     if (!filters) {
                         throw new Error('Backend matching events type must include its filters')
                     }
-                    const params = toParams({ ...filters, session_ids: [props.sessionRecordingId] })
+                    const params = toParams({
+                        ...convertUniversalFiltersToLegacyFilters(filters),
+                        session_ids: [props.sessionRecordingId],
+                    })
                     const response = await api.recordings.getMatchingEvents(params)
                     return response.results.map((x) => ({ uuid: x } as MatchedRecordingEvent))
                 },

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -62,7 +62,7 @@ interface EventUUIDsMatching {
 
 interface BackendEventsMatching {
     matchType: 'backend'
-    filters: RecordingFilters
+    filters: RecordingUniversalFilters
 }
 
 export type MatchingEventsMatchType = NoEventsToMatch | EventNamesMatching | EventUUIDsMatching | BackendEventsMatching
@@ -126,7 +126,7 @@ const capturePartialFilters = (filters: Partial<RecordingFilters>): void => {
     })
 }
 
-function convertUniversalFiltersToLegacyFilters(universalFilters: RecordingUniversalFilters): RecordingFilters {
+export function convertUniversalFiltersToLegacyFilters(universalFilters: RecordingUniversalFilters): RecordingFilters {
     const nestedFilters = universalFilters.filter_group.values[0] as UniversalFiltersGroup
     const filters = nestedFilters.values as UniversalFilterValue[]
 


### PR DESCRIPTION
## Problem

The backend still expects the legacy filter format

## Changes

I'd missed converting the filters from universal to legacy when finding matching events in the inspector
