### PR TITLE
feat(hog): highlight globals in metadata

### DIFF
--- a/posthog/hogql/bytecode.py
+++ b/posthog/hogql/bytecode.py
@@ -174,11 +174,11 @@ class BytecodeBuilder(Visitor):
             chain.extend([Operation.STRING, element])
         if self.context.globals and node.chain[0] in self.context.globals:
             self.context.notices.append(
-                HogQLNotice(start=node.start, end=node.end, message="Global variable: " + node.chain[0])
+                HogQLNotice(start=node.start, end=node.end, message="Global variable: " + str(node.chain[0]))
             )
         else:
             self.context.warnings.append(
-                HogQLNotice(start=node.start, end=node.end, message="Unknown global variable: " + node.chain[0])
+                HogQLNotice(start=node.start, end=node.end, message="Unknown global variable: " + str(node.chain[0]))
             )
         return [*chain, Operation.GET_GLOBAL, len(node.chain)]
 

--- a/posthog/hogql/bytecode.py
+++ b/posthog/hogql/bytecode.py
@@ -7,6 +7,7 @@ from hogvm.python.execute import execute_bytecode, BytecodeResult
 from hogvm.python.stl import STL
 from posthog.hogql import ast
 from posthog.hogql.base import AST
+from posthog.hogql.context import HogQLContext
 from posthog.hogql.errors import QueryError
 from posthog.hogql.parser import parse_program
 from posthog.hogql.visitor import Visitor
@@ -14,6 +15,7 @@ from hogvm.python.operation import (
     Operation,
     HOGQL_BYTECODE_IDENTIFIER,
 )
+from posthog.schema import HogQLNotice
 
 if TYPE_CHECKING:
     from posthog.models import Team
@@ -58,11 +60,12 @@ def create_bytecode(
     expr: ast.Expr | ast.Statement | ast.Program,
     supported_functions: Optional[set[str]] = None,
     args: Optional[list[str]] = None,
+    context: Optional[HogQLContext] = None,
 ) -> list[Any]:
     bytecode: list[Any] = []
     if args is None:
         bytecode.append(HOGQL_BYTECODE_IDENTIFIER)
-    bytecode.extend(BytecodeBuilder(supported_functions, args).visit(expr))
+    bytecode.extend(BytecodeBuilder(supported_functions, args, context).visit(expr))
     return bytecode
 
 
@@ -80,7 +83,12 @@ class HogFunction:
 
 
 class BytecodeBuilder(Visitor):
-    def __init__(self, supported_functions: Optional[set[str]] = None, args: Optional[list[str]] = None):
+    def __init__(
+        self,
+        supported_functions: Optional[set[str]] = None,
+        args: Optional[list[str]] = None,
+        context: Optional[HogQLContext] = None,
+    ):
         super().__init__()
         self.supported_functions = supported_functions or set()
         self.locals: list[Local] = []
@@ -91,6 +99,7 @@ class BytecodeBuilder(Visitor):
         if args is not None:
             for arg in reversed(args):
                 self._declare_local(arg)
+        self.context = context or HogQLContext(team_id=None)
 
     def _start_scope(self):
         self.scope_depth += 1
@@ -163,6 +172,14 @@ class BytecodeBuilder(Visitor):
         chain = []
         for element in reversed(node.chain):
             chain.extend([Operation.STRING, element])
+        if self.context.globals and node.chain[0] in self.context.globals:
+            self.context.notices.append(
+                HogQLNotice(start=node.start, end=node.end, message="Global variable: " + node.chain[0])
+            )
+        else:
+            self.context.warnings.append(
+                HogQLNotice(start=node.start, end=node.end, message="Unknown global variable: " + node.chain[0])
+            )
         return [*chain, Operation.GET_GLOBAL, len(node.chain)]
 
     def visit_tuple_access(self, node: ast.TupleAccess):
@@ -490,7 +507,7 @@ class BytecodeBuilder(Visitor):
         elif not isinstance(node.body, ast.ReturnStatement):
             body = ast.Block(declarations=[node.body, ast.ReturnStatement(expr=None)])
 
-        bytecode = create_bytecode(body, all_known_functions, node.params)
+        bytecode = create_bytecode(body, all_known_functions, node.params, self.context)
         self.functions[node.name] = HogFunction(node.name, node.params, bytecode)
         return [Operation.DECLARE_FN, node.name, len(node.params), len(bytecode), *bytecode]
 

--- a/posthog/hogql/metadata.py
+++ b/posthog/hogql/metadata.py
@@ -32,52 +32,44 @@ def get_hogql_metadata(
     query_modifiers = create_default_modifiers_for_team(team)
 
     try:
+        context = HogQLContext(
+            team_id=team.pk,
+            modifiers=query_modifiers,
+            enable_select_queries=True,
+            debug=query.debug or False,
+            globals=query.globals,
+        )
         if query.language == HogLanguage.HOG:
             program = parse_program(query.query)
-            create_bytecode(program, supported_functions={"fetch", "posthogCapture"}, args=[])
-        else:
-            if query.language == HogLanguage.HOG_QL_EXPR or query.language == HogLanguage.HOG_TEMPLATE:
-                context = HogQLContext(
-                    team_id=team.pk,
-                    modifiers=query_modifiers,
-                    debug=query.debug or False,
-                    enable_select_queries=True,
-                    globals=query.globals,
-                )
-                node: ast.Expr
-                if query.language == HogLanguage.HOG_TEMPLATE:
-                    node = parse_string_template(query.query)
-                else:
-                    node = parse_expr(query.query)
-                if query.sourceQuery is not None:
-                    source_query = get_query_runner(query=query.sourceQuery, team=team).to_query()
-                    process_expr_on_table(node, context=context, source_query=source_query)
-                else:
-                    process_expr_on_table(node, context=context)
-            elif query.language == HogLanguage.HOG_QL:
-                context = HogQLContext(
-                    team_id=team.pk,
-                    modifiers=query_modifiers,
-                    enable_select_queries=True,
-                    debug=query.debug or False,
-                    globals=query.globals,
-                )
-                select_ast = parse_select(query.query)
-                if query.filters:
-                    select_ast = replace_filters(select_ast, query.filters, team)
-                _is_valid_view = is_valid_view(select_ast)
-                response.isValidView = _is_valid_view
-                print_ast(
-                    select_ast,
-                    context=context,
-                    dialect="clickhouse",
-                )
+            create_bytecode(program, supported_functions={"fetch", "posthogCapture"}, args=[], context=context)
+        elif query.language == HogLanguage.HOG_QL_EXPR or query.language == HogLanguage.HOG_TEMPLATE:
+            node: ast.Expr
+            if query.language == HogLanguage.HOG_TEMPLATE:
+                node = parse_string_template(query.query)
             else:
-                raise ValueError(f"Unsupported language: {query.language}")
-            response.warnings = context.warnings
-            response.notices = context.notices
-            response.errors = context.errors
-            response.isValid = len(response.errors) == 0
+                node = parse_expr(query.query)
+            if query.sourceQuery is not None:
+                source_query = get_query_runner(query=query.sourceQuery, team=team).to_query()
+                process_expr_on_table(node, context=context, source_query=source_query)
+            else:
+                process_expr_on_table(node, context=context)
+        elif query.language == HogLanguage.HOG_QL:
+            select_ast = parse_select(query.query)
+            if query.filters:
+                select_ast = replace_filters(select_ast, query.filters, team)
+            _is_valid_view = is_valid_view(select_ast)
+            response.isValidView = _is_valid_view
+            print_ast(
+                select_ast,
+                context=context,
+                dialect="clickhouse",
+            )
+        else:
+            raise ValueError(f"Unsupported language: {query.language}")
+        response.warnings = context.warnings
+        response.notices = context.notices
+        response.errors = context.errors
+        response.isValid = len(response.errors) == 0
     except Exception as e:
         response.isValid = False
         if isinstance(e, ExposedHogQLError):

--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from posthog.hogql.metadata import get_hogql_metadata
 from posthog.models import PropertyDefinition, Cohort
 from posthog.schema import HogQLMetadata, HogQLMetadataResponse, HogQLQuery
@@ -27,9 +29,9 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
             team=self.team,
         )
 
-    def _program(self, query: str) -> HogQLMetadataResponse:
+    def _program(self, query: str, globals: Optional[dict] = None) -> HogQLMetadataResponse:
         return get_hogql_metadata(
-            query=HogQLMetadata(kind="HogQLMetadata", language="hog", query=query, response=None),
+            query=HogQLMetadata(kind="HogQLMetadata", language="hog", query=query, globals=globals, response=None),
             team=self.team,
         )
 
@@ -340,6 +342,21 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
                 "notices": [],
                 "warnings": [],
                 "errors": [{"end": 15, "fix": None, "message": "Hog function `NONO` is not implemented", "start": 9}],
+            },
+        )
+
+    def test_hog_program_globals(self):
+        metadata = self._program("print(event, region)", globals={"event": "banana"})
+        self.assertEqual(
+            metadata.dict(),
+            metadata.dict()
+            | {
+                "query": "print(event, region)",
+                "isValid": True,
+                "isValidView": False,
+                "notices": [{"end": 11, "fix": None, "message": "Global variable: event", "start": 6}],
+                "warnings": [{"end": 19, "fix": None, "message": "Unknown global variable: region", "start": 13}],
+                "errors": [],
             },
         )
 


### PR DESCRIPTION
## Problem

In Hog 1) undefined globals resolve to `null`, 2) undefined globals weren't indicated 3) all typos resolve to nulls 4) thus it's easy to make bugs

## Changes

![2024-07-16 15 58 06](https://github.com/user-attachments/assets/fd2c3e5c-8b7f-4ecd-856a-ed479613bbed)


## How did you test this code?

Added a backend test for metadata