### PR TITLE
fix(insights): Actors Query didn't output results for the "Other" breakdown value

### DIFF
--- a/posthog/hogql_queries/insights/trends/breakdown.py
+++ b/posthog/hogql_queries/insights/trends/breakdown.py
@@ -274,6 +274,9 @@ class Breakdown:
         histogram_bin_count: int | None = None,
         group_type_index: int | None = None,
     ):
+        if lookup_value == BREAKDOWN_OTHER_STRING_LABEL:
+            return None
+
         is_numeric_breakdown = isinstance(histogram_bin_count, int)
 
         if breakdown_type == "hogql":


### PR DESCRIPTION
## Problem

When multiple breakdowns are selected, the Actors Query didn't output any results for the "Other" breakdown value.

## Changes

When the "Other" value is selected, breakdown filters don't apply, so the query outputs all persons (see #23788). I've mirrored the same approach for multiple breakdowns.

**Before**

<img width="577" alt="Screenshot 2024-07-17 at 18 30 14" src="https://github.com/user-attachments/assets/f95b5083-dfc4-4de0-9e81-bf35154e0a85">

**After**

<img width="595" alt="Screenshot 2024-07-17 at 18 28 58" src="https://github.com/user-attachments/assets/96b894ed-ce23-4c78-af25-1cd43cd3750a">

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

I've also added a test but it should be removed in the future.
