### PR TITLE
feat: add datadome tracing header to allowlist

### DIFF
--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1743,6 +1743,7 @@ class TestCapture(BaseTest):
                 "highlight",
                 ["x-highlight-request"],
             ),
+            ("DateDome", ["x-datadome-clientid"]),
         ]
     )
     def test_cors_allows_tracing_headers(self, _: str, path: str, headers: list[str]) -> None:

--- a/posthog/utils_cors.py
+++ b/posthog/utils_cors.py
@@ -9,6 +9,7 @@ CORS_ALLOWED_TRACING_HEADERS = (
     "Sentry-Trace",
     "Baggage",
     "x-highlight-request",
+    "x-datadome-clientid",
 )
 
 


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/15538 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/17802) and https://posthog.com/questions/cors-error-retry-loop-with-on-site-form

adds a header to the cors allowlist