### PR TITLE
fix: handle none properties in filters

### DIFF
--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -162,7 +162,9 @@ class Insight(models.Model):
                             {"type": "AND", "values": dashboard_properties},
                         ],
                     }
-                elif self.filters.get("properties", {}).get("type"):
+                elif not self.filters.get("properties"):
+                    filters["properties"] = dashboard_properties
+                elif self.filters.get("properties").get("type"):
                     filters["properties"] = {
                         "type": "AND",
                         "values": [
@@ -170,8 +172,6 @@ class Insight(models.Model):
                             {"type": "AND", "values": dashboard_properties},
                         ],
                     }
-                elif not self.filters.get("properties"):
-                    filters["properties"] = dashboard_properties
                 else:
                     raise ValidationError("Unrecognized property format: ", self.filters["properties"])
             elif self.filters.get("properties"):

--- a/posthog/models/test/test_insight_model.py
+++ b/posthog/models/test/test_insight_model.py
@@ -64,6 +64,15 @@ class TestInsightModel(BaseTest):
 
         assert filters_with_dashboard_with_same_date_from["date_from"] == "-30d"
 
+    def test_dashboard_filters_works_with_null_properties(self) -> None:
+        insight = Insight.objects.create(
+            team=self.team, filters={"date_from": "-30d", "compare": True, "properties": None}
+        )
+        dashboard = Dashboard.objects.create(team=self.team, filters={"date_from": "all", "properties": {"a": 1}})
+
+        # Check that this doesn't throw an error
+        insight.dashboard_filters(dashboard=dashboard)
+
     def test_dashboard_with_date_from_all_overrides_compare(self) -> None:
         insight = Insight.objects.create(team=self.team, filters={"date_from": "-30d", "compare": True})
         dashboard = Dashboard.objects.create(team=self.team, filters={"date_from": "all"})


### PR DESCRIPTION
## Problem

Dashboards can fail if an insight has properites set to None in the database.

https://posthog.sentry.io/issues/5531847694/?project=1899813&query=id%3Acf64c5b8f99d4ab888bc6941c23bb251&referrer=issue-stream&statsPeriod=14d&stream_index=0

## Changes

Change the order of the checks to prevent this

## How did you test this code?

Wrote a test. 