### PR TITLE
fix(data-warehouse): Dont fail empty table jobs and update UI to match

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Schemas.tsx
@@ -150,6 +150,12 @@ export const SchemaTable = ({ schemas, isLoading }: SchemaTableProps): JSX.Eleme
                                     </Link>
                                 )
                             }
+
+                            // Synced but no rows
+                            if (schema.status === 'Completed') {
+                                return <div>No rows to query</div>
+                            }
+
                             return <div>Not yet synced</div>
                         },
                     },
@@ -172,7 +178,16 @@ export const SchemaTable = ({ schemas, isLoading }: SchemaTableProps): JSX.Eleme
                         title: 'Rows Synced',
                         key: 'rows_synced',
                         render: function Render(_, schema) {
-                            return (schema.table?.row_count ?? 0).toLocaleString()
+                            if (schema.table) {
+                                return schema.table.row_count.toLocaleString()
+                            }
+
+                            // Synced but no rows
+                            if (schema.status === 'Completed') {
+                                return 0
+                            }
+
+                            return ''
                         },
                     },
                     {

--- a/posthog/temporal/data_imports/pipelines/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline.py
@@ -131,13 +131,14 @@ class DataImportPipeline:
                 counts = Counter(filtered_rows)
                 total_counts = counts + total_counts
 
-                async_to_sync(validate_schema_and_update_table)(
-                    run_id=self.inputs.run_id,
-                    team_id=self.inputs.team_id,
-                    schema_id=self.inputs.schema_id,
-                    table_schema=self.source.schema.tables,
-                    row_count=total_counts.total(),
-                )
+                if total_counts.total() != 0:
+                    async_to_sync(validate_schema_and_update_table)(
+                        run_id=self.inputs.run_id,
+                        team_id=self.inputs.team_id,
+                        schema_id=self.inputs.schema_id,
+                        table_schema=self.source.schema.tables,
+                        row_count=total_counts.total(),
+                    )
 
                 pipeline_runs = pipeline_runs + 1
         else:
@@ -165,13 +166,14 @@ class DataImportPipeline:
             counts = Counter(filtered_rows)
             total_counts = total_counts + counts
 
-            async_to_sync(validate_schema_and_update_table)(
-                run_id=self.inputs.run_id,
-                team_id=self.inputs.team_id,
-                schema_id=self.inputs.schema_id,
-                table_schema=self.source.schema.tables,
-                row_count=total_counts.total(),
-            )
+            if total_counts.total() != 0:
+                async_to_sync(validate_schema_and_update_table)(
+                    run_id=self.inputs.run_id,
+                    team_id=self.inputs.team_id,
+                    schema_id=self.inputs.schema_id,
+                    table_schema=self.source.schema.tables,
+                    row_count=total_counts.total(),
+                )
 
         return dict(total_counts)
 


### PR DESCRIPTION
## Problem
- The current implementation with Delta files means we're not writing out empty tables to S3, causing the schema validation step to fail

## Changes
- Dont fail the job when we sync zero rows
- Update the table UI to better reflect the status of the table 
- (note: this will not be an issue once DLT fix stuff on their end)

<img width="1222" alt="image" src="https://github.com/user-attachments/assets/daa3274a-acaf-499d-bea9-3c4b559b584c">


## Does this work well for both Cloud and self-hosted?
Yes
## How did you test this code?
Locally