### PR TITLE
fix: update feature flags usage note in billing

### DIFF
--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -498,7 +498,7 @@ export const FeatureFlagUsageNotice = ({ product }: { product: BillingProductV2T
         <p className="mt-4 ml-0 text-sm text-muted italic">
             <IconInfo className="mr-1" />
             Questions? Here's{' '}
-            <Link to="https://posthog.com/docs/feature-flags/common-questions#billing-usage" className="italic">
+            <Link to="https://posthog.com/docs/feature-flags/common-questions#billing--usage" className="italic">
                 how we calculate usage
             </Link>{' '}
             for feature flags.

--- a/frontend/src/scenes/billing/BillingProduct.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.tsx
@@ -1,4 +1,4 @@
-import { IconCheckCircle, IconChevronDown, IconDocument, IconPlus } from '@posthog/icons'
+import { IconCheckCircle, IconChevronDown, IconDocument, IconInfo, IconPlus } from '@posthog/icons'
 import { LemonButton, Link } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
@@ -214,6 +214,9 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                                 )}
                                                 <div className="grow">
                                                     <BillingGauge items={billingGaugeItems} product={product} />
+                                                    {!product.subscribed && (
+                                                        <FeatureFlagUsageNotice product={product} />
+                                                    )}
                                                 </div>
                                             </div>
                                             {product.subscribed ? (
@@ -291,6 +294,7 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
                                         <div className="grow">
                                             <div className="grow">
                                                 <BillingGauge items={billingGaugeItems} product={product} />
+                                                <FeatureFlagUsageNotice product={product} />
                                             </div>
                                             {/* TODO: rms: remove this notice after August 8 2024 */}
                                             {product.type == ProductKey.DATA_WAREHOUSE &&
@@ -487,4 +491,17 @@ export const BillingProduct = ({ product }: { product: BillingProductV2Type }): 
             />
         </div>
     )
+}
+
+export const FeatureFlagUsageNotice = ({ product }: { product: BillingProductV2Type }): JSX.Element | null => {
+    return product.type === 'feature_flags' ? (
+        <p className="mt-4 ml-0 text-sm text-muted italic">
+            <IconInfo className="mr-1" />
+            Questions? Here's{' '}
+            <Link to="https://posthog.com/docs/feature-flags/common-questions#billing-usage" className="italic">
+                how we calculate usage
+            </Link>{' '}
+            for feature flags.
+        </p>
+    ) : null
 }

--- a/frontend/src/scenes/billing/BillingProductPricingTable.tsx
+++ b/frontend/src/scenes/billing/BillingProductPricingTable.tsx
@@ -1,12 +1,12 @@
-import { IconArrowRightDown, IconInfo } from '@posthog/icons'
-import { LemonBanner, LemonTable, LemonTableColumns, Link } from '@posthog/lemon-ui'
+import { IconArrowRightDown } from '@posthog/icons'
+import { LemonBanner, LemonTable, LemonTableColumns } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import { compactNumber } from 'lib/utils'
 
 import { BillingProductV2Type, BillingTableTierRow, ProductPricingTierSubrows } from '~/types'
 
 import { billingLogic } from './billingLogic'
-import { getTierDescription } from './BillingProduct'
+import { FeatureFlagUsageNotice, getTierDescription } from './BillingProduct'
 
 function Subrows(props: ProductPricingTierSubrows): JSX.Element {
     return (
@@ -181,19 +181,7 @@ export const BillingProductPricingTable = ({
                             rowExpandable: (row) => !!row.subrows?.rows?.length,
                         }}
                     />
-                    {product.type === 'feature_flags' && (
-                        <p className="mt-4 ml-0 text-sm text-muted italic">
-                            <IconInfo className="mr-1" />
-                            Using local evaluation? Here's{' '}
-                            <Link
-                                to="https://posthog.com/docs/feature-flags/bootstrapping-and-local-evaluation#server-side-local-evaluation"
-                                className="italic"
-                            >
-                                how we calculate usage
-                            </Link>
-                            .
-                        </p>
-                    )}
+                    <FeatureFlagUsageNotice product={product} />
                     <LemonBanner type="warning" className="text-sm pt-2">
                         Tier breakdowns are updated once daily and may differ from the gauge above.
                     </LemonBanner>


### PR DESCRIPTION
## Problem

On billing we link to a feature flags doc that explains how local evaluation works. 

BUT that doc had nothing about usage or billing 🙈 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- Changes the link to the correct link.
- Adds the note to free plans as well (it used to only show up if you expanded the usage table, which only exists for paid plans)
- Changes text to make it more generic about usage in general, not just local evaluation

![Arc 2024-07-10 10 29 24](https://github.com/PostHog/posthog/assets/18598166/21081688-abf3-4d4c-8e87-20f08162159e)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

N/A

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
