### PR TITLE
feat: add client id and topic metadata refresh arguments to node kafka consumer

### DIFF
--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -385,6 +385,7 @@ abstract class CdpConsumerBase {
             fetchBatchSize: this.hub.INGESTION_BATCH_SIZE,
             batchingTimeoutMs: this.hub.KAFKA_CONSUMPTION_BATCHING_TIMEOUT_MS,
             topicCreationTimeoutMs: this.hub.KAFKA_TOPIC_CREATION_TIMEOUT_MS,
+            topicMetadataRefreshInterval: this.hub.KAFKA_TOPIC_METADATA_REFRESH_INTERVAL_MS,
             eachBatch: async (messages, { heartbeat }) => {
                 return await this.handleEachBatch(messages, heartbeat)
             },

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -46,6 +46,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_SASL_MECHANISM: undefined,
         KAFKA_SASL_USER: undefined,
         KAFKA_SASL_PASSWORD: undefined,
+        KAFKA_CLIENT_ID: undefined,
         KAFKA_CLIENT_RACK: undefined,
         KAFKA_CONSUMPTION_MAX_BYTES: 10_485_760, // Default value for kafkajs
         KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION: 1_048_576, // Default value for kafkajs, must be bigger than message size
@@ -58,6 +59,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_CONSUMPTION_SESSION_TIMEOUT_MS: 30_000,
         KAFKA_CONSUMPTION_MAX_POLL_INTERVAL_MS: 300_000,
         KAFKA_TOPIC_CREATION_TIMEOUT_MS: isDevEnv() ? 30_000 : 5_000, // rdkafka default is 5s, increased in devenv to resist to slow kafka
+        KAFKA_TOPIC_METADATA_REFRESH_INTERVAL_MS: undefined,
         KAFKA_FLUSH_FREQUENCY_MS: isTestEnv() ? 5 : 500,
         APP_METRICS_FLUSH_FREQUENCY_MS: isTestEnv() ? 5 : 20_000,
         APP_METRICS_FLUSH_MAX_QUEUE_SIZE: isTestEnv() ? 5 : 1000,

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -132,7 +132,6 @@ export const startBatchConsumer = async ({
 
     const consumerConfig: ConsumerGlobalConfig = {
         ...connectionConfig,
-        'topic.metadata.refresh.interval.ms': topicMetadataRefreshInterval,
         'group.id': groupId,
         'session.timeout.ms': sessionTimeout,
         'max.poll.interval.ms': maxPollIntervalMs,
@@ -186,6 +185,10 @@ export const startBatchConsumer = async ({
 
     if (kafkaStatisticIntervalMs) {
         consumerConfig['statistics.interval.ms'] = kafkaStatisticIntervalMs
+    }
+
+    if (topicMetadataRefreshInterval) {
+        consumerConfig['topic.metadata.refresh.interval.ms'] = topicMetadataRefreshInterval
     }
 
     if (debug) {

--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -76,6 +76,7 @@ export const startBatchConsumer = async ({
     fetchMinBytes,
     maxHealthHeartbeatIntervalMs = 60_000,
     autoOffsetStore = true,
+    topicMetadataRefreshInterval,
 }: {
     connectionConfig: GlobalConfig
     groupId: string
@@ -97,6 +98,7 @@ export const startBatchConsumer = async ({
     debug?: string
     queuedMaxMessagesKBytes?: number
     fetchMinBytes?: number
+    topicMetadataRefreshInterval?: number
     /**
      * default to 0 which disables logging
      * granularity of 1000ms
@@ -130,6 +132,7 @@ export const startBatchConsumer = async ({
 
     const consumerConfig: ConsumerGlobalConfig = {
         ...connectionConfig,
+        'topic.metadata.refresh.interval.ms': topicMetadataRefreshInterval,
         'group.id': groupId,
         'session.timeout.ms': sessionTimeout,
         'max.poll.interval.ms': maxPollIntervalMs,

--- a/plugin-server/src/kafka/config.ts
+++ b/plugin-server/src/kafka/config.ts
@@ -17,7 +17,7 @@ export const createRdConnectionConfigFromEnvVars = (kafkaConfig: KafkaConfig): G
     // convert those vars into connection settings that node-rdkafka can use. We
     // also set the client.id to the hostname of the machine. This is useful for debugging.
     const config: GlobalConfig = {
-        'client.id': hostname(),
+        'client.id': kafkaConfig.KAFKA_CLIENT_ID || hostname(),
         'metadata.broker.list': kafkaConfig.KAFKA_HOSTS,
         'security.protocol': kafkaConfig.KAFKA_SECURITY_PROTOCOL
             ? (kafkaConfig.KAFKA_SECURITY_PROTOCOL.toLowerCase() as GlobalConfig['security.protocol'])

--- a/plugin-server/src/main/ingestion-queues/kafka-queue.ts
+++ b/plugin-server/src/main/ingestion-queues/kafka-queue.ts
@@ -197,6 +197,7 @@ export class IngestionConsumer {
             consumerMaxWaitMs: this.pluginsServer.KAFKA_CONSUMPTION_MAX_WAIT_MS,
             fetchBatchSize: this.pluginsServer.INGESTION_BATCH_SIZE,
             topicCreationTimeoutMs: this.pluginsServer.KAFKA_TOPIC_CREATION_TIMEOUT_MS,
+            topicMetadataRefreshInterval: this.pluginsServer.KAFKA_TOPIC_METADATA_REFRESH_INTERVAL_MS,
             eachBatch: (payload) => this.eachBatchConsumer(payload),
         })
         this.consumerReady = true

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -510,6 +510,7 @@ export class SessionRecordingIngester {
             consumerErrorBackoffMs: this.config.KAFKA_CONSUMPTION_ERROR_BACKOFF_MS,
             batchingTimeoutMs: this.config.KAFKA_CONSUMPTION_BATCHING_TIMEOUT_MS,
             topicCreationTimeoutMs: this.config.KAFKA_TOPIC_CREATION_TIMEOUT_MS,
+            topicMetadataRefreshInterval: this.config.KAFKA_TOPIC_METADATA_REFRESH_INTERVAL_MS,
             eachBatch: async (messages, { heartbeat }) => {
                 return await this.scheduleWork(this.handleEachBatch(messages, heartbeat))
             },

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -149,6 +149,7 @@ export interface PluginsServerConfig extends CdpConfig {
     KAFKA_SASL_MECHANISM: KafkaSaslMechanism | undefined
     KAFKA_SASL_USER: string | undefined
     KAFKA_SASL_PASSWORD: string | undefined
+    KAFKA_CLIENT_ID: string | undefined
     KAFKA_CLIENT_RACK: string | undefined
     KAFKA_CONSUMPTION_MAX_BYTES: number
     KAFKA_CONSUMPTION_MAX_BYTES_PER_PARTITION: number
@@ -161,6 +162,7 @@ export interface PluginsServerConfig extends CdpConfig {
     KAFKA_CONSUMPTION_SESSION_TIMEOUT_MS: number
     KAFKA_CONSUMPTION_MAX_POLL_INTERVAL_MS: number
     KAFKA_TOPIC_CREATION_TIMEOUT_MS: number
+    KAFKA_TOPIC_METADATA_REFRESH_INTERVAL_MS: number | undefined
     KAFKA_PRODUCER_LINGER_MS: number // linger.ms rdkafka parameter
     KAFKA_PRODUCER_BATCH_SIZE: number // batch.size rdkafka parameter
     KAFKA_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES: number // queue.buffering.max.messages rdkafka parameter

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -244,6 +244,7 @@ export type KafkaConfig = {
     KAFKA_SASL_USER?: string
     KAFKA_SASL_PASSWORD?: string
     KAFKA_CLIENT_RACK?: string
+    KAFKA_CLIENT_ID?: string
 }
 
 export function createKafkaClient({


### PR DESCRIPTION
## Problem

we're trying out warpstream which requires us to be able to set client.id for some features

additionally warpstream requires us to set topic metadata refresh ms to a much lower than default value (we should probably do this for kafka too as it should help during updates)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
