### PR TITLE
fix: only log blocking session for relevant partition

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -776,7 +776,7 @@ export class SessionRecordingIngester {
                  * OR the latest offset we have consumed for that partition
                  */
                 const partition = parseInt(p)
-                blockingSessions = blockingSessions.filter((s) => s.partition === partition)
+                const partitionBlockingSessions = blockingSessions.filter((s) => s.partition === partition)
 
                 const tp = {
                     topic: this.topic,
@@ -785,13 +785,13 @@ export class SessionRecordingIngester {
 
                 status.info('🔁', `blob_ingester_consumer - committing offset for partition`, {
                     ...tp,
-                    blockingSessions,
+                    partitionBlockingSessions,
                 })
 
                 let potentiallyBlockingSession: SessionManager | undefined
 
                 let activeSessionsOnThisPartition = 0
-                for (const sessionManager of blockingSessions) {
+                for (const sessionManager of partitionBlockingSessions) {
                     const lowestOffset = sessionManager.getLowestOffset()
                     activeSessionsOnThisPartition++
                     if (

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -776,6 +776,7 @@ export class SessionRecordingIngester {
                  * OR the latest offset we have consumed for that partition
                  */
                 const partition = parseInt(p)
+                blockingSessions = blockingSessions.filter((s) => s.partition === partition)
 
                 const tp = {
                     topic: this.topic,
@@ -791,15 +792,13 @@ export class SessionRecordingIngester {
 
                 let activeSessionsOnThisPartition = 0
                 for (const sessionManager of blockingSessions) {
-                    if (sessionManager.partition === partition) {
-                        const lowestOffset = sessionManager.getLowestOffset()
-                        activeSessionsOnThisPartition++
-                        if (
-                            lowestOffset !== null &&
-                            lowestOffset < (potentiallyBlockingSession?.getLowestOffset() || Infinity)
-                        ) {
-                            potentiallyBlockingSession = sessionManager
-                        }
+                    const lowestOffset = sessionManager.getLowestOffset()
+                    activeSessionsOnThisPartition++
+                    if (
+                        lowestOffset !== null &&
+                        lowestOffset < (potentiallyBlockingSession?.getLowestOffset() || Infinity)
+                    ) {
+                        potentiallyBlockingSession = sessionManager
                     }
                 }
 


### PR DESCRIPTION
## Problem
 
blobby logs are extremely noisy, and in this case we're logging all blocking sessions instead of filtering to the partition first. Refactor a bit to cut this noise down
## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
