### PR TITLE
fix: redirect to persons in notebooks

### DIFF
--- a/frontend/src/scenes/persons/PersonDisplay.tsx
+++ b/frontend/src/scenes/persons/PersonDisplay.tsx
@@ -8,8 +8,6 @@ import { ProfilePicture, ProfilePictureProps } from 'lib/lemon-ui/ProfilePicture
 import { useMemo, useState } from 'react'
 import { useNotebookNode } from 'scenes/notebooks/Nodes/NotebookNodeContext'
 
-import { NotebookNodeType } from '~/types'
-
 import { asDisplay, asLink } from './person-utils'
 import { PersonPreview } from './PersonPreview'
 
@@ -83,19 +81,6 @@ export function PersonDisplay({
                               router.actions.push(href)
                           } else {
                               setVisible(true)
-
-                              if (notebookNode && person) {
-                                  notebookNode.actions.updateAttributes({
-                                      children: [
-                                          {
-                                              type: NotebookNodeType.Person,
-                                              attrs: {
-                                                  id: person.distinct_id || person.distinct_ids?.[0],
-                                              },
-                                          },
-                                      ],
-                                  })
-                              }
                           }
                       }
                     : undefined
@@ -107,7 +92,7 @@ export function PersonDisplay({
                 <Link
                     to={href}
                     onClick={(e) => {
-                        if (!noPopover) {
+                        if (!noPopover && !notebookNode) {
                             e.preventDefault()
                             return
                         }


### PR DESCRIPTION
## Problem

We were inserting canvas `children` into notebooks when clicking on a person as a result of https://github.com/PostHog/posthog/pull/18129. Looks like the feature flag referenced there no longer exists in the codebase so I'm just going to remove the offending code entirely

## Changes

|Before|After|
|----|----|
| ![before](https://github.com/user-attachments/assets/68cd6279-5e84-49eb-a0ef-158c6ba7a351) | ![after](https://github.com/user-attachments/assets/8d8ff774-8e5b-4e74-af2a-3bd46b187875) |

(Now redirects to the persons page)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually