### PR TITLE
poc: try using long timeout to capture canvas with playwright

### DIFF
--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -38,6 +38,7 @@ declare module '@storybook/types' {
             snapshotBrowsers?: SupportedBrowserName[]
             /** If taking a component snapshot, you can narrow it down by specifying the selector. */
             snapshotTargetSelector?: string
+            snapshotTimeout?: number
             /** specify an alternative viewport size */
             viewport?: { width: number; height: number }
         }
@@ -164,7 +165,8 @@ async function expectStoryToMatchSnapshot(
     await page.waitForFunction(() => Array.from(document.images).every((i: HTMLImageElement) => i.complete))
     await waitForPageReady(page)
     await page.waitForLoadState('networkidle')
-    await page.waitForTimeout(2000)
+    const timeout = storyContext.parameters?.testOptions?.snapshotTimeout || 2000
+    await page.waitForTimeout(timeout)
 
     await check(page, context, browser, 'light', storyContext.parameters?.testOptions?.snapshotTargetSelector)
 

--- a/frontend/src/scenes/dashboard/DashboardInsightCardLegend.stories.tsx
+++ b/frontend/src/scenes/dashboard/DashboardInsightCardLegend.stories.tsx
@@ -20,6 +20,7 @@ const meta: Meta = {
         layout: 'fullscreen',
         viewMode: 'story',
         mockDate: '2023-02-01',
+        snapshotTimeout: 15000,
     },
 }
 export default meta


### PR DESCRIPTION
## Problem

supposedly playwright can capture canvas elements...

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
