### PR TITLE
fix(bi): Fixed bugginess with lots of BI series

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -33,7 +33,7 @@ export const SeriesTab = (): JSX.Element => {
             />
             <LemonLabel className="mt-4">Y-axis</LemonLabel>
             {yData.map((series, index) => (
-                <YSeries series={series} index={index} key={series?.column.name} />
+                <YSeries series={series} index={index} key={`${series?.column.name}-${index}`} />
             ))}
             <LemonButton
                 className="mt-1"


### PR DESCRIPTION
## Problem
- Multiple series using the same column causes the series config to freeze and go a bit funky

## Changes
- Use a better `key` for rendering the series to handle multiple series referencing the same column

## Does this work well for both Cloud and self-hosted?
Yup

## How did you test this code?
Tested locally