### PR TITLE
feat(data-warehouse): Turn off `should_sync` on jobs that have non retryable errors

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -32,6 +32,14 @@ from posthog.warehouse.models import (
     ExternalDataSource,
 )
 from posthog.temporal.common.logger import bind_temporal_worker_logger
+from posthog.warehouse.models.external_data_schema import aupdate_should_sync
+
+
+Non_Retryable_Schema_Errors = [
+    "NoSuchTableError",
+    "401 Client Error: Unauthorized for url: https://api.stripe.com",
+    "403 Client Error: Forbidden for url: https://api.stripe.com",
+]
 
 
 @dataclasses.dataclass
@@ -53,6 +61,11 @@ async def update_external_data_job_model(inputs: UpdateExternalDataJobStatusInpu
         logger.exception(
             f"External data job failed for external data schema {inputs.schema_id} with error: {inputs.internal_error}"
         )
+
+        has_non_retryable_error = any(error in inputs.internal_error for error in Non_Retryable_Schema_Errors)
+        if has_non_retryable_error:
+            logger.info("Schema has a non-retryable error - turning off syncing")
+            await aupdate_should_sync(schema_id=inputs.schema_id, team_id=inputs.team_id, should_sync=False)
 
     await sync_to_async(update_external_job_status)(
         run_id=uuid.UUID(inputs.id),

--- a/posthog/temporal/tests/external_data/test_external_data_job.py
+++ b/posthog/temporal/tests/external_data/test_external_data_job.py
@@ -344,8 +344,9 @@ async def test_update_external_job_activity_with_non_retryable_error(activity_en
         schema_id=str(schema.pk),
         team_id=team.id,
     )
+    with mock.patch("posthog.warehouse.models.external_data_schema.external_data_workflow_exists", return_value=False):
+        await activity_environment.run(update_external_data_job_model, inputs)
 
-    await activity_environment.run(update_external_data_job_model, inputs)
     await sync_to_async(new_job.refresh_from_db)()
     await sync_to_async(schema.refresh_from_db)()
 

--- a/posthog/temporal/tests/external_data/test_external_data_job.py
+++ b/posthog/temporal/tests/external_data/test_external_data_job.py
@@ -264,6 +264,98 @@ async def test_update_external_job_activity(activity_environment, team, **kwargs
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
+async def test_update_external_job_activity_with_retryable_error(activity_environment, team, **kwargs):
+    new_source = await sync_to_async(ExternalDataSource.objects.create)(
+        source_id=uuid.uuid4(),
+        connection_id=uuid.uuid4(),
+        destination_id=uuid.uuid4(),
+        team=team,
+        status="running",
+        source_type="Stripe",
+    )
+
+    schema = await sync_to_async(ExternalDataSchema.objects.create)(
+        name=PIPELINE_TYPE_SCHEMA_DEFAULT_MAPPING[new_source.source_type][0],
+        team_id=team.id,
+        source_id=new_source.pk,
+        should_sync=True,
+    )
+
+    new_job = await sync_to_async(create_external_data_job)(
+        team_id=team.id,
+        external_data_source_id=new_source.pk,
+        workflow_id=activity_environment.info.workflow_id,
+        workflow_run_id=activity_environment.info.workflow_run_id,
+        external_data_schema_id=schema.id,
+    )
+
+    inputs = UpdateExternalDataJobStatusInputs(
+        id=str(new_job.id),
+        run_id=str(new_job.id),
+        status=ExternalDataJob.Status.COMPLETED,
+        latest_error=None,
+        internal_error="Some other retryable error",
+        schema_id=str(schema.pk),
+        team_id=team.id,
+    )
+
+    await activity_environment.run(update_external_data_job_model, inputs)
+    await sync_to_async(new_job.refresh_from_db)()
+    await sync_to_async(schema.refresh_from_db)()
+
+    assert new_job.status == ExternalDataJob.Status.COMPLETED
+    assert schema.status == ExternalDataJob.Status.COMPLETED
+    assert schema.should_sync is True
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_update_external_job_activity_with_non_retryable_error(activity_environment, team, **kwargs):
+    new_source = await sync_to_async(ExternalDataSource.objects.create)(
+        source_id=uuid.uuid4(),
+        connection_id=uuid.uuid4(),
+        destination_id=uuid.uuid4(),
+        team=team,
+        status="running",
+        source_type="Stripe",
+    )
+
+    schema = await sync_to_async(ExternalDataSchema.objects.create)(
+        name=PIPELINE_TYPE_SCHEMA_DEFAULT_MAPPING[new_source.source_type][0],
+        team_id=team.id,
+        source_id=new_source.pk,
+        should_sync=True,
+    )
+
+    new_job = await sync_to_async(create_external_data_job)(
+        team_id=team.id,
+        external_data_source_id=new_source.pk,
+        workflow_id=activity_environment.info.workflow_id,
+        workflow_run_id=activity_environment.info.workflow_run_id,
+        external_data_schema_id=schema.id,
+    )
+
+    inputs = UpdateExternalDataJobStatusInputs(
+        id=str(new_job.id),
+        run_id=str(new_job.id),
+        status=ExternalDataJob.Status.COMPLETED,
+        latest_error=None,
+        internal_error="NoSuchTableError: TableA",
+        schema_id=str(schema.pk),
+        team_id=team.id,
+    )
+
+    await activity_environment.run(update_external_data_job_model, inputs)
+    await sync_to_async(new_job.refresh_from_db)()
+    await sync_to_async(schema.refresh_from_db)()
+
+    assert new_job.status == ExternalDataJob.Status.COMPLETED
+    assert schema.status == ExternalDataJob.Status.COMPLETED
+    assert schema.should_sync is False
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
 async def test_run_stripe_job(activity_environment, team, minio_client, **kwargs):
     async def setup_job_1():
         new_source = await sync_to_async(ExternalDataSource.objects.create)(

--- a/posthog/warehouse/data_load/service.py
+++ b/posthog/warehouse/data_load/service.py
@@ -1,5 +1,6 @@
 from dataclasses import asdict
 from datetime import timedelta
+from typing import TYPE_CHECKING
 
 from temporalio.client import (
     Schedule,
@@ -28,7 +29,6 @@ from posthog.temporal.common.schedule import (
     unpause_schedule,
 )
 from posthog.temporal.utils import ExternalDataWorkflowInputs
-from posthog.warehouse.models import ExternalDataSource
 import temporalio
 from temporalio.client import Client as TemporalClient
 from asgiref.sync import async_to_sync
@@ -36,10 +36,12 @@ from asgiref.sync import async_to_sync
 from django.conf import settings
 import s3fs
 
-from posthog.warehouse.models.external_data_schema import ExternalDataSchema
+if TYPE_CHECKING:
+    from posthog.warehouse.models import ExternalDataSource
+    from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 
 
-def get_sync_schedule(external_data_schema: ExternalDataSchema):
+def get_sync_schedule(external_data_schema: "ExternalDataSchema"):
     inputs = ExternalDataWorkflowInputs(
         team_id=external_data_schema.team_id,
         external_data_schema_id=external_data_schema.id,
@@ -66,7 +68,9 @@ def get_sync_schedule(external_data_schema: ExternalDataSchema):
     )
 
 
-def get_sync_frequency(external_data_schema: ExternalDataSchema):
+def get_sync_frequency(external_data_schema: "ExternalDataSchema"):
+    from posthog.warehouse.models.external_data_schema import ExternalDataSchema
+
     if external_data_schema.sync_frequency == ExternalDataSchema.SyncFrequency.DAILY:
         return timedelta(days=1)
     elif external_data_schema.sync_frequency == ExternalDataSchema.SyncFrequency.WEEKLY:
@@ -78,8 +82,8 @@ def get_sync_frequency(external_data_schema: ExternalDataSchema):
 
 
 def sync_external_data_job_workflow(
-    external_data_schema: ExternalDataSchema, create: bool = False
-) -> ExternalDataSchema:
+    external_data_schema: "ExternalDataSchema", create: bool = False
+) -> "ExternalDataSchema":
     temporal = sync_connect()
 
     schedule = get_sync_schedule(external_data_schema)
@@ -93,8 +97,8 @@ def sync_external_data_job_workflow(
 
 
 async def a_sync_external_data_job_workflow(
-    external_data_schema: ExternalDataSchema, create: bool = False
-) -> ExternalDataSchema:
+    external_data_schema: "ExternalDataSchema", create: bool = False
+) -> "ExternalDataSchema":
     temporal = await async_connect()
 
     schedule = get_sync_schedule(external_data_schema)
@@ -107,17 +111,17 @@ async def a_sync_external_data_job_workflow(
     return external_data_schema
 
 
-def trigger_external_data_source_workflow(external_data_source: ExternalDataSource):
+def trigger_external_data_source_workflow(external_data_source: "ExternalDataSource"):
     temporal = sync_connect()
     trigger_schedule(temporal, schedule_id=str(external_data_source.id))
 
 
-def trigger_external_data_workflow(external_data_schema: ExternalDataSchema):
+def trigger_external_data_workflow(external_data_schema: "ExternalDataSchema"):
     temporal = sync_connect()
     trigger_schedule(temporal, schedule_id=str(external_data_schema.id))
 
 
-async def a_trigger_external_data_workflow(external_data_schema: ExternalDataSchema):
+async def a_trigger_external_data_workflow(external_data_schema: "ExternalDataSchema"):
     temporal = await async_connect()
     await a_trigger_schedule(temporal, schedule_id=str(external_data_schema.id))
 
@@ -153,7 +157,7 @@ def delete_external_data_schedule(schedule_id: str):
         raise
 
 
-async def a_delete_external_data_schedule(external_data_source: ExternalDataSource):
+async def a_delete_external_data_schedule(external_data_source: "ExternalDataSource"):
     temporal = await async_connect()
     try:
         await a_delete_schedule(temporal, schedule_id=str(external_data_source.id))
@@ -185,4 +189,6 @@ def delete_data_import_folder(folder_path: str):
 
 
 def is_any_external_data_job_paused(team_id: int) -> bool:
+    from posthog.warehouse.models import ExternalDataSource
+
     return ExternalDataSource.objects.filter(team_id=team_id, status=ExternalDataSource.Status.PAUSED).exists()

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -79,6 +79,15 @@ def aget_schema_by_id(schema_id: str, team_id: int) -> ExternalDataSchema | None
 
 
 @database_sync_to_async
+def aupdate_should_sync(schema_id: str, team_id: int, should_sync: bool) -> ExternalDataSchema | None:
+    schema = ExternalDataSchema.objects.get(id=schema_id, team_id=team_id)
+    schema.should_sync = should_sync
+    schema.save()
+
+    return schema
+
+
+@database_sync_to_async
 def get_active_schemas_for_source_id(source_id: uuid.UUID, team_id: int):
     return list(ExternalDataSchema.objects.filter(team_id=team_id, source_id=source_id, should_sync=True).all())
 

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -6,6 +6,12 @@ from posthog.models.team import Team
 from posthog.models.utils import CreatedMetaFields, UUIDModel, sane_repr
 import uuid
 import psycopg2
+from posthog.warehouse.data_load.service import (
+    external_data_workflow_exists,
+    pause_external_data_schedule,
+    sync_external_data_job_workflow,
+    unpause_external_data_schedule,
+)
 from posthog.warehouse.types import IncrementalFieldType
 from posthog.warehouse.models.ssh_tunnel import SSHTunnel
 from posthog.warehouse.util import database_sync_to_async
@@ -83,6 +89,17 @@ def aupdate_should_sync(schema_id: str, team_id: int, should_sync: bool) -> Exte
     schema = ExternalDataSchema.objects.get(id=schema_id, team_id=team_id)
     schema.should_sync = should_sync
     schema.save()
+
+    schedule_exists = external_data_workflow_exists(schema_id)
+
+    if schedule_exists:
+        if should_sync is False:
+            pause_external_data_schedule(schema_id)
+        elif should_sync is True:
+            unpause_external_data_schedule(schema_id)
+    else:
+        if should_sync is True:
+            sync_external_data_job_workflow(schema, create=True)
 
     return schema
 


### PR DESCRIPTION
## Problem
- We're continuously running jobs that will never succeed due to an error that can't be resolved

## Changes
- If we hit one of these non-retryable errors, turn off the schema syncing and update temporal schedule
- Only applies when:
  - The SQL database has been deleted and therefore can't be synced
  - We get either a 401 or 403 error from Stripe

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Unit tests and local testing