### PR TITLE
fix(batch-exports): Remove duplicate configuration field

### DIFF
--- a/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/batch_exports/BatchExportEditForm.tsx
@@ -107,16 +107,6 @@ export function BatchExportGeneralEditFields({
                         <LemonInput placeholder="Name your workflow for future reference" />
                     </LemonField>
                 )}
-                {featureFlags[FEATURE_FLAGS.PERSON_BATCH_EXPORTS] && (
-                    <LemonField name="model" label="Model" info="A model defines the data that will be exported.">
-                        <LemonSelect
-                            options={[
-                                { value: 'events', label: 'Events' },
-                                { value: 'persons', label: 'Persons' },
-                            ]}
-                        />
-                    </LemonField>
-                )}
                 <div className="flex gap-2 items-start flex-wrap">
                     <LemonField
                         name="interval"


### PR DESCRIPTION
## Problem

The "Model" is duplicated and pops up in both the left and the right side of the configuration page:

![image](https://github.com/user-attachments/assets/81f45cfb-0f7b-4c48-91f8-2426fead28c3)

Only the left side should be used.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Remove a field from configuration frontend.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
