### PR TITLE
fix: Add restricted area around new proxy button

### DIFF
--- a/frontend/src/lib/components/RestrictedArea.tsx
+++ b/frontend/src/lib/components/RestrictedArea.tsx
@@ -1,5 +1,4 @@
 import { useValues } from 'kea'
-import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { useMemo } from 'react'
 
 import { organizationLogic } from '../../scenes/organizationLogic'
@@ -60,20 +59,4 @@ export function useRestrictedArea({ scope, minimumAccessLevel }: UseRestrictedAr
     }, [currentOrganization])
 
     return restrictionReason
-}
-
-export function RestrictedArea({
-    Component,
-    minimumAccessLevel,
-    scope = RestrictionScope.Organization,
-}: RestrictedAreaProps): JSX.Element {
-    const restrictionReason = useRestrictedArea({ minimumAccessLevel, scope })
-
-    return restrictionReason ? (
-        <Tooltip title={restrictionReason} placement="top-start" delayMs={0}>
-            <Component isRestricted={true} restrictionReason={restrictionReason} />
-        </Tooltip>
-    ) : (
-        <Component isRestricted={false} restrictionReason={null} />
-    )
 }

--- a/frontend/src/lib/components/RestrictedArea.tsx
+++ b/frontend/src/lib/components/RestrictedArea.tsx
@@ -71,9 +71,7 @@ export function RestrictedArea({
 
     return restrictionReason ? (
         <Tooltip title={restrictionReason} placement="top-start" delayMs={0}>
-            <span>
-                <Component isRestricted={true} restrictionReason={restrictionReason} />
-            </span>
+            <Component isRestricted={true} restrictionReason={restrictionReason} />
         </Tooltip>
     ) : (
         <Component isRestricted={false} restrictionReason={null} />

--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -8,7 +8,7 @@ import { IconPencil, IconX } from '@posthog/icons'
 import { BindLogic, useActions, useValues } from 'kea'
 import { PropertyFilterIcon } from 'lib/components/PropertyFilters/components/PropertyFilterIcon'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
-import { RestrictedArea, RestrictedComponentProps, RestrictionScope } from 'lib/components/RestrictedArea'
+import { RestrictedArea, RestrictionScope } from 'lib/components/RestrictedArea'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TeamMembershipLevel } from 'lib/constants'
@@ -185,21 +185,17 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                 </div>
                 {isEventsQuery(query.source) && query.showPersistentColumnConfigurator ? (
                     <RestrictedArea
-                        Component={function SaveColumnsAsDefault({
-                            isRestricted,
-                        }: RestrictedComponentProps): JSX.Element {
-                            return (
-                                <LemonCheckbox
-                                    label="Save as default for all project members"
-                                    className="mt-2"
-                                    data-attr="events-table-save-columns-as-default-toggle"
-                                    bordered
-                                    checked={saveAsDefault}
-                                    onChange={toggleSaveAsDefault}
-                                    disabled={isRestricted}
-                                />
-                            )
-                        }}
+                        Component={({ isRestricted, restrictionReason }) => (
+                            <LemonCheckbox
+                                label="Save as default for all project members"
+                                className="mt-2"
+                                data-attr="events-table-save-columns-as-default-toggle"
+                                bordered
+                                checked={saveAsDefault}
+                                onChange={toggleSaveAsDefault}
+                                disabledReason={isRestricted ? restrictionReason : undefined}
+                            />
+                        )}
                         minimumAccessLevel={TeamMembershipLevel.Admin}
                         scope={RestrictionScope.Project}
                     />

--- a/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
+++ b/frontend/src/queries/nodes/DataTable/ColumnConfigurator/ColumnConfigurator.tsx
@@ -8,7 +8,7 @@ import { IconPencil, IconX } from '@posthog/icons'
 import { BindLogic, useActions, useValues } from 'kea'
 import { PropertyFilterIcon } from 'lib/components/PropertyFilters/components/PropertyFilterIcon'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
-import { RestrictedArea, RestrictionScope } from 'lib/components/RestrictedArea'
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TeamMembershipLevel } from 'lib/constants'
@@ -86,6 +86,10 @@ export function ColumnConfigurator({ query, setQuery }: ColumnConfiguratorProps)
 }
 
 function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Element {
+    const restrictionReason = useRestrictedArea({
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+        scope: RestrictionScope.Project,
+    })
     const { modalVisible, columns, saveAsDefault } = useValues(columnConfiguratorLogic)
     const { hideModal, moveColumn, setColumns, selectColumn, unselectColumn, save, toggleSaveAsDefault } =
         useActions(columnConfiguratorLogic)
@@ -184,20 +188,14 @@ function ColumnConfiguratorModal({ query }: ColumnConfiguratorProps): JSX.Elemen
                     </div>
                 </div>
                 {isEventsQuery(query.source) && query.showPersistentColumnConfigurator ? (
-                    <RestrictedArea
-                        Component={({ isRestricted, restrictionReason }) => (
-                            <LemonCheckbox
-                                label="Save as default for all project members"
-                                className="mt-2"
-                                data-attr="events-table-save-columns-as-default-toggle"
-                                bordered
-                                checked={saveAsDefault}
-                                onChange={toggleSaveAsDefault}
-                                disabledReason={isRestricted ? restrictionReason : undefined}
-                            />
-                        )}
-                        minimumAccessLevel={TeamMembershipLevel.Admin}
-                        scope={RestrictionScope.Project}
+                    <LemonCheckbox
+                        label="Save as default for all project members"
+                        className="mt-2"
+                        data-attr="events-table-save-columns-as-default-toggle"
+                        bordered
+                        checked={saveAsDefault}
+                        onChange={toggleSaveAsDefault}
+                        disabledReason={restrictionReason}
                     />
                 ) : null}
             </div>

--- a/frontend/src/scenes/settings/project/AddMembersModal.tsx
+++ b/frontend/src/scenes/settings/project/AddMembersModal.tsx
@@ -2,7 +2,6 @@ import { IconPlus } from '@posthog/icons'
 import { LemonButton, LemonModal, LemonSelect, LemonSelectOption } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import { Form } from 'kea-forms'
-import { RestrictedComponentProps } from 'lib/components/RestrictedArea'
 import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
 import { usersLemonSelectOptions } from 'lib/components/UserSelectItem'
 import { TeamMembershipLevel } from 'lib/constants'
@@ -17,7 +16,7 @@ import { AvailableFeature } from '~/types'
 
 import { teamMembersLogic } from './teamMembersLogic'
 
-export function AddMembersModalWithButton({ isRestricted, restrictionReason }: RestrictedComponentProps): JSX.Element {
+export function AddMembersModalWithButton({ disabledReason }: { disabledReason: string | null }): JSX.Element {
     const { addableMembers, allMembersLoading } = useValues(teamMembersLogic)
     const { currentTeam } = useValues(teamLogic)
     const { guardAvailableFeature } = useValues(upgradeModalLogic)
@@ -42,7 +41,7 @@ export function AddMembersModalWithButton({ isRestricted, restrictionReason }: R
                     })
                 }
                 icon={<IconPlus />}
-                disabledReason={isRestricted ? restrictionReason : undefined}
+                disabledReason={disabledReason}
             >
                 Add members to project
             </LemonButton>

--- a/frontend/src/scenes/settings/project/AddMembersModal.tsx
+++ b/frontend/src/scenes/settings/project/AddMembersModal.tsx
@@ -17,7 +17,7 @@ import { AvailableFeature } from '~/types'
 
 import { teamMembersLogic } from './teamMembersLogic'
 
-export function AddMembersModalWithButton({ isRestricted }: RestrictedComponentProps): JSX.Element {
+export function AddMembersModalWithButton({ isRestricted, restrictionReason }: RestrictedComponentProps): JSX.Element {
     const { addableMembers, allMembersLoading } = useValues(teamMembersLogic)
     const { currentTeam } = useValues(teamLogic)
     const { guardAvailableFeature } = useValues(upgradeModalLogic)
@@ -42,7 +42,7 @@ export function AddMembersModalWithButton({ isRestricted }: RestrictedComponentP
                     })
                 }
                 icon={<IconPlus />}
-                disabled={isRestricted}
+                disabledReason={isRestricted ? restrictionReason : undefined}
             >
                 Add members to project
             </LemonButton>

--- a/frontend/src/scenes/settings/project/ManagedReverseProxy.tsx
+++ b/frontend/src/scenes/settings/project/ManagedReverseProxy.tsx
@@ -16,7 +16,7 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
-import { RestrictedArea, RestrictedComponentProps, RestrictionScope } from 'lib/components/RestrictedArea'
+import { RestrictedArea, RestrictionScope } from 'lib/components/RestrictedArea'
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
@@ -141,22 +141,18 @@ export function ManagedReverseProxy(): JSX.Element {
                             There is a maximum of {MAX_PROXY_RECORDS} records allowed per organization
                         </LemonBanner>
                     ) : (
-                        <div className="space-y-2">
+                        <div className="flex space-y-2">
                             <RestrictedArea
-                                Component={function NewManagedProxy({
-                                    isRestricted,
-                                }: RestrictedComponentProps): JSX.Element {
-                                    return (
-                                        <LemonButton
-                                            onClick={showForm}
-                                            type="secondary"
-                                            icon={<IconPlus />}
-                                            disabled={isRestricted}
-                                        >
-                                            New managed proxy
-                                        </LemonButton>
-                                    )
-                                }}
+                                Component={({ isRestricted, restrictionReason }) => (
+                                    <LemonButton
+                                        onClick={showForm}
+                                        type="secondary"
+                                        icon={<IconPlus />}
+                                        disabledReason={isRestricted ? restrictionReason : undefined}
+                                    >
+                                        New managed proxy
+                                    </LemonButton>
+                                )}
                                 minimumAccessLevel={OrganizationMembershipLevel.Admin}
                                 scope={RestrictionScope.Organization}
                             />

--- a/frontend/src/scenes/settings/project/ManagedReverseProxy.tsx
+++ b/frontend/src/scenes/settings/project/ManagedReverseProxy.tsx
@@ -16,6 +16,8 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
+import { RestrictedArea, RestrictedComponentProps, RestrictionScope } from 'lib/components/RestrictedArea'
+import { OrganizationMembershipLevel } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 
@@ -139,9 +141,26 @@ export function ManagedReverseProxy(): JSX.Element {
                             There is a maximum of {MAX_PROXY_RECORDS} records allowed per organization
                         </LemonBanner>
                     ) : (
-                        <LemonButton onClick={showForm} type="secondary" icon={<IconPlus />}>
-                            New managed proxy
-                        </LemonButton>
+                        <div className="space-y-2">
+                            <RestrictedArea
+                                Component={function NewManagedProxy({
+                                    isRestricted,
+                                }: RestrictedComponentProps): JSX.Element {
+                                    return (
+                                        <LemonButton
+                                            onClick={showForm}
+                                            type="secondary"
+                                            icon={<IconPlus />}
+                                            disabled={isRestricted}
+                                        >
+                                            New managed proxy
+                                        </LemonButton>
+                                    )
+                                }}
+                                minimumAccessLevel={OrganizationMembershipLevel.Admin}
+                                scope={RestrictionScope.Organization}
+                            />
+                        </div>
                     )
                 ) : (
                     <CreateRecordForm />

--- a/frontend/src/scenes/settings/project/ManagedReverseProxy.tsx
+++ b/frontend/src/scenes/settings/project/ManagedReverseProxy.tsx
@@ -16,7 +16,7 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
-import { RestrictedArea, RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
@@ -35,6 +35,11 @@ const statusText = {
 export function ManagedReverseProxy(): JSX.Element {
     const { formState, proxyRecords, proxyRecordsLoading } = useValues(proxyLogic)
     const { showForm, deleteRecord } = useActions(proxyLogic)
+
+    const restrictionReason = useRestrictedArea({
+        minimumAccessLevel: OrganizationMembershipLevel.Admin,
+        scope: RestrictionScope.Organization,
+    })
 
     const maxRecordsReached = proxyRecords.length >= MAX_PROXY_RECORDS
 
@@ -87,10 +92,7 @@ export function ManagedReverseProxy(): JSX.Element {
             render: function Render(_, { id, status }) {
                 return (
                     status != 'deleting' &&
-                    !useRestrictedArea({
-                        minimumAccessLevel: OrganizationMembershipLevel.Admin,
-                        scope: RestrictionScope.Organization,
-                    }) && (
+                    !restrictionReason && (
                         <LemonMenu
                             items={[
                                 {
@@ -146,20 +148,14 @@ export function ManagedReverseProxy(): JSX.Element {
                         </LemonBanner>
                     ) : (
                         <div className="flex space-y-2">
-                            <RestrictedArea
-                                Component={({ isRestricted, restrictionReason }) => (
-                                    <LemonButton
-                                        onClick={showForm}
-                                        type="secondary"
-                                        icon={<IconPlus />}
-                                        disabledReason={isRestricted ? restrictionReason : undefined}
-                                    >
-                                        New managed proxy
-                                    </LemonButton>
-                                )}
-                                minimumAccessLevel={OrganizationMembershipLevel.Admin}
-                                scope={RestrictionScope.Organization}
-                            />
+                            <LemonButton
+                                onClick={showForm}
+                                type="secondary"
+                                icon={<IconPlus />}
+                                disabledReason={restrictionReason}
+                            >
+                                New managed proxy
+                            </LemonButton>
                         </div>
                     )
                 ) : (

--- a/frontend/src/scenes/settings/project/ManagedReverseProxy.tsx
+++ b/frontend/src/scenes/settings/project/ManagedReverseProxy.tsx
@@ -16,7 +16,12 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
-import { RestrictedArea, RestrictedComponentProps, RestrictionScope } from 'lib/components/RestrictedArea'
+import {
+    RestrictedArea,
+    RestrictedComponentProps,
+    RestrictionScope,
+    useRestrictedArea,
+} from 'lib/components/RestrictedArea'
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
@@ -86,7 +91,11 @@ export function ManagedReverseProxy(): JSX.Element {
             className: 'flex justify-center',
             render: function Render(_, { id, status }) {
                 return (
-                    status != 'deleting' && (
+                    status != 'deleting' &&
+                    !useRestrictedArea({
+                        minimumAccessLevel: OrganizationMembershipLevel.Admin,
+                        scope: RestrictionScope.Organization,
+                    }) && (
                         <LemonMenu
                             items={[
                                 {
@@ -141,7 +150,7 @@ export function ManagedReverseProxy(): JSX.Element {
                             There is a maximum of {MAX_PROXY_RECORDS} records allowed per organization
                         </LemonBanner>
                     ) : (
-                        <div className="space-y-2">
+                        <div className="inline-flex space-y-2">
                             <RestrictedArea
                                 Component={function NewManagedProxy({
                                     isRestricted,

--- a/frontend/src/scenes/settings/project/ManagedReverseProxy.tsx
+++ b/frontend/src/scenes/settings/project/ManagedReverseProxy.tsx
@@ -147,7 +147,7 @@ export function ManagedReverseProxy(): JSX.Element {
                             There is a maximum of {MAX_PROXY_RECORDS} records allowed per organization
                         </LemonBanner>
                     ) : (
-                        <div className="flex space-y-2">
+                        <div className="flex">
                             <LemonButton
                                 onClick={showForm}
                                 type="secondary"

--- a/frontend/src/scenes/settings/project/ProjectAccessControl.tsx
+++ b/frontend/src/scenes/settings/project/ProjectAccessControl.tsx
@@ -1,7 +1,7 @@
 import { IconCrown, IconLeave, IconLock, IconUnlock } from '@posthog/icons'
 import { LemonButton, LemonSelect, LemonSelectOption, LemonSnack, LemonSwitch, LemonTable } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
-import { RestrictedArea, RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
 import { OrganizationMembershipLevel, TeamMembershipLevel } from 'lib/constants'
 import { IconCancel } from 'lib/lemon-ui/icons'
@@ -133,6 +133,10 @@ function ActionsComponent(member: FusedTeamMemberType): JSX.Element | null {
 export function ProjectTeamMembers(): JSX.Element | null {
     const { user } = useValues(userLogic)
     const { allMembers, allMembersLoading } = useValues(teamMembersLogic)
+    const restrictionReason = useRestrictedArea({
+        minimumAccessLevel: OrganizationMembershipLevel.Admin,
+        scope: RestrictionScope.Project,
+    })
 
     if (!user) {
         return null
@@ -187,11 +191,7 @@ export function ProjectTeamMembers(): JSX.Element | null {
         <>
             <h3 className="flex justify-between items-center mt-4">
                 Members with Project Access
-                <RestrictedArea
-                    Component={AddMembersModalWithButton}
-                    minimumAccessLevel={OrganizationMembershipLevel.Admin}
-                    scope={RestrictionScope.Project}
-                />
+                <AddMembersModalWithButton disabledReason={restrictionReason} />
             </h3>
 
             <LemonTable


### PR DESCRIPTION
## Problem

The managed proxy API restricts new proxies to org admins, but we don't have the same restriction in the UI, leading to confusion for non org admin users

I elected to just restrict the button itself so all users can see the status of proxies

<img width="526" alt="image" src="https://github.com/user-attachments/assets/ad0c5648-2773-4e04-b4f8-cc71032ce20b">


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

ran locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
