### PR TITLE
feat(web-analytics): Make channel type Referral when no other rule matches

### DIFF
--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -111,7 +111,7 @@ multiIf(
     (
         {referring_domain} = '$direct'
         AND ({medium} IS NULL)
-        AND ({source} IS NULL OR {source} IN ('(direct)', 'direct'))
+        AND ({source} IS NULL OR {source} IN ('(direct)', 'direct', '$direct'))
     ),
     'Direct',
 
@@ -130,6 +130,12 @@ multiIf(
 
             match({medium}, 'push$'),
             'Push',
+
+            {referring_domain} == '$direct',
+            'Direct',
+
+            {referring_domain} IS NOT NULL,
+            'Referral',
 
             'Unknown'
         )

--- a/posthog/hogql/database/schema/test/test_channel_type.py
+++ b/posthog/hogql/database/schema/test/test_channel_type.py
@@ -265,15 +265,28 @@ class TestChannelType(ClickhouseTestMixin, APIBaseTest):
             ),
         )
 
+    def test_direct_with_red_herring_utm_tags_is_direct(self):
+        self.assertEqual(
+            "Direct",
+            self._get_person_initial_channel_type(
+                {
+                    "$initial_referring_domain": "$direct",
+                    "$initial_utm_source": "what",
+                    "$initial_utm_medium": "who",
+                    "$initial_utm_campaign": "slim shady",
+                }
+            ),
+        )
+
     def test_no_info_is_unknown(self):
         self.assertEqual(
             "Unknown",
             self._get_person_initial_channel_type({}),
         )
 
-    def test_unknown_domain_is_unknown(self):
+    def test_unknown_domain_is_referral(self):
         self.assertEqual(
-            "Unknown",
+            "Referral",
             self._get_person_initial_channel_type(
                 {
                     "$initial_referring_domain": "some-unknown-domain.example.com",
@@ -283,7 +296,7 @@ class TestChannelType(ClickhouseTestMixin, APIBaseTest):
 
     def test_doesnt_fail_on_numbers(self):
         self.assertEqual(
-            "Unknown",
+            "Referral",
             self._get_person_initial_channel_type(
                 {
                     "$initial_referring_domain": "example.com",

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -505,8 +505,6 @@ ORDER BY "context.columns.visitors" DESC,
                 return parse_expr("tupleElement(breakdown_value, 2) IS NOT NULL")
             case WebStatsBreakdown.CITY:
                 return parse_expr("tupleElement(breakdown_value, 2) IS NOT NULL")
-            case WebStatsBreakdown.INITIAL_CHANNEL_TYPE:
-                return parse_expr("TRUE")  # actually show null values
             case WebStatsBreakdown.INITIAL_UTM_SOURCE:
                 return parse_expr("TRUE")  # actually show null values
             case WebStatsBreakdown.INITIAL_UTM_CAMPAIGN:

--- a/posthog/hogql_queries/web_analytics/test/test_session_attribution_explorer_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/test/test_session_attribution_explorer_query_runner.py
@@ -112,7 +112,7 @@ class TestSessionAttributionQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert results == [
             (
                 7,
-                ["Paid Unknown", "Unknown"],
+                ["Paid Unknown", "Referral"],
                 ["referring_domain1a", "referring_domain1b", "referring_domain2"],
                 ["source1", "source2"],
                 ["medium1", "medium2"],
@@ -154,7 +154,7 @@ class TestSessionAttributionQueryRunner(ClickhouseTestMixin, APIBaseTest):
             ),
             (
                 1,
-                ["Unknown"],
+                ["Referral"],
                 ["referring_domain2"],
                 ["source2"],
                 ["medium2"],
@@ -188,7 +188,7 @@ class TestSessionAttributionQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 ["glcid,gad_source"],
                 ["http://example.com/1a", "http://example.com/1b"],
             ),
-            (1, "Unknown", ["referring_domain2"], "source2", "medium2", ["campaign2"], [], ["http://example.com/2"]),
+            (1, "Referral", ["referring_domain2"], "source2", "medium2", ["campaign2"], [], ["http://example.com/2"]),
         ]
 
     @parameterized.expand([[SessionTableVersion.V1], [SessionTableVersion.V2]])


### PR DESCRIPTION
## Problem

My understanding of the Referral channel type was a bit wrong, and @andyvan-ph helped me out ([slack link](https://posthog.slack.com/archives/C01FHN8DNN6/p1721300108253099)), and this was prompted by some cooperation with a customer ([zendesk link](https://posthoghelp.zendesk.com/agent/tickets/14945))

## Changes

Change the channel type logic to give Referral if:
* not paid
* no other rule matches
* referring domain is not $direct
* referring domain is not null

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Updated the tests
