### PR TITLE
feat: Enable person batch export for all destinations

### DIFF
--- a/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
@@ -107,21 +107,16 @@ export function BatchExportGeneralEditFields({
                         <LemonInput placeholder="Name your workflow for future reference" />
                     </LemonField>
                 )}
-                {featureFlags[FEATURE_FLAGS.PERSON_BATCH_EXPORTS] &&
-                    // Suppported destinations for Persons batch exports.
-                    // TODO: Add them all once supported
-                    (batchExportConfigForm.destination === 'S3' ||
-                        batchExportConfigForm.destination === 'BigQuery' ||
-                        batchExportConfigForm.destination === 'Snowflake') && (
-                        <LemonField name="model" label="Model" info="A model defines the data that will be exported.">
-                            <LemonSelect
-                                options={[
-                                    { value: 'events', label: 'Events' },
-                                    { value: 'persons', label: 'Persons' },
-                                ]}
-                            />
-                        </LemonField>
-                    )}
+                {featureFlags[FEATURE_FLAGS.PERSON_BATCH_EXPORTS] && (
+                    <LemonField name="model" label="Model" info="A model defines the data that will be exported.">
+                        <LemonSelect
+                            options={[
+                                { value: 'events', label: 'Events' },
+                                { value: 'persons', label: 'Persons' },
+                            ]}
+                        />
+                    </LemonField>
+                )}
                 <div className="flex gap-2 items-start flex-wrap">
                     <LemonField
                         name="interval"

--- a/frontend/src/scenes/pipeline/PipelineBatchExportConfiguration.tsx
+++ b/frontend/src/scenes/pipeline/PipelineBatchExportConfiguration.tsx
@@ -112,37 +112,32 @@ export function PipelineBatchExportConfiguration({ service, id }: { service?: st
                                 <LemonInput type="text" />
                             </LemonField>
 
-                            {featureFlags[FEATURE_FLAGS.PERSON_BATCH_EXPORTS] &&
-                                // Suppported destinations for Persons batch exports.
-                                // TODO: Add configuration all once supported
-                                (configuration.destination === 'S3' ||
-                                    configuration.destination === 'BigQuery' ||
-                                    configuration.destination === 'Snowflake') && (
-                                    <>
-                                        <LemonField
-                                            name="model"
-                                            label="Model"
-                                            info="A model defines the data that will be exported."
-                                        >
-                                            <LemonSelect
-                                                options={tables.map((table) => ({
-                                                    value: table.name,
-                                                    label: table.id,
-                                                }))}
-                                                value={selectedModel}
-                                                onSelect={(newValue) => {
-                                                    setSelectedModel(newValue)
-                                                }}
-                                            />
-                                        </LemonField>
-
-                                        <DatabaseTable
-                                            table={selectedModel ? selectedModel : 'events'}
-                                            tables={tables}
-                                            inEditSchemaMode={false}
+                            {featureFlags[FEATURE_FLAGS.PERSON_BATCH_EXPORTS] && (
+                                <>
+                                    <LemonField
+                                        name="model"
+                                        label="Model"
+                                        info="A model defines the data that will be exported."
+                                    >
+                                        <LemonSelect
+                                            options={tables.map((table) => ({
+                                                value: table.name,
+                                                label: table.id,
+                                            }))}
+                                            value={selectedModel}
+                                            onSelect={(newValue) => {
+                                                setSelectedModel(newValue)
+                                            }}
                                         />
-                                    </>
-                                )}
+                                    </LemonField>
+
+                                    <DatabaseTable
+                                        table={selectedModel ? selectedModel : 'events'}
+                                        tables={tables}
+                                        inEditSchemaMode={false}
+                                    />
+                                </>
+                            )}
                         </div>
                         <div className="border bg-bg-light p-3 rounded flex-2 min-w-100">
                             <BatchExportConfigurationFields

--- a/frontend/src/scenes/pipeline/pipelineBatchExportConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineBatchExportConfigurationLogic.tsx
@@ -176,9 +176,15 @@ const personsTable: DatabaseSchemaBatchExportTable = {
             type: 'json',
             schema_valid: true,
         },
-        version: {
-            name: 'version',
-            hogql_value: 'version',
+        person_version: {
+            name: 'person_version',
+            hogql_value: 'person_version',
+            type: 'integer',
+            schema_valid: true,
+        },
+        person_distinct_id_version: {
+            name: 'person_distinct_id_version',
+            hogql_value: 'person_distinct_id_version',
             type: 'integer',
             schema_valid: true,
         },


### PR DESCRIPTION
## Problem

We now support person batch exports also in Postgres and Redshift, so we can remove this check on destination type.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
