### PR TITLE
fix: chart.js plugin initialization

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -5,7 +5,7 @@ import '../../../../../scenes/insights/InsightTooltip/InsightTooltip.scss'
 
 import { LemonTable } from '@posthog/lemon-ui'
 import { ChartData, ChartType, Color, GridLineOptions, TickOptions, TooltipModel } from 'chart.js'
-import { AnnotationPluginOptions, LineAnnotationOptions } from 'chartjs-plugin-annotation'
+import annotationPlugin, { AnnotationPluginOptions, LineAnnotationOptions } from 'chartjs-plugin-annotation'
 import dataLabelsPlugin from 'chartjs-plugin-datalabels'
 import clsx from 'clsx'
 import { useValues } from 'kea'
@@ -20,6 +20,8 @@ import { ChartDisplayType, GraphType } from '~/types'
 
 import { dataVisualizationLogic } from '../../dataVisualizationLogic'
 import { displayLogic } from '../../displayLogic'
+
+Chart.register(annotationPlugin)
 
 export const LineGraph = (): JSX.Element => {
     const canvasRef = useRef<HTMLCanvasElement | null>(null)

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -6,7 +6,7 @@ import '../../../../../scenes/insights/InsightTooltip/InsightTooltip.scss'
 import { LemonTable } from '@posthog/lemon-ui'
 import { ChartData, ChartType, Color, GridLineOptions, TickOptions, TooltipModel } from 'chart.js'
 import annotationPlugin, { AnnotationPluginOptions, LineAnnotationOptions } from 'chartjs-plugin-annotation'
-import ChartDataLabels from 'chartjs-plugin-datalabels'
+import dataLabelsPlugin from 'chartjs-plugin-datalabels'
 import clsx from 'clsx'
 import { useValues } from 'kea'
 import { Chart, ChartItem, ChartOptions } from 'lib/Chart'
@@ -20,6 +20,8 @@ import { ChartDisplayType, GraphType } from '~/types'
 
 import { dataVisualizationLogic } from '../../dataVisualizationLogic'
 import { displayLogic } from '../../displayLogic'
+
+Chart.register(annotationPlugin)
 
 export const LineGraph = (): JSX.Element => {
     const canvasRef = useRef<HTMLCanvasElement | null>(null)
@@ -258,12 +260,11 @@ export const LineGraph = (): JSX.Element => {
             },
         }
 
-        Chart.register(annotationPlugin)
         const newChart = new Chart(canvasRef.current?.getContext('2d') as ChartItem, {
             type: isBarChart ? GraphType.Bar : GraphType.Line,
             data,
             options,
-            plugins: [ChartDataLabels],
+            plugins: [dataLabelsPlugin, annotationPlugin],
         })
         return () => newChart.destroy()
     }, [xData, yData, visualizationType, goalLines])

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -5,7 +5,7 @@ import '../../../../../scenes/insights/InsightTooltip/InsightTooltip.scss'
 
 import { LemonTable } from '@posthog/lemon-ui'
 import { ChartData, ChartType, Color, GridLineOptions, TickOptions, TooltipModel } from 'chart.js'
-import annotationPlugin, { AnnotationPluginOptions, LineAnnotationOptions } from 'chartjs-plugin-annotation'
+import { AnnotationPluginOptions, LineAnnotationOptions } from 'chartjs-plugin-annotation'
 import dataLabelsPlugin from 'chartjs-plugin-datalabels'
 import clsx from 'clsx'
 import { useValues } from 'kea'
@@ -20,8 +20,6 @@ import { ChartDisplayType, GraphType } from '~/types'
 
 import { dataVisualizationLogic } from '../../dataVisualizationLogic'
 import { displayLogic } from '../../displayLogic'
-
-Chart.register(annotationPlugin)
 
 export const LineGraph = (): JSX.Element => {
     const canvasRef = useRef<HTMLCanvasElement | null>(null)
@@ -264,7 +262,7 @@ export const LineGraph = (): JSX.Element => {
             type: isBarChart ? GraphType.Bar : GraphType.Line,
             data,
             options,
-            plugins: [dataLabelsPlugin, annotationPlugin],
+            plugins: [dataLabelsPlugin],
         })
         return () => newChart.destroy()
     }, [xData, yData, visualizationType, goalLines])


### PR DESCRIPTION
## Problem

Chart.js plugin was initializing during the render phase, so any other already initialized charts would crash on the following render because they didn't have that plugin's state.

![Posthog Image](https://github.com/PostHog/posthog/assets/13541795/4681ea76-06c8-4388-a8d8-73e4a9239eee)

### How to reproduce

1. Create a HogQL insight with a line chart
2. Add the insight to a dashboard
3. Add any other trends insight with a line chart
4. Open a dashboard with a direct link
5. Observe the result above

## Changes

Register plugin globally.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing

## Additional context

[Support Ticket](https://posthoghelp.zendesk.com/agent/tickets/15492)
