### PR TITLE
chore(dev-ex): Added the ability to debug non-ph code in vscode tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -160,6 +160,15 @@
             "pythonLaunchName": "Pytest: Current File",
             "cppConfig": "custom",
             "cppAttachName": "(lldb) Attach"
+        },
+        {
+            "name": "Python: Debug Tests",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "purpose": ["debug-test"],
+            "console": "integratedTerminal",
+            "justMyCode": false
         }
     ],
     "compounds": [


### PR DESCRIPTION
## Problem
- I wanna be able to debug pip packages code when running unit tests in debug mode from vscode

## Changes
- From [here](https://stackoverflow.com/questions/76235458/in-vs-code-how-can-i-disable-justmycode-when-running-pytest-in-testing-tab) - add a new launch config with `"justMyCode": false` set

## Does this work well for both Cloud and self-hosted?
n/a

## How did you test this code?
Debugged DLT code locally 