### PR TITLE
feat(cdp): Icon loader improvements

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
@@ -170,7 +170,6 @@ export function HogFunctionConfiguration({ templateId, id }: { templateId?: stri
                                         {({ value, onChange }) => (
                                             <HogFunctionIconEditable
                                                 logicKey={id ?? templateId ?? 'new'}
-                                                search={configuration.name}
                                                 src={value}
                                                 onChange={(val) => onChange(val)}
                                             />

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionIcon.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionIcon.tsx
@@ -2,6 +2,7 @@ import { LemonButton, LemonFileInput, LemonInput, LemonSkeleton, lemonToast, Pop
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { IconUploadFile } from 'lib/lemon-ui/icons'
+import { useState } from 'react'
 
 import { hogFunctionIconLogic, HogFunctionIconLogicProps } from './hogFunctionIconLogic'
 
@@ -105,18 +106,14 @@ export function HogFunctionIconEditable({
                         {possibleIcons?.map((icon) => (
                             <span
                                 key={icon.id}
-                                className="w-14 h-14 cursor-pointer"
+                                className="cursor-pointer"
                                 onClick={() => {
                                     const nonTempUrl = icon.url.replace('&temp=true', '')
                                     props.onChange?.(nonTempUrl)
                                     setShowPopover(false)
                                 }}
                             >
-                                <img
-                                    src={icon.url}
-                                    title={icon.name}
-                                    className="w-full h-full rounded overflow-hidden"
-                                />
+                                <HogFunctionIcon src={icon.url} />
                             </span>
                         )) ??
                             (possibleIconsLoading ? (
@@ -142,15 +139,31 @@ export function HogFunctionIcon({
     src?: string
     size?: 'small' | 'medium' | 'large'
 }): JSX.Element {
+    const [loaded, setLoaded] = useState(false)
+
     return (
         <span
-            className={clsx('flex items-center justify-center', {
+            className={clsx('relative flex items-center justify-center', {
                 'w-8 h-8 text-2xl': size === 'small',
                 'w-10 h-10 text-4xl': size === 'medium',
                 'w-12 h-12 text-6xl': size === 'large',
             })}
         >
-            {src ? <img className="w-full h-full rounded overflow-hidden" src={src} /> : <span>🦔</span>}
+            {src ? (
+                <>
+                    <img
+                        className={clsx(
+                            'w-full h-full rounded overflow-hidden transition-opacity',
+                            loaded ? 'opacity-100' : 'opacity-0'
+                        )}
+                        src={src}
+                        onLoad={() => setLoaded(true)}
+                    />
+                    {!loaded && <LemonSkeleton className="absolute w-full h-full" />}
+                </>
+            ) : (
+                <span>🦔</span>
+            )}
         </span>
     )
 }

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionIcon.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionIcon.tsx
@@ -48,15 +48,7 @@ export function HogFunctionIconEditable({
     const { setShowPopover, setSearchTerm } = useActions(hogFunctionIconLogic(props))
 
     const content = (
-        <span
-            className={clsx('relative cursor-pointer', {
-                'w-8 h-8': size === 'small',
-                'w-10 h-10': size === 'medium',
-                'w-12 h-12': size === 'large',
-            })}
-            onClick={() => setShowPopover(!showPopover)}
-        >
-            {possibleIconsLoading ? <Spinner className="absolute -top-1 -right-1" /> : null}
+        <span className="cursor-pointer" onClick={() => setShowPopover(!showPopover)}>
             <HogFunctionIcon size={size} src={props.src} />
         </span>
     )

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionIconLogic.ts
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionIconLogic.ts
@@ -62,7 +62,7 @@ export const hogFunctionIconLogic = kea<hogFunctionIconLogicType>([
         ],
     })),
 
-    listeners(({ actions, values, props }) => ({
+    listeners(({ actions }) => ({
         setShowPopover: ({ show }) => {
             if (show) {
                 actions.loadPossibleIcons()

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionIconLogic.ts
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionIconLogic.ts
@@ -1,4 +1,4 @@
-import { actions, kea, key, listeners, path, props, propsChanged, reducers } from 'kea'
+import { actions, kea, key, listeners, path, props, reducers } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 
@@ -8,7 +8,6 @@ import type { hogFunctionIconLogicType } from './hogFunctionIconLogicType'
 
 export interface HogFunctionIconLogicProps {
     logicKey: string
-    search: string
     src?: string
     onChange?: (src: string) => void
 }
@@ -41,12 +40,12 @@ export const hogFunctionIconLogic = kea<hogFunctionIconLogicType>([
         ],
     }),
 
-    loaders(({ props, values }) => ({
+    loaders(({ values }) => ({
         possibleIcons: [
             null as HogFunctionIconResponse[] | null,
             {
                 loadPossibleIcons: async (_, breakpoint) => {
-                    const search = values.searchTerm ?? props.search
+                    const search = values.searchTerm
 
                     if (!search) {
                         return []
@@ -64,17 +63,6 @@ export const hogFunctionIconLogic = kea<hogFunctionIconLogicType>([
     })),
 
     listeners(({ actions, values, props }) => ({
-        loadPossibleIconsSuccess: async () => {
-            const autoChange = props.onChange && (!props.src || props.src.includes('temp=true'))
-            if (!autoChange) {
-                return
-            }
-            const firstValue = values.possibleIcons?.[0]
-            if (firstValue) {
-                props.onChange?.(firstValue.url)
-            }
-        },
-
         setShowPopover: ({ show }) => {
             if (show) {
                 actions.loadPossibleIcons()
@@ -85,13 +73,4 @@ export const hogFunctionIconLogic = kea<hogFunctionIconLogicType>([
             actions.loadPossibleIcons()
         },
     })),
-
-    propsChanged(({ props, actions }, oldProps) => {
-        if (!props.onChange) {
-            return
-        }
-        if (!props.src || (props.search !== oldProps.search && props.src.includes('temp=true'))) {
-            actions.loadPossibleIcons()
-        }
-    }),
 ])

--- a/posthog/cdp/templates/webhook/template_webhook.py
+++ b/posthog/cdp/templates/webhook/template_webhook.py
@@ -6,7 +6,7 @@ template: HogFunctionTemplate = HogFunctionTemplate(
     id="template-webhook",
     name="HTTP Webhook",
     description="Sends a webhook templated by the incoming event data",
-    icon_url="/static/posthog-icon.svg?temp=true",
+    icon_url="/static/posthog-icon.svg",
     hog="""
 let res := fetch(inputs.url, {
   'headers': inputs.headers,


### PR DESCRIPTION
## Problem

Noticed a bug in the loader but also wanted to tidy it up as the auto-icon stuff never really worked that well.

## Changes

![2024-07-26 12 04 02](https://github.com/user-attachments/assets/912a9734-2f40-4ee8-9571-446e9284e26e)


* Icons don't auto set anymore as it never really worked
* Cache the icon response to reduce api token usage
* Lazy load images

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
