### PR TITLE
feat: Add batch utilization metric for blobby

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -119,6 +119,11 @@ export const sessionInfoSummary = new Summary({
     percentiles: [0.1, 0.25, 0.5, 0.9, 0.99],
 })
 
+const gaugeBatchUtilization = new Gauge({
+    name: 'recording_blob_ingestion_batch_utilization',
+    help: 'Indicates how big batches are we are processing compared to the max batch size. Useful as a scaling metric',
+})
+
 type PartitionMetrics = {
     lastMessageTimestamp?: number
     lastMessageOffset?: number
@@ -342,6 +347,8 @@ export class SessionRecordingIngester {
                 assignedPartitions: this.assignedPartitions,
             })
         }
+
+        gaugeBatchUtilization.set(messages.length / this.config.SESSION_RECORDING_KAFKA_BATCH_SIZE)
 
         await runInstrumentedFunction({
             statsKey: `recordingingester.handleEachBatch`,


### PR DESCRIPTION
## Problem

Best kind of metrics are utilization based like CPU. Blobby's batch utilization is I think the best metric for how underload it is (in combination with CPU).

## Changes

* Adds the gauge
* Follow up will use this for keda scaling

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
