### PR TITLE
feat(BI): Added area charts to BI

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -12,6 +12,7 @@ import { useValues } from 'kea'
 import { Chart, ChartItem, ChartOptions } from 'lib/Chart'
 import { getGraphColors, getSeriesColor } from 'lib/colors'
 import { InsightLabel } from 'lib/components/InsightLabel'
+import { hexToRGBA } from 'lib/utils'
 import { useEffect, useRef } from 'react'
 import { ensureTooltip } from 'scenes/insights/views/LineGraph/LineGraph'
 
@@ -32,6 +33,7 @@ export const LineGraph = (): JSX.Element => {
     // via props. Make this a purely presentational component
     const { xData, yData, presetChartHeight, visualizationType, showEditingUI } = useValues(dataVisualizationLogic)
     const isBarChart = visualizationType === ChartDisplayType.ActionsBar
+    const isAreaChart = visualizationType === ChartDisplayType.ActionsAreaGraph
 
     const { goalLines } = useValues(displayLogic)
 
@@ -44,11 +46,12 @@ export const LineGraph = (): JSX.Element => {
             labels: xData.data,
             datasets: yData.map(({ data }, index) => {
                 const color = getSeriesColor(index)
+                const backgroundColor = isAreaChart ? hexToRGBA(color, 0.5) : color
 
                 return {
                     data,
                     borderColor: color,
-                    backgroundColor: color,
+                    backgroundColor: backgroundColor,
                     borderWidth: isBarChart ? 0 : 2,
                     pointRadius: 0,
                     hitRadius: 0,
@@ -56,6 +59,7 @@ export const LineGraph = (): JSX.Element => {
                     hoverBorderWidth: isBarChart ? 0 : 2,
                     hoverBorderRadius: isBarChart ? 0 : 2,
                     type: isBarChart ? GraphType.Bar : GraphType.Line,
+                    fill: isAreaChart ? 'origin' : false,
                 } as ChartData['datasets'][0]
             }),
         }
@@ -249,7 +253,7 @@ export const LineGraph = (): JSX.Element => {
                 y: {
                     display: true,
                     beginAtZero: true,
-                    stacked: false,
+                    stacked: isAreaChart,
                     ticks: {
                         display: true,
                         ...tickOptions,

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
@@ -1,7 +1,7 @@
 import { IconGraph, IconTrends } from '@posthog/icons'
 import { LemonSelect, LemonSelectOptions } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
-import { Icon123, IconTableChart } from 'lib/lemon-ui/icons'
+import { Icon123, IconAreaChart, IconTableChart } from 'lib/lemon-ui/icons'
 
 import { ChartDisplayType } from '~/types'
 
@@ -39,6 +39,11 @@ export const TableDisplay = (): JSX.Element => {
                     value: ChartDisplayType.ActionsBar,
                     icon: <IconGraph />,
                     label: 'Bar chart',
+                },
+                {
+                    value: ChartDisplayType.ActionsAreaGraph,
+                    icon: <IconAreaChart />,
+                    label: 'Area chart',
                 },
             ],
         },

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -107,7 +107,8 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
         )
     } else if (
         visualizationType === ChartDisplayType.ActionsLineGraph ||
-        visualizationType === ChartDisplayType.ActionsBar
+        visualizationType === ChartDisplayType.ActionsBar ||
+        visualizationType === ChartDisplayType.ActionsAreaGraph
     ) {
         component = <Chart />
     } else if (visualizationType === ChartDisplayType.BoldNumber) {


### PR DESCRIPTION
## Changes
- Adds area chart type to BI

<img width="840" alt="image" src="https://github.com/user-attachments/assets/56f3da4c-ff60-4432-913c-51b6f8600da4">


## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
Tested locally