### PR TITLE
feat(hogql): Allow union all in views

### DIFF
--- a/posthog/hogql/metadata.py
+++ b/posthog/hogql/metadata.py
@@ -113,10 +113,14 @@ def process_expr_on_table(
 
 
 def is_valid_view(select_query: ast.SelectQuery | ast.SelectUnionQuery) -> bool:
-    if not isinstance(select_query, ast.SelectQuery):
-        return False
-    for field in select_query.select:
-        if not isinstance(field, ast.Alias):
-            return False
+    if isinstance(select_query, ast.SelectQuery):
+        for field in select_query.select:
+            if not isinstance(field, ast.Alias):
+                return False
+    elif isinstance(select_query, ast.SelectUnionQuery):
+        for select in select_query.select_queries:
+            for field in select.select:
+                if not isinstance(field, ast.Alias):
+                    return False
 
     return True


### PR DESCRIPTION
## Problem
- We dont allow a `UNION ALL` in a view

## Changes
- Allow a `UNION ALL` within views
- We disallowed this from https://github.com/PostHog/posthog/pull/17518 - @mariusandra do you know of any reason why I can't allow this? Testing this locally works, but I can't get any context from the original PR as to why we didn't allow this in the first place

## Does this work well for both Cloud and self-hosted?
I imagine so

## How did you test this code?
In me browser