### PR TITLE
fix: Use Django ORM `.db_manager()` instead of `.using()`

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -536,7 +536,7 @@ class FeatureFlagViewSet(
         methods=["GET"], detail=False, throttle_classes=[FeatureFlagThrottle], required_scopes=["feature_flag:read"]
     )
     def local_evaluation(self, request: request.Request, **kwargs):
-        feature_flags: QuerySet[FeatureFlag] = FeatureFlag.objects.using(DATABASE_FOR_LOCAL_EVALUATION).filter(
+        feature_flags: QuerySet[FeatureFlag] = FeatureFlag.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION).filter(
             team_id=self.team_id, deleted=False, active=True
         )
 
@@ -548,7 +548,7 @@ class FeatureFlagViewSet(
         if should_send_cohorts:
             seen_cohorts_cache = {
                 cohort.pk: cohort
-                for cohort in Cohort.objects.using(DATABASE_FOR_LOCAL_EVALUATION).filter(
+                for cohort in Cohort.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION).filter(
                     team_id=self.team_id, deleted=False
                 )
             }
@@ -591,7 +591,7 @@ class FeatureFlagViewSet(
                             cohort = seen_cohorts_cache[id]
                         else:
                             cohort = (
-                                Cohort.objects.using(DATABASE_FOR_LOCAL_EVALUATION)
+                                Cohort.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION)
                                 .filter(id=id, team_id=self.team_id, deleted=False)
                                 .first()
                             )
@@ -611,7 +611,7 @@ class FeatureFlagViewSet(
                 ],
                 "group_type_mapping": {
                     str(row.group_type_index): row.group_type
-                    for row in GroupTypeMapping.objects.using(DATABASE_FOR_LOCAL_EVALUATION).filter(
+                    for row in GroupTypeMapping.objects.db_manager(DATABASE_FOR_LOCAL_EVALUATION).filter(
                         team_id=self.team_id
                     )
                 },

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -3660,16 +3660,16 @@ class TestDecideUsesReadReplica(TransactionTestCase):
     databases = {"default", "replica"}
 
     def setup_user_and_team_in_db(self, dbname: str = "default"):
-        organization = Organization.objects.using(dbname).create(
+        organization = Organization.objects.db_manager(dbname).create(
             name="Org 1", slug=f"org-{dbname}-{random.randint(1, 1000000)}"
         )
-        team = Team.objects.using(dbname).create(organization=organization, name="Team 1 org 1")
-        user = User.objects.using(dbname).create(
+        team = Team.objects.db_manager(dbname).create(organization=organization, name="Team 1 org 1")
+        user = User.objects.db_manager(dbname).create(
             email=f"test-{random.randint(1, 100000)}@posthog.com",
             password="password",
             first_name="first_name",
         )
-        OrganizationMembership.objects.using(dbname).create(
+        OrganizationMembership.objects.db_manager(dbname).create(
             user=user,
             organization=organization,
             level=OrganizationMembership.Level.OWNER,
@@ -3681,7 +3681,7 @@ class TestDecideUsesReadReplica(TransactionTestCase):
         created_flags = []
         created_persons = []
         for flag in flags:
-            f = FeatureFlag.objects.using(dbname).create(
+            f = FeatureFlag.objects.db_manager(dbname).create(
                 team=team,
                 rollout_percentage=flag.get("rollout_percentage") or None,
                 filters=flag.get("filters") or {},
@@ -3692,13 +3692,13 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             )
             created_flags.append(f)
         for person in persons:
-            p = Person.objects.using(dbname).create(
+            p = Person.objects.db_manager(dbname).create(
                 team=team,
                 properties=person["properties"],
             )
             created_persons.append(p)
             for distinct_id in person["distinct_ids"]:
-                PersonDistinctId.objects.using(dbname).create(person=p, distinct_id=distinct_id, team=team)
+                PersonDistinctId.objects.db_manager(dbname).create(person=p, distinct_id=distinct_id, team=team)
 
         return created_flags, created_persons
 
@@ -4132,15 +4132,15 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             )  # assigned by distinct_id hash
 
         # new person, merged from old distinct ID
-        PersonDistinctId.objects.using("default").create(person=person, distinct_id="other_id", team=self.team)
+        PersonDistinctId.objects.db_manager("default").create(person=person, distinct_id="other_id", team=self.team)
         # hash key override already exists
-        FeatureFlagHashKeyOverride.objects.using("default").create(
+        FeatureFlagHashKeyOverride.objects.db_manager("default").create(
             team=self.team,
             person=person,
             hash_key="example_id",
             feature_flag_key="beta-feature",
         )
-        FeatureFlagHashKeyOverride.objects.using("default").create(
+        FeatureFlagHashKeyOverride.objects.db_manager("default").create(
             team=self.team,
             person=person,
             hash_key="example_id",
@@ -4305,7 +4305,7 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             )  # assigned by distinct_id hash
 
         # new person, merged from old distinct ID
-        PersonDistinctId.objects.using("default").create(person=person, distinct_id="other_id", team=self.team)
+        PersonDistinctId.objects.db_manager("default").create(person=person, distinct_id="other_id", team=self.team)
 
         # request with hash key overrides and _new_ writes should go to main database
         with self.assertNumQueries(8, using="replica"), self.assertNumQueries(9, using="default"):
@@ -4388,10 +4388,12 @@ class TestDecideUsesReadReplica(TransactionTestCase):
         ]
         self.setup_flags_in_db("replica", team, user, flags, persons)
 
-        GroupTypeMapping.objects.using("replica").create(team=self.team, group_type="organization", group_type_index=0)
-        GroupTypeMapping.objects.using("default").create(team=self.team, group_type="project", group_type_index=1)
+        GroupTypeMapping.objects.db_manager("replica").create(
+            team=self.team, group_type="organization", group_type_index=0
+        )
+        GroupTypeMapping.objects.db_manager("default").create(team=self.team, group_type="project", group_type_index=1)
 
-        Group.objects.using("replica").create(
+        Group.objects.db_manager("replica").create(
             team_id=self.team.pk,
             group_type_index=0,
             group_key="foo",

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -496,7 +496,7 @@ def get_dependent_cohorts(
                 if not current_cohort:
                     continue
             else:
-                current_cohort = Cohort.objects.using(using_database).get(
+                current_cohort = Cohort.objects.db_manager(using_database).get(
                     pk=cohort_id, team_id=cohort.team_id, deleted=False
                 )
                 seen_cohorts_cache[cohort_id] = current_cohort

--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -180,7 +180,7 @@ class FeatureFlag(models.Model):
                                 if not cohort:
                                     return self.conditions
                             else:
-                                cohort = Cohort.objects.using(using_database).get(
+                                cohort = Cohort.objects.db_manager(using_database).get(
                                     pk=cohort_id, team_id=self.team_id, deleted=False
                                 )
                                 seen_cohorts_cache[cohort_id] = cohort
@@ -284,7 +284,7 @@ class FeatureFlag(models.Model):
                             if not cohort:
                                 continue
                         else:
-                            cohort = Cohort.objects.using(using_database).get(
+                            cohort = Cohort.objects.db_manager(using_database).get(
                                 pk=cohort_id, team_id=self.team_id, deleted=False
                             )
                             seen_cohorts_cache[cohort_id] = cohort
@@ -407,7 +407,7 @@ def set_feature_flags_for_team_in_cache(
         all_feature_flags = feature_flags
     else:
         all_feature_flags = list(
-            FeatureFlag.objects.using(using_database).filter(team_id=team_id, active=True, deleted=False)
+            FeatureFlag.objects.db_manager(using_database).filter(team_id=team_id, active=True, deleted=False)
         )
 
     serialized_flags = MinimalFeatureFlagSerializer(all_feature_flags, many=True).data

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -71,7 +71,7 @@ class OrganizationManager(models.Manager):
         """Instead of doing the legwork of creating an organization yourself, delegate the details with bootstrap."""
         from .project import Project  # Avoiding circular import
 
-        with transaction.atomic(using=self._db):
+        with transaction.atomic(using=self.db):
             organization = Organization.objects.create(**kwargs)
             _, team = Project.objects.create_with_team(organization=organization, team_fields=team_fields)
             organization_membership: Optional[OrganizationMembership] = None

--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -71,7 +71,7 @@ class OrganizationManager(models.Manager):
         """Instead of doing the legwork of creating an organization yourself, delegate the details with bootstrap."""
         from .project import Project  # Avoiding circular import
 
-        with transaction.atomic():
+        with transaction.atomic(using=self._db):
             organization = Organization.objects.create(**kwargs)
             _, team = Project.objects.create_with_team(organization=organization, team_fields=team_fields)
             organization_membership: Optional[OrganizationMembership] = None

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -12,8 +12,10 @@ MAX_LIMIT_DISTINCT_IDS = 2500
 
 
 class PersonManager(models.Manager):
+    model: "Person"
+
     def create(self, *args: Any, **kwargs: Any):
-        with transaction.atomic():
+        with transaction.atomic(using=self._db):
             if not kwargs.get("distinct_ids"):
                 return super().create(*args, **kwargs)
             distinct_ids = kwargs.pop("distinct_ids")

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -12,8 +12,6 @@ MAX_LIMIT_DISTINCT_IDS = 2500
 
 
 class PersonManager(models.Manager):
-    model: "Person"
-
     def create(self, *args: Any, **kwargs: Any):
         with transaction.atomic(using=self._db):
             if not kwargs.get("distinct_ids"):

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -13,7 +13,7 @@ MAX_LIMIT_DISTINCT_IDS = 2500
 
 class PersonManager(models.Manager):
     def create(self, *args: Any, **kwargs: Any):
-        with transaction.atomic(using=self._db):
+        with transaction.atomic(using=self.db):
             if not kwargs.get("distinct_ids"):
                 return super().create(*args, **kwargs)
             distinct_ids = kwargs.pop("distinct_ids")

--- a/posthog/models/project.py
+++ b/posthog/models/project.py
@@ -13,7 +13,7 @@ class ProjectManager(models.Manager):
     def create_with_team(self, team_fields: Optional[dict] = None, **kwargs) -> tuple["Project", "Team"]:
         from .team import Team
 
-        with transaction.atomic(using=self._db):
+        with transaction.atomic(using=self.db):
             common_id = Team.objects.increment_id_sequence()
             project = self.create(id=common_id, **kwargs)
             team = Team.objects.create(

--- a/posthog/models/project.py
+++ b/posthog/models/project.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
 
 
 class ProjectManager(models.Manager):
+    model: "Project"
+
     def create_with_team(self, team_fields: Optional[dict] = None, **kwargs) -> tuple["Project", "Team"]:
         from .team import Team
 

--- a/posthog/models/project.py
+++ b/posthog/models/project.py
@@ -10,12 +10,10 @@ if TYPE_CHECKING:
 
 
 class ProjectManager(models.Manager):
-    model: "Project"
-
     def create_with_team(self, team_fields: Optional[dict] = None, **kwargs) -> tuple["Project", "Team"]:
         from .team import Team
 
-        with transaction.atomic():
+        with transaction.atomic(using=self._db):
             common_id = Team.objects.increment_id_sequence()
             project = self.create(id=common_id, **kwargs)
             team = Team.objects.create(

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -102,7 +102,7 @@ class TeamManager(models.Manager):
     def create(self, *args, **kwargs) -> "Team":
         from ..project import Project
 
-        with transaction.atomic(using=self._db):
+        with transaction.atomic(using=self.db):
             if "id" not in kwargs:
                 kwargs["id"] = self.increment_id_sequence()
             if kwargs.get("project") is None and kwargs.get("project_id") is None:
@@ -115,7 +115,7 @@ class TeamManager(models.Manager):
                     project_kwargs["organization_id"] = organization_id
                 if name := kwargs.get("name"):
                     project_kwargs["name"] = name
-                kwargs["project"] = Project.objects.db_manager(self._db).create(id=kwargs["id"], **project_kwargs)
+                kwargs["project"] = Project.objects.db_manager(self.db).create(id=kwargs["id"], **project_kwargs)
             return super().create(*args, **kwargs)
 
     def get_team_from_token(self, token: Optional[str]) -> Optional["Team"]:

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -62,8 +62,6 @@ class AvailableExtraSettings:
 
 
 class TeamManager(models.Manager):
-    model: "Team"
-
     def get_queryset(self):
         return super().get_queryset().defer(*DEPRECATED_ATTRS)
 

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -62,6 +62,8 @@ class AvailableExtraSettings:
 
 
 class TeamManager(models.Manager):
+    model: "Team"
+
     def get_queryset(self):
         return super().get_queryset().defer(*DEPRECATED_ATTRS)
 
@@ -102,7 +104,7 @@ class TeamManager(models.Manager):
     def create(self, *args, **kwargs) -> "Team":
         from ..project import Project
 
-        with transaction.atomic():
+        with transaction.atomic(using=self._db):
             if "id" not in kwargs:
                 kwargs["id"] = self.increment_id_sequence()
             if kwargs.get("project") is None and kwargs.get("project_id") is None:
@@ -115,7 +117,7 @@ class TeamManager(models.Manager):
                     project_kwargs["organization_id"] = organization_id
                 if name := kwargs.get("name"):
                     project_kwargs["name"] = name
-                kwargs["project"] = Project.objects.create(id=kwargs["id"], **project_kwargs)
+                kwargs["project"] = Project.objects.db_manager(self._db).create(id=kwargs["id"], **project_kwargs)
             return super().create(*args, **kwargs)
 
     def get_team_from_token(self, token: Optional[str]) -> Optional["Team"]:

--- a/posthog/plugins/site.py
+++ b/posthog/plugins/site.py
@@ -52,7 +52,7 @@ def get_decide_site_apps(team: "Team", using_database: str = "default") -> list[
     from posthog.models import PluginConfig, PluginSourceFile
 
     sources = (
-        PluginConfig.objects.using(using_database)
+        PluginConfig.objects.db_manager(using_database)
         .filter(
             team=team,
             enabled=True,

--- a/posthog/queries/base.py
+++ b/posthog/queries/base.py
@@ -297,13 +297,17 @@ def property_to_Q(
         if cohorts_cache is not None:
             if cohorts_cache.get(cohort_id) is None:
                 queried_cohort = (
-                    Cohort.objects.using(using_database).filter(pk=cohort_id, team_id=team_id, deleted=False).first()
+                    Cohort.objects.db_manager(using_database)
+                    .filter(pk=cohort_id, team_id=team_id, deleted=False)
+                    .first()
                 )
                 cohorts_cache[cohort_id] = queried_cohort or ""
 
             cohort = cohorts_cache[cohort_id]
         else:
-            cohort = Cohort.objects.using(using_database).filter(pk=cohort_id, team_id=team_id, deleted=False).first()
+            cohort = (
+                Cohort.objects.db_manager(using_database).filter(pk=cohort_id, team_id=team_id, deleted=False).first()
+            )
 
         if not cohort:
             # Don't match anything if cohort doesn't exist
@@ -312,7 +316,7 @@ def property_to_Q(
         if cohort.is_static:
             return Q(
                 Exists(
-                    CohortPeople.objects.using(using_database)
+                    CohortPeople.objects.db_manager(using_database)
                     .filter(
                         cohort_id=cohort_id,
                         person_id=OuterRef("id"),


### PR DESCRIPTION
## Problem

Sometimes we want to query our Postgres replica, instead of the default DB. We've been using `Foo.objects.using()` for this, but while working on #23246, I discovered there is an issue with this: `.using()` completely bypasses any model managers defined by us, as it returns a plain Django queryset. Hence cases like `.using().special_create_method()` just fail.

## Changes

There's a simple fix: `.db_manager()` does the same thing as `.using()`, except it returns the model manager rather than a queryset. Our methods are available at last!

Important to note that in model manager methods, we must remember to pass on `using=self._db` to `transaction.atomic()`, as well as to other managers being used. Otherwise we'd end up with one method acidentally operating on different database instances, leading to wonkiness. (This is honestly pretty easy to miss, sadly there isn't a linter rule for it.)
