### PR TITLE
fix: remove nulls from rusty-hook payloads

### DIFF
--- a/plugin-server/src/worker/rusty-hook.ts
+++ b/plugin-server/src/worker/rusty-hook.ts
@@ -162,7 +162,7 @@ export class RustyHook {
                 // rusty-hook. By returning `false`, we leave it to the `AsyncFunctionExecutor` to
                 // call `fetch` inline.
                 if (response.status >= 400) {
-                    const message = 'Hoghook enqueue failed with an HTTP 4XX'
+                    const message = 'Hoghook enqueue failed with an HTTP Error'
                     Sentry.captureMessage(message, {
                         extra: {
                             status: response.status,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

We're seeing some `error returned from database: unsupported Unicode escape sequence` from Postgres when trying to INSERT.

## Changes

`\u0000` should be the only invalid string in Postgres, see our TS utils here: https://github.com/PostHog/posthog/blob/506b8e226f3f55675b803a04f618893961d0e917/plugin-server/src/utils/db/utils.ts#L172-L194

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Added / existing