### PR TITLE
feat(data-warehouse): Added pagination to syncs tab

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2082,8 +2082,16 @@ const api = {
                 .withAction('source_prefix')
                 .create({ data: { source_type, prefix } })
         },
-        async jobs(sourceId: ExternalDataStripeSource['id']): Promise<ExternalDataJob[]> {
-            return await new ApiRequest().externalDataSource(sourceId).withAction('jobs').get()
+        async jobs(
+            sourceId: ExternalDataStripeSource['id'],
+            before: string | null,
+            after: string | null
+        ): Promise<ExternalDataJob[]> {
+            return await new ApiRequest()
+                .externalDataSource(sourceId)
+                .withAction('jobs')
+                .withQueryString({ before, after })
+                .get()
         },
     },
 

--- a/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
@@ -1,6 +1,6 @@
 import { TZLabel } from '@posthog/apps-common'
-import { LemonTable, LemonTag, LemonTagType } from '@posthog/lemon-ui'
-import { useValues } from 'kea'
+import { LemonButton, LemonTable, LemonTag, LemonTagType } from '@posthog/lemon-ui'
+import { useActions, useValues } from 'kea'
 
 import { ExternalDataJob } from '~/types'
 
@@ -15,7 +15,8 @@ const StatusTagSetting: Record<ExternalDataJob['status'], LemonTagType> = {
 }
 
 export const Syncs = (): JSX.Element => {
-    const { jobs, jobsLoading } = useValues(dataWarehouseSourceSettingsLogic)
+    const { jobs, jobsLoading, canLoadMoreJobs } = useValues(dataWarehouseSourceSettingsLogic)
+    const { loadMoreJobs } = useActions(dataWarehouseSourceSettingsLogic)
 
     return (
         <LemonTable
@@ -60,6 +61,17 @@ export const Syncs = (): JSX.Element => {
                           noIndent: true,
                       }
                     : undefined
+            }
+            footer={
+                <LemonButton
+                    onClick={loadMoreJobs}
+                    type="secondary"
+                    fullWidth
+                    center
+                    disabledReason={!canLoadMoreJobs ? "There's nothing more to load" : undefined}
+                >
+                    {canLoadMoreJobs ? `Load older jobs` : 'No older jobs'}
+                </LemonButton>
             }
         />
     )


### PR DESCRIPTION
## Problem
- When a user has a lot of syncs, like US team 2, the syncs tab of source settings is wild to load

## Changes
- Added pagination to the sync/jobs tab
- Auto loads in newer jobs, and adds a "load more" button for older jobs

## Does this work well for both Cloud and self-hosted?
Yup

## How did you test this code?
Backend tests