### PR TITLE
fix: totally disable stats collection by default

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -172,7 +172,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_OVERFLOW_BUCKET_REPLENISH_RATE: 5_000_000, // 5MB/second uncompressed, sustained
         SESSION_RECORDING_OVERFLOW_BUCKET_CAPACITY: 200_000_000, // 200MB burst
         SESSION_RECORDING_OVERFLOW_MIN_PER_BATCH: 1_000_000, // All sessions consume at least 1MB/batch, to penalise poor batching
-        SESSION_RECORDING_KAFKA_CONSUMPTION_STATISTICS_EVENT_INTERVAL_MS: 30_000, // emit stats event once every 30 seconds - DEBUG value, TODO: default should be 0
+        SESSION_RECORDING_KAFKA_CONSUMPTION_STATISTICS_EVENT_INTERVAL_MS: 0, // 0 disables stats collection
         SESSION_RECORDING_KAFKA_FETCH_MIN_BYTES: 1_048_576, // 1MB
         // CDP
         CDP_WATCHER_OBSERVATION_PERIOD: 10000,

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -172,12 +172,15 @@ export const startBatchConsumer = async ({
         'partition.assignment.strategy': 'cooperative-sticky',
         rebalance_cb: true,
         offset_commit_cb: true,
-        'statistics.interval.ms': kafkaStatisticIntervalMs,
     }
 
     // undefined is valid but things get unhappy if you provide that explicitly
     if (fetchMinBytes) {
         consumerConfig['fetch.min.bytes'] = fetchMinBytes
+    }
+
+    if (kafkaStatisticIntervalMs) {
+        consumerConfig['statistics.interval.ms'] = kafkaStatisticIntervalMs
     }
 
     if (debug) {


### PR DESCRIPTION
let's disable this by default so that we don't even try to set it on the config