### PR TITLE
feat(hogql): allow timezone argument for formatDateTime function

### DIFF
--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -494,7 +494,7 @@ HOGQL_CLICKHOUSE_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "subtractSeconds": HogQLFunctionMeta("subtractSeconds", 2, 2),
     "subtractQuarters": HogQLFunctionMeta("subtractQuarters", 2, 2),
     "timeSlots": HogQLFunctionMeta("timeSlots", 2, 3),
-    "formatDateTime": HogQLFunctionMeta("formatDateTime", 2, 2),
+    "formatDateTime": HogQLFunctionMeta("formatDateTime", 2, 3),
     "dateName": HogQLFunctionMeta("dateName", 2, 2),
     "monthName": HogQLFunctionMeta("monthName", 1, 1),
     "fromUnixTimestamp": HogQLFunctionMeta(


### PR DESCRIPTION
## Problem

Customer request here https://posthog.slack.com/archives/C0368RPHLQH/p1722329676896359 needs a timezone conversion function that supports a non-constant timezone i.e. `toString` or `formatDateTime`.

## Changes

This PR allows the third param for setting a timezone with `formatDateTime`.

## How did you test this code?

Example usage

```sql
select 
    formatDateTime(timestamp, '%T', 'Europe/Vienna'), 
    formatDateTime(timestamp, '%T', properties.$geoip_time_zone)
from events
```