### PR TITLE
fix(web-analytics): Use events rather than sharded_events for raw_sessions backfill

### DIFF
--- a/posthog/models/raw_sessions/sql.py
+++ b/posthog/models/raw_sessions/sql.py
@@ -215,7 +215,7 @@ SELECT
 
     -- replay
     false as maybe_has_session_replay
-FROM {database}.sharded_events
+FROM {database}.events
 WHERE bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7 -- has a session id and is valid uuidv7
 """.format(
         database=settings.CLICKHOUSE_DATABASE,


### PR DESCRIPTION
## Problem

I believe this is the root cause for some users seeing a disceprency in their v1 vs v2 session table calculations.

The previous backfill script for v1 used `events` rather than `sharded_events`, and worked as expected. It was a mistake to use `sharded_events` for v2.

I've had to revert the sessions table back to v1 for the time being, but this means that the bounce rate fix is also rolled back (i.e. bounce rate is broken again), so it'd be great to make forward progress on this ASAP

## Changes

Change the backfill to use events rather than sharded_events

## Does this work well for both Cloud and self-hosted?

Yes (though idk if self-hosted people are likely to run the backfill)

## How did you test this code?

n/a
