### PR TITLE
fix(web-analytics): Fix select * from sessions with v2 sessions

### DIFF
--- a/posthog/hogql/database/schema/sessions_v2.py
+++ b/posthog/hogql/database/schema/sessions_v2.py
@@ -104,6 +104,7 @@ class RawSessionsTableV2(Table):
 
     def avoid_asterisk_fields(self) -> list[str]:
         return [
+            "session_id_v7",  # HogQL insights currently don't support returning uint128s due to json serialisation
             # our clickhouse driver can't return aggregate states
             "distinct_id",
             "entry_url",

--- a/posthog/hogql/database/schema/sessions_v2.py
+++ b/posthog/hogql/database/schema/sessions_v2.py
@@ -106,9 +106,14 @@ class RawSessionsTableV2(Table):
 
     def avoid_asterisk_fields(self) -> list[str]:
         return [
-            # these are discouraged from being used in queries, use session_id_v7 instead
+            # ideally we'd prefer people to use session_id_v7, but we don't support uint128s in some parts of our stack,
+            # e.g. see https://posthog.sentry.io/issues/5613026650/
+            # we don't want to completely remove it, as it's useful elsewhere, but we don't want to prevent people from
+            # doing select * from sessions
+            "session_id_v7"
+            # id is just an alias for session_id
             "id",
-            "session_id",
+            # we can't return uuid_v7s to the front end, as it tries to cast a uint128
             # our clickhouse driver can't return aggregate states
             "entry_url",
             "end_url",

--- a/posthog/hogql/database/schema/test/test_sessions_v2.py
+++ b/posthog/hogql/database/schema/test/test_sessions_v2.py
@@ -25,7 +25,29 @@ class TestSessionsV2(ClickhouseTestMixin, APIBaseTest):
             modifiers=modifiers,
         )
 
-    def test_select_star(self):
+    def test_select_star_from_raw_sessions(self):
+        session_id = str(uuid7())
+
+        _create_event(
+            event="$pageview",
+            team=self.team,
+            distinct_id="d1",
+            properties={"$current_url": "https://example.com", "$session_id": session_id},
+        )
+
+        response = self.__execute(
+            parse_select(
+                "select * from raw_sessions",
+                placeholders={"session_id": ast.Constant(value=session_id)},
+            ),
+        )
+
+        self.assertEqual(
+            len(response.results or []),
+            1,
+        )
+
+    def test_select_star_from_sessions(self):
         session_id = str(uuid7())
 
         _create_event(


### PR DESCRIPTION
## Problem

See this sentry https://posthog.sentry.io/issues/5613026650/ 

## Changes
For now, hide session_id_v7 from asterisk. This doesn't fully solve the problem, but it does let you do `select * from sessions`

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

This code is pretty well tested already, there's already a test that `select * from sessions` succeeds. I added a test for `select * from raw_sessions`
Plus these work in the front end:
<img width="1739" alt="Screenshot 2024-07-17 at 19 21 48" src="https://github.com/user-attachments/assets/581d86f4-a483-405c-b5d7-a8c987a5f49a">
<img width="1778" alt="Screenshot 2024-07-17 at 19 30 57" src="https://github.com/user-attachments/assets/7d9d86f4-d057-4c54-9c8d-66a3cd58e121">
