### PR TITLE
fix(surveys): Allow removing events from selection

### DIFF
--- a/frontend/src/lib/components/EventSelect/EventSelect.tsx
+++ b/frontend/src/lib/components/EventSelect/EventSelect.tsx
@@ -40,6 +40,9 @@ export const EventSelect = ({
         if (onChange) {
             onChange(selectedEvents.filter((p) => p !== name))
         }
+        if (onItemChange && selectedItems) {
+            onItemChange(selectedItems?.filter((p) => p.name !== name))
+        }
     }
 
     // Add in the toggle popover logic for the passed in element


### PR DESCRIPTION
## Problem

The EventSelect control didn't handle removing items from the selectedItems list  if only `onItemChange` is specified in the control.

## Changes

Added a call to `onItemChange` when an element is removed from the selectedEvents.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

1. Manually in local development.
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
