### PR TITLE
feat(vscode): add launch config for local https

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,20 @@
             }
         },
         {
+            "name": "Frontend (https)",
+            "command": "pnpm start",
+            "request": "launch",
+            "type": "node-terminal",
+            "cwd": "${workspaceFolder}",
+            "presentation": {
+                "group": "main"
+            },
+            "env": {
+                "LOCAL_HTTPS": "1",
+                "JS_URL": "https://secure.posthog.dev"
+            }
+        },
+        {
             "name": "Backend",
             "consoleName": "Backend",
             "type": "debugpy",
@@ -187,6 +201,21 @@
                 "Backend (with local billing)",
                 "Celery Threaded Pool",
                 "Frontend",
+                "Plugin Server",
+                "Temporal Worker"
+            ],
+            "stopAll": true,
+            "presentation": {
+                "order": 2,
+                "group": "compound"
+            }
+        },
+        {
+            "name": "PostHog (https)",
+            "configurations": [
+                "Backend",
+                "Celery Threaded Pool",
+                "Frontend (https)",
                 "Plugin Server",
                 "Temporal Worker"
             ],


### PR DESCRIPTION
## Problem

The docs here are outdated and don't actually work any more https://posthog.com/handbook/engineering/setup-ssl-locally. Specifically the `pnpm start-https` command is missing. 

## Changes

Adds a launch configuration for local https that works. I'll update docs / other configs later on.

## How did you test this code?

Debugging with `secure.posthog.dev`