### PR TITLE
fix(insights): fix saving insights with cached selector state

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -1,5 +1,5 @@
 import { LemonDialog, LemonInput } from '@posthog/lemon-ui'
-import { actions, connect, events, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, events, kea, key, listeners, LogicWrapper, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 import api from 'lib/api'
@@ -56,7 +56,7 @@ export const createEmptyInsight = (
     result: null,
 })
 
-export const insightLogic = kea<insightLogicType>([
+export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType>([
     props({} as InsightLogicProps),
     key(keyForInsightLogicProps('new')),
     path((key) => ['scenes', 'insights', 'insightLogic', key]),

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -294,8 +294,8 @@ export const insightLogic = kea<insightLogicType>([
     })),
     selectors({
         query: [
-            (s) => [s.insightProps],
-            (insightProps): Node | null => insightDataLogic.findMounted(insightProps)?.values.query || null,
+            (s) => [(state) => insightDataLogic.findMounted(s.insightProps(state))?.values.query || null],
+            (node): Node | null => node,
         ],
         queryBasedInsightSaving: [
             (s) => [s.featureFlags],


### PR DESCRIPTION
## Problem

It's not possible to save changes to an existing insight, after it has already been saved once. See also https://posthog.slack.com/archives/C0368RPHLQH/p1722589465723629.

## Changes

Debugging this I logged the query that goes into the api payload in the `saveInsight` listener and saw that it would receive an outdated `query`. I then logged the inputs of the query selector and saw that everything is correct there. 

Thus the conclusion is that the selector is erroneously cached. I don't know if this is an user error on my part or a bug in kea, but the changes in this PR seem to fix the problem.

## How did you test this code?

Tried locally