### PR TITLE
fix: more specific key to enable verbose kea logging

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -114,7 +114,7 @@ export function initKea({ routerHistory, routerLocation, beforePlugins }: InitKe
     ]
 
     // To enable logging, run localStorage.setItem("debug", true) in the console
-    if (window.JS_KEA_VERBOSE_LOGGING || ('localStorage' in window && window.localStorage.getItem('debug'))) {
+    if (window.JS_KEA_VERBOSE_LOGGING || ('localStorage' in window && window.localStorage.getItem('ph-kea-debug'))) {
         plugins.push(loggerPlugin)
     }
 

--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -113,7 +113,7 @@ export function initKea({ routerHistory, routerLocation, beforePlugins }: InitKe
         waitForPlugin,
     ]
 
-    // To enable logging, run localStorage.setItem("debug", true) in the console
+    // To enable logging, run localStorage.setItem("ph-kea-debug", true) in the console
     if (window.JS_KEA_VERBOSE_LOGGING || ('localStorage' in window && window.localStorage.getItem('ph-kea-debug'))) {
         plugins.push(loggerPlugin)
     }


### PR DESCRIPTION
see: https://x.com/hrishio/status/1820125443153957238

`debug` is too vague a key to use to enable verbose kea debugging in posthog - particularly because it's included in the toolbar so can appear to leak into other sites if other tools use `debug` in local storage to enable debugging
