### PR TITLE
fix(hog): 0-indexed array errors to resolver

### DIFF
--- a/hogql_parser/parser.cpp
+++ b/hogql_parser/parser.cpp
@@ -1822,35 +1822,6 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   VISIT(ColumnExprArrayAccess) {
     PyObject* property = visitAsPyObject(ctx->columnExpr(1));
-    int is_property_a_constant = is_ast_node_instance(property, "Constant");
-    if (is_property_a_constant == -1) {
-      Py_DECREF(property);
-      throw PyInternalError();
-    }
-    if (is_property_a_constant) {
-      PyObject* property_value = PyObject_GetAttrString(property, "value");
-      if (!property_value) {
-        Py_DECREF(property);
-        throw PyInternalError();
-      }
-      PyObject* zero = PyLong_FromLong(0);
-      if (!zero) {
-        Py_DECREF(property_value);
-        Py_DECREF(property);
-        throw PyInternalError();
-      }
-      int is_property_zero = PyObject_RichCompareBool(property_value, zero, Py_EQ);
-      Py_DECREF(zero);
-      Py_DECREF(property_value);
-      if (is_property_zero == -1) {
-        Py_DECREF(property);
-        throw PyInternalError();
-      }
-      if (is_property_zero) {
-        Py_DECREF(property);
-        throw SyntaxError("SQL indexes start from one, not from zero. E.g: array[1]");
-      }
-    }
     PyObject* object;
     try {
       object = visitAsPyObject(ctx->columnExpr(0));
@@ -1863,35 +1834,6 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
 
   VISIT(ColumnExprNullArrayAccess) {
     PyObject* property = visitAsPyObject(ctx->columnExpr(1));
-    int is_property_a_constant = is_ast_node_instance(property, "Constant");
-    if (is_property_a_constant == -1) {
-      Py_DECREF(property);
-      throw PyInternalError();
-    }
-    if (is_property_a_constant) {
-      PyObject* property_value = PyObject_GetAttrString(property, "value");
-      if (!property_value) {
-        Py_DECREF(property);
-        throw PyInternalError();
-      }
-      PyObject* zero = PyLong_FromLong(0);
-      if (!zero) {
-        Py_DECREF(property_value);
-        Py_DECREF(property);
-        throw PyInternalError();
-      }
-      int is_property_zero = PyObject_RichCompareBool(property_value, zero, Py_EQ);
-      Py_DECREF(zero);
-      Py_DECREF(property_value);
-      if (is_property_zero == -1) {
-        Py_DECREF(property);
-        throw PyInternalError();
-      }
-      if (is_property_zero) {
-        Py_DECREF(property);
-        throw SyntaxError("SQL indexes start from one, not from zero. E.g: array[1]");
-      }
-    }
     PyObject* object;
     try {
       object = visitAsPyObject(ctx->columnExpr(0));
@@ -2029,21 +1971,6 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   VISIT(ColumnExprTupleAccess) {
     PyObject* index = PyLong_FromString(ctx->DECIMAL_LITERAL()->getText().c_str(), NULL, 10);
     if (!index) throw PyInternalError();
-    PyObject* zero = PyLong_FromLong(0);
-    if (!zero) {
-      Py_DECREF(index);
-      throw PyInternalError();
-    }
-    int is_index_zero = PyObject_RichCompareBool(index, zero, Py_EQ);
-    Py_DECREF(zero);
-    if (is_index_zero == -1) {
-      Py_DECREF(index);
-      throw PyInternalError();
-    }
-    if (is_index_zero) {
-      Py_DECREF(index);
-      throw SyntaxError("SQL indexes start from one, not from zero. E.g: array[1]");
-    }
     PyObject* tuple;
     try {
       tuple = visitAsPyObject(ctx->columnExpr());
@@ -2057,21 +1984,6 @@ class HogQLParseTreeConverter : public HogQLParserBaseVisitor {
   VISIT(ColumnExprNullTupleAccess) {
     PyObject* index = PyLong_FromString(ctx->DECIMAL_LITERAL()->getText().c_str(), NULL, 10);
     if (!index) throw PyInternalError();
-    PyObject* zero = PyLong_FromLong(0);
-    if (!zero) {
-      Py_DECREF(index);
-      throw PyInternalError();
-    }
-    int is_index_zero = PyObject_RichCompareBool(index, zero, Py_EQ);
-    Py_DECREF(zero);
-    if (is_index_zero == -1) {
-      Py_DECREF(index);
-      throw PyInternalError();
-    }
-    if (is_index_zero) {
-      Py_DECREF(index);
-      throw SyntaxError("SQL indexes start from one, not from zero. E.g: array[1]");
-    }
     PyObject* tuple;
     try {
       tuple = visitAsPyObject(ctx->columnExpr());

--- a/hogql_parser/setup.py
+++ b/hogql_parser/setup.py
@@ -32,7 +32,7 @@ module = Extension(
 
 setup(
     name="hogql_parser",
-    version="1.0.28",
+    version="1.0.29",
     url="https://github.com/PostHog/posthog/tree/master/hogql_parser",
     author="PostHog Inc.",
     author_email="hey@posthog.com",

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -802,15 +802,11 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
     def visitColumnExprArrayAccess(self, ctx: HogQLParser.ColumnExprArrayAccessContext):
         object: ast.Expr = self.visit(ctx.columnExpr(0))
         property: ast.Expr = self.visit(ctx.columnExpr(1))
-        if isinstance(property, ast.Constant) and property.value == 0:
-            raise SyntaxError("SQL indexes start from one, not from zero. E.g: array[1]")
         return ast.ArrayAccess(array=object, property=property)
 
     def visitColumnExprNullArrayAccess(self, ctx: HogQLParser.ColumnExprNullArrayAccessContext):
         object: ast.Expr = self.visit(ctx.columnExpr(0))
         property: ast.Expr = self.visit(ctx.columnExpr(1))
-        if isinstance(property, ast.Constant) and property.value == 0:
-            raise SyntaxError("SQL indexes start from one, not from zero. E.g: array[1]")
         return ast.ArrayAccess(array=object, property=property, nullish=True)
 
     def visitColumnExprPropertyAccess(self, ctx: HogQLParser.ColumnExprPropertyAccessContext):
@@ -865,15 +861,11 @@ class HogQLParseTreeConverter(ParseTreeVisitor):
     def visitColumnExprTupleAccess(self, ctx: HogQLParser.ColumnExprTupleAccessContext):
         tuple = self.visit(ctx.columnExpr())
         index = int(ctx.DECIMAL_LITERAL().getText())
-        if index == 0:
-            raise SyntaxError("SQL indexes start from one, not from zero. E.g: array[1]")
         return ast.TupleAccess(tuple=tuple, index=index)
 
     def visitColumnExprNullTupleAccess(self, ctx: HogQLParser.ColumnExprNullTupleAccessContext):
         tuple = self.visit(ctx.columnExpr())
         index = int(ctx.DECIMAL_LITERAL().getText())
-        if index == 0:
-            raise SyntaxError("SQL indexes start from one, not from zero. E.g: array[1]")
         return ast.TupleAccess(tuple=tuple, index=index, nullish=True)
 
     def visitColumnExprCase(self, ctx: HogQLParser.ColumnExprCaseContext):

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -691,6 +691,9 @@ class Resolver(CloningVisitor):
     def visit_array_access(self, node: ast.ArrayAccess):
         node = super().visit_array_access(node)
 
+        if self.dialect == "clickhouse" and isinstance(node.property, ast.Constant) and node.property.value == 0:
+            raise QueryError("SQL indexes start from one, not from zero. E.g: array[1]")
+
         array = node.array
         while isinstance(array, ast.Alias):
             array = array.expr
@@ -718,6 +721,9 @@ class Resolver(CloningVisitor):
 
     def visit_tuple_access(self, node: ast.TupleAccess):
         node = super().visit_tuple_access(node)
+
+        if self.dialect == "clickhouse" and node.index == 0:
+            raise QueryError("SQL indexes start from one, not from zero. E.g: array.1")
 
         tuple = node.tuple
         while isinstance(tuple, ast.Alias):

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -1563,26 +1563,6 @@ def parser_test_factory(backend: Literal["python", "cpp"]):
             )
             self.assertEqual(expr, expected)
 
-        def test_property_access_with_arrays_zero_index_error(self):
-            query = f"SELECT properties.something[0] FROM events"
-            with self.assertRaisesMessage(
-                SyntaxError,
-                "SQL indexes start from one, not from zero. E.g: array[1]",
-            ) as e:
-                self._select(query)
-            self.assertEqual(e.exception.start, 7)
-            self.assertEqual(e.exception.end, 30)
-
-        def test_property_access_with_tuples_zero_index_error(self):
-            query = f"SELECT properties.something.0 FROM events"
-            with self.assertRaisesMessage(
-                SyntaxError,
-                "SQL indexes start from one, not from zero. E.g: array[1]",
-            ) as e:
-                self._select(query)
-            self.assertEqual(e.exception.start, 7)
-            self.assertEqual(e.exception.end, 29)
-
         def test_reserved_keyword_alias_error(self):
             query = f"SELECT 0 AS trUE FROM events"
             with self.assertRaisesMessage(

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -387,10 +387,10 @@ class TestPrinter(BaseTest):
             "Aggregation 'avg' cannot be nested inside another aggregation 'avg'.",
         )
         self._assert_expr_error("person.chipotle", "Field not found: chipotle")
-        self._assert_expr_error("properties.0", "SQL indexes start from one, not from zero. E.g: array[1]")
+        self._assert_expr_error("properties.0", "SQL indexes start from one, not from zero. E.g: array.1")
         self._assert_expr_error(
             "properties.id.0",
-            "SQL indexes start from one, not from zero. E.g: array[1]",
+            "SQL indexes start from one, not from zero. E.g: array.1",
         )
         self._assert_expr_error(
             "event as `as%d`",

--- a/posthog/hogql/test/test_query.py
+++ b/posthog/hogql/test/test_query.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 
 from posthog import datetime
 from posthog.hogql import ast
-from posthog.hogql.errors import SyntaxError, QueryError
+from posthog.hogql.errors import QueryError
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.test.utils import pretty_print_in_tests, pretty_print_response_in_tests
@@ -1022,14 +1022,14 @@ class TestQuery(ClickhouseTestMixin, APIBaseTest):
 
     def test_property_access_with_arrays_zero_index_error(self):
         query = f"SELECT properties.something[0] FROM events"
-        with self.assertRaises(SyntaxError) as e:
+        with self.assertRaises(QueryError) as e:
             execute_hogql_query(query, team=self.team)
         self.assertEqual(str(e.exception), "SQL indexes start from one, not from zero. E.g: array[1]")
 
         query = f"SELECT properties.something.0 FROM events"
-        with self.assertRaises(SyntaxError) as e:
+        with self.assertRaises(QueryError) as e:
             execute_hogql_query(query, team=self.team)
-        self.assertEqual(str(e.exception), "SQL indexes start from one, not from zero. E.g: array[1]")
+        self.assertEqual(str(e.exception), "SQL indexes start from one, not from zero. E.g: array.1")
 
     def test_time_window_functions(self):
         query = """

--- a/requirements.in
+++ b/requirements.in
@@ -93,7 +93,7 @@ phonenumberslite==8.13.6
 openai==1.10.0
 tiktoken==0.6.0
 nh3==0.2.14
-hogql-parser==1.0.28
+hogql-parser==1.0.29
 zxcvbn==4.4.28
 zstd==1.5.5.1
 xmlsec==1.3.13 # Do not change this version - it will break SAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -279,7 +279,7 @@ h11==0.13.0
     #   wsproto
 hexbytes==1.0.0
     # via dlt
-hogql-parser==1.0.28
+hogql-parser==1.0.29
     # via -r requirements.in
 httpcore==1.0.2
     # via httpx


### PR DESCRIPTION
## Problem

Hog complains about 0-indexed arrays, even though arrays in Hog are 0-indexed

## Changes

Moves the complaining from the parser into the resolver, effectively bypassing it if dealing with just Hog.

## How did you test this code?

Moved tests around.