### PR TITLE
fix: set team properties when someone starts onboarding

### DIFF
--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -36,7 +36,7 @@ export function ProductCard({
     className?: string
 }): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
-    const { setIncludeIntro } = useActions(onboardingLogic)
+    const { setIncludeIntro, setTeamPropertiesForProduct } = useActions(onboardingLogic)
     const { user } = useValues(userLogic)
     const { reportOnboardingProductSelected } = useActions(eventUsageLogic)
     const onboardingCompleted = currentTeam?.has_completed_onboarding_for?.[productKey]
@@ -49,6 +49,7 @@ export function ProductCard({
             key={productKey}
             onClick={() => {
                 setIncludeIntro(false)
+                setTeamPropertiesForProduct(productKey as ProductKey)
                 if (!onboardingCompleted) {
                     const includeFirstOnboardingProductOnUserProperties = user?.date_joined
                         ? new Date(user?.date_joined) > new Date('2024-01-10T00:00:00Z')


### PR DESCRIPTION
## Problem

We want people to have the correct team properties set (eg enable recordings for the team) as soon as they start onboarding. 

This existed from the product intro page, but not from the regular Products page, which is the entry point for most people.

**Potential issue:** 

What if someone is just clicking around? Onboarding currently suppresses notifications that team settings been changed. With our single-subscribe, we now run the risk of: 
- someone clicking this just 'cause
- then going through analytics onboarding
- subscribing
- racking up a bill because they turned replay on when they didn't really want it

What is the best user experience here? 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Sets team properties when starting onboarding from products page

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

I didn't... Maybe you can @pauldambra? Cypress test would be nice.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
