### PR TITLE
feat: Make install script clone with `--depth 1` saving 910 Mb of download size

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -77,7 +77,7 @@ sudo apt update
 echo "Installing PostHog 🦔 from Github"
 sudo apt install -y git
 # try to clone - if folder is already there pull latest for that branch
-git clone https://github.com/PostHog/posthog.git &> /dev/null || true
+git clone https://github.com/PostHog/posthog.git --depth 1 &> /dev/null || true
 cd posthog
 
 if [[ "$POSTHOG_APP_TAG" = "latest-release" ]]


### PR DESCRIPTION
## Problem
- When starting the install script in the repo's readme, it clones the whole repository, this can be reduced to only the latest commit, reducing the download size from 980mb to 70mb.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- Simply added `--depth 1` to make the clone require ~70mb as opposed to ~980mb in the self-hosted install script

## Before / After 

> My internet connection is quite fast, I was downloading at about 50 Mb/s

| Before | After | 
| ------------- | ------------- |
| Executed in **30.31 secs** | Executed in **6.59 secs** |
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Self-hosted install will be faster
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
I ran the following:
```
time git clone https://github.com/PostHog/posthog.git --depth 1 &> /dev/null
time git clone https://github.com/PostHog/posthog.git &> /dev/null
```

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
