### PR TITLE
fix(admin): Allow empty `DashboardTile.text` or `.insight`

### DIFF
--- a/posthog/models/dashboard_tile.py
+++ b/posthog/models/dashboard_tile.py
@@ -33,16 +33,10 @@ class DashboardTile(models.Model):
     # Relations
     dashboard = models.ForeignKey("posthog.Dashboard", on_delete=models.CASCADE, related_name="tiles")
     insight = models.ForeignKey(
-        "posthog.Insight",
-        on_delete=models.CASCADE,
-        related_name="dashboard_tiles",
-        null=True,
+        "posthog.Insight", on_delete=models.CASCADE, related_name="dashboard_tiles", null=True, blank=True
     )
     text = models.ForeignKey(
-        "posthog.Text",
-        on_delete=models.CASCADE,
-        related_name="dashboard_tiles",
-        null=True,
+        "posthog.Text", on_delete=models.CASCADE, related_name="dashboard_tiles", null=True, blank=True
     )
 
     # Tile layout and style


### PR DESCRIPTION
## Problem

Currently cannot fix a user's dashboard (ZEN-15846) as I can't save the dashboard in the admin interface – Django admin requires both the `insight` and `text` foreign keys to be set, which is absurd.

## Change

Added two `blank=True`s to the existing `null=True`s.