### PR TITLE
fix(persons-modal): Correct series names display in persons modal

### DIFF
--- a/frontend/src/queries/nodes/DataTable/InsightActorsQueryOptions.tsx
+++ b/frontend/src/queries/nodes/DataTable/InsightActorsQueryOptions.tsx
@@ -21,7 +21,7 @@ export function InsightActorsQueryOptions({ setQuery, query }: InsightActorsQuer
 
     return query && insightActorsQueryOptions ? (
         <>
-            {cleanedInsightActorsQueryOptions(insightActorsQueryOptions).map(([key, options]) => (
+            {cleanedInsightActorsQueryOptions(insightActorsQueryOptions, query).map(([key, options]) => (
                 <div key={key}>
                     <LemonSelect
                         fullWidth

--- a/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
+++ b/frontend/src/scenes/trends/persons-modal/PersonsModal.tsx
@@ -162,7 +162,7 @@ export function PersonsModal({
                     ) : null}
 
                     {query &&
-                        cleanedInsightActorsQueryOptions(insightActorsQueryOptions).map(([key, options]) =>
+                        cleanedInsightActorsQueryOptions(insightActorsQueryOptions, query).map(([key, options]) =>
                             key === 'breakdowns' ? (
                                 options.map(({ values }, index) => (
                                     <div key={`${key}_${index}`}>

--- a/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
+++ b/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
@@ -53,9 +53,30 @@ export const pathsTitle = (props: { mode: pathModes; label: string }): React.Rea
 }
 
 export const cleanedInsightActorsQueryOptions = (
-    insightActorsQueryOptions: InsightActorsQueryOptionsResponse | null
+    insightActorsQueryOptions: InsightActorsQueryOptionsResponse | null,
+    query: any
 ): [string, any[]][] => {
-    return Object.entries(insightActorsQueryOptions ?? {}).filter(([, value]) => {
-        return Array.isArray(value) && !!value.length
-    })
+    if (!query || !query.source) {
+        return Object.entries(insightActorsQueryOptions ?? {}).filter(([, value]) => {
+            return Array.isArray(value) && !!value.length
+        })
+    }
+    const seriesNames = query.source.series.map((s: any) => s.custom_name || s.name)
+
+    return Object.entries(insightActorsQueryOptions ?? {})
+        .filter(([, value]) => {
+            return Array.isArray(value) && !!value.length
+        })
+        .map(([key, value]) => {
+            if (key === 'series') {
+                return [
+                    key,
+                    value.map((v: any, index: number) => ({
+                        ...v,
+                        label: seriesNames[index],
+                    })),
+                ]
+            }
+            return [key, value]
+        })
 }

--- a/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
+++ b/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
@@ -1,8 +1,10 @@
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { getCoreFilterDefinition } from 'lib/taxonomy'
 import { pluralize } from 'lib/utils'
 
-import { InsightActorsQueryOptionsResponse } from '~/queries/schema'
+import { InsightActorsQuery, InsightActorsQueryOptionsResponse } from '~/queries/schema'
+import { isTrendsQuery } from '~/queries/utils'
 import { StepOrderValue } from '~/types'
 
 export const funnelTitle = (props: {
@@ -54,26 +56,28 @@ export const pathsTitle = (props: { mode: pathModes; label: string }): React.Rea
 
 export const cleanedInsightActorsQueryOptions = (
     insightActorsQueryOptions: InsightActorsQueryOptionsResponse | null,
-    query: any
+    query: InsightActorsQuery
 ): [string, any[]][] => {
     const cleanedOptions = Object.entries(insightActorsQueryOptions ?? {}).filter(([, value]) => {
         return Array.isArray(value) && !!value.length
     })
-    if (!query || !query.source) {
-        return cleanedOptions
-    }
-    const seriesNames = query.source.series.map((s: any) => s.custom_name || s.name)
-    const cleanedOptionsWithCustomSeriesNames: [string, any[]][] = cleanedOptions.map(([key, value]) => {
+    const source = query?.source
+    const seriesNames = isTrendsQuery(source) ? source.series.map((s: any) => s.custom_name) : []
+    const cleanedOptionsWithAdjustedSeriesNames: [string, any[]][] = cleanedOptions.map(([key, value]) => {
         if (key === 'series') {
             return [
                 key,
                 value.map((v: any, index: number) => ({
                     ...v,
-                    label: seriesNames[index],
+                    label:
+                        seriesNames[index] ??
+                        getCoreFilterDefinition(v.label, TaxonomicFilterGroupType.Events)?.label ??
+                        v.label,
                 })),
             ]
         }
         return [key, value]
     })
-    return cleanedOptionsWithCustomSeriesNames
+
+    return cleanedOptionsWithAdjustedSeriesNames
 }

--- a/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
+++ b/frontend/src/scenes/trends/persons-modal/persons-modal-utils.tsx
@@ -56,27 +56,24 @@ export const cleanedInsightActorsQueryOptions = (
     insightActorsQueryOptions: InsightActorsQueryOptionsResponse | null,
     query: any
 ): [string, any[]][] => {
+    const cleanedOptions = Object.entries(insightActorsQueryOptions ?? {}).filter(([, value]) => {
+        return Array.isArray(value) && !!value.length
+    })
     if (!query || !query.source) {
-        return Object.entries(insightActorsQueryOptions ?? {}).filter(([, value]) => {
-            return Array.isArray(value) && !!value.length
-        })
+        return cleanedOptions
     }
     const seriesNames = query.source.series.map((s: any) => s.custom_name || s.name)
-
-    return Object.entries(insightActorsQueryOptions ?? {})
-        .filter(([, value]) => {
-            return Array.isArray(value) && !!value.length
-        })
-        .map(([key, value]) => {
-            if (key === 'series') {
-                return [
-                    key,
-                    value.map((v: any, index: number) => ({
-                        ...v,
-                        label: seriesNames[index],
-                    })),
-                ]
-            }
-            return [key, value]
-        })
+    const cleanedOptionsWithCustomSeriesNames: [string, any[]][] = cleanedOptions.map(([key, value]) => {
+        if (key === 'series') {
+            return [
+                key,
+                value.map((v: any, index: number) => ({
+                    ...v,
+                    label: seriesNames[index],
+                })),
+            ]
+        }
+        return [key, value]
+    })
+    return cleanedOptionsWithCustomSeriesNames
 }


### PR DESCRIPTION
- Update the  function to map custom names () from the  to the dropdown options.
- Add checks to handle cases where  or  might be undefined, preventing potential errors.
- Ensure user-defined custom names are displayed in the series dropdown instead of the default  labels.

## Problem
The series dropdown within the persons modal was displaying the default `$pageview` label instead of the custom names provided by the user. This issue was caused by the dropdown not properly mapping the custom names from the `query.source.series`.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- Modified the `cleanedInsightActorsQueryOptions` function to include custom names from the `query.source.series`.
- Added checks to handle cases where `query` or `query.source` might be undefined.
- Updated the dropdown to display custom names instead of the default `$pageview` labels.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

<img width="585" alt="image" src="https://github.com/user-attachments/assets/37426ec1-43cf-421f-ad7b-7335e77d1127">


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- Ran `pnpm test:unit` to ensure all unit tests pass.
- Manually tested the changes by:
  1. Creating or viewing an insight with multiple pageviews as series.
  2. Renaming each series using the pencil icon in the Detailed results table.
  3. Hovering over a point on the chart to see the name changes in the modal.
  4. Clicking to view people and confirming the series dropdown displays the custom names.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
