### PR TITLE
chore(CI): add heathcheck to kafka & redis container, wait before tests

### DIFF
--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -105,7 +105,7 @@ jobs:
               if: needs.changes.outputs.plugin-server == 'true'
               run: |
                   docker compose -f docker-compose.dev.yml down
-                  docker compose -f docker-compose.dev.yml up -d --wait
+                  docker compose -f docker-compose.dev.yml up -d
 
             - name: Add Kafka to /etc/hosts
               if: needs.changes.outputs.plugin-server == 'true'
@@ -151,9 +151,11 @@ jobs:
               if: needs.changes.outputs.plugin-server == 'true'
               run: cd plugin-server && pnpm i
 
-            - name: Wait for Clickhouse & Kafka
+            - name: Wait for Clickhouse, Redis & Kafka
               if: needs.changes.outputs.plugin-server == 'true'
-              run: bin/check_kafka_clickhouse_up
+              run: |
+                  docker compose -f docker-compose.dev.yml up kafka redis clickhouse -d --wait
+                  bin/check_kafka_clickhouse_up
 
             - name: Set up databases
               if: needs.changes.outputs.plugin-server == 'true'
@@ -199,7 +201,7 @@ jobs:
             - name: Stop/Start stack with Docker Compose
               run: |
                   docker compose -f docker-compose.dev.yml down
-                  docker compose -f docker-compose.dev.yml up -d --wait
+                  docker compose -f docker-compose.dev.yml up -d
 
             - name: Add Kafka to /etc/hosts
               run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
@@ -241,8 +243,10 @@ jobs:
                   pnpm install --frozen-lockfile
                   pnpm build
 
-            - name: Wait for Clickhouse & Kafka
-              run: bin/check_kafka_clickhouse_up
+            - name: Wait for Clickhouse, Redis & Kafka
+              run: |
+                  docker compose -f docker-compose.dev.yml up kafka redis clickhouse -d --wait
+                  bin/check_kafka_clickhouse_up
 
             - name: Set up databases
               env:

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -105,7 +105,7 @@ jobs:
               if: needs.changes.outputs.plugin-server == 'true'
               run: |
                   docker compose -f docker-compose.dev.yml down
-                  docker compose -f docker-compose.dev.yml up -d
+                  docker compose -f docker-compose.dev.yml up -d --wait
 
             - name: Add Kafka to /etc/hosts
               if: needs.changes.outputs.plugin-server == 'true'
@@ -199,7 +199,7 @@ jobs:
             - name: Stop/Start stack with Docker Compose
               run: |
                   docker compose -f docker-compose.dev.yml down
-                  docker compose -f docker-compose.dev.yml up -d
+                  docker compose -f docker-compose.dev.yml up -d --wait
 
             - name: Add Kafka to /etc/hosts
               run: echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -19,6 +19,11 @@ services:
         image: redis:6.2.7-alpine
         restart: on-failure
         command: redis-server --maxmemory-policy allkeys-lru --maxmemory 200mb
+        healthcheck:
+            test: ['CMD', 'redis-cli', 'ping']
+            interval: 3s
+            timeout: 10s
+            retries: 10
 
     clickhouse:
         #
@@ -42,6 +47,11 @@ services:
             KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
             KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
             ALLOW_PLAINTEXT_LISTENER: 'true'
+        healthcheck:
+            test: kafka-cluster.sh cluster-id --bootstrap-server localhost:9092 || exit 1
+            interval: 3s
+            timeout: 10s
+            retries: 10
 
     kafka_ui:
         image: provectuslabs/kafka-ui:latest


### PR DESCRIPTION
## Problem

plugin-server tests sometimes start before the kafka broker is healthy, and then fail.

## Changes

- Add healthchecks to the kafka and redis containers, copied from the rust stack
- Change the `Wait for Clickhouse & Kafka` step to check the container healthchecks for better accuracy. Only check redis, clickhouse & kafka, as the maildev container is unhealthy but not needed for these tests



## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
