### PR TITLE
chore(hogql): Open up team_id on function based tables

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1,6 +1,6 @@
 import dataclasses
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypeAlias, cast, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional, TypeAlias, cast, Union
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from django.db.models import Q
@@ -496,7 +496,7 @@ def serialize_database(
         elif isinstance(table, Table):
             field_input = table.fields
 
-        fields = serialize_fields(field_input, context, table_key)
+        fields = serialize_fields(field_input, context, table_key, table_type="posthog")
         fields_dict = {field.name: field for field in fields}
         tables[table_key] = DatabaseSchemaPostHogTable(fields=fields_dict, id=table_key, name=table_key)
 
@@ -524,7 +524,7 @@ def serialize_database(
         if isinstance(table, Table):
             field_input = table.fields
 
-        fields = serialize_fields(field_input, context, table_key, warehouse_table.columns)
+        fields = serialize_fields(field_input, context, table_key, warehouse_table.columns, table_type="external")
         fields_dict = {field.name: field for field in fields}
 
         # Schema
@@ -580,7 +580,7 @@ def serialize_database(
         if view is None:
             continue
 
-        fields = serialize_fields(view.fields, context, view_name)
+        fields = serialize_fields(view.fields, context, view_name, table_type="external")
         fields_dict = {field.name: field for field in fields}
 
         saved_query: list[DataWarehouseSavedQuery] = list(
@@ -620,7 +620,11 @@ HOGQL_CHARACTERS_TO_BE_WRAPPED = ["@", "-", "!", "$", "+"]
 
 
 def serialize_fields(
-    field_input, context: HogQLContext, table_name: str, db_columns: Optional[DataWarehouseTableColumns] = None
+    field_input,
+    context: HogQLContext,
+    table_name: str,
+    db_columns: Optional[DataWarehouseTableColumns] = None,
+    table_type: Literal["posthog"] | Literal["external"] = "posthog",
 ) -> list[DatabaseSchemaField]:
     from posthog.hogql.database.models import SavedQuery
     from posthog.hogql.resolver import resolve_types_from_table
@@ -645,7 +649,7 @@ def serialize_fields(
         else:
             hogql_value = str(field_key)
 
-        if field_key == "team_id":
+        if field_key == "team_id" and table_type == "posthog":
             pass
         elif isinstance(field, DatabaseField):
             if field.hidden:

--- a/posthog/hogql/database/models.py
+++ b/posthog/hogql/database/models.py
@@ -128,7 +128,11 @@ class Table(FieldOrTable):
         return []
 
     def get_asterisk(self):
-        fields_to_avoid = [*self.avoid_asterisk_fields(), "team_id"]
+        if isinstance(self, FunctionCallTable):
+            fields_to_avoid = self.avoid_asterisk_fields()
+        else:
+            fields_to_avoid = [*self.avoid_asterisk_fields(), "team_id"]
+
         asterisk: dict[str, FieldOrTable] = {}
         for key, field_ in self.fields.items():
             if key in fields_to_avoid:

--- a/posthog/warehouse/api/saved_query.py
+++ b/posthog/warehouse/api/saved_query.py
@@ -35,7 +35,7 @@ class DataWarehouseSavedQuerySerializer(serializers.ModelSerializer):
         team_id = self.context["team_id"]
         context = HogQLContext(team_id=team_id, database=create_hogql_database(team_id=team_id))
 
-        fields = serialize_fields(view.hogql_definition().fields, context, view.name)
+        fields = serialize_fields(view.hogql_definition().fields, context, view.name, table_type="external")
         return [
             SerializedField(
                 key=field.name,

--- a/posthog/warehouse/api/table.py
+++ b/posthog/warehouse/api/table.py
@@ -68,7 +68,11 @@ class TableSerializer(serializers.ModelSerializer):
             fields = table.hogql_definition().fields
 
         serializes_fields = serialize_fields(
-            fields, HogQLContext(database=database, team_id=self.context["team_id"]), table.name, table.columns
+            fields,
+            HogQLContext(database=database, team_id=self.context["team_id"]),
+            table.name,
+            table.columns,
+            table_type="external",
         )
 
         return [
@@ -132,7 +136,10 @@ class SimpleTableSerializer(serializers.ModelSerializer):
             database = create_hogql_database(team_id=self.context["team_id"])
 
         fields = serialize_fields(
-            table.hogql_definition().fields, HogQLContext(database=database, team_id=team_id), table.name
+            table.hogql_definition().fields,
+            HogQLContext(database=database, team_id=team_id),
+            table.name,
+            table_type="external",
         )
         return [
             SerializedField(


### PR DESCRIPTION
## Problem
- we have certain rules for the usage of `team_id` in hogql, for example, we got output when using an asterisk `*` during a select query - this is great when referring to posthog-owned tables, but it does mean we sometimes hide columns from data warehouse users who may also be using `team_id`

## Changes
- Allow `team_id` when we serialize fields on a table **if** the table is not a posthog-owned table
- Allow `team_id` when selecting all columns on a table **if** the table is a function call table (e.g. S3 table)

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested it in the SQL editor 