### PR TITLE
fix(batch-exports): Retry forever on daily

### DIFF
--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -689,17 +689,12 @@ async def execute_batch_export_insert_activity(
         maximum_retry_interval_seconds: Maximum interval in seconds between retries.
     """
     get_export_started_metric().add(1)
-    retry_policy = RetryPolicy(
-        initial_interval=dt.timedelta(seconds=initial_retry_interval_seconds),
-        maximum_interval=dt.timedelta(seconds=maximum_retry_interval_seconds),
-        maximum_attempts=maximum_attempts,
-        non_retryable_error_types=non_retryable_error_types,
-    )
 
     if interval == "hour":
         start_to_close_timeout = dt.timedelta(hours=1)
     elif interval == "day":
         start_to_close_timeout = dt.timedelta(days=1)
+        maximum_attempts = 0
     elif interval.startswith("every"):
         _, value, unit = interval.split(" ")
         kwargs = {unit: int(value)}
@@ -707,6 +702,13 @@ async def execute_batch_export_insert_activity(
         start_to_close_timeout = max(dt.timedelta(minutes=10), dt.timedelta(**kwargs))
     else:
         raise ValueError(f"Unsupported interval: '{interval}'")
+
+    retry_policy = RetryPolicy(
+        initial_interval=dt.timedelta(seconds=initial_retry_interval_seconds),
+        maximum_interval=dt.timedelta(seconds=maximum_retry_interval_seconds),
+        maximum_attempts=maximum_attempts,
+        non_retryable_error_types=non_retryable_error_types,
+    )
 
     try:
         records_completed = await workflow.execute_activity(


### PR DESCRIPTION
## Problem

Network connections to our databases keep being dropped with really long-running batch exports. These errors should be retried forever, but temporal doesn't let us define errors to retry on, only errors _not_ to retry on. Since we haven't defined all the errors we don't want to retry on, having permanent retries has the risk of putting us in a forever loop.

Despite that, something has to be done. And maybe jumping somewhat into the loop will shine light into those errors that should be added to `non_retryable_error_types`. 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

So, as a first step, we are adding infinite retries for daily batch exports, which are the ones that have the higher chance of being long-running, due to naturally looking at a broader, larger, range of data. Moreover, the slower frequency gives us more time to tackle any problems.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
