### PR TITLE
fix(data-warehouse): Fix exception logging

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -460,7 +460,6 @@ posthog/api/notebook.py:0: error: Incompatible types in assignment (expression h
 posthog/warehouse/data_load/validate_schema.py:0: error: Incompatible types in assignment (expression has type "dict[str, dict[str, str | bool]] | dict[str, str]", variable has type "dict[str, dict[str, str]]")  [assignment]
 posthog/temporal/data_imports/workflow_activities/create_job_model.py:0: error: Incompatible types in assignment (expression has type "list[str]", variable has type "dict[str, list[tuple[str, str]]]")  [assignment]
 posthog/temporal/data_imports/workflow_activities/create_job_model.py:0: error: Argument 1 has incompatible type "dict[str, list[tuple[str, str]]]"; expected "list[Any]"  [arg-type]
-posthog/temporal/data_imports/workflow_activities/create_job_model.py:0: error: "CreateExternalDataJobModelActivityInputs" has no attribute "external_data_source_id"  [attr-defined]
 posthog/temporal/data_imports/pipelines/rest_source/__init__.py:0: error: Not all union combinations were tried because there are too many unions  [misc]
 posthog/temporal/data_imports/pipelines/rest_source/__init__.py:0: error: Argument 2 to "source" has incompatible type "str | None"; expected "str"  [arg-type]
 posthog/temporal/data_imports/pipelines/rest_source/__init__.py:0: error: Argument 3 to "source" has incompatible type "str | None"; expected "str"  [arg-type]

--- a/posthog/temporal/data_imports/workflow_activities/create_job_model.py
+++ b/posthog/temporal/data_imports/workflow_activities/create_job_model.py
@@ -111,6 +111,6 @@ async def create_external_data_job_model_activity(inputs: CreateExternalDataJobM
         return str(run.id), schema_model.is_incremental
     except Exception as e:
         logger.exception(
-            f"External data job failed on create_external_data_job_model_activity for {inputs.external_data_source_id} with error: {e}"
+            f"External data job failed on create_external_data_job_model_activity for {str(inputs.source_id)} with error: {e}"
         )
         raise


### PR DESCRIPTION
## Problem
- When `create_external_data_job_model_activity` runs into an exception, we log the exception out, but we were referencing a variable in the error message that doesn't exist, causing a new exception to be thrown and the real exception getting lost

## Changes
- Fix the variable reference

## Does this work well for both Cloud and self-hosted?
Yep

