### PR TITLE
chore: bump the timeout for the `mark_deletions_done` query that is run before async deletes

### DIFF
--- a/posthog/models/async_deletion/delete_events.py
+++ b/posthog/models/async_deletion/delete_events.py
@@ -91,7 +91,7 @@ class AsyncEventDeletion(AsyncDeletionProcess):
             WHERE {" OR ".join(conditions)}
             """,
             args,
-            settings={"max_query_size": MAX_QUERY_SIZE},
+            settings={"max_query_size": MAX_QUERY_SIZE, "max_execution_time": 30 * 60},
         )
         return {tuple(row) for row in clickhouse_result}
 


### PR DESCRIPTION
## Problem

we are timing out on the accounting query that runs before deletes which is blocking deletes themselves

## Changes

increase execution time limit to 30 minutes

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
