### PR TITLE
fix(cdp): Don't crash on produce failure

### DIFF
--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -145,6 +145,8 @@ abstract class CdpConsumerBase {
                     value: Buffer.from(JSON.stringify(x.value)),
                     key: x.key,
                     waitForAck: true,
+                }).catch((reason) => {
+                    status.error('⚠️', `failed to produce message: ${reason}`)
                 })
             )
         )

--- a/plugin-server/tests/cdp/cdp-processed-events-consumer.test.ts
+++ b/plugin-server/tests/cdp/cdp-processed-events-consumer.test.ts
@@ -49,7 +49,7 @@ jest.mock('../../src/utils/db/kafka-producer-wrapper', () => {
             connect: jest.fn(),
         },
         disconnect: jest.fn(),
-        produce: jest.fn(),
+        produce: jest.fn(() => Promise.resolve()),
     }
     return {
         KafkaProducerWrapper: jest.fn(() => mockKafkaProducer),


### PR DESCRIPTION
## Problem

```
2024-07-25 20:21:23.855	
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
2024-07-25 20:21:23.855	
MessageSizeTooLarge: Broker: Message size too large
2024-07-25 20:21:23.855	
    at KafkaProducerWrapper.produce (/code/plugin-server/dist/utils/db/kafka-producer-wrapper.js:35:23)
2024-07-25 20:21:23.855	
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
2024-07-25 20:21:23.855	
    at async Promise.all (index 308)
2024-07-25 20:21:23.855	
    at async CdpProcessedEventsConsumer.produceQueuedMessages (/code/plugin-server/dist/cdp/cdp-consumers.js:98:9)
2024-07-25 20:21:23.855	
    at async func (/code/plugin-server/dist/cdp/cdp-consumers.js:91:17)
2024-07-25 20:21:23.855	
    at async runInstrumentedFunction (/code/plugin-server/dist/main/utils.js:45:24)
2024-07-25 20:21:23.855	
    at async CdpProcessedEventsConsumer.handleEachBatch (/code/plugin-server/dist/cdp/cdp-consumers.js:86:16)
2024-07-25 20:21:23.855	
    at async eachBatch (/code/plugin-server/dist/cdp/cdp-consumers.js:311:24)
2024-07-25 20:21:23.855	
    at async startConsuming (/code/plugin-server/dist/kafka/batch-consumer.js:112:17)
2024-07-25 20:21:23.855	
    at async Object.join (/code/plugin-server/dist/kafka/batch-consumer.js:168:13)
```

## Changes

Catch exception

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Do it live