### PR TITLE
feat: Added common batch utilization gauge

### DIFF
--- a/plugin-server/src/kafka/batch-consumer.ts
+++ b/plugin-server/src/kafka/batch-consumer.ts
@@ -281,6 +281,8 @@ export const startBatchConsumer = async ({
                     continue
                 }
 
+                gaugeBatchUtilization.labels({ groupId }).set(messages.length / fetchBatchSize)
+
                 status.debug('🔁', 'main_loop_consumed', { messagesLength: messages.length })
                 if (!messages.length && !callEachBatchWhenEmpty) {
                     status.debug('🔁', 'main_loop_empty_batch', { cause: 'empty' })
@@ -411,4 +413,10 @@ const kafkaAbsolutePartitionCount = new Gauge({
     name: 'kafka_absolute_partition_count',
     help: 'Number of partitions assigned to this consumer. (Absolute value from the consumer state.)',
     labelNames: ['topic'],
+})
+
+const gaugeBatchUtilization = new Gauge({
+    name: 'consumer_batch_utilization',
+    help: 'Indicates how big batches are we are processing compared to the max batch size. Useful as a scaling metric',
+    labelNames: ['groupId'],
 })

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -119,11 +119,6 @@ export const sessionInfoSummary = new Summary({
     percentiles: [0.1, 0.25, 0.5, 0.9, 0.99],
 })
 
-const gaugeBatchUtilization = new Gauge({
-    name: 'recording_blob_ingestion_batch_utilization',
-    help: 'Indicates how big batches are we are processing compared to the max batch size. Useful as a scaling metric',
-})
-
 type PartitionMetrics = {
     lastMessageTimestamp?: number
     lastMessageOffset?: number
@@ -347,8 +342,6 @@ export class SessionRecordingIngester {
                 assignedPartitions: this.assignedPartitions,
             })
         }
-
-        gaugeBatchUtilization.set(messages.length / this.config.SESSION_RECORDING_KAFKA_BATCH_SIZE)
 
         await runInstrumentedFunction({
             statsKey: `recordingingester.handleEachBatch`,


### PR DESCRIPTION
## Problem

Realized the metric isn't only useful for Mr Blobby

## Changes

* Added batch utilization as a general metric given how useful it is 
* Will follow up to scale CDP consumers off of it
* Removed the blobby metric as nothing depended on it yet

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
