### PR TITLE
feat(web-analytics): Add backfill raw sessions script using celery

### DIFF
--- a/posthog/management/commands/backfill_raw_sessions_table_2.py
+++ b/posthog/management/commands/backfill_raw_sessions_table_2.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import structlog
+from django.core.management.base import BaseCommand
+
+from datetime import datetime
+
+
+from posthog.tasks.tasks import backfill_raw_sessions_table
+
+logger = structlog.get_logger(__name__)
+
+TARGET_TABLE = "raw_sessions"
+
+SETTINGS = {
+    "max_execution_time": 3600  # 1 hour
+}
+
+
+@dataclass
+class BackfillQuery:
+    start_date: datetime
+    end_date: datetime
+    use_offline_workload: bool
+    team_id: Optional[int]
+
+    def execute(
+        self,
+    ) -> None:
+        task = backfill_raw_sessions_table.apply_async(
+            kwargs={
+                "start_date": self.start_date,
+                "end_date": self.end_date,
+                "use_offline_workload": self.use_offline_workload,
+                "team_id": self.team_id,
+            }
+        )
+        # wait for completion
+        task.get()
+
+
+class Command(BaseCommand):
+    help = f"Backfill the {TARGET_TABLE} table from events."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--start-date", required=True, type=str, help="first day to run backfill on (format YYYY-MM-DD)"
+        )
+        parser.add_argument(
+            "--end-date", required=True, type=str, help="last day to run backfill, inclusive, on (format YYYY-MM-DD)"
+        )
+        parser.add_argument(
+            "--live-run", action="store_true", help="actually execute INSERT queries (default is dry-run)"
+        )
+        parser.add_argument(
+            "--no-use-offline-workload",
+            action="store_true",
+            help="enable this to not run this on the offline nodes. Defaults to running on offline nodes unless this flag is set",
+        )
+        parser.add_argument(
+            "--print-counts", action="store_true", help="print events and session count beforehand and afterwards"
+        )
+        parser.add_argument("--team-id", type=int, help="Team id (will do all teams if not set)")
+
+    def handle(
+        self,
+        *,
+        live_run: bool,
+        start_date: str,
+        end_date: str,
+        no_use_offline_workload: bool,
+        team_id: Optional[int],
+        **options,
+    ):
+        logger.setLevel(logging.INFO)
+
+        start_datetime = datetime.strptime(start_date, "%Y-%m-%d")
+        end_datetime = datetime.strptime(end_date, "%Y-%m-%d")
+
+        BackfillQuery(
+            start_datetime, end_datetime, use_offline_workload=not no_use_offline_workload, team_id=team_id
+        ).execute()

--- a/posthog/tasks/backfill_raw_sessions_table.py
+++ b/posthog/tasks/backfill_raw_sessions_table.py
@@ -1,9 +1,8 @@
-import time
+from datetime import datetime, timedelta
 from typing import Optional
 
 import structlog
 
-from datetime import datetime, timedelta
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
 from posthog.models.raw_sessions.sql import RAW_SESSION_TABLE_BACKFILL_SELECT_SQL
@@ -20,7 +19,6 @@ SETTINGS = {
 def run_backfill_raw_sessions_table_for_day(
     date: datetime, team_id: Optional[int] = None, use_offline_workload: bool = True
 ):
-    time.sleep(10)
     logger.info(f"Starting backfill for {date.strftime('%Y-%m-%d')}")
     date_where = f"toStartOfDay(timestamp) = '{date.strftime('%Y-%m-%d')}'"
 

--- a/posthog/tasks/backfill_raw_sessions_table.py
+++ b/posthog/tasks/backfill_raw_sessions_table.py
@@ -1,0 +1,52 @@
+import time
+from typing import Optional
+
+import structlog
+
+from datetime import datetime, timedelta
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.connection import Workload
+from posthog.models.raw_sessions.sql import RAW_SESSION_TABLE_BACKFILL_SELECT_SQL
+
+logger = structlog.get_logger(__name__)
+
+TARGET_TABLE = "raw_sessions"
+
+SETTINGS = {
+    "max_execution_time": 3600  # 1 hour
+}
+
+
+def run_backfill_raw_sessions_table_for_day(
+    date: datetime, team_id: Optional[int] = None, use_offline_workload: bool = True
+):
+    time.sleep(10)
+    logger.info(f"Starting backfill for {date.strftime('%Y-%m-%d')}")
+    date_where = f"toStartOfDay(timestamp) = '{date.strftime('%Y-%m-%d')}'"
+
+    if team_id is not None:
+        team_where = f"team_id = {team_id}"
+    else:
+        team_where = "true"
+
+    select_query = (
+        RAW_SESSION_TABLE_BACKFILL_SELECT_SQL()
+        + f"""
+AND and(
+    {date_where},
+    {team_where}
+)"""
+    )
+
+    insert_query = f"""INSERT INTO {TARGET_TABLE} {select_query} SETTINGS max_execution_time=3600"""
+    sync_execute(
+        query=insert_query,
+        workload=Workload.OFFLINE if use_offline_workload else Workload.DEFAULT,
+        settings=SETTINGS,
+    )
+    logger.info(f"Finished backfill for {date.strftime('%Y-%m-%d')}")
+
+
+def get_days_to_backfill(start_date: datetime, end_date: datetime):
+    num_days = (end_date - start_date).days + 1
+    return [start_date + timedelta(days=i) for i in reversed(range(num_days))]

--- a/posthog/tasks/backfill_raw_sessions_table.py
+++ b/posthog/tasks/backfill_raw_sessions_table.py
@@ -18,7 +18,7 @@ SETTINGS = {
 
 def run_backfill_raw_sessions_table_for_day(
     date: datetime, team_id: Optional[int] = None, use_offline_workload: bool = True
-):
+) -> None:
     logger.info(f"Starting backfill for {date.strftime('%Y-%m-%d')}")
     date_where = f"toStartOfDay(timestamp) = '{date.strftime('%Y-%m-%d')}'"
 
@@ -45,6 +45,6 @@ AND and(
     logger.info(f"Finished backfill for {date.strftime('%Y-%m-%d')}")
 
 
-def get_days_to_backfill(start_date: datetime, end_date: datetime):
+def get_days_to_backfill(start_date: datetime, end_date: datetime) -> list[datetime]:
     num_days = (end_date - start_date).days + 1
     return [start_date + timedelta(days=i) for i in reversed(range(num_days))]

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -944,7 +944,7 @@ def calculate_external_data_rows_synced() -> None:
     retry_jitter=True,
 )
 def backfill_raw_sessions_table_for_day(
-    *_: list[Any], date: datetime, team_id: Optional[int] = None, use_offline_workload: bool = True
+    *_: list[Any], date: "datetime", team_id: Optional[int] = None, use_offline_workload: bool = True
 ) -> None:
     try:
         from posthog.tasks.backfill_raw_sessions_table import run_backfill_raw_sessions_table_for_day

--- a/posthog/tasks/test/test_backfill_raw_sessions_table.py
+++ b/posthog/tasks/test/test_backfill_raw_sessions_table.py
@@ -48,7 +48,7 @@ class TestBackfillRawSessionsTable(APIBaseTest):
         results = execute_hogql_query("SELECT id FROM sessions", team=self.team, modifiers=modifiers).results
         assert len(results) == 2
 
-    def test_get_dates_are_inclusive(self):
+    def test_get_dates_are_inclusive(self) -> None:
         start_date = datetime(2022, 1, 1)
         end_date = datetime(2022, 1, 3)
         dates = get_days_to_backfill(start_date, end_date)

--- a/posthog/tasks/test/test_backfill_raw_sessions_table.py
+++ b/posthog/tasks/test/test_backfill_raw_sessions_table.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+
+from freezegun import freeze_time
+
+from posthog.clickhouse.client import sync_execute
+from posthog.hogql.query import execute_hogql_query
+from posthog.models.raw_sessions.sql import DROP_RAW_SESSION_TABLE_SQL, RAW_SESSIONS_TABLE_SQL
+from posthog.models.utils import uuid7
+from posthog.schema import HogQLQueryModifiers, SessionTableVersion
+from posthog.tasks.backfill_raw_sessions_table import run_backfill_raw_sessions_table_for_day, get_days_to_backfill
+from posthog.test.base import APIBaseTest, _create_event
+
+
+class TestBackfillRawSessionsTable(APIBaseTest):
+    @freeze_time("2024-07-26T09:00:00Z")
+    def test_schedule_feature_flag_multiple_changes(self) -> None:
+        modifiers = HogQLQueryModifiers(sessionTableVersion=SessionTableVersion.V2)
+
+        s1 = str(uuid7())
+        s2 = str(uuid7())
+
+        # create some events
+        _create_event(
+            event="pageview",
+            distinct_id=s1,
+            team=self.team,
+            properties={"$session_id": s1},
+        )
+        _create_event(
+            event="pageview",
+            distinct_id=s2,
+            team=self.team,
+            properties={"$session_id": s2},
+        )
+        results = execute_hogql_query("SELECT id FROM sessions", team=self.team, modifiers=modifiers).results
+        assert len(results) == 2
+
+        # delete those sessions, so we can backfill them
+        sync_execute(DROP_RAW_SESSION_TABLE_SQL())
+        sync_execute(RAW_SESSIONS_TABLE_SQL())
+        results = execute_hogql_query("SELECT id FROM sessions", team=self.team, modifiers=modifiers).results
+        assert len(results) == 0
+
+        # backfill sessions
+        run_backfill_raw_sessions_table_for_day(datetime(2024, 7, 26), team_id=self.team.pk)
+
+        # check that the sessions exist
+        results = execute_hogql_query("SELECT id FROM sessions", team=self.team, modifiers=modifiers).results
+        assert len(results) == 2
+
+    def test_get_dates_are_inclusive(self):
+        start_date = datetime(2022, 1, 1)
+        end_date = datetime(2022, 1, 3)
+        dates = get_days_to_backfill(start_date, end_date)
+        assert len(dates) == 3
+        assert dates == [datetime(2022, 1, 3), datetime(2022, 1, 2), datetime(2022, 1, 1)]


### PR DESCRIPTION
## Problem

The backfill script required a lot of babysitting, moving it to celery should make life easier

## Changes
Move the backfill script to celery. In theory this means I should just be able to start it running and trust that it will finish eventually.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
It has some tests