### PR TITLE
feat(web-analytics): Improve attribution based on customer feedback

### DIFF
--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -90,7 +90,7 @@ multiIf(
     ),
     coalesce(
         hogql_lookupPaidSourceType({source}),
-        hogql_lookupPaidDomainType({referring_domain}),
+        hogql_lookupPaidSourceType({referring_domain}),
         if(
             match({campaign}, '^(.*(([^a-df-z]|^)shop|shopping).*)$'),
             'Paid Shopping',
@@ -117,7 +117,7 @@ multiIf(
 
     coalesce(
         hogql_lookupOrganicSourceType({source}),
-        hogql_lookupOrganicDomainType({referring_domain}),
+        hogql_lookupOrganicSourceType({referring_domain}),
         if(
             match({campaign}, '^(.*(([^a-df-z]|^)shop|shopping).*)$'),
             'Organic Shopping',

--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -90,13 +90,13 @@ multiIf(
     ),
     coalesce(
         hogql_lookupPaidSourceType({source}),
-        hogql_lookupPaidSourceType({referring_domain}),
         if(
             match({campaign}, '^(.*(([^a-df-z]|^)shop|shopping).*)$'),
             'Paid Shopping',
             NULL
         ),
         hogql_lookupPaidMediumType({medium}),
+        hogql_lookupPaidSourceType({referring_domain}),
         multiIf (
             {gad_source} = '1',
             'Paid Search',
@@ -117,13 +117,13 @@ multiIf(
 
     coalesce(
         hogql_lookupOrganicSourceType({source}),
-        hogql_lookupOrganicSourceType({referring_domain}),
         if(
             match({campaign}, '^(.*(([^a-df-z]|^)shop|shopping).*)$'),
             'Organic Shopping',
             NULL
         ),
         hogql_lookupOrganicMediumType({medium}),
+        hogql_lookupOrganicSourceType({referring_domain}),
         multiIf(
             match({campaign}, '^(.*video.*)$'),
             'Organic Video',

--- a/posthog/hogql/database/schema/test/test_channel_type.py
+++ b/posthog/hogql/database/schema/test/test_channel_type.py
@@ -63,6 +63,7 @@ class TestReferringDomainType(ClickhouseTestMixin, APIBaseTest):
             "Shopping",
             self._get_initial_referring_domain_type("stripe.com"),
         )
+        self.assertEqual("Shopping", self._get_initial_referring_domain_type("shopping.yahoo.co.jp"))
 
     def test_social(self):
         self.assertEqual(
@@ -72,6 +73,14 @@ class TestReferringDomainType(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(
             "Social",
             self._get_initial_referring_domain_type("old.reddit.com"),
+        )
+        self.assertEqual(
+            "Social",
+            self._get_initial_referring_domain_type("plus.google.com"),
+        )
+        self.assertEqual(
+            "Social",
+            self._get_initial_referring_domain_type("news.ycombinator.com"),
         )
 
 
@@ -567,6 +576,58 @@ class TestChannelType(ClickhouseTestMixin, APIBaseTest):
                     "referring_domain": "l.facebook.com",
                     "gclid": "",
                     "gad_source": "",
+                }
+            ),
+        )
+
+    def test_hacker_news(self):
+        # news.ycombinator.com is interesting because we don't have an entry for ycombinator.com, only the subdomain
+
+        self.assertEqual(
+            "Organic Social",
+            self._get_session_channel_type(
+                {
+                    "utm_source": "",
+                    "utm_medium": "in-product",
+                    "utm_campaign": "empty-state-docs-link",
+                    "$referring_domain": "news.ycombinator.com",
+                    "gclid": "",
+                    "gad_source": "",
+                }
+            ),
+        )
+
+        self.assertEqual(
+            "Organic Social",
+            self._get_session_channel_type(
+                {
+                    "utm_source": "news.ycombinator.com",
+                    "utm_medium": "in-product",
+                    "utm_campaign": "empty-state-docs-link",
+                    "$referring_domain": "$direct",
+                    "gclid": "",
+                    "gad_source": "",
+                }
+            ),
+        )
+
+    def test_google_plus(self):
+        # plus.google.com is interesting because it should be social, but just google.com is search
+        self.assertEqual(
+            "Organic Social",
+            self._get_session_channel_type(
+                {
+                    "utm_source": "plus.google.com",
+                    "$referring_domain": "$direct",
+                }
+            ),
+        )
+
+        self.assertEqual(
+            "Organic Social",
+            self._get_session_channel_type(
+                {
+                    "$referring_domain": "plus.google.com",
                 }
             ),
         )

--- a/posthog/hogql/database/schema/test/test_channel_type.py
+++ b/posthog/hogql/database/schema/test/test_channel_type.py
@@ -580,6 +580,29 @@ class TestChannelType(ClickhouseTestMixin, APIBaseTest):
             ),
         )
 
+        # the customer also provided us with a list of urls that weren't attributing correctly, and we changed the
+        # algorithm to give utm_medium priority over referring domain. This tests a few specific examples:
+        self.assertEqual(
+            "Email",
+            self._get_session_channel_type(
+                {
+                    "utm_source": "substack",
+                    "utm_medium": "email",
+                    "$referring_domain": "bing.com",
+                }
+            ),
+        )
+        self.assertEqual(
+            "Affiliate",
+            self._get_session_channel_type(
+                {
+                    "utm_source": "Foo",
+                    "utm_medium": "affiliate",
+                    "$referring_domain": "bing.com",
+                }
+            ),
+        )
+
     def test_hacker_news(self):
         # news.ycombinator.com is interesting because we don't have an entry for ycombinator.com, only the subdomain
 

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -1014,10 +1014,8 @@ HOGQL_POSTHOG_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "matchesAction": HogQLFunctionMeta("matchesAction", 1, 1),
     "sparkline": HogQLFunctionMeta("sparkline", 1, 1),
     "hogql_lookupDomainType": HogQLFunctionMeta("hogql_lookupDomainType", 1, 1),
-    "hogql_lookupPaidDomainType": HogQLFunctionMeta("hogql_lookupPaidDomainType", 1, 1),
     "hogql_lookupPaidSourceType": HogQLFunctionMeta("hogql_lookupPaidSourceType", 1, 1),
     "hogql_lookupPaidMediumType": HogQLFunctionMeta("hogql_lookupPaidMediumType", 1, 1),
-    "hogql_lookupOrganicDomainType": HogQLFunctionMeta("hogql_lookupOrganicDomainType", 1, 1),
     "hogql_lookupOrganicSourceType": HogQLFunctionMeta("hogql_lookupOrganicSourceType", 1, 1),
     "hogql_lookupOrganicMediumType": HogQLFunctionMeta("hogql_lookupOrganicMediumType", 1, 1),
 }

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -905,21 +905,15 @@ class _Printer(Visitor):
 
             if self.dialect in ("hogql", "clickhouse"):
                 if node.name == "hogql_lookupDomainType":
-                    return f"dictGetOrNull('channel_definition_dict', 'domain_type', (cutToFirstSignificantSubdomain(coalesce({args[0]}, '')), 'source'))"
-                elif node.name == "hogql_lookupPaidDomainType":
-                    return f"dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce({args[0]}, '')), 'source'))"
+                    return f"coalesce(dictGetOrNull('channel_definition_dict', 'domain_type', (coalesce({args[0]}, ''), 'source')), dictGetOrNull('channel_definition_dict', 'domain_type', (cutToFirstSignificantSubdomain(coalesce({args[0]}, '')), 'source')))"
                 elif node.name == "hogql_lookupPaidSourceType":
-                    return (
-                        f"dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce({args[0]}, ''), 'source'))"
-                    )
+                    return f"coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce({args[0]}, ''), 'source')) , dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce({args[0]}, '')), 'source')))"
                 elif node.name == "hogql_lookupPaidMediumType":
                     return (
                         f"dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce({args[0]}, ''), 'medium'))"
                     )
-                elif node.name == "hogql_lookupOrganicDomainType":
-                    return f"dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce({args[0]}, '')), 'source'))"
                 elif node.name == "hogql_lookupOrganicSourceType":
-                    return f"dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce({args[0]}, ''), 'source'))"
+                    return f"coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce({args[0]}, ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce({args[0]}, '')), 'source')))"
                 elif node.name == "hogql_lookupOrganicMediumType":
                     return f"dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce({args[0]}, ''), 'medium'))"
             raise QueryError(f"Unexpected unresolved HogQL function '{node.name}(...)'")

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -1443,28 +1443,15 @@ class TestPrinter(BaseTest):
         )
         self.assertEqual(
             (
-                "SELECT dictGetOrNull('channel_definition_dict', 'domain_type', "
-                "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source')) "
-                f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS} SETTINGS "
-                "readonly=2, max_execution_time=10, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=2000000, max_expanded_ast_elements=2000000, max_query_size=1048576, max_bytes_before_external_group_by=0"
-            ),
-            printed,
-        )
-
-    def test_lookup_paid_domain_type(self):
-        query = parse_select("select hogql_lookupPaidDomainType('www.google.com') from events")
-        printed = print_ast(
-            query,
-            HogQLContext(team_id=self.team.pk, enable_select_queries=True),
-            dialect="clickhouse",
-            settings=HogQLGlobalSettings(max_execution_time=10),
-        )
-        self.assertEqual(
-            (
-                "SELECT dictGetOrNull('channel_definition_dict', 'type_if_paid', "
-                "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source')) "
-                f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS} SETTINGS "
-                "readonly=2, max_execution_time=10, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=2000000, max_expanded_ast_elements=2000000, max_query_size=1048576, max_bytes_before_external_group_by=0"
+                "SELECT coalesce(dictGetOrNull('channel_definition_dict', 'domain_type', "
+                "(coalesce(%(hogql_val_0)s, ''), 'source')), "
+                "dictGetOrNull('channel_definition_dict', 'domain_type', "
+                "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source'))) "
+                f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 50000 SETTINGS "
+                "readonly=2, max_execution_time=10, allow_experimental_object_type=1, "
+                "format_csv_allow_double_quotes=0, max_ast_elements=2000000, "
+                "max_expanded_ast_elements=2000000, max_query_size=1048576, "
+                "max_bytes_before_external_group_by=0"
             ),
             printed,
         )
@@ -1479,10 +1466,15 @@ class TestPrinter(BaseTest):
         )
         self.assertEqual(
             (
-                "SELECT dictGetOrNull('channel_definition_dict', 'type_if_paid', "
-                "(coalesce(%(hogql_val_0)s, ''), 'source')) "
-                f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS} SETTINGS "
-                "readonly=2, max_execution_time=10, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=2000000, max_expanded_ast_elements=2000000, max_query_size=1048576, max_bytes_before_external_group_by=0"
+                "SELECT coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', "
+                "(coalesce(%(hogql_val_0)s, ''), 'source')) , "
+                "dictGetOrNull('channel_definition_dict', 'type_if_paid', "
+                "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source'))) "
+                f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 50000 SETTINGS "
+                "readonly=2, max_execution_time=10, allow_experimental_object_type=1, "
+                "format_csv_allow_double_quotes=0, max_ast_elements=2000000, "
+                "max_expanded_ast_elements=2000000, max_query_size=1048576, "
+                "max_bytes_before_external_group_by=0"
             ),
             printed,
         )
@@ -1505,24 +1497,6 @@ class TestPrinter(BaseTest):
             printed,
         )
 
-    def test_lookup_organic_domain_type(self):
-        query = parse_select("select hogql_lookupOrganicDomainType('www.google.com') from events")
-        printed = print_ast(
-            query,
-            HogQLContext(team_id=self.team.pk, enable_select_queries=True),
-            dialect="clickhouse",
-            settings=HogQLGlobalSettings(max_execution_time=10),
-        )
-        self.assertEqual(
-            (
-                "SELECT dictGetOrNull('channel_definition_dict', 'type_if_organic', "
-                "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source')) "
-                f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS} SETTINGS "
-                "readonly=2, max_execution_time=10, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=2000000, max_expanded_ast_elements=2000000, max_query_size=1048576, max_bytes_before_external_group_by=0"
-            ),
-            printed,
-        )
-
     def test_lookup_organic_source_type(self):
         query = parse_select("select hogql_lookupOrganicSourceType('google') from events")
         printed = print_ast(
@@ -1533,10 +1507,15 @@ class TestPrinter(BaseTest):
         )
         self.assertEqual(
             (
-                "SELECT dictGetOrNull('channel_definition_dict', 'type_if_organic', "
-                "(coalesce(%(hogql_val_0)s, ''), 'source')) "
-                f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS} SETTINGS "
-                "readonly=2, max_execution_time=10, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=2000000, max_expanded_ast_elements=2000000, max_query_size=1048576, max_bytes_before_external_group_by=0"
+                "SELECT coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', "
+                "(coalesce(%(hogql_val_0)s, ''), 'source')), "
+                "dictGetOrNull('channel_definition_dict', 'type_if_organic', "
+                "(cutToFirstSignificantSubdomain(coalesce(%(hogql_val_0)s, '')), 'source'))) "
+                f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT 50000 SETTINGS "
+                "readonly=2, max_execution_time=10, allow_experimental_object_type=1, "
+                "format_csv_allow_double_quotes=0, max_ast_elements=2000000, "
+                "max_expanded_ast_elements=2000000, max_query_size=1048576, "
+                "max_bytes_before_external_group_by=0"
             ),
             printed,
         )


### PR DESCRIPTION

## Problem

Originally from https://github.com/PostHog/posthog/pull/23630 but pulled out to make reviewing a bit more manageable

It didn't really make sense to have hogql_lookupOrganicSourceType and hogql_lookupOrganicDomainType as different functions. Additionally, we were prioritising domain lookups over utm_medium, which was probably backwards.

https://posthoghelp.zendesk.com/agent/tickets/14945 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/23244) provided a list of their attribution as a guide.

## Changes

Merge hogql_lookupOrganicSourceType and hogql_lookupOrganicDomainType (and do the same for paid), make utm_medium take prioirty over domain.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added some tests for some of the examples in the ticket
