### PR TITLE
fix: avoid setting filters if a filters attachment already exists

### DIFF
--- a/frontend/src/scenes/pipeline/pipelinePluginConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelinePluginConfigurationLogic.tsx
@@ -148,7 +148,8 @@ export const pipelinePluginConfigurationLogic = kea<pipelinePluginConfigurationL
                         lemonToast.error('Data pipelines add-on is required for enabling new destinations.')
                         return values.pluginConfig
                     }
-                    const { enabled, order, name, description, filters, ...config } = formdata
+                    const { enabled, order, name, description, ...config } = formdata
+                    const { filters } = formdata // This is to make sure the config object includes the filters field
 
                     const formData = getPluginConfigFormData(
                         values.plugin.config_schema,
@@ -160,7 +161,7 @@ export const pipelinePluginConfigurationLogic = kea<pipelinePluginConfigurationL
                     formData.append('description', description)
 
                     const sanitizedFilters = sanitizeFilters(filters)
-                    if (filters) {
+                    if (filters && !formData.has('add_attachment[filters]')) {
                         formData.append('filters', sanitizedFilters ? JSON.stringify(sanitizedFilters) : '')
                     }
 


### PR DESCRIPTION
## Problem
 

filter out plugin: filters file wasn't uploaded correctly.

slack context: https://posthog.slack.com/archives/C0374DA782U/p1721045288390139?thread_ts=1721036910.510769&cid=C0374DA782U

## Changes

- do not set filters if a filters attachment already exists 
-> this should only be the case were the plugin schema includes an attachment with the filters key ([example](https://github.com/PostHog/posthog-filter-out-plugin/blob/main/plugin.json#L10-L16))

## Does this work well for both Cloud and self-hosted?

- Yes

## How did you test this code?

- I updated the filter out plugin through the new pipeline UI

->  I couldn't test if hog functions still work because "Hog functions are not enabled for you yet."