### PR TITLE
fix(admin): reverts "Allow empty `DashboardTile.text` or `.insight`"

### DIFF
--- a/posthog/models/dashboard_tile.py
+++ b/posthog/models/dashboard_tile.py
@@ -33,10 +33,16 @@ class DashboardTile(models.Model):
     # Relations
     dashboard = models.ForeignKey("posthog.Dashboard", on_delete=models.CASCADE, related_name="tiles")
     insight = models.ForeignKey(
-        "posthog.Insight", on_delete=models.CASCADE, related_name="dashboard_tiles", null=True, blank=True
+        "posthog.Insight",
+        on_delete=models.CASCADE,
+        related_name="dashboard_tiles",
+        null=True,
     )
     text = models.ForeignKey(
-        "posthog.Text", on_delete=models.CASCADE, related_name="dashboard_tiles", null=True, blank=True
+        "posthog.Text",
+        on_delete=models.CASCADE,
+        related_name="dashboard_tiles",
+        null=True,
     )
 
     # Tile layout and style


### PR DESCRIPTION
Reverts PostHog/posthog#23868

I think this broke CI... https://posthog.slack.com/archives/C0368RPHLQH/p1721426076083439