### PR TITLE
fix: upgrade time to fix rust build using rust 1.80.0

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3749,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -3770,9 +3770,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -65,7 +65,7 @@ sqlx = { version = "0.7", features = [
   "tls-native-tls",
   "uuid",
 ] }
-time = { version = "0.3.20", features = [
+time = { version = "0.3.36", features = [
   "formatting",
   "macros",
   "parsing",


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
This was a surprise. A rust upgrade broke a library we use:

```
# cargo c
    Checking time v0.3.34
    Checking opentelemetry-proto v0.5.0
    Checking feature-flags v0.1.0 (/Users/brett/Development/posthog/posthog/rust/feature-flags)
    Checking opentelemetry-otlp v0.15.0
error[E0282]: type annotations needed for `Box<_>`
  --> /Users/brett/.cargo/registry/src/index.crates.io-6f17d22bba15001f/time-0.3.34/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
help: consider giving `items` an explicit type, where the placeholders `_` are specified
   |
83 |     let items: Box<_> = format_items
   |              ++++++++

For more information about this error, try `rustc --explain E0282`.
error: could not compile `time` (lib) due to 1 previous error
```

## Changes

Bumped the `time` dep.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
