### PR TITLE
fix: pass secret to django worker

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -186,6 +186,7 @@ services:
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
+            SECRET_KEY: $POSTHOG_SECRET
         depends_on:
             - db
             - redis


### PR DESCRIPTION
Without this, the django worker endlessly crashes

## Problem

Self hosted instances don't work without this.

## Changes

Pass the secret key to the django worker so it doesn't endlessly crash. I believe the issue is from this https://github.com/PostHog/posthog/blob/c339d252e0a76f5aaceea64d2d646e34ff7a9d2c/posthog/settings/access.py#L60

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Can't test cloud but should work.

## How did you test this code?

Ran it on my own self hosted machine
