### PR TITLE
fix: Use correct version keys in Snowflake

### DIFF
--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -395,8 +395,8 @@ class SnowflakeClient:
         stage_table: str,
         merge_key: collections.abc.Iterable[SnowflakeField],
         update_when_matched: collections.abc.Iterable[SnowflakeField],
-        person_version_key: str = "version",
-        person_distinct_id_version_key: str = "version",
+        person_version_key: str = "person_version",
+        person_distinct_id_version_key: str = "person_distinct_id_version",
     ):
         """Merge two identical person model tables in Snowflake."""
         merge_condition = "ON "


### PR DESCRIPTION
## Problem

Version keys were not updated for Snowflake batch export like in other destinations.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Update version keys.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added a unit test to cover.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
