### PR TITLE
fix(surveys): add validation to multi-choice survey questions with empty choices

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1124,13 +1124,13 @@ export const surveyLogic = kea<surveyLogicType>([
                 // to scroll to the right error section
                 name: !name && 'Please enter a name.',
                 questions: questions.map((question) => {
-                    const baseErrors = {
+                    const questionErrors = {
                         question: !question.question && 'Please enter a question label.',
                     }
 
                     if (question.type === SurveyQuestionType.Rating) {
                         return {
-                            ...baseErrors,
+                            ...questionErrors,
                             display: !question.display && 'Please choose a display type.',
                             scale: !question.scale && 'Please choose a scale.',
                             lowerBoundLabel: !question.lowerBoundLabel && 'Please enter a lower bound label.',
@@ -1141,14 +1141,14 @@ export const surveyLogic = kea<surveyLogicType>([
                         question.type === SurveyQuestionType.MultipleChoice
                     ) {
                         return {
-                            ...baseErrors,
+                            ...questionErrors,
                             choices: question.choices.some((choice) => !choice.trim())
                                 ? 'Please ensure all choices are non-empty.'
                                 : undefined,
                         }
                     }
 
-                    return baseErrors
+                    return questionErrors
                 }),
                 // release conditions controlled using a PureField in the form
                 targeting_flag_filters: values.flagPropertyErrors,

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1123,15 +1123,33 @@ export const surveyLogic = kea<surveyLogicType>([
                 // NOTE: When more validation errors are added, the submitSurveyFailure listener should be updated
                 // to scroll to the right error section
                 name: !name && 'Please enter a name.',
-                questions: questions.map((question) => ({
-                    question: !question.question && 'Please enter a question.',
-                    ...(question.type === SurveyQuestionType.Rating
-                        ? {
-                              display: !question.display && 'Please choose a display type.',
-                              scale: !question.scale && 'Please choose a scale.',
-                          }
-                        : {}),
-                })),
+                questions: questions.map((question) => {
+                    const baseErrors = {
+                        question: !question.question && 'Please enter a question label.',
+                    }
+
+                    if (question.type === SurveyQuestionType.Rating) {
+                        return {
+                            ...baseErrors,
+                            display: !question.display && 'Please choose a display type.',
+                            scale: !question.scale && 'Please choose a scale.',
+                            lowerBoundLabel: !question.lowerBoundLabel && 'Please enter a lower bound label.',
+                            upperBoundLabel: !question.upperBoundLabel && 'Please enter an upper bound label.',
+                        }
+                    } else if (
+                        question.type === SurveyQuestionType.SingleChoice ||
+                        question.type === SurveyQuestionType.MultipleChoice
+                    ) {
+                        return {
+                            ...baseErrors,
+                            choices: question.choices.some((choice) => !choice.trim())
+                                ? 'Please ensure all choices are non-empty.'
+                                : undefined,
+                        }
+                    }
+
+                    return baseErrors
+                }),
                 // release conditions controlled using a PureField in the form
                 targeting_flag_filters: values.flagPropertyErrors,
                 // controlled using a PureField in the form

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -179,8 +179,11 @@ class SurveySerializerCreateUpdateOnly(SurveySerializer):
                 )
 
             choices = raw_question.get("choices")
-            if choices and not isinstance(choices, list):
-                raise serializers.ValidationError("Question choices must be a list of strings")
+            if choices:
+                if not isinstance(choices, list):
+                    raise serializers.ValidationError("Question choices must be a list of strings")
+                if any(not choice.strip() for choice in choices):
+                    raise serializers.ValidationError("Question choices cannot be empty")
 
             link = raw_question.get("link")
             if link:

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -1586,6 +1586,27 @@ class TestSurveyQuestionValidation(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response_data
         assert response_data["detail"] == "Question choices must be a list of strings"
 
+    def test_validate_malformed_question_choices_as_array_of_empty_strings(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "Notebooks beta release survey",
+                "description": "Get feedback on the new notebooks feature",
+                "type": "popover",
+                "questions": [
+                    {
+                        "question": "this is my question",
+                        "type": "multiple_choice",
+                        "choices": ["", ""],
+                    }
+                ],
+            },
+            format="json",
+        )
+        response_data = response.json()
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response_data
+        assert response_data["detail"] == "Question choices cannot be empty"
+
 
 class TestSurveyQuestionValidationWithEnterpriseFeatures(APIBaseTest):
     def setUp(self):


### PR DESCRIPTION
## Problem

Fixes the problem described in https://github.com/PostHog/posthog/issues/23651

## Changes

### Before

You could save a question with no choice content, like this

![image](https://github.com/user-attachments/assets/782d59ec-c116-4a7d-b823-2554eefa3be4)

### After

If you're trying to save a question with no choices, you get an error in the UI

<img width="953" alt="Screenshot 2024-07-11 at 2 06 32 PM" src="https://github.com/user-attachments/assets/42fc0ffe-7198-4f51-a3de-e0fa0771c8e0">


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

- Manually tested UI for both single-response and multi-response multiple-choice questions
- Wrote unit tests for the API
