### PR TITLE
chore(data-warehouse): Auto reload jobs

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
@@ -21,6 +21,7 @@ export const Syncs = (): JSX.Element => {
         <LemonTable
             dataSource={jobs}
             loading={jobsLoading}
+            disableTableWhileLoading={false}
             columns={[
                 {
                     title: 'Schema',

--- a/frontend/src/scenes/data-warehouse/settings/source/dataWarehouseSourceSettingsLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/source/dataWarehouseSourceSettingsLogic.ts
@@ -118,17 +118,31 @@ export const dataWarehouseSourceSettingsLogic = kea<dataWarehouseSourceSettingsL
     }),
     listeners(({ values, actions, cache }) => ({
         loadSourceSuccess: () => {
-            clearTimeout(cache.refreshTimeout)
+            clearTimeout(cache.sourceRefreshTimeout)
 
-            cache.refreshTimeout = setTimeout(() => {
+            cache.sourceRefreshTimeout = setTimeout(() => {
                 actions.loadSource()
             }, REFRESH_INTERVAL)
         },
         loadSourceFailure: () => {
-            clearTimeout(cache.refreshTimeout)
+            clearTimeout(cache.sourceRefreshTimeout)
 
-            cache.refreshTimeout = setTimeout(() => {
+            cache.sourceRefreshTimeout = setTimeout(() => {
                 actions.loadSource()
+            }, REFRESH_INTERVAL)
+        },
+        loadJobsSuccess: () => {
+            clearTimeout(cache.jobsRefreshTimeout)
+
+            cache.jobsRefreshTimeout = setTimeout(() => {
+                actions.loadJobs()
+            }, REFRESH_INTERVAL)
+        },
+        loadJobsFailure: () => {
+            clearTimeout(cache.jobsRefreshTimeout)
+
+            cache.jobsRefreshTimeout = setTimeout(() => {
+                actions.loadJobs()
             }, REFRESH_INTERVAL)
         },
         reloadSchema: async ({ schema }) => {


### PR DESCRIPTION
## Problem
- The syncs tab of data warehouse settings doesn't auto reload, and so new syncs don't load in here until you refresh the page

## Changes
- Auto reload the tabs data
