### PR TITLE
fix(data-warehouse): Allow internal DB in a source, if using a ssh tunnel

### DIFF
--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -441,7 +441,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         ssh_tunnel_auth_type_passphrase = ssh_tunnel_auth_type_obj.get("passphrase", None)
         ssh_tunnel_auth_type_private_key = ssh_tunnel_auth_type_obj.get("private_key", None)
 
-        if not self._validate_postgres_host(host, self.team_id):
+        if not self._validate_database_host(host, self.team_id, using_ssh_tunnel):
             raise InternalPostgresError()
 
         new_source_model = ExternalDataSource.objects.create(
@@ -686,10 +686,10 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     )
 
             # Validate internal postgres
-            if not self._validate_postgres_host(host, self.team_id):
+            if not self._validate_database_host(host, self.team_id, using_ssh_tunnel):
                 return Response(
                     status=status.HTTP_400_BAD_REQUEST,
-                    data={"message": "Cannot use internal Postgres database"},
+                    data={"message": "Cannot use internal database"},
                 )
 
             try:
@@ -893,7 +893,10 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 return value
         return None
 
-    def _validate_postgres_host(self, host: str, team_id: int) -> bool:
+    def _validate_database_host(self, host: str, team_id: int, using_ssh_tunnel: bool) -> bool:
+        if using_ssh_tunnel:
+            return True
+
         if host.startswith("172") or host.startswith("10") or host.startswith("localhost"):
             if is_cloud():
                 region = get_instance_region()

--- a/posthog/warehouse/api/test/test_external_data_source.py
+++ b/posthog/warehouse/api/test/test_external_data_source.py
@@ -635,7 +635,7 @@ class TestExternalDataSource(APIBaseTest):
                 },
             )
             self.assertEqual(response.status_code, 400)
-            self.assertEqual(response.json(), {"message": "Cannot use internal Postgres database"})
+            self.assertEqual(response.json(), {"message": "Cannot use internal database"})
 
         with override_settings(CLOUD_DEPLOYMENT="EU"):
             team_1 = Team.objects.create(id=1, organization=self.team.organization)
@@ -679,7 +679,7 @@ class TestExternalDataSource(APIBaseTest):
                 },
             )
             self.assertEqual(response.status_code, 400)
-            self.assertEqual(response.json(), {"message": "Cannot use internal Postgres database"})
+            self.assertEqual(response.json(), {"message": "Cannot use internal database"})
 
     def test_source_jobs(self):
         source = self._create_external_data_source()

--- a/posthog/warehouse/api/test/test_table.py
+++ b/posthog/warehouse/api/test/test_table.py
@@ -247,7 +247,7 @@ class TestTable(APIBaseTest):
         return_value=True,
     )
     @patch("posthog.tasks.warehouse.get_ph_client")
-    def test_table_name_duplicate(self, patch_get_columns, patch_validate_column_type):
+    def test_table_name_duplicate(self, patch_get_columns, patch_validate_column_type, patch_get_ph_client):
         response = self.client.post(
             f"/api/projects/{self.team.id}/warehouse_tables/",
             {

--- a/posthog/warehouse/api/test/test_table.py
+++ b/posthog/warehouse/api/test/test_table.py
@@ -246,6 +246,7 @@ class TestTable(APIBaseTest):
         "posthog.warehouse.models.table.DataWarehouseTable.validate_column_type",
         return_value=True,
     )
+    @patch("posthog.tasks.warehouse.get_ph_client")
     def test_table_name_duplicate(self, patch_get_columns, patch_validate_column_type):
         response = self.client.post(
             f"/api/projects/{self.team.id}/warehouse_tables/",


### PR DESCRIPTION
## Problem
- When using a SSH tunnel to connect to a database via data warehouse, you can't connect to a local host/ip due to our internal limitations
- Reported in this [support ticket](https://posthoghelp.zendesk.com/agent/tickets/16164)

## Changes
- allow internal IPs/hosts if the source is using a ssh tunnel 

## Does this work well for both Cloud and self-hosted?
Yep
