### PR TITLE
chore(hogql): Expose bad argument errors from CH

### DIFF
--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -136,7 +136,7 @@ CLICKHOUSE_ERROR_CODE_LOOKUP: dict[int, ErrorCodeMeta] = {
     33: ErrorCodeMeta("CANNOT_READ_ALL_DATA"),
     34: ErrorCodeMeta("TOO_MANY_ARGUMENTS_FOR_FUNCTION"),
     35: ErrorCodeMeta("TOO_FEW_ARGUMENTS_FOR_FUNCTION"),
-    36: ErrorCodeMeta("BAD_ARGUMENTS"),
+    36: ErrorCodeMeta("BAD_ARGUMENTS", user_safe=True),
     37: ErrorCodeMeta("UNKNOWN_ELEMENT_IN_AST"),
     38: ErrorCodeMeta("CANNOT_PARSE_DATE", user_safe=True),
     39: ErrorCodeMeta("TOO_LARGE_SIZE_COMPRESSED"),


### PR DESCRIPTION
## Problem
A query failed on prod for me with the generic error message - this should be exposable in all cases I think:
<img width="899" alt="image" src="https://github.com/user-attachments/assets/9972f7b2-05fa-45e1-ad7d-a7e30797a6c8">


## Changes
- Expose bad argument clickhouse errors
