### PR TITLE
fix(cdp): do sync fetch on hoghook 5XX

### DIFF
--- a/plugin-server/src/worker/rusty-hook.ts
+++ b/plugin-server/src/worker/rusty-hook.ts
@@ -157,19 +157,23 @@ export class RustyHook {
                     break
                 }
 
-                // TODO: Remove this after more thorough testing of hoghooks. For now, we don't
-                // want to choke up Hog ingestion if something is wrong with our payload. By
-                // returning `false`, we leave it to the `AsyncFunctionExecutor` to call `fetch`
-                // inline.
-                if (response.status >= 400 && response.status < 500) {
+                // TODO: Remove this after more thorough testing of hoghooks. For now, we don't want
+                // to choke up Hog ingestion if something is wrong with our payload or with
+                // rusty-hook. By returning `false`, we leave it to the `AsyncFunctionExecutor` to
+                // call `fetch` inline.
+                if (response.status >= 400) {
                     const message = 'Hoghook enqueue failed with an HTTP 4XX'
-                    const extra = {
+                    Sentry.captureMessage(message, {
+                        extra: {
+                            status: response.status,
+                            statusText: response.statusText,
+                        },
+                    })
+                    status.error('🔴', message, {
                         status: response.status,
                         statusText: response.statusText,
                         payload,
-                    }
-                    status.error('🔴', message, extra)
-                    Sentry.captureMessage(message, { extra })
+                    })
                     return false
                 }
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We need to fix some payloads that Postgres doesn't agree with, but we're not entirely sure what they are yet.

## Changes

On rusty-hook 500 Error, log the payload and do a synchronous node fetch.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
Existing