### PR TITLE
fix(web-analytics): Fix more instances where count() should have been uniq()

### DIFF
--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -194,7 +194,7 @@ SELECT
 FROM (
     SELECT
         breakdown_value,
-        count(person_id) AS visitors,
+        uniq(person_id) AS visitors,
         sum(filtered_pageview_count) AS views
     FROM (
         SELECT
@@ -301,7 +301,7 @@ SELECT
 FROM (
     SELECT
         breakdown_value,
-        count(person_id) AS visitors,
+        uniq(person_id) AS visitors,
         sum(filtered_pageview_count) AS views
     FROM (
         SELECT


### PR DESCRIPTION
## Problem

There are some more places where count() should be uniq(), and therefore the total visitors count is wrong.

This led to a bug where some users were seeing values of users in the breakdown that were greater than the total in the overview. E.g.

Overview:
<img width="731" alt="Screenshot 2024-07-30 at 16 54 49" src="https://github.com/user-attachments/assets/628e0b9c-af43-4ae2-bf8c-5b7d364a9be9">

Breakdown:
<img width="792" alt="Screenshot 2024-07-30 at 16 55 00" src="https://github.com/user-attachments/assets/b75761bd-566e-4d45-8a8b-aa02ca10c1a6">

495 > 471 should not be possible, and it's because `count(person_id)` is just counting the number of rows where the value is not null, rather than counting the unique person ids.

## Changes

Fix this and improve the tests

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Added some more test cases
