### PR TITLE
fix: no unexpected buffer error when we expect a buffer

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -274,6 +274,7 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
         persistRecording: true,
         maybePersistRecording: true,
         pollRealtimeSnapshots: true,
+        stopRealtimePolling: true,
         setTrackedWindow: (windowId: string | null) => ({ windowId }),
     }),
     reducers(() => ({
@@ -287,6 +288,13 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
             {} as Partial<RecordingEventsFilters>,
             {
                 setFilters: (state, { filters }) => ({ ...state, ...filters }),
+            },
+        ],
+        isRealtimePolling: [
+            false as boolean,
+            {
+                pollRealtimeSnapshots: () => true,
+                stopRealtimePolling: () => false,
             },
         ],
         isNotFound: [
@@ -621,6 +629,8 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                 cache.realTimePollingTimeoutID = setTimeout(() => {
                     actions.loadSnapshotsForSource({ source: SnapshotSourceType.realtime })
                 }, props.realTimePollingIntervalMilliseconds || DEFAULT_REALTIME_POLLING_MILLIS)
+            } else {
+                actions.stopRealtimePolling()
             }
         },
         loadEventsSuccess: () => {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -104,6 +104,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             [
                 'snapshotsLoaded',
                 'snapshotsLoading',
+                'isRealtimePolling',
                 'sessionPlayerData',
                 'sessionPlayerMetaData',
                 'sessionPlayerMetaDataLoading',
@@ -778,10 +779,11 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 actions.setCurrentSegment(segment)
             }
 
-            if (!values.snapshotsLoaded) {
-                // We haven't started properly loading yet so nothing to do
+            if (!values.snapshotsLoaded || values.isRealtimePolling) {
+                // We haven't started properly loading, or we're still polling so nothing to do
             } else if (!values.snapshotsLoading && segment?.kind === 'buffer') {
-                // If not currently loading anything and part of the recording hasn't loaded, set error state
+                // If not currently loading anything,
+                // and part of the recording hasn't loaded, set error state
                 values.player?.replayer?.pause()
                 actions.endBuffer()
                 console.error("Error: Player tried to seek to a position that hasn't loaded yet")


### PR DESCRIPTION
If the last segment of a recording is a buffer and we have finished loading we show an error

But we could still be polling for new realtime data so this error is misleading and frustrating

This removes the error state in that case. The played _should_ buffer and continue playing - but I'll need to test this in prod, or figure out how to fake it locally.