### PR TITLE
feat(hog): json input autocomplete and syntax highlighting

### DIFF
--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -9,6 +9,7 @@ import { findNextFocusableElement, findPreviousFocusableElement } from 'lib/mona
 import { hogQLAutocompleteProvider } from 'lib/monaco/hogQLAutocompleteProvider'
 import { hogQLMetadataProvider } from 'lib/monaco/hogQLMetadataProvider'
 import * as hog from 'lib/monaco/languages/hog'
+import * as hogJson from 'lib/monaco/languages/hogJson'
 import * as hogQL from 'lib/monaco/languages/hogQL'
 import * as hogTemplate from 'lib/monaco/languages/hogTemplate'
 import { inStorybookTestRunner } from 'lib/utils'
@@ -88,6 +89,18 @@ function initEditor(
                 hogQLAutocompleteProvider(HogLanguage.hogTemplate)
             )
             monaco.languages.registerCodeActionProvider('hogTemplate', hogQLMetadataProvider())
+        }
+    }
+    if (editorProps?.language === 'hogJson') {
+        if (!monaco.languages.getLanguages().some(({ id }) => id === 'hogJson')) {
+            monaco.languages.register({
+                id: 'hogJson',
+                mimetypes: ['application/hog+json'],
+            })
+            monaco.languages.setLanguageConfiguration('hogJson', hogJson.conf())
+            monaco.languages.setMonarchTokensProvider('hogJson', hogJson.language())
+            monaco.languages.registerCompletionItemProvider('hogJson', hogQLAutocompleteProvider(HogLanguage.hogJson))
+            monaco.languages.registerCodeActionProvider('hogJson', hogQLMetadataProvider())
         }
     }
     if (options.tabFocusMode) {

--- a/frontend/src/lib/monaco/languages/hogJson.ts
+++ b/frontend/src/lib/monaco/languages/hogJson.ts
@@ -1,0 +1,153 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable no-useless-escape */
+import { languages } from 'monaco-editor'
+
+import { conf as _conf, language as _language } from './hog'
+
+export const conf: () => languages.LanguageConfiguration = () => ({
+    ..._conf(),
+})
+
+export const language: () => languages.IMonarchLanguage = () => ({
+    ..._language(),
+    jsonKeywords: ['true', 'false', 'null', 'undefined'],
+    tokenizer: {
+        root: [[/[{}]/, 'delimiter.bracket'], { include: 'json' }],
+
+        json: [
+            // whitespace
+            { include: '@whitespace' },
+
+            // numbers
+            [/(@digits)[eE]([\-+]?(@digits))?/, 'number.float'],
+            [/(@digits)\.(@digits)([eE][\-+]?(@digits))?/, 'number.float'],
+            [/(@digits)n?/, 'number'],
+            [
+                /[\w@]+/,
+                {
+                    cases: {
+                        '@jsonKeywords': 'keyword',
+                    },
+                },
+            ],
+
+            // delimiter: after number because of .\d floats
+            [/[;,.]/, 'delimiter'],
+
+            // strings
+            [/"([^"\\]|\\.)*$/, 'string.invalid'], // non-teminated string
+            [/"/, 'string', '@string_format_json'],
+        ],
+
+        hog: [
+            // whitespace
+            { include: '@whitespace' },
+
+            // delimiters and operators
+            [/[()\[\]]/, '@brackets'],
+            [/[<>](?!@symbols)/, '@brackets'],
+            [/!(?=([^=]|$))/, 'delimiter'],
+            [
+                /@symbols/,
+                {
+                    cases: {
+                        '@operators': 'delimiter',
+                        '@default': '',
+                    },
+                },
+            ],
+
+            // numbers
+            [/(@digits)[eE]([\-+]?(@digits))?/, 'number.float'],
+            [/(@digits)\.(@digits)([eE][\-+]?(@digits))?/, 'number.float'],
+            [/(@digits)n?/, 'number'],
+
+            // delimiter: after number because of .\d floats
+            [/[;,.]/, 'delimiter'],
+
+            // strings that are actually fields, show as type.identifier to highlight
+            [/"([^"\\]|\\.)*$/, 'type.identifier.invalid'], // non-teminated type.identifier
+            [/'([^'\\]|\\.)*$/, 'type.identifier.invalid'], // non-teminated type.identifier
+            [/"/, 'type.identifier', '@string_double'],
+            [/`/, 'type.identifier', '@string_backtick'],
+
+            // strings
+            [/f'/, 'string', '@string_format'],
+            [/'/, 'string', '@string_single'],
+
+            // identifiers and keywords
+            [
+                /#?[a-z_$][\w$]*/,
+                {
+                    cases: {
+                        '@keywords': 'keyword',
+                        '@default': 'identifier',
+                    },
+                },
+            ],
+        ],
+
+        whitespace: [
+            [/[ \t\r\n]+/, ''],
+            [/\/\*\*(?!\/)/, 'comment.doc', '@jsdoc'],
+            [/\/\*/, 'comment', '@comment'],
+            [/\/\/.*$/, 'comment'],
+            [/--.*$/, 'comment'],
+        ],
+
+        comment: [
+            [/[^\/*]+/, 'comment'],
+            [/\*\//, 'comment', '@pop'],
+            [/[\/*]/, 'comment'],
+        ],
+
+        jsdoc: [
+            [/[^\/*]+/, 'comment.doc'],
+            [/\*\//, 'comment.doc', '@pop'],
+            [/[\/*]/, 'comment.doc'],
+        ],
+
+        string_double: [
+            [/[^\\"]+/, 'type.identifier'],
+            [/@escapes/, 'type.identifier.escape'],
+            [/\\./, 'type.identifier.escape.invalid'],
+            [/"/, 'type.identifier', '@pop'],
+        ],
+
+        string_backtick: [
+            [/[^\\`]+/, 'type.identifier'],
+            [/@escapes/, 'type.identifier.escape'],
+            [/\\./, 'type.identifier.escape.invalid'],
+            [/`/, 'type.identifier', '@pop'],
+        ],
+
+        string_single: [
+            [/[^\\']+/, 'string'],
+            [/@escapes/, 'string.escape'],
+            [/\\./, 'string.escape.invalid'],
+            [/'/, 'string', '@pop'],
+        ],
+
+        string_format: [
+            [/\{/, { token: 'delimiter.bracket', next: '@bracketCounting' }],
+            [/[^\\'{]+/, 'string'],
+            [/@escapes/, 'string.escape'],
+            [/\\./, 'string.escape.invalid'],
+            [/'/, 'string', '@pop'],
+        ],
+
+        string_format_json: [
+            [/\{/, { token: 'delimiter.bracket', next: '@bracketCounting' }],
+            [/[^\\"{]+/, 'string'],
+            [/@escapes/, 'string.escape'],
+            [/\\./, 'string.escape.invalid'],
+            [/"/, 'string', '@pop'],
+        ],
+
+        bracketCounting: [
+            [/\{/, 'delimiter.bracket', '@bracketCounting'],
+            [/\}/, 'delimiter.bracket', '@pop'],
+            { include: 'hog' },
+        ],
+    },
+})

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -4501,7 +4501,7 @@
             ]
         },
         "HogLanguage": {
-            "enum": ["hog", "hogQL", "hogQLExpr", "hogTemplate"],
+            "enum": ["hog", "hogJson", "hogQL", "hogQLExpr", "hogTemplate"],
             "type": "string"
         },
         "HogQLAutocomplete": {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -344,6 +344,7 @@ export interface HogQLAutocompleteResponse {
 
 export enum HogLanguage {
     hog = 'hog',
+    hogJson = 'hogJson',
     hogQL = 'hogQL',
     hogQLExpr = 'hogQLExpr',
     hogTemplate = 'hogTemplate',

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
@@ -1,7 +1,6 @@
 import { closestCenter, DndContext } from '@dnd-kit/core'
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { Monaco } from '@monaco-editor/react'
 import { IconGear, IconLock, IconPlus, IconTrash, IconX } from '@posthog/icons'
 import {
     LemonButton,
@@ -20,10 +19,8 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { CodeEditorInline, CodeEditorInlineProps } from 'lib/monaco/CodeEditorInline'
 import { CodeEditorResizeable } from 'lib/monaco/CodeEditorResizable'
 import { capitalizeFirstLetter } from 'lib/utils'
-import { languages } from 'monaco-editor'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 
-import { groupsModel } from '~/models/groupsModel'
 import { HogFunctionInputSchemaType, HogFunctionInputType } from '~/types'
 
 import { hogFunctionConfigurationLogic } from './hogFunctionConfigurationLogic'
@@ -43,115 +40,16 @@ export type HogFunctionInputWithSchemaProps = {
 
 const typeList = ['string', 'boolean', 'dictionary', 'choice', 'json', 'integration'] as const
 
-function useAutocompleteOptions(): languages.CompletionItem[] {
-    const { groupTypes } = useValues(groupsModel)
-
-    return useMemo(() => {
-        const options = [
-            ['event', 'The entire event payload as a JSON object'],
-            ['event.name', 'The name of the event e.g. $pageview'],
-            ['event.distinct_id', 'The distinct_id of the event'],
-            ['event.timestamp', 'The timestamp of the event'],
-            ['event.url', 'URL to the event in PostHog'],
-            ['event.properties', 'Properties of the event'],
-            ['event.properties.<key>', 'The individual property of the event'],
-            ['person', 'The entire person payload as a JSON object'],
-            ['project.uuid', 'The UUID of the Person in PostHog'],
-            ['person.url', 'URL to the person in PostHog'],
-            ['person.properties', 'Properties of the person'],
-            ['person.properties.<key>', 'The individual property of the person'],
-            ['project.id', 'ID of the project in PostHog'],
-            ['project.name', 'Name of the project'],
-            ['project.url', 'URL to the project in PostHog'],
-            ['source.name', 'Name of the source of this message'],
-            ['source.url', 'URL to the source of this message in PostHog'],
-        ]
-
-        groupTypes.forEach((groupType) => {
-            options.push([`groups.${groupType.group_type}`, `The entire group payload as a JSON object`])
-            options.push([`groups.${groupType.group_type}.id`, `The ID or 'key' of the group`])
-            options.push([`groups.${groupType.group_type}.url`, `URL to the group in PostHog`])
-            options.push([`groups.${groupType.group_type}.properties`, `Properties of the group`])
-            options.push([`groups.${groupType.group_type}.properties.<key>`, `The individual property of the group`])
-            options.push([`groups.${groupType.group_type}.index`, `Index of the group`])
-        })
-
-        const items: languages.CompletionItem[] = options.map(([key, value]) => {
-            return {
-                label: key,
-                kind: languages.CompletionItemKind.Variable,
-                detail: value,
-                insertText: key,
-                range: {
-                    startLineNumber: 1,
-                    endLineNumber: 1,
-                    startColumn: 0,
-                    endColumn: 0,
-                },
-            }
-        })
-
-        return items
-    }, [groupTypes])
-}
-
 function JsonConfigField(props: {
     onChange?: (value: string) => void
     className?: string
     autoFocus?: boolean
     value?: string
 }): JSX.Element {
-    const suggestions = useAutocompleteOptions()
-    const [monaco, setMonaco] = useState<Monaco>()
-
-    useEffect(() => {
-        if (!monaco) {
-            return
-        }
-        monaco.languages.setLanguageConfiguration('json', {
-            wordPattern: /[a-zA-Z0-9_\-.]+/,
-        })
-
-        const provider = monaco.languages.registerCompletionItemProvider('json', {
-            triggerCharacters: ['{', '{{'],
-            provideCompletionItems: async (model, position) => {
-                const word = model.getWordUntilPosition(position)
-
-                const wordWithTrigger = model.getValueInRange({
-                    startLineNumber: position.lineNumber,
-                    startColumn: 0,
-                    endLineNumber: position.lineNumber,
-                    endColumn: position.column,
-                })
-
-                if (wordWithTrigger.indexOf('{') === -1) {
-                    return { suggestions: [] }
-                }
-
-                const localSuggestions = suggestions.map((x) => ({
-                    ...x,
-                    insertText: x.insertText,
-                    range: {
-                        startLineNumber: position.lineNumber,
-                        endLineNumber: position.lineNumber,
-                        startColumn: word.startColumn,
-                        endColumn: word.endColumn,
-                    },
-                }))
-
-                return {
-                    suggestions: localSuggestions,
-                    incomplete: false,
-                }
-            },
-        })
-
-        return () => provider.dispose()
-    }, [suggestions, monaco])
-
+    const { exampleInvocationGlobalsWithInputs } = useValues(hogFunctionConfigurationLogic)
     return (
         <CodeEditorResizeable
-            language="json"
+            language="hogJson"
             value={typeof props.value !== 'string' ? JSON.stringify(props.value, null, 2) : props.value}
             onChange={(v) => props.onChange?.(v ?? '')}
             options={{
@@ -159,23 +57,12 @@ function JsonConfigField(props: {
                 minimap: {
                     enabled: false,
                 },
-                quickSuggestions: {
-                    other: true,
-                    strings: true,
-                },
-                suggest: {
-                    showWords: false,
-                    showFields: false,
-                    showKeywords: false,
-                },
                 scrollbar: {
                     vertical: 'hidden',
                     verticalScrollbarSize: 0,
                 },
             }}
-            onMount={(_editor, monaco) => {
-                setMonaco(monaco)
-            }}
+            globals={exampleInvocationGlobalsWithInputs}
         />
     )
 }

--- a/posthog/hogql/test/test_autocomplete.py
+++ b/posthog/hogql/test/test_autocomplete.py
@@ -56,6 +56,17 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
         )
         return get_hogql_autocomplete(query=autocomplete, team=self.team, database_arg=database)
 
+    def _json(self, query: str, start: int, end: int, database: Optional[Database] = None) -> HogQLAutocompleteResponse:
+        autocomplete = HogQLAutocomplete(
+            kind="HogQLAutocomplete",
+            query=query,
+            language=HogLanguage.HOG_JSON,
+            sourceQuery=HogQLQuery(query="select * from events"),
+            startPosition=start,
+            endPosition=end,
+        )
+        return get_hogql_autocomplete(query=autocomplete, team=self.team, database_arg=database)
+
     def _program(
         self, query: str, start: int, end: int, database: Optional[Database] = None
     ) -> HogQLAutocompleteResponse:
@@ -328,6 +339,26 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
         assert len(results.suggestions) == 0
 
         results = self._template(query=query, start=5, end=6, database=database)
+        assert len(results.suggestions) == 0
+
+    def test_autocomplete_template_json(self):
+        database = create_hogql_database(team_id=self.team.pk, team_arg=self.team)
+
+        query = '{ "key": "val_{event.distinct_id}_ue" }'
+        results = self._json(query=query, start=18, end=20, database=database)
+
+        suggestions = list(filter(lambda x: x.label == "event", results.suggestions))
+        assert len(suggestions) == 1
+
+        suggestion = suggestions[0]
+        assert suggestion is not None
+        assert suggestion.label == "event"
+        assert suggestion.insertText == "event"
+
+        results = self._json(query=query, start=5, end=5, database=database)
+        assert len(results.suggestions) == 0
+
+        results = self._json(query=query, start=5, end=6, database=database)
         assert len(results.suggestions) == 0
 
     def test_autocomplete_hog(self):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -489,6 +489,7 @@ class GoalLine(BaseModel):
 
 class HogLanguage(StrEnum):
     HOG = "hog"
+    HOG_JSON = "hogJson"
     HOG_QL = "hogQL"
     HOG_QL_EXPR = "hogQLExpr"
     HOG_TEMPLATE = "hogTemplate"


### PR DESCRIPTION
## Problem

Autocomplete didn't work for the JSON input fields

## Changes

![2024-07-18 12 03 07](https://github.com/user-attachments/assets/e4c363e2-aad5-4c09-b313-23a373bd9ad0)

The code to find the start of the string where to autocomplete is quite "happy path only", but I assume we're all happy to go down this path today.

## How did you test this code?

See screencast. Added a test