### PR TITLE
fix(lemon-ui): a hook in LemonSelect captures an old function reference

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonSelect/LemonSelect.tsx
@@ -121,7 +121,7 @@ export function LemonSelect<T extends string | number | boolean | null>({
                 }
                 onSelect?.(newValue)
             }),
-        [options, value]
+        [options, value, onChange, onSelect]
     )
 
     const activeLeaf = allLeafOptions.find((o) => o.value === value)


### PR DESCRIPTION
## Problem

The `onChange` and `onSelect` callbacks weren't dependencies of `useMemo` in LemonSelect, which kept old references to the callbacks.

## Changes

**Before**

![2024-07-18 13 31 51](https://github.com/user-attachments/assets/adfbc942-eeea-4959-a3d7-0a8b00d82750)

**After**

![2024-07-18 12 40 14](https://github.com/user-attachments/assets/46d17bef-9724-4a6c-9c8f-1ff12a28c7dc)

## Does this work well for both Cloud and self-hosted?

Yes