### PR TITLE
feat: Add BatchExportBackfill modal to pipeline UI

### DIFF
--- a/frontend/src/scenes/batch_exports/BatchExportScene.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportScene.tsx
@@ -53,7 +53,7 @@ export function RunsTab(): JSX.Element {
         runsDateRange,
         batchExportConfigLoading,
     } = useValues(batchExportLogic)
-    const { loadNextBatchExportRuns, openBackfillModal, setRunsDateRange, retryRun } = useActions(batchExportLogic)
+    const { loadNextBatchExportRuns, setRunsDateRange, retryRun } = useActions(batchExportLogic)
 
     const [dateRangeVisible, setDateRangeVisible] = useState(false)
 
@@ -99,13 +99,13 @@ export function RunsTab(): JSX.Element {
                             </Popover>
                         </div>
                         <BatchExportRunsGrouped
+                            id={batchExportConfig.id}
                             groupedRuns={groupedRuns}
                             loading={batchExportRunsResponseLoading}
                             retryRun={retryRun}
                             hasMoreRunsToLoad={!!batchExportRunsResponse?.next}
                             loadOlderRuns={loadNextBatchExportRuns}
                             interval={batchExportConfig.interval}
-                            openBackfillModal={openBackfillModal}
                         />
                     </div>
                 </div>

--- a/frontend/src/scenes/pipeline/BatchExportBackfill.tsx
+++ b/frontend/src/scenes/pipeline/BatchExportBackfill.tsx
@@ -1,0 +1,74 @@
+import { useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonCalendarSelectInput } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
+
+import { batchExportRunsLogic, BatchExportRunsLogicProps } from './batchExportRunsLogic'
+
+export function BatchExportBackfill({ id }: BatchExportRunsLogicProps): JSX.Element {
+    const logic = batchExportRunsLogic({ id })
+
+    const { batchExportConfig, isBackfillModalOpen, isBackfillFormSubmitting } = useValues(logic)
+    const { closeBackfillModal } = useActions(logic)
+
+    return (
+        <LemonModal
+            title="Backfill batch export"
+            onClose={closeBackfillModal}
+            isOpen={isBackfillModalOpen}
+            width="30rem"
+            footer={
+                <>
+                    <LemonButton
+                        type="secondary"
+                        data-attr="batch-export-backfill-cancel"
+                        disabledReason={isBackfillFormSubmitting ? 'Please wait...' : undefined}
+                        onClick={closeBackfillModal}
+                    >
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        form="batch-export-backfill-form"
+                        htmlType="submit"
+                        type="primary"
+                        data-attr="batch-export-backfill-submit"
+                        loading={isBackfillFormSubmitting}
+                    >
+                        Schedule runs
+                    </LemonButton>
+                </>
+            }
+        >
+            <p>
+                Backfilling a batch export will sequentially run all batch periods that fall within the range specified
+                below. The runs will export data in <b>{batchExportConfig?.interval}</b> intervals, from the start date
+                until the end date is reached.
+            </p>
+            <Form
+                logic={logic}
+                formKey="backfillForm"
+                id="batch-export-backfill-form"
+                enableFormOnSubmit
+                className="space-y-2"
+            >
+                <LemonField name="start_at" label="Start Date" className="flex-1">
+                    {({ value, onChange }) => (
+                        <LemonCalendarSelectInput value={value} onChange={onChange} placeholder="Select start date" />
+                    )}
+                </LemonField>
+
+                <LemonField name="end_at" label="End date" className="flex-1">
+                    {({ value, onChange }) => (
+                        <LemonCalendarSelectInput
+                            value={value}
+                            onChange={onChange}
+                            placeholder="Select end date (optional)"
+                        />
+                    )}
+                </LemonField>
+            </Form>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/pipeline/BatchExportBackfill.tsx
+++ b/frontend/src/scenes/pipeline/BatchExportBackfill.tsx
@@ -47,7 +47,8 @@ export function BatchExportBackfill({ id }: BatchExportRunsLogicProps): JSX.Elem
                 until the end date is reached.
             </p>
             <Form
-                logic={logic}
+                logic={batchExportRunsLogic}
+                props={{ id: id } as BatchExportRunsLogicProps}
                 formKey="backfillForm"
                 id="batch-export-backfill-form"
                 enableFormOnSubmit


### PR DESCRIPTION
## Problem

New pipeline UI doesn't have a batch export backfill modal, button does nothing.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add the modal. Basically the same as old UI, with some slight wording changes.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Manually ran, looks the same.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
