### PR TITLE
chore(actions): Rename "Copy" to "Duplicate"

### DIFF
--- a/frontend/src/scenes/data-management/actions/ActionsTable.tsx
+++ b/frontend/src/scenes/data-management/actions/ActionsTable.tsx
@@ -155,8 +155,8 @@ export function ActionsTable(): JSX.Element {
                                 <LemonButton to={urls.action(action.id)} fullWidth>
                                     Edit
                                 </LemonButton>
-                                <LemonButton to={urls.copyAction(action)} fullWidth>
-                                    Copy
+                                <LemonButton to={urls.duplicateAction(action)} fullWidth>
+                                    Duplicate
                                 </LemonButton>
                                 <LemonButton
                                     to={urls.replay(ReplayTabs.Recent, {

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -450,7 +450,7 @@ export const routes: Record<string, Scene> = {
     [urls.dashboardSubcriptions(':id')]: Scene.Dashboard,
     [urls.dashboardSubcription(':id', ':subscriptionId')]: Scene.Dashboard,
     [urls.createAction()]: Scene.Action,
-    [urls.copyAction(null)]: Scene.Action,
+    [urls.duplicateAction(null)]: Scene.Action,
     [urls.action(':id')]: Scene.Action,
     [urls.ingestionWarnings()]: Scene.DataManagement,
     [urls.insightNew()]: Scene.Insight,

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -50,7 +50,7 @@ export const urls = {
 
     sharedDashboard: (shareToken: string): string => `/shared_dashboard/${shareToken}`,
     createAction: (): string => `/data-management/actions/new`,
-    copyAction: (action: ActionType | null): string => {
+    duplicateAction: (action: ActionType | null): string => {
         const queryParams = action ? `?copy=${encodeURIComponent(JSON.stringify(action))}` : ''
         return `/data-management/actions/new/${queryParams}`
     },


### PR DESCRIPTION
## Problem

You can't really _copy_ an action in PostHog, but you can duplicate (sort of – it's a different UX pattern from e.g. dashboards).

## Changes

Renamed "Copy" to "Duplicate".