### PR TITLE
feat(hog): bump hogvm

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -50,7 +50,7 @@
         "@google-cloud/storage": "^5.8.5",
         "@maxmind/geoip2-node": "^3.4.0",
         "@posthog/clickhouse": "^1.7.0",
-        "@posthog/hogvm": "^1.0.29",
+        "@posthog/hogvm": "^1.0.30",
         "@posthog/plugin-scaffold": "1.4.4",
         "@sentry/node": "^7.49.0",
         "@sentry/profiling-node": "^0.3.0",

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -44,8 +44,8 @@ dependencies:
     specifier: ^1.7.0
     version: 1.7.0
   '@posthog/hogvm':
-    specifier: ^1.0.29
-    version: 1.0.29(luxon@3.4.4)(re2@1.20.3)
+    specifier: ^1.0.30
+    version: 1.0.30(luxon@3.4.4)(re2@1.20.3)
   '@posthog/plugin-scaffold':
     specifier: 1.4.4
     version: 1.4.4
@@ -3110,8 +3110,8 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /@posthog/hogvm@1.0.29(luxon@3.4.4)(re2@1.20.3):
-    resolution: {integrity: sha512-mj9ppJTskp1G+rPsvaNwmgGy1EjcmNz7h9i7U/zRwYaXErz7omqVTIZujA2OUoR9NXuR8L5QaqQuhXiTEuRruA==}
+  /@posthog/hogvm@1.0.30(luxon@3.4.4)(re2@1.20.3):
+    resolution: {integrity: sha512-u501rsyskUUnFgMUZjYDfU3pBKp17CKq7aHPAgFpQVFLt1fE9KOQT/hakBjhM9OFUHpjod3SJX3NpbXhOgjz3Q==}
     peerDependencies:
       luxon: ^3.4.4
       re2: ^1.21.3


### PR DESCRIPTION
## Problem

Forgot to push one version bump.

## Changes

Makes it so that Hog scripts that `return` early also return the ops/memUsed/etc metadata.

## How did you test this code?

CI