### PR TITLE
feat(clickhouse): Start writing property groups on events

### DIFF
--- a/posthog/clickhouse/migrations/0074_add_custom_and_features_property_groups.py
+++ b/posthog/clickhouse/migrations/0074_add_custom_and_features_property_groups.py
@@ -4,7 +4,7 @@ from posthog.clickhouse.property_groups import sharded_events_property_groups
 operations = [
     run_sql_with_exceptions(statement)
     for statement in [
-        *sharded_events_property_groups.get_alter_table_statements("custom"),
-        *sharded_events_property_groups.get_alter_table_statements("feature_flags"),
+        *sharded_events_property_groups.get_alter_create_statements("custom"),
+        *sharded_events_property_groups.get_alter_create_statements("feature_flags"),
     ]
 ]

--- a/posthog/clickhouse/migrations/0074_add_custom_and_features_property_groups.py
+++ b/posthog/clickhouse/migrations/0074_add_custom_and_features_property_groups.py
@@ -5,6 +5,6 @@ operations = [
     run_sql_with_exceptions(statement)
     for statement in [
         *event_property_groups.get_alter_table_statements("custom"),
-        *event_property_groups.get_alter_table_statements("features"),
+        *event_property_groups.get_alter_table_statements("feature_flags"),
     ]
 ]

--- a/posthog/clickhouse/migrations/0074_add_custom_and_features_property_groups.py
+++ b/posthog/clickhouse/migrations/0074_add_custom_and_features_property_groups.py
@@ -1,10 +1,10 @@
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.clickhouse.property_groups import event_property_groups
+from posthog.clickhouse.property_groups import sharded_events_property_groups
 
 operations = [
     run_sql_with_exceptions(statement)
     for statement in [
-        *event_property_groups.get_alter_table_statements("custom"),
-        *event_property_groups.get_alter_table_statements("feature_flags"),
+        *sharded_events_property_groups.get_alter_table_statements("custom"),
+        *sharded_events_property_groups.get_alter_table_statements("feature_flags"),
     ]
 ]

--- a/posthog/clickhouse/migrations/0074_add_custom_and_features_property_groups.py
+++ b/posthog/clickhouse/migrations/0074_add_custom_and_features_property_groups.py
@@ -1,0 +1,10 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.property_groups import event_property_groups
+
+operations = [
+    run_sql_with_exceptions(statement)
+    for statement in [
+        *event_property_groups.get_alter_table_statements("custom"),
+        *event_property_groups.get_alter_table_statements("features"),
+    ]
+]

--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -29,7 +29,7 @@ class PropertyGroupManager:
         definition = self.__groups[name]
         return [
             f"ALTER TABLE {self.__table} ON CLUSTER {self.__cluster} ADD COLUMN {column_name} Map(String, String) MATERIALIZED {self.__get_map_expression(definition)} CODEC({definition.codec})",
-            f"ALTER TABLE {self.__table} ON CLUSTER {self.__cluster} ADD INDEX {column_name}_keys_bf mapValues({column_name}) TYPE bloom_filter",
+            f"ALTER TABLE {self.__table} ON CLUSTER {self.__cluster} ADD INDEX {column_name}_keys_bf mapKeys({column_name}) TYPE bloom_filter",
             f"ALTER TABLE {self.__table} ON CLUSTER {self.__cluster} ADD INDEX {column_name}_values_bf mapValues({column_name}) TYPE bloom_filter",
         ]
 

--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -1,4 +1,4 @@
-from collections.abc import MutableMapping
+from collections.abc import Iterable, MutableMapping
 from dataclasses import dataclass
 
 
@@ -21,7 +21,7 @@ class PropertyGroupManager:
     def __get_map_expression(self, definition: PropertyGroupDefinition) -> str:
         return f"mapSort(mapFilter((key, _) -> {definition.filter_expression}, CAST(JSONExtractKeysAndValues({self.__source_column}, 'String'), 'Map(String, String)')))"
 
-    def get_alter_table_statements(self, name: str) -> str:
+    def get_alter_table_statements(self, name: str) -> Iterable[str]:
         column_name = f"{self.__source_column}_group_{name}"
         definition = self.__groups[name]
         return [

--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -31,7 +31,7 @@ class PropertyGroupManager:
         ]
 
 
-event_property_groups = PropertyGroupManager("events", "properties")
+sharded_events_property_groups = PropertyGroupManager("sharded_events", "properties")
 
 ignore_custom_properties = [
     # `token` & `distinct_id` properties are sent with ~50% of events and by
@@ -62,11 +62,11 @@ ignore_custom_properties = [
     "rdt_cid",  # reddit
 ]
 
-event_property_groups.register(
+sharded_events_property_groups.register(
     "custom",
     PropertyGroupDefinition(
         f"key NOT LIKE '$%' AND key NOT IN (" + f", ".join(f"'{name}'" for name in ignore_custom_properties) + f")"
     ),
 )
 
-event_property_groups.register("feature_flags", PropertyGroupDefinition("key like '$feature/%'"))
+sharded_events_property_groups.register("feature_flags", PropertyGroupDefinition("key like '$feature/%'"))

--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -1,0 +1,72 @@
+from collections.abc import MutableMapping
+from dataclasses import dataclass
+
+
+@dataclass
+class PropertyGroupDefinition:
+    filter_expression: str
+    codec: str = "ZSTD(1)"
+
+
+class PropertyGroupManager:
+    def __init__(self, table: str, source_column: str) -> None:
+        self.__table = table
+        self.__source_column = source_column
+        self.__groups: MutableMapping[str, PropertyGroupDefinition] = {}
+
+    def register(self, name: str, definition: PropertyGroupDefinition) -> None:
+        assert name not in self.__groups, "property group names can only be used once"
+        self.__groups[name] = definition
+
+    def __get_map_expression(self, definition: PropertyGroupDefinition) -> str:
+        return f"mapSort(mapFilter((key, _) -> {definition.filter_expression}, CAST(JSONExtractKeysAndValues({self.__source_column}, 'String'), 'Map(String, String)')))"
+
+    def get_alter_table_statements(self, name: str) -> str:
+        column_name = f"{self.__source_column}_group_{name}"
+        definition = self.__groups[name]
+        return [
+            f"ALTER TABLE {self.__table} ADD COLUMN {column_name} Map(String, string) MATERIALIZED {self.__get_map_expression(definition)} CODEC({definition.codec})",
+            f"ALTER TABLE {self.__table} ADD INDEX {column_name}_keys_bf mapValues({column_name}) TYPE bloom_filter",
+            f"ALTER TABLE {self.__table} ADD INDEX {column_name}_values_bf mapValues({column_name}) TYPE bloom_filter",
+        ]
+
+
+event_property_groups = PropertyGroupManager("events", "properties")
+
+ignore_custom_properties = [
+    # `token` & `distinct_id` properties are sent with ~50% of events and by
+    # many teams, and should not be treated as custom properties and their use
+    # should be optimized separately
+    "token",
+    "distinct_id",
+    # campaign properties are defined by external entities and are commonly used
+    # across a large number of teams, and should also be optimized separately
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_content",
+    "utm_term",
+    "gclid",  # google ads
+    "gad_source",  # google ads
+    "gclsrc",  # google ads 360
+    "dclid",  # google display ads
+    "gbraid",  # google ads, web to app
+    "wbraid",  # google ads, app to web
+    "fbclid",  # facebook
+    "msclkid",  # microsoft
+    "twclid",  # twitter
+    "li_fat_id",  # linkedin
+    "mc_cid",  # mailchimp campaign id
+    "igshid",  # instagram
+    "ttclid",  # tiktok
+    "rdt_cid",  # reddit
+]
+
+event_property_groups.register(
+    "custom",
+    PropertyGroupDefinition(
+        f"key NOT LIKE '$%' AND key NOT IN (" + f", ".join(f"'{name}'" for name in ignore_custom_properties) + f")"
+    ),
+)
+
+event_property_groups.register("feature_flags", PropertyGroupDefinition("key like '$feature/%'"))

--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -25,7 +25,7 @@ class PropertyGroupManager:
         column_name = f"{self.__source_column}_group_{name}"
         definition = self.__groups[name]
         return [
-            f"ALTER TABLE {self.__table} ADD COLUMN {column_name} Map(String, string) MATERIALIZED {self.__get_map_expression(definition)} CODEC({definition.codec})",
+            f"ALTER TABLE {self.__table} ADD COLUMN {column_name} Map(String, String) MATERIALIZED {self.__get_map_expression(definition)} CODEC({definition.codec})",
             f"ALTER TABLE {self.__table} ADD INDEX {column_name}_keys_bf mapValues({column_name}) TYPE bloom_filter",
             f"ALTER TABLE {self.__table} ADD INDEX {column_name}_values_bf mapValues({column_name}) TYPE bloom_filter",
         ]

--- a/posthog/clickhouse/property_groups.py
+++ b/posthog/clickhouse/property_groups.py
@@ -24,7 +24,7 @@ class PropertyGroupManager:
     def __get_map_expression(self, definition: PropertyGroupDefinition) -> str:
         return f"mapSort(mapFilter((key, _) -> {definition.filter_expression}, CAST(JSONExtractKeysAndValues({self.__source_column}, 'String'), 'Map(String, String)')))"
 
-    def get_alter_table_statements(self, name: str) -> Iterable[str]:
+    def get_alter_create_statements(self, name: str) -> Iterable[str]:
         column_name = f"{self.__source_column}_group_{name}"
         definition = self.__groups[name]
         return [


### PR DESCRIPTION
## Problem

We store object properties as serialized JSON in `String` fields on `events` (`properties`, `person_properties`, `groupN_properties`), `persons`, and `groups`. Unless otherwise optimized as materialized columns, we query these property fields and use JSON extraction functions to extract property values when a property is referenced in a query.

This approach provides us with a lot of flexibility about the data we accept, store, and query — but it also comes with disadvantages, mainly that these columns can grow very large (in terms of bytes stored), and whenever we need to read from this column, we need to load _all_ of the properties (even those we don't need or care about) and parse the data (which we often do multiple times per query.) Additionally, because these columns can grow very large and often we need to "drink the whole ocean" so to speak to extract a small number of keys from the column's value, we are likely polluting the page cache with infrequently used values and unnecessarily causing turnover in the page cache, further increasing the cost of these operations.

## Changes

This introduces the idea of "property groups" which is a set of properties that are extracted from the properties at write time and materialized into a `Map(String, String)` for all property keys that satisfy a defined filter expression, and defines two property groups to start:

1. **"custom" properties**, which include all properties that do not start with `$` _except_ for several properties that we expect to be present on a large number of events across many teams, and
2. **"feature flag" properties**, which include all properties that start with `$features/`.

These groups are kept separate for a couple of reasons:

1. Maps work best with a low number of values, [since extracting a key from a Map type requires a linear scan — they are not hash tables, but instead two `Array(T)` columns](https://clickhouse.com/docs/en/sql-reference/data-types/map) (technically three, with the third being a `Array(UInt*)` type) with some syntactic sugar for key indexing and [some additional functions that are available for the data type](https://clickhouse.com/docs/en/sql-reference/functions/tuple-map-functions#function-map),
2. Analyzing the query log data has shown that the majority of queries that access non-materialized properties exclusively reference custom properties, and there is a reasonable number of queries that access feature flag properties exclusively. The number of queries that reference _both_ is quite low, which means we can avoid reading unnecessary bytes for other properties that are not used within the query.

[Coarse benchmarking has shown that even with the linear scan, accessing keys in a map is significantly faster than extracting them from the full JSON payload, though still slower than reading from a materialized column.](https://posthog.slack.com/archives/C076E99B152/p1722018603697369?thread_ts=1721942497.817339&cid=C076E99B152) The somewhat obvious downside is that it requires additional storage to materialize these structures.

This PR only includes the write path so that we can get a head start on backfilling maps for previously written rows without depending on the read path implementation. It also gives us the opportunity to start collecting data for capacity planning/forecasting purposes about what the overhead of these columns will be. It also gives us a starting point to verify to our benchmarks on our own production hardware and production datasets versus development snapshots.

### Type Conversion
This switches the JSON extraction method used from `JSONExtractKeysAndValuesRaw(payload)` to `JSONExtractKeysAndValues(payload, 'String')`, which differs from the `-Raw` variant in that it returns _unescaped_ values for strings extracted from the payload, while passing through all other values as the raw equivalent.[^1]

For example,

```
SELECT
    arrayJoin(JSONExtractKeysAndValues('{"number": 1.0, "string": "hello", "boolean": true, "array": [], "object": {}, "null": null}', 'String')) AS value,
    toTypeName(value) AS type

Query id: 7ab82c87-5081-40b9-a7e0-b597c336a7f2

┌─value──────────────┬─type──────────────────┐
│ ('number','1')     │ Tuple(String, String) │
│ ('string','hello') │ Tuple(String, String) │
│ ('boolean','true') │ Tuple(String, String) │
│ ('array','[]')     │ Tuple(String, String) │
│ ('object','{}')    │ Tuple(String, String) │
└────────────────────┴───────────────────────┘

5 rows in set. Elapsed: 0.001 sec. 
```

Returning the unescaped string allows string operations to be performed against the values [without the overhead of any additional preprocessing to unescape the values](https://posthog.slack.com/archives/C076E99B152/p1722018603697369?thread_ts=1721942497.817339&cid=C076E99B152). It also avoids the [escaping bugs involved when strings are preprocessed by chopping off leading and trailing quotes](https://posthog.slack.com/archives/C076E99B152/p1721945207404109?thread_ts=1721942497.817339&cid=C076E99B152).

#### Handling Null Values when Reading
Note that in the above example, the `null` value is not present in the output map.

Property values are exposed using subcolumn-like `property.name` syntax, which will be translated to `property[name]` like in this example:

```
SELECT
    CAST(JSONExtractKeysAndValuesRaw('{}'), 'Map(String, String)')['name'] AS value,
    toTypeName(value) AS type

Query id: 5ef7c31f-efb5-45d1-8997-b8438699b18d

┌─value─┬─type───┐
│       │ String │
└───────┴────────┘

1 row in set. Elapsed: 0.001 sec. 
```

Because we are storing properties in `Map(String, String)`, the value returned when a key is not present in the map is the _default type_. To identify this case, we'll need to guard it when reading like so:

```
SELECT
    if(has(CAST(JSONExtractKeysAndValuesRaw('{}'), 'Map(String, String)') AS map, 'key'), 'key ', NULL) AS value,
    toTypeName(value) AS type

Query id: d41ecb96-f968-48f0-bc00-bcf86431d435

┌─value─┬─type─────────────┐
│ ᴺᵁᴸᴸ  │ Nullable(String) │
└───────┴──────────────────┘

1 row in set. Elapsed: 0.002 sec. 
```

With this approach, we can distinguish between missing values and empty values, as well as a `NULL` value and the string `"null"`. The overhead of this `has` operation at query time seems to be negligible over large sets. 

Because properties are exposed as virtual columns in HogQL, we don't need to distinguish between reasons a column does not have a value (i.e. whether it was sent as a `NULL` value, or just not sent at all) since all rows within the same table should have a homogenous schema.

#### Handling Non-String Values when Reading
Non-string values can still be trivially coerced to their types as defined in property definitions with via the same logic as used today, or with JSON extraction functions, e.g.:

```
SELECT
    JSONExtract('1', 'Float64'),
    JSONExtract('true', 'Boolean')

Query id: 8e382c1b-efb0-464c-8e97-0e0c362b8fb3

┌─JSONExtract('1', 'Float64')─┬─JSONExtract('true', 'Boolean')─┐
│                           1 │ true                           │
└─────────────────────────────┴────────────────────────────────┘

1 row in set. Elapsed: 0.001 sec. 
```

This also has the (maybe dubious, but also maybe useful, considering we allow property types to be changed after creation) benefit of allowing values that are valid JSON but were originally sent _as_ strings to be coerced to different types without an intermediate processing step, as in this example:

```
SELECT
    JSONExtract(CAST(JSONExtractKeysAndValues('{"a":"true"}', 'String'), 'Map(String, String)')['a'], 'Boolean') AS value,
    toTypeName(value) AS type

Query id: df4b1d16-53a0-47f3-8ec7-6d20d3369815

┌─value─┬─type─┐
│ true  │ Bool │
└───────┴──────┘

1 row in set. Elapsed: 0.001 sec. 
```

Compare with the `-Raw` equivalent:

```
SELECT
    JSONExtract(CAST(JSONExtractKeysAndValuesRaw('{"a":"true"}'), 'Map(String, String)')['a'], 'Boolean') AS value,
    toTypeName(value) AS type

Query id: 54e898bc-b833-40ec-8b3a-0b87818ed548

┌─value─┬─type─┐
│ false │ Bool │
└───────┴──────┘

1 row in set. Elapsed: 0.001 sec. 
```

### Indexes
One of the benefits of storing properties in a structured type is that it improves our ability to use data skipping indexes on property data. With bloom filters indexes on both keys and values, we can avoid reading whole data parts in some cases, dramatically improving query execution time.

These indexes only provide benefits when a property is referenced in a `WHERE` clause that uses specific operators (equality/inequality, in/not in), but since filtering by property is a very common case, these indexes will likely be useful.

These indexes work best when:

1. property keys are set on a small proportion of events within the property group, allowing the bloom filter on the keys array to exclude parts that do not include the property key (or keys), and/or
2. property values are set on a small proportion of the overall values within that property group, allowing bloom filter on values to exclude parts that do not include the property value (or values.)

## Does this work well for both Cloud and self-hosted?
It works with both.

For cloud, we can manage the materialization (backfill) of previously written rows manually.

For self-hosted, we'll need to figure something out to ensure the materialization occurs synchronously or asynchronously, or decide not to provide external support these optimizations.

## How did you test this code?

Do what now?

[^1]: This behavior appears to be design, see: https://github.com/ClickHouse/ClickHouse/issues/30487, https://github.com/ClickHouse/ClickHouse/pull/25452
