### PR TITLE
fix(insights): formatting of numeric values

### DIFF
--- a/frontend/src/scenes/insights/utils.test.ts
+++ b/frontend/src/scenes/insights/utils.test.ts
@@ -377,6 +377,26 @@ describe('formatBreakdownLabel()', () => {
         expect(formatBreakdownLabel(10, breakdownFilter, [], identity, 2)).toEqual('10')
         expect(formatBreakdownLabel(10, breakdownFilter, [], () => '10s', 0)).toEqual('10s')
     })
+
+    it('handles stringified numbers', () => {
+        const formatter = (_breakdown: any, v: any): any => `${v}s`
+
+        const breakdownFilter1: BreakdownFilter = {
+            breakdown: '$session_duration',
+            breakdown_type: 'session',
+        }
+        expect(formatBreakdownLabel('661', breakdownFilter1, undefined, formatter)).toEqual('661s')
+
+        const breakdownFilter2: BreakdownFilter = {
+            breakdowns: [
+                {
+                    value: '$session_duration',
+                    type: 'session',
+                },
+            ],
+        }
+        expect(formatBreakdownLabel('661', breakdownFilter2, undefined, formatter, 0)).toEqual('661s')
+    })
 })
 
 describe('formatBreakdownType()', () => {

--- a/frontend/src/scenes/insights/utils.test.ts
+++ b/frontend/src/scenes/insights/utils.test.ts
@@ -397,6 +397,26 @@ describe('formatBreakdownLabel()', () => {
         }
         expect(formatBreakdownLabel('661', breakdownFilter2, undefined, formatter, 0)).toEqual('661s')
     })
+
+    it('handles array first', () => {
+        const formatter = (_: any, value: any, type: any): any => (type === 'session' ? `${value}s` : value)
+
+        const breakdownFilter1: BreakdownFilter = {
+            breakdown: '$session_duration',
+            breakdown_type: 'session',
+        }
+        expect(formatBreakdownLabel(['661'], breakdownFilter1, undefined, formatter)).toEqual('661s')
+
+        const breakdownFilter2: BreakdownFilter = {
+            breakdowns: [
+                {
+                    value: '$session_duration',
+                    type: 'session',
+                },
+            ],
+        }
+        expect(formatBreakdownLabel('661', breakdownFilter2, undefined, formatter, 0)).toEqual('661s')
+    })
 })
 
 describe('formatBreakdownType()', () => {

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -219,6 +219,37 @@ function isValidJsonArray(maybeJson: string): boolean {
     return false
 }
 
+function formatNumericBreakdownLabel(
+    breakdown_value: number,
+    breakdownFilter: BreakdownFilter | null | undefined,
+    formatPropertyValueForDisplay: FormatPropertyValueForDisplayFunction | undefined,
+    multipleBreakdownIndex: number | undefined
+): string {
+    if (isOtherBreakdown(breakdown_value)) {
+        return BREAKDOWN_OTHER_DISPLAY
+    }
+
+    if (isNullBreakdown(breakdown_value)) {
+        return BREAKDOWN_NULL_DISPLAY
+    }
+
+    if (formatPropertyValueForDisplay) {
+        const nestedBreakdown =
+            typeof multipleBreakdownIndex === 'number'
+                ? breakdownFilter?.breakdowns?.[multipleBreakdownIndex]
+                : undefined
+
+        return (
+            formatPropertyValueForDisplay(
+                nestedBreakdown?.value ?? breakdownFilter?.breakdown,
+                breakdown_value
+            )?.toString() ?? 'None'
+        )
+    }
+
+    return String(breakdown_value)
+}
+
 export function formatBreakdownLabel(
     breakdown_value: BreakdownKeyType | undefined,
     breakdownFilter: BreakdownFilter | null | undefined,
@@ -248,48 +279,50 @@ export function formatBreakdownLabel(
             return formattedBucketStart
         }
         return `${formattedBucketStart} – ${formattedBucketEnd}`
-    } else if (breakdownFilter?.breakdown_type === 'cohort') {
+    }
+
+    if (breakdownFilter?.breakdown_type === 'cohort') {
         // :TRICKY: Different endpoints represent the all users cohort breakdown differently
         if (breakdown_value === 0 || breakdown_value === 'all') {
             return 'All Users'
         }
 
         return cohorts?.filter((c) => c.id == breakdown_value)[0]?.name ?? (breakdown_value || '').toString()
-    } else if (typeof breakdown_value == 'number') {
-        if (isOtherBreakdown(breakdown_value)) {
-            return BREAKDOWN_OTHER_DISPLAY
-        }
+    }
 
-        if (isNullBreakdown(breakdown_value)) {
-            return BREAKDOWN_NULL_DISPLAY
-        }
+    if (typeof breakdown_value == 'number') {
+        return formatNumericBreakdownLabel(
+            breakdown_value,
+            breakdownFilter,
+            formatPropertyValueForDisplay,
+            multipleBreakdownIndex
+        )
+    }
 
-        if (formatPropertyValueForDisplay) {
-            const nestedBreakdown =
-                typeof multipleBreakdownIndex === 'number'
-                    ? breakdownFilter?.breakdowns?.[multipleBreakdownIndex]
-                    : undefined
+    const maybeNumericValue = Number(breakdown_value)
+    if (!Number.isNaN(maybeNumericValue)) {
+        return formatNumericBreakdownLabel(
+            maybeNumericValue,
+            breakdownFilter,
+            formatPropertyValueForDisplay,
+            multipleBreakdownIndex
+        )
+    }
 
-            return (
-                formatPropertyValueForDisplay(
-                    nestedBreakdown?.value ?? breakdownFilter?.breakdown,
-                    breakdown_value
-                )?.toString() ?? 'None'
-            )
-        }
-
-        return String(breakdown_value)
-    } else if (typeof breakdown_value == 'string') {
+    if (typeof breakdown_value == 'string') {
         return isOtherBreakdown(breakdown_value) || breakdown_value === 'nan'
             ? BREAKDOWN_OTHER_DISPLAY
             : isNullBreakdown(breakdown_value) || breakdown_value === ''
             ? BREAKDOWN_NULL_DISPLAY
             : breakdown_value
-    } else if (Array.isArray(breakdown_value)) {
+    }
+
+    if (Array.isArray(breakdown_value)) {
         return breakdown_value
             .map((v, index) => formatBreakdownLabel(v, breakdownFilter, cohorts, formatPropertyValueForDisplay, index))
             .join('::')
     }
+
     return ''
 }
 


### PR DESCRIPTION
## Problem

Before implementing multiple breakdowns, I noticed that we don't output any more numeric values, so formatting was off for the session duration, for example. It is related to #23139. Additionally, the first formatting of numeric properties worked only for events because we didn't pass the property type to the formatter function. A re-selection of the same property applied the formatting as expected.

<img width="1057" alt="Screenshot 2024-07-11 at 17 37 23" src="https://github.com/PostHog/posthog/assets/13541795/032ad3a0-40ef-4cad-a9f9-022ea01d6a33">

#### Values with a single breakdown (`breakdownFilter.breakdown`)

- `breakdown_histogram_bin_count` enabled: JSON with a number array like `"[1,15.01]"`. The formatting is correct.
- `breakdown_histogram_bin_count` disabled: string. The formatting is incorrect.

#### Values with multiple breakdowns (`breakdownFilter.breakdowns`)

Always outputs an array of strings:
- `histogram_bin_count` enabled: JSON with a number array like `"[1,15.01]"`. The formatting is correct.
- `histogram_bin_count` disabled: string. The formatting is incorrect.

For backward compatibility, it might be better to typecast values on the backend instead of the frontend. Let me know if that's the case.

## Changes

- Catch numeric breakdown values on the frontend to apply formatting
- Fix passing a property type to the formatter function

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added a few tests to catch regressions in the future.