### PR TITLE
fix: replayer reacting to realtime changes

### DIFF
--- a/frontend/src/scenes/session-recordings/apm/playerInspector/ItemPerformanceEvent.tsx
+++ b/frontend/src/scenes/session-recordings/apm/playerInspector/ItemPerformanceEvent.tsx
@@ -65,7 +65,7 @@ export interface ItemPerformanceEvent {
     item: PerformanceEvent
     expanded: boolean
     setExpanded: (expanded: boolean) => void
-    finalTimestamp?: Dayjs
+    finalTimestamp: Dayjs | null
 }
 
 function renderTimeBenchmark(milliseconds: number): JSX.Element {

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -143,7 +143,7 @@ function snapshotDescription(snapshot: eventWithTime): string {
 
 function timeRelativeToStart(
     thingWithTime: eventWithTime | PerformanceEvent | RecordingConsoleLogV2 | RecordingEventType,
-    start: Dayjs | undefined
+    start: Dayjs | null
 ): {
     timeInRecording: number
     timestamp: dayjs.Dayjs

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.test.ts
@@ -94,8 +94,8 @@ describe('sessionRecordingDataLogic', () => {
             expect(logic.values).toMatchObject({
                 bufferedToTime: null,
                 durationMs: 0,
-                start: undefined,
-                end: undefined,
+                start: null,
+                end: null,
                 segments: [],
                 sessionEventsData: null,
                 filters: {},
@@ -146,8 +146,8 @@ describe('sessionRecordingDataLogic', () => {
                 .toMatchValues({
                     sessionPlayerData: {
                         bufferedToTime: null,
-                        start: undefined,
-                        end: undefined,
+                        start: null,
+                        end: null,
                         durationMs: 0,
                         segments: [],
                         sessionRecordingId: '2',

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -754,11 +754,25 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
             },
         ],
 
+        firstSnapshot: [
+            (s) => [s.snapshots],
+            (snapshots): RecordingSnapshot | null => {
+                return snapshots[0] || null
+            },
+        ],
+
+        lastSnapshot: [
+            (s) => [s.snapshots],
+            (snapshots): RecordingSnapshot | null => {
+                return snapshots[snapshots.length - 1] || null
+            },
+        ],
+
         start: [
-            (s) => [s.snapshots, s.sessionPlayerMetaData],
-            (snapshots, meta): Dayjs | null => {
+            (s) => [s.firstSnapshot, s.sessionPlayerMetaData],
+            (firstSnapshot, meta): Dayjs | null => {
                 const eventStart = meta?.start_time ? dayjs(meta.start_time) : null
-                const snapshotStart = snapshots?.[0] ? dayjs(snapshots[0].timestamp) : null
+                const snapshotStart = firstSnapshot ? dayjs(firstSnapshot.timestamp) : null
 
                 // whichever is earliest
                 if (eventStart && snapshotStart) {
@@ -769,10 +783,10 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
         ],
 
         end: [
-            (s) => [s.snapshots, s.sessionPlayerMetaData],
-            (snapshots, meta): Dayjs | null => {
+            (s) => [s.lastSnapshot, s.sessionPlayerMetaData],
+            (lastSnapshot, meta): Dayjs | null => {
                 const eventEnd = meta?.end_time ? dayjs(meta.end_time) : null
-                const snapshotEnd = snapshots?.slice(-1)[0] ? dayjs(snapshots?.slice(-1)[0].timestamp) : null
+                const snapshotEnd = lastSnapshot ? dayjs(lastSnapshot.timestamp) : null
 
                 // whichever is latest
                 if (eventEnd && snapshotEnd) {

--- a/frontend/src/scenes/session-recordings/player/utils/segmenter.ts
+++ b/frontend/src/scenes/session-recordings/player/utils/segmenter.ts
@@ -46,8 +46,8 @@ export const mapSnapshotsToWindowId = (snapshots: RecordingSnapshot[]): Record<s
 
 export const createSegments = (
     snapshots: RecordingSnapshot[],
-    start?: Dayjs,
-    end?: Dayjs,
+    start: Dayjs | null,
+    end: Dayjs | null,
     trackedWindow?: string | null
 ): RecordingSegment[] => {
     let segments: RecordingSegment[] = []

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -913,8 +913,8 @@ export interface SessionPlayerData {
     bufferedToTime: number | null
     snapshotsByWindowId: Record<string, eventWithTime[]>
     durationMs: number
-    start?: Dayjs
-    end?: Dayjs
+    start: Dayjs | null
+    end: Dayjs | null
     fullyLoaded: boolean
     sessionRecordingId: SessionRecordingId
 }


### PR DESCRIPTION
as we poll for realtime data we want the player to buffer at the end, and to start playing again as new data comes in

![2024-07-14 20 47 22](https://github.com/user-attachments/assets/fcb6d486-0cc9-4d66-8156-c38329ee47c2)
