### PR TITLE
fix: cohort query reduce memory usage

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -32,7 +32,8 @@
   WHERE team_id = 2
     AND cohort_id = 2
     AND version < 0
-    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1
+    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1,
+                          join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohort.test_cohortpeople_with_not_in_cohort_operator
@@ -66,7 +67,8 @@
   WHERE team_id = 2
     AND cohort_id = 2
     AND version < 0
-    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1
+    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1,
+                          join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohort.test_cohortpeople_with_not_in_cohort_operator.1
@@ -115,7 +117,8 @@
            HAVING max(is_deleted) = 0
            AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))) SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
      WHERE 1 = 1
-       AND ((((performed_event_condition_X_level_level_0_level_0_level_0_0)))) SETTINGS optimize_aggregation_in_order=1 ) as person
+       AND ((((performed_event_condition_X_level_level_0_level_0_level_0_0)))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                        join_algorithm = 'auto' ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,
@@ -126,7 +129,8 @@
   WHERE team_id = 2
     AND cohort_id = 2
     AND version < 0
-    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1
+    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1,
+                          join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_and_no_precalculation
@@ -181,7 +185,8 @@
                        HAVING max(is_deleted) = 0
                        AND (((((NOT has(['something1'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', ''))))))) SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
                  WHERE 1 = 1
-                   AND ((((performed_event_condition_X_level_level_0_level_0_level_0_0)))) SETTINGS optimize_aggregation_in_order=1 ) ))
+                   AND ((((performed_event_condition_X_level_level_0_level_0_level_0_0)))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                                    join_algorithm = 'auto' ) ))
   '''
 # ---
 # name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_for_behavioural_cohorts
@@ -211,7 +216,8 @@
           AND event IN ['signup']
         GROUP BY person_id) behavior_query
      WHERE 1 = 1
-       AND (((first_time_condition_X_level_level_0_level_0_0))) SETTINGS optimize_aggregation_in_order=1 ) as person
+       AND (((first_time_condition_X_level_level_0_level_0_0))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                         join_algorithm = 'auto' ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,
@@ -222,7 +228,8 @@
   WHERE team_id = 2
     AND cohort_id = 2
     AND version < 0
-    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1
+    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1,
+                          join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohort.test_cohortpeople_with_not_in_cohort_operator_for_behavioural_cohorts.1
@@ -257,7 +264,8 @@
         GROUP BY person_id) behavior_query
      WHERE 1 = 1
        AND ((((performed_event_condition_X_level_level_0_level_0_level_0_0))
-             AND ((((NOT first_time_condition_X_level_level_0_level_1_level_0_level_0_level_0_0)))))) SETTINGS optimize_aggregation_in_order=1 ) as person
+             AND ((((NOT first_time_condition_X_level_level_0_level_1_level_0_level_0_level_0_0)))))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                                               join_algorithm = 'auto' ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,
@@ -268,7 +276,8 @@
   WHERE team_id = 2
     AND cohort_id = 2
     AND version < 0
-    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1
+    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1,
+                          join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohort.test_static_cohort_precalculated

--- a/ee/clickhouse/queries/enterprise_cohort_query.py
+++ b/ee/clickhouse/queries/enterprise_cohort_query.py
@@ -85,7 +85,7 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
         {q}
         WHERE 1 = 1
         {conditions}
-        SETTINGS optimize_aggregation_in_order=1
+        SETTINGS optimize_aggregation_in_order = 1, join_algorithm = 'partial_merge'
         """
 
         return final_query, self.params

--- a/ee/clickhouse/queries/enterprise_cohort_query.py
+++ b/ee/clickhouse/queries/enterprise_cohort_query.py
@@ -85,7 +85,7 @@ class EnterpriseCohortQuery(FOSSCohortQuery):
         {q}
         WHERE 1 = 1
         {conditions}
-        SETTINGS optimize_aggregation_in_order = 1, join_algorithm = 'partial_merge'
+        SETTINGS optimize_aggregation_in_order = 1, join_algorithm = 'auto'
         """
 
         return final_query, self.params

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -46,7 +46,8 @@
   WHERE 1 = 1
     AND ((((performed_event_condition_None_level_level_0_level_0_level_0_0)
            OR (performed_event_condition_None_level_level_0_level_0_level_1_0))
-          AND ((first_time_condition_None_level_level_0_level_1_level_0_0)))) SETTINGS optimize_aggregation_in_order=1
+          AND ((first_time_condition_None_level_level_0_level_1_level_0_0)))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                       join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_cohort_filter_with_another_cohort_with_event_sequence
@@ -117,7 +118,8 @@
         AND (((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', ''))))) SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
     AND ((((steps_0))
-          AND (steps_1))) SETTINGS optimize_aggregation_in_order=1
+          AND (steps_1))) SETTINGS optimize_aggregation_in_order = 1,
+                                   join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_cohort_filter_with_extra
@@ -159,7 +161,8 @@
         HAVING max(is_deleted) = 0
         AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'name'), '^"|"$', '')))))) SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
-    AND (((performed_event_condition_None_level_level_0_level_0_0))) SETTINGS optimize_aggregation_in_order=1
+    AND (((performed_event_condition_None_level_level_0_level_0_0))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                              join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_cohort_filter_with_extra.1
@@ -197,7 +200,8 @@
         HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
     AND ((((has(['test'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
-          OR ((performed_event_condition_None_level_level_0_level_1_level_0_0)))) SETTINGS optimize_aggregation_in_order=1
+          OR ((performed_event_condition_None_level_level_0_level_1_level_0_0)))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                           join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_performed_event_sequence
@@ -240,7 +244,8 @@
              AND timestamp >= now() - INTERVAL 7 day ))
      GROUP BY person_id) funnel_query
   WHERE 1 = 1
-    AND (((steps_0))) SETTINGS optimize_aggregation_in_order=1
+    AND (((steps_0))) SETTINGS optimize_aggregation_in_order = 1,
+                               join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_performed_event_sequence_and_clause_with_additional_event
@@ -288,7 +293,8 @@
      GROUP BY person_id) funnel_query
   WHERE 1 = 1
     AND (((steps_0)
-          OR (performed_event_multiple_condition_None_level_level_0_level_1_0))) SETTINGS optimize_aggregation_in_order=1
+          OR (performed_event_multiple_condition_None_level_level_0_level_1_0))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                          join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_performed_event_sequence_with_person_properties
@@ -351,7 +357,8 @@
         AND ((has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), 'email'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = funnel_query.person_id
   WHERE 1 = 1
     AND (((steps_0)
-          AND (performed_event_multiple_condition_None_level_level_0_level_1_0))) SETTINGS optimize_aggregation_in_order=1
+          AND (performed_event_multiple_condition_None_level_level_0_level_1_0))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                           join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_performed_event_with_event_filters_and_explicit_date
@@ -378,7 +385,8 @@
        AND timestamp >= now() - INTERVAL 4 day
      GROUP BY person_id) behavior_query
   WHERE 1 = 1
-    AND (((performed_event_condition_None_level_level_0_level_0_0))) SETTINGS optimize_aggregation_in_order=1
+    AND (((performed_event_condition_None_level_level_0_level_0_0))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                              join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_person
@@ -416,7 +424,8 @@
         HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
     AND (((performed_event_condition_None_level_level_0_level_0_0)
-          OR (has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person_props, '$sample_field'), '^"|"$', ''))))) SETTINGS optimize_aggregation_in_order=1
+          OR (has(['test@posthog.com'], replaceRegexpAll(JSONExtractRaw(person_props, '$sample_field'), '^"|"$', ''))))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                                                                  join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_person_materialized
@@ -454,7 +463,8 @@
         HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
   WHERE 1 = 1
     AND (((performed_event_condition_None_level_level_0_level_0_0)
-          OR (has(['test@posthog.com'], "pmat_$sample_field")))) SETTINGS optimize_aggregation_in_order=1
+          OR (has(['test@posthog.com'], "pmat_$sample_field")))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                          join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_person_properties_with_pushdowns
@@ -506,7 +516,8 @@
     AND ((((performed_event_condition_None_level_level_0_level_0_level_0_0)
            OR (performed_event_condition_None_level_level_0_level_0_level_1_0)
            OR (has(['special'], replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', ''))))
-          AND ((first_time_condition_None_level_level_0_level_1_level_0_0)))) SETTINGS optimize_aggregation_in_order=1
+          AND ((first_time_condition_None_level_level_0_level_1_level_0_0)))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                       join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_person_props_only
@@ -596,7 +607,8 @@
              (SELECT person_id as id
               FROM person_static_cohort
               WHERE cohort_id = 2
-                AND team_id = 2)))) SETTINGS optimize_aggregation_in_order=1
+                AND team_id = 2)))) SETTINGS optimize_aggregation_in_order = 1,
+                                             join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_static_cohort_filter_with_extra
@@ -646,7 +658,8 @@
               FROM person_static_cohort
               WHERE cohort_id = 2
                 AND team_id = 2))
-          AND (performed_event_condition_None_level_level_0_level_1_0))) SETTINGS optimize_aggregation_in_order=1
+          AND (performed_event_condition_None_level_level_0_level_1_0))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                  join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_static_cohort_filter_with_extra.2
@@ -687,7 +700,8 @@
                FROM person_static_cohort
                WHERE cohort_id = 2
                  AND team_id = 2)))
-          OR ((performed_event_condition_None_level_level_0_level_1_level_0_0)))) SETTINGS optimize_aggregation_in_order=1
+          OR ((performed_event_condition_None_level_level_0_level_1_level_0_0)))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                           join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohortQuery.test_unwrapping_static_cohort_filter_hidden_in_layers_of_cohorts
@@ -742,6 +756,7 @@
                    FROM person_static_cohort
                    WHERE cohort_id = 2
                      AND team_id = 2)))
-          OR (performed_event_condition_None_level_level_0_level_1_0))) SETTINGS optimize_aggregation_in_order=1
+          OR (performed_event_condition_None_level_level_0_level_1_0))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                 join_algorithm = 'auto'
   '''
 # ---

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -1035,7 +1035,8 @@
   WHERE team_id = 2
     AND cohort_id = 2
     AND version < 1
-    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1
+    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1,
+                          join_algorithm = 'auto'
   '''
 # ---
 # name: TestExperimentAuxiliaryEndpoints.test_create_exposure_cohort_for_experiment_with_custom_action_filters_exposure.1
@@ -1095,7 +1096,8 @@
           AND timestamp >= now() - INTERVAL 6 day
         GROUP BY person_id) behavior_query
      WHERE 1 = 1
-       AND (((performed_event_condition_X_level_level_0_level_0_0))) SETTINGS optimize_aggregation_in_order=1 ) as person
+       AND (((performed_event_condition_X_level_level_0_level_0_0))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                              join_algorithm = 'auto' ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,
@@ -1106,6 +1108,7 @@
   WHERE team_id = 2
     AND cohort_id = 2
     AND version < 1
-    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1
+    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1,
+                          join_algorithm = 'auto'
   '''
 # ---

--- a/posthog/api/test/__snapshots__/test_cohort.ambr
+++ b/posthog/api/test/__snapshots__/test_cohort.ambr
@@ -51,7 +51,8 @@
            HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1)) person ON person.person_id = behavior_query.person_id
      WHERE 1 = 1
        AND ((((has(['something'], replaceRegexpAll(JSONExtractRaw(person_props, '$some_prop'), '^"|"$', ''))))
-             OR ((performed_event_condition_X_level_level_0_level_1_level_0_0)))) SETTINGS optimize_aggregation_in_order=1 ) as person
+             OR ((performed_event_condition_X_level_level_0_level_1_level_0_0)))) SETTINGS optimize_aggregation_in_order = 1,
+                                                                                           join_algorithm = 'auto' ) as person
   UNION ALL
   SELECT person_id,
          cohort_id,
@@ -62,7 +63,8 @@
   WHERE team_id = 2
     AND cohort_id = 2
     AND version < 1
-    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1
+    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1,
+                          join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohort.test_async_deletion_of_cohort.10
@@ -144,7 +146,8 @@
   WHERE team_id = 2
     AND cohort_id = 2
     AND version < 2
-    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1
+    AND sign = 1 SETTINGS optimize_aggregation_in_order = 1,
+                          join_algorithm = 'auto'
   '''
 # ---
 # name: TestCohort.test_async_deletion_of_cohort.6

--- a/posthog/models/cohort/sql.py
+++ b/posthog/models/cohort/sql.py
@@ -46,7 +46,7 @@ UNION ALL
 SELECT person_id, cohort_id, team_id, -1, version
 FROM cohortpeople
 WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s AND version < %(new_version)s AND sign = 1
-SETTINGS optimize_aggregation_in_order = 1
+SETTINGS optimize_aggregation_in_order = 1, join_algorithm = 'partial_merge'
 """
 
 # NOTE: Group by version id to ensure that signs are summed between corresponding rows.

--- a/posthog/models/cohort/sql.py
+++ b/posthog/models/cohort/sql.py
@@ -46,7 +46,7 @@ UNION ALL
 SELECT person_id, cohort_id, team_id, -1, version
 FROM cohortpeople
 WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s AND version < %(new_version)s AND sign = 1
-SETTINGS optimize_aggregation_in_order = 1, join_algorithm = 'partial_merge'
+SETTINGS optimize_aggregation_in_order = 1, join_algorithm = 'auto'
 """
 
 # NOTE: Group by version id to ensure that signs are summed between corresponding rows.


### PR DESCRIPTION
## Problem
Fixes this [ticket](https://posthoghelp.zendesk.com/agent/tickets/16184) where the cohort query OOMs.
Cohorts query generate a full outer join sometimes which causes Clickhouse query to OOM.

## Changes
Changing the cohort query settings to have `join_algorithm = 'auto'. This detects when the memory limit will be violated and falls back to a different algorithm like 'partial_merge' which will be slower but use less memory. 
Since cohort calculations happen in background, ok to sacrifice speed to avoid OOM.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->


## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
