### PR TITLE
feat(capture): allow to route exception and heatmap events to separate topic

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -78,4 +78,4 @@ tracing = "0.1.40"
 tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version="0.3.18", features = ["env-filter"] }
 url = { version = "2.5.0 " }
-uuid = { version = "1.6.1", features = ["v7", "serde"] }
+uuid = { version = "1.6.1", features = ["v4", "v7", "serde"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -78,4 +78,4 @@ tracing = "0.1.40"
 tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version="0.3.18", features = ["env-filter"] }
 url = { version = "2.5.0 " }
-uuid = { version = "1.6.1", features = ["v4", "v7", "serde"] }
+uuid = { version = "1.6.1", features = ["v7", "serde"] }

--- a/rust/capture/src/api.rs
+++ b/rust/capture/src/api.rs
@@ -84,6 +84,7 @@ impl IntoResponse for CaptureError {
 pub enum DataType {
     AnalyticsMain,
     AnalyticsHistorical,
+    ClientIngestionWarning,
     HeatmapMain,
     ExceptionMain,
 }

--- a/rust/capture/src/api.rs
+++ b/rust/capture/src/api.rs
@@ -84,6 +84,8 @@ impl IntoResponse for CaptureError {
 pub enum DataType {
     AnalyticsMain,
     AnalyticsHistorical,
+    HeatmapMain,
+    ExceptionMain,
 }
 #[derive(Clone, Debug, Serialize, Eq, PartialEq)]
 pub struct ProcessedEvent {

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -55,6 +55,8 @@ pub struct KafkaConfig {
     #[envconfig(default = "events_plugin_ingestion_historical")]
     pub kafka_historical_topic: String,
     #[envconfig(default = "events_plugin_ingestion")]
+    pub kafka_client_ingestion_warning_topic: String,
+    #[envconfig(default = "events_plugin_ingestion")]
     pub kafka_exceptions_topic: String,
     #[envconfig(default = "events_plugin_ingestion")]
     pub kafka_heatmaps_topic: String,

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -54,6 +54,10 @@ pub struct KafkaConfig {
     pub kafka_topic: String,
     #[envconfig(default = "events_plugin_ingestion_historical")]
     pub kafka_historical_topic: String,
+    #[envconfig(default = "events_plugin_ingestion")]
+    pub kafka_exceptions_topic: String,
+    #[envconfig(default = "events_plugin_ingestion")]
+    pub kafka_heatmaps_topic: String,
     #[envconfig(default = "false")]
     pub kafka_tls: bool,
 }

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -193,7 +193,10 @@ impl KafkaSink {
                     (&self.main_topic, Some(event_key.as_str()))
                 }
             }
-            DataType::ClientIngestionWarning => (&self.client_ingestion_warning_topic, Some(event_key.as_str())),
+            DataType::ClientIngestionWarning => (
+                &self.client_ingestion_warning_topic,
+                Some(event_key.as_str()),
+            ),
             DataType::HeatmapMain => (&self.heatmaps_topic, Some(event_key.as_str())),
             DataType::ExceptionMain => (&self.exceptions_topic, Some(event_key.as_str())),
         };
@@ -334,6 +337,7 @@ mod tests {
             kafka_hosts: cluster.bootstrap_servers(),
             kafka_topic: "events_plugin_ingestion".to_string(),
             kafka_historical_topic: "events_plugin_ingestion_historical".to_string(),
+            kafka_client_ingestion_warning_topic: "events_plugin_ingestion".to_string(),
             kafka_exceptions_topic: "events_plugin_ingestion".to_string(),
             kafka_heatmaps_topic: "events_plugin_ingestion".to_string(),
             kafka_tls: false,

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -110,6 +110,7 @@ pub struct KafkaSink {
     partition: Option<OverflowLimiter>,
     main_topic: String,
     historical_topic: String,
+    client_ingestion_warning_topic: String,
     exceptions_topic: String,
     heatmaps_topic: String,
 }
@@ -160,6 +161,7 @@ impl KafkaSink {
             partition,
             main_topic: config.kafka_topic,
             historical_topic: config.kafka_historical_topic,
+            client_ingestion_warning_topic: config.kafka_client_ingestion_warning_topic,
             exceptions_topic: config.kafka_exceptions_topic,
             heatmaps_topic: config.kafka_heatmaps_topic,
         })
@@ -191,6 +193,7 @@ impl KafkaSink {
                     (&self.main_topic, Some(event_key.as_str()))
                 }
             }
+            DataType::ClientIngestionWarning => (&self.client_ingestion_warning_topic, Some(event_key.as_str())),
             DataType::HeatmapMain => (&self.heatmaps_topic, Some(event_key.as_str())),
             DataType::ExceptionMain => (&self.exceptions_topic, Some(event_key.as_str())),
         };

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -110,6 +110,8 @@ pub struct KafkaSink {
     partition: Option<OverflowLimiter>,
     main_topic: String,
     historical_topic: String,
+    exceptions_topic: String,
+    heatmaps_topic: String,
 }
 
 impl KafkaSink {
@@ -158,6 +160,8 @@ impl KafkaSink {
             partition,
             main_topic: config.kafka_topic,
             historical_topic: config.kafka_historical_topic,
+            exceptions_topic: config.kafka_exceptions_topic,
+            heatmaps_topic: config.kafka_heatmaps_topic,
         })
     }
 
@@ -187,6 +191,8 @@ impl KafkaSink {
                     (&self.main_topic, Some(event_key.as_str()))
                 }
             }
+            DataType::HeatmapMain => (&self.heatmaps_topic, Some(event_key.as_str())),
+            DataType::ExceptionMain => (&self.exceptions_topic, Some(event_key.as_str())),
         };
 
         match self.producer.send_result(FutureRecord {
@@ -325,6 +331,8 @@ mod tests {
             kafka_hosts: cluster.bootstrap_servers(),
             kafka_topic: "events_plugin_ingestion".to_string(),
             kafka_historical_topic: "events_plugin_ingestion_historical".to_string(),
+            kafka_exceptions_topic: "events_plugin_ingestion".to_string(),
+            kafka_heatmaps_topic: "events_plugin_ingestion".to_string(),
             kafka_tls: false,
         };
         let sink = KafkaSink::new(config, handle, limiter).expect("failed to create sink");

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -182,14 +182,12 @@ pub fn process_single_event(
         return Err(CaptureError::MissingEventName);
     }
 
-    let data_type = match event.event.as_str() {
-        "$$client_ingestion_warning" => DataType::ClientIngestionWarning,
-        "$exception" => DataType::ExceptionMain,
-        "$$heatmap" => DataType::HeatmapMain,
-        _ => match context.historical_migration {
-            true => DataType::AnalyticsHistorical,
-            false => DataType::AnalyticsMain,
-        },
+    let data_type = match (event.event.as_str(), context.historical_migration) {
+        ("$$client_ingestion_warning", _) => DataType::ClientIngestionWarning,
+        ("$exception", _) => DataType::ExceptionMain,
+        ("$$heatmap", _) => DataType::HeatmapMain,
+        (_, true) => DataType::AnalyticsHistorical,
+        (_, false) => DataType::AnalyticsMain
     };
 
     let data = serde_json::to_string(&event).map_err(|e| {

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -187,7 +187,7 @@ pub fn process_single_event(
         ("$exception", _) => DataType::ExceptionMain,
         ("$$heatmap", _) => DataType::HeatmapMain,
         (_, true) => DataType::AnalyticsHistorical,
-        (_, false) => DataType::AnalyticsMain
+        (_, false) => DataType::AnalyticsMain,
     };
 
     let data = serde_json::to_string(&event).map_err(|e| {

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -182,9 +182,13 @@ pub fn process_single_event(
         return Err(CaptureError::MissingEventName);
     }
 
-    let data_type = match context.historical_migration {
-        true => DataType::AnalyticsHistorical,
-        false => DataType::AnalyticsMain,
+    let data_type = match event.event.as_str() {
+        "$exception" => DataType::ExceptionMain,
+        "$$heatmap" => DataType::HeatmapMain,
+        _ => match context.historical_migration {
+            true => DataType::AnalyticsHistorical,
+            false => DataType::AnalyticsMain,
+        },
     };
 
     let data = serde_json::to_string(&event).map_err(|e| {

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -183,6 +183,7 @@ pub fn process_single_event(
     }
 
     let data_type = match event.event.as_str() {
+        "$$client_ingestion_warning" => DataType::ClientIngestionWarning,
         "$exception" => DataType::ExceptionMain,
         "$$heatmap" => DataType::HeatmapMain,
         _ => match context.historical_migration {

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -45,6 +45,8 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
         kafka_hosts: "kafka:9092".to_string(),
         kafka_topic: "events_plugin_ingestion".to_string(),
         kafka_historical_topic: "events_plugin_ingestion_historical".to_string(),
+        kafka_exceptions_topic: "events_plugin_ingestion".to_string(),
+        kafka_heatmaps_topic: "events_plugin_ingestion".to_string(),
         kafka_tls: false,
     },
     otel_url: None,
@@ -177,6 +179,15 @@ impl EphemeralTopic {
             Some(Err(err)) => bail!("kafka read error: {}", err),
             None => bail!("kafka read timeout"),
         }
+    }
+
+    pub(crate) fn assert_empty(&self) {
+        assert!(
+            self.consumer
+                .poll(Timeout::After(Duration::from_secs(1)))
+                .is_none(),
+            "topic holds more messages"
+        )
     }
 
     pub fn topic_name(&self) -> &str {

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -45,6 +45,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
         kafka_hosts: "kafka:9092".to_string(),
         kafka_topic: "events_plugin_ingestion".to_string(),
         kafka_historical_topic: "events_plugin_ingestion_historical".to_string(),
+        kafka_client_ingestion_warning_topic: "events_plugin_ingestion".to_string(),
         kafka_exceptions_topic: "events_plugin_ingestion".to_string(),
         kafka_heatmaps_topic: "events_plugin_ingestion".to_string(),
         kafka_tls: false,

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -1,13 +1,13 @@
 use std::num::NonZeroU32;
 use time::Duration;
 
+use crate::common::*;
 use anyhow::Result;
 use assert_json_diff::assert_json_include;
 use capture::limiters::billing::QuotaResource;
 use reqwest::StatusCode;
 use serde_json::json;
-
-use crate::common::*;
+use uuid::Uuid;
 mod common;
 
 #[tokio::test]
@@ -408,6 +408,92 @@ async fn it_applies_billing_limits() -> Result<()> {
             "distinct_id": distinct_id
         })
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_routes_exceptions_and_heapmaps_to_separate_topics() -> Result<()> {
+    setup_tracing();
+
+    let token = random_string("token", 16);
+    let distinct_id = random_string("id", 16);
+    let uuids: [Uuid; 4] = core::array::from_fn(|_| Uuid::new_v4());
+
+    let main_topic = EphemeralTopic::new().await;
+    let exceptions_topic = EphemeralTopic::new().await;
+    let heatmaps_topic = EphemeralTopic::new().await;
+
+    let mut config = DEFAULT_CONFIG.clone();
+    config.kafka.kafka_topic = main_topic.topic_name().to_string();
+    config.kafka.kafka_exceptions_topic = exceptions_topic.topic_name().to_string();
+    config.kafka.kafka_heatmaps_topic = heatmaps_topic.topic_name().to_string();
+
+    let server = ServerHandle::for_config(config).await;
+
+    let event = json!([{
+        "token": token,
+        "event": "event1",
+        "uuid": uuids[0],
+        "distinct_id": distinct_id
+    },{
+        "token": token,
+        "event": "$$heatmap",
+        "uuid": uuids[1],
+        "distinct_id": distinct_id
+    },{
+        "token": token,
+        "event": "$exception",
+        "uuid": uuids[2],
+        "distinct_id": distinct_id
+    },{
+        "token": token,
+        "event": "event2",
+        "uuid": uuids[3],
+        "distinct_id": distinct_id
+    }]);
+
+    let res = server.capture_events(event.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    // Regular events are pushed to the main analytics topic
+    assert_json_include!(
+        actual: main_topic.next_event()?,
+        expected: json!({
+            "token": token,
+        "uuid": uuids[0],
+            "distinct_id": distinct_id
+        })
+    );
+    assert_json_include!(
+        actual: main_topic.next_event()?,
+        expected: json!({
+            "token": token,
+        "uuid": uuids[3],
+            "distinct_id": distinct_id
+        })
+    );
+    main_topic.assert_empty();
+
+    // Special-cased events are pushed to their own topics
+    assert_json_include!(
+        actual: exceptions_topic.next_event()?,
+        expected: json!({
+            "token": token,
+        "uuid": uuids[2],
+            "distinct_id": distinct_id
+        })
+    );
+    exceptions_topic.assert_empty();
+    assert_json_include!(
+        actual: heatmaps_topic.next_event()?,
+        expected: json!({
+            "token": token,
+        "uuid": uuids[1],
+            "distinct_id": distinct_id
+        })
+    );
+    heatmaps_topic.assert_empty();
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

`$exception` and `$$heatmap` events are pushed to the main `/e` endpoint, but we want the ability to capture them into separate Kafka topics for better isolation.

This PR is a quick-and-easy way to achieve this while I work on a revamping of the routing decision.

## Changes

- Add the `HeatmapMain` and `ExceptionMain` data types. We don't support overflow nor historical for these yet
- Add two more envvars to specify the destination topics for these datatypes. For now, they default to the main ingestion topic, we'll tune chart values when the consumers are ready
- Add an integration test for this

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Integration test.

Interestingly, integration tests start getting flaky on macos, with `failed to send request: reqwest::Error { kind: Request, url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Ipv4(127.0.0.1)), port: Some(54798), path: "/i/v0/e", query: None, fragment: None }, source: Error { kind: Connect, source: Some(ConnectError("tcp open error", Os { code: 24, kind: Uncategorized, message: "Too many open files" })) } }` errors, because all test cases run in parallel. But running a smaller subset still works fine.

Let's check how the Linux CI behaves while I investigate how to cap concurrency.