### PR TITLE
feat(bi): Added support for decimal numbers in BI

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -95,6 +95,9 @@ const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number 
                         <LemonField name="suffix" label="Suffix">
                             <LemonInput placeholder="USD" />
                         </LemonField>
+                        <LemonField name="decimalPlaces" label="Decimal places">
+                            <LemonInput type="number" min={0} />
+                        </LemonField>
                     </Form>
                 }
                 visible={isSettingsOpen}

--- a/frontend/src/queries/nodes/DataVisualization/Components/ySeriesLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/ySeriesLogic.ts
@@ -47,6 +47,7 @@ export const ySeriesLogic = kea<ySeriesLogicType>([
                 prefix: props.series?.settings?.formatting?.prefix ?? '',
                 suffix: props.series?.settings?.formatting?.suffix ?? '',
                 style: props.series?.settings?.formatting?.style ?? 'none',
+                decimalPlaces: props.series?.settings?.formatting?.decimalPlaces ?? '',
             },
             submit: async (format) => {
                 actions.updateYSeries(props.seriesIndex, props.series.column.name, {
@@ -54,6 +55,8 @@ export const ySeriesLogic = kea<ySeriesLogicType>([
                         prefix: format.prefix,
                         suffix: format.suffix,
                         style: format.style,
+                        decimalPlaces:
+                            format.decimalPlaces === '' ? undefined : parseInt(format.decimalPlaces.toString(), 10),
                     },
                 })
                 actions.setSettingsOpen(false)

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2046,6 +2046,9 @@
         "ChartSettingsFormatting": {
             "additionalProperties": false,
             "properties": {
+                "decimalPlaces": {
+                    "type": "number"
+                },
                 "prefix": {
                     "type": "string"
                 },

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -560,6 +560,7 @@ export interface ChartSettingsFormatting {
     prefix?: string
     suffix?: string
     style?: 'none' | 'number' | 'percent'
+    decimalPlaces?: number
 }
 
 export interface ChartSettings {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -169,6 +169,7 @@ class ChartSettingsFormatting(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    decimalPlaces: Optional[float] = None
     prefix: Optional[str] = None
     style: Optional[Style] = None
     suffix: Optional[str] = None


### PR DESCRIPTION
## Problem
- We dont support displaying floating point number in BI

## Changes
- Support floating point numbers
- Allow the user to choose the amount of decimal places per series

<img width="399" alt="image" src="https://github.com/user-attachments/assets/a4954621-b03b-4b4c-88e7-e9086a814a37">

<img width="405" alt="image" src="https://github.com/user-attachments/assets/2bf4c20a-300e-4223-a0ca-9e18fe0ed215">
