### PR TITLE
fix(cdp): Fix up fetch responses

### DIFF
--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -188,6 +188,13 @@ export class HogExecutor {
             return errorRes(asyncFunctionResponse.error ?? 'No VM state provided for async response')
         }
 
+        if (asyncFunctionResponse.response?.body && typeof asyncFunctionResponse.response?.body === 'string') {
+            // TODO: Ensure this is done in rusty hook
+            try {
+                asyncFunctionResponse.response.body = JSON.parse(asyncFunctionResponse.response.body)
+            } catch (e) {}
+        }
+
         // Add the response to the stack to continue execution
         invocation.vmState.stack.push(convertJSToHog(asyncFunctionResponse.response ?? null))
         invocation.timings.push(...(asyncFunctionResponse.timings ?? []))


### PR DESCRIPTION
## Problem

Something changed in hoghooks and the response is no longer parsed it seems...

## Changes

* Do the parsing in the executor to be extra sure

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
