### PR TITLE
chore: count all the things

### DIFF
--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -85,6 +85,12 @@ EVENTS_DROPPED_OVER_QUOTA_COUNTER = Counter(
     labelnames=[LABEL_RESOURCE_TYPE, "token"],
 )
 
+EVENTS_REJECTED_OVER_QUOTA_COUNTER = Counter(
+    "capture_events_rejected_over_quota",
+    "Events rejected by capture due to quota-limiting, send a quota limiting signal to the client which stops sending us traffic.",
+    labelnames=[LABEL_RESOURCE_TYPE, "token"],
+)
+
 PARTITION_KEY_CAPACITY_EXCEEDED_COUNTER = Counter(
     "capture_partition_key_capacity_exceeded_total",
     "Indicates that automatic partition override is active for a given key. Value incremented once a minute.",
@@ -673,6 +679,7 @@ def get_event(request):
     # so we check if a random number if less than the given sample rate
     # that means we can set SAMPLE_RATE to 0 to disable this and 1 to turn on for all clients
     if recordings_were_quota_limited and random() < settings.RECORDINGS_QUOTA_LIMITING_RESPONSES_SAMPLE_RATE:
+        EVENTS_REJECTED_OVER_QUOTA_COUNTER.labels(resource_type="recordings", token=token).inc()
         response_body["quota_limited"] = ["recordings"]
 
     return cors_response(request, JsonResponse(response_body))


### PR DESCRIPTION
when we start rejecting this traffic we'll be able to see its impact in an absence on https://grafana.prod-us.posthog.dev/d/session-replay/session-replay?var-role=recordings-blob-ingestion&var-kafka=recordings-kafka-exporter&var-pod=$__all&var-partition=$__all&from=now-3h&to=now&timezone=utc&viewPanel=panel-13

but that's a little vague
let's actively count these rejections