### PR TITLE
fix: Revert "fix: Roll back sessions v2 (#23990)"

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -82,6 +82,7 @@ from posthog.schema import (
     PersonsOnEventsMode,
     SessionTableVersion,
 )
+from posthog.utils import get_instance_region
 from posthog.warehouse.models.external_data_job import ExternalDataJob
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 from posthog.warehouse.models.external_data_source import ExternalDataSource
@@ -248,7 +249,9 @@ def create_hogql_database(
             join_function=join_with_persons_table,
         )
 
-    if modifiers.sessionTableVersion == SessionTableVersion.V2:
+    if modifiers.sessionTableVersion == SessionTableVersion.V2 or (
+        get_instance_region() == "EU" and modifiers.sessionTableVersion == SessionTableVersion.AUTO
+    ):
         raw_sessions = RawSessionsTableV2()
         database.raw_sessions = raw_sessions
         sessions = SessionsTableV2()


### PR DESCRIPTION
This reverts commit 71d587717af5c6977575e60e044b0cf303907830.

## Problem

We rolled this back after the backfill didn't run correctly, but it has run successfully now.

## Changes

Revert the roll-back

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Put 2 specific teams back on v2, manually checked that they got the same results as with v1.