### PR TITLE
feat: add flag to disable email verification in case on incidents

### DIFF
--- a/posthog/api/authentication.py
+++ b/posthog/api/authentication.py
@@ -33,7 +33,7 @@ from two_factor.views.utils import (
     validate_remember_device_cookie,
 )
 
-from posthog.api.email_verification import EmailVerifier
+from posthog.api.email_verification import EmailVerifier, is_email_verification_disabled
 from posthog.email import is_email_available
 from posthog.event_usage import report_user_logged_in, report_user_password_reset
 from posthog.models import OrganizationDomain, User
@@ -147,7 +147,7 @@ class LoginSerializer(serializers.Serializer):
             raise serializers.ValidationError("Invalid email or password.", code="invalid_credentials")
 
         # We still let them log in if is_email_verified is null so existing users don't get locked out
-        if is_email_available() and user.is_email_verified is not True:
+        if is_email_available() and user.is_email_verified is not True and not is_email_verification_disabled(user):
             EmailVerifier.create_token_and_send_email_verification(user)
             # If it's None, we want to let them log in still since they are an existing user
             # If it's False, we want to tell them to check their email

--- a/posthog/api/email_verification.py
+++ b/posthog/api/email_verification.py
@@ -7,7 +7,7 @@ from sentry_sdk import capture_exception
 from posthog.models.user import User
 from posthog.tasks.email import send_email_verification
 
-VERIFICATION_DISABLED_FLAG = "email_verification_disabled"
+VERIFICATION_DISABLED_FLAG = "email-verification-disabled"
 
 
 def is_email_verification_disabled(user: User) -> bool:

--- a/posthog/api/email_verification.py
+++ b/posthog/api/email_verification.py
@@ -1,3 +1,4 @@
+import posthoganalytics
 from django.contrib.auth.models import AbstractBaseUser
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from rest_framework import exceptions
@@ -5,6 +6,18 @@ from sentry_sdk import capture_exception
 
 from posthog.models.user import User
 from posthog.tasks.email import send_email_verification
+
+VERIFICATION_DISABLED_FLAG = "email_verification_disabled"
+
+
+def is_email_verification_disabled(user: User) -> bool:
+    # using disabled here so that the default state (if no flag exists) is that verification defaults to ON.
+    return user.organization is not None and posthoganalytics.feature_enabled(
+        VERIFICATION_DISABLED_FLAG,
+        user.organization.id,
+        groups={"organization": str(user.organization.id)},
+        group_properties={"organization": {"id": str(user.organization.id)}},
+    )
 
 
 class EmailVerificationTokenGenerator(PasswordResetTokenGenerator):

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -15,10 +15,7 @@ from sentry_sdk import capture_exception
 from social_core.pipeline.partial import partial
 from social_django.strategy import DjangoStrategy
 
-from posthog.api.email_verification import (
-    EmailVerifier,
-    is_email_verification_disabled,
-)
+from posthog.api.email_verification import EmailVerifier, is_email_verification_disabled
 from posthog.api.shared import UserBasicSerializer
 from posthog.demo.matrix import MatrixManager
 from posthog.demo.products.hedgebox import HedgeboxMatrix
@@ -49,7 +46,15 @@ def verify_email_or_login(request: HttpRequest, user: User) -> None:
 
 
 def get_redirect_url(uuid: str, is_email_verified: bool) -> str:
-    return "/verify_email/" + uuid if is_email_available() and not is_email_verified and not settings.DEMO else "/"
+    user = User.objects.get(uuid=uuid)
+    return (
+        "/verify_email/" + uuid
+        if is_email_available()
+        and not is_email_verified
+        and not is_email_verification_disabled(user)
+        and not settings.DEMO
+        else "/"
+    )
 
 
 class SignupSerializer(serializers.Serializer):

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -15,7 +15,10 @@ from sentry_sdk import capture_exception
 from social_core.pipeline.partial import partial
 from social_django.strategy import DjangoStrategy
 
-from posthog.api.email_verification import EmailVerifier
+from posthog.api.email_verification import (
+    EmailVerifier,
+    is_email_verification_disabled,
+)
 from posthog.api.shared import UserBasicSerializer
 from posthog.demo.matrix import MatrixManager
 from posthog.demo.products.hedgebox import HedgeboxMatrix
@@ -39,7 +42,7 @@ logger = structlog.get_logger(__name__)
 
 
 def verify_email_or_login(request: HttpRequest, user: User) -> None:
-    if is_email_available() and not user.is_email_verified:
+    if is_email_available() and not user.is_email_verified and not is_email_verification_disabled(user):
         EmailVerifier.create_token_and_send_email_verification(user)
     else:
         login(request, user, backend="django.contrib.auth.backends.ModelBackend")

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -145,8 +145,7 @@ class TestSignupAPI(APIBaseTest):
 
         # Assert that the user is logged in
         response = self.client.get("/api/users/@me/")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["email"], "hedgehog@posthog.com")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         mock_is_email_available.assert_called()
         # Assert the email was sent.


### PR DESCRIPTION
## Problem

If there is an issue with email sending (today Mailgun had some sort of incident), new users can't sign up fully because they can't get the verification email. We should have some way to disable email verification quickly when this happens. Users will still get the verification notices in-app so they should eventually verify.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds a flag check for `email-verification-disabled` to signup and authentication.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Self-hosted shouldn't be impacted

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Wrote some signup tests for verification (they were missing...) and for checking for the flag value and skipping if disabled = true.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
