### PR TITLE
fix: disable dashboard insights refresh chaining

### DIFF
--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -21,7 +21,6 @@ from posthog.api.insight import InsightSerializer, InsightViewSet
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSetMixin
-from posthog.clickhouse.client.async_task_chain import task_chain_context
 from posthog.event_usage import report_user_action
 from posthog.helpers import create_dashboard_from_template
 from posthog.helpers.dashboard_templates import create_from_template
@@ -458,9 +457,8 @@ class DashboardsViewSet(
         dashboard = get_object_or_404(queryset, pk=pk)
         dashboard.last_accessed_at = now()
         dashboard.save(update_fields=["last_accessed_at"])
-        with task_chain_context():
-            serializer = DashboardSerializer(dashboard, context={"view": self, "request": request})
-            return Response(serializer.data)
+        serializer = DashboardSerializer(dashboard, context={"view": self, "request": request})
+        return Response(serializer.data)
 
     @action(methods=["PATCH"], detail=True)
     def move_tile(self, request: Request, *args: Any, **kwargs: Any) -> Response:


### PR DESCRIPTION
## Problem
Temporary fix for https://posthoghelp.zendesk.com/agent/tickets/15410 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/18748)
Where one broken insight on the dashboard prevents entire dashboard from refreshing as insights are refreshed one at a time

## Changes
Disable 'chaining' for dashboard insight refresh.
When `/dashboard` refresh is triggered, all the insights on it are refreshed in parallel (instead of sequentially before), so one slow insight won't hold back the other insight.

Impact is more async queries per dashboard. But we still limit concurrency per team [here](https://github.com/PostHog/posthog/blob/fix/disable-dashboard-insight-refresh-chaining/posthog/tasks/tasks.py/#L53)

## Caveats
1. The UI still [polls 2 insights at a time](https://github.com/PostHog/posthog/blob/fix/disable-dashboard-insight-refresh-chaining/frontend/src/scenes/dashboard/dashboardLogic.tsx/#L1085) so if 2 broken insights on a dashboard are polled first then they'll both prevent the UI from reading updated results for other insights. Can increase this limit?
2. Haven't disabled [chaining for shared dashboards](https://github.com/PostHog/posthog/blob/fix/disable-dashboard-insight-refresh-chaining/posthog/api/sharing.py#L278) yet but would make sense to disable that as well.

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally by replicating user scenario.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
