### PR TITLE
fix: Site app url for early access

### DIFF
--- a/frontend/src/scenes/early-access-features/InstructionsModal.tsx
+++ b/frontend/src/scenes/early-access-features/InstructionsModal.tsx
@@ -3,8 +3,9 @@ import { useValues } from 'kea'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import EarlyAccessFeatureImage from 'public/early-access-feature-demo.png'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { urls } from 'scenes/urls'
 
-import { FeatureFlagType } from '~/types'
+import { FeatureFlagType, PipelineStage, Region } from '~/types'
 
 interface InstructionsModalProps {
     flag: FeatureFlagType['key']
@@ -25,7 +26,15 @@ export function InstructionsModal({ onClose, visible, flag }: InstructionsModalP
                     header: 'Option 1: Widget Site App',
                     content: (
                         <div>
-                            Give your users a <Link to="https://app.posthog.com/project/apps/574">prebuilt widget</Link>{' '}
+                            Give your users a{' '}
+                            <Link
+                                to={urls.pipelineNodeNew(
+                                    PipelineStage.SiteApp,
+                                    preflight?.region === Region.EU ? 332 : 574
+                                )}
+                            >
+                                prebuilt widget
+                            </Link>{' '}
                             to opt-in to features
                             <img className="max-h-full max-w-full mt-2.5" src={EarlyAccessFeatureImage} />
                         </div>


### PR DESCRIPTION
## Problem

The url was wrong

Fixes https://github.com/PostHog/posthog/issues/24100

## Changes

* Repairs the url and accounts for regions

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
