### PR TITLE
chore(cdp): Rename response var

### DIFF
--- a/plugin-server/src/cdp/async-function-executor.ts
+++ b/plugin-server/src/cdp/async-function-executor.ts
@@ -105,7 +105,7 @@ export class AsyncFunctionExecutor {
                     duration_ms: duration,
                 })
 
-                asyncFunctionResponse.vmResponse = {
+                asyncFunctionResponse.response = {
                     status: fetchResponse.status,
                     body: body,
                 }

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -150,7 +150,7 @@ export class CdpApi {
                         addLog(response, 'error', 'Failed to execute async function')
                     }
                     asyncFunctionRequest.vmState.stack.push(
-                        convertJSToHog(asyncRes?.asyncFunctionResponse.vmResponse ?? null)
+                        convertJSToHog(asyncRes?.asyncFunctionResponse.response ?? null)
                     )
                     response.timings.push(...(asyncRes?.asyncFunctionResponse.timings ?? []))
                 }

--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -221,12 +221,12 @@ export class HogExecutor {
         const { vmState } = invocation.asyncFunctionRequest ?? {}
         const { asyncFunctionResponse } = invocation
 
-        if (!vmState || !asyncFunctionResponse.vmResponse || asyncFunctionResponse.error) {
+        if (!vmState || !asyncFunctionResponse.response || asyncFunctionResponse.error) {
             return errorRes(invocation.error ?? 'No VM state provided for async response')
         }
 
         // Add the response to the stack to continue execution
-        vmState.stack.push(convertJSToHog(asyncFunctionResponse.vmResponse ?? null))
+        vmState.stack.push(convertJSToHog(asyncFunctionResponse.response ?? null))
 
         return this.execute(hogFunction, baseInvocation, vmState)
     }

--- a/plugin-server/src/cdp/types.ts
+++ b/plugin-server/src/cdp/types.ts
@@ -176,7 +176,7 @@ export type HogFunctionInvocationAsyncResponse = HogFunctionInvocationResult & {
         /** An error message to indicate something went wrong and the invocation should be stopped */
         error?: any
         /** The data to be passed to the Hog function from the response */
-        vmResponse?: any
+        response?: any
         timings: HogFunctionTiming[]
     }
 }

--- a/plugin-server/tests/cdp/cdp-processed-events-consumer.test.ts
+++ b/plugin-server/tests/cdp/cdp-processed-events-consumer.test.ts
@@ -266,7 +266,7 @@ describe('CDP Processed Events Consuner', () => {
                         vmState: expect.any(Object),
                     },
                     asyncFunctionResponse: {
-                        vmResponse: {
+                        response: {
                             status: 200,
                             body: { success: true },
                         },

--- a/plugin-server/tests/cdp/hog-executor.test.ts
+++ b/plugin-server/tests/cdp/hog-executor.test.ts
@@ -23,7 +23,7 @@ const simulateMockFetchAsyncResponse = (result: HogFunctionInvocationResult): Ho
                     duration_ms: 100,
                 },
             ],
-            vmResponse: {
+            response: {
                 status: 200,
                 body: 'success',
             },


### PR DESCRIPTION
## Problem

vmResponse is confusing and was a bad idea. 

## Changes

* Now its just response

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
