### PR TITLE
fix(chartjs): fix chartjs usage after upgrade

### DIFF
--- a/frontend/src/lib/components/Sparkline.tsx
+++ b/frontend/src/lib/components/Sparkline.tsx
@@ -112,8 +112,7 @@ export function Sparkline({
                                 },
                             },
                             grid: {
-                                borderDash: [2],
-                                drawBorder: false,
+                                tickBorderDash: [2],
                                 display: true,
                                 tickLength: 0,
                             },

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -93,15 +93,14 @@ export const LineGraph = (): JSX.Element => {
             font: {
                 family: '-apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
                 size: 12,
-                weight: '500',
+                weight: 'normal',
             },
         }
 
         const gridOptions: Partial<GridLineOptions> = {
             color: colors.axisLine as Color,
-            borderColor: colors.axisLine as Color,
             tickColor: colors.axisLine as Color,
-            borderDash: [4, 2],
+            tickBorderDash: [4, 2],
         }
 
         const options: ChartOptions = {

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -1,7 +1,7 @@
 import 'chartjs-adapter-dayjs-3'
 
 import { LegendOptions } from 'chart.js'
-import { _DeepPartialObject } from 'chart.js/types/utils'
+import { DeepPartial } from 'chart.js/dist/types/utils'
 import ChartDataLabels from 'chartjs-plugin-datalabels'
 import ChartjsPluginStacked100, { ExtendedChartData } from 'chartjs-plugin-stacked100'
 import clsx from 'clsx'
@@ -236,7 +236,7 @@ export interface LineGraphProps {
     hideAnnotations?: boolean
     hideXAxis?: boolean
     hideYAxis?: boolean
-    legend?: _DeepPartialObject<LegendOptions<ChartType>>
+    legend?: DeepPartial<LegendOptions<ChartType>>
     yAxisScaleType?: string | null
 }
 
@@ -401,14 +401,13 @@ export function LineGraph_({
             font: {
                 family: '-apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Roboto", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
                 size: 12,
-                weight: '500',
+                weight: 'normal',
             },
         }
         const gridOptions: Partial<GridLineOptions> = {
             color: colors.axisLine as Color,
-            borderColor: colors.axisLine as Color,
             tickColor: colors.axisLine as Color,
-            borderDash: [4, 2],
+            tickBorderDash: [4, 2],
         }
 
         const tooltipOptions: Partial<TooltipOptions> = {
@@ -625,7 +624,7 @@ export function LineGraph_({
                                   padding: 10,
                                   font: {
                                       size: 14,
-                                      weight: '600',
+                                      weight: 'bold',
                                   },
                               }
                             : {}),

--- a/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsLineGraph.tsx
@@ -1,5 +1,5 @@
 import { ChartType, defaults, LegendOptions } from 'chart.js'
-import { _DeepPartialObject } from 'chart.js/types/utils'
+import { DeepPartial } from 'chart.js/dist/types/utils'
 import { useValues } from 'kea'
 import { Chart } from 'lib/Chart'
 import { DateDisplay } from 'lib/components/DateDisplay'
@@ -51,7 +51,7 @@ export function ActionsLineGraph({
     const shortenLifecycleLabels = (s: string | undefined): string =>
         capitalizeFirstLetter(s?.split(' - ')?.[1] ?? s ?? 'None')
 
-    const legend: _DeepPartialObject<LegendOptions<ChartType>> = {
+    const legend: DeepPartial<LegendOptions<ChartType>> = {
         display: false,
     }
     if (isLifecycle && !!showLegend) {


### PR DESCRIPTION
## Problem

Typescript complains about Chart.js things after https://github.com/PostHog/posthog/commit/a29f4081d370412ccd1a0241502dc0a6acc32728.

## Changes

Fixes those things while keeping existing styles

## How did you test this code?

Clicking around on some insights + rendering a HogQL spark line. The ticks look a bit different, but better IMO. Couldn't find the survey insight, so the "bold" option there is untested.