### PR TITLE
fix(data-warehouse): Check whether the table schema is valid via a backgorund celery task

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -596,6 +596,7 @@ posthog/api/plugin_log_entry.py:0: error: Name "timezone.datetime" is not define
 posthog/api/plugin_log_entry.py:0: error: Module "django.utils.timezone" does not explicitly export attribute "datetime"  [attr-defined]
 posthog/warehouse/api/external_data_source.py:0: error: Incompatible return value type (got "tuple[ExternalDataSource, dict[str, list[tuple[str, str]]]]", expected "tuple[ExternalDataSource, list[Any]]")  [return-value]
 posthog/warehouse/api/external_data_source.py:0: error: Incompatible return value type (got "tuple[ExternalDataSource, dict[str, list[tuple[str, str]]]]", expected "tuple[ExternalDataSource, list[Any]]")  [return-value]
+posthog/warehouse/api/table.py:0: error: Unused "type: ignore" comment  [unused-ignore]
 posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py:0: error: Need type annotation for "_execute_calls" (hint: "_execute_calls: list[<type>] = ...")  [var-annotated]
 posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py:0: error: Need type annotation for "_execute_async_calls" (hint: "_execute_async_calls: list[<type>] = ...")  [var-annotated]
 posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py:0: error: Need type annotation for "_cursors" (hint: "_cursors: list[<type>] = ...")  [var-annotated]

--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -596,7 +596,6 @@ posthog/api/plugin_log_entry.py:0: error: Name "timezone.datetime" is not define
 posthog/api/plugin_log_entry.py:0: error: Module "django.utils.timezone" does not explicitly export attribute "datetime"  [attr-defined]
 posthog/warehouse/api/external_data_source.py:0: error: Incompatible return value type (got "tuple[ExternalDataSource, dict[str, list[tuple[str, str]]]]", expected "tuple[ExternalDataSource, list[Any]]")  [return-value]
 posthog/warehouse/api/external_data_source.py:0: error: Incompatible return value type (got "tuple[ExternalDataSource, dict[str, list[tuple[str, str]]]]", expected "tuple[ExternalDataSource, list[Any]]")  [return-value]
-posthog/warehouse/api/table.py:0: error: Unsupported target for indexed assignment ("dict[str, str | bool] | str")  [index]
 posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py:0: error: Need type annotation for "_execute_calls" (hint: "_execute_calls: list[<type>] = ...")  [var-annotated]
 posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py:0: error: Need type annotation for "_execute_async_calls" (hint: "_execute_async_calls: list[<type>] = ...")  [var-annotated]
 posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py:0: error: Need type annotation for "_cursors" (hint: "_cursors: list[<type>] = ...")  [var-annotated]

--- a/posthog/warehouse/api/test/test_table.py
+++ b/posthog/warehouse/api/test/test_table.py
@@ -20,7 +20,8 @@ class TestTable(APIBaseTest):
         "posthog.warehouse.models.table.DataWarehouseTable.validate_column_type",
         return_value=True,
     )
-    def test_create_columns(self, patch_get_columns, patch_validate_column_type):
+    @patch("posthog.tasks.warehouse.get_ph_client")
+    def test_create_columns(self, patch_get_columns, patch_validate_column_type, patch_get_ph_client):
         response = self.client.post(
             f"/api/projects/{self.team.id}/warehouse_tables/",
             {
@@ -58,7 +59,8 @@ class TestTable(APIBaseTest):
         "posthog.warehouse.models.table.DataWarehouseTable.validate_column_type",
         return_value=False,
     )
-    def test_create_columns_invalid_schema(self, patch_get_columns, patch_validate_column_type):
+    @patch("posthog.tasks.warehouse.get_ph_client")
+    def test_create_columns_invalid_schema(self, patch_get_columns, patch_validate_column_type, patch_get_ph_client):
         response = self.client.post(
             f"/api/projects/{self.team.id}/warehouse_tables/",
             {

--- a/posthog/warehouse/api/test/test_view.py
+++ b/posthog/warehouse/api/test/test_view.py
@@ -99,7 +99,8 @@ class TestView(APIBaseTest):
         "posthog.warehouse.models.datawarehouse_saved_query.DataWarehouseSavedQuery.get_columns",
         return_value={"id": "String", "a_column": "String"},
     )
-    def test_view_with_external_table(self, patch_get_columns_1, patch_get_columns_2):
+    @patch("posthog.tasks.warehouse.get_ph_client")
+    def test_view_with_external_table(self, patch_get_columns_1, patch_get_columns_2, patch_get_ph_client):
         response = self.client.post(
             f"/api/projects/{self.team.id}/warehouse_tables/",
             {


### PR DESCRIPTION
## Problem
- When adding a manual source file, we check each column to ensure the type we get back from clickhouse is correct and valid. This operation can take a long time on wide or large data sets, often making the creation request exceed the 60s timeout

## Changes
- Run the schema validity in the background via a celery worker
  - This doesn't need to give any feedback to the user in real time

## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
Added a unit test