### PR TITLE
feat: Plugin creation and update based on org plugin_access_level not ownership

### DIFF
--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -111,6 +111,12 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):
         """
         raise NotImplementedError()
 
+    def get_base_permission_classes(self):
+        if isinstance(self.request.successful_authenticator, SharingAccessTokenAuthentication):
+            return [SharingTokenPermission()]
+
+        return [IsAuthenticated, APIScopePermission]
+
     # We want to try and ensure that the base permission and authentication are always used
     # so we offer a way to add additional classes
     def get_permissions(self):
@@ -119,12 +125,9 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):
         except NotImplementedError:
             pass
 
-        if isinstance(self.request.successful_authenticator, SharingAccessTokenAuthentication):
-            return [SharingTokenPermission()]
-
         # NOTE: We define these here to make it hard _not_ to use them. If you want to override them, you have to
         # override the entire method.
-        permission_classes: list = [IsAuthenticated, APIScopePermission]
+        permission_classes = self.get_base_permission_classes()
 
         if self.is_team_view:
             permission_classes.append(TeamMemberAccessPermission)

--- a/posthog/api/test/__snapshots__/test_plugin.ambr
+++ b/posthog/api/test/__snapshots__/test_plugin.ambr
@@ -58,6 +58,15 @@
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.10
   '''
+  SELECT 1 AS "a"
+  FROM "posthog_organizationmembership"
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
+  LIMIT 1
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.11
+  '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
@@ -81,21 +90,38 @@
   LIMIT 21
   '''
 # ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.11
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.12
+  '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.13
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_plugin"
-  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         OR "posthog_plugin"."is_global"
-         OR "posthog_plugin"."id" IN
-           (SELECT U0."plugin_id"
-            FROM "posthog_pluginconfig" U0
-            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (NOT U0."deleted"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
   '''
 # ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.12
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.14
   '''
   SELECT "posthog_plugin"."id",
          "posthog_plugin"."organization_id",
@@ -121,39 +147,12 @@
          "posthog_plugin"."source",
          "posthog_plugin"."created_at",
          "posthog_plugin"."updated_at",
-         "posthog_plugin"."log_level",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
+         "posthog_plugin"."log_level"
   FROM "posthog_plugin"
-  INNER JOIN "posthog_organization" ON ("posthog_plugin"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         OR "posthog_plugin"."is_global"
-         OR "posthog_plugin"."id" IN
-           (SELECT U0."plugin_id"
-            FROM "posthog_pluginconfig" U0
-            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (NOT U0."deleted"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
   LIMIT 100
   '''
 # ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.13
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.15
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -185,63 +184,29 @@
   LIMIT 21
   '''
 # ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.14
-  '''
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.15
-  '''
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21
-  '''
-# ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.16
   '''
-  SELECT 1 AS "a"
-  FROM "posthog_organizationmembership"
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 1
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
   '''
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.17
@@ -271,46 +236,16 @@
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.18
   '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_plugin"
-  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         OR "posthog_plugin"."is_global"
-         OR "posthog_plugin"."id" IN
-           (SELECT U0."plugin_id"
-            FROM "posthog_pluginconfig" U0
-            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (NOT U0."deleted"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
+  SELECT 1 AS "a"
+  FROM "posthog_organizationmembership"
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
+  LIMIT 1
   '''
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.19
   '''
-  SELECT "posthog_plugin"."id",
-         "posthog_plugin"."organization_id",
-         "posthog_plugin"."plugin_type",
-         "posthog_plugin"."is_global",
-         "posthog_plugin"."is_preinstalled",
-         "posthog_plugin"."is_stateless",
-         "posthog_plugin"."name",
-         "posthog_plugin"."description",
-         "posthog_plugin"."url",
-         "posthog_plugin"."icon",
-         "posthog_plugin"."config_schema",
-         "posthog_plugin"."tag",
-         "posthog_plugin"."archive",
-         "posthog_plugin"."latest_tag",
-         "posthog_plugin"."latest_tag_checked_at",
-         "posthog_plugin"."capabilities",
-         "posthog_plugin"."metrics",
-         "posthog_plugin"."public_jobs",
-         "posthog_plugin"."error",
-         "posthog_plugin"."from_json",
-         "posthog_plugin"."from_web",
-         "posthog_plugin"."source",
-         "posthog_plugin"."created_at",
-         "posthog_plugin"."updated_at",
-         "posthog_plugin"."log_level",
-         "posthog_organization"."id",
+  SELECT "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
          "posthog_organization"."created_at",
@@ -328,17 +263,9 @@
          "posthog_organization"."setup_section_2_completed",
          "posthog_organization"."personalization",
          "posthog_organization"."domain_whitelist"
-  FROM "posthog_plugin"
-  INNER JOIN "posthog_organization" ON ("posthog_plugin"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         OR "posthog_plugin"."is_global"
-         OR "posthog_plugin"."id" IN
-           (SELECT U0."plugin_id"
-            FROM "posthog_pluginconfig" U0
-            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (NOT U0."deleted"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
-  LIMIT 100
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
   '''
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.2
@@ -368,6 +295,68 @@
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.20
   '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.21
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_plugin"
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.22
+  '''
+  SELECT "posthog_plugin"."id",
+         "posthog_plugin"."organization_id",
+         "posthog_plugin"."plugin_type",
+         "posthog_plugin"."is_global",
+         "posthog_plugin"."is_preinstalled",
+         "posthog_plugin"."is_stateless",
+         "posthog_plugin"."name",
+         "posthog_plugin"."description",
+         "posthog_plugin"."url",
+         "posthog_plugin"."icon",
+         "posthog_plugin"."config_schema",
+         "posthog_plugin"."tag",
+         "posthog_plugin"."archive",
+         "posthog_plugin"."latest_tag",
+         "posthog_plugin"."latest_tag_checked_at",
+         "posthog_plugin"."capabilities",
+         "posthog_plugin"."metrics",
+         "posthog_plugin"."public_jobs",
+         "posthog_plugin"."error",
+         "posthog_plugin"."from_json",
+         "posthog_plugin"."from_web",
+         "posthog_plugin"."source",
+         "posthog_plugin"."created_at",
+         "posthog_plugin"."updated_at",
+         "posthog_plugin"."log_level"
+  FROM "posthog_plugin"
+  LIMIT 100
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.23
+  '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
          "posthog_user"."last_login",
@@ -396,65 +385,6 @@
   FROM "posthog_user"
   WHERE "posthog_user"."id" = 2
   LIMIT 21
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.21
-  '''
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.22
-  '''
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
-  LIMIT 21
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.23
-  '''
-  SELECT 1 AS "a"
-  FROM "posthog_organizationmembership"
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 1
   '''
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.24
@@ -484,19 +414,104 @@
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.25
   '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_plugin"
-  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         OR "posthog_plugin"."is_global"
-         OR "posthog_plugin"."id" IN
-           (SELECT U0."plugin_id"
-            FROM "posthog_pluginconfig" U0
-            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (NOT U0."deleted"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
   '''
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.26
+  '''
+  SELECT 1 AS "a"
+  FROM "posthog_organizationmembership"
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
+  LIMIT 1
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.27
+  '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.28
+  '''
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.29
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_plugin"
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.3
+  '''
+  SELECT 1 AS "a"
+  FROM "posthog_organizationmembership"
+  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+         AND "posthog_organizationmembership"."user_id" = 2)
+  LIMIT 1
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.30
   '''
   SELECT "posthog_plugin"."id",
          "posthog_plugin"."organization_id",
@@ -522,45 +537,9 @@
          "posthog_plugin"."source",
          "posthog_plugin"."created_at",
          "posthog_plugin"."updated_at",
-         "posthog_plugin"."log_level",
-         "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
+         "posthog_plugin"."log_level"
   FROM "posthog_plugin"
-  INNER JOIN "posthog_organization" ON ("posthog_plugin"."organization_id" = "posthog_organization"."id")
-  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         OR "posthog_plugin"."is_global"
-         OR "posthog_plugin"."id" IN
-           (SELECT U0."plugin_id"
-            FROM "posthog_pluginconfig" U0
-            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (NOT U0."deleted"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
   LIMIT 100
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.3
-  '''
-  SELECT 1 AS "a"
-  FROM "posthog_organizationmembership"
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 1
   '''
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.4
@@ -590,19 +569,36 @@
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.5
   '''
-  SELECT COUNT(*) AS "__count"
-  FROM "posthog_plugin"
-  WHERE ("posthog_plugin"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         OR "posthog_plugin"."is_global"
-         OR "posthog_plugin"."id" IN
-           (SELECT U0."plugin_id"
-            FROM "posthog_pluginconfig" U0
-            INNER JOIN "posthog_team" U1 ON (U0."team_id" = U1."id")
-            WHERE (NOT U0."deleted"
-                   AND U1."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)))
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
   '''
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.6
+  '''
+  SELECT COUNT(*) AS "__count"
+  FROM "posthog_plugin"
+  '''
+# ---
+# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.7
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -631,31 +627,6 @@
          "posthog_user"."email_opt_in"
   FROM "posthog_user"
   WHERE "posthog_user"."id" = 2
-  LIMIT 21
-  '''
-# ---
-# name: TestPluginAPI.test_listing_plugins_is_not_nplus1.7
-  '''
-  SELECT "posthog_organization"."id",
-         "posthog_organization"."name",
-         "posthog_organization"."slug",
-         "posthog_organization"."created_at",
-         "posthog_organization"."updated_at",
-         "posthog_organization"."plugins_access_level",
-         "posthog_organization"."for_internal_metrics",
-         "posthog_organization"."is_member_join_email_enabled",
-         "posthog_organization"."enforce_2fa",
-         "posthog_organization"."is_hipaa",
-         "posthog_organization"."customer_id",
-         "posthog_organization"."available_product_features",
-         "posthog_organization"."usage",
-         "posthog_organization"."never_drop_data",
-         "posthog_organization"."customer_trust_scores",
-         "posthog_organization"."setup_section_2_completed",
-         "posthog_organization"."personalization",
-         "posthog_organization"."domain_whitelist"
-  FROM "posthog_organization"
-  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
   LIMIT 21
   '''
 # ---
@@ -686,10 +657,26 @@
 # ---
 # name: TestPluginAPI.test_listing_plugins_is_not_nplus1.9
   '''
-  SELECT 1 AS "a"
-  FROM "posthog_organizationmembership"
-  WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
-         AND "posthog_organizationmembership"."user_id" = 2)
-  LIMIT 1
+  SELECT "posthog_organization"."id",
+         "posthog_organization"."name",
+         "posthog_organization"."slug",
+         "posthog_organization"."created_at",
+         "posthog_organization"."updated_at",
+         "posthog_organization"."plugins_access_level",
+         "posthog_organization"."for_internal_metrics",
+         "posthog_organization"."is_member_join_email_enabled",
+         "posthog_organization"."enforce_2fa",
+         "posthog_organization"."is_hipaa",
+         "posthog_organization"."customer_id",
+         "posthog_organization"."available_product_features",
+         "posthog_organization"."usage",
+         "posthog_organization"."never_drop_data",
+         "posthog_organization"."customer_trust_scores",
+         "posthog_organization"."setup_section_2_completed",
+         "posthog_organization"."personalization",
+         "posthog_organization"."domain_whitelist"
+  FROM "posthog_organization"
+  WHERE "posthog_organization"."id" = '00000000-0000-0000-0000-000000000000'::uuid
+  LIMIT 21
   '''
 # ---

--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -38,15 +38,11 @@ except ImportError:
     pass
 
 
-def raise_if_plugin_installed(url: str, organization_id: str):
+def raise_if_plugin_installed(url: str):
     url_without_private_key = url.split("?")[0]
-    if (
-        Plugin.objects.filter(
-            models.Q(url=url_without_private_key) | models.Q(url__startswith=f"{url_without_private_key}?")
-        )
-        .filter(organization_id=organization_id)
-        .exists()
-    ):
+    if Plugin.objects.filter(
+        models.Q(url=url_without_private_key) | models.Q(url__startswith=f"{url_without_private_key}?")
+    ).exists():
         raise ValidationError(f'Plugin from URL "{url_without_private_key}" already installed!')
 
 
@@ -125,7 +121,7 @@ class PluginManager(models.Manager):
         plugin_json: Optional[dict[str, Any]] = None
         if kwargs.get("plugin_type", None) != Plugin.PluginType.SOURCE:
             plugin_json = update_validated_data_from_url(kwargs, kwargs["url"])
-            raise_if_plugin_installed(kwargs["url"], kwargs["organization_id"])
+            raise_if_plugin_installed(kwargs["url"])
         plugin = Plugin.objects.create(**kwargs)
         if plugin_json:
             PluginSourceFile.objects.sync_from_plugin_archive(plugin, plugin_json)


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Inline plugins will not have organization, in any case we haven't been using organization ownership for a long time, but rather organization's plugin_access_level, so removing anything tied to organization ownership and switching it over to plugin access level to be root.

Also removed jobs api which has been deprecated for a long time, there's no UI button to trigger them for the past 6 months.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
