### PR TITLE
fix(insights): disable the add breakdown button for more than one data warehouse property

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -39,7 +39,7 @@ export function TaxonomicBreakdownFilter({
         updateBreakdownFilter,
         updateDisplay,
     }
-    const { breakdownArray, addBreakdownDisabled, breakdownOptionsOpened, isMultipleBreakdownsEnabled } = useValues(
+    const { breakdownArray, isAddBreakdownDisabled, breakdownOptionsOpened, isMultipleBreakdownsEnabled } = useValues(
         taxonomicBreakdownFilterLogic(logicProps)
     )
     const { toggleBreakdownOptions } = useActions(taxonomicBreakdownFilterLogic(logicProps))
@@ -85,7 +85,7 @@ export function TaxonomicBreakdownFilter({
             </div>
             <div className="flex flex-wrap gap-2 items-center">
                 {tags}
-                {!addBreakdownDisabled && <TaxonomicBreakdownButton disabledReason={disabledReason} />}
+                {!isAddBreakdownDisabled && <TaxonomicBreakdownButton disabledReason={disabledReason} />}
             </div>
         </BindLogic>
     )

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -39,7 +39,7 @@ export function TaxonomicBreakdownFilter({
         updateBreakdownFilter,
         updateDisplay,
     }
-    const { breakdownArray, maxBreakdownsSelected, breakdownOptionsOpened, isMultipleBreakdownsEnabled } = useValues(
+    const { breakdownArray, addBreakdownDisabled, breakdownOptionsOpened, isMultipleBreakdownsEnabled } = useValues(
         taxonomicBreakdownFilterLogic(logicProps)
     )
     const { toggleBreakdownOptions } = useActions(taxonomicBreakdownFilterLogic(logicProps))
@@ -85,7 +85,7 @@ export function TaxonomicBreakdownFilter({
             </div>
             <div className="flex flex-wrap gap-2 items-center">
                 {tags}
-                {!maxBreakdownsSelected && <TaxonomicBreakdownButton disabledReason={disabledReason} />}
+                {!addBreakdownDisabled && <TaxonomicBreakdownButton disabledReason={disabledReason} />}
             </div>
         </BindLogic>
     )

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.test.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.test.ts
@@ -1,4 +1,4 @@
-import { expectLogic } from 'kea-test-utils'
+import { expectLogic, partial } from 'kea-test-utils'
 import { TaxonomicFilterGroup, TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 import { initKeaTests } from '~/test/init'
@@ -130,6 +130,24 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 breakdown: '$lib_version',
                 breakdown_group_type_index: 0,
             })
+        })
+    })
+
+    describe('isAddBreakdownDisabled', () => {
+        it('no breakdowns', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {},
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            logic.mount()
+            await expectLogic(logic).toMatchValues(
+                partial({
+                    isAddBreakdownDisabled: false,
+                })
+            )
         })
     })
 

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.test.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.test.ts
@@ -1,10 +1,12 @@
-import { expectLogic, partial } from 'kea-test-utils'
+import { expectLogic } from 'kea-test-utils'
 import { TaxonomicFilterGroup, TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 import { initKeaTests } from '~/test/init'
 import { InsightLogicProps } from '~/types'
 
-import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
+import * as breakdownLogic from './taxonomicBreakdownFilterLogic'
+
+const { taxonomicBreakdownFilterLogic } = breakdownLogic
 
 const taxonomicGroupFor = (
     type: TaxonomicFilterGroupType,
@@ -134,6 +136,10 @@ describe('taxonomicBreakdownFilterLogic', () => {
     })
 
     describe('isAddBreakdownDisabled', () => {
+        function mockFeatureFlag(): void {
+            jest.spyOn(breakdownLogic, 'multipleBreakdownsEnabled').mockReturnValue(true)
+        }
+
         it('no breakdowns', async () => {
             logic = taxonomicBreakdownFilterLogic({
                 insightProps,
@@ -143,11 +149,186 @@ describe('taxonomicBreakdownFilterLogic', () => {
                 updateDisplay,
             })
             logic.mount()
-            await expectLogic(logic).toMatchValues(
-                partial({
-                    isAddBreakdownDisabled: false,
-                })
-            )
+            await expectLogic(logic).toMatchValues({
+                isAddBreakdownDisabled: false,
+            })
+        })
+
+        it('breakdown is selected', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown: 'prop',
+                    breakdown_type: 'event',
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            logic.mount()
+            await expectLogic(logic).toMatchValues({
+                isAddBreakdownDisabled: true,
+            })
+        })
+
+        it('multiple breakdowns', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdowns: [],
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            logic.mount()
+            await expectLogic(logic).toMatchValues({
+                isAddBreakdownDisabled: false,
+            })
+        })
+
+        it('multiple breakdowns can be added', async () => {
+            mockFeatureFlag()
+
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdowns: [
+                        {
+                            value: 'prop1',
+                            type: 'event',
+                        },
+                    ],
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            logic.mount()
+            await expectLogic(logic).toMatchValues({
+                isAddBreakdownDisabled: false,
+            })
+
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdowns: [
+                        {
+                            value: 'prop1',
+                            type: 'event',
+                        },
+                        {
+                            value: 'prop2',
+                            type: 'event',
+                        },
+                    ],
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            logic.mount()
+            await expectLogic(logic).toMatchValues({
+                isAddBreakdownDisabled: false,
+            })
+        })
+
+        it('multiple breakdowns allows max three elements', async () => {
+            mockFeatureFlag()
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdowns: [
+                        {
+                            value: 'prop1',
+                            type: 'event',
+                        },
+                        {
+                            value: 'prop2',
+                            type: 'event',
+                        },
+                        {
+                            value: 'prop3',
+                            type: 'event',
+                        },
+                    ],
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+            await expectLogic(logic).toMatchValues({
+                isAddBreakdownDisabled: true,
+            })
+        })
+
+        it('only one data warehouse breakdown is allowed', async () => {
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown_type: 'data_warehouse_person_property',
+                    breakdown: 'prop',
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            logic.mount()
+            await expectLogic(logic).toMatchValues({
+                isAddBreakdownDisabled: true,
+            })
+
+            mockFeatureFlag()
+
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown_type: 'data_warehouse',
+                    breakdown: 'prop',
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            logic.mount()
+            await expectLogic(logic).toMatchValues({
+                isAddBreakdownDisabled: true,
+            })
+        })
+
+        it('no restrictions on cohorts', async () => {
+            mockFeatureFlag()
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown_type: 'cohort',
+                    breakdown: [1],
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            logic.mount()
+            await expectLogic(logic).toMatchValues({
+                isAddBreakdownDisabled: false,
+            })
+
+            logic = taxonomicBreakdownFilterLogic({
+                insightProps,
+                breakdownFilter: {
+                    breakdown_type: 'cohort',
+                    breakdown: [1, 2],
+                },
+                isTrends: true,
+                updateBreakdownFilter,
+                updateDisplay,
+            })
+            logic.mount()
+            await expectLogic(logic).toMatchValues({
+                isAddBreakdownDisabled: false,
+            })
         })
     })
 

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -139,7 +139,7 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
         ],
         breakdownFilter: [(_, p) => [p.breakdownFilter], (breakdownFilter) => breakdownFilter],
         includeSessions: [(_, p) => [p.isTrends], (isTrends) => isTrends],
-        addBreakdownDisabled: [
+        isAddBreakdownDisabled: [
             (s) => [s.breakdownFilter, s.isMultipleBreakdownsEnabled, s.isDataWarehouseSeries],
             ({ breakdown, breakdowns, breakdown_type }, isMultipleBreakdownsEnabled, isDataWarehouseSeries) => {
                 // Multiple breakdowns don't yet support the data warehouse, so it fallbacks to a single breakdown.

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -139,10 +139,15 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
         ],
         breakdownFilter: [(_, p) => [p.breakdownFilter], (breakdownFilter) => breakdownFilter],
         includeSessions: [(_, p) => [p.isTrends], (isTrends) => isTrends],
-        maxBreakdownsSelected: [
+        addBreakdownDisabled: [
             (s) => [s.breakdownFilter, s.isMultipleBreakdownsEnabled, s.isDataWarehouseSeries],
-            ({ breakdown, breakdowns }, isMultipleBreakdownsEnabled, isDataWarehouseSeries) => {
-                if (isMultipleBreakdownsEnabled && !isDataWarehouseSeries) {
+            ({ breakdown, breakdowns, breakdown_type }, isMultipleBreakdownsEnabled, isDataWarehouseSeries) => {
+                // Multiple breakdowns don't yet support the data warehouse, so it fallbacks to a single breakdown.
+                if (
+                    isMultipleBreakdownsEnabled &&
+                    !isDataWarehouseSeries &&
+                    (!breakdown_type || isMultipleBreakdownType(breakdown_type))
+                ) {
                     return Array.isArray(breakdowns) && breakdowns.length >= 3
                 }
 

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -148,7 +148,7 @@ export const taxonomicBreakdownFilterLogic = kea<taxonomicBreakdownFilterLogicTy
                     !isDataWarehouseSeries &&
                     (!breakdown_type || isMultipleBreakdownType(breakdown_type))
                 ) {
-                    return Array.isArray(breakdowns) && breakdowns.length >= 3
+                    return breakdowns && breakdowns.length >= 3
                 }
 
                 return !Array.isArray(breakdown) && breakdown != null
@@ -469,6 +469,6 @@ function checkBreakdownExists(
     )
 }
 
-export function multipleBreakdownsEnabled(flags: FeatureFlagsSet): boolean {
+export const multipleBreakdownsEnabled = (flags: FeatureFlagsSet): boolean => {
     return !!flags[FEATURE_FLAGS.MULTIPLE_BREAKDOWNS]
 }


### PR DESCRIPTION
## Problem

Since multiple breakdowns don't yet support data warehouse properties, we only want to display the add breakdown button when there are no breakdowns.

## Changes

**Before**

<img width="537" alt="Screenshot 2024-07-17 at 13 18 27" src="https://github.com/user-attachments/assets/a6e58f79-91ab-4c71-9e30-30299979c92f">

**After**

<img width="524" alt="Screenshot 2024-07-17 at 13 18 03" src="https://github.com/user-attachments/assets/19cf28d2-00f9-424f-966c-4671e742528c">


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing and unit tests
