### PR TITLE
chore: split out kafka producer settings

### DIFF
--- a/posthog/kafka_client/client.py
+++ b/posthog/kafka_client/client.py
@@ -136,16 +136,7 @@ class _KafkaProducer:
                 **{"api_version_auto_timeout_ms": 30000}
                 if settings.DEBUG
                 else {},  # Local development connections could be really slow
-                **{
-                    "metadata_max_age_ms": "60000",
-                    "batch_size": "16000000",
-                    "max_request_size": "104857600",
-                    "linger_ms": "100",
-                    "partitioner": "consistent_random",
-                    "max_in_flight_requests_per_connection": "1000000",
-                }
-                if settings.KAFKA_PRODUCER_USE_WARPSTREAM_SETTINGS
-                else {},
+                **settings.KAFKA_PRODUCER_SETTINGS,
                 **_sasl_params(),
             )
 

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -220,9 +220,18 @@ KAFKA_PREFIX = os.getenv("KAFKA_PREFIX", "")
 
 KAFKA_BASE64_KEYS = get_from_env("KAFKA_BASE64_KEYS", False, type_cast=str_to_bool)
 
-KAFKA_PRODUCER_USE_WARPSTREAM_SETTINGS = get_from_env(
-    "KAFKA_PRODUCER_USE_WARPSTREAM_SETTINGS", False, type_cast=str_to_bool
-)
+KAFKA_PRODUCER_SETTINGS = {
+    key: value
+    for key, value in {
+        "metadata_max_age_ms": os.getenv("KAFKA_PRODUCER_METADATA_MAX_AGE_MS"),
+        "batch_size": os.getenv("KAFKA_PRODUCER_BATCH_SIZE"),
+        "max_request_size": os.getenv("KAFKA_PRODUCER_MAX_REQUEST_SIZE"),
+        "linger_ms": os.getenv("KAFKA_PRODUCER_LINGER_MS"),
+        "partitioner": os.getenv("KAFKA_PRODUCER_PARTITIONER"),
+        "max_in_flight_requests_per_connection": os.getenv("KAFKA_PRODUCER_MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION"),
+    }.items()
+    if value is not None
+}
 
 SESSION_RECORDING_KAFKA_MAX_REQUEST_SIZE_BYTES: int = get_from_env(
     "SESSION_RECORDING_KAFKA_MAX_REQUEST_SIZE_BYTES",


### PR DESCRIPTION
## Problem

we set all these defaults just to be a bit quicker, but of course now we need to handle them separately

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
