### PR TITLE
chore(admin): exclude the layouts field of Insight in Django Admin

### DIFF
--- a/posthog/admin/admins/insight_admin.py
+++ b/posthog/admin/admins/insight_admin.py
@@ -5,6 +5,8 @@ from posthog.models import Insight
 
 
 class InsightAdmin(admin.ModelAdmin):
+    exclude = ("layouts",)
+
     list_display = (
         "id",
         "short_id",


### PR DESCRIPTION
## Problem

The Insight's model `layouts` field was deprecated two years ago. It should be safe to remove it from the Django Admin panel now. Otherwise, it's not possible to save an insight without entering a non-empty value, e.g., a non-empty dict or string. Both the frontend and backend use the Dashboard Tile model and its `layouts` field.

## Changes

I excluded the field from the admin form.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing