### PR TITLE
fix(experiments): auto load results after experiment launched

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -164,7 +164,7 @@ export function NoResultsEmptyState(): JSX.Element {
 
     function ChecklistItem({ failureReason, checked }: { failureReason: string; checked: boolean }): JSX.Element {
         const failureReasonToText = {
-            'no-events': 'Events have been received',
+            'no-events': 'Experiment events have been received',
             'no-flag-info': 'Feature flag information is present on the events',
             'no-control-variant': 'Events with the control variant received',
             'no-test-variant': 'Events with at least one test variant received',

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -581,6 +581,10 @@ export const experimentLogic = kea<experimentLogicType>([
             if (values.changingSecondaryMetrics) {
                 actions.loadSecondaryMetricResults()
             }
+
+            if (values.experiment?.start_date) {
+                actions.loadExperimentResults()
+            }
         },
         setExperiment: async ({ experiment }) => {
             const experimentEntitiesChanged =


### PR DESCRIPTION
## Changes
For a running experiment, auto-load results when the experiment gets launched (updated). This ensures the "no results diagnostics" panel shows up right away:
![image](https://github.com/PostHog/posthog/assets/22996112/613bb7f6-1bc4-4c8e-af2c-c45ed5ac6d81)

## How did you test this code?
👀 
