### PR TITLE
fix: escape . in regex

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/index.test.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/index.test.ts
@@ -18,12 +18,13 @@ describe('CorsPlugin', () => {
         }
     )
 
-    it.each(['https://app.posthog.com/my-image.jpeg'])(
-        'should not replace non-font urls in links',
-        (content: string) => {
-            expect(CorsPlugin._replaceFontUrl(content)).toEqual(content)
-        }
-    )
+    it.each([
+        'https://app.posthog.com/my-image.jpeg',
+        // ttf substring was matching in a previous version
+        'https://app-static.eu.posthog.com/static/index-EBVVDttf.css',
+    ])('should not replace non-font urls in links', (content: string) => {
+        expect(CorsPlugin._replaceFontUrl(content)).toEqual(content)
+    })
 
     it('can replace a modulepreload js link', () => {
         const el = document.createElement('link')

--- a/frontend/src/scenes/session-recordings/player/rrweb/index.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/index.ts
@@ -13,18 +13,18 @@ export const CorsPlugin: ReplayPlugin & {
     _replaceFontCssUrls: (value: string | null): string | null => {
         return (
             value?.replace(
-                /url\("(https:\/\/\S*(?:.eot|.woff2|.ttf|.woff)\S*)"\)/gi,
+                /url\("(https:\/\/\S*(?:\.eot|\.woff2|\.ttf|\.woff)\S*)"\)/gi,
                 `url("${PROXY_URL}/proxy?url=$1")`
             ) || null
         )
     },
 
     _replaceFontUrl: (value: string): string => {
-        return value.replace(/^(https:\/\/\S*(?:.eot|.woff2|.ttf|.woff)\S*)$/i, `${PROXY_URL}/proxy?url=$1`)
+        return value.replace(/^(https:\/\/\S*(?:\.eot|\.woff2|\.ttf|\.woff)\S*)$/i, `${PROXY_URL}/proxy?url=$1`)
     },
 
     _replaceJSUrl: (value: string): string => {
-        return value.replace(/^(https:\/\/\S*(?:.js)\S*)$/i, `${PROXY_URL}/proxy?url=$1`)
+        return value.replace(/^(https:\/\/\S*(?:\.js)\S*)$/i, `${PROXY_URL}/proxy?url=$1`)
     },
 
     onBuild: (node) => {


### PR DESCRIPTION
## Problem

`https://app-static.eu.posthog.com/static/index-EBVVDttf.css` was incorrectly being proxied.

The `ttf` substring was being interpreted as a font file

## Changes

Update the regex to look for `.` character, not `.` in regex which means any character
