### PR TITLE
fix(data-warehouse): only enable checkbox if sync method is set

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SchemaForm.tsx
@@ -4,7 +4,7 @@ import { useActions, useValues } from 'kea'
 import { sourceWizardLogic } from '../../new/sourceWizardLogic'
 import { SyncMethodForm } from './SyncMethodForm'
 
-export default function PostgresSchemaForm(): JSX.Element {
+export default function SchemaForm(): JSX.Element {
     const { toggleSchemaShouldSync, openSyncMethodModal } = useActions(sourceWizardLogic)
     const { databaseSchema } = useValues(sourceWizardLogic)
 
@@ -26,6 +26,11 @@ export default function PostgresSchemaForm(): JSX.Element {
                                             onChange={(checked) => {
                                                 toggleSchemaShouldSync(schema, checked)
                                             }}
+                                            disabledReason={
+                                                schema.sync_type === null
+                                                    ? 'Please set up a sync method first'
+                                                    : undefined
+                                            }
                                         />
                                     )
                                 },

--- a/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
+++ b/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
@@ -7,7 +7,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { ManualLinkSourceType, SourceConfig } from '~/types'
 
 import { DataWarehouseInitialBillingLimitNotice } from '../DataWarehouseInitialBillingLimitNotice'
-import PostgresSchemaForm from '../external/forms/PostgresSchemaForm'
+import SchemaForm from '../external/forms/SchemaForm'
 import SourceForm from '../external/forms/SourceForm'
 import { SyncProgressStep } from '../external/forms/SyncProgressStep'
 import { DatawarehouseTableForm } from '../new/DataWarehouseTableForm'
@@ -241,7 +241,7 @@ function SecondStep(): JSX.Element {
 function ThirdStep(): JSX.Element {
     return (
         <ModalPage page={3}>
-            <PostgresSchemaForm />
+            <SchemaForm />
         </ModalPage>
     )
 }


### PR DESCRIPTION
## Problem

- you can check the sync box on the schema form even without a sync method set up

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- disable unless sync method set up

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
