### PR TITLE
fix: Heartbeat more often by default

### DIFF
--- a/posthog/temporal/common/heartbeat.py
+++ b/posthog/temporal/common/heartbeat.py
@@ -20,7 +20,7 @@ class Heartbeater:
             maintained while in the context manager to avoid garbage collection.
     """
 
-    def __init__(self, details: tuple[typing.Any, ...] = (), factor: int = 2):
+    def __init__(self, details: tuple[typing.Any, ...] = (), factor: int = 12):
         self._details: tuple[typing.Any, ...] = details
         self.factor = factor
         self.heartbeat_task: asyncio.Task | None = None


### PR DESCRIPTION
## Problem

Saw some occasional timeouts on long-running exports. If I had to guess, the likely underlying cause is some blocking code we haven't fully stripped out.

However, there is a chance we are not heart-beating frequently enough: With current defaults, we heartbeat only twice during each heartbeat timeout period (once every 60 seconds, in a 120 second heartbeat timeout).

Since that's an easier fix without much of a downside, let's try bumping the default heartbeat factor to 12. Ultimately, this leads to heartbeats every 10 seconds instead of 60 (120 / 12 = 10s, instead of 120 / 2 = 60s).

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Bump heartbeat default factor to 12 to heartbeat every 10 seconds instead of 60.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
