### PR TITLE
feat(web-analytics): Make sessions v2 use uniq ids rather than raw counts for event count totals

### DIFF
--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -940,6 +940,7 @@ HOGQL_AGGREGATIONS: dict[str, HogQLFunctionMeta] = {
     "uniqHLL12If": HogQLFunctionMeta("uniqHLL12If", 2, None, aggregate=True),
     "uniqTheta": HogQLFunctionMeta("uniqTheta", 1, None, aggregate=True),
     "uniqThetaIf": HogQLFunctionMeta("uniqThetaIf", 2, None, aggregate=True),
+    "uniqMerge": HogQLFunctionMeta("uniqMerge", 1, None, aggregate=True),
     "median": HogQLFunctionMeta("median", 1, 1, aggregate=True),
     "medianIf": HogQLFunctionMeta("medianIf", 2, 2, aggregate=True),
     "medianExact": HogQLFunctionMeta("medianExact", 1, 1, aggregate=True),


### PR DESCRIPTION
## Problem

The double-counting of events on EU didn't go away with sessions v2, but I did build in a workaround, which is that we also store the count of uniq event uuids for pageview, autocapture, and screen events.

## Changes

This PR uses those instead, and adds a couple of tests

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added some tests
