### PR TITLE
fix: Properly retry on S3 upload part timeouts

### DIFF
--- a/posthog/templates/email/batch_export_run_failure.html
+++ b/posthog/templates/email/batch_export_run_failure.html
@@ -3,7 +3,7 @@
 {% block heading %}PostHog batch export {{ name }} has failed{% endblock %}
 {% block section %}
 <p>
-  There's been a fatal error with your batch export {{ name }} at {{ time }}. Due to the nature of the error, it cannot be retried automatically and requires manual intervention.
+  There's been a fatal error with your batch export {{ name }} at {{ time }}. Due to the nature of the error, we could not automatically recover from the failure and it requires manual intervention.
 
   We recommend reviewing the batch export logs for error details:
 </p>
@@ -14,7 +14,9 @@
 </div>
 
 <p>
-  After reviewing the logs, and addressing any errors in them, you can retry the batch export run manually. If the batch export continues to fail we will disable it.
+  In the logs you may find configuration errors that can be addressed by yourself, like an incorrect credential, or an unreachable warehouse. If you’re feeling extra-adventurous, sometimes a manual retry can fix things!
+
+  If you can't diagnose the issue, please contact us for help. Keep in mind that if the batch export continues to fail we will have to disable it.
 </p>
 {% endblock %}
 

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -434,15 +434,16 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
         logger.error("Batch export failed with error: %s", batch_export_run.latest_error)
 
     elif batch_export_run.status == BatchExportRun.Status.FAILED:
-        logger.error("Batch export failed with non-retryable error: %s", batch_export_run.latest_error)
+        logger.error("Batch export failed with non-recoverable error: %s", batch_export_run.latest_error)
 
         from posthog.tasks.email import send_batch_export_run_failure
 
         try:
-            logger.info("Sending failure notification email for run %s", inputs.id)
             await database_sync_to_async(send_batch_export_run_failure)(inputs.id)
         except Exception:
             logger.exception("Failure email notification could not be sent")
+        else:
+            logger.info("Failure notification email for run %s has been sent", inputs.id)
 
         is_over_failure_threshold = await check_if_over_failure_threshold(
             inputs.batch_export_id,

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -428,11 +428,12 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
 
                 async def flush_to_bigquery(
                     local_results_file,
-                    records_since_last_flush,
-                    bytes_since_last_flush,
+                    records_since_last_flush: int,
+                    bytes_since_last_flush: int,
                     flush_counter: int,
                     last_inserted_at,
-                    last,
+                    last: bool,
+                    error: Exception | None,
                 ):
                     logger.debug(
                         "Loading %s records of size %s bytes",

--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -522,6 +522,7 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs) -> Records
                     flush_counter: int,
                     last_inserted_at,
                     last: bool,
+                    error: Exception | None,
                 ):
                     logger.debug(
                         "Copying %s records of size %s bytes",

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -485,7 +485,16 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
                 flush_counter: int,
                 last_inserted_at: dt.datetime,
                 last: bool,
+                error: Exception | None,
             ):
+                if error is not None:
+                    logger.debug("Error while writing part %d", s3_upload.part_number + 1, exc_info=error)
+                    logger.warn(
+                        "An error was detected while writing part %d. Partial part will not be uploaded in case it can be retried.",
+                        s3_upload.part_number + 1,
+                    )
+                    return
+
                 logger.debug(
                     "Uploading %s part %s containing %s records with size %s bytes",
                     "last " if last else "",

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -7,6 +7,7 @@ import posixpath
 import typing
 
 import aioboto3
+import botocore.exceptions
 import pyarrow as pa
 from django.conf import settings
 from temporalio import activity, workflow
@@ -115,6 +116,18 @@ class NoUploadInProgressError(Exception):
 
     def __init__(self):
         super().__init__("No multi-part upload is in progress. Call 'create' to start one.")
+
+
+class IntermittentUploadPartTimeoutError(Exception):
+    """Exception raised when an S3 upload part times out.
+
+    This is generally a transient or intermittent error that can be handled by a retry.
+    However, it's wrapped by a `botocore.exceptions.ClientError` that generally includes
+    non-retryable errors. So, we can re-raise our own exception in those cases.
+    """
+
+    def __init__(self, part_number: int):
+        super().__init__(f"An intermittent `RequestTimeout` was raised while attempting to upload part {part_number}")
 
 
 class S3MultiPartUploadState(typing.NamedTuple):
@@ -274,13 +287,22 @@ class S3MultiPartUpload:
         reader = io.BufferedReader(body)  # type: ignore
 
         async with self.s3_client() as s3_client:
-            response = await s3_client.upload_part(
-                Bucket=self.bucket_name,
-                Key=self.key,
-                PartNumber=next_part_number,
-                UploadId=self.upload_id,
-                Body=reader,
-            )
+            try:
+                response = await s3_client.upload_part(
+                    Bucket=self.bucket_name,
+                    Key=self.key,
+                    PartNumber=next_part_number,
+                    UploadId=self.upload_id,
+                    Body=reader,
+                )
+            except botocore.exceptions.ClientError as err:
+                error_code = err.response.get("Error", {}).get("Code", None)
+
+                if error_code is not None and error_code == "RequestTimeout":
+                    raise IntermittentUploadPartTimeoutError(part_number=next_part_number) from err
+                else:
+                    raise
+
         reader.detach()  # BufferedReader closes the file otherwise.
 
         self.parts.append({"PartNumber": next_part_number, "ETag": response["ETag"]})

--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -627,6 +627,7 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs) -> Recor
                     flush_counter: int,
                     last_inserted_at,
                     last: bool,
+                    error: Exception | None,
                 ):
                     logger.info(
                         "Putting %sfile %s containing %s records with size %s bytes",

--- a/posthog/temporal/tests/batch_exports/test_temporary_file.py
+++ b/posthog/temporal/tests/batch_exports/test_temporary_file.py
@@ -226,7 +226,13 @@ async def test_jsonl_writer_writes_record_batches(record_batch):
     inserted_ats_seen: list[LastInsertedAt] = []
 
     async def store_in_memory_on_flush(
-        batch_export_file, records_since_last_flush, bytes_since_last_flush, flush_counter, last_inserted_at, is_last
+        batch_export_file,
+        records_since_last_flush,
+        bytes_since_last_flush,
+        flush_counter,
+        last_inserted_at,
+        is_last,
+        error,
     ):
         assert writer.records_since_last_flush == record_batch.num_rows
         in_memory_file_obj.write(batch_export_file.read())
@@ -264,7 +270,13 @@ async def test_csv_writer_writes_record_batches(record_batch):
     inserted_ats_seen = []
 
     async def store_in_memory_on_flush(
-        batch_export_file, records_since_last_flush, bytes_since_last_flush, flush_counter, last_inserted_at, is_last
+        batch_export_file,
+        records_since_last_flush,
+        bytes_since_last_flush,
+        flush_counter,
+        last_inserted_at,
+        is_last,
+        error,
     ):
         in_memory_file_obj.write(batch_export_file.read().decode("utf-8"))
         inserted_ats_seen.append(last_inserted_at)
@@ -304,7 +316,13 @@ async def test_parquet_writer_writes_record_batches(record_batch):
     inserted_ats_seen = []
 
     async def store_in_memory_on_flush(
-        batch_export_file, records_since_last_flush, bytes_since_last_flush, flush_counter, last_inserted_at, is_last
+        batch_export_file,
+        records_since_last_flush,
+        bytes_since_last_flush,
+        flush_counter,
+        last_inserted_at,
+        is_last,
+        error,
     ):
         in_memory_file_obj.write(batch_export_file.read())
         inserted_ats_seen.append(last_inserted_at)


### PR DESCRIPTION
## Problem

If an error is raised while we are trying to upload a part, we should
ignore the upload and let the retry run pick up from the failed part.
Otherwise, we could be uploading a part that doesn't reach the
required minimum size of 5MiB.

Moreover, if the error was a timeout, we should unwrap it from it's
`ClientError` and raise our own retryable exception, otherwise the
export will fail when a retry could have helped.

Finally, users should be more strongly encouraged to retry an export
that failed before reaching for support.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* `BatchExportTemporaryFile` passes an `error` to the `flush_callable` containing the last exception raised.
* S3 batch export flush now returns early if an error is passed, before uploading a part.
* If `upload_part` raises a `ClientError` with error code `RequestTimeout` we instead re-raise our own (retryable) exception.
* Notification email was updated.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added two unit tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
