### PR TITLE
fix: replay opt in

### DIFF
--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -178,6 +178,14 @@ const SessionReplayOnboarding = (): JSX.Element => {
             value: currentTeam?.capture_performance_opt_in ?? true,
             visible: true,
         },
+        {
+            type: 'toggle',
+            title: 'Record user sessions',
+            description: 'Watch recordings of how users interact with your web app to see what can be improved.',
+            teamProperty: 'session_recording_opt_in',
+            value: true,
+            visible: false,
+        },
     ]
 
     if (hasAvailableFeature(AvailableFeature.REPLAY_RECORDING_DURATION_MINIMUM)) {


### PR DESCRIPTION
Going through onboarding for replay - at least if you weren't going to subscribe and choose a free plan - does not enable replay

That feels wrong

Added it as a hidden enabled toggle since it feels implicit you're turning replay on

Checked in prod with a new project
And validated locally that this now enables replay