### PR TITLE
chore: on demand kafka statistics event logging

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -172,7 +172,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_OVERFLOW_BUCKET_REPLENISH_RATE: 5_000_000, // 5MB/second uncompressed, sustained
         SESSION_RECORDING_OVERFLOW_BUCKET_CAPACITY: 200_000_000, // 200MB burst
         SESSION_RECORDING_OVERFLOW_MIN_PER_BATCH: 1_000_000, // All sessions consume at least 1MB/batch, to penalise poor batching
-
+        SESSION_RECORDING_KAFKA_CONSUMPTION_STATISTICS_EVENT_INTERVAL_MS: 30_000, // emit stats event once every 30 seconds - DEBUG value, TODO: default should be 0
         // CDP
         CDP_WATCHER_OBSERVATION_PERIOD: 10000,
         CDP_WATCHER_DISABLED_PERIOD: 1000 * 60 * 10,

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -98,7 +98,7 @@ export const startBatchConsumer = async ({
      * configures kafka to emit a statistics event on this interval
      * consumer has to register a callback to listen to the event
      */
-    kafkaStatisticIntervalMs: number
+    kafkaStatisticIntervalMs?: number
 }): Promise<BatchConsumer> => {
     // Starts consuming from `topic` in batches of `fetchBatchSize` messages,
     // with consumer group id `groupId`. We use `connectionConfig` to connect
@@ -110,8 +110,8 @@ export const startBatchConsumer = async ({
     // Kafka.
     //
     // Note that we do not handle any pre-fetching explicitly, rather
-    // node-rdkafka will fill it's own internal queue of messages as fast as it
-    // can, and we will consume from that queue periodicatlly. Prefetching will
+    // node-rdkafka will fill its own internal queue of messages as fast as it
+    // can, and we will consume from that queue periodically. Prefetching will
     // stop if the internal queue is full, and will resume once we have
     // `consume`d some messages.
     //

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -95,7 +95,7 @@ export const startBatchConsumer = async ({
     /**
      * default to 0 which disables logging
      * granularity of 1000ms
-     * configures kafka to emit a statics event on this interval
+     * configures kafka to emit a statistics event on this interval
      * consumer has to register a callback to listen to the event
      */
     kafkaStatisticIntervalMs: number

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -97,6 +97,7 @@ export const startBatchConsumer = async ({
      * granularity of 1000ms
      * configures kafka to emit a statistics event on this interval
      * consumer has to register a callback to listen to the event
+     * see https://github.com/confluentinc/librdkafka/blob/master/STATISTICS.md
      */
     kafkaStatisticIntervalMs?: number
 }): Promise<BatchConsumer> => {

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -72,6 +72,7 @@ export const startBatchConsumer = async ({
     callEachBatchWhenEmpty = false,
     debug,
     queuedMaxMessagesKBytes = 102400,
+    kafkaStatisticIntervalMs = 0,
 }: {
     connectionConfig: GlobalConfig
     groupId: string
@@ -91,6 +92,13 @@ export const startBatchConsumer = async ({
     callEachBatchWhenEmpty?: boolean
     debug?: string
     queuedMaxMessagesKBytes?: number
+    /**
+     * default to 0 which disables logging
+     * granularity of 1000ms
+     * configures kafka to emit a statics event on this interval
+     * consumer has to register a callback to listen to the event
+     */
+    kafkaStatisticIntervalMs: number
 }): Promise<BatchConsumer> => {
     // Starts consuming from `topic` in batches of `fetchBatchSize` messages,
     // with consumer group id `groupId`. We use `connectionConfig` to connect
@@ -159,6 +167,7 @@ export const startBatchConsumer = async ({
         'partition.assignment.strategy': 'cooperative-sticky',
         rebalance_cb: true,
         offset_commit_cb: true,
+        'statistics.interval.ms': kafkaStatisticIntervalMs,
     }
 
     if (debug) {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -513,6 +513,7 @@ export class SessionRecordingIngester {
             },
             callEachBatchWhenEmpty: true, // Useful as we will still want to account for flushing sessions
             debug: this.config.SESSION_RECORDING_KAFKA_DEBUG,
+            kafkaStatisticIntervalMs: this.config.SESSION_RECORDING_KAFKA_CONSUMPTION_STATISTICS_EVENT_INTERVAL_MS,
         })
 
         this.totalNumPartitions = (await getPartitionsForTopic(this.connectedBatchConsumer, this.topic)).length
@@ -548,6 +549,11 @@ export class SessionRecordingIngester {
             // we need to listen to disconnect and make sure we're stopped
             status.info('🔁', 'blob_ingester_consumer batch consumer disconnected, cleaning up', { err })
             await this.stop()
+        })
+
+        // nothing happens here unless we configure SESSION_RECORDING_KAFKA_CONSUMPTION_STATISTICS_EVENT_INTERVAL_MS
+        this.batchConsumer.consumer.on('event.stats', (stats) => {
+            status.info('🪵', 'blob_ingester_consumer - kafka stats', { stats })
         })
     }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -553,7 +553,7 @@ export class SessionRecordingIngester {
 
         // nothing happens here unless we configure SESSION_RECORDING_KAFKA_CONSUMPTION_STATISTICS_EVENT_INTERVAL_MS
         this.batchConsumer.consumer.on('event.stats', (stats) => {
-            status.info('🪵', 'blob_ingester_consumer - kafka stats', { stats })
+            status.info('🪵', 'blob_ingester_consumer - kafka stats', { stats: JSON.parse(stats) })
         })
     }
 

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -266,6 +266,9 @@ export interface PluginsServerConfig extends CdpConfig {
 
     POSTHOG_SESSION_RECORDING_REDIS_HOST: string | undefined
     POSTHOG_SESSION_RECORDING_REDIS_PORT: number | undefined
+
+    // kafka debug stats interval
+    SESSION_RECORDING_KAFKA_CONSUMPTION_STATISTICS_EVENT_INTERVAL_MS: number
 }
 
 export interface Hub extends PluginsServerConfig {


### PR DESCRIPTION
log event statistics from each pod every 30 seconds
can be configured using env SESSION_RECORDING_KAFKA_CONSUMPTION_STATISTICS_EVENT_INTERVAL_MS
defaulted to 30 seconds just for now to avoid two restarts to roll this out for blobby