### PR TITLE
feat: add billing error from url params

### DIFF
--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -546,6 +546,13 @@ export const billingLogic = kea<billingLogicType>([
                 const products = _search.products.split(',')
                 actions.setScrollToProductKey(products[0])
             }
+            if (_search.billing_error) {
+                actions.setBillingAlert({
+                    status: 'error',
+                    title: 'Error',
+                    message: _search.billing_error,
+                })
+            }
             actions.setRedirectPath()
             actions.setIsOnboarding()
         },


### PR DESCRIPTION
## Problem

Related to https://github.com/PostHog/billing/pull/748 so we can show the billing error on the billing page and not in JSON on a random page.
