### PR TITLE
fix(batch-exports): Switch send email function to sync

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -166,13 +166,13 @@ def send_batch_export_run_failure(
     is_email_available_result = is_email_available(with_absolute_urls=True)
     if not is_email_available_result:
         logger.warning("Email service is not available")
-        return
+        return None
 
     batch_export_run: BatchExportRun = BatchExportRun.objects.select_related("batch_export__team").get(
         id=batch_export_run_id
     )
     team: Team = batch_export_run.batch_export.team
-    logger = logger.bind(team_id=team.id, batch_export_id=batch_export_run.batch_export.id)  # type: ignore
+    logger = logger.bind(team_id=team.id, batch_export_id=batch_export_run.batch_export.id)
 
     logger.info("Preparing notification email for batch export run %s", batch_export_run_id)
 
@@ -198,7 +198,7 @@ def send_batch_export_run_failure(
 
     memberships_to_email = []
     memberships = OrganizationMembership.objects.select_related("user", "organization").filter(
-        organization_id=team.organization_id  # type: ignore
+        organization_id=team.organization_id
     )
 
     for membership in memberships:

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import posthoganalytics
 import structlog
-from asgiref.sync import sync_to_async
 from celery import shared_task
 from django.conf import settings
 from django.utils import timezone
@@ -159,22 +158,21 @@ def send_fatal_plugin_error(
         message.send(send_async=False)
 
 
-@shared_task(**EMAIL_TASK_KWARGS)
-async def send_batch_export_run_failure(
+def send_batch_export_run_failure(
     batch_export_run_id: str,
 ) -> None:
-    logger = structlog.get_logger("django")
+    logger = structlog.get_logger(__name__)
 
-    is_email_available_result = await sync_to_async(is_email_available)(with_absolute_urls=True)
+    is_email_available_result = is_email_available(with_absolute_urls=True)
     if not is_email_available_result:
         logger.warning("Email service is not available")
         return
 
-    batch_export_run: BatchExportRun = await sync_to_async(
-        BatchExportRun.objects.select_related("batch_export__team").get
-    )(id=batch_export_run_id)
+    batch_export_run: BatchExportRun = BatchExportRun.objects.select_related("batch_export__team").get(
+        id=batch_export_run_id
+    )
     team: Team = batch_export_run.batch_export.team
-    logger = logger.new(team_id=team.id)
+    logger = logger.bind(team_id=team.id, batch_export_id=batch_export_run.batch_export.id)
 
     logger.info("Preparing notification email for batch export run %s", batch_export_run_id)
 
@@ -185,7 +183,7 @@ async def send_batch_export_run_failure(
         f"batch_export_run_email_batch_export_{batch_export_run.batch_export.id}_last_updated_at_{last_updated_at_date}"
     )
 
-    message = await sync_to_async(EmailMessage)(
+    message = EmailMessage(
         campaign_key=campaign_key,
         subject=f"PostHog: {batch_export_run.batch_export.name} batch export run failure",
         template_name="batch_export_run_failure",
@@ -202,11 +200,9 @@ async def send_batch_export_run_failure(
     memberships = OrganizationMembership.objects.select_related("user", "organization").filter(
         organization_id=team.organization_id
     )
-    all_memberships: list[OrganizationMembership] = await sync_to_async(list)(memberships)  # type: ignore
-    for membership in all_memberships:
-        has_notification_settings_enabled = await sync_to_async(membership.user.notification_settings.get)(
-            "batch_export_run_failure", True
-        )
+
+    for membership in memberships:
+        has_notification_settings_enabled = membership.user.notification_settings.get("batch_export_run_failure", True)
 
         if has_notification_settings_enabled is False:
             logger.warning("User doesn't have batch export notifications enabled")
@@ -226,7 +222,7 @@ async def send_batch_export_run_failure(
 
         for membership in memberships_to_email:
             message.add_recipient(email=membership.user.email, name=membership.user.first_name)
-        await sync_to_async(message.send)(send_async=True)
+        message.send(send_async=False)
     else:
         logger.info("No available recipients for notification email")
 

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -172,7 +172,7 @@ def send_batch_export_run_failure(
         id=batch_export_run_id
     )
     team: Team = batch_export_run.batch_export.team
-    logger = logger.bind(team_id=team.id, batch_export_id=batch_export_run.batch_export.id)
+    logger = logger.bind(team_id=team.id, batch_export_id=batch_export_run.batch_export.id)  # type: ignore
 
     logger.info("Preparing notification email for batch export run %s", batch_export_run_id)
 
@@ -198,7 +198,7 @@ def send_batch_export_run_failure(
 
     memberships_to_email = []
     memberships = OrganizationMembership.objects.select_related("user", "organization").filter(
-        organization_id=team.organization_id
+        organization_id=team.organization_id  # type: ignore
     )
 
     for membership in memberships:

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -1,8 +1,6 @@
 import datetime as dt
 from unittest.mock import MagicMock, patch
 
-import pytest
-from asgiref.sync import sync_to_async
 from freezegun import freeze_time
 
 from posthog.api.authentication import password_reset_token_generator
@@ -159,7 +157,7 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
         batch_export_destination = BatchExportDestination.objects.create(
             type=BatchExportDestination.Destination.S3, config={"bucket_name": "my_production_s3_bucket"}
         )
-        batch_export = BatchExport.objects.create(
+        batch_export = BatchExport.objects.create(  # type: ignore
             team=user.team, name="A batch export", destination=batch_export_destination
         )
         now = dt.datetime.now()
@@ -176,35 +174,34 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
         assert mocked_email_messages[0].send.call_count == 1
         assert mocked_email_messages[0].html_body
 
-    @pytest.mark.asyncio
-    async def test_send_batch_export_run_failure_with_settings(self, MockEmailMessage: MagicMock) -> None:
+    def test_send_batch_export_run_failure_with_settings(self, MockEmailMessage: MagicMock) -> None:
         mocked_email_messages = mock_email_messages(MockEmailMessage)
-        batch_export_destination = await sync_to_async(BatchExportDestination.objects.create)(
+        batch_export_destination = BatchExportDestination.objects.create(
             type=BatchExportDestination.Destination.S3, config={"bucket_name": "my_production_s3_bucket"}
         )
-        batch_export = await sync_to_async(BatchExport.objects.create)(
+        batch_export = BatchExport.objects.create(  # type: ignore
             team=self.user.team, name="A batch export", destination=batch_export_destination
         )
         now = dt.datetime.now()
-        batch_export_run = await sync_to_async(BatchExportRun.objects.create)(
+        batch_export_run = BatchExportRun.objects.create(
             batch_export=batch_export,
             status=BatchExportRun.Status.FAILED,
             data_interval_start=now - dt.timedelta(hours=1),
             data_interval_end=now,
         )
 
-        await sync_to_async(self._create_user)("test2@posthog.com")
+        self._create_user("test2@posthog.com")
         self.user.partial_notification_settings = {"batch_export_run_failure": False}
-        await sync_to_async(self.user.save)()
+        self.user.save()
 
-        await send_batch_export_run_failure(batch_export_run.id)
+        send_batch_export_run_failure(batch_export_run.id)
         # Should only be sent to user2
         assert mocked_email_messages[0].to == [{"recipient": "test2@posthog.com", "raw_email": "test2@posthog.com"}]
 
         self.user.partial_notification_settings = {"batch_export_run_failure": True}
-        await sync_to_async(self.user.save)()
+        self.user.save()
 
-        await send_batch_export_run_failure(batch_export_run.id)
+        send_batch_export_run_failure(batch_export_run.id)
         # should be sent to both
         assert len(mocked_email_messages[1].to) == 2
 

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -439,7 +439,8 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
         from posthog.tasks.email import send_batch_export_run_failure
 
         try:
-            await send_batch_export_run_failure(inputs.id)
+            logger.info("Sending failure notification email for run %s", inputs.id)
+            await database_sync_to_async(send_batch_export_run_failure)(inputs.id)
         except Exception:
             logger.exception("Failure email notification could not be sent")
 


### PR DESCRIPTION
## Problem

Still not sure why the task in charge of sending failure emails is not working in EU. Since we are the only ones doing an async thing, let's switch to sync code in case that has anything to do. We'll wrap the function in `database_sync_to_async` as it has proven useful to ensure safe database access from an async temporal activity.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Updated tests to do sync calls.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
