### PR TITLE
fix(batch-exports): Use VARCHAR(65535) type instead of text

### DIFF
--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -219,7 +219,10 @@ def get_redshift_fields_from_record_schema(
             if pa_field.name in known_super_columns and use_super is True:
                 pg_type = "SUPER"
             else:
-                pg_type = "TEXT"
+                # Redshift treats `TEXT` as `VARCHAR(256)`, not as unlimited length like PostgreSQL.
+                # So, instead of `TEXT` we use the largest possible `VARCHAR`.
+                # See: https://docs.aws.amazon.com/redshift/latest/dg/r_Character_types.html
+                pg_type = "VARCHAR(65535)"
 
         elif pa.types.is_signed_integer(pa_field.type) or pa.types.is_unsigned_integer(pa_field.type):
             if pa.types.is_uint64(pa_field.type) or pa.types.is_int64(pa_field.type):


### PR DESCRIPTION
## Problem

When casting to Redshift types, we incorrectly assumed Redshift character types behaved the same (or similarly) to PostgreSQL types (which Redshift is based on). Unfortunately, this is not the case: While PostgreSQL's `TEXT` represents unlimited length, Redshift's `TEXT` is converted to `VARCHAR(256)`. This is causing problems when values exceed 256 in length.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Obviously "unlimited" can be tricky or a straight-up lie, but Redshift could have at least used the maximum length possible, `VARCHAR(65535)`. So, that's what we do here.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
