### PR TITLE
fix(cdp): Add patch to webhook template options

### DIFF
--- a/posthog/cdp/templates/webhook/template_webhook.py
+++ b/posthog/cdp/templates/webhook/template_webhook.py
@@ -37,6 +37,10 @@ fetch(inputs.url, {
                     "value": "PUT",
                 },
                 {
+                    "label": "PATCH",
+                    "value": "PATCH",
+                },
+                {
                     "label": "GET",
                     "value": "GET",
                 },


### PR DESCRIPTION
## Problem

We forgot patch

## Changes

* Adds patch

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
