### PR TITLE
docs(bot): explain  label for stale PR bot

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -19,7 +19,7 @@ jobs:
                   remove-issue-stale-when-updated: true
                   days-before-pr-stale: 7
                   days-before-pr-close: 7
-                  stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in another week."
+                  stale-pr-message: "This PR hasn't seen activity in a week! Should it be merged, closed, or further worked on? If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in another week. If you want to permanentely keep it open, use the `waiting` label."
                   close-pr-message: "This PR was closed due to lack of activity. Feel free to reopen if it's still relevant."
                   stale-pr-label: stale
                   remove-pr-stale-when-updated: true


### PR DESCRIPTION
## Problem

The `waiting` label to exempt PRs from the stale bot isn't widely known.

## Changes

Adds a hint to the PR comment.

## How did you test this code?

n/a