### PR TITLE
fix(cdp): Spread overflow traffic

### DIFF
--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -18,7 +18,7 @@ import { runInstrumentedFunction } from '../main/utils'
 import { AppMetric2Type, Hub, RawClickHouseEvent, TeamId, TimestampFormat } from '../types'
 import { KafkaProducerWrapper } from '../utils/db/kafka-producer-wrapper'
 import { status } from '../utils/status'
-import { castTimestampOrNow } from '../utils/utils'
+import { castTimestampOrNow, UUIDT } from '../utils/utils'
 import { RustyHook } from '../worker/rusty-hook'
 import { AsyncFunctionExecutor } from './async-function-executor'
 import { GroupsManager } from './groups-manager'
@@ -271,14 +271,13 @@ abstract class CdpConsumerBase {
                     const functionState = this.hogWatcher.getFunctionState(item.hogFunctionId)
 
                     if (functionState === HogWatcherState.overflowed) {
-                        // TODO: _Maybe_ report to AppMetrics 2 when it is ready
                         this.messagesToProduce.push({
                             topic: KAFKA_CDP_FUNCTION_OVERFLOW,
                             value: {
                                 source: 'hog_function_callback',
                                 payload: item,
                             },
-                            key: item.hogFunctionId,
+                            key: new UUIDT().toString(), // Random key to spread across consumers
                         })
                         // We don't report overflowed metric to appmetrics as it is sort of a meta-metric
                         counterFunctionInvocation.inc({ outcome: 'overflowed' })


### PR DESCRIPTION
## Problem

Overflowing traffic is traffic that is not being delivered well and as such the ordering becomes less important.
At the very least for this V0.1 solution.

## Changes

* Randomly generate the kafka key so it is spread across all consumers

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
