### PR TITLE
feat(cdp): Add default error messages to salesforce templates

### DIFF
--- a/posthog/cdp/templates/salesforce/template_salesforce.py
+++ b/posthog/cdp/templates/salesforce/template_salesforce.py
@@ -24,7 +24,7 @@ template_create: HogFunctionTemplate = HogFunctionTemplate(
     description="Create objects in Salesforce",
     icon_url="/static/services/salesforce.png",
     hog="""
-fetch(f'https://posthog.my.salesforce.com/services/data/v61.0/sobjects/{inputs.path}', {
+let res := fetch(f'https://posthog.my.salesforce.com/services/data/v61.0/sobjects/{inputs.path}', {
   'body': inputs.properties,
   'method': 'POST',
   'headers': {
@@ -32,6 +32,10 @@ fetch(f'https://posthog.my.salesforce.com/services/data/v61.0/sobjects/{inputs.p
     'Content-Type': 'application/json'
   }
 });
+
+if (res.status >= 400) {
+  print('Bad response:', res.status, res.body)
+}
 """.strip(),
     inputs_schema=[
         common_inputs["oauth"],
@@ -68,7 +72,7 @@ template_update: HogFunctionTemplate = HogFunctionTemplate(
     description="Update objects in Salesforce",
     icon_url="/static/services/salesforce.png",
     hog="""
-fetch(f'https://posthog.my.salesforce.com/services/data/v61.0/sobjects/{inputs.path}', {
+let res := fetch(f'https://posthog.my.salesforce.com/services/data/v61.0/sobjects/{inputs.path}', {
   'body': inputs.properties,
   'method': 'PATCH',
   'headers': {
@@ -76,6 +80,10 @@ fetch(f'https://posthog.my.salesforce.com/services/data/v61.0/sobjects/{inputs.p
     'Content-Type': 'application/json'
   }
 });
+
+if (res.status >= 400) {
+  print('Bad response:', res.status, res.body)
+}
 """.strip(),
     inputs_schema=[
         common_inputs["oauth"],


### PR DESCRIPTION
## Problem

Debugging our own integration and it turns out the api was giving errors back but we were ignoring them.



## Changes

* Adds some error printing to the templates
* Wondering if we should do this by default for all fetch requests 🤔 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
