### PR TITLE
chore: for surveys features just prompt to upgrade

### DIFF
--- a/frontend/src/scenes/surveys/SurveyCustomization.tsx
+++ b/frontend/src/scenes/surveys/SurveyCustomization.tsx
@@ -66,7 +66,7 @@ export function Customization({ appearance, surveyQuestionItem, onAppearanceChan
                                     disabledReason={
                                         surveysStylingAvailable
                                             ? null
-                                            : 'Subscribe to surveys to customize survey position.'
+                                            : 'Upgrade your plan to customize survey position.'
                                     }
                                 >
                                     {position}

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -82,7 +82,7 @@ export default function SurveyEdit(): JSX.Element {
     const { thankYouMessageDescriptionContentType = null } = survey.appearance ?? {}
     const surveysRecurringScheduleDisabledReason = surveysRecurringScheduleAvailable
         ? undefined
-        : 'Subscribe to surveys for repeating surveys over a duration of time'
+        : 'Upgrade your plan to use repeating surveys'
 
     if (survey.iteration_count && survey.iteration_count > 0) {
         setSchedule('recurring')
@@ -427,7 +427,7 @@ export default function SurveyEdit(): JSX.Element {
                                                 disabledReason={
                                                     surveysMultipleQuestionsAvailable
                                                         ? null
-                                                        : 'Subscribe to surveys for multiple questions'
+                                                        : 'Upgrade your plan to get multiple questions'
                                                 }
                                                 onClick={() => {
                                                     setSurveyValue('questions', [
@@ -441,7 +441,7 @@ export default function SurveyEdit(): JSX.Element {
                                             </LemonButton>
                                             {!surveysMultipleQuestionsAvailable && (
                                                 <Link to="/organization/billing" target="_blank" targetBlankIcon>
-                                                    Subscribe
+                                                    Upgrade
                                                 </Link>
                                             )}
                                         </div>


### PR DESCRIPTION
## Problem

We no longer have single-product-subscribe, so the tooltips here didn't make sense.

![Arc 2024-07-24 10 11 08](https://github.com/user-attachments/assets/e8b6640a-53fc-40d1-aa06-a322d304dc87)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Changes the language. I wondered if we should use a standard paygate but i think there was an intentional decision to _not_ do that - they want to show the features and how they might be used, but not let them be used without the right plan.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

👀 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
