### PR TITLE
fix(data-warehouse): Use replace for hubspot syncs

### DIFF
--- a/posthog/temporal/data_imports/pipelines/hubspot/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/hubspot/__init__.py
@@ -83,7 +83,7 @@ def hubspot(
         yield dlt.resource(
             crm_objects,
             name=endpoint,
-            write_disposition="append",
+            write_disposition="replace",
         )(
             object_type=OBJECT_TYPE_SINGULAR[endpoint],
             api_key=api_key,


### PR DESCRIPTION
## Problem
- We're syncing duplicated data for hubspot

## Changes
- Update hubspot to use `replace` so that on every sync, it syncs the full table and doesn't duplicate any existing data

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
- I didnt