### PR TITLE
Superday - Update SidePanelSupport.tsx

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -4,6 +4,7 @@ import {
     IconDatabase,
     IconDecisionTree,
     IconFeatures,
+    IconBug,
     IconFlask,
     IconHelmet,
     IconMap,
@@ -288,6 +289,19 @@ export const SidePanelSupport = (): JSX.Element => {
                                             targetBlank
                                         >
                                             Request a feature
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to={`https://github.com/PostHog/posthog/issues/new?labels=bug&template=bug_report.yml&debug-info=${encodeURIComponent(
+                                                getPublicSupportSnippet(region, currentOrganization, currentTeam)
+                                            )}`}
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                 </ul>


### PR DESCRIPTION
IconBug needs to be defined so it can be actually imported

## Problem

We are adding a "Report a bug" button in the support menu which contains a link to report a bug as part of the SuperDay activities.

## Changes

Added the "Report a bug" button to the side support panel.
![Screenshot 2024-07-19 at 15 34 26](https://github.com/user-attachments/assets/901a2e9b-f5bb-406f-8b6d-9157d102d46f)

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

I tested in my local environment successfully (no errors).
