### PR TITLE
fix(data-warehouse): Skip validate schema when no rows were synced

### DIFF
--- a/.github/actions/run-backend-tests/action.yml
+++ b/.github/actions/run-backend-tests/action.yml
@@ -186,6 +186,8 @@ runs:
           id: run-temporal-tests
           if: ${{ inputs.segment == 'Temporal' }}
           shell: bash
+          env:
+              AWS_S3_ALLOW_UNSAFE_RENAME: 'true'
           run: |
               pytest posthog/temporal -m "not async_migrations" \
                   --splits ${{ inputs.concurrency }} --group ${{ inputs.group }} \

--- a/posthog/temporal/data_imports/pipelines/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline.py
@@ -131,7 +131,7 @@ class DataImportPipeline:
                 counts = Counter(filtered_rows)
                 total_counts = counts + total_counts
 
-                if total_counts.total() != 0:
+                if total_counts.total() > 0:
                     async_to_sync(validate_schema_and_update_table)(
                         run_id=self.inputs.run_id,
                         team_id=self.inputs.team_id,
@@ -166,7 +166,7 @@ class DataImportPipeline:
             counts = Counter(filtered_rows)
             total_counts = total_counts + counts
 
-            if total_counts.total() != 0:
+            if total_counts.total() > 0:
                 async_to_sync(validate_schema_and_update_table)(
                     run_id=self.inputs.run_id,
                     team_id=self.inputs.team_id,

--- a/posthog/warehouse/data_load/validate_schema.py
+++ b/posthog/warehouse/data_load/validate_schema.py
@@ -88,6 +88,10 @@ async def validate_schema_and_update_table(
 
     logger = await bind_temporal_worker_logger(team_id=team_id)
 
+    if row_count == 0:
+        logger.warn("Skipping `validate_schema_and_update_table` due to `row_count` being 0")
+        return
+
     job: ExternalDataJob = await get_external_data_job(job_id=run_id)
 
     credential: DataWarehouseCredential = await get_or_create_datawarehouse_credential(


### PR DESCRIPTION
## Problem
- Validating the warehouse table schema when no rows were synced still seems to be an issue

<img width="1367" alt="image" src="https://github.com/user-attachments/assets/f31389b9-fac6-4c8e-af37-c84acab90a3b">


## Changes
- Add even more checks to ensure we don't run `validate schema` when no rows are returned

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Locally 
