### PR TITLE
fix(batchexports): Optimize person batch exports query for memory usage

### DIFF
--- a/posthog/clickhouse/migrations/0073_update_person_batch_exports_query_for_memory.py
+++ b/posthog/clickhouse/migrations/0073_update_person_batch_exports_query_for_memory.py
@@ -1,0 +1,11 @@
+from posthog.batch_exports.sql import (
+    CREATE_PERSONS_BATCH_EXPORT_VIEW,
+)
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+operations = map(
+    run_sql_with_exceptions,
+    [
+        CREATE_PERSONS_BATCH_EXPORT_VIEW,
+    ],
+)

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -48,6 +48,9 @@ FROM
         interval_end={interval_end}
     ) AS persons
 FORMAT ArrowStream
+-- This is half of configured MAX_MEMORY_USAGE for batch exports.
+-- TODO: Make the setting available to all queries.
+SETTINGS max_bytes_before_external_group_by=50000000000
 """
 
 SELECT_FROM_EVENTS_VIEW = Template("""

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -437,6 +437,7 @@ async def get_client(
                 database=settings.CLICKHOUSE_DATABASE,
                 max_execution_time=settings.CLICKHOUSE_MAX_EXECUTION_TIME,
                 max_memory_usage=settings.CLICKHOUSE_MAX_MEMORY_USAGE,
+                max_bytes_before_external_group_by=settings.CLICKHOUSE_MAX_MEMORY_USAGE // 2,
                 max_block_size=max_block_size,
                 output_format_arrow_string_as_string="true",
                 **kwargs,

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -437,7 +437,6 @@ async def get_client(
                 database=settings.CLICKHOUSE_DATABASE,
                 max_execution_time=settings.CLICKHOUSE_MAX_EXECUTION_TIME,
                 max_memory_usage=settings.CLICKHOUSE_MAX_MEMORY_USAGE,
-                max_bytes_before_external_group_by=settings.CLICKHOUSE_MAX_MEMORY_USAGE // 2,
                 max_block_size=max_block_size,
                 output_format_arrow_string_as_string="true",
                 **kwargs,


### PR DESCRIPTION
## Problem

Some teams can have _very large_ properties, which makes the persons batch exports query run out of memory. 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

The solution has multiple parts:
* Move person table (the one that has the chonky `properties` column) to the left side of the join. As the bigger table, having this on the right was probably blocking clickhouse from using a good join algorithm
* Use `PREWHERE` to filter join tables. I can't believe clickhouse is actually reading properties when filtering by a different column, but I don't run out of memory when reading if I use `PREWHERE`, so...
* Use `max_bytes_before_external_group_by` set to half of `max_memory_usage`. This will make clickhouse spill partial results to disk, thus reducing memory usage during the aggregation (this happens after the select that `PREWHERE` helps us with). Half is a recommendation from clickhouse, the higher we go the worse performance, but less memory usage. We can play around with this parameter later if needed.

Ultimately, this will cause batch exports queries that use up large amounts of memory run slower, but given the nature of batch exports, we should be able to tolerate the performance hit.

Finally, it's important to note that we enforce a 100GB (~93GiB) memory limit on all batch export queries. This limit is left **untouched** by this PR, and it's **very likely** that queries will now use less memory as they will be spilling partial results to disk instead. This should result in overall better performance for all due to ClickHouse evicting less pages from cache.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Manually ran query. It goes fast.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
