### PR TITLE
fix(batch-exports): Use a stable column ordering for persons export

### DIFF
--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -40,7 +40,14 @@ AsyncBytesGenerator = collections.abc.AsyncGenerator[bytes, None]
 AsyncRecordsGenerator = collections.abc.AsyncGenerator[pa.RecordBatch, None]
 
 SELECT_FROM_PERSONS_VIEW = """
-SELECT *
+SELECT
+    persons.team_id AS team_id,
+    persons.distinct_id AS distinct_id,
+    persons.person_id AS person_id,
+    persons.properties AS properties,
+    persons.person_distinct_id_version AS person_distinct_id_version,
+    persons.person_version AS person_version,
+    persons._inserted_at AS _inserted_at
 FROM
     persons_batch_export(
         team_id={team_id},


### PR DESCRIPTION
## Problem

`SELECT *` produces a different column ordering every time. Although not a big deal as downstream queries do not use the wildcard to match columns, it can be confusing for a user creating multiple exports to see different column orderings every time.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Do not use wildcard but instead select specific columns. Not a functional change as the columns we are selecting are all of them.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
