### PR TITLE
fix(data-warehouse): Fix editing a view button

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
+++ b/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
@@ -11,7 +11,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { urls } from 'scenes/urls'
 
 import { Query } from '~/queries/Query/Query'
-import { DatabaseSchemaTable } from '~/queries/schema'
+import { DatabaseSchemaTable, NodeKind } from '~/queries/schema'
 
 import { viewLinkLogic } from '../viewLinkLogic'
 import { ViewLinkModal } from '../ViewLinkModal'
@@ -130,7 +130,12 @@ export const DatabaseTableTreeWithItems = ({ inline }: DatabaseTableTreeProps): 
             {table.type == 'view' && (
                 <LemonButton
                     onClick={() => {
-                        router.actions.push(urls.dataWarehouseView(table.id, table.query))
+                        router.actions.push(
+                            urls.dataWarehouseView(table.id, {
+                                kind: NodeKind.DataVisualizationNode,
+                                source: table.query,
+                            })
+                        )
                     }}
                     data-attr="schema-list-item-edit"
                     fullWidth


### PR DESCRIPTION
## Problem
- Hitting "edit view definition" within data warehouse was opening the `Query` component with the raw query in JSON form, when we really wanna be opening the `Query` component as a `DataVisualiztionNode`
- Fixed this [support ticket](https://posthoghelp.zendesk.com/agent/tickets/16276)

## Changes
- Make sure we're passing the correct node kind through

## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
Tested locally