### PR TITLE
fix: make retention queries respect team timezones and work behind UTC time

### DIFF
--- a/frontend/src/scenes/retention/retentionTableLogic.ts
+++ b/frontend/src/scenes/retention/retentionTableLogic.ts
@@ -81,19 +81,19 @@ export const retentionTableLogic = kea<retentionTableLogicType>([
                     } else {
                         switch (period) {
                             case 'Hour':
-                                firstColumn = dayjs(currentResult.date).format('MMM D, h A')
+                                firstColumn = dayjs.utc(currentResult.date).format('MMM D, h A')
                                 break
                             case 'Month':
-                                firstColumn = dayjs(currentResult.date).format('MMM YYYY')
+                                firstColumn = dayjs.utc(currentResult.date).format('MMM YYYY')
                                 break
                             case 'Week': {
-                                const startDate = dayjs(currentResult.date)
+                                const startDate = dayjs.utc(currentResult.date)
                                 const endDate = startDate.add(6, 'day') // To show last day of the week we add 6 days, not 7
                                 firstColumn = `${startDate.format('MMM D')} to ${endDate.format('MMM D')}`
                                 break
                             }
                             default:
-                                firstColumn = dayjs(currentResult.date).format('MMM D')
+                                firstColumn = dayjs.utc(currentResult.date).format('MMM D')
                         }
                     }
 

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -373,7 +373,9 @@ class RetentionQueryRunner(QueryRunner):
             first_interval, self.query_date_range.interval_name.title()
         )
         if self.query_date_range.interval_type == IntervalType.HOUR:
-            date = date + self.team.timezone_info.utcoffset(date)
+            utfoffset = self.team.timezone_info.utcoffset(date)
+            if utfoffset is not None:
+                date = date + utfoffset
         return date
 
     def calculate(self) -> RetentionQueryResponse:

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -368,6 +368,14 @@ class RetentionQueryRunner(QueryRunner):
 
         return refresh_frequency
 
+    def get_date(self, first_interval):
+        date = self.query_date_range.date_from() + self.query_date_range.determine_time_delta(
+            first_interval, self.query_date_range.interval_name.title()
+        )
+        if self.query_date_range.interval_type == IntervalType.HOUR:
+            date = date + self.team.timezone_info.utcoffset(date)
+        return date
+
     def calculate(self) -> RetentionQueryResponse:
         query = self.to_query()
         hogql = to_printed_hogql(query, self.team)
@@ -388,7 +396,6 @@ class RetentionQueryRunner(QueryRunner):
             }
             for (breakdown_values, intervals_from_base, count) in response.results
         }
-
         results = [
             {
                 "values": [
@@ -396,12 +403,7 @@ class RetentionQueryRunner(QueryRunner):
                     for return_interval in range(self.query_date_range.total_intervals - first_interval)
                 ],
                 "label": f"{self.query_date_range.interval_name.title()} {first_interval}",
-                "date": (
-                    self.query_date_range.date_from()
-                    + self.query_date_range.determine_time_delta(
-                        first_interval, self.query_date_range.interval_name.title()
-                    )
-                ),
+                "date": self.get_date(first_interval),
             }
             for first_interval in range(self.query_date_range.total_intervals)
         ]


### PR DESCRIPTION
## Problem

Retention queries display dates incorrectly if your local machine is in a timezone that is behind UTC. We pass months as the first of the month at midnight, and when dayjs converts them, they show up as the previous month.

Also we don't respect team time zone settings at all - the times that show up in retention queries when in hourly mode are local time to your machine.

https://github.com/PostHog/posthog/issues/24173

## Changes

Fixes the two issues above. Respects the team time setting (this was taken at 4:38 PM Pacific time (UTC-7) on a New york time team UTC-4):
![image](https://github.com/user-attachments/assets/77fe5ec5-7f7a-4f1e-b6f1-8582a30de575)

Handles months correctly when the local computer lags UTC:
![image](https://github.com/user-attachments/assets/7ac8bc4d-9e0d-4574-b093-16136043cb8b)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Wrote a test and tested in dev with different time zones on my computer.