### PR TITLE
fix(cdp): Handle if there are no logs

### DIFF
--- a/plugin-server/src/cdp/utils.ts
+++ b/plugin-server/src/cdp/utils.ts
@@ -170,6 +170,10 @@ export const prepareLogEntriesForClickhouse = (
 
     const sortedLogs = logs.sort((a, b) => a.timestamp.toMillis() - b.timestamp.toMillis())
 
+    if (sortedLogs.length === 0) {
+        return []
+    }
+
     // Start with a timestamp that is guaranteed to be before the first log entry
     let previousTimestamp = sortedLogs[0].timestamp.minus(1)
 


### PR DESCRIPTION
## Problem

Noticed [an issue](https://posthog.sentry.io/issues/5654423963/?project=6423401&query=is%3Aunresolved+cdp&referrer=issue-stream&statsPeriod=24h&stream_index=0) with the log production code if the logs list was empty

## Changes

* Checks for logs length

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

* will follow up with tests