### PR TITLE
fix: Salesforce redirection logic

### DIFF
--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -3,6 +3,7 @@ import { actions, afterMount, connect, kea, listeners, path, selectors } from 'k
 import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
 import api from 'lib/api'
+import { fromParamsGivenUrl } from 'lib/utils'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
 
@@ -49,9 +50,9 @@ export const integrationsLogic = kea<integrationsLogicType>([
     })),
     listeners(({ actions }) => ({
         handleOauthCallback: async ({ kind, searchParams }) => {
-            const { state, code, error, next } = searchParams
-
-            const replaceUrl = next || urls.settings('project')
+            const { state, code, error } = searchParams
+            const { next } = fromParamsGivenUrl(state)
+            let replaceUrl: string = next || urls.settings('project')
 
             if (error) {
                 lemonToast.error(`Failed due to "${error}"`)
@@ -60,10 +61,13 @@ export const integrationsLogic = kea<integrationsLogicType>([
             }
 
             try {
-                await api.integrations.create({
+                const integration = await api.integrations.create({
                     kind,
-                    config: { state, code, next },
+                    config: { state, code },
                 })
+
+                // Add the integration ID to the replaceUrl so that the landing page can use it
+                replaceUrl += `${replaceUrl.includes('?') ? '&' : '?'}integration_id=${integration.id}`
 
                 actions.loadIntegrations()
                 lemonToast.success(`Integration successful.`)

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -71,9 +71,10 @@ export const integrationsLogic = kea<integrationsLogicType>([
 
                 actions.loadIntegrations()
                 lemonToast.success(`Integration successful.`)
-                router.actions.replace(replaceUrl)
             } catch (e) {
                 lemonToast.error(`Something went wrong. Please try again.`)
+            } finally {
+                router.actions.replace(replaceUrl)
             }
         },
 

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -52,7 +52,7 @@ export const integrationsLogic = kea<integrationsLogicType>([
         handleOauthCallback: async ({ kind, searchParams }) => {
             const { state, code, error } = searchParams
             const { next } = fromParamsGivenUrl(state)
-            let replaceUrl: string = next || urls.settings('project')
+            let replaceUrl: string = next || urls.settings('project-integrations')
 
             if (error) {
                 lemonToast.error(`Failed due to "${error}"`)

--- a/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
+++ b/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
@@ -31,6 +31,7 @@ export type LemonMenuItemLeaf =
       })
     | (LemonMenuItemBase & {
           to: string
+          disableClientSideRouting?: boolean
           targetBlank?: boolean
           items?: never
           keyboardShortcut?: KeyboardShortcut
@@ -38,6 +39,7 @@ export type LemonMenuItemLeaf =
     | (LemonMenuItemBase & {
           onClick: () => void
           to: string
+          disableClientSideRouting?: boolean
           targetBlank?: boolean
           items?: never
           keyboardShortcut?: KeyboardShortcut

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -389,6 +389,30 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                 ...values.defaultFormState,
                 ...(cache.configFromUrl || {}),
             })
+
+            if (router.values.searchParams.integration_target) {
+                // `integration_target` is a special query parameter that indicates we should set the value of a specific input to the integration ID if it exists
+                if (router.values.searchParams.integration_id) {
+                    // This indicates that we triggered an integration flow and have an integration ID to set
+                    actions.setConfigurationValues({
+                        inputs: {
+                            [router.values.searchParams.integration_target]: {
+                                value: router.values.searchParams.integration_id,
+                            },
+                        },
+                    })
+                }
+
+                router.actions.replace(
+                    router.values.location.pathname,
+                    {
+                        ...router.values.searchParams,
+                        integration_target: undefined,
+                        integration_id: undefined,
+                    },
+                    router.values.hashParams
+                )
+            }
         },
 
         duplicate: async () => {
@@ -483,10 +507,14 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
 
     subscriptions(({ props, cache }) => ({
         configuration: (configuration) => {
+            if (!Object.keys(configuration).length) {
+                return
+            }
+
             if (props.templateId) {
                 // Sync state to the URL bar if new
                 cache.ignoreUrlChange = true
-                router.actions.replace(router.values.location.pathname, undefined, {
+                router.actions.replace(router.values.location.pathname, router.values.searchParams, {
                     configuration,
                 })
             }

--- a/frontend/src/scenes/pipeline/hogfunctions/integrations/HogFunctionInputIntegration.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/integrations/HogFunctionInputIntegration.tsx
@@ -1,3 +1,4 @@
+import { IconX } from '@posthog/icons'
 import { LemonButton, LemonMenu, LemonSkeleton } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import api from 'lib/api'
@@ -18,11 +19,6 @@ export type HogFunctionInputIntegrationProps = HogFunctionInputIntegrationConfig
 
 export function HogFunctionInputIntegration({ schema, ...props }: HogFunctionInputIntegrationProps): JSX.Element {
     return <HogFunctionIntegrationChoice {...props} schema={schema} />
-    return (
-        <div className="text-danger">
-            <p>Unsupported integration type: {schema.integration}</p>
-        </div>
-    )
 }
 
 function HogFunctionIntegrationChoice({
@@ -46,17 +42,34 @@ function HogFunctionIntegrationChoice({
     const button = (
         <LemonMenu
             items={[
-                ...(integrationsOfKind?.map((integration) => ({
-                    icon: <img src={integration.icon_url} className="w-6 h-6" />,
-                    onClick: () => onChange?.(integration.id),
-                    label: integration.name,
-                })) || []),
                 {
-                    to: api.integrations.authorizeUrl({
-                        kind,
-                        next: window.location.pathname,
-                    }),
-                    label: `Connect to a different ${kind} integration`,
+                    items: [
+                        ...(integrationsOfKind?.map((integration) => ({
+                            icon: <img src={integration.icon_url} className="w-6 h-6 rounded" />,
+                            onClick: () => onChange?.(integration.id),
+                            active: integration.id === value,
+                            label: integration.name,
+                        })) || []),
+                    ],
+                },
+                {
+                    items: [
+                        {
+                            to: api.integrations.authorizeUrl({
+                                kind,
+                                next: `${window.location.pathname}?integration_target=${schema.key}`,
+                            }),
+                            disableClientSideRouting: true,
+                            label: integrationsOfKind?.length
+                                ? `Connect to a different ${kind} integration`
+                                : `Connect to ${kind}`,
+                        },
+                        {
+                            onClick: () => onChange?.(null),
+                            label: 'Clear',
+                            sideIcon: <IconX />,
+                        },
+                    ],
                 },
             ]}
         >

--- a/frontend/src/scenes/pipeline/hogfunctions/integrations/HogFunctionInputIntegration.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/integrations/HogFunctionInputIntegration.tsx
@@ -1,10 +1,11 @@
-import { IconX } from '@posthog/icons'
+import { IconExternal, IconX } from '@posthog/icons'
 import { LemonButton, LemonMenu, LemonSkeleton } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import api from 'lib/api'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { IntegrationView } from 'lib/integrations/IntegrationView'
 import { capitalizeFirstLetter } from 'lib/utils'
+import { urls } from 'scenes/urls'
 
 import { HogFunctionInputSchemaType } from '~/types'
 
@@ -42,16 +43,18 @@ function HogFunctionIntegrationChoice({
     const button = (
         <LemonMenu
             items={[
-                {
-                    items: [
-                        ...(integrationsOfKind?.map((integration) => ({
-                            icon: <img src={integration.icon_url} className="w-6 h-6 rounded" />,
-                            onClick: () => onChange?.(integration.id),
-                            active: integration.id === value,
-                            label: integration.name,
-                        })) || []),
-                    ],
-                },
+                integrationsOfKind?.length
+                    ? {
+                          items: [
+                              ...(integrationsOfKind?.map((integration) => ({
+                                  icon: <img src={integration.icon_url} className="w-6 h-6 rounded" />,
+                                  onClick: () => onChange?.(integration.id),
+                                  active: integration.id === value,
+                                  label: integration.name,
+                              })) || []),
+                          ],
+                      }
+                    : null,
                 {
                     items: [
                         {
@@ -64,11 +67,22 @@ function HogFunctionIntegrationChoice({
                                 ? `Connect to a different ${kind} integration`
                                 : `Connect to ${kind}`,
                         },
+                    ],
+                },
+                {
+                    items: [
                         {
-                            onClick: () => onChange?.(null),
-                            label: 'Clear',
-                            sideIcon: <IconX />,
+                            to: urls.settings('project-integrations'),
+                            label: 'Manage integrations',
+                            sideIcon: <IconExternal />,
                         },
+                        value
+                            ? {
+                                  onClick: () => onChange?.(null),
+                                  label: 'Clear',
+                                  sideIcon: <IconX />,
+                              }
+                            : null,
                     ],
                 },
             ]}

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -113,8 +113,6 @@ class OauthIntegration:
     def authorize_url(cls, kind: str, next="") -> str:
         oauth_config = cls.oauth_config_for_kind(kind)
 
-        # Build the url safely with the parameters
-
         query_params = {
             "client_id": oauth_config.client_id,
             "scope": oauth_config.scope,

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -4,6 +4,7 @@ import hmac
 import time
 from datetime import timedelta
 from typing import Any, Literal
+from urllib.parse import urlencode
 
 from django.db import models
 import requests
@@ -104,15 +105,25 @@ class OauthIntegration:
         raise NotImplementedError(f"Oauth config for kind {kind} not implemented")
 
     @classmethod
-    def redirect_uri(cls, kind: str, next: str = "") -> str:
+    def redirect_uri(cls, kind: str) -> str:
         # The redirect uri is fixed but should always be https and include the "next" parameter for the frontend to redirect
-        return f"{settings.SITE_URL.replace('http://', 'https://')}/integrations/{kind}/callback?next={next}"
+        return f"{settings.SITE_URL.replace('http://', 'https://')}/integrations/{kind}/callback"
 
     @classmethod
-    def authorize_url(cls, kind: str, next: str = "") -> str:
+    def authorize_url(cls, kind: str, next="") -> str:
         oauth_config = cls.oauth_config_for_kind(kind)
 
-        return f"{oauth_config.authorize_url}?client_id={oauth_config.client_id}&scope={oauth_config.scope}&redirect_uri={cls.redirect_uri(kind, next)}"
+        # Build the url safely with the parameters
+
+        query_params = {
+            "client_id": oauth_config.client_id,
+            "scope": oauth_config.scope,
+            "redirect_uri": cls.redirect_uri(kind),
+            "response_type": "code",
+            "state": urlencode({"next": next}),
+        }
+
+        return f"{oauth_config.authorize_url}?{urlencode(query_params)}"
 
     @classmethod
     def integration_from_oauth_response(
@@ -120,16 +131,13 @@ class OauthIntegration:
     ) -> Integration:
         oauth_config = cls.oauth_config_for_kind(kind)
 
-        next = params["next"]
-        code = params["code"]
-
         res = requests.post(
             oauth_config.token_url,
             data={
                 "client_id": oauth_config.client_id,
                 "client_secret": oauth_config.client_secret,
-                "code": code,
-                "redirect_uri": OauthIntegration.redirect_uri(kind, next=next),
+                "code": params["code"],
+                "redirect_uri": OauthIntegration.redirect_uri(kind),
                 "grant_type": "authorization_code",
             },
         )


### PR DESCRIPTION
## Problem

Salesforce doesn't include query params in the redirect uri (in fact the oauth standard doesn't allow it). We should use state instead and now we do. Also it was a bit V0 in general

## Changes
<img width="668" alt="Screenshot 2024-07-18 at 12 29 03" src="https://github.com/user-attachments/assets/edd35c8c-bebc-434d-894c-b5e7427ea5e3">
<img width="650" alt="Screenshot 2024-07-18 at 12 28 48" src="https://github.com/user-attachments/assets/2b40d8a0-6171-45d4-ac2a-7590e0aad90c">


* Change to have the "next" in state
* Indicate which integration is selected
* Allow clearing of the selected integration
* Link out to all integrations in settings
* Auto select the integration when successful

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
