### PR TITLE
SUPERDAY: Added a New Bug Report button as well as a link in the sidebar to see all reported bugs

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.tsx
@@ -1,6 +1,6 @@
 import './SidePanel.scss'
 
-import { IconEllipsis, IconFeatures, IconGear, IconInfo, IconNotebook, IconSupport } from '@posthog/icons'
+import { IconBugs, IconEllipsis, IconFeatures, IconGear, IconInfo, IconNotebook, IconSupport } from '@posthog/icons'
 import { LemonButton, LemonMenu, LemonMenuItems, LemonModal } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
@@ -64,6 +64,11 @@ export const SIDE_PANEL_TABS: Record<
         label: 'Feature previews',
         Icon: IconFeatures,
         Content: SidePanelFeaturePreviews,
+    },
+    [SidePanelTab.BugReports]: {
+        label: 'Bug reports',
+        Icon: IconBugs,
+        Content: SidePanelBugReports,
     },
 
     [SidePanelTab.Activity]: {

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -290,6 +290,17 @@ export const SidePanelSupport = (): JSX.Element => {
                                             Request a feature
                                         </LemonButton>
                                     </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to={`https://github.com/PostHog/posthog/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml`}
+                                            icon={<IconBugs />}
+                                            targetBlank
+                                        >
+                                            Report a bug
+                                        </LemonButton>
+                                    </li>
                                 </ul>
                             </Section>
                         </>

--- a/frontend/src/lib/lemon-ui/icons/categories.ts
+++ b/frontend/src/lib/lemon-ui/icons/categories.ts
@@ -1,6 +1,7 @@
 export const UNUSED_ICONS = [
     'IconAdvanced',
     'IconAsterisk',
+    'IconBugs',
     'IconGridMasonry',
     'IconApps',
     'IconRibbon',

--- a/frontend/src/scenes/moveToPostHogCloud/MoveToPostHogCloud.tsx
+++ b/frontend/src/scenes/moveToPostHogCloud/MoveToPostHogCloud.tsx
@@ -73,6 +73,13 @@ const CLOUD_FEATURES: CloudFeature[] = [
         link: 'https://posthog.com/pricing',
     },
     {
+        name: 'Open-Source Bug Reporting',
+        description:
+            'All bug reports submitted through the dashboard are publicly available.',
+        icon: <IconBugs />,
+        link: 'https://github.com/PostHog/posthog/issues',
+    },
+    {
         name: 'World-class support',
         description:
             'PostHog Cloud customers get access to our world-class support team, not just the community forum.',


### PR DESCRIPTION
@joethreepwood ,

New button added to report a new bug that should appear right below the request a feature button in the bottom-right corner:


Also added a button for the entire list of bugs to the left-hand side panel

And listed it as a something on the MoveToPostHogCloud.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
The end user. They need an easy way to report a bug right from the dashboad.

## Changes

<!-- If there are frontend changes, please include screenshots. -->

![2024-07-26 14 30 43](https://github.com/user-attachments/assets/8d173b8d-3134-42ab-acdb-2c78182058e8)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._


## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

I couldn't test. It's my SuperDay, didn't have the time to get an entire env set up. Discussed with @slshults and he mentioned that for the icon file “...no worries about the icon, they’re often hard to find buried in the repo.  You can press ahead without…”
