### PR TITLE
fix(data-warehouse): Auto reload source settings scene

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
@@ -46,8 +46,7 @@ const StatusTagSetting = {
 }
 
 export const SchemaTable = ({ schemas, isLoading }: SchemaTableProps): JSX.Element => {
-    const { reloadSchema, resyncSchema } = useActions(dataWarehouseSettingsLogic)
-    const { updateSchema } = useActions(dataWarehouseSourceSettingsLogic)
+    const { updateSchema, reloadSchema, resyncSchema } = useActions(dataWarehouseSourceSettingsLogic)
     const { schemaReloadingById } = useValues(dataWarehouseSettingsLogic)
 
     return (
@@ -55,6 +54,7 @@ export const SchemaTable = ({ schemas, isLoading }: SchemaTableProps): JSX.Eleme
             <LemonTable
                 dataSource={schemas}
                 loading={isLoading}
+                disableTableWhileLoading={false}
                 columns={[
                     {
                         title: 'Schema Name',


### PR DESCRIPTION
## Problem
- The source settings scene didn't have auto-loading of the source data when the source/schema updated

## Changes
- Added auto-reloading of the source data
- Moved the resync/reload schema logic into the correct kea logic to enable optimistic UI updates

## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
Locally