### PR TITLE
fix: playlist height wrapper

### DIFF
--- a/frontend/src/lib/components/Playlist/Playlist.scss
+++ b/frontend/src/lib/components/Playlist/Playlist.scss
@@ -51,7 +51,7 @@
 
 .SessionRecordingPlaylistHeightWrapper {
     // NOTE: Somewhat random way to offset the various headers and tabs above the playlist
-    height: calc(100vh - 9rem);
+    height: calc(100vh - 15rem);
     min-height: 41rem;
 }
 


### PR DESCRIPTION
## Problem

Fixes https://posthoghelp.zendesk.com/agent/tickets/15595 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/17813)

## Changes

Now that the new filters are released and live on top of the playlist we need to add extra margin

|Before|After|
|----|----|
| ![Screenshot 2024-07-11 at 10 05 26](https://github.com/PostHog/posthog/assets/6685876/b891178d-5938-4d95-aec8-6c48307ee93c) | ![Screenshot 2024-07-11 at 10 05 09](https://github.com/PostHog/posthog/assets/6685876/202d761c-e8c6-442d-ae13-43ab16d734ee) |