### PR TITLE
chore: update cached team data when we notice the first event

### DIFF
--- a/plugin-server/src/worker/ingestion/property-definitions-manager.ts
+++ b/plugin-server/src/worker/ingestion/property-definitions-manager.ts
@@ -134,7 +134,7 @@ export class PropertyDefinitionsManager {
                 this.syncEventDefinitions(team, event),
                 this.syncEventProperties(team, event, properties),
                 this.syncPropertyDefinitions(team, event, properties),
-                this.teamManager.setTeamIngestedEvent(team, properties),
+                this.teamManager.setTeamIngestedEvent(team),
             ])
         } finally {
             clearTimeout(timeout)

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -1,4 +1,3 @@
-import { Properties } from '@posthog/plugin-scaffold'
 import LRU from 'lru-cache'
 
 import { ONE_MINUTE } from '../../config/constants'
@@ -6,7 +5,6 @@ import { TeamIDWithConfig } from '../../main/ingestion-queues/session-recording/
 import { PipelineEvent, PluginsServerConfig, Team, TeamId } from '../../types'
 import { PostgresRouter, PostgresUse } from '../../utils/db/postgres'
 import { timeoutGuard } from '../../utils/db/utils'
-import { posthog } from '../../utils/posthog'
 
 export class TeamManager {
     postgres: PostgresRouter
@@ -104,7 +102,7 @@ export class TeamManager {
         }
     }
 
-    public async setTeamIngestedEvent(team: Team, properties: Properties) {
+    public async setTeamIngestedEvent(team: Team) {
         if (team && !team.ingested_event) {
             await this.postgres.query(
                 PostgresUse.COMMON_WRITE,
@@ -118,32 +116,6 @@ export class TeamManager {
             // wait a while before pulling the team data from the DB, but it might
             // help a bit.
             this.teamCache.set(team.id, { ...team, ingested_event: true })
-
-            // First event for the team captured
-            const organizationMembers = await this.postgres.query(
-                PostgresUse.COMMON_WRITE,
-                'SELECT distinct_id FROM posthog_user JOIN posthog_organizationmembership ON posthog_user.id = posthog_organizationmembership.user_id WHERE organization_id = $1',
-                [team.organization_id],
-                'posthog_organizationmembership'
-            )
-            const distinctIds: { distinct_id: string }[] = organizationMembers.rows
-            for (const { distinct_id } of distinctIds) {
-                posthog.capture({
-                    distinctId: distinct_id,
-                    event: 'first team event ingested',
-                    properties: {
-                        team: team.uuid,
-                        sdk: properties.$lib,
-                        realm: properties.realm,
-                        host: properties.$host,
-                    },
-                    groups: {
-                        project: team.uuid,
-                        organization: team.organization_id,
-                        instance: this.instanceSiteUrl,
-                    },
-                })
-            }
         }
     }
 }

--- a/plugin-server/src/worker/ingestion/team-manager.ts
+++ b/plugin-server/src/worker/ingestion/team-manager.ts
@@ -113,6 +113,12 @@ export class TeamManager {
                 'setTeamIngestedEvent'
             )
 
+            // This doesn't totally stop the first event from being spammed if a
+            // new team suddenly gets a lot of events, since other pods will still
+            // wait a while before pulling the team data from the DB, but it might
+            // help a bit.
+            this.teamCache.set(team.id, { ...team, ingested_event: true })
+
             // First event for the team captured
             const organizationMembers = await this.postgres.query(
                 PostgresUse.COMMON_WRITE,

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1224,19 +1224,6 @@ test('capture first team event', async () => {
         new UUIDT().toString()
     )
 
-    expect(posthog.capture).toHaveBeenCalledWith({
-        distinctId: 'plugin_test_user_distinct_id_1001',
-        event: 'first team event ingested',
-        properties: {
-            team: team.uuid,
-        },
-        groups: {
-            project: team.uuid,
-            organization: team.organization_id,
-            instance: 'unknown',
-        },
-    })
-
     team = await getFirstTeam(hub)
     expect(team.ingested_event).toEqual(true)
 


### PR DESCRIPTION
## Problem

A flood of events happening in between the first even being seen and the cached team object being invalidated makes us spam "first event" events. We shouldn't use this anywhere any more, so we can get rid of it entirely.

Tagging the growth team in case they still rely on this for any analytics or anything, just shout and I'll abandon.