### PR TITLE
chore: re-order support links

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -434,9 +434,9 @@ export const supportLogic = kea<supportLogicType>([
                             `\n\n-----` +
                             `\nKind: ${kind}` +
                             `\nTarget area: ${target_area}` +
-                            getCurrentLocationLink() +
-                            getSessionReplayLink() +
                             `\nReport event: http://go/ticketByUUID/${zendesk_ticket_uuid}` +
+                            getSessionReplayLink() +
+                            getCurrentLocationLink() +
                             getDjangoAdminLink(
                                 userLogic.values.user,
                                 cloudRegion,


### PR DESCRIPTION
## Problem

[this PR](https://github.com/PostHog/posthog/pull/23737) changed the order of support links, which feels very weird.

ticket before the PR: https://posthoghelp.zendesk.com/agent/tickets/15667 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/18258)
ticket after the PR: https://posthoghelp.zendesk.com/agent/tickets/15955 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/18432)

## Changes

change the order to be:
1. kind
2. target_area
3. report event
4. replay
5. location
6. admin ui
7. Sentry
8. PoE