### PR TITLE
test(e2e): Actually run Celery tasks async in `e2e-test-runner`

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -191,7 +191,7 @@ jobs:
                   OBJECT_STORAGE_SECRET_ACCESS_KEY=object_storage_root_password
                   GITHUB_ACTION_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   CELERY_METRICS_PORT=8999
-                  CLOUD_DEPLOYMENT=1
+                  CLOUD_DEPLOYMENT=E2E
                   EOT
 
             - name: Start PostHog

--- a/.run/Celery Threads.run.xml
+++ b/.run/Celery Threads.run.xml
@@ -21,7 +21,7 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/manage.py" />
-    <option name="PARAMETERS" value="run_autoreload_celery" />
+    <option name="PARAMETERS" value="run_autoreload_celery --type=worker" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="false" />

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -94,7 +94,7 @@
             },
             "request": "launch",
             "program": "${workspaceFolder}/manage.py",
-            "args": ["run_autoreload_celery"],
+            "args": ["run_autoreload_celery", "--type=worker"],
             "console": "integratedTerminal",
             "python": "${workspaceFolder}/env/bin/python",
             "cwd": "${workspaceFolder}",

--- a/bin/e2e-test-runner
+++ b/bin/e2e-test-runner
@@ -64,7 +64,7 @@ export PGUSER="${PGUSER:=posthog}"
 export PGPASSWORD="${PGPASSWORD:=posthog}"
 export PGPORT="${PGPORT:=5432}"
 export DATABASE_URL="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${DATABASE}"
-export CLOUD_DEPLOYMENT=DEV
+export CLOUD_DEPLOYMENT=E2E
 
 source ./bin/celery-queues.env
 

--- a/bin/e2e-test-runner
+++ b/bin/e2e-test-runner
@@ -92,8 +92,7 @@ setupDev() {
   python manage.py setup_dev &
 }
 
-nc -z localhost 9092 || ( echo -e "\033[0;31mKafka isn't running. Please run\n\tdocker compose -f docker-compose.dev.yml up zookeeper kafka clickhouse db redis\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
-wget -nv -t1 --spider 'http://localhost:8123/' || ( echo -e "\033[0;31mClickhouse isn't running. Please run\n\tdocker compose -f docker-compose.dev.yml up zookeeper kafka clickhouse db redis.\nI'll wait while you do that.\033[0m" ; bin/check_kafka_clickhouse_up )
+bin/check_kafka_clickhouse_up
 
 $SKIP_RECREATE_DATABASE || recreateDatabases
 $SKIP_MIGRATE || migrateDatabases

--- a/bin/e2e-test-runner
+++ b/bin/e2e-test-runner
@@ -46,15 +46,14 @@ do
     fi
 done
 
-export DEBUG=1
 export NO_RESTART_LOOP=1
 export CYPRESS_BASE_URL=http://localhost:8080
 export SECURE_COOKIES=0
 export SKIP_SERVICE_VERSION_REQUIREMENTS=1
 export KAFKA_HOSTS=kafka:9092
 export CLICKHOUSE_DATABASE=posthog_test
-export TEST=1 # Plugin server and kafka revert to 'default' Clickhouse database if TEST is not set
 export CLICKHOUSE_SECURE=0
+export JS_URL=http://localhost:8234
 export E2E_TESTING=1
 export SECRET_KEY=e2e_test
 export EMAIL_HOST=email.test.posthog.net

--- a/bin/e2e-test-runner
+++ b/bin/e2e-test-runner
@@ -46,7 +46,6 @@ do
     fi
 done
 
-export NO_RESTART_LOOP=1
 export CYPRESS_BASE_URL=http://localhost:8080
 export SECURE_COOKIES=0
 export SKIP_SERVICE_VERSION_REQUIREMENTS=1
@@ -65,7 +64,9 @@ export PGUSER="${PGUSER:=posthog}"
 export PGPASSWORD="${PGPASSWORD:=posthog}"
 export PGPORT="${PGPORT:=5432}"
 export DATABASE_URL="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}/${DATABASE}"
-export CLOUD_DEPLOYMENT=1
+export CLOUD_DEPLOYMENT=DEV
+
+source ./bin/celery-queues.env
 
 trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
@@ -102,4 +103,6 @@ $SKIP_SETUP_DEV || setupDev
 # Only start webpack if not already running
 nc -vz 127.0.0.1 8234 2> /dev/null || ./bin/start-frontend &
 pnpm dlx cypress open --config-file cypress.e2e.config.ts &
+uv pip install -r requirements.txt -r requirements-dev.txt
+python manage.py run_autoreload_celery --type=worker &
 python manage.py runserver 8080

--- a/bin/start-worker
+++ b/bin/start-worker
@@ -7,8 +7,8 @@ trap 'kill $(jobs -p)' EXIT
 source ./bin/celery-queues.env
 
 # start celery worker with heartbeat (-B)
-SKIP_ASYNC_MIGRATIONS_SETUP=0 CELERY_WORKER_QUEUES=$CELERY_WORKER_QUEUES celery -A posthog worker --without-heartbeat --without-mingle --pool=threads -Ofair -n node@%h &
-celery -A posthog beat -S redbeat.RedBeatScheduler &
+python manage.py run_autoreload_celery --type=worker &
+python manage.py run_autoreload_celery --type=beat &
 
 if [[ "$PLUGIN_SERVER_IDLE" != "1" && "$PLUGIN_SERVER_IDLE" != "true" ]]; then
   ./bin/plugin-server

--- a/cypress.e2e.config.ts
+++ b/cypress.e2e.config.ts
@@ -99,15 +99,16 @@ export default defineConfig({
                     const redisClient = await createClient()
                         .on('error', (err) => console.log('Redis client error', err))
                         .connect()
-                    for await (const key of redisClient.scanIterator({
-                        TYPE: 'string',
-                        MATCH: '*cache*',
-                        COUNT: 100,
-                    })) {
+                    // Clear cache
+                    for await (const key of redisClient.scanIterator({ TYPE: 'string', MATCH: '*cache*', COUNT: 500 })) {
+                        await redisClient.del(key)
+                    }
+                    // Also clear the more ephemeral async query statuses
+                    for await (const key of redisClient.scanIterator({ TYPE: 'string', MATCH: 'query_async*', COUNT: 500 })) {
                         await redisClient.del(key)
                     }
                     await redisClient.quit()
-                    return null
+                    return null // Cypress requires _some_ return value
                 },
             })
 

--- a/cypress/e2e/insights-saved.cy.ts
+++ b/cypress/e2e/insights-saved.cy.ts
@@ -1,0 +1,44 @@
+import { urls } from 'scenes/urls'
+
+import { createInsight } from '../productAnalytics'
+
+chai.Assertion.addMethod('neverHaveChild', function (childSelector) {
+    this._obj.on('DOMNodeInserted', () => {
+        const matchCount = cy.$$(childSelector, this._obj).length
+        if (matchCount > 0) {
+            throw new Error(
+                `Expected element to never have child ${childSelector}, but found ${matchCount} match${
+                    matchCount > 1 ? 'es' : ''
+                }`
+            )
+        }
+    })
+})
+
+// For tests related to trends please check trendsElements.js
+// insight tests were split up because Cypress was struggling with this many tests in one file🙈
+describe('Insights - saved', () => {
+    it('Data is available immediately', () => {
+        void createInsight('saved insight').then((newInsightId) => {
+            cy.get('[data-attr=trend-line-graph]').should('exist') // Results cached
+            cy.visit(urls.insightView(newInsightId)) // Full refresh
+            cy.get('.InsightViz').should('exist').should('neverHaveChild', '.insight-empty-state') // Only cached data
+            cy.get('[data-attr=trend-line-graph]').should('exist')
+        })
+    })
+
+    it('If cache empty, initiate async refresh', () => {
+        cy.intercept('GET', /\/api\/projects\/\d+\/insights\/?\?[^/]*?refresh=async/).as('getInsightsRefreshAsync')
+        let newInsightId: string
+        void createInsight('saved insight').then((insightId) => {
+            newInsightId = insightId
+        })
+        cy.task('resetInsightCache').then(() => {
+            cy.visit(urls.insightView(newInsightId)) // Full refresh
+            cy.get('.insight-empty-state').should('exist') // There should be a loading state for a moment
+            cy.wait('@getInsightsRefreshAsync').then(() => {
+                cy.get('[data-attr=trend-line-graph]').should('exist')
+            })
+        })
+    })
+})

--- a/cypress/e2e/insights-saved.cy.ts
+++ b/cypress/e2e/insights-saved.cy.ts
@@ -19,7 +19,7 @@ chai.Assertion.addMethod('neverHaveChild', function (childSelector) {
 // insight tests were split up because Cypress was struggling with this many tests in one file🙈
 describe('Insights - saved', () => {
     it('Data is available immediately', () => {
-        void createInsight('saved insight').then((newInsightId) => {
+        createInsight('saved insight').then((newInsightId) => {
             cy.get('[data-attr=trend-line-graph]').should('exist') // Results cached
             cy.visit(urls.insightView(newInsightId)) // Full refresh
             cy.get('.InsightViz').should('exist').should('neverHaveChild', '.insight-empty-state') // Only cached data
@@ -30,7 +30,7 @@ describe('Insights - saved', () => {
     it('If cache empty, initiate async refresh', () => {
         cy.intercept('GET', /\/api\/projects\/\d+\/insights\/?\?[^/]*?refresh=async/).as('getInsightsRefreshAsync')
         let newInsightId: string
-        void createInsight('saved insight').then((insightId) => {
+        createInsight('saved insight').then((insightId) => {
             newInsightId = insightId
         })
         cy.task('resetInsightCache').then(() => {

--- a/cypress/productAnalytics/index.ts
+++ b/cypress/productAnalytics/index.ts
@@ -192,16 +192,14 @@ export const dashboard = {
     },
 }
 
-export function createInsight(insightName: string): Promise<string> {
-    return new Promise((resolve) => {
-        savedInsights.createNewInsightOfType('TRENDS')
-        insight.applyFilter()
-        insight.editName(insightName)
-        insight.save()
-        // return insight id from the url
-        cy.url().then((url) => {
-            resolve(url.split('/').at(-1))
-        })
+export function createInsight(insightName: string): Cypress.Chainable<string> {
+    savedInsights.createNewInsightOfType('TRENDS')
+    insight.applyFilter()
+    insight.editName(insightName)
+    insight.save()
+    // return insight id from the url
+    return cy.url().then((url) => {
+        return url.split('/').at(-1)
     })
 }
 

--- a/cypress/productAnalytics/index.ts
+++ b/cypress/productAnalytics/index.ts
@@ -192,11 +192,17 @@ export const dashboard = {
     },
 }
 
-export function createInsight(insightName: string): void {
-    savedInsights.createNewInsightOfType('TRENDS')
-    insight.applyFilter()
-    insight.editName(insightName)
-    insight.save()
+export function createInsight(insightName: string): Promise<string> {
+    return new Promise((resolve) => {
+        savedInsights.createNewInsightOfType('TRENDS')
+        insight.applyFilter()
+        insight.editName(insightName)
+        insight.save()
+        // return insight id from the url
+        cy.url().then((url) => {
+            resolve(url.split('/').at(-1))
+        })
+    })
 }
 
 export function duplicateDashboardFromMenu(duplicateTiles = false): void {

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -23,6 +23,10 @@ Cypress.on('window:before:load', (win) => {
     win._cypress_posthog_captures = []
 })
 
+before(() => {
+    cy.task('resetInsightCache') // Reset insight cache before each suite
+})
+
 beforeEach(() => {
     Cypress.env('POSTHOG_PROPERTY_CURRENT_TEST_TITLE', Cypress.currentTest.title)
     Cypress.env('POSTHOG_PROPERTY_CURRENT_TEST_FULL_TITLE', Cypress.currentTest.titlePath.join(' > '))

--- a/posthog/caching/insight_caching_state.py
+++ b/posthog/caching/insight_caching_state.py
@@ -181,7 +181,7 @@ def sync_insight_caching_state(
         # This is a best-effort kind synchronization, safe to ignore errors
         logger.warn(
             "Failed to sync InsightCachingState, ignoring",
-            exception=err,
+            exception=str(err),
             team_id=team_id,
             insight_id=insight_id,
             dashboard_tile_id=dashboard_tile_id,

--- a/posthog/clickhouse/table_engines.py
+++ b/posthog/clickhouse/table_engines.py
@@ -49,7 +49,7 @@ class MergeTreeEngine:
             shard_key, replica_key = "noshard", "{replica}-{shard}"
 
         # ZK is not automatically cleaned up after DROP TABLE. Avoid zk path conflicts in tests by generating unique paths.
-        if settings.TEST and self.zookeeper_path_key is None or self.force_unique_zk_path:
+        if (settings.TEST or settings.E2E_TESTING) and self.zookeeper_path_key is None or self.force_unique_zk_path:
             self.set_zookeeper_path_key(str(uuid.uuid4()))
 
         if self.zookeeper_path_key is not None:

--- a/posthog/management/commands/migrate_clickhouse.py
+++ b/posthog/management/commands/migrate_clickhouse.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
             password=CLICKHOUSE_PASSWORD,
             cluster=CLICKHOUSE_CLUSTER,
             verify_ssl_cert=False,
-            randomize_replica_paths=settings.TEST,
+            randomize_replica_paths=settings.TEST or settings.E2E_TESTING,
         )
         if options["plan"] or options["check"]:
             print("List of clickhouse migrations to be applied:")

--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -24,7 +24,7 @@ OPT_OUT_CAPTURE: bool = get_from_env("OPT_OUT_CAPTURE", False, type_cast=str_to_
 BENCHMARK: bool = get_from_env("BENCHMARK", False, type_cast=str_to_bool)
 if E2E_TESTING:
     logger.warning(
-        ["️WARNING! E2E_TESTING is set to `True`. This is a security vulnerability unless you are running tests."]
+        "️WARNING! Environment variable E2E_TESTING is enabled. This is a security vulnerability unless you are running tests."
     )
 
 IS_COLLECT_STATIC = len(sys.argv) > 1 and sys.argv[1] == "collectstatic"

--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -14,8 +14,9 @@ DEBUG: bool = get_from_env("DEBUG", False, type_cast=str_to_bool)
 TEST = "test" in sys.argv or sys.argv[0].endswith("pytest") or get_from_env("TEST", False, type_cast=str_to_bool)  # type: bool
 DEMO: bool = get_from_env("DEMO", False, type_cast=str_to_bool)  # Whether this is a managed demo environment
 CLOUD_DEPLOYMENT: str | None = get_from_env(
-    "CLOUD_DEPLOYMENT", optional=True
-)  # "US", "EU", or "DEV" - unset on self-hosted
+    "CLOUD_DEPLOYMENT",
+    optional=True,  # "US", "EU", "DEV", or "E2E" - unset on self-hosted
+)
 SELF_CAPTURE: bool = get_from_env("SELF_CAPTURE", DEBUG and not DEMO, type_cast=str_to_bool)
 E2E_TESTING: bool = get_from_env(
     "E2E_TESTING", False, type_cast=str_to_bool


### PR DESCRIPTION
## Problem

Adding accurate E2E tests for behavior relying on Celery tasks hasn't been possible, as `bin/e2e-test-runner` was actually running PostHog in TEST _and_ DEBUG mode, resulting in non-production-like behavior, e.g. Celery tasks being always executed sync (`CELERY_ALWAYS_EAGER` setting) or Django cache being in-memory rather than over Redis.

With async insight execution being critical now (e.g. see #23808), we need to be able to test it.

## Changes

This makes a few changes to the setup of `bin/e2e-test-runner` so that PostHog behavior mirrors production. This has allowed adding a test for async insight execution, that actually verifies execution being kicked off, and polled results becoming soon available.

It doesn't look like significant changes to the CI workflow are necessary, as it doesn't set `TEST=1` or `DEBUG=1` and already starts `bin/docker-worker`.