### PR TITLE
chore(experiments): set up instrumentation for experiment flip-flopping

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -8,6 +8,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 from statshog.defaults.django import statsd
+import posthoganalytics
 
 from ee.clickhouse.queries.experiments.funnel_experiment_result import (
     ClickhouseFunnelExperimentResult,
@@ -125,6 +126,18 @@ def _experiment_results_cached(
 
     timestamp = now()
     fresh_result_package = {"result": result, "last_refresh": now(), "is_cached": False}
+
+    posthoganalytics.capture(
+        experiment.created_by.email,
+        "experiment result calculated",
+        properties={
+            "experiment_id": experiment.id,
+            "goal_type": experiment.filters.get("insight", "FUNNELS"),
+            "significant": result["significant"],
+            "significance_code": result["significance_code"],
+            "probability": result["probability"],
+        },
+    )
 
     update_cached_state(
         experiment.team.pk,

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -127,15 +127,16 @@ def _experiment_results_cached(
     timestamp = now()
     fresh_result_package = {"result": result, "last_refresh": now(), "is_cached": False}
 
+    # Event to detect experiment significance flip-flopping
     posthoganalytics.capture(
         experiment.created_by.email,
         "experiment result calculated",
         properties={
             "experiment_id": experiment.id,
             "goal_type": experiment.filters.get("insight", "FUNNELS"),
-            "significant": result["significant"],
-            "significance_code": result["significance_code"],
-            "probability": result["probability"],
+            "significant": result.get("significant"),
+            "significance_code": result.get("significance_code"),
+            "probability": result.get("probability"),
         },
     )
 

--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -133,6 +133,7 @@ def _experiment_results_cached(
         "experiment result calculated",
         properties={
             "experiment_id": experiment.id,
+            "name": experiment.name,
             "goal_type": experiment.filters.get("insight", "FUNNELS"),
             "significant": result.get("significant"),
             "significance_code": result.get("significance_code"),


### PR DESCRIPTION
## Problem
Flip-flopping: when an experiment has been declared `significant`, but becomes `not significant` due to new data.

We want to track how often this happens, for which experiments, and decide if we need to adjust something in our methodology.

## Changes
- Capture an event whenever results get recalculated

Then, we can use the following query to get the list of flip-flopping experiments. Note that we only check the instances when significant -> not significant. The inverse is normal and expected (every experiment is initially not significant).

```sql
WITH flip_flops AS (
    SELECT
        timestamp,
        JSONExtractString(properties, 'experiment_id') AS experiment_id,
        JSONExtractString(properties, 'significant') AS significant_str,
        CASE
            WHEN significant_str = 'true' THEN 1
            WHEN significant_str = 'false' THEN 0
            ELSE NULL
        END AS significant,
        lagInFrame(
            CASE
                WHEN significant_str = 'true' THEN 1
                WHEN significant_str = 'false' THEN 0
                ELSE NULL
            END,
            1
        ) OVER (PARTITION BY experiment_id ORDER BY timestamp) AS previous_significant
    FROM events
    WHERE event = 'experiment result calculated'
),
significance_changes AS (
    SELECT
        experiment_id,
        countIf(previous_significant = 1 AND significant = 0) AS flip_flop_count
    FROM flip_flops
    GROUP BY experiment_id
)
SELECT
    experiment_id
FROM significance_changes
WHERE flip_flop_count > 0
``` 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally:
- Events get captured on results recalculation
- The query above returns correct results