### PR TITLE
fix(batch-exports): Redshift uses correct person keys for batch export

### DIFF
--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -121,8 +121,8 @@ class RedshiftClient(PostgreSQLClient):
         stage_table_name: str,
         schema: str,
         merge_key: Fields,
-        update_when_matched: Fields,
-        version_key: str = "version",
+        person_version_key: str = "person_version",
+        person_distinct_id_version_key: str = "person_distinct_id_version",
     ) -> None:
         """Merge two identical tables in PostgreSQL."""
         if schema:
@@ -153,13 +153,17 @@ class RedshiftClient(PostgreSQLClient):
         delete_query = sql.SQL("""\
         DELETE FROM {stage_table}
         USING {final_table} AS final
-        WHERE {merge_condition} AND {stage_table}.{stage_version_key} > final.{final_version_key};
+        WHERE {merge_condition}
+        AND {stage_table}.{stage_person_version_key} < final.{final_person_version_key}
+        AND {stage_table}.{stage_person_distinct_id_version_key} < final.{final_person_distinct_id_version_key};
         """).format(
             final_table=final_table_identifier,
             stage_table=stage_table_identifier,
             merge_condition=delete_condition,
-            stage_version_key=sql.Identifier(version_key),
-            final_version_key=sql.Identifier(version_key),
+            stage_person_version_key=sql.Identifier(person_version_key),
+            final_person_version_key=sql.Identifier(person_version_key),
+            stage_person_distinct_id_version_key=sql.Identifier(person_distinct_id_version_key),
+            final_person_distinct_id_version_key=sql.Identifier(person_distinct_id_version_key),
         )
 
         merge_query = sql.SQL("""\
@@ -487,7 +491,6 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs) -> Records
                         final_table_name=redshift_table,
                         stage_table_name=redshift_stage_table,
                         schema=inputs.schema,
-                        update_when_matched=table_fields,
                         merge_key=merge_key,
                     )
 


### PR DESCRIPTION
## Problem

At some point we switched person batch exports to use two version fields, but didn't update the Redshift batch export. Also, I noticed the sign of the comparison was inverted.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Delete from stage when fields in final are of a higher version (so there is no need to merge them into final).
* Use two version keys like all other exports.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Unfortunately, we can't test merges in local CI as Redshift uses a different syntax that's not supported by PostgreSQL.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
