### PR TITLE
fix(insights): formatting of group breakdowns

### DIFF
--- a/frontend/src/scenes/insights/utils.test.ts
+++ b/frontend/src/scenes/insights/utils.test.ts
@@ -417,6 +417,38 @@ describe('formatBreakdownLabel()', () => {
         }
         expect(formatBreakdownLabel('661', breakdownFilter2, undefined, formatter, 0)).toEqual('661s')
     })
+
+    it('handles group breakdowns', () => {
+        const formatter = jest.fn((_, v) => v)
+
+        const breakdownFilter1: BreakdownFilter = {
+            breakdown: 'name',
+            breakdown_group_type_index: 0,
+            breakdown_type: 'group',
+        }
+        expect(formatBreakdownLabel('661', breakdownFilter1, undefined, formatter)).toEqual('661')
+        expect(formatter).toHaveBeenCalledWith('name', 661, 'group', 0)
+
+        formatter.mockClear()
+
+        const breakdownFilter2: BreakdownFilter = {
+            breakdowns: [{ property: 'name', type: 'group', group_type_index: 0 }],
+        }
+        expect(formatBreakdownLabel(['661'], breakdownFilter2, undefined, formatter, 0)).toEqual('661')
+        expect(formatter).toHaveBeenCalledWith('name', 661, 'group', 0)
+
+        formatter.mockClear()
+
+        const breakdownFilter3: BreakdownFilter = {
+            breakdowns: [
+                { property: 'name', type: 'group', group_type_index: 0 },
+                { property: 'test', type: 'group', group_type_index: 1 },
+            ],
+        }
+        expect(formatBreakdownLabel(['661', '662'], breakdownFilter3, undefined, formatter, 0)).toEqual('661::662')
+        expect(formatter).toHaveBeenNthCalledWith(1, 'name', 661, 'group', 0)
+        expect(formatter).toHaveBeenNthCalledWith(2, 'test', 662, 'group', 1)
+    })
 })
 
 describe('formatBreakdownType()', () => {

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -20,6 +20,7 @@ import {
     EntityFilter,
     EntityTypes,
     EventType,
+    GroupTypeIndex,
     InsightShortId,
     InsightType,
     PathType,
@@ -240,11 +241,16 @@ function formatNumericBreakdownLabel(
                 ? breakdownFilter?.breakdowns?.[multipleBreakdownIndex]
                 : undefined
 
+        const groupIndex = (nestedBreakdown?.group_type_index ?? breakdownFilter?.breakdown_group_type_index) as
+            | GroupTypeIndex
+            | undefined
+
         return (
             formatPropertyValueForDisplay(
                 nestedBreakdown?.property ?? breakdownFilter?.breakdown,
                 breakdown_value,
-                propertyFilterTypeToPropertyDefinitionType(nestedBreakdown?.type ?? breakdownFilter?.breakdown_type)
+                propertyFilterTypeToPropertyDefinitionType(nestedBreakdown?.type ?? breakdownFilter?.breakdown_type),
+                groupIndex
             )?.toString() ?? 'None'
         )
     }


### PR DESCRIPTION
## Problem

Fixes the regression of the group breakdown formatting.

## Changes

Pass the `group_index_type` to the formatter function.

**Before**

<img width="680" alt="Screenshot 2024-07-26 at 17 37 08" src="https://github.com/user-attachments/assets/66238e92-bca8-4d65-87fb-bd060c602dd0">

**After**

<img width="741" alt="Screenshot 2024-07-26 at 17 36 15" src="https://github.com/user-attachments/assets/faeb8a24-1ad7-437e-8a3f-5853568f49bf">

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

- Manual testing
- Unit tests
- Added a test to catch regressions in the future

## Additional context

[Support Ticket](https://posthoghelp.zendesk.com/agent/tickets/15809)