### PR TITLE
fix: no swallowing errors, greedy

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -637,7 +637,16 @@ def get_event(request):
             scope.set_tag("ph-team-token", token)
             capture_exception(exc, {"data": data})
         logger.exception("kafka_session_recording_produce_failure", exc_info=exc)
-        pass
+        return cors_response(
+            request,
+            generate_exception_response(
+                "capture",
+                "Unable to store recording snapshot. Please try again. If you are the owner of this app you can check the logs for further details.",
+                code="server_error",
+                type="server_error",
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            ),
+        )
 
     statsd.incr("posthog_cloud_raw_endpoint_success", tags={"endpoint": "capture"})
     return cors_response(request, JsonResponse({"status": 1}))

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -25,7 +25,7 @@ from django.test import override_settings
 from django.test.client import MULTIPART_CONTENT, Client
 from django.utils import timezone
 from freezegun import freeze_time
-from kafka.errors import KafkaError, MessageSizeTooLargeError, KafkaTimeoutError
+from kafka.errors import KafkaError, MessageSizeTooLargeError, KafkaTimeoutError, NoBrokersAvailable
 from kafka.producer.future import FutureProduceResult, FutureRecordMetadata
 from kafka.structs import TopicPartition
 from parameterized import parameterized
@@ -580,6 +580,21 @@ class TestCapture(BaseTest):
 
         # signal that the client should not retry, we don't want endless retries for unprocessable entries
         assert response.status_code == 400
+
+    @patch("posthog.kafka_client.client._KafkaProducer.produce")
+    def test_replay_capture_other_kafka_error(self, kafka_produce: MagicMock) -> None:
+        kafka_produce.side_effect = [
+            NoBrokersAvailable(),
+            None,  # Return None for successful calls
+        ]
+
+        response = self._send_august_2023_version_session_recording_event(
+            event_data=[
+                {"type": 2, "data": {"lots": "of data"}, "$window_id": "the window id", "timestamp": 1234567890}
+            ],
+        )
+
+        assert response.status_code == 503
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_capture_snapshot_event_from_android(self, _kafka_produce: MagicMock) -> None:

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -583,10 +583,7 @@ class TestCapture(BaseTest):
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_replay_capture_other_kafka_error(self, kafka_produce: MagicMock) -> None:
-        kafka_produce.side_effect = [
-            NoBrokersAvailable(),
-            None,  # Return None for successful calls
-        ]
+        kafka_produce.side_effect = NoBrokersAvailable()
 
         response = self._send_august_2023_version_session_recording_event(
             event_data=[


### PR DESCRIPTION
recordings capture swallows all unexpected errors... this is slightly silly