### PR TITLE
feat: allow configuring fetch min bytes on plugin server batch consumer

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -173,6 +173,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_OVERFLOW_BUCKET_CAPACITY: 200_000_000, // 200MB burst
         SESSION_RECORDING_OVERFLOW_MIN_PER_BATCH: 1_000_000, // All sessions consume at least 1MB/batch, to penalise poor batching
         SESSION_RECORDING_KAFKA_CONSUMPTION_STATISTICS_EVENT_INTERVAL_MS: 30_000, // emit stats event once every 30 seconds - DEBUG value, TODO: default should be 0
+        SESSION_RECORDING_KAFKA_FETCH_MIN_BYTES: 1_048_576, // 1MB
         // CDP
         CDP_WATCHER_OBSERVATION_PERIOD: 10000,
         CDP_WATCHER_DISABLED_PERIOD: 1000 * 60 * 10,

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -145,7 +145,7 @@ export const startBatchConsumer = async ({
         // https://github.com/confluentinc/librdkafka/blob/e75de5be191b6b8e9602efc969f4af64071550de/CONFIGURATION.md?plain=1#L122
         // Initial maximum number of bytes per topic+partition to request when fetching messages from the broker. If the client encounters a message larger than this value it will gradually try to increase it until the entire message can be fetched.
         'fetch.message.max.bytes': consumerMaxBytes,
-        'fetch.min.bytes': fetchMinBytes,
+        'fetch.min.bytes': fetchMinBytes || 1, // consumer default is 1 if not provided
         'fetch.wait.max.ms': consumerMaxWaitMs,
         'fetch.error.backoff.ms': consumerErrorBackoffMs,
         'enable.partition.eof': true,

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -145,7 +145,6 @@ export const startBatchConsumer = async ({
         // https://github.com/confluentinc/librdkafka/blob/e75de5be191b6b8e9602efc969f4af64071550de/CONFIGURATION.md?plain=1#L122
         // Initial maximum number of bytes per topic+partition to request when fetching messages from the broker. If the client encounters a message larger than this value it will gradually try to increase it until the entire message can be fetched.
         'fetch.message.max.bytes': consumerMaxBytes,
-        'fetch.min.bytes': fetchMinBytes || 1, // consumer default is 1 if not provided
         'fetch.wait.max.ms': consumerMaxWaitMs,
         'fetch.error.backoff.ms': consumerErrorBackoffMs,
         'enable.partition.eof': true,
@@ -172,6 +171,11 @@ export const startBatchConsumer = async ({
         rebalance_cb: true,
         offset_commit_cb: true,
         'statistics.interval.ms': kafkaStatisticIntervalMs,
+    }
+
+    // undefined is valid but things get unhappy if you provide that explicitly
+    if (fetchMinBytes) {
+        consumerConfig['fetch.min.bytes'] = fetchMinBytes
     }
 
     if (debug) {

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -74,6 +74,7 @@ export const startBatchConsumer = async ({
     queuedMaxMessagesKBytes = 102400,
     kafkaStatisticIntervalMs = 0,
     fetchMinBytes,
+    maxHealthHeartbeatIntervalMs = 60_000,
 }: {
     connectionConfig: GlobalConfig
     groupId: string
@@ -102,6 +103,7 @@ export const startBatchConsumer = async ({
      * see https://github.com/confluentinc/librdkafka/blob/master/STATISTICS.md
      */
     kafkaStatisticIntervalMs?: number
+    maxHealthHeartbeatIntervalMs?: number
 }): Promise<BatchConsumer> => {
     // Starts consuming from `topic` in batches of `fetchBatchSize` messages,
     // with consumer group id `groupId`. We use `connectionConfig` to connect
@@ -329,7 +331,7 @@ export const startBatchConsumer = async ({
     const isHealthy = () => {
         // We define health as the last consumer loop having run in the last
         // minute. This might not be bullet-proof, let's see.
-        return Date.now() - lastHeartbeatTime < 60000
+        return Date.now() - lastHeartbeatTime < maxHealthHeartbeatIntervalMs
     }
 
     const stop = async () => {

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -73,6 +73,7 @@ export const startBatchConsumer = async ({
     debug,
     queuedMaxMessagesKBytes = 102400,
     kafkaStatisticIntervalMs = 0,
+    fetchMinBytes,
 }: {
     connectionConfig: GlobalConfig
     groupId: string
@@ -92,6 +93,7 @@ export const startBatchConsumer = async ({
     callEachBatchWhenEmpty?: boolean
     debug?: string
     queuedMaxMessagesKBytes?: number
+    fetchMinBytes?: number
     /**
      * default to 0 which disables logging
      * granularity of 1000ms
@@ -143,6 +145,7 @@ export const startBatchConsumer = async ({
         // https://github.com/confluentinc/librdkafka/blob/e75de5be191b6b8e9602efc969f4af64071550de/CONFIGURATION.md?plain=1#L122
         // Initial maximum number of bytes per topic+partition to request when fetching messages from the broker. If the client encounters a message larger than this value it will gradually try to increase it until the entire message can be fetched.
         'fetch.message.max.bytes': consumerMaxBytes,
+        'fetch.min.bytes': fetchMinBytes,
         'fetch.wait.max.ms': consumerMaxWaitMs,
         'fetch.error.backoff.ms': consumerErrorBackoffMs,
         'enable.partition.eof': true,

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -499,7 +499,7 @@ export class SessionRecordingIngester {
             fetchMinBytes: this.config.SESSION_RECORDING_KAFKA_FETCH_MIN_BYTES,
             // our messages are very big, so we don't want to queue too many
             queuedMinMessages: this.config.SESSION_RECORDING_KAFKA_QUEUE_SIZE,
-            // we'll anyway never queue more than the value set hereSESSION_RECORDING_KAFKA_FETCH_MIN_BYTES
+            // we'll anyway never queue more than the value set here
             // since we have large messages we'll need this to be a reasonable multiple
             // of the likely message size times the fetchBatchSize
             // or we'll always hit the batch timeout

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -515,6 +515,7 @@ export class SessionRecordingIngester {
             callEachBatchWhenEmpty: true, // Useful as we will still want to account for flushing sessions
             debug: this.config.SESSION_RECORDING_KAFKA_DEBUG,
             kafkaStatisticIntervalMs: this.config.SESSION_RECORDING_KAFKA_CONSUMPTION_STATISTICS_EVENT_INTERVAL_MS,
+            maxHealthHeartbeatIntervalMs: KAFKA_CONSUMER_SESSION_TIMEOUT_MS * 2, // we don't want to proactively declare healthy - we'll let the broker do it
         })
 
         this.totalNumPartitions = (await getPartitionsForTopic(this.connectedBatchConsumer, this.topic)).length

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -496,9 +496,10 @@ export class SessionRecordingIngester {
             // we only use 9 or 10MB but there's no reason to limit this 🤷️
             consumerMaxBytes: this.config.KAFKA_CONSUMPTION_MAX_BYTES,
             consumerMaxBytesPerPartition: this.config.KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION,
+            fetchMinBytes: this.config.SESSION_RECORDING_KAFKA_FETCH_MIN_BYTES,
             // our messages are very big, so we don't want to queue too many
             queuedMinMessages: this.config.SESSION_RECORDING_KAFKA_QUEUE_SIZE,
-            // we'll anyway never queue more than the value set here
+            // we'll anyway never queue more than the value set hereSESSION_RECORDING_KAFKA_FETCH_MIN_BYTES
             // since we have large messages we'll need this to be a reasonable multiple
             // of the likely message size times the fetchBatchSize
             // or we'll always hit the batch timeout

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -263,6 +263,7 @@ export interface PluginsServerConfig extends CdpConfig {
     SESSION_RECORDING_KAFKA_QUEUE_SIZE_KB: number | undefined
     SESSION_RECORDING_KAFKA_DEBUG: string | undefined
     SESSION_RECORDING_MAX_PARALLEL_FLUSHES: number
+    SESSION_RECORDING_KAFKA_FETCH_MIN_BYTES: number
 
     POSTHOG_SESSION_RECORDING_REDIS_HOST: string | undefined
     POSTHOG_SESSION_RECORDING_REDIS_PORT: number | undefined


### PR DESCRIPTION
blobby has large messages
so it can afford to wait for longer to allow the broker to provide larger batches