### PR TITLE
fix(monaco): schema leak

### DIFF
--- a/frontend/src/queries/QueryEditor/QueryEditor.tsx
+++ b/frontend/src/queries/QueryEditor/QueryEditor.tsx
@@ -1,10 +1,9 @@
-import { useMonaco } from '@monaco-editor/react'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
 import { CodeEditor } from 'lib/monaco/CodeEditor'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
 import { urls } from 'scenes/urls'
 
@@ -26,23 +25,6 @@ export function QueryEditor(props: QueryEditorProps): JSX.Element {
     const [key] = useState(() => i++)
     const { queryInput, error, inputChanged } = useValues(queryEditorLogic({ ...props, key }))
     const { setQueryInput, saveQuery } = useActions(queryEditorLogic({ ...props, key }))
-    const monaco = useMonaco()
-
-    useEffect(() => {
-        if (!monaco) {
-            return
-        }
-        monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
-            validate: true,
-            schemas: [
-                {
-                    uri: 'http://internal/node-schema.json',
-                    fileMatch: ['*'], // associate with our model
-                    schema: schema,
-                },
-            ],
-        })
-    }, [monaco])
 
     return (
         <>
@@ -70,6 +52,7 @@ export function QueryEditor(props: QueryEditorProps): JSX.Element {
                                 value={queryInput}
                                 onChange={(v) => setQueryInput(v ?? '')}
                                 height={height}
+                                schema={schema}
                             />
                         )}
                     </AutoSizer>

--- a/frontend/src/scenes/dashboard/DashboardTemplateEditor.tsx
+++ b/frontend/src/scenes/dashboard/DashboardTemplateEditor.tsx
@@ -1,14 +1,10 @@
-import { useMonaco } from '@monaco-editor/react'
 import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { CodeEditor } from 'lib/monaco/CodeEditor'
-import { useEffect } from 'react'
 
 import { dashboardTemplateEditorLogic } from './dashboardTemplateEditorLogic'
 
 export function DashboardTemplateEditor({ inline = false }: { inline?: boolean }): JSX.Element {
-    const monaco = useMonaco()
-
     const {
         closeDashboardTemplateEditor,
         createDashboardTemplate,
@@ -19,26 +15,6 @@ export function DashboardTemplateEditor({ inline = false }: { inline?: boolean }
 
     const { isOpenNewDashboardTemplateModal, editorValue, validationErrors, templateSchema, id } =
         useValues(dashboardTemplateEditorLogic)
-
-    useEffect(() => {
-        if (!monaco) {
-            return
-        }
-
-        const schemas = []
-        if (templateSchema) {
-            schemas.push({
-                uri: 'http://internal/node-schema.json',
-                fileMatch: ['*'],
-                schema: templateSchema,
-            })
-        } // TODO: better error handling if it can't load the template schema
-
-        monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
-            validate: true,
-            schemas: schemas,
-        })
-    }, [monaco, templateSchema])
 
     return (
         <LemonModal
@@ -97,6 +73,8 @@ export function DashboardTemplateEditor({ inline = false }: { inline?: boolean }
                 onValidate={(markers) => {
                     updateValidationErrors(markers)
                 }}
+                path={id ? `dashboard-templates/${id}.json` : 'dashboard-templates/new.json'}
+                schema={templateSchema}
                 height={600}
             />
         </LemonModal>

--- a/frontend/src/scenes/plugins/source/PluginSource.tsx
+++ b/frontend/src/scenes/plugins/source/PluginSource.tsx
@@ -45,18 +45,6 @@ export function PluginSource({
         if (!monaco) {
             return
         }
-        monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
-            jsx: currentFile.endsWith('.tsx')
-                ? monaco.languages.typescript.JsxEmit.React
-                : monaco.languages.typescript.JsxEmit.Preserve,
-            esModuleInterop: true,
-        })
-    }, [monaco, currentFile])
-
-    useEffect(() => {
-        if (!monaco) {
-            return
-        }
         void import('./types/packages.json').then((files) => {
             for (const [fileName, fileContents] of Object.entries(files).filter(
                 ([fileName]) => fileName !== 'default'


### PR DESCRIPTION
## Problem

Monaco schema validation leaked between editor instances

## Changes

Upstream schema support into `<CodeEditor>` itself.

## How did you test this code?

I compared what was working in production and tried to replicate it locally. We still get stuff like this:

![Screenshot 2024-07-09 at 13 31 38](https://github.com/PostHog/posthog/assets/53387/b83ab50a-4344-4eeb-bec4-bfc8988af2dc)

However schema-based autocomplete (e.g. for query nodes or dashboard templates) seems to be broken. I didn't manage to fix it (yet?). I did manage to fix schemas leaking between editors.
