### PR TITLE
chore: log/sentry on hoghook HTTP 4XX while we do testing

### DIFF
--- a/plugin-server/src/cdp/async-function-executor.ts
+++ b/plugin-server/src/cdp/async-function-executor.ts
@@ -81,8 +81,10 @@ export class AsyncFunctionExecutor {
 
             // If the caller hasn't forced it to be synchronous and the team has the rustyhook enabled, enqueue it
             if (!options?.sync && this.hogHookEnabledForTeams(request.teamId)) {
-                await this.rustyHook.enqueueForHog(request)
-                return
+                const enqueued = await this.rustyHook.enqueueForHog(request)
+                if (enqueued) {
+                    return
+                }
             }
 
             status.info('🦔', `[HogExecutor] Webhook not sent via rustyhook, sending directly instead`)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
I'd like to test out hoghooks in production, but don't want to choke up ingestion while I do some trial and error.

## Changes

Add temporary bail out on HTTP 4XX, which will fall back to `fetch`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Existing
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
