### PR TITLE
feat(web-analytics): Allow changing session attribution explorer settings without closing the menu

### DIFF
--- a/frontend/src/scenes/web-analytics/SessionAttributionExplorer/SessionAttributionExplorerScene.tsx
+++ b/frontend/src/scenes/web-analytics/SessionAttributionExplorer/SessionAttributionExplorerScene.tsx
@@ -173,6 +173,7 @@ export const GroupByFilter = (): JSX.Element => {
                         ),
                     }
                 })}
+                closeOnClickInside={false}
             >
                 <LemonButton icon={<IconPlus />} size="small" type="secondary">
                     Group by


### PR DESCRIPTION
## Problem

This menu closes when you press one of the filters
<img width="239" alt="Screenshot 2024-07-17 at 16 09 34" src="https://github.com/user-attachments/assets/bad89306-ec70-4c86-8996-ef39ee9eef6e">


## Changes

![ezgif-1-376dbce001](https://github.com/user-attachments/assets/567f79eb-5622-4a0d-874e-61d4d225f76e)


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually tested, doing what I did in the video
