### PR TITLE
chore: Increase self-hosted RAM requirement to 8GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The fastest and most reliable way to get started with PostHog is signing up for 
 
 ### Open-source hobby deploy (Advanced)
 
-You can deploy a hobby instance in one line on Linux with Docker (recommended 4GB memory):
+You can deploy a hobby instance in one line on Linux with Docker (recommended 8GB memory):
 
  ```bash 
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/posthog/posthog/HEAD/bin/deploy-hobby)" 


### PR DESCRIPTION
4GB is no longer sufficient for a hobby instance of PostHog. I've done some testing on AWS, and 4GB can't even get the instance started.

I've also proposed this change in the docs repo.