### PR TITLE
fix: user paths url selector search

### DIFF
--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -21,6 +21,7 @@
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
     AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%qw%'
+  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
   LIMIT 10
   '''
 # ---
@@ -34,6 +35,7 @@
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
     AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%QW%'
+  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
   LIMIT 10
   '''
 # ---
@@ -47,6 +49,7 @@
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
     AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%6%'
+  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
   LIMIT 10
   '''
 # ---
@@ -61,6 +64,7 @@
     AND timestamp <= '2020-01-20 23:59:59'
     AND (event = 'random event')
     AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%6%'
+  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
   LIMIT 10
   '''
 # ---
@@ -76,6 +80,7 @@
     AND (event = 'foo'
          OR event = 'random event')
     AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%6%'
+  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
   LIMIT 10
   '''
 # ---
@@ -90,6 +95,7 @@
     AND timestamp <= '2020-01-20 23:59:59'
     AND (event = '404_i_dont_exist')
     AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%qw%'
+  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
   LIMIT 10
   '''
 # ---
@@ -115,6 +121,7 @@
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
     AND "mat_random_prop" ILIKE '%qw%'
+  order by length("mat_random_prop")
   LIMIT 10
   '''
 # ---
@@ -128,6 +135,7 @@
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
     AND "mat_random_prop" ILIKE '%QW%'
+  order by length("mat_random_prop")
   LIMIT 10
   '''
 # ---
@@ -141,6 +149,7 @@
     AND timestamp >= '2020-01-13 00:00:00'
     AND timestamp <= '2020-01-20 23:59:59'
     AND "mat_random_prop" ILIKE '%6%'
+  order by length("mat_random_prop")
   LIMIT 10
   '''
 # ---
@@ -155,6 +164,7 @@
     AND timestamp <= '2020-01-20 23:59:59'
     AND (event = 'random event')
     AND "mat_random_prop" ILIKE '%6%'
+  order by length("mat_random_prop")
   LIMIT 10
   '''
 # ---
@@ -170,6 +180,7 @@
     AND (event = 'foo'
          OR event = 'random event')
     AND "mat_random_prop" ILIKE '%6%'
+  order by length("mat_random_prop")
   LIMIT 10
   '''
 # ---
@@ -184,6 +195,7 @@
     AND timestamp <= '2020-01-20 23:59:59'
     AND (event = '404_i_dont_exist')
     AND "mat_random_prop" ILIKE '%qw%'
+  order by length("mat_random_prop")
   LIMIT 10
   '''
 # ---

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -306,6 +306,7 @@ WHERE
     {parsed_date_to}
     {event_filter}
     {value_filter}
+{order_by_clause}
 LIMIT 10
 """
 

--- a/posthog/queries/property_values.py
+++ b/posthog/queries/property_values.py
@@ -27,6 +27,7 @@ def get_property_values_for_key(
     property_exists_filter = ""
     event_filter = ""
     value_filter = ""
+    order_by_clause = ""
     extra_params = {}
 
     if mat_column_exists:
@@ -48,6 +49,8 @@ def get_property_values_for_key(
         value_filter = "AND {} ILIKE %(value)s".format(property_field)
         extra_params["value"] = "%{}%".format(value)
 
+        order_by_clause = f"order by length({property_field})"
+
     return insight_sync_execute(
         SELECT_PROP_VALUES_SQL_WITH_FILTER.format(
             parsed_date_from=parsed_date_from,
@@ -56,6 +59,7 @@ def get_property_values_for_key(
             event_filter=event_filter,
             value_filter=value_filter,
             property_exists_filter=property_exists_filter,
+            order_by_clause=order_by_clause,
         ),
         {"team_id": team.pk, "key": key, **extra_params},
         query_type="get_property_values_with_value",


### PR DESCRIPTION
## Problem
Fixes #23870 

Current search query has a `limit 10` clause and returns randomly ordered results which means users can't always get the url they're searching for. Eg while searching for this URL, the exact URL I'm trying to match, doesn't come up

See here for example of issue
https://posthog.slack.com/archives/C0368RPHLQH/p1721472155417729?thread_ts=1721434937.496499&cid=C0368RPHLQH

## Changes
Added ordering the returned results.

<img width="589" alt="image" src="https://github.com/user-attachments/assets/6324e0e8-a41d-4745-8e89-4a03f13757b5">
<img width="587" alt="image" src="https://github.com/user-attachments/assets/0be48762-e917-4a10-8e63-c4c83e4d26ae">

Also just reading docs it seems like we're going to be moving away from the `/events/` endpoint, but this was a quick fix for the high priority bug, can move to `/query` endpoint eventually, which will require a slight refactor in the `taxonomicFilterLogic`



👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A

## How did you test this code?
Tested on UI
