### PR TITLE
fix(insights): ActorsQuery throws an error on a boolean breakdown property

### DIFF
--- a/posthog/hogql_queries/insights/trends/breakdown.py
+++ b/posthog/hogql_queries/insights/trends/breakdown.py
@@ -296,7 +296,11 @@ class Breakdown:
             return ast.Or(
                 exprs=[
                     none_expr,
-                    ast.CompareOperation(left=left, op=ast.CompareOperationOp.Eq, right=ast.Constant(value="")),
+                    ast.CompareOperation(
+                        left=self.get_replace_null_values_transform(left),
+                        op=ast.CompareOperationOp.Eq,
+                        right=ast.Constant(value=""),
+                    ),
                 ]
             )
 
@@ -323,7 +327,11 @@ class Breakdown:
             except json.JSONDecodeError:
                 raise ValueError("Breakdown value must be a valid JSON array if the the bin count is selected.")
 
-        return ast.CompareOperation(left=left, op=ast.CompareOperationOp.Eq, right=ast.Constant(value=lookup_value))
+        return ast.CompareOperation(
+            left=self.get_replace_null_values_transform(left),
+            op=ast.CompareOperationOp.Eq,
+            right=ast.Constant(value=lookup_value),
+        )
 
     def _get_breakdown_values_transform(self, node: ast.Expr, normalize_url: bool | None = None) -> ast.Call:
         if normalize_url:

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -258,7 +258,7 @@
            WHERE and(equals(groups.team_id, 2), ifNull(equals(index, 0), 0))
            GROUP BY groups.group_type_index,
                     groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-        WHERE and(equals(e.team_id, 2), equals(e.event, 'sign up'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-02 00:00:00.000000', 6, 'UTC')), less(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-03 00:00:00.000000', 6, 'UTC')), ifNull(equals(e__group_0.properties___industry, 'technology'), 0)))
+        WHERE and(equals(e.team_id, 2), equals(e.event, 'sign up'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-02 00:00:00.000000', 6, 'UTC')), less(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-03 00:00:00.000000', 6, 'UTC')), ifNull(equals(ifNull(nullIf(toString(e__group_0.properties___industry), ''), '$$_posthog_breakdown_null_$$'), 'technology'), 0)))
      GROUP BY actor_id) AS source
   INNER JOIN
     (SELECT argMax(toTimeZone(person.created_at, 'UTC'), person.version) AS created_at,
@@ -276,7 +276,7 @@
                                                          FROM groups
                                                          WHERE and(equals(groups.team_id, 2), ifNull(equals(index, 0), 0))
                                                          GROUP BY groups.group_type_index, groups.group_key) AS e__group_0 ON equals(e.`$group_0`, e__group_0.key)
-                                                      WHERE and(equals(e.team_id, 2), equals(e.event, 'sign up'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-02 00:00:00.000000', 6, 'UTC')), less(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-03 00:00:00.000000', 6, 'UTC')), ifNull(equals(e__group_0.properties___industry, 'technology'), 0)))
+                                                      WHERE and(equals(e.team_id, 2), equals(e.event, 'sign up'), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-02 00:00:00.000000', 6, 'UTC')), less(toTimeZone(e.timestamp, 'UTC'), toDateTime64('2020-01-03 00:00:00.000000', 6, 'UTC')), ifNull(equals(ifNull(nullIf(toString(e__group_0.properties___industry), ''), '$$_posthog_breakdown_null_$$'), 'technology'), 0)))
                                                    GROUP BY actor_id) AS source)))
      GROUP BY person.id
      HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)) SETTINGS optimize_aggregation_in_order=1) AS persons ON equals(persons.id, source.actor_id)


### PR DESCRIPTION
## Problem

If you select a boolean breakdown and open the Persons modal, the query will throw an exception (#23715).

**Before**

![2024-07-15 18 55 56](https://github.com/user-attachments/assets/d0baf85c-bec0-4170-adad-ccdf1c2c3e34)

**After**

![2024-07-15 18 54 01](https://github.com/user-attachments/assets/b7568b84-b1fb-4f93-ad61-ee0f252cf7fe)


## Changes

Type cast values to the String type and compare strings except for numeric ranges when `histogram_bin_count` is enabled.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unit tests, manual testing and added a new test.