### PR TITLE
chore(data-warehouse): Upgraded sql alchemy

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -74,10 +74,10 @@ semantic_version==2.8.5
 scikit-learn==1.5.0
 slack_sdk==3.17.1
 snowflake-connector-python==3.6.0
-snowflake-sqlalchemy==1.5.3
+snowflake-sqlalchemy==1.6.1
 social-auth-app-django==5.0.0
 social-auth-core==4.3.0
-sqlalchemy==1.4.52
+sqlalchemy==2.0.31
 sshtunnel==0.4.0
 statshog==1.0.6
 structlog==23.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -570,7 +570,7 @@ snowflake-connector-python==3.6.0
     # via
     #   -r requirements.in
     #   snowflake-sqlalchemy
-snowflake-sqlalchemy==1.5.3
+snowflake-sqlalchemy==1.6.1
     # via -r requirements.in
 social-auth-app-django==5.0.0
     # via -r requirements.in
@@ -582,7 +582,7 @@ sortedcontainers==2.4.0
     # via
     #   snowflake-connector-python
     #   trio
-sqlalchemy==1.4.52
+sqlalchemy==2.0.31
     # via
     #   -r requirements.in
     #   snowflake-sqlalchemy
@@ -641,6 +641,7 @@ typing-extensions==4.7.1
     #   pydantic-core
     #   qrcode
     #   snowflake-connector-python
+    #   sqlalchemy
     #   stripe
     #   temporalio
 tzdata==2023.3


### PR DESCRIPTION
## Problem
- I had to downgrade the `sql-alchemy` package when adding support for snowflake due to the snowflake package not supporting the newer versions of SQL alchemy https://github.com/PostHog/posthog/pull/22723

## Changes
- A new version of `snowflake-sqlalchemy` was released 2-weeks ago with support for V2 of SQL alchemy! https://github.com/snowflakedb/snowflake-sqlalchemy/issues/380#issuecomment-2218234943
- Upgrades our pip packages

<img width="1229" alt="image" src="https://github.com/user-attachments/assets/36bd60a9-ed0f-4a61-9df8-d379c0438dee">


## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
Synced a snowflake and postgres db