### PR TITLE
fix(experiments): display MDE value

### DIFF
--- a/cypress/e2e/experiments.cy.ts
+++ b/cypress/e2e/experiments.cy.ts
@@ -61,7 +61,7 @@ describe('Experiments', () => {
         cy.contains(secondaryMetricName).should('exist')
 
         // Edit minimum acceptable improvement
-        cy.get('input[data-attr="min-acceptable-improvement"]').type('{selectall}20').should('have.value', '20')
+        cy.get('input[data-attr="min-detectable-effect"]').type('{selectall}20').should('have.value', '20')
 
         // Save experiment
         cy.get('[data-attr="save-experiment"]').first().click()

--- a/cypress/e2e/experiments.cy.ts
+++ b/cypress/e2e/experiments.cy.ts
@@ -60,7 +60,7 @@ describe('Experiments', () => {
         cy.get('[data-attr="create-annotation-submit"]').click()
         cy.contains(secondaryMetricName).should('exist')
 
-        // Edit minimum acceptable improvement
+        // Edit minimum detectable effect
         cy.get('input[data-attr="min-detectable-effect"]').type('{selectall}20').should('have.value', '20')
 
         // Save experiment

--- a/frontend/src/lib/lemon-ui/Tooltip/Tooltip.tsx
+++ b/frontend/src/lib/lemon-ui/Tooltip/Tooltip.tsx
@@ -26,6 +26,7 @@ export interface TooltipProps {
     title: string | React.ReactNode | (() => string)
     children: JSX.Element
     delayMs?: number
+    closeDelayMs?: number
     offset?: number
     arrowOffset?: number
     placement?: Placement
@@ -41,6 +42,7 @@ export function Tooltip({
     offset = 8,
     arrowOffset,
     delayMs = 500,
+    closeDelayMs = 0,
     visible: controlledOpen,
 }: TooltipProps): JSX.Element {
     const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
@@ -66,7 +68,7 @@ export function Tooltip({
         move: false,
         delay: {
             open: delayMs,
-            close: 0,
+            close: closeDelayMs,
         },
     })
     const focus = useFocus(context)

--- a/frontend/src/lib/lemon-ui/Tooltip/Tooltip.tsx
+++ b/frontend/src/lib/lemon-ui/Tooltip/Tooltip.tsx
@@ -42,7 +42,7 @@ export function Tooltip({
     offset = 8,
     arrowOffset,
     delayMs = 500,
-    closeDelayMs = 0,
+    closeDelayMs = 0, // Set this to some delay to ensure the content stays open when hovered
     visible: controlledOpen,
 }: TooltipProps): JSX.Element {
     const [uncontrolledOpen, setUncontrolledOpen] = useState(false)

--- a/frontend/src/scenes/experiments/ExperimentPreview.tsx
+++ b/frontend/src/scenes/experiments/ExperimentPreview.tsx
@@ -107,8 +107,8 @@ export function ExperimentPreview({
                 {(experimentId === 'new' || editingExistingExperiment) && (
                     <div className="mb-4 experiment-preview-row">
                         <div className="flex items-center">
-                            <b>Minimum acceptable improvement</b>
-                            <Tooltip title="Minimum acceptable improvement is a calculation that estimates the smallest significant improvement you are willing to accept.">
+                            <b>Minimum detectable effect</b>
+                            <Tooltip title="Minimum detectable effect is a calculation that estimates the smallest significant improvement you are willing to accept.">
                                 <IconInfo className="ml-1 text-muted text-xl" />
                             </Tooltip>
                         </div>
@@ -129,7 +129,7 @@ export function ExperimentPreview({
                                 className="w-1/3"
                             />
                             <LemonInput
-                                data-attr="min-acceptable-improvement"
+                                data-attr="min-detectable-effect"
                                 type="number"
                                 min={1}
                                 max={sliderMaxValue}

--- a/frontend/src/scenes/experiments/ExperimentView/DataCollection.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DataCollection.tsx
@@ -45,7 +45,7 @@ export function DataCollection(): JSX.Element {
             <Tooltip
                 title={
                     <div>
-                        <div>{`Based on the Minimum Acceptable Improvement of ${experiment.parameters.minimum_detectable_effect}%.`}</div>
+                        <div>{`Based on the Minimum detectable effect of ${experiment.parameters.minimum_detectable_effect}%.`}</div>
                         {hasHighRunningTime && (
                             <div className="mt-2">
                                 Given the current data, this experiment might take a while to reach statistical

--- a/frontend/src/scenes/experiments/ExperimentView/DataCollection.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DataCollection.tsx
@@ -128,10 +128,14 @@ export function DataCollection(): JSX.Element {
                         <span>Minimum detectable effect</span>
                         <Tooltip
                             title={
-                                <div>
+                                <div className="space-y-2">
                                     <div>
-                                        The Minimum detectable effect represents the smallest change or difference that
-                                        you want to be able to detect in your experiment.
+                                        The Minimum detectable effect represents the smallest change that you want to be
+                                        able to detect in your experiment.
+                                    </div>
+                                    <div>
+                                        To make things easier, we initially set this value to a reasonable default.
+                                        However, we encourage you to review and adjust it based on your specific goals.
                                     </div>
                                     <div>
                                         Read more in the{' '}

--- a/frontend/src/scenes/experiments/ExperimentView/DataCollection.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DataCollection.tsx
@@ -1,7 +1,7 @@
 import '../Experiment.scss'
 
 import { IconInfo } from '@posthog/icons'
-import { LemonButton, LemonModal, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonModal, Link, Tooltip } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { AnimationType } from 'lib/animations/animations'
 import { Animation } from 'lib/components/Animation/Animation'
@@ -16,8 +16,14 @@ import { EllipsisAnimation } from './components'
 import { DataCollectionCalculator } from './DataCollectionCalculator'
 
 export function DataCollection(): JSX.Element {
-    const { experimentId, experiment, experimentInsightType, funnelResultsPersonsTotal, actualRunningTime } =
-        useValues(experimentLogic)
+    const {
+        experimentId,
+        experiment,
+        experimentInsightType,
+        funnelResultsPersonsTotal,
+        actualRunningTime,
+        minimumDetectableEffect,
+    } = useValues(experimentLogic)
 
     const { openExperimentCollectionGoalModal } = useActions(experimentLogic)
 
@@ -66,78 +72,95 @@ export function DataCollection(): JSX.Element {
                     <IconInfo className="text-muted-alt text-base" />
                 </Tooltip>
             </div>
-            <div className="mt-2 mb-1 font-semibold">{`${
-                experimentProgressPercent > 100 ? 100 : experimentProgressPercent.toFixed(2)
-            }% complete`}</div>
-            <LemonProgress
-                className="w-full border"
-                bgColor="var(--bg-table)"
-                size="large"
-                percent={experimentProgressPercent}
-            />
-            {experimentInsightType === InsightType.TRENDS && (
-                <div className="flex justify-between mt-0">
-                    {experiment.end_date ? (
-                        <div>
-                            Ran for <b>{actualRunningTime}</b> {formatUnitByQuantity(actualRunningTime, 'day')}
-                        </div>
-                    ) : (
-                        <div>
-                            <b>{actualRunningTime}</b> {formatUnitByQuantity(actualRunningTime, 'day')} running
-                        </div>
-                    )}
-                    <div className="inline-flex space-x-1 items-center">
-                        {hasHighRunningTime ? (
-                            <>
-                                Goal:&nbsp;
-                                <b> &gt; 2</b>&nbsp;months
-                            </>
-                        ) : (
-                            <>
-                                Goal:&nbsp;
-                                <b>{recommendedRunningTime}</b>&nbsp;
-                                {formatUnitByQuantity(recommendedRunningTime, 'day')}
-                            </>
-                        )}
-                        <GoalTooltip />
-                    </div>
-                </div>
-            )}
-            {experimentInsightType === InsightType.FUNNELS && (
-                <div className="flex justify-between mt-0">
-                    {experiment.end_date ? (
-                        <div>
-                            Saw <b>{humanFriendlyNumber(funnelResultsPersonsTotal)}</b>{' '}
-                            {formatUnitByQuantity(funnelResultsPersonsTotal, 'participant')}
-                        </div>
-                    ) : (
-                        <div>
-                            <b>{humanFriendlyNumber(funnelResultsPersonsTotal)}</b>{' '}
-                            {formatUnitByQuantity(funnelResultsPersonsTotal, 'participant')} seen
+            <div className="flex">
+                <div className="w-3/5 pr-4">
+                    <div className="mt-2 mb-1 font-semibold">{`${
+                        experimentProgressPercent > 100 ? 100 : experimentProgressPercent.toFixed(2)
+                    }% complete`}</div>
+                    <LemonProgress
+                        className="w-full border"
+                        bgColor="var(--bg-table)"
+                        size="large"
+                        percent={experimentProgressPercent}
+                    />
+                    {experimentInsightType === InsightType.TRENDS && (
+                        <div className="flex justify-between mt-0">
+                            <span className="flex items-center text-xs">
+                                Completed&nbsp;
+                                <b>{actualRunningTime} of</b>
+                                {hasHighRunningTime ? (
+                                    <b>&nbsp; &gt; 60 days</b>
+                                ) : (
+                                    <span>
+                                        &nbsp;
+                                        <b>{recommendedRunningTime}</b>{' '}
+                                        {formatUnitByQuantity(recommendedRunningTime, 'day')}
+                                    </span>
+                                )}
+                                <span className="ml-1 text-xs">
+                                    <GoalTooltip />
+                                </span>
+                            </span>
                         </div>
                     )}
-                    <div className="space-x-1 flex items-center">
-                        <span>
-                            Goal: <b>{humanFriendlyNumber(recommendedSampleSize)}</b>{' '}
-                            {formatUnitByQuantity(recommendedSampleSize, 'participant')}
-                        </span>
-                        <GoalTooltip />
+                    {experimentInsightType === InsightType.FUNNELS && (
+                        <div className="flex justify-between mt-0">
+                            <div className="space-x-1 flex items-center text-xs">
+                                <span>
+                                    Saw&nbsp;
+                                    <b>
+                                        {humanFriendlyNumber(funnelResultsPersonsTotal)} of{' '}
+                                        {humanFriendlyNumber(recommendedSampleSize)}{' '}
+                                    </b>{' '}
+                                    {formatUnitByQuantity(recommendedSampleSize, 'participant')}
+                                </span>
+                                <GoalTooltip />
+                            </div>
+                        </div>
+                    )}
+                </div>
+                <LemonDivider className="my-0" vertical />
+                <div className="w-2/5 pl-4">
+                    <div className={`text-lg font-semibold ${experiment.end_date ? 'mt-4' : ''}`}>
+                        {minimumDetectableEffect}%
                     </div>
+                    <div className="text-xs space-x-1 text-sm flex">
+                        <span>Minimum detectable effect</span>
+                        <Tooltip
+                            title={
+                                <div>
+                                    <div>
+                                        The Minimum detectable effect represents the smallest change or difference that
+                                        you want to be able to detect in your experiment.
+                                    </div>
+                                    <div>
+                                        Read more in the{' '}
+                                        <Link to="https://posthog.com/docs/experiments/sample-size-running-time#minimum-detectable-effect-mde">
+                                            documentation.
+                                        </Link>
+                                    </div>
+                                </div>
+                            }
+                            closeDelayMs={200}
+                        >
+                            <IconInfo className="text-muted-alt text-base" />
+                        </Tooltip>
+                    </div>
+                    {!experiment.end_date && (
+                        <div className="w-24">
+                            <LemonButton
+                                className="mt-2"
+                                size="xsmall"
+                                type="secondary"
+                                onClick={openExperimentCollectionGoalModal}
+                            >
+                                <span className="px-0">Edit</span>
+                            </LemonButton>
+                        </div>
+                    )}
+                    <DataCollectionGoalModal experimentId={experimentId} />
                 </div>
-            )}
-            {!experiment.end_date && (
-                <div className="w-24">
-                    <LemonButton
-                        className="mt-3"
-                        size="small"
-                        type="secondary"
-                        onClick={openExperimentCollectionGoalModal}
-                    >
-                        Recalculate
-                    </LemonButton>
-                </div>
-            )}
-            <DataCollectionGoalModal experimentId={experimentId} />
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/experiments/ExperimentView/DataCollectionCalculator.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DataCollectionCalculator.tsx
@@ -1,5 +1,5 @@
 import { IconInfo } from '@posthog/icons'
-import { LemonBanner, LemonInput, Tooltip } from '@posthog/lemon-ui'
+import { LemonBanner, LemonInput, Link, Tooltip } from '@posthog/lemon-ui'
 import { BindLogic, useActions, useValues } from 'kea'
 import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
 import { humanFriendlyNumber } from 'lib/utils'
@@ -136,9 +136,25 @@ export function DataCollectionCalculator({ experimentId }: ExperimentCalculatorP
             <div className="w-full">
                 <div className="mb-4 experiment-preview-row">
                     <div className="flex items-center">
-                        <b>Minimum acceptable improvement</b>
-                        <Tooltip title="Minimum acceptable improvement is a calculation that estimates the smallest significant improvement you are willing to accept.">
-                            <IconInfo className="ml-1 text-muted text-xl" />
+                        <b>Minimum detectable effect</b>
+                        <Tooltip
+                            title={
+                                <div>
+                                    <div>
+                                        The Minimum detectable effect represents the smallest change or difference that
+                                        you want to be able to detect in your experiment.
+                                    </div>
+                                    <div>
+                                        Read more in the{' '}
+                                        <Link to="https://posthog.com/docs/experiments/sample-size-running-time#minimum-detectable-effect-mde">
+                                            documentation.
+                                        </Link>
+                                    </div>
+                                </div>
+                            }
+                            closeDelayMs={200}
+                        >
+                            <IconInfo className="text-muted-alt text-base ml-1" />
                         </Tooltip>
                     </div>
                     <div className="flex gap-4">
@@ -159,7 +175,7 @@ export function DataCollectionCalculator({ experimentId }: ExperimentCalculatorP
                         />
                         <LemonInput
                             className="w-1/6"
-                            data-attr="min-acceptable-improvement"
+                            data-attr="min-detectable-effect"
                             type="number"
                             min={1}
                             max={sliderMaxValue}

--- a/frontend/src/scenes/experiments/ExperimentView/DataCollectionCalculator.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DataCollectionCalculator.tsx
@@ -139,10 +139,14 @@ export function DataCollectionCalculator({ experimentId }: ExperimentCalculatorP
                         <b>Minimum detectable effect</b>
                         <Tooltip
                             title={
-                                <div>
+                                <div className="space-y-2">
                                     <div>
-                                        The Minimum detectable effect represents the smallest change or difference that
-                                        you want to be able to detect in your experiment.
+                                        The Minimum detectable effect represents the smallest change that you want to be
+                                        able to detect in your experiment.
+                                    </div>
+                                    <div>
+                                        To make things easier, we initially set this value to a reasonable default.
+                                        However, we encourage you to review and adjust it based on your specific goals.
                                     </div>
                                     <div>
                                         Read more in the{' '}

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -860,7 +860,6 @@ export const experimentLogic = kea<experimentLogicType>([
                     return (userMathValue ?? propertyMathValue) as PropertyMathType | CountPerActorMathType | undefined
                 },
         ],
-        // TODO: unify naming (Minimum detectable change/Minimum detectable effect/Minimum acceptable improvement)
         minimumDetectableEffect: [
             (s) => [s.experiment, s.experimentInsightType, s.conversionMetrics, s.trendResults],
             (newExperiment, experimentInsightType, conversionMetrics, trendResults): number => {


### PR DESCRIPTION
## Changes
- Display the Minimum detectable effect next to the sample size/running time progress bar. This value often needs to be adjusted by users, but it wasn't obvious for some of them where they could find it. The Edit button makes it clear and displays the modal where they can recalculate the sample size/running time.
- Use consistent naming "Minimum detectable effect" which is the industry standard
- Add tooltips with a link to the docs, hopefully making this concept easier to understand
- Make the Data Collection progress bar nicer

|Before|After|
|----|----|
|<img width="630" alt="image" src="https://github.com/user-attachments/assets/ee256f28-52d4-4525-ae92-f4862336038b">|<img width="582" alt="image" src="https://github.com/user-attachments/assets/3ed44b91-48eb-4472-ae9b-e129d0285735">|	

<img width="556" alt="image" src="https://github.com/user-attachments/assets/68d1fe23-3e4e-41f9-a43d-2d055eff906a">

## How did you test this code?
👀 
