### PR TITLE
feat(queries): Use analytics limited queue for cache warming tasks

### DIFF
--- a/bin/celery-queues.env
+++ b/bin/celery-queues.env
@@ -2,4 +2,4 @@
 # Important: Add new queues to make Celery consume tasks from them.
 
 # NOTE: Keep in sync with posthog/tasks/utils.py
-CELERY_WORKER_QUEUES=celery,stats,email,analytics_queries,long_running,exports,subscription_delivery,usage_reports,session_replay_embeddings,session_replay_general,session_replay_persistence
+CELERY_WORKER_QUEUES=celery,stats,email,analytics_queries,analytics_limited,long_running,exports,subscription_delivery,usage_reports,session_replay_embeddings,session_replay_general,session_replay_persistence

--- a/posthog/caching/test/test_warming.py
+++ b/posthog/caching/test/test_warming.py
@@ -125,9 +125,9 @@ class TestScheduleWarmingForTeamsTask(APIBaseTest):
 
     @patch("posthog.caching.warming.largest_teams")
     @patch("posthog.caching.warming.priority_insights")
-    @patch("posthog.caching.warming.group")
+    @patch("posthog.caching.warming.warm_insight_cache_task.si")
     def test_schedule_warming_for_teams_task_with_empty_insight_tuples(
-        self, mock_group, mock_priority_insights, mock_largest_teams
+        self, mock_warm_insight_cache_task_si, mock_priority_insights, mock_largest_teams
     ):
         mock_largest_teams.return_value = [self.team1.pk, self.team2.pk]
         mock_priority_insights.return_value = iter([])
@@ -135,23 +135,21 @@ class TestScheduleWarmingForTeamsTask(APIBaseTest):
         schedule_warming_for_teams_task()
 
         mock_priority_insights.assert_called()
-        mock_group.assert_called()
-        call_args_list = list(mock_group.call_args_list[0][0][0])
-        self.assertEqual(len(call_args_list), 0)
+        mock_warm_insight_cache_task_si.assert_not_called()
 
     @patch("posthog.caching.warming.largest_teams")
     @patch("posthog.caching.warming.priority_insights")
-    @patch("posthog.caching.warming.group")
+    @patch("posthog.caching.warming.warm_insight_cache_task.si")
     def test_schedule_warming_for_teams_task_with_non_empty_insight_tuples(
-        self, mock_group, mock_priority_insights, mock_largest_teams
+        self, mock_warm_insight_cache_task_si, mock_priority_insights, mock_largest_teams
     ):
         mock_largest_teams.return_value = [self.team1.pk, self.team2.pk]
         mock_priority_insights.return_value = iter([("1234", "5678"), ("2345", None)])
 
         schedule_warming_for_teams_task()
 
-        mock_group.assert_called()
-        call_args_list = list(mock_group.call_args_list[0][0][0])
-        self.assertEqual(len(call_args_list), 2)
-        self.assertEqual(call_args_list[0].args, ("1234", "5678"))
-        self.assertEqual(call_args_list[1].args, ("2345", None))
+        mock_priority_insights.assert_called()
+        self.assertEqual(mock_warm_insight_cache_task_si.call_count, 2)
+        self.assertEqual(mock_warm_insight_cache_task_si.call_args_list[0][0][0], "1234")
+        self.assertEqual(mock_warm_insight_cache_task_si.call_args_list[0][0][1], "5678")
+        self.assertEqual(mock_warm_insight_cache_task_si.call_args_list[1][0][0], "2345")

--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import structlog
 from celery import shared_task
-from celery.canvas import chain
+from celery.canvas import group
 from django.db.models import Q
 from prometheus_client import Counter
 from sentry_sdk import capture_exception
@@ -80,25 +80,22 @@ def priority_insights(team: Team) -> Generator[tuple[int, Optional[int]], None, 
     yield from dashboard_tiles
 
 
-@shared_task(ignore_result=True, expires=60 * 60)
+@shared_task(ignore_result=True, expires=60 * 15)
 def schedule_warming_for_teams_task():
-    team_ids = largest_teams(limit=3)
+    team_ids = largest_teams(limit=10)
 
     teams = Team.objects.filter(Q(pk__in=team_ids) | Q(extra_settings__insights_cache_warming=True))
 
     logger.info("Warming insight cache: teams", team_ids=[team.pk for team in teams])
 
-    # TODO: Needs additional thoughts about concurrency and rate limiting if we launch chains for a lot of teams at once
-
     for team in teams:
         insight_tuples = priority_insights(team)
 
-        task_groups = chain(*(warm_insight_cache_task.si(*insight_tuple) for insight_tuple in insight_tuples))
-        task_groups.apply_async()
+        group(warm_insight_cache_task.si(*insight_tuple) for insight_tuple in insight_tuples)()
 
 
 @shared_task(
-    queue=CeleryQueue.LONG_RUNNING.value,
+    queue=CeleryQueue.ANALYTICS_LIMITED.value,  # Important! Prevents Clickhouse from being overwhelmed
     ignore_result=True,
     expires=60 * 60,
     autoretry_for=(CHQueryErrorTooManySimultaneousQueries,),

--- a/posthog/tasks/utils.py
+++ b/posthog/tasks/utils.py
@@ -31,6 +31,7 @@ class CeleryQueue(Enum):
     EMAIL = "email"
     LONG_RUNNING = "long_running"  # any task that has a good chance of taking more than a few seconds should go here
     ANALYTICS_QUERIES = "analytics_queries"
+    ANALYTICS_LIMITED = "analytics_limited"
     EXPORTS = "exports"
     SUBSCRIPTION_DELIVERY = "subscription_delivery"
     USAGE_REPORTS = "usage_reports"


### PR DESCRIPTION
## Problem

We used chains to limit how that cache warming tasks are executed one after another.
There is however now the possibility to use a queue that has limited worker threads, thereby limiting concurrency: https://github.com/PostHog/charts/pull/1499

## Changes

- use limited queue
- adjust to warm for more teams
