### PR TITLE
fix: Use django logger in email task

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -163,7 +163,7 @@ def send_fatal_plugin_error(
 async def send_batch_export_run_failure(
     batch_export_run_id: str,
 ) -> None:
-    logger = structlog.get_logger()
+    logger = structlog.get_logger("django")
 
     is_email_available_result = await sync_to_async(is_email_available)(with_absolute_urls=True)
     if not is_email_available_result:


### PR DESCRIPTION
## Problem

Still not seeing any logs. Now trying to specify the name of a well-known logger.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
