### PR TITLE
feat(notebooks): add error boundary around components

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NodeWrapper.tsx
@@ -259,11 +259,13 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
 
                                         {Settings && editingNodeId === nodeId && containerSize === 'small' ? (
                                             <div className="NotebookNode__settings">
-                                                <Settings
-                                                    key={nodeId}
-                                                    attributes={attributes}
-                                                    updateAttributes={updateAttributes}
-                                                />
+                                                <ErrorBoundary>
+                                                    <Settings
+                                                        key={nodeId}
+                                                        attributes={attributes}
+                                                        updateAttributes={updateAttributes}
+                                                    />
+                                                </ErrorBoundary>
                                             </div>
                                         ) : null}
 
@@ -278,7 +280,12 @@ function NodeWrapper<T extends CustomNotebookNodeAttributes>(props: NodeWrapperP
                                             onClick={!expanded && expandOnClick ? () => setExpanded(true) : undefined}
                                             onMouseDown={onResizeStart}
                                         >
-                                            <Component attributes={attributes} updateAttributes={updateAttributes} />
+                                            <ErrorBoundary>
+                                                <Component
+                                                    attributes={attributes}
+                                                    updateAttributes={updateAttributes}
+                                                />
+                                            </ErrorBoundary>
                                         </div>
                                     </>
                                 )}


### PR DESCRIPTION
## Problem

Each notebook node has a `Settings` and `Component` child passed in. In case of an error in these it would become impossible to edit the node.

<img width="440" alt="Screenshot 2024-07-31 at 10 10 28" src="https://github.com/user-attachments/assets/e9007d1a-df90-40f6-b3c9-ca36e11f9b6e">

## Changes

Wraps them in an `<ErrorBoundary />`:

<img width="445" alt="Screenshot 2024-07-31 at 10 10 50" src="https://github.com/user-attachments/assets/4ace76e6-0bd3-4827-9940-6aa37cb18713">

## How did you test this code?

See screenshots