### PR TITLE
fix: Bump log levels and add more log lines to email task

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -167,7 +167,7 @@ async def send_batch_export_run_failure(
 
     is_email_available_result = await sync_to_async(is_email_available)(with_absolute_urls=True)
     if not is_email_available_result:
-        logger.debug("Email service is not available")
+        logger.warning("Email service is not available")
         return
 
     batch_export_run: BatchExportRun = await sync_to_async(
@@ -175,6 +175,8 @@ async def send_batch_export_run_failure(
     )(id=batch_export_run_id)
     team: Team = batch_export_run.batch_export.team
     logger = logger.new(team_id=team.id)
+
+    logger.info("Preparing notification email for batch export run %s", batch_export_run_id)
 
     # NOTE: We are taking only the date component to cap the number of emails at one per day per batch export.
     last_updated_at_date = batch_export_run.last_updated_at.strftime("%Y-%m-%d")
@@ -194,7 +196,7 @@ async def send_batch_export_run_failure(
             "name": batch_export_run.batch_export.name,
         },
     )
-    logger.debug("Prepared notification email for campaign %s", campaign_key)
+    logger.info("Prepared notification email for campaign %s", campaign_key)
 
     memberships_to_email = []
     memberships = OrganizationMembership.objects.select_related("user", "organization").filter(
@@ -205,8 +207,11 @@ async def send_batch_export_run_failure(
         has_notification_settings_enabled = await sync_to_async(membership.user.notification_settings.get)(
             "batch_export_run_failure", True
         )
+
         if has_notification_settings_enabled is False:
+            logger.warning("User doesn't have batch export notifications enabled")
             continue
+
         team_permissions = UserPermissions(membership.user).team(team)
         # Only send the email to users who have access to the affected project
         # Those without access have `effective_membership_level` of `None`
@@ -217,13 +222,13 @@ async def send_batch_export_run_failure(
             memberships_to_email.append(membership)
 
     if memberships_to_email:
-        logger.debug("Sending failure notification email")
+        logger.info("Sending failure notification email")
 
         for membership in memberships_to_email:
             message.add_recipient(email=membership.user.email, name=membership.user.first_name)
         await sync_to_async(message.send)(send_async=True)
     else:
-        logger.debug("No available recipients for notification email")
+        logger.info("No available recipients for notification email")
 
 
 @shared_task(**EMAIL_TASK_KWARGS)


### PR DESCRIPTION
## Problem

Not seeing any logs when emails are not sent by batch exports. Let's bump the log levels up and add more log lines.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
