### PR TITLE
draft(hog): json input as hog

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
@@ -1,7 +1,6 @@
 import { closestCenter, DndContext } from '@dnd-kit/core'
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { Monaco } from '@monaco-editor/react'
 import { IconGear, IconLock, IconPlus, IconTrash, IconX } from '@posthog/icons'
 import {
     LemonButton,
@@ -19,10 +18,8 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { CodeEditorInline, CodeEditorInlineProps } from 'lib/monaco/CodeEditorInline'
 import { CodeEditorResizeable } from 'lib/monaco/CodeEditorResizable'
 import { capitalizeFirstLetter } from 'lib/utils'
-import { languages } from 'monaco-editor'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 
-import { groupsModel } from '~/models/groupsModel'
 import { HogFunctionInputSchemaType, HogFunctionInputType } from '~/types'
 
 import { hogFunctionConfigurationLogic } from './hogFunctionConfigurationLogic'
@@ -42,117 +39,19 @@ export type HogFunctionInputWithSchemaProps = {
 
 const typeList = ['string', 'boolean', 'dictionary', 'choice', 'json', 'integration'] as const
 
-function useAutocompleteOptions(): languages.CompletionItem[] {
-    const { groupTypes } = useValues(groupsModel)
-
-    return useMemo(() => {
-        const options = [
-            ['event', 'The entire event payload as a JSON object'],
-            ['event.name', 'The name of the event e.g. $pageview'],
-            ['event.distinct_id', 'The distinct_id of the event'],
-            ['event.timestamp', 'The timestamp of the event'],
-            ['event.url', 'URL to the event in PostHog'],
-            ['event.properties', 'Properties of the event'],
-            ['event.properties.<key>', 'The individual property of the event'],
-            ['person', 'The entire person payload as a JSON object'],
-            ['project.uuid', 'The UUID of the Person in PostHog'],
-            ['person.url', 'URL to the person in PostHog'],
-            ['person.properties', 'Properties of the person'],
-            ['person.properties.<key>', 'The individual property of the person'],
-            ['project.id', 'ID of the project in PostHog'],
-            ['project.name', 'Name of the project'],
-            ['project.url', 'URL to the project in PostHog'],
-            ['source.name', 'Name of the source of this message'],
-            ['source.url', 'URL to the source of this message in PostHog'],
-        ]
-
-        groupTypes.forEach((groupType) => {
-            options.push([`groups.${groupType.group_type}`, `The entire group payload as a JSON object`])
-            options.push([`groups.${groupType.group_type}.id`, `The ID or 'key' of the group`])
-            options.push([`groups.${groupType.group_type}.url`, `URL to the group in PostHog`])
-            options.push([`groups.${groupType.group_type}.properties`, `Properties of the group`])
-            options.push([`groups.${groupType.group_type}.properties.<key>`, `The individual property of the group`])
-            options.push([`groups.${groupType.group_type}.index`, `Index of the group`])
-        })
-
-        const items: languages.CompletionItem[] = options.map(([key, value]) => {
-            return {
-                label: key,
-                kind: languages.CompletionItemKind.Variable,
-                detail: value,
-                insertText: key,
-                range: {
-                    startLineNumber: 1,
-                    endLineNumber: 1,
-                    startColumn: 0,
-                    endColumn: 0,
-                },
-            }
-        })
-
-        return items
-    }, [groupTypes])
-}
-
 function JsonConfigField(props: {
     onChange?: (value: string) => void
     className?: string
     autoFocus?: boolean
     value?: string
 }): JSX.Element {
-    const suggestions = useAutocompleteOptions()
-    const [monaco, setMonaco] = useState<Monaco>()
-
-    useEffect(() => {
-        if (!monaco) {
-            return
-        }
-        monaco.languages.setLanguageConfiguration('json', {
-            wordPattern: /[a-zA-Z0-9_\-.]+/,
-        })
-
-        const provider = monaco.languages.registerCompletionItemProvider('json', {
-            triggerCharacters: ['{', '{{'],
-            provideCompletionItems: async (model, position) => {
-                const word = model.getWordUntilPosition(position)
-
-                const wordWithTrigger = model.getValueInRange({
-                    startLineNumber: position.lineNumber,
-                    startColumn: 0,
-                    endLineNumber: position.lineNumber,
-                    endColumn: position.column,
-                })
-
-                if (wordWithTrigger.indexOf('{') === -1) {
-                    return { suggestions: [] }
-                }
-
-                const localSuggestions = suggestions.map((x) => ({
-                    ...x,
-                    insertText: x.insertText,
-                    range: {
-                        startLineNumber: position.lineNumber,
-                        endLineNumber: position.lineNumber,
-                        startColumn: word.startColumn,
-                        endColumn: word.endColumn,
-                    },
-                }))
-
-                return {
-                    suggestions: localSuggestions,
-                    incomplete: false,
-                }
-            },
-        })
-
-        return () => provider.dispose()
-    }, [suggestions, monaco])
-
+    const { exampleInvocationGlobalsWithInputs } = useValues(hogFunctionConfigurationLogic)
     return (
         <CodeEditorResizeable
-            language="json"
+            language="hog"
             value={typeof props.value !== 'string' ? JSON.stringify(props.value, null, 2) : props.value}
             onChange={(v) => props.onChange?.(v ?? '')}
+            globals={exampleInvocationGlobalsWithInputs}
             options={{
                 lineNumbers: 'off',
                 minimap: {
@@ -171,9 +70,6 @@ function JsonConfigField(props: {
                     vertical: 'hidden',
                     verticalScrollbarSize: 0,
                 },
-            }}
-            onMount={(_editor, monaco) => {
-                setMonaco(monaco)
             }}
         />
     )

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -262,14 +262,14 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                     if (input.required && !value) {
                         inputErrors[key] = 'This field is required'
                     }
-
-                    if (input.type === 'json' && typeof value === 'string') {
-                        try {
-                            JSON.parse(value)
-                        } catch (e) {
-                            inputErrors[key] = 'Invalid JSON'
-                        }
-                    }
+                    //
+                    // if (input.type === 'json' && typeof value === 'string') {
+                    //     try {
+                    //         JSON.parse(value)
+                    //     } catch (e) {
+                    //         inputErrors[key] = 'Invalid JSON'
+                    //     }
+                    // }
                 })
 
                 return Object.keys(inputErrors).length > 0


### PR DESCRIPTION
## Problem

I need to develop a new complex "HogJSON" autocomplete mode, plus new syntax highlighting grammar from monaco. I'd like to not do that.

## Changes

Here's a proposal for a simpler alternative. What if we turn our "JSON" inputs into just pure Hog inputs.

So going from this:

![Screenshot 2024-07-17 at 13 38 33](https://github.com/user-attachments/assets/1c3012b0-3d41-4023-a58c-69b270a5738e)

to this:

![Screenshot 2024-07-17 at 13 42 15](https://github.com/user-attachments/assets/89727776-454a-405d-b37d-84fbc3165686)

The only reason not to is that you can't paste in "regular JSON" (unless we implement some monaco middleware 🤔), as JSON strings are treated as fields/globals. Luckily you will get informed easily:

![image](https://github.com/user-attachments/assets/19c7aee7-2e3a-4b54-becb-76fb790e4319)

The benefits are: less characters (`"{}"`), instant autocomplete, no need to worry about special syntax for objects to escape strings.

![Screenshot 2024-07-17 at 13 42 21](https://github.com/user-attachments/assets/2a651817-ad24-422a-bc7c-d7b0a22facff)



## How did you test this code?

It's not working yet. I only did some frontend changes. Putting this out for feedback.