### PR TITLE
fix(batch-exports): Wrap redshift flush in transaction

### DIFF
--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -296,31 +296,32 @@ async def insert_records_to_redshift(
 
     total_rows_exported = 0
 
-    async with redshift_client.async_client_cursor() as cursor:
-        batch = []
-        pre_query_str = pre_query.as_string(cursor).encode("utf-8")
-
-        async def flush_to_redshift(batch):
-            nonlocal total_rows_exported
-
-            values = b",".join(batch).replace(b" E'", b" '")
-            await cursor.execute(pre_query_str + values)
-            rows_exported.add(len(batch))
-            total_rows_exported += len(batch)
-            # It would be nice to record BYTES_EXPORTED for Redshift, but it's not worth estimating
-            # the byte size of each batch the way things are currently written. We can revisit this
-            # in the future if we decide it's useful enough.
-
-        async for record in records_iterator:
-            batch.append(cursor.mogrify(template, record).encode("utf-8"))
-            if len(batch) < batch_size:
-                continue
-
-            await flush_to_redshift(batch)
+    async with redshift_client.connection.transaction():
+        async with redshift_client.async_client_cursor() as cursor:
             batch = []
+            pre_query_str = pre_query.as_string(cursor).encode("utf-8")
 
-        if len(batch) > 0:
-            await flush_to_redshift(batch)
+            async def flush_to_redshift(batch):
+                nonlocal total_rows_exported
+
+                values = b",".join(batch).replace(b" E'", b" '")
+                await cursor.execute(pre_query_str + values)
+                rows_exported.add(len(batch))
+                total_rows_exported += len(batch)
+                # It would be nice to record BYTES_EXPORTED for Redshift, but it's not worth estimating
+                # the byte size of each batch the way things are currently written. We can revisit this
+                # in the future if we decide it's useful enough.
+
+            async for record in records_iterator:
+                batch.append(cursor.mogrify(template, record).encode("utf-8"))
+                if len(batch) < batch_size:
+                    continue
+
+                await flush_to_redshift(batch)
+                batch = []
+
+            if len(batch) > 0:
+                await flush_to_redshift(batch)
 
     return total_rows_exported
 


### PR DESCRIPTION
## Problem

Deleting a stage table in Redshift, which happens right at the end of the batch export, is failing with a "some previous operation failed". Every other operation is wrapped in its own transaction, except for the flush. Let's wrap it too in case that's failing.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Wrap redshift flush in transaction.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
