### PR TITLE
fix(hog): autocomplete should just take globals

### DIFF
--- a/posthog/hogql/autocomplete.py
+++ b/posthog/hogql/autocomplete.py
@@ -385,7 +385,7 @@ def get_hogql_autocomplete(
             query_to_try = query.query[: query.endPosition] + extra_characters + query.query[query.endPosition :]
             query_start = query.startPosition
             query_end = query.endPosition + length_to_add
-            select_ast: Optional[ast.SelectQuery] = None
+            select_ast: Optional[ast.AST] = None
 
             if query.language == HogLanguage.HOG_QL:
                 with timings.measure("parse_select"):
@@ -466,7 +466,9 @@ def get_hogql_autocomplete(
 
             if query.filters:
                 try:
-                    select_ast = cast(ast.SelectQuery, replace_filters(select_ast, query.filters, team))
+                    select_ast = cast(
+                        ast.SelectQuery, replace_filters(cast(ast.SelectQuery, select_ast), query.filters, team)
+                    )
                 except Exception:
                     pass
 

--- a/posthog/hogql/autocomplete.py
+++ b/posthog/hogql/autocomplete.py
@@ -385,7 +385,7 @@ def get_hogql_autocomplete(
             query_to_try = query.query[: query.endPosition] + extra_characters + query.query[query.endPosition :]
             query_start = query.startPosition
             query_end = query.endPosition + length_to_add
-            node_ast: ast.AST
+            select_ast: Optional[ast.SelectQuery] = None
 
             if query.language == HogLanguage.HOG_QL:
                 with timings.measure("parse_select"):
@@ -393,29 +393,20 @@ def get_hogql_autocomplete(
                     root_node: ast.AST = select_ast
             elif query.language == HogLanguage.HOG_QL_EXPR:
                 with timings.measure("parse_expr"):
-                    node_ast = parse_expr(query_to_try, timings=timings)
+                    root_node = parse_expr(query_to_try, timings=timings)
                     select_ast = cast(ast.SelectQuery, clone_expr(source_query, clear_locations=True))
-                    select_ast.select = [node_ast]
-                    root_node = node_ast
+                    select_ast.select = [root_node]
             elif query.language == HogLanguage.HOG_TEMPLATE:
                 with timings.measure("parse_template"):
-                    node_ast = parse_string_template(query_to_try, timings=timings)
-                    select_ast = cast(ast.SelectQuery, clone_expr(source_query, clear_locations=True))
-                    select_ast.select = [node_ast]
-                    root_node = node_ast
+                    root_node = parse_string_template(query_to_try, timings=timings)
             elif query.language == HogLanguage.HOG:
                 with timings.measure("parse_program"):
-                    node_ast = parse_program(query_to_try, timings=timings)
-                    select_ast = cast(ast.SelectQuery, clone_expr(source_query, clear_locations=True))
-                    root_node = node_ast
+                    root_node = parse_program(query_to_try, timings=timings)
             elif query.language == HogLanguage.HOG_JSON:
                 query_to_try, query_start, query_end = extract_json_row(query_to_try, query_start, query_end)
                 if query_to_try == "":
                     break
-                node_ast = parse_string_template(query_to_try, timings=timings)
-                select_ast = cast(ast.SelectQuery, clone_expr(source_query, clear_locations=True))
-                select_ast.select = [node_ast]
-                root_node = node_ast
+                root_node = parse_string_template(query_to_try, timings=timings)
             else:
                 raise ValueError(f"Unsupported autocomplete language: {query.language}")
 
@@ -470,8 +461,7 @@ def get_hogql_autocomplete(
                 filtered_globals = {key: value for key, value in query.globals.items() if key not in existing_values}
                 add_globals_to_suggestions(filtered_globals, response)
 
-            if query.language in (HogLanguage.HOG, HogLanguage.HOG_TEMPLATE) and query.sourceQuery is None:
-                # For Hog, break after the remaining globals are added
+            if select_ast is None:
                 break
 
             if query.filters:

--- a/posthog/hogql/test/test_autocomplete.py
+++ b/posthog/hogql/test/test_autocomplete.py
@@ -50,7 +50,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
             kind="HogQLAutocomplete",
             query=query,
             language=HogLanguage.HOG_TEMPLATE,
-            sourceQuery=HogQLQuery(query="select * from events"),
+            globals={"event": "$pageview"},
             startPosition=start,
             endPosition=end,
         )
@@ -61,7 +61,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
             kind="HogQLAutocomplete",
             query=query,
             language=HogLanguage.HOG_JSON,
-            sourceQuery=HogQLQuery(query="select * from events"),
+            globals={"event": "$pageview"},
             startPosition=start,
             endPosition=end,
         )
@@ -345,7 +345,7 @@ class TestAutocomplete(ClickhouseTestMixin, APIBaseTest):
         database = create_hogql_database(team_id=self.team.pk, team_arg=self.team)
 
         query = '{ "key": "val_{event.distinct_id}_ue" }'
-        results = self._json(query=query, start=18, end=20, database=database)
+        results = self._json(query=query, start=15, end=20, database=database)
 
         suggestions = list(filter(lambda x: x.label == "event", results.suggestions))
         assert len(suggestions) == 1


### PR DESCRIPTION
## Problem

We are resolving template strings as if they're on the `select * from events` scope, causing Hog invocation fields to error:

![image](https://github.com/user-attachments/assets/589abb03-030a-439b-b23e-5af78a3f3e0f)

## Changes

Only use `globals` for template strings and JSON

## How did you test this code?

Updated tests, tried in the browser