### PR TITLE
fix: ready and willing

### DIFF
--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -329,9 +329,11 @@ export const startBatchConsumer = async ({
     const mainLoop = startConsuming()
 
     const isHealthy = () => {
-        // We define health as the last consumer loop having run in the last
-        // minute. This might not be bullet-proof, let's see.
-        return Date.now() - lastHeartbeatTime < maxHealthHeartbeatIntervalMs
+        // this is called as a readiness and a liveness probe
+        const hasRun = lastHeartbeatTime > 0
+        const isWithinInterval = Date.now() - lastHeartbeatTime < maxHealthHeartbeatIntervalMs
+        const isConnected = consumer.isConnected()
+        return hasRun ? isConnected && isWithinInterval : isConnected
     }
 
     const stop = async () => {


### PR DESCRIPTION
we call _healthy for blobby as a readiness probe
but that checks if we're actually processing
if we've not yet processed we can report whether we're connected

a pod that never receives a message but stays connected would stay healthy but i'd hope the lack of heartbeat from not consuming would mean kafka fixes it instead of k8s