### PR TITLE
feat(data-warehouse): add username for ssh connections to MySQL datab…

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -301,6 +301,13 @@ export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
                                 value: 'keypair',
                                 fields: [
                                     {
+                                        name: 'username',
+                                        label: 'Tunnel username',
+                                        type: 'text',
+                                        required: false,
+                                        placeholder: 'User1',
+                                    },
+                                    {
                                         name: 'private_key',
                                         label: 'Tunnel private key',
                                         type: 'textarea',


### PR DESCRIPTION
…ases

## Problem

MySQL Datawarehouse connections are currently missing the ability to specify a username on SSH connections.
