### PR TITLE
feat: consume existing org invite when using JIT

### DIFF
--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -615,7 +615,7 @@ class TestSignupAPI(APIBaseTest):
             response, "/login?error_code=no_new_organizations"
         )  # show the user an error; operation not permitted
 
-    def run_test_for_allowed_domain(self, mock_sso_providers, mock_request, mock_capture):
+    def run_test_for_allowed_domain(self, mock_sso_providers, mock_request, mock_capture, use_invite: bool = False):
         # Make sure Google Auth is valid for this test instance
         mock_sso_providers.return_value = {"google-oauth2": True}
 
@@ -627,6 +627,18 @@ class TestSignupAPI(APIBaseTest):
             organization=new_org,
         )
         new_project = Team.objects.create(organization=new_org, name="My First Project")
+
+        if use_invite:
+            private_project: Team = Team.objects.create(
+                organization=new_org, name="Private Project", access_control=True
+            )
+            OrganizationInvite.objects.create(
+                target_email="jane@hogflix.posthog.com",
+                organization=new_org,
+                first_name="Jane",
+                level=OrganizationMembership.Level.MEMBER,
+                private_project_access=[{"id": private_project.id, "level": ExplicitTeamMembership.Level.ADMIN}],
+            )
         user_count = User.objects.count()
         response = self.client.get(reverse("social:begin", kwargs={"backend": "google-oauth2"}))
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
@@ -654,6 +666,23 @@ class TestSignupAPI(APIBaseTest):
             OrganizationMembership.Level.MEMBER,
         )
         self.assertFalse(mock_capture.call_args.kwargs["properties"]["is_organization_first_user"])
+
+        if use_invite:
+            # make sure the org invite no longer exists
+            self.assertEqual(
+                OrganizationInvite.objects.filter(
+                    organization=new_org, target_email="jane@hogflix.posthog.com"
+                ).count(),
+                0,
+            )
+            teams = user.teams.all()
+            # make sure user has access to the private project specified in the invite
+            self.assertTrue(teams.filter(pk=private_project.pk).exists())
+            org_membership = OrganizationMembership.objects.get(organization=new_org, user=user)
+            explicit_team_membership = ExplicitTeamMembership.objects.get(
+                team=private_project, parent_membership=org_membership
+            )
+            assert explicit_team_membership.level == ExplicitTeamMembership.Level.ADMIN
 
     @patch("posthoganalytics.capture")
     @mock.patch("social_core.backends.base.BaseAuth.request")
@@ -685,6 +714,30 @@ class TestSignupAPI(APIBaseTest):
     ):
         with self.is_cloud(True):
             self.run_test_for_allowed_domain(mock_sso_providers, mock_request, mock_capture)
+        assert mock_update_distinct_ids.called_once()
+        assert mock_update_billing_customer_email.called_once()
+        assert mock_update_billing_admin_emails.called_once()
+
+    @patch("posthoganalytics.capture")
+    @mock.patch("ee.billing.billing_manager.BillingManager.update_billing_distinct_ids")
+    @mock.patch("ee.billing.billing_manager.BillingManager.update_billing_customer_email")
+    @mock.patch("ee.billing.billing_manager.BillingManager.update_billing_admin_emails")
+    @mock.patch("social_core.backends.base.BaseAuth.request")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
+    @mock.patch("posthog.tasks.user_identify.identify_task")
+    @pytest.mark.ee
+    def test_social_signup_with_allowed_domain_on_cloud_with_existing_invite(
+        self,
+        mock_identify,
+        mock_sso_providers,
+        mock_request,
+        mock_update_distinct_ids,
+        mock_update_billing_customer_email,
+        mock_update_billing_admin_emails,
+        mock_capture,
+    ):
+        with self.is_cloud(True):
+            self.run_test_for_allowed_domain(mock_sso_providers, mock_request, mock_capture, use_invite=True)
         assert mock_update_distinct_ids.called_once()
         assert mock_update_billing_customer_email.called_once()
         assert mock_update_billing_admin_emails.called_once()


### PR DESCRIPTION
## Problem

We can now specify team/project access on invites via the API (https://github.com/PostHog/posthog/pull/23586). However, when users sign in via JIT provisioning, invites are not automatically consumed, so they don't get the invite-specified team access. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

When a user logs in with SSO and uses JIT provisioning, look for an invite for the domain-associated org for that email address, and consume that invite (giving access to the private projects)when joining the org.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Should.

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Wrote a test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
