### PR TITLE
fix(ingestion): Use `$os_name` as fallback for `$os`

### DIFF
--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -65,6 +65,7 @@ export const eventToPersonProperties = new Set([
     '$current_url',
     '$pathname',
     '$os',
+    '$os_name', // $os_name is a special case, it's treated as an alias of $os!
     '$os_version',
     '$referring_domain',
     '$referrer',
@@ -117,6 +118,18 @@ export function personInitialAndUTMProperties(properties: Properties): Propertie
     if (maybeSetOnce.length > 0) {
         propertiesCopy.$set_once = { ...Object.fromEntries(maybeSetOnce), ...(properties.$set_once || {}) }
     }
+
+    if (propertiesCopy.$os_name) {
+        // For the purposes of $initial properties, $os_name is treated as a fallback alias of $os, starting August 2024
+        // It's as special case due to _some_ SDKs using $os_name: https://github.com/PostHog/posthog-js-lite/issues/244
+        propertiesCopy.$os ??= propertiesCopy.$os_name
+        propertiesCopy.$set.$os ??= propertiesCopy.$os_name
+        propertiesCopy.$set_once.$initial_os ??= propertiesCopy.$os_name
+        // Make sure $os_name is not used in $set/$set_once, as that hasn't been a thing before
+        delete propertiesCopy.$set.$os_name
+        delete propertiesCopy.$set_once.$initial_os_name
+    }
+
     return propertiesCopy
 }
 

--- a/plugin-server/tests/utils/db/utils.test.ts
+++ b/plugin-server/tests/utils/db/utils.test.ts
@@ -108,4 +108,28 @@ describe('personInitialAndUTMProperties()', () => {
             $set: { $current_url: 'https://test.com' },
         })
     })
+
+    it('treats $os_name as fallback for $os', () => {
+        const propertiesOsNameOnly = {
+            $os_name: 'Android',
+        }
+        expect(personInitialAndUTMProperties(propertiesOsNameOnly)).toEqual({
+            $os: 'Android',
+            $os_name: 'Android',
+            $set_once: { $initial_os: 'Android' },
+            $set: { $os: 'Android' },
+        })
+
+        // Also test that $os takes precedence, with $os_name preserved (although this should not happen in the wild)
+        const propertiesBothOsKeys = {
+            $os: 'Windows',
+            $os_name: 'Android',
+        }
+        expect(personInitialAndUTMProperties(propertiesBothOsKeys)).toEqual({
+            $os: 'Windows',
+            $os_name: 'Android',
+            $set_once: { $initial_os: 'Windows' },
+            $set: { $os: 'Windows' },
+        })
+    })
 })


### PR DESCRIPTION
## Problem

Addresses https://github.com/PostHog/posthog-js-lite/issues/244: some libraries save the OS name as `$os` (e.g. `posthog-js`) and others as `$os_name` (e.g. `posthog-react-native`). Fixing this "properly" requires customers to roll out an update of our SDK, so @marandaneto and I propose also adding an `$os_name` →  `$os` aliasing layer to ingestion.

## Changes

Building on https://github.com/PostHog/posthog/pull/17393's to add special handling of `$os_name`. If `$os` isn't present, it's populated based on `$os_name`, along with `$set.$os` and `$set_once.$initial_os`.

## How did you test this code?

Added a unit test.