### PR TITLE
feat(insights): migrate a breakdown to multiple breakdowns when users edit insights

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.test.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.test.ts
@@ -23,6 +23,10 @@ const updateBreakdownFilter = jest.fn()
 const updateDisplay = jest.fn()
 const insightProps: InsightLogicProps = { dashboardItemId: 'new' }
 
+function mockFeatureFlag(logic: any): void {
+    logic.selectors.isMultipleBreakdownsEnabled = jest.fn().mockReturnValue(true)
+}
+
 describe('taxonomicBreakdownFilterLogic', () => {
     let logic: ReturnType<typeof taxonomicBreakdownFilterLogic.build>
 
@@ -131,13 +135,47 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 breakdown_group_type_index: 0,
             })
         })
+
+        it('sets a limit', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {},
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.setBreakdownLimit(99)
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({
+                breakdown_limit: 99,
+            })
+        })
+
+        it('sets a hide other aggregation', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {},
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.setBreakdownHideOtherAggregation(true)
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({
+                breakdown_hide_other_aggregation: true,
+            })
+        })
     })
 
     describe('multiple breakdowns', () => {
-        function mockFeatureFlag(logic: any): void {
-            logic.selectors.isMultipleBreakdownsEnabled = jest.fn().mockReturnValue(true)
-        }
-
         it('adds a breakdown for events', async () => {
             logic = taxonomicBreakdownFilterLogic({
                 insightProps,
@@ -342,6 +380,538 @@ describe('taxonomicBreakdownFilterLogic', () => {
             }).toFinishListeners()
 
             expect(updateBreakdownFilter).not.toHaveBeenCalled()
+        })
+
+        it('replaceBreakdown replaces a data warehouse breakdown with multiple breakdowns', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown: 'prop',
+                    breakdown_type: 'data_warehouse',
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+            const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.EventProperties, undefined)
+
+            await expectLogic(logic, () => {
+                logic.actions.replaceBreakdown(
+                    {
+                        type: 'data_warehouse',
+                        value: 'prop',
+                    },
+                    {
+                        group: group,
+                        value: 'prop2',
+                    }
+                )
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({
+                breakdowns: [
+                    {
+                        type: 'event',
+                        value: 'prop2',
+                    },
+                ],
+            })
+        })
+
+        it('replaceBreakdown replaces a data warehouse breakdown with a single breakdown on another data warehouse breakdown', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown: 'prop',
+                    breakdown_type: 'data_warehouse',
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+            const group: TaxonomicFilterGroup = taxonomicGroupFor(
+                TaxonomicFilterGroupType.DataWarehousePersonProperties,
+                undefined
+            )
+
+            await expectLogic(logic, () => {
+                logic.actions.replaceBreakdown(
+                    {
+                        type: 'data_warehouse',
+                        value: 'prop',
+                    },
+                    {
+                        group: group,
+                        value: 'prop2',
+                    }
+                )
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({
+                breakdowns: undefined,
+                breakdown_type: 'data_warehouse_person_property',
+                breakdown: 'prop2',
+            })
+        })
+
+        it('replaceBreakdown replaces multiple breakdowns with a single breakdown when there is a data warehouse', async () => {
+            const updateBreakdownFilter = jest.fn().mockImplementation()
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdowns: [
+                        {
+                            type: 'event',
+                            value: 'prop',
+                        },
+                    ],
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+            const group: TaxonomicFilterGroup = taxonomicGroupFor(
+                TaxonomicFilterGroupType.DataWarehousePersonProperties,
+                undefined
+            )
+
+            await expectLogic(logic, () => {
+                logic.actions.replaceBreakdown(
+                    {
+                        type: 'event',
+                        value: 'prop',
+                    },
+                    {
+                        group: group,
+                        value: 'prop2',
+                    }
+                )
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({
+                breakdowns: undefined,
+                breakdown_type: 'data_warehouse_person_property',
+                breakdown: 'prop2',
+            })
+
+            expect(updateBreakdownFilter.mock.calls[0][0]).toHaveProperty('breakdowns', undefined)
+        })
+    })
+
+    describe('single breakdown to multiple breakdowns', () => {
+        it('addBreakdown: replaces a breakdown', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown: 'prop',
+                    breakdown_type: 'event',
+                    breakdown_normalize_url: true,
+                    breakdown_group_type_index: 0,
+                    breakdown_histogram_bin_count: 10,
+                    breakdown_hide_other_aggregation: true,
+                    breakdown_limit: 10,
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+            const changedBreakdown = 'c'
+            const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.EventProperties, undefined)
+
+            await expectLogic(logic, () => {
+                logic.actions.addBreakdown(changedBreakdown, group)
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({
+                breakdown: undefined,
+                breakdown_type: undefined,
+                breakdown_histogram_bin_count: undefined,
+                breakdown_normalize_url: undefined,
+                breakdowns: [
+                    {
+                        value: 'prop',
+                        type: 'event',
+                        normalize_url: true,
+                        group_type_index: 0,
+                        histogram_bin_count: 10,
+                    },
+                    {
+                        value: 'c',
+                        type: 'event',
+                    },
+                ],
+            })
+        })
+
+        it('addBreakdown: does not add a duplicate multiple breakdown', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown: 'prop',
+                    breakdown_type: 'event',
+                    breakdown_normalize_url: true,
+                    breakdown_group_type_index: 0,
+                    breakdown_histogram_bin_count: 10,
+                    breakdown_hide_other_aggregation: true,
+                    breakdown_limit: 10,
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+            const changedBreakdown = 'prop'
+            const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.EventProperties, undefined)
+
+            await expectLogic(logic, () => {
+                logic.actions.addBreakdown(changedBreakdown, group)
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).not.toHaveBeenCalled()
+        })
+
+        it('addBreakdown: does not migrate a cohort breakdown', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown_type: 'cohort',
+                    breakdown: ['all', 1],
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+            const changedBreakdown = 2
+            const group: TaxonomicFilterGroup = taxonomicGroupFor(
+                TaxonomicFilterGroupType.CohortsWithAllUsers,
+                undefined
+            )
+
+            await expectLogic(logic, () => {
+                logic.actions.addBreakdown(changedBreakdown, group)
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({
+                breakdown_type: 'cohort',
+                breakdown: ['all', 1, 2],
+                breakdown_group_type_index: undefined,
+                breakdown_normalize_url: undefined,
+                breakdown_histogram_bin_count: undefined,
+            })
+        })
+
+        it('addBreakdown: does not migrate a data warehouse properties breakdown', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown_type: 'data_warehouse',
+                    breakdown: 'prop',
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+            const changedBreakdown = 'new_prop'
+            const group: TaxonomicFilterGroup = taxonomicGroupFor(
+                TaxonomicFilterGroupType.DataWarehouseProperties,
+                undefined
+            )
+
+            await expectLogic(logic, () => {
+                logic.actions.addBreakdown(changedBreakdown, group)
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({
+                breakdown_type: 'data_warehouse',
+                breakdown: 'new_prop',
+            })
+        })
+
+        it('addBreakdown: does not migrate a data warehouse person property breakdown', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown_type: 'data_warehouse_person_property',
+                    breakdown: 'prop',
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+            const changedBreakdown = 'new_prop'
+            const group: TaxonomicFilterGroup = taxonomicGroupFor(
+                TaxonomicFilterGroupType.DataWarehousePersonProperties,
+                undefined
+            )
+
+            await expectLogic(logic, () => {
+                logic.actions.addBreakdown(changedBreakdown, group)
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({
+                breakdown_type: 'data_warehouse_person_property',
+                breakdown: 'new_prop',
+            })
+        })
+
+        // In the UI it's not possible to add a second breakdown to a data warehouse query, but just in case.
+        it('addBreakdown: does add multiple breakdowns when there is a data warehouse breakdown', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown_type: 'data_warehouse_person_property',
+                    breakdown: 'prop',
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+            const changedBreakdown = 'new_prop'
+            const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.PersonProperties, undefined)
+
+            await expectLogic(logic, () => {
+                logic.actions.addBreakdown(changedBreakdown, group)
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({
+                breakdowns: [
+                    {
+                        type: 'person',
+                        value: 'new_prop',
+                    },
+                ],
+            })
+        })
+
+        it('removeBreakdown: deletes a breakdown correctly', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown_type: 'event',
+                    breakdown: 'prop',
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.removeBreakdown('prop', 'event')
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({})
+        })
+
+        it('replaceBreakdown: replaces a breakdown', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown: 'prop',
+                    breakdown_type: 'event',
+                    breakdown_normalize_url: true,
+                    breakdown_group_type_index: 0,
+                    breakdown_histogram_bin_count: 10,
+                    breakdown_hide_other_aggregation: true,
+                    breakdown_limit: 10,
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+            const changedBreakdown = 'c'
+            const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.PersonProperties, undefined)
+
+            await expectLogic(logic, () => {
+                logic.actions.replaceBreakdown(
+                    {
+                        type: 'event',
+                        value: 'prop',
+                    },
+                    {
+                        value: changedBreakdown,
+                        group,
+                    }
+                )
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({
+                breakdown: undefined,
+                breakdown_type: undefined,
+                breakdown_histogram_bin_count: undefined,
+                breakdown_normalize_url: undefined,
+                breakdown_group_type_index: undefined,
+                breakdowns: [
+                    {
+                        value: 'c',
+                        type: 'person',
+                    },
+                ],
+            })
+        })
+
+        it('replaceBreakdown: does not add a duplicate multiple breakdown', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown: 'prop',
+                    breakdown_type: 'event',
+                    breakdown_normalize_url: true,
+                    breakdown_group_type_index: 0,
+                    breakdown_histogram_bin_count: 10,
+                    breakdown_hide_other_aggregation: true,
+                    breakdown_limit: 10,
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+            const changedBreakdown = 'prop'
+            const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.EventProperties, undefined)
+
+            await expectLogic(logic, () => {
+                logic.actions.replaceBreakdown(
+                    {
+                        type: 'event',
+                        value: 'prop',
+                    },
+                    {
+                        value: changedBreakdown,
+                        group,
+                    }
+                )
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).not.toHaveBeenCalled()
+        })
+
+        it('setNormalizeBreakdownURL: updates correctly', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown: 'prop',
+                    breakdown_type: 'event',
+                    breakdown_normalize_url: true,
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.setNormalizeBreakdownURL('prop', 'event', false)
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({ breakdown_normalize_url: false })
+        })
+
+        it('setHistogramBinsUsed: updates correctly', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown: 'prop',
+                    breakdown_type: 'event',
+                    breakdown_histogram_bin_count: 10,
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.setHistogramBinsUsed('prop', 'event', false)
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({ breakdown_histogram_bin_count: undefined })
+        })
+
+        it('setHistogramBinCount: updates correctly', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown: 'prop',
+                    breakdown_type: 'event',
+                    breakdown_histogram_bin_count: 5,
+                },
+                histogramBinsUsed: true,
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.setHistogramBinCount('prop', 'event', 10)
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({ breakdown_histogram_bin_count: 10 })
+        })
+
+        it('setBreakdownLimit: updates correctly', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown_limit: 10,
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.setBreakdownLimit(99)
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({
+                breakdown_limit: 99,
+            })
+        })
+
+        it('setBreakdownHideOtherAggregation: updates correctly', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {},
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.setBreakdownHideOtherAggregation(true)
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({
+                breakdown_hide_other_aggregation: true,
+            })
         })
     })
 })

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.test.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.test.ts
@@ -700,6 +700,46 @@ describe('taxonomicBreakdownFilterLogic', () => {
             })
         })
 
+        it('addBreakdown: handles existing cohort breakdown and a new non-cohort property', async () => {
+            const updateBreakdownFilter = jest.fn().mockImplementation()
+
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown_type: 'cohort',
+                    breakdown: [1, 2],
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            mockFeatureFlag(logic)
+            logic.mount()
+            const changedBreakdown = '$lib_version'
+            const group: TaxonomicFilterGroup = taxonomicGroupFor(TaxonomicFilterGroupType.GroupsPrefix, 0)
+
+            await expectLogic(logic, () => {
+                logic.actions.addBreakdown(changedBreakdown, group)
+            }).toFinishListeners()
+
+            expect(updateBreakdownFilter).toHaveBeenCalledWith({
+                breakdown_type: undefined,
+                breakdown: undefined,
+                breakdowns: [
+                    {
+                        type: 'group',
+                        value: '$lib_version',
+                        group_type_index: 0,
+                    },
+                ],
+            })
+            expect(updateBreakdownFilter.mock.calls[0][0]).toHaveProperty('breakdown', undefined)
+            expect(updateBreakdownFilter.mock.calls[0][0]).toHaveProperty('breakdown_type', undefined)
+            expect(updateBreakdownFilter.mock.calls[0][0]).toHaveProperty('breakdown_group_type_index', undefined)
+            expect(updateBreakdownFilter.mock.calls[0][0]).toHaveProperty('breakdown_histogram_bin_count', undefined)
+            expect(updateBreakdownFilter.mock.calls[0][0]).toHaveProperty('breakdown_normalize_url', undefined)
+        })
+
         it('removeBreakdown: deletes a breakdown correctly', async () => {
             logic = taxonomicBreakdownFilterLogic({
                 insightProps,

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -214,15 +214,20 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
                 values.getPropertyDefinition(breakdown, propertyDefinitionType)?.name || (breakdown as string)
             )
 
+            const { breakdownFilter } = values
+
             // TODO: We're preventing duplicated cohorts with a Set. A better fix would be
             // to make excludedProperties work for cohorts in the TaxonomicFilter.
             const cohortBreakdown =
-                values.breakdownFilter?.breakdown_type === 'cohort'
+                breakdownFilter?.breakdown_type === 'cohort'
                     ? (Array.from(new Set([...values.breakdownCohortArray, breakdown])) as (string | number)[])
                     : ([breakdown] as (string | number)[])
 
             if (values.isMultipleBreakdownsEnabled && isMultipleBreakdownType(breakdownType)) {
-                if (checkBreakdownExists(values.breakdownFilter.breakdowns, breakdown, breakdownType)) {
+                if (
+                    checkBreakdownExists(breakdownFilter.breakdowns, breakdown, breakdownType) ||
+                    (breakdownFilter.breakdown === breakdown && breakdownType === breakdownFilter.breakdown_type)
+                ) {
                     return
                 }
 
@@ -234,11 +239,33 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
                     normalize_url: isNormalizeable ? true : undefined,
                 }
 
-                props.updateBreakdownFilter({
-                    breakdowns: values.breakdownFilter.breakdowns
-                        ? [...values.breakdownFilter.breakdowns, newBreakdown]
-                        : [newBreakdown],
-                })
+                const breakdowns = breakdownFilter.breakdowns
+                    ? [...breakdownFilter.breakdowns, newBreakdown]
+                    : [newBreakdown]
+
+                // Keep backwards compatibility with old breakdowns. If there is a breakdown, convert it first to multiple breakdowns.
+                if (isSingleBreakdown(breakdownFilter) && isMultipleBreakdownType(breakdownFilter.breakdown_type)) {
+                    props.updateBreakdownFilter({
+                        breakdown: undefined,
+                        breakdown_type: undefined,
+                        breakdown_histogram_bin_count: undefined,
+                        breakdown_normalize_url: undefined,
+                        breakdowns: [
+                            {
+                                value: breakdownFilter.breakdown as string,
+                                type: breakdownFilter.breakdown_type,
+                                group_type_index: breakdownFilter.breakdown_group_type_index,
+                                histogram_bin_count: breakdownFilter.breakdown_histogram_bin_count,
+                                normalize_url: breakdownFilter.breakdown_normalize_url,
+                            },
+                            ...breakdowns,
+                        ],
+                    })
+                } else {
+                    props.updateBreakdownFilter({
+                        breakdowns,
+                    })
+                }
             } else {
                 props.updateBreakdownFilter({
                     breakdowns: undefined,
@@ -338,8 +365,26 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
                 isMultipleBreakdownType(breakdownType) &&
                 typeof breakdownValue === 'string'
             ) {
-                props.updateBreakdownFilter?.({
-                    breakdowns: values.breakdownFilter.breakdowns?.map((savedBreakdown) => {
+                // Backward compatibility. If there is a single breakdown, remove it.
+                if (!values.breakdownFilter.breakdowns) {
+                    props.updateBreakdownFilter?.({
+                        breakdowns: [
+                            {
+                                value: breakdownValue,
+                                type: breakdownType,
+                                group_type_index: newBreakdown.group.groupTypeIndex,
+                                histogram_bin_count: isHistogramable ? 10 : undefined,
+                                normalize_url: isNormalizeable ? true : undefined,
+                            },
+                        ],
+                        breakdown: undefined,
+                        breakdown_type: undefined,
+                        breakdown_histogram_bin_count: undefined,
+                        breakdown_normalize_url: undefined,
+                        breakdown_group_type_index: undefined,
+                    })
+                } else {
+                    const breakdowns = values.breakdownFilter.breakdowns?.map((savedBreakdown) => {
                         if (
                             savedBreakdown.value === previousBreakdown.value &&
                             savedBreakdown.type === previousBreakdown.type
@@ -357,8 +402,12 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
                         }
 
                         return savedBreakdown
-                    }),
-                })
+                    })
+
+                    props.updateBreakdownFilter?.({
+                        breakdowns,
+                    })
+                }
             } else {
                 actions.addBreakdown(newBreakdown.value, newBreakdown.group)
             }
@@ -371,7 +420,7 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
             })
         },
         setNormalizeBreakdownURL: ({ normalizeBreakdownURL, breakdown, breakdownType }) => {
-            if (values.isMultipleBreakdownsEnabled) {
+            if (values.isMultipleBreakdownsEnabled && !isSingleBreakdown(values.breakdownFilter)) {
                 props.updateBreakdownFilter?.({
                     breakdown_normalize_url: undefined,
                     breakdowns: updateNestedBreakdown(
@@ -390,7 +439,7 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
             }
         },
         setHistogramBinsUsed: ({ binsUsed, binCount, breakdown, breakdownType }) => {
-            if (values.isMultipleBreakdownsEnabled) {
+            if (values.isMultipleBreakdownsEnabled && !isSingleBreakdown(values.breakdownFilter)) {
                 props.updateBreakdownFilter?.({
                     breakdown_histogram_bin_count: undefined,
                     breakdowns: updateNestedBreakdown(
@@ -411,7 +460,7 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
         setHistogramBinCount: async ({ count, breakdown, breakdownType }, breakpoint) => {
             await breakpoint(1000)
 
-            if (values.isMultipleBreakdownsEnabled) {
+            if (values.isMultipleBreakdownsEnabled && !isSingleBreakdown(values.breakdownFilter)) {
                 props.updateBreakdownFilter?.({
                     breakdown_histogram_bin_count: undefined,
                     breakdowns: updateNestedBreakdown(
@@ -466,4 +515,8 @@ function checkBreakdownExists(
 
 export function multipleBreakdownsEnabled(flags: FeatureFlagsSet): boolean {
     return !!flags[FEATURE_FLAGS.MULTIPLE_BREAKDOWNS]
+}
+
+export function isSingleBreakdown(breakdownFilter?: BreakdownFilter | null): boolean {
+    return !!(breakdownFilter && breakdownFilter.breakdown_type && breakdownFilter.breakdown)
 }

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -250,6 +250,7 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
                         breakdown_type: undefined,
                         breakdown_histogram_bin_count: undefined,
                         breakdown_normalize_url: undefined,
+                        breakdown_group_type_index: undefined,
                         breakdowns: [
                             {
                                 value: breakdownFilter.breakdown as string,
@@ -263,6 +264,11 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
                     })
                 } else {
                     props.updateBreakdownFilter({
+                        breakdown: undefined,
+                        breakdown_type: undefined,
+                        breakdown_histogram_bin_count: undefined,
+                        breakdown_normalize_url: undefined,
+                        breakdown_group_type_index: undefined,
                         breakdowns,
                     })
                 }

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterUtils.ts
@@ -11,7 +11,7 @@ export const isURLNormalizeable = (propertyName: string): boolean => {
     return ['$current_url', '$pathname'].includes(propertyName)
 }
 
-export function isMultipleBreakdownType(breakdownType: BreakdownType): breakdownType is MultipleBreakdownType {
+export function isMultipleBreakdownType(breakdownType?: BreakdownType | null): breakdownType is MultipleBreakdownType {
     const types: MultipleBreakdownType[] = ['person', 'event', 'group', 'session', 'hogql']
-    return (types as string[]).includes(breakdownType)
+    return !!breakdownType && (types as string[]).includes(breakdownType)
 }


### PR DESCRIPTION
## Problem

This PR provides a compatibility layer for single and multiple breakdowns. If you have a saved insight with a single breakdown and you edit this insight by adding a new breakdown, the UI doesn't apply the new breakdown or remove all breakdowns.

Multiple breakdowns currently support all breakdown types except for cohorts and data warehouse properties, which use the `breakdown` property (single breakdown), so there should be a compatibility layer that handles all breakdown types.

**Before**

![2024-07-16 15 50 08](https://github.com/user-attachments/assets/d438e84f-e7de-4dc6-bb3b-3c67dd26a3c0)

**After**

![2024-07-16 15 47 27](https://github.com/user-attachments/assets/6540d87d-6eab-4ae1-b78f-7ba03fa5d119)


## Changes

Updated the logic to handle breakdowns and multiple breakdowns:
- Data warehouse and cohorts: no changes, so only one breakdown is available.
- All other types: the `breakdown` property gets converted to the `breakdowns` property when someone adds another breakdown.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing and added unit tests for the compatibility layer.
