### PR TITLE
fix: replay email property

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteSelectResults.tsx
@@ -68,7 +68,7 @@ export function InfiniteSelectResults({
         <RenderComponent
             {...(activeTaxonomicGroup?.componentProps ?? {})}
             value={value}
-            onChange={(newValue) => selectItem(activeTaxonomicGroup, newValue, newValue)}
+            onChange={(newValue, item) => selectItem(activeTaxonomicGroup, newValue, item)}
         />
     ) : (
         <InfiniteList popupAnchorElement={popupAnchorElement} />

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -616,7 +616,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
     }),
     listeners(({ actions, values, props }) => ({
         selectItem: ({ group, value, item }) => {
-            if (item) {
+            if (item || group.type === TaxonomicFilterGroupType.HogQLExpression) {
                 props.onChange?.(group, value, item)
             }
             actions.setSearchQuery('')


### PR DESCRIPTION
## Problem

Email filter from the Replay Taxonomic page is not working because it's being inserted as a Replay property, not a Person property.

## Changes

Pass out the item with the `propertyFilterType` set as Person which will be picked up during the creation of the filter
https://github.com/PostHog/posthog/blob/031f74f025184f1eae8c0872309cf9462ffa3a66/frontend/src/lib/components/UniversalFilters/universalFiltersLogic.ts#L115

This was [previously implemented](https://github.com/PostHog/posthog/pull/22869) but had to be [reverted](https://github.com/PostHog/posthog/pull/22894) because I broke the inline HogQL editor (see [Slack](https://posthog.slack.com/archives/C0368RPHLQH/p1718134640664799?thread_ts=1718133011.123429&cid=C0368RPHLQH) for context). Adding the extra condition to `taxonomicFilterLogic` makes sure I don't break things again

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Verified locally