### PR TITLE
fix(data-warehouse): Add refresh token support for paging hubspot

### DIFF
--- a/posthog/temporal/data_imports/pipelines/hubspot/helpers.py
+++ b/posthog/temporal/data_imports/pipelines/hubspot/helpers.py
@@ -171,7 +171,16 @@ def fetch_data(
         if _next:
             next_url = _next["link"]
             # Get the next page response
-            r = requests.get(next_url, headers=headers)
+            try:
+                r = requests.get(next_url, headers=headers)
+            except http_requests.exceptions.HTTPError as e:
+                if e.response.status_code == 401:
+                    # refresh token
+                    api_key = refresh_access_token(refresh_token)
+                    headers = _get_headers(api_key)
+                    r = requests.get(next_url, headers=headers)
+                else:
+                    raise
             _data = r.json()
         else:
             _data = None


### PR DESCRIPTION
## Problem
- When paging Hubspot endpoints, we may hit the 30min expiry timeout on the access token

## Changes
- If we get a 401 back, refresh the token and try again
- (we already do this further up when we call the first page)

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
👀 