### PR TITLE
fix: Revert "chore(plugin-server): bump node-rdkafka to 3.1.0"

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -73,7 +73,7 @@
         "lru-cache": "^6.0.0",
         "luxon": "^3.4.4",
         "node-fetch": "^2.6.1",
-        "node-rdkafka": "^3.1.0",
+        "node-rdkafka": "^2.17.0",
         "node-schedule": "^2.1.0",
         "pg": "^8.6.0",
         "pino": "^8.6.0",
@@ -137,7 +137,7 @@
     },
     "pnpm": {
         "patchedDependencies": {
-            "node-rdkafka@3.1.0": "patches/node-rdkafka@3.1.0.patch"
+            "node-rdkafka@2.17.0": "patches/node-rdkafka@2.17.0.patch"
         }
     }
 }

--- a/plugin-server/patches/node-rdkafka@2.17.0.patch
+++ b/plugin-server/patches/node-rdkafka@2.17.0.patch
@@ -1,3 +1,35 @@
+diff --git a/Oops.rej b/Oops.rej
+new file mode 100644
+index 0000000000000000000000000000000000000000..328fc546fcb400745783b3562f1cb1cb055e1804
+--- /dev/null
++++ b/Oops.rej
+@@ -0,0 +1,26 @@
++@@ -1,25 +0,0 @@
++-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
++-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
++-
++-name: Publish node-rdkafka
++-
++-on:
++-  release:
++-    types: [created]
++-
++-jobs:
++-  publish-npm:
++-    runs-on: ubuntu-latest
++-    steps:
++-      - uses: actions/checkout@v3
++-        with:
++-          submodules: recursive
++-      - uses: actions/setup-node@v3
++-        with:
++-          node-version: 18
++-          registry-url: https://registry.npmjs.org/
++-          cache: "npm"
++-      - run: npm ci
++-      - run: npm publish
++-        env:
++-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 diff --git a/docker-compose.yml b/docker-compose.yml
 index abe29df25c7312382074b3e15289cb862a340247..8a12f135b4f96e5a0dd25e7c21adb2b3b0e644fa 100644
 --- a/docker-compose.yml
@@ -519,10 +551,10 @@ index a167483f1e0ea15c4edcb368e36640b4349574e8..38fcfd7464afb7df682b7b5f1fdb228b
  
      it('should happen gracefully', function(cb) {
 diff --git a/index.d.ts b/index.d.ts
-index 43bedfc97223ee938c6d0f2c5b2c4ecec7dfa800..e10a6d7258613b8ff78b21e9da3d2370f042c5cf 100644
+index d7ce7e61e985ce46ceae2c10329d6448cc487dca..2c7b9a3d40b0547209c2cffe1f4e62d9573ab617 100644
 --- a/index.d.ts
 +++ b/index.d.ts
-@@ -227,6 +227,12 @@ export class KafkaConsumer extends Client<KafkaConsumerEvents> {
+@@ -223,6 +223,12 @@ export class KafkaConsumer extends Client<KafkaConsumerEvents> {
      consume(cb: (err: LibrdKafkaError, messages: Message[]) => void): void;
      consume(): void;
  
@@ -749,10 +781,10 @@ index a6aadbd64609e5d5ae1a80205aac7ce3a49d9345..f817aa976c83b74670c7464099679eb3
      topic_result="$?"
      if [ "$topic_result" == "1" ]; then
 diff --git a/src/kafka-consumer.cc b/src/kafka-consumer.cc
-index 0f5e32eda8968a26733d7c76cbdce71bfe7d7085..eec338eb06e5502960f12e826b1a48bdc146361f 100644
+index 019b0cb6478756120efe9a5f6f1bb4182b4af4ea..3895407788ae31ae38d7707eb63528ebac6e3b24 100644
 --- a/src/kafka-consumer.cc
 +++ b/src/kafka-consumer.cc
-@@ -197,6 +197,32 @@ Baton KafkaConsumer::Assign(std::vector<RdKafka::TopicPartition*> partitions) {
+@@ -179,6 +179,32 @@ Baton KafkaConsumer::Assign(std::vector<RdKafka::TopicPartition*> partitions) {
    return Baton(errcode);
  }
  
@@ -785,7 +817,7 @@ index 0f5e32eda8968a26733d7c76cbdce71bfe7d7085..eec338eb06e5502960f12e826b1a48bd
  Baton KafkaConsumer::Unassign() {
    if (!IsClosing() && !IsConnected()) {
      return Baton(RdKafka::ERR__STATE);
-@@ -213,12 +239,46 @@ Baton KafkaConsumer::Unassign() {
+@@ -195,12 +221,46 @@ Baton KafkaConsumer::Unassign() {
  
    // Destroy the old list of partitions since we are no longer using it
    RdKafka::TopicPartition::destroy(m_partitions);
@@ -832,7 +864,7 @@ index 0f5e32eda8968a26733d7c76cbdce71bfe7d7085..eec338eb06e5502960f12e826b1a48bd
  Baton KafkaConsumer::Commit(std::vector<RdKafka::TopicPartition*> toppars) {
    if (!IsConnected()) {
      return Baton(RdKafka::ERR__STATE);
-@@ -487,6 +547,12 @@ Baton KafkaConsumer::RefreshAssignments() {
+@@ -469,6 +529,12 @@ Baton KafkaConsumer::RefreshAssignments() {
    }
  }
  
@@ -845,7 +877,7 @@ index 0f5e32eda8968a26733d7c76cbdce71bfe7d7085..eec338eb06e5502960f12e826b1a48bd
  std::string KafkaConsumer::Name() {
    if (!IsConnected()) {
      return std::string("");
-@@ -546,8 +612,11 @@ void KafkaConsumer::Init(v8::Local<v8::Object> exports) {
+@@ -527,8 +593,11 @@ void KafkaConsumer::Init(v8::Local<v8::Object> exports) {
    Nan::SetPrototypeMethod(tpl, "committed", NodeCommitted);
    Nan::SetPrototypeMethod(tpl, "position", NodePosition);
    Nan::SetPrototypeMethod(tpl, "assign", NodeAssign);
@@ -857,7 +889,7 @@ index 0f5e32eda8968a26733d7c76cbdce71bfe7d7085..eec338eb06e5502960f12e826b1a48bd
  
    Nan::SetPrototypeMethod(tpl, "commit", NodeCommit);
    Nan::SetPrototypeMethod(tpl, "commitSync", NodeCommitSync);
-@@ -778,6 +847,64 @@ NAN_METHOD(KafkaConsumer::NodeAssign) {
+@@ -759,6 +828,64 @@ NAN_METHOD(KafkaConsumer::NodeAssign) {
    info.GetReturnValue().Set(Nan::True());
  }
  
@@ -922,7 +954,7 @@ index 0f5e32eda8968a26733d7c76cbdce71bfe7d7085..eec338eb06e5502960f12e826b1a48bd
  NAN_METHOD(KafkaConsumer::NodeUnassign) {
    Nan::HandleScope scope;
  
-@@ -798,6 +925,71 @@ NAN_METHOD(KafkaConsumer::NodeUnassign) {
+@@ -779,6 +906,71 @@ NAN_METHOD(KafkaConsumer::NodeUnassign) {
    info.GetReturnValue().Set(Nan::True());
  }
  
@@ -1021,7 +1053,7 @@ index c91590ecc5d47c1d7a2a93c3e46b4b4657525df0..43e016db4ec47121051cb282f718a2b3
    static NAN_METHOD(NodeUnsubscribe);
    static NAN_METHOD(NodeCommit);
 diff --git a/test/consumer.spec.js b/test/consumer.spec.js
-index 4fc3bd53208bdaafa3df2df1e5bd9184387b8859..2d32c854d13f99531b9b6a36765c65fa42dd8d62 100644
+index 40b52ee4e1c718890f43b91adfb543319d5cc342..5e1a5655be0d2598163478aaaae936213c3bf27c 100644
 --- a/test/consumer.spec.js
 +++ b/test/consumer.spec.js
 @@ -77,7 +77,7 @@ module.exports = {

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -1,13 +1,13 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  node-rdkafka@3.1.0:
-    hash: 2blh4g6m4osumqx2eqyegyjb7q
-    path: patches/node-rdkafka@3.1.0.patch
+  node-rdkafka@2.17.0:
+    hash: p4aetcvho53cvjti6c3zi7tfaq
+    path: patches/node-rdkafka@2.17.0.patch
 
 dependencies:
   '@aws-sdk/client-s3':
@@ -113,8 +113,8 @@ dependencies:
     specifier: ^2.6.1
     version: 2.6.9
   node-rdkafka:
-    specifier: ^3.1.0
-    version: 3.1.0(patch_hash=2blh4g6m4osumqx2eqyegyjb7q)
+    specifier: ^2.17.0
+    version: 2.17.0(patch_hash=p4aetcvho53cvjti6c3zi7tfaq)
   node-schedule:
     specifier: ^2.1.0
     version: 2.1.1
@@ -8318,10 +8318,6 @@ packages:
     resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
     dev: false
 
-  /nan@2.20.0:
-    resolution: {integrity: sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==}
-    dev: false
-
   /nanoassert@1.1.0:
     resolution: {integrity: sha512-C40jQ3NzfkP53NsO8kEOFd79p4b9kDXQMwgiY1z8ZwrDZgUyom0AHwGegF4Dm99L+YoYhuaB0ceerUcXmqr1rQ==}
     dev: true
@@ -8435,13 +8431,13 @@ packages:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
 
-  /node-rdkafka@3.1.0(patch_hash=2blh4g6m4osumqx2eqyegyjb7q):
-    resolution: {integrity: sha512-H0FeV6cgkFX/NHKPyWsUHoC4l645/2vfKVdTyvKmwX+nafHuZzT6xVWl2kJQBNVJcRVgtQA1Loz6iXWhq03RKw==}
-    engines: {node: '>=16'}
+  /node-rdkafka@2.17.0(patch_hash=p4aetcvho53cvjti6c3zi7tfaq):
+    resolution: {integrity: sha512-vFABzRcE5FaH0WqfqJRxDoqeG6P8UEB3M4qFQ7SkwMgQueMMO78+fm8MYfl5hLW3bBYfBekK2BXIIr0lDQtSEQ==}
+    engines: {node: '>=6.0.0'}
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
-      nan: 2.20.0
+      nan: 2.17.0
     dev: false
     patched: true
 


### PR DESCRIPTION
Reverts PostHog/posthog#23863

ran into constant rebalancing issues after upgrading to this with the blob ingester on warpstream