### PR TITLE
feat(web-analytics): Default EU to using sessions v2

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -82,6 +82,7 @@ from posthog.schema import (
     PersonsOnEventsMode,
     SessionTableVersion,
 )
+from posthog.utils import get_instance_region
 from posthog.warehouse.models.external_data_job import ExternalDataJob
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 from posthog.warehouse.models.external_data_source import ExternalDataSource
@@ -248,7 +249,9 @@ def create_hogql_database(
             join_function=join_with_persons_table,
         )
 
-    if modifiers.sessionTableVersion in [SessionTableVersion.V2]:
+    if modifiers.sessionTableVersion == SessionTableVersion.V2 or (
+        get_instance_region() == "EU" and modifiers.sessionTableVersion == SessionTableVersion.AUTO
+    ):
         raw_sessions = RawSessionsTableV2()
         database.raw_sessions = raw_sessions
         sessions = SessionsTableV2()


### PR DESCRIPTION
MERGE https://github.com/PostHog/posthog/pull/23780 first

## Problem

It's time to get EU onto v2 sessions, as the table has been backfilled and tested by us

## Changes

Set the default sessions table to v2

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Sessions table v2 has a ton of tests, and we've been dogfooding it for over a week
