### PR TITLE
chore(bi): Added QoL updates to BI

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/DisplayTab.tsx
@@ -1,5 +1,5 @@
 import { IconPlusSmall, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonInput, LemonLabel } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonLabel, LemonSwitch } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
 
@@ -17,11 +17,10 @@ export const DisplayTab = (): JSX.Element => {
 
     return (
         <div className="flex flex-col w-full">
-            <LemonLabel>Chart settings</LemonLabel>
-
-            <div className="mt-1 mb-2">
-                <LemonLabel className="mt-2 mb-1">Begin Y axis at zero</LemonLabel>
-                <LemonCheckbox
+            <div className="mt-1 mb-2 flex">
+                <LemonSwitch
+                    className="flex-1"
+                    label="Begin Y axis at zero"
                     checked={chartSettings.yAxisAtZero ?? true}
                     onChange={(value) => {
                         updateChartSettings({ yAxisAtZero: value })
@@ -30,9 +29,10 @@ export const DisplayTab = (): JSX.Element => {
             </div>
 
             {isStackedBarChart && (
-                <div className="mt-1 mb-2">
-                    <LemonLabel className="mt-2 mb-1">Stack bars 100%</LemonLabel>
-                    <LemonCheckbox
+                <div className="mt-1 mb-2 flex">
+                    <LemonSwitch
+                        className="flex-1"
+                        label="Stack bars 100%"
                         checked={chartSettings.stackBars100 ?? false}
                         onChange={(value) => {
                             updateChartSettings({ stackBars100: value })
@@ -69,10 +69,10 @@ export const DisplayTab = (): JSX.Element => {
                         />
                     </div>
                 ))}
+                <LemonButton className="mt-1" onClick={() => addGoalLine()} icon={<IconPlusSmall />} fullWidth>
+                    Add goal line
+                </LemonButton>
             </div>
-            <LemonButton className="mt-1" onClick={() => addGoalLine()} icon={<IconPlusSmall />} fullWidth>
-                Add goal line
-            </LemonButton>
         </div>
     )
 }

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -24,9 +24,14 @@ export enum SideBarTab {
     Display = 'display',
 }
 
+export interface ColumnType {
+    name: string
+    isNumerical: boolean
+}
+
 export interface Column {
     name: string
-    type: string
+    type: ColumnType
     label: string
     dataIndex: number
 }
@@ -58,19 +63,22 @@ export interface SelectedYAxis {
 export const EmptyYAxisSeries: AxisSeries<number> = {
     column: {
         name: 'None',
-        type: 'None',
+        type: {
+            name: 'None',
+            isNumerical: false,
+        },
         label: 'None',
         dataIndex: -1,
     },
     data: [],
 }
 
-const DefaultAxisSettings: AxisSeriesSettings = {
+const DefaultAxisSettings = (): AxisSeriesSettings => ({
     formatting: {
         prefix: '',
         suffix: '',
     },
-}
+})
 
 export const formatDataWithSettings = (data: number, settings?: AxisSeriesSettings): string => {
     const decimalPlaces = settings?.formatting?.decimalPlaces
@@ -96,6 +104,40 @@ export const formatDataWithSettings = (data: number, settings?: AxisSeriesSettin
     return dataAsString
 }
 
+const toFriendlyClickhouseTypeName = (type: string): string => {
+    if (type.indexOf('Int') !== -1) {
+        return 'INTEGER'
+    }
+    if (type.indexOf('Float') !== -1) {
+        return 'FLOAT'
+    }
+    if (type.indexOf('DateTime') !== -1) {
+        return 'DATETIME'
+    }
+    if (type.indexOf('Date') !== -1) {
+        return 'DATE'
+    }
+    if (type.indexOf('Boolean') !== -1) {
+        return 'BOOLEAN'
+    }
+    if (type.indexOf('Decimal') !== -1) {
+        return 'DECIMAL'
+    }
+    if (type.indexOf('String') !== -1) {
+        return 'STRING'
+    }
+
+    return type
+}
+
+const isNumericalType = (type: string): boolean => {
+    if (type.indexOf('Int') !== -1 || type.indexOf('Float') !== -1 || type.indexOf('Decimal') !== -1) {
+        return true
+    }
+
+    return false
+}
+
 export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
     key((props) => props.key),
     path(['queries', 'nodes', 'DataVisualization', 'dataVisualizationLogic']),
@@ -116,7 +158,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
         ],
     })),
     props({ query: {} } as DataVisualizationLogicProps),
-    actions({
+    actions(({ values }) => ({
         setVisualizationType: (visualizationType: ChartDisplayType) => ({ visualizationType }),
         updateXSeries: (columnName: string) => ({
             columnName,
@@ -126,13 +168,17 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             columnName,
             settings,
         }),
-        addYSeries: (columnName?: string, settings?: AxisSeriesSettings) => ({ columnName, settings }),
+        addYSeries: (columnName?: string, settings?: AxisSeriesSettings) => ({
+            columnName,
+            settings,
+            allNumericalColumns: values.numericalColumns,
+        }),
         deleteYSeries: (seriesIndex: number) => ({ seriesIndex }),
         clearAxis: true,
         setQuery: (node: DataVisualizationNode) => ({ node }),
         updateChartSettings: (settings: ChartSettings) => ({ settings }),
         setSideBarTab: (tab: SideBarTab) => ({ tab }),
-    }),
+    })),
     reducers(({ props }) => ({
         visualizationType: [
             ChartDisplayType.ActionsTable as ChartDisplayType,
@@ -151,20 +197,32 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             null as (SelectedYAxis | null)[] | null,
             {
                 clearAxis: () => null,
-                addYSeries: (state, { columnName, settings }) => {
+                addYSeries: (state, { columnName, settings, allNumericalColumns }) => {
                     if (!state && columnName !== undefined) {
-                        return [{ name: columnName, settings: settings ?? DefaultAxisSettings }]
+                        return [{ name: columnName, settings: settings ?? DefaultAxisSettings() }]
                     }
 
                     if (!state) {
                         return [null]
                     }
 
+                    if (!columnName) {
+                        const ungraphedColumns = allNumericalColumns.filter(
+                            (n) => !state.map((m) => m?.name).includes(n.name)
+                        )
+                        if (ungraphedColumns.length > 0) {
+                            return [
+                                ...state,
+                                { name: ungraphedColumns[0].name, settings: settings ?? DefaultAxisSettings() },
+                            ]
+                        }
+                    }
+
                     return [
                         ...state,
                         columnName === undefined
                             ? null
-                            : { name: columnName, settings: settings ?? DefaultAxisSettings },
+                            : { name: columnName, settings: settings ?? DefaultAxisSettings() },
                     ]
                 },
                 updateYSeries: (state, { seriesIndex, columnName, settings }) => {
@@ -230,11 +288,20 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                     const type = types[index]?.[1]
                     return {
                         name: column,
-                        type,
+                        type: {
+                            name: toFriendlyClickhouseTypeName(type),
+                            isNumerical: isNumericalType(type),
+                        },
                         label: `${column} - ${type}`,
                         dataIndex: index,
                     }
                 })
+            },
+        ],
+        numericalColumns: [
+            (s) => [s.columns],
+            (columns): Column[] => {
+                return columns.filter((n) => n.type.isNumerical)
             },
         ],
         query: [(_state, props) => [props.query], (query) => query],
@@ -324,7 +391,10 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                     return {
                         column: {
                             name: 'None',
-                            type: 'None',
+                            type: {
+                                name: 'None',
+                                isNumerical: false,
+                            },
                             label: 'None',
                             dataIndex: -1,
                         },
@@ -386,11 +456,13 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
         }
     }),
     subscriptions(({ props, actions, values }) => ({
-        columns: (value: { name: string; type: string }[], oldValue: { name: string; type: string }[]) => {
+        columns: (value: Column[], oldValue: Column[]) => {
             // If response is cleared, then don't update any internal values
             if (!values.response || !values.response.results) {
                 return
             }
+
+            const oldSelectedYAxis: (SelectedYAxis | null)[] | null = JSON.parse(JSON.stringify(values.selectedYAxis))
 
             if (oldValue && oldValue.length) {
                 if (JSON.stringify(value) !== JSON.stringify(oldValue)) {
@@ -400,16 +472,22 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
 
             // Set default axis values
             if (values.response && values.selectedXAxis === null && values.selectedYAxis === null) {
-                const types: string[][] = values.response['types']
-                const yAxisTypes = types.find((n) => n[1].indexOf('Int') !== -1 || n[1].indexOf('Float') !== -1)
-                const xAxisTypes = types.find((n) => n[1].indexOf('Date') !== -1)
+                const xAxisTypes = value.find((n) => n.type.name.indexOf('DATE') !== -1)
+                const yAxisTypes = value.filter((n) => n.type.isNumerical)
 
                 if (yAxisTypes) {
-                    actions.addYSeries(yAxisTypes[0])
+                    yAxisTypes.forEach((y) => {
+                        if (oldSelectedYAxis) {
+                            const lastValue = oldSelectedYAxis.find((n) => n?.name === y.name)
+                            return actions.addYSeries(y.name, lastValue?.settings)
+                        }
+
+                        actions.addYSeries(y.name)
+                    })
                 }
 
                 if (xAxisTypes) {
-                    actions.updateXSeries(xAxisTypes[0])
+                    actions.updateXSeries(xAxisTypes.name)
                 }
             }
         },


### PR DESCRIPTION
## Changes
- A bunch of quality-of-life updates to BI 
  - Show series color in series tab
  - Make column types nicer to read and within a lemon tag
  - You can only add an extra Y-series if there exists a series that isn't plotted 
  - You can only plot numerical Y-series
  - using lemon switches instead of checkboxes on the display tab
  - Cleanup around padding/margins
  - Auto pre-plots all numerical series when the query is updated
  - Persists the column settings when the query is updated

<img width="780" alt="image" src="https://github.com/user-attachments/assets/dd485ad8-e4e1-4fbe-9a68-2e1173d02f16">

<img width="774" alt="image" src="https://github.com/user-attachments/assets/71dcab33-5eb7-47f2-b7e4-41151310c052">
