### PR TITLE
fix(web-analytics): Fix empty channel types

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2023 PostHog Inc.
+Copyright (c) 2020-2024 PostHog Inc.
 
 Portions of this software are licensed as follows:
 

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -515,6 +515,10 @@ ORDER BY "context.columns.visitors" DESC,
                 return parse_expr("TRUE")  # actually show null values
             case WebStatsBreakdown.INITIAL_UTM_CONTENT:
                 return parse_expr("TRUE")  # actually show null values
+            case WebStatsBreakdown.INITIAL_CHANNEL_TYPE:
+                return parse_expr(
+                    "breakdown_value IS NOT NULL AND breakdown_value != ''"
+                )  # we need to check for empty strings as well due to how the left join works
             case _:
                 return parse_expr("breakdown_value IS NOT NULL")
 


### PR DESCRIPTION
## Problem

Events without a session id appear in the channel type breakdown as an empty string. This can be pretty confusing for users, see https://posthoghelp.zendesk.com/agent/tickets/16277 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/18789)

## Changes

Add a condition that removes rows with an empty channel type.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added some tests
