### PR TITLE
feat: Added debugging to webhook template

### DIFF
--- a/posthog/cdp/templates/webhook/template_webhook.py
+++ b/posthog/cdp/templates/webhook/template_webhook.py
@@ -8,11 +8,16 @@ template: HogFunctionTemplate = HogFunctionTemplate(
     description="Sends a webhook templated by the incoming event data",
     icon_url="/static/posthog-icon.svg?temp=true",
     hog="""
-fetch(inputs.url, {
+let res := fetch(inputs.url, {
   'headers': inputs.headers,
   'body': inputs.body,
   'method': inputs.method
 });
+
+if (inputs.debug) {
+  print('Response', res.status, res.body);
+}
+
 """.strip(),
     inputs_schema=[
         {
@@ -66,6 +71,15 @@ fetch(inputs.url, {
             "label": "Headers",
             "secret": False,
             "required": False,
+        },
+        {
+            "key": "debug",
+            "type": "boolean",
+            "label": "Log responses",
+            "description": "Logs the response of http calls for debugging.",
+            "secret": False,
+            "required": False,
+            "default": False,
         },
     ],
 )

--- a/posthog/cdp/templates/webhook/test_template_webhook.py
+++ b/posthog/cdp/templates/webhook/test_template_webhook.py
@@ -7,7 +7,7 @@ class TestTemplateWebhook(BaseHogFunctionTemplateTest):
     template = template_webhook
 
     def test_function_works(self):
-        res = self.run_function(
+        self.run_function(
             inputs={
                 "url": "https://posthog.com",
                 "method": "GET",

--- a/posthog/cdp/templates/webhook/test_template_webhook.py
+++ b/posthog/cdp/templates/webhook/test_template_webhook.py
@@ -1,3 +1,4 @@
+from inline_snapshot import snapshot
 from posthog.cdp.templates.helpers import BaseHogFunctionTemplateTest
 from posthog.cdp.templates.webhook.template_webhook import template as template_webhook
 
@@ -12,16 +13,27 @@ class TestTemplateWebhook(BaseHogFunctionTemplateTest):
                 "method": "GET",
                 "headers": {},
                 "body": {"hello": "world"},
+                "debug": False,
             }
         )
 
-        assert res.result is None
+        assert self.get_mock_fetch_calls()[0] == snapshot(
+            ("https://posthog.com", {"headers": {}, "body": {"hello": "world"}, "method": "GET"})
+        )
+        assert self.get_mock_print_calls() == snapshot([])
 
-        assert self.get_mock_fetch_calls()[0] == (
-            "https://posthog.com",
-            {
+    def test_prints_when_debugging(self):
+        self.run_function(
+            inputs={
+                "url": "https://posthog.com",
+                "method": "GET",
                 "headers": {},
                 "body": {"hello": "world"},
-                "method": "GET",
-            },
+                "debug": True,
+            }
         )
+
+        assert self.get_mock_fetch_calls()[0] == snapshot(
+            ("https://posthog.com", {"headers": {}, "body": {"hello": "world"}, "method": "GET"})
+        )
+        assert self.get_mock_print_calls() == snapshot([("Response", 200, {})])


### PR DESCRIPTION
## Problem

You probably don't want to log responses. But when you do, you really do.

## Changes

* Adds an option to log responses to the webhook template 

Question - should we have this as an abstract concept for all templates?

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
