### PR TITLE
chore(hooks): memory, metrics and timeout optimizations

### DIFF
--- a/rust/hook-api/src/handlers/webhook.rs
+++ b/rust/hook-api/src/handlers/webhook.rs
@@ -99,16 +99,20 @@ pub async fn post_hoghook(
     // the original payload unmodified so that it can be passed through exactly as it came to us.
     let async_function_request = payload
         .get("asyncFunctionRequest")
-        .ok_or_else(|| bad_request("missing required field 'asyncFunctionRequest'"))?
+        .ok_or_else(|| bad_request("missing required field 'asyncFunctionRequest'".to_owned()))?
         .clone();
     let async_function_request: HoghookAsyncFunctionRequest =
         serde_json::from_value(async_function_request).map_err(|err| {
-            let msg = format!("unable to deserialize 'asyncFunctionRequest': {}", err);
-            bad_request(&msg)
+            bad_request(format!(
+                "unable to deserialize 'asyncFunctionRequest': {}",
+                err
+            ))
         })?;
 
     if async_function_request.name != "fetch" {
-        return Err(bad_request("asyncFunctionRequest.name must be 'fetch'"));
+        return Err(bad_request(
+            "asyncFunctionRequest.name must be 'fetch'".to_owned(),
+        ));
     }
 
     // Note that the URL is parsed (and thus validated as a valid URL) as part of
@@ -145,13 +149,11 @@ pub async fn post_hoghook(
     Ok(Json(WebhookPostResponse { error: None }))
 }
 
-fn bad_request(msg: &str) -> (StatusCode, Json<WebhookPostResponse>) {
+fn bad_request(msg: String) -> (StatusCode, Json<WebhookPostResponse>) {
     error!(msg);
     (
         StatusCode::BAD_REQUEST,
-        Json(WebhookPostResponse {
-            error: Some(msg.to_owned()),
-        }),
+        Json(WebhookPostResponse { error: Some(msg) }),
     )
 }
 
@@ -169,11 +171,11 @@ where
 }
 
 fn get_hostname(url_str: &str) -> Result<String, (StatusCode, Json<WebhookPostResponse>)> {
-    let url = Url::parse(url_str).map_err(|_| bad_request("could not parse url"))?;
+    let url = Url::parse(url_str).map_err(|_| bad_request("could not parse url".to_owned()))?;
 
     match url.host_str() {
         Some(hostname) => Ok(hostname.to_owned()),
-        None => Err(bad_request("couldn't extract hostname from url")),
+        None => Err(bad_request("couldn't extract hostname from url".to_owned())),
     }
 }
 

--- a/rust/hook-common/src/metrics.rs
+++ b/rust/hook-common/src/metrics.rs
@@ -29,12 +29,12 @@ pub fn setup_metrics_routes(router: Router) -> Router {
 }
 
 pub fn setup_metrics_recorder() -> PrometheusHandle {
-    const EXPONENTIAL_SECONDS: &[f64] = &[
-        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+    const BUCKETS: &[f64] = &[
+        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 50.0, 100.0, 250.0,
     ];
 
     PrometheusBuilder::new()
-        .set_buckets(EXPONENTIAL_SECONDS)
+        .set_buckets(BUCKETS)
         .unwrap()
         .install_recorder()
         .unwrap()

--- a/rust/hook-common/src/pgqueue.rs
+++ b/rust/hook-common/src/pgqueue.rs
@@ -6,8 +6,7 @@ use std::{str::FromStr, sync::Arc};
 
 use async_trait::async_trait;
 use chrono;
-use serde::{self, Serialize};
-use serde_json::Value;
+use serde;
 use sqlx::postgres::any::AnyConnectionBackend;
 use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
 use thiserror::Error;
@@ -632,13 +631,6 @@ RETURNING
         &self,
         job: NewJob<J, M>,
     ) -> PgQueueResult<()> {
-        // TODO: Escaping. I think sqlx doesn't support identifiers.
-        let metadata = remove_null_characters_from_json(&job.metadata)
-            .map_err(|error| DatabaseError::SerializationError { error })?;
-        let parameters = remove_null_characters_from_json(&job.parameters)
-            .map_err(|error| DatabaseError::SerializationError { error })?;
-        let target = remove_null_characters_from_string(&job.target);
-
         let base_query = r#"
 INSERT INTO job_queue
     (attempt, created_at, scheduled_at, max_attempts, metadata, parameters, queue, status, target)
@@ -648,10 +640,10 @@ VALUES
 
         sqlx::query(base_query)
             .bind(job.max_attempts)
-            .bind(metadata)
-            .bind(parameters)
+            .bind(&job.metadata)
+            .bind(&job.parameters)
             .bind(&self.name)
-            .bind(&target)
+            .bind(&job.target)
             .execute(&self.pool)
             .await
             .map_err(|error| DatabaseError::QueryError {
@@ -661,16 +653,6 @@ VALUES
 
         Ok(())
     }
-}
-
-fn remove_null_characters_from_string(s: &str) -> String {
-    s.replace('\u{0000}', "")
-}
-
-fn remove_null_characters_from_json<T: Serialize>(value: &T) -> Result<Value, serde_json::Error> {
-    let json_string = serde_json::to_string(value)?;
-    let sanitized_string = json_string.replace("\\u0000", "");
-    serde_json::from_str(&sanitized_string)
 }
 
 #[cfg(test)]
@@ -755,18 +737,6 @@ mod tests {
         tx_job.complete().await.expect("failed to complete job");
 
         batch.commit().await.expect("failed to commit transaction");
-    }
-
-    #[sqlx::test(migrations = "../migrations")]
-    async fn test_bad_unicode(db: PgPool) {
-        let job_target = String::from('\0');
-        let json_with_null: serde_json::Value =
-            serde_json::from_str(r#"{"key":"\u0000"}"#).expect("failed to serialize json");
-
-        let queue = PgQueue::new_from_pool("test_bad_unicode", db).await;
-
-        let new_job = NewJob::new(1, json_with_null.clone(), json_with_null, &job_target);
-        queue.enqueue(new_job).await.expect("failed to enqueue job");
     }
 
     #[sqlx::test(migrations = "../migrations")]


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We want to deploy Hoghooks more widely, and need to iron out any more latent edge cases.

## Changes

Changes are broken up by commit and should mostly be self explanatory.

* Our dequeue metrics graphs were bad because buckets were only tuned to be small (for timings, not things like "batch size").
* ~~We weren't timing out on body reads, a bad destination server could hang a bunch of workers without a timeout. (They still can clog things up, but this should help somewhat for now.)~~ Removed this, it turns out of Reqwest Client timeout covers reading the response body too
* Added retry logic if we timeout reading the response body.
* Enhanced some error types so we collect HTTP Status/Response in the right place for producing to Kafka. (There is still some intermingling between old-style Rusty-Hook, which cares about putting errors in the DB, and Hoghook, which cares about producing to Kafka... We can clean this up soon probably.)
* Other misc stuff I found while re-reading the hot path.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->
Yes.

## How did you test this code?

Existing / new.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
