### PR TITLE
feat: Part 1 of ability to spin up different pipelines

### DIFF
--- a/plugin-server/README.md
+++ b/plugin-server/README.md
@@ -61,6 +61,7 @@ testing:
         DATABASE_URL=postgres://posthog:posthog@localhost:5432/test_posthog \
         PLUGINS_DEFAULT_LOG_LEVEL=0 \
         RELOAD_PLUGIN_JITTER_MAX_MS=0 \
+        PLUGIN_SERVER_MODE=functional-tests \
         pnpm start:dev
     ```
 1. run the tests:

--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -19,6 +19,7 @@ export APP_METRICS_FLUSH_FREQUENCY_MS=0 # Reduce the potential for spurious erro
 export APP_METRICS_GATHERED_FOR_ALL=true
 export PLUGINS_DEFAULT_LOG_LEVEL=0 # All logs, as debug logs are used in synchronization barriers
 export NODE_ENV=production-functional-tests
+export PLUGIN_SERVER_MODE=functional-tests # running all capabilities is too slow
 
 # Not important at all, but I like to see nice red/green for tests
 export FORCE_COLOR=true

--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -14,6 +14,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 ingestion: true,
                 ingestionOverflow: true,
                 ingestionHistorical: true,
+                eventsIngestionPipelines: true, // with null PluginServerMode we run all of them
                 pluginScheduledTasks: true,
                 processPluginJobs: true,
                 processAsyncOnEventHandlers: true,
@@ -45,6 +46,12 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
             return {
                 mmdb: true,
                 ingestionHistorical: true,
+                ...sharedCapabilities,
+            }
+        case PluginServerMode.events_ingestion:
+            return {
+                mmdb: true,
+                eventsIngestionPipelines: true,
                 ...sharedCapabilities,
             }
         case PluginServerMode.analytics_ingestion:

--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -106,5 +106,22 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
                 cdpFunctionOverflow: true,
                 ...sharedCapabilities,
             }
+        // This is only for functional tests, which time out if all capabilities are used
+        // ideally we'd run just the specific capability needed per test, but that's not easy to do atm
+        case PluginServerMode.functional_tests:
+            return {
+                mmdb: true,
+                ingestion: true,
+                ingestionHistorical: true,
+                eventsIngestionPipelines: true,
+                pluginScheduledTasks: true,
+                processPluginJobs: true,
+                processAsyncOnEventHandlers: true,
+                processAsyncWebhooksHandlers: true,
+                sessionRecordingBlobIngestion: true,
+                appManagementSingleton: true,
+                preflightSchedules: true,
+                ...sharedCapabilities,
+            }
     }
 }

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -119,6 +119,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         OBJECT_STORAGE_SECRET_ACCESS_KEY: 'object_storage_root_password',
         OBJECT_STORAGE_BUCKET: 'posthog',
         PLUGIN_SERVER_MODE: null,
+        PLUGIN_SERVER_EVENTS_INGESTION_PIPELINE: null,
         PLUGIN_LOAD_SEQUENTIALLY: false,
         KAFKAJS_LOG_LEVEL: 'WARN',
         APP_METRICS_GATHERED_FOR_ALL: isDevEnv() ? true : false,

--- a/plugin-server/src/config/kafka-topics.ts
+++ b/plugin-server/src/config/kafka-topics.ts
@@ -2,7 +2,7 @@
 
 import { isTestEnv } from '../utils/env-utils'
 
-const suffix = isTestEnv() ? '_test' : ''
+export const suffix = isTestEnv() ? '_test' : ''
 export const prefix = process.env.KAFKA_PREFIX || ''
 
 export const KAFKA_EVENTS_JSON = `${prefix}clickhouse_events_json${suffix}`

--- a/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
+++ b/plugin-server/src/main/ingestion-queues/batch-processing/each-batch-ingestion.ts
@@ -33,6 +33,7 @@ export enum IngestionOverflowMode {
     RerouteRandomly, // discards partition locality
     ConsumeSplitByDistinctId,
     ConsumeSplitEvenly,
+    ConsumeSplitEventlyWithoutIngestionWarning,
 }
 
 type IngestionSplitBatch = {
@@ -300,10 +301,12 @@ export function splitIngestionBatch(
         overflowMode
     )
 
-    if (overflowMode === IngestionOverflowMode.ConsumeSplitEvenly) {
+    if (
+        overflowMode === IngestionOverflowMode.ConsumeSplitEvenly ||
+        overflowMode === IngestionOverflowMode.ConsumeSplitEventlyWithoutIngestionWarning
+    ) {
         /**
-         * Grouping by distinct_id is inefficient here, because only a few ones are overflowing
-         * at a time. When messages are sent to overflow, we already give away the ordering guarantee,
+         * Grouping by distinct_id is not necessary here, we already give away the ordering guarantee,
          * so we just return batches of one to increase concurrency.
          * TODO: add a PipelineEvent[] field to IngestionSplitBatch for batches of 1
          */

--- a/plugin-server/src/main/ingestion-queues/events-ingestion-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/events-ingestion-consumer.ts
@@ -1,0 +1,60 @@
+import { Message } from 'node-rdkafka'
+
+import { buildStringMatcher } from '../../config/config'
+import { prefix as KAFKA_PREFIX, suffix as KAFKA_SUFFIX } from '../../config/kafka-topics'
+import { Hub } from '../../types'
+import { status } from '../../utils/status'
+import { eachBatchParallelIngestion, IngestionOverflowMode } from './batch-processing/each-batch-ingestion'
+import { IngestionConsumer } from './kafka-queue'
+
+export type PipelineType = {
+    topic: string
+    consumer_group: string
+}
+
+export const PIPELINES: { [key: string]: PipelineType } = {
+    ingestion_warnings: {
+        topic: 'events_ingestion_warnings',
+        consumer_group: 'events_ingestion_warnings',
+    },
+    heatmaps: {
+        topic: 'events_ingestion_heatmaps',
+        consumer_group: 'events_ingestion_heatmaps',
+    },
+}
+
+export const startEventsIngestionPipelineConsumer = async ({
+    hub, // TODO: remove needing to pass in the whole hub and be more selective on dependency injection.
+    pipeline,
+}: {
+    hub: Hub
+    pipeline: PipelineType
+}) => {
+    /*
+        Consumes events from the topic and consumer passed in.
+    */
+    status.info(
+        '🔁',
+        `Starting events ingestion pipeline on topic ${pipeline.topic} consumer ${pipeline.consumer_group} with rdkafka`
+    )
+
+    const tokenBlockList = buildStringMatcher(hub.DROP_EVENTS_BY_TOKEN, false)
+    // No overflow and split all events evenly, i.e. there's no ordering guarantees here.
+    const batchHandler = async (messages: Message[], queue: IngestionConsumer): Promise<void> => {
+        await eachBatchParallelIngestion(
+            tokenBlockList,
+            messages,
+            queue,
+            IngestionOverflowMode.ConsumeSplitEventlyWithoutIngestionWarning
+        )
+    }
+
+    const kafka_topic = `${KAFKA_PREFIX}${pipeline.topic}${KAFKA_SUFFIX}`
+    const kafka_consumer = `${KAFKA_PREFIX}${pipeline.consumer_group}${KAFKA_SUFFIX}`
+
+    const queue = new IngestionConsumer(hub, kafka_topic, kafka_consumer, batchHandler)
+
+    const { isHealthy } = await queue.start()
+
+    return { queue, isHealthy }
+}

--- a/plugin-server/src/main/ingestion-queues/events-ingestion-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/events-ingestion-consumer.ts
@@ -14,12 +14,16 @@ export type PipelineType = {
 
 export const PIPELINES: { [key: string]: PipelineType } = {
     ingestion_warnings: {
-        topic: 'events_ingestion_warnings',
-        consumer_group: 'events_ingestion_warnings',
+        topic: 'client_iwarnings_ingestion',
+        consumer_group: 'client_iwarnings_ingestion',
     },
     heatmaps: {
-        topic: 'events_ingestion_heatmaps',
-        consumer_group: 'events_ingestion_heatmaps',
+        topic: 'heatmaps_ingestion',
+        consumer_group: 'heatmaps_ingestion',
+    },
+    exceptions: {
+        topic: 'exceptions_ingestion',
+        consumer_group: 'exceptions_ingestion',
     },
 }
 

--- a/plugin-server/src/main/ingestion-queues/events-ingestion-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/events-ingestion-consumer.ts
@@ -37,9 +37,11 @@ export const startEventsIngestionPipelineConsumer = async ({
     /*
         Consumes events from the topic and consumer passed in.
     */
+    const kafka_topic = `${KAFKA_PREFIX}${pipeline.topic}${KAFKA_SUFFIX}`
+    const kafka_consumer = `${KAFKA_PREFIX}${pipeline.consumer_group}`
     status.info(
         '🔁',
-        `Starting events ingestion pipeline on topic ${pipeline.topic} consumer ${pipeline.consumer_group} with rdkafka`
+        `Starting events ingestion pipeline on topic ${kafka_topic} consumer ${kafka_consumer} with rdkafka`
     )
 
     const tokenBlockList = buildStringMatcher(hub.DROP_EVENTS_BY_TOKEN, false)
@@ -52,9 +54,6 @@ export const startEventsIngestionPipelineConsumer = async ({
             IngestionOverflowMode.ConsumeSplitEventlyWithoutIngestionWarning
         )
     }
-
-    const kafka_topic = `${KAFKA_PREFIX}${pipeline.topic}${KAFKA_SUFFIX}`
-    const kafka_consumer = `${KAFKA_PREFIX}${pipeline.consumer_group}${KAFKA_SUFFIX}`
 
     const queue = new IngestionConsumer(hub, kafka_topic, kafka_consumer, batchHandler)
 

--- a/plugin-server/src/sentry.ts
+++ b/plugin-server/src/sentry.ts
@@ -39,6 +39,7 @@ export function initSentry(config: PluginsServerConfig): void {
                 tags: {
                     PLUGIN_SERVER_MODE: config.PLUGIN_SERVER_MODE,
                     DEPLOYMENT: config.CLOUD_DEPLOYMENT,
+                    PLUGIN_SERVER_EVENTS_INGESTION_PIPELINE: config.PLUGIN_SERVER_EVENTS_INGESTION_PIPELINE,
                 },
             },
             release,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -74,6 +74,7 @@ export enum PluginServerMode {
     ingestion = 'ingestion',
     ingestion_overflow = 'ingestion-overflow',
     ingestion_historical = 'ingestion-historical',
+    events_ingestion = 'events-ingestion',
     async_onevent = 'async-onevent',
     async_webhooks = 'async-webhooks',
     jobs = 'jobs',
@@ -203,6 +204,7 @@ export interface PluginsServerConfig extends CdpConfig {
     OBJECT_STORAGE_SECRET_ACCESS_KEY: string
     OBJECT_STORAGE_BUCKET: string // the object storage bucket name
     PLUGIN_SERVER_MODE: PluginServerMode | null
+    PLUGIN_SERVER_EVENTS_INGESTION_PIPELINE: string | null // TODO: shouldn't be a string probably
     PLUGIN_LOAD_SEQUENTIALLY: boolean // could help with reducing memory usage spikes on startup
     KAFKAJS_LOG_LEVEL: 'NOTHING' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR'
     APP_METRICS_GATHERED_FOR_ALL: boolean // whether to gather app metrics for all teams
@@ -322,6 +324,7 @@ export interface PluginServerCapabilities {
     ingestion?: boolean
     ingestionOverflow?: boolean
     ingestionHistorical?: boolean
+    eventsIngestionPipelines?: boolean
     pluginScheduledTasks?: boolean
     processPluginJobs?: boolean
     processAsyncOnEventHandlers?: boolean

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -85,6 +85,7 @@ export enum PluginServerMode {
     cdp_processed_events = 'cdp-processed-events',
     cdp_function_callbacks = 'cdp-function-callbacks',
     cdp_function_overflow = 'cdp-function-overflow',
+    functional_tests = 'functional-tests',
 }
 
 export const stringToPluginServerMode = Object.fromEntries(

--- a/plugin-server/tests/e2e.timeout.test.ts
+++ b/plugin-server/tests/e2e.timeout.test.ts
@@ -40,7 +40,7 @@ describe('e2e ingestion timeout', () => {
             }
         `)
         await resetTestDatabaseClickhouse(extraServerConfig)
-        const startResponse = await startPluginsServer(extraServerConfig, makePiscina)
+        const startResponse = await startPluginsServer(extraServerConfig, makePiscina, { ingestion: true })
         hub = startResponse.hub
         stopServer = startResponse.stop
         posthog = createPosthog(hub, pluginConfig39)

--- a/plugin-server/tests/server.test.ts
+++ b/plugin-server/tests/server.test.ts
@@ -19,10 +19,7 @@ function numberOfScheduledJobs() {
 describe('server', () => {
     let pluginsServer: Partial<ServerInstance> | null = null
 
-    function createPluginServer(
-        config: Partial<PluginsServerConfig> = {},
-        capabilities: PluginServerCapabilities | undefined = undefined
-    ) {
+    function createPluginServer(config: Partial<PluginsServerConfig>, capabilities: PluginServerCapabilities) {
         return startPluginsServer(
             {
                 WORKER_CONCURRENCY: 2,
@@ -43,20 +40,94 @@ describe('server', () => {
         pluginsServer = null
     })
 
-    test('startPluginsServer does not error', async () => {
+    // Running all capabilities together takes too long in tests, so they are split up
+    test('startPluginsServer does not error - ingestion', async () => {
         const testCode = `
         async function processEvent (event) {
             return event
         }
     `
         await resetTestDatabase(testCode)
-        pluginsServer = await createPluginServer()
+        pluginsServer = await createPluginServer(
+            {},
+            {
+                http: true,
+                mmdb: true,
+                ingestion: true,
+                ingestionOverflow: true,
+                ingestionHistorical: true,
+                appManagementSingleton: true,
+                preflightSchedules: true,
+            }
+        )
+    })
+    test('startPluginsServer does not error - pipelines', async () => {
+        const testCode = `
+        async function processEvent (event) {
+            return event
+        }
+    `
+        await resetTestDatabase(testCode)
+        pluginsServer = await createPluginServer(
+            {},
+            {
+                http: true,
+                eventsIngestionPipelines: true,
+            }
+        )
+    })
+
+    test('startPluginsServer does not error - cdp', async () => {
+        const testCode = `
+        async function processEvent (event) {
+            return event
+        }
+    `
+        await resetTestDatabase(testCode)
+        pluginsServer = await createPluginServer(
+            {},
+            {
+                http: true,
+                pluginScheduledTasks: true,
+                processPluginJobs: true,
+                processAsyncOnEventHandlers: true,
+                processAsyncWebhooksHandlers: true,
+                cdpProcessedEvents: true,
+                cdpFunctionCallbacks: true,
+                cdpFunctionOverflow: true,
+            }
+        )
+    })
+
+    test('startPluginsServer does not error - replay', async () => {
+        const testCode = `
+        async function processEvent (event) {
+            return event
+        }
+    `
+        await resetTestDatabase(testCode)
+        pluginsServer = await createPluginServer(
+            {},
+            {
+                http: true,
+                sessionRecordingBlobIngestion: true,
+                sessionRecordingBlobOverflowIngestion: true,
+            }
+        )
     })
 
     test('starting and stopping node-schedule scheduled jobs', async () => {
         expect(numberOfScheduledJobs()).toEqual(0)
 
-        pluginsServer = await createPluginServer()
+        pluginsServer = await createPluginServer(
+            {},
+            {
+                http: true,
+                pluginScheduledTasks: true,
+                processAsyncWebhooksHandlers: true,
+                preflightSchedules: true,
+            }
+        )
 
         expect(numberOfScheduledJobs()).toBeGreaterThan(1)
 
@@ -67,8 +138,11 @@ describe('server', () => {
     })
 
     describe('plugin-server capabilities', () => {
-        test('starts all main services by default', async () => {
-            pluginsServer = await createPluginServer()
+        test('starts graphile for scheduled tasks capability', async () => {
+            pluginsServer = await createPluginServer(
+                {},
+                { ingestion: true, pluginScheduledTasks: true, processPluginJobs: true }
+            )
 
             expect(startGraphileWorker).toHaveBeenCalled()
         })

--- a/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
+++ b/plugin-server/tests/worker/ingestion/postgres-parity.test.ts
@@ -45,7 +45,7 @@ describe('postgres parity', () => {
         `)
         await resetTestDatabaseClickhouse(extraServerConfig)
         console.log('[TEST] Starting plugins server')
-        const startResponse = await startPluginsServer(extraServerConfig, makePiscina)
+        const startResponse = await startPluginsServer(extraServerConfig, makePiscina, { ingestion: true })
         hub = startResponse.hub
         stopServer = startResponse.stop
         teamId++


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Longer term vision is PIPELINES also contains sth like 
`getInstance: async (hub: PipelineContext) => new NoopPipelineEngine(hub),` to get the pipeline, but for now, lets start with being able to define the topic and consumer group.

For hobby deploy & local dev (i.e. PluginServerMode = null)  we run all of the events ingestion pipelines.
In prod we can define to run each pipeline on a different host. We could run multiple on the same host, but for simplicity let's not do that now.

The pipelines by default don't have any ordering guarantees as by default new products aren't supposed to update persons (which isn't currently enfoced, but will be in follow-up PRs).

Made some tests a lot faster by only using necessary capabilities, which should lead to less flaky test failures for everyone going forward.
before:
<img width="468" alt="Screenshot 2024-07-16 at 20 07 28" src="https://github.com/user-attachments/assets/fb38884c-86a2-4299-8646-2b6d30746a76">
after:
<img width="478" alt="Screenshot 2024-07-16 at 20 07 21" src="https://github.com/user-attachments/assets/107adc6a-33ea-4a9e-bb4a-ac089db1a4a6">

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added functional test for ingestion warnings. Verified in local kafka-ui that the message was sent to client_iwarnings_ingestion topic as we have them set-up in prod.

Locally made historical topic from python capture be client_iwarnings_ingestion and saw events being ingested normally.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
