### PR TITLE
feat: tell clients when they should stop spamming recordings

### DIFF
--- a/ee/api/test/test_capture.py
+++ b/ee/api/test/test_capture.py
@@ -264,7 +264,7 @@ class TestCaptureAPI(APIBaseTest):
     def test_quota_limited_recordings_return_retry_after_header_when_enabled(
         self, _kafka_produce, _fake_token_limiting
     ) -> None:
-        with self.settings(QUOTA_LIMITING_ENABLED=True, RECORDINGS_QUOTA_LIMITING_RESPONSES=True):
+        with self.settings(QUOTA_LIMITING_ENABLED=True, RECORDINGS_QUOTA_LIMITING_RESPONSES_SAMPLE_RATE=1):
 
             def fake_limiter(*args, **kwargs):
                 return [self.team.api_token] if args[0] == QuotaResource.RECORDINGS else []
@@ -281,7 +281,7 @@ class TestCaptureAPI(APIBaseTest):
     def test_quota_limited_recordings_do_not_return_retry_after_header_when_disabled(
         self, _kafka_produce, _fake_token_limiting
     ) -> None:
-        with self.settings(QUOTA_LIMITING_ENABLED=True, RECORDINGS_QUOTA_LIMITING_RESPONSES=False):
+        with self.settings(QUOTA_LIMITING_ENABLED=True, RECORDINGS_QUOTA_LIMITING_RESPONSES_SAMPLE_RATE=0):
 
             def fake_limiter(*args, **kwargs):
                 return [self.team.api_token] if args[0] == QuotaResource.RECORDINGS else []

--- a/ee/api/test/test_capture.py
+++ b/ee/api/test/test_capture.py
@@ -1,10 +1,13 @@
 import json
+
+from django.http import HttpResponse
 from django.test.client import Client
 from kafka.errors import NoBrokersAvailable
 from rest_framework import status
-from typing import Any
+from typing import Any, Optional
 from unittest.mock import patch
 
+from ee.billing.quota_limiting import QuotaResource
 from posthog.settings.data_stores import KAFKA_EVENTS_PLUGIN_INGESTION
 from posthog.test.base import APIBaseTest
 
@@ -17,6 +20,59 @@ class TestCaptureAPI(APIBaseTest):
     def setUp(self):
         super().setUp()
         self.client = Client()
+
+    def _send_event(self, expected_status_code: int = status.HTTP_200_OK) -> HttpResponse:
+        event_response = self.client.post(
+            "/e/",
+            data={
+                "data": json.dumps(
+                    [
+                        {"event": "beep", "properties": {"distinct_id": "eeee", "token": self.team.api_token}},
+                        {"event": "boop", "properties": {"distinct_id": "aaaa", "token": self.team.api_token}},
+                    ]
+                ),
+                "api_key": self.team.api_token,
+            },
+        )
+        assert event_response.status_code == expected_status_code
+        return event_response
+
+    def _send_session_recording_event(
+        self,
+        number_of_events=1,
+        event_data: Optional[dict] = None,
+        snapshot_source=3,
+        snapshot_type=1,
+        session_id="abc123",
+        window_id="def456",
+        distinct_id="ghi789",
+        timestamp=1658516991883,
+        expected_status_code: int = status.HTTP_200_OK,
+    ) -> tuple[dict, HttpResponse]:
+        if event_data is None:
+            event_data = {}
+
+        event = {
+            "event": "$snapshot",
+            "properties": {
+                "$snapshot_data": {
+                    "type": snapshot_type,
+                    "data": {"source": snapshot_source, "data": event_data},
+                    "timestamp": timestamp,
+                },
+                "$session_id": session_id,
+                "$window_id": window_id,
+                "distinct_id": distinct_id,
+            },
+            "offset": 1993,
+        }
+
+        capture_recording_response = self.client.post(
+            "/s/", data={"data": json.dumps([event for _ in range(number_of_events)]), "api_key": self.team.api_token}
+        )
+        assert capture_recording_response.status_code == expected_status_code
+
+        return event, capture_recording_response
 
     @patch("posthog.kafka_client.client._KafkaProducer.produce")
     def test_produce_to_kafka(self, kafka_produce):
@@ -202,3 +258,52 @@ class TestCaptureAPI(APIBaseTest):
 
             kafka_produce_call = kafka_produce.call_args_list[1].kwargs
             self.assertEqual(kafka_produce_call["key"], None)
+
+    @patch("ee.billing.quota_limiting.list_limited_team_attributes")
+    @patch("posthog.kafka_client.client._KafkaProducer.produce")
+    def test_quota_limited_recordings_return_retry_after_header_when_enabled(
+        self, _kafka_produce, _fake_token_limiting
+    ) -> None:
+        with self.settings(QUOTA_LIMITING_ENABLED=True, RECORDINGS_QUOTA_LIMITING_RESPONSES=True):
+
+            def fake_limiter(*args, **kwargs):
+                return [self.team.api_token] if args[0] == QuotaResource.RECORDINGS else []
+
+            _fake_token_limiting.side_effect = fake_limiter
+
+            _, response = self._send_session_recording_event()
+            # it is three hours to midnight
+            json_data = json.loads(response.content.decode("utf-8"))
+            assert json_data.get("quota_limited", None) == ["recordings"]
+
+    @patch("ee.billing.quota_limiting.list_limited_team_attributes")
+    @patch("posthog.kafka_client.client._KafkaProducer.produce")
+    def test_quota_limited_recordings_do_not_return_retry_after_header_when_disabled(
+        self, _kafka_produce, _fake_token_limiting
+    ) -> None:
+        with self.settings(QUOTA_LIMITING_ENABLED=True, RECORDINGS_QUOTA_LIMITING_RESPONSES=False):
+
+            def fake_limiter(*args, **kwargs):
+                return [self.team.api_token] if args[0] == QuotaResource.RECORDINGS else []
+
+            _fake_token_limiting.side_effect = fake_limiter
+
+            _, response = self._send_session_recording_event()
+            # it is three hours to midnight
+            json_data = json.loads(response.content.decode("utf-8"))
+            assert "quota_limited" not in json_data
+
+    @patch("ee.billing.quota_limiting.list_limited_team_attributes")
+    @patch("posthog.kafka_client.client._KafkaProducer.produce")
+    def test_quota_limited_events_do_not_return_retry_after_header(self, _kafka_produce, _fake_token_limiting) -> None:
+        with self.settings(QUOTA_LIMITING_ENABLED=True):
+
+            def fake_limiter(*args, **kwargs):
+                return [self.team.api_token] if args[0] == QuotaResource.RECORDINGS else []
+
+            _fake_token_limiting.side_effect = fake_limiter
+
+            response = self._send_event()
+
+            json_data = json.loads(response.content.decode("utf-8"))
+            assert "quota_limited" not in json_data

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 import re
 from random import random
@@ -322,9 +323,16 @@ def drop_performance_events(events: list[Any]) -> list[Any]:
     return cleaned_list
 
 
-def drop_events_over_quota(token: str, events: list[Any]) -> list[Any]:
+@dataclasses.dataclass(frozen=True)
+class EventsOverQuotaResult:
+    events: list[Any]
+    events_were_limited: bool
+    recordings_were_limited: bool
+
+
+def drop_events_over_quota(token: str, events: list[Any]) -> EventsOverQuotaResult:
     if not settings.EE_AVAILABLE:
-        return events
+        return EventsOverQuotaResult(events, False, False)
 
     from ee.billing.quota_limiting import QuotaResource, list_limited_team_attributes
 
@@ -336,12 +344,15 @@ def drop_events_over_quota(token: str, events: list[Any]) -> list[Any]:
         QuotaResource.RECORDINGS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
     )
 
+    recordings_were_limited = False
+    events_were_limited = False
     for event in events:
         if event.get("event") in SESSION_RECORDING_EVENT_NAMES:
             EVENTS_RECEIVED_COUNTER.labels(resource_type="recordings").inc()
             if token in limited_tokens_recordings:
                 EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource_type="recordings", token=token).inc()
                 if settings.QUOTA_LIMITING_ENABLED:
+                    recordings_were_limited = True
                     continue
 
         else:
@@ -349,11 +360,14 @@ def drop_events_over_quota(token: str, events: list[Any]) -> list[Any]:
             if token in limited_tokens_events:
                 EVENTS_DROPPED_OVER_QUOTA_COUNTER.labels(resource_type="events", token=token).inc()
                 if settings.QUOTA_LIMITING_ENABLED:
+                    events_were_limited = True
                     continue
 
         results.append(event)
 
-    return results
+    return EventsOverQuotaResult(
+        results, events_were_limited=events_were_limited, recordings_were_limited=recordings_were_limited
+    )
 
 
 def lib_version_from_query_params(request) -> str:
@@ -461,8 +475,12 @@ def get_event(request):
         except Exception as e:
             capture_exception(e)
 
+        # we're not going to change the response for events
+        recordings_were_quota_limited = False
         try:
-            events = drop_events_over_quota(token, events)
+            events_over_quota_result = drop_events_over_quota(token, events)
+            events = events_over_quota_result.events
+            recordings_were_quota_limited = events_over_quota_result.recordings_were_limited
         except Exception as e:
             # NOTE: Whilst we are testing this code we want to track exceptions but allow the events through if anything goes wrong
             capture_exception(e)
@@ -649,7 +667,12 @@ def get_event(request):
         )
 
     statsd.incr("posthog_cloud_raw_endpoint_success", tags={"endpoint": "capture"})
-    return cors_response(request, JsonResponse({"status": 1}))
+
+    response_body: dict[str, int | list[str]] = {"status": 1}
+    if recordings_were_quota_limited and settings.RECORDINGS_QUOTA_LIMITING_RESPONSES:
+        response_body["quota_limited"] = ["recordings"]
+
+    return cors_response(request, JsonResponse(response_body))
 
 
 def replace_with_warning(

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -26,6 +26,11 @@ EVENT_PARTITION_KEYS_TO_OVERRIDE = get_list(os.getenv("EVENT_PARTITION_KEYS_TO_O
 EVENTS_DEAD_LETTER_QUEUE_STATSD_METRIC = "events_added_to_dead_letter_queue"
 
 QUOTA_LIMITING_ENABLED = get_from_env("QUOTA_LIMITING_ENABLED", False, type_cast=str_to_bool)
+# when enabled we will return content in capture responses if recordings are quota limited
+# session recording clients can stop sending events if they receive a quota limited response
+RECORDINGS_QUOTA_LIMITING_RESPONSES = get_from_env(
+    "RECORDINGS_QUOTA_LIMITING_RESPONSES", default=False, type_cast=str_to_bool
+)
 
 # Capture-side overflow detection for analytics events.
 # Not accurate enough, superseded by detection in plugin-server and should be phased out.

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -28,8 +28,8 @@ EVENTS_DEAD_LETTER_QUEUE_STATSD_METRIC = "events_added_to_dead_letter_queue"
 QUOTA_LIMITING_ENABLED = get_from_env("QUOTA_LIMITING_ENABLED", False, type_cast=str_to_bool)
 # when enabled we will return content in capture responses if recordings are quota limited
 # session recording clients can stop sending events if they receive a quota limited response
-RECORDINGS_QUOTA_LIMITING_RESPONSES = get_from_env(
-    "RECORDINGS_QUOTA_LIMITING_RESPONSES", default=False, type_cast=str_to_bool
+RECORDINGS_QUOTA_LIMITING_RESPONSES_SAMPLE_RATE = get_from_env(
+    "RECORDINGS_QUOTA_LIMITING_RESPONSES_SAMPLE_RATE", default=0, type_cast=float
 )
 
 # Capture-side overflow detection for analytics events.


### PR DESCRIPTION
we have code in posthog-js checking each response to see if it should stop sending things to us
we never tell it anything

this adds a flag we can turn on on the recordings pods to include the expected body content when recordings are quota limited

---

checked that things carry on working when either bool is false
and that snapshot events come once a minute when they're both true