### PR TITLE
fix: account for personless customers

### DIFF
--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
@@ -242,7 +242,7 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
             },
         ],
         quickFilterProperties: [
-            ['$geoip_country_name', ...(values.currentTeam?.person_display_name_properties || [])] as string[],
+            [...(values.currentTeam?.person_display_name_properties || [])] as string[],
             {
                 persist: true,
             },


### PR DESCRIPTION
## Problem

Originally discovered in https://posthoghelp.zendesk.com/agent/tickets/15795 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/18133)

Not every customer has person profiles

## Changes

We used to include the `Country Name` property as a default in Replay because it is a common thing to filter on.

Now that customers don't always have person properties this filter doesn't always work.

Given we have no way of knowing in app if the customer users persons it's probably just safer to remove this default.

Someone can add it for themselves pretty easily if they want to set is as one of their default user properties.