### PR TITLE
feat: add field to skip sending invite emails

### DIFF
--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -25,6 +25,7 @@ from posthog.tasks.email import send_invite
 
 class OrganizationInviteSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
+    send_email = serializers.BooleanField(write_only=True, default=True)
 
     class Meta:
         model = OrganizationInvite
@@ -40,6 +41,7 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
             "updated_at",
             "message",
             "private_project_access",
+            "send_email",
         ]
         read_only_fields = [
             "id",
@@ -96,12 +98,13 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
             user__email=validated_data["target_email"],
         ).exists():
             raise exceptions.ValidationError("A user with this email address already belongs to the organization.")
+        send_email = validated_data.pop("send_email", True)
         invite: OrganizationInvite = OrganizationInvite.objects.create(
             organization_id=self.context["organization_id"],
             created_by=self.context["request"].user,
             **validated_data,
         )
-        if is_email_available(with_absolute_urls=True):
+        if is_email_available(with_absolute_urls=True) and send_email:
             invite.emailing_attempt_made = True
             send_invite(invite_id=invite.id)
             invite.save()


### PR DESCRIPTION
## Problem

We're enabling JIT consumption of invites so that users can automatically be added to the correct private projects/teams when they sign up. 

This means that an invite will be created for the user (via the API), but the user doesn't need to know about the invite because it will be automatically consumed when they log in with JIT.

So we need a way to disable invite emails.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

There were a couple ways this could have been accomplished:

1. Setting to disable invite emails for the whole org.
    - But then what if someone _wants_ to send an invite email for eg. a contractor who doesn't use JIT to sign up?
2. Intelligently know if the org has JIT enabled, if the target_email is part of the verified domain, and don't send emails in that case.
    - But what if some org _wants_ to have the invite emails, even though they have JIT, because it alerts their users that their PostHog instance is ready for them?
3. Specify it on the /invite API endpoint (what I decided to do)
    - This seemed the most flexible, and easy for the user to implement (the requesting customer has this all scripted, so it's just a param to add to their script).

So, this:

- Accepts a `send_email` field in the /invites API endpoint, defaults to True
- Skips sending the email if this is False

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

N/A - JIT not available on self-hosted

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added a test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
