### PR TITLE
refactor(insights): use query based insight for adding to/removing from dashboard

### DIFF
--- a/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
+++ b/frontend/src/lib/components/AddToDashboard/addToDashboardModalLogic.ts
@@ -21,7 +21,7 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>([
     key(keyForInsightLogicProps('new')),
     path((key) => ['lib', 'components', 'AddToDashboard', 'saveToDashboardModalLogic', key]),
     connect((props: InsightLogicProps) => ({
-        values: [insightLogic(props), ['queryBasedInsight', 'legacyInsight']],
+        values: [insightLogic(props), ['queryBasedInsight']],
         actions: [
             insightLogic(props),
             ['updateInsight', 'updateInsightSuccess', 'updateInsightFailure'],
@@ -101,7 +101,9 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>([
             // TODO be able to update not by patching `dashboards` against insight
             // either patch dashboard_tiles on the insight or add a dashboard_tiles API
             actions.updateInsight(
-                { ...values.legacyInsight, dashboards: [...(values.legacyInsight.dashboards || []), dashboardId] },
+                {
+                    dashboards: [...(values.queryBasedInsight.dashboards || []), dashboardId],
+                },
                 () => {
                     actions.reportSavedInsightToDashboard()
                     dashboardsModel.actions.tileAddedToDashboard(dashboardId)
@@ -117,9 +119,8 @@ export const addToDashboardModalLogic = kea<addToDashboardModalLogicType>([
         removeFromDashboard: async ({ dashboardId }): Promise<void> => {
             actions.updateInsight(
                 {
-                    ...values.legacyInsight,
-                    dashboards: (values.legacyInsight.dashboards || []).filter((d) => d !== dashboardId),
-                    dashboard_tiles: (values.legacyInsight.dashboard_tiles || []).filter(
+                    dashboards: (values.queryBasedInsight.dashboards || []).filter((d) => d !== dashboardId),
+                    dashboard_tiles: (values.queryBasedInsight.dashboard_tiles || []).filter(
                         (dt) => dt.dashboard_id !== dashboardId
                     ),
                 },

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -9,7 +9,6 @@ import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
-import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { insightsModel } from '~/models/insightsModel'
@@ -528,7 +527,7 @@ describe('insightLogic', () => {
         logic.actions.saveInsight()
         await expectLogic(logic).toDispatchActions([savedInsightsLogic.actionTypes.addInsight])
 
-        logic.actions.updateInsight({ filters: { insight: InsightType.FUNNELS } })
+        logic.actions.updateInsight({ name: 'my new name' })
         await expectLogic(logic).toDispatchActions([savedInsightsLogic.actionTypes.setInsight])
     })
 
@@ -552,6 +551,9 @@ describe('insightLogic', () => {
         savedInsightsLogic.mount()
         logic = insightLogic({
             dashboardItemId: Insight43,
+            cachedInsight: {
+                id: 3,
+            },
         })
         logic.mount()
 
@@ -589,42 +591,6 @@ describe('insightLogic', () => {
             .toMatchValues({
                 location: partial({ pathname: '/insights/12/edit' }),
             })
-    })
-
-    describe('emptyFilters', () => {
-        let theEmptyFiltersLogic: ReturnType<typeof insightLogic.build>
-        beforeEach(() => {
-            const insight = {
-                result: ['result from api'],
-            }
-            theEmptyFiltersLogic = insightLogic({
-                dashboardItemId: undefined,
-                cachedInsight: insight,
-            })
-            theEmptyFiltersLogic.mount()
-            silenceKeaLoadersErrors()
-        })
-        afterEach(resumeKeaLoadersErrors)
-
-        it('does not call the api on update when empty filters and no query', async () => {
-            await expectLogic(theEmptyFiltersLogic, () => {
-                theEmptyFiltersLogic.actions.updateInsight({
-                    name: 'name',
-                    filters: {},
-                    query: undefined,
-                })
-            }).toNotHaveDispatchedActions(['updateInsightSuccess'])
-        })
-
-        it('does call the api on update when empty filters but query is present', async () => {
-            await expectLogic(theEmptyFiltersLogic, () => {
-                theEmptyFiltersLogic.actions.updateInsight({
-                    name: 'name',
-                    filters: {},
-                    query: { kind: NodeKind.DataTableNode } as DataTableNode,
-                })
-            }).toDispatchActions(['updateInsightSuccess'])
-        })
     })
 
     describe('reacts to external changes', () => {


### PR DESCRIPTION
## Problem

The saga of removing `filters` continues.

## Changes

In this chapter we're going to use query based insights for the "add to dashboard" and "remove from dashboard" functionality.

## How did you test this code?

Tested adding and removing an insight