### PR TITLE
fix(insights): filter to query conversion of multiple breakdowns

### DIFF
--- a/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/filter_to_query.py
@@ -324,17 +324,19 @@ def _breakdown_filter(_filter: dict):
     if _filter.get("breakdowns") is not None and isinstance(_filter["breakdowns"], list):
         breakdowns = []
         for breakdown in _filter["breakdowns"]:
-            if isinstance(breakdown, dict) and "property" in breakdown:
+            if isinstance(breakdown, dict) and ("value" in breakdown or "property" in breakdown):
                 breakdowns.append(
                     {
                         "type": breakdown.get("type", "event"),
-                        "value": breakdown["property"],
+                        "value": breakdown.get("value", breakdown.get("property")),
                         "normalize_url": breakdown.get("normalize_url", None),
+                        "histogram_bin_count": breakdown.get("histogram_bin_count", None),
+                        "group_type_index": breakdown.get("group_type_index", None),
                     }
                 )
 
         if len(breakdowns) > 0:
-            breakdownFilter["breakdowns"] = breakdowns
+            breakdownFilter["breakdowns"] = breakdowns[:3]
 
     if breakdownFilter["breakdown"] is not None and breakdownFilter["breakdown_type"] is None:
         breakdownFilter["breakdown_type"] = "event"


### PR DESCRIPTION
## Problem

Fixes a bug in the `filter_to_query` function that used the legacy `property` field of multiple breakdowns. I should've implemented a unit test to catch that, but I didn't :(

## Changes

- Use the `property` field of the `breakdowns` array for legacy multiple breakdowns.
- Use the `value` field of the `breakdowns` array for new multiple breakdowns.

**Screenshot before**

<img width="746" alt="Screenshot 2024-07-16 at 17 23 40" src="https://github.com/user-attachments/assets/eb16ec34-ac04-4682-be96-777421ac2864">

**Screenshot after**

<img width="710" alt="Screenshot 2024-07-16 at 17 23 13" src="https://github.com/user-attachments/assets/d928f32e-5e90-4979-9556-de7dbd826640">

(My actions in the app cause the difference in count between screenshots)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing, unit tests and added additional tests.
