### PR TITLE
fix: remove redundant controls from InsightCard for Data Table

### DIFF
--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -93,6 +93,7 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
                 cachedResults={props.cachedResults}
                 uniqueKey={uniqueKey}
                 context={queryContext}
+                readOnly={readOnly}
             />
         )
     } else if (isSavedInsightNode(query)) {

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -31,6 +31,7 @@ interface DataTableVisualizationProps {
     /* Cached Results are provided when shared or exported,
     the data node logic becomes read only implicitly */
     cachedResults?: AnyResponseType
+    readOnly?: boolean
 }
 
 let uniqueNode = 0
@@ -70,6 +71,7 @@ export function DataTableVisualization(props: DataTableVisualizationProps): JSX.
 }
 
 function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX.Element {
+    const { readOnly } = props
     const { query, visualizationType, showEditingUI, showResultControls, sourceFeatures, response, responseLoading } =
         useValues(dataVisualizationLogic)
 
@@ -112,7 +114,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
     return (
         <div className="DataVisualization flex flex-1">
             <div className="relative w-full flex flex-col gap-4 flex-1 overflow-hidden">
-                {showEditingUI && (
+                {!readOnly && showEditingUI && (
                     <>
                         <HogQLQueryEditor query={query.source} setQuery={setQuerySource} embedded />
                         {sourceFeatures.has(QueryFeature.dateRangePicker) && (
@@ -130,7 +132,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
                         )}
                     </>
                 )}
-                {showResultControls && (
+                {!readOnly && showResultControls && (
                     <>
                         <LemonDivider className="my-0" />
                         <div className="flex gap-4 justify-between flex-wrap">


### PR DESCRIPTION
## Problem

Fixes #[23553](https://github.com/PostHog/posthog/issues/23553)

## Changes

I've added the `readOnly` mode to mirror other viz types. For some reason, DataTableVIsualization was the one that didn't have it.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing