### PR TITLE
fix(bi): Use a better tooltip mode for graphs

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -155,7 +155,7 @@ export const LineGraph = (): JSX.Element => {
                 // TODO: A lot of this is v similar to the trends LineGraph - considering merging these
                 tooltip: {
                     enabled: false,
-                    mode: 'nearest',
+                    mode: 'index',
                     intersect: false,
                     external({ tooltip }: { chart: Chart; tooltip: TooltipModel<ChartType> }) {
                         if (!canvasRef.current) {


### PR DESCRIPTION
## Problem
Tooltips on BI charts dont always reflect where the mouse is pointed, it's rather annoying

## Changes
- Change the tooltip mode to `index` - https://www.chartjs.org/docs/latest/configuration/interactions.html#index
- The tooltip now updates _every_ time

