### PR TITLE
fix(cdp): Add default partition key to kinesis destination

### DIFF
--- a/posthog/cdp/templates/aws_kinesis/template_aws_kinesis.py
+++ b/posthog/cdp/templates/aws_kinesis/template_aws_kinesis.py
@@ -117,6 +117,7 @@ if (res.status >= 200 and res.status < 300) {
             "key": "aws_kinesis_partition_key",
             "type": "string",
             "label": "Kinesis Partition Key",
+            "description": "If not provided, a random UUID will be generated.",
             "default": "{event.uuid}",
             "secret": False,
             "required": False,

--- a/posthog/cdp/templates/aws_kinesis/template_aws_kinesis.py
+++ b/posthog/cdp/templates/aws_kinesis/template_aws_kinesis.py
@@ -16,7 +16,7 @@ fn getPayload() {
 
   let payload := jsonStringify({
     'StreamName': inputs.aws_kinesis_stream_arn,
-    'PartitionKey': inputs.aws_kinesis_partition_key,
+    'PartitionKey': inputs.aws_kinesis_partition_key ?? generateUUIDv4(),
     'Data': base64Encode(jsonStringify(inputs.payload)),
   })
 
@@ -117,6 +117,7 @@ if (res.status >= 200 and res.status < 300) {
             "key": "aws_kinesis_partition_key",
             "type": "string",
             "label": "Kinesis Partition Key",
+            "default": "{event.uuid}",
             "secret": False,
             "required": False,
         },


### PR DESCRIPTION
## Problem

We make it optional but thats not truly implemented

## Changes

* Stays optional but default to event uuid or uuid if not provided at all

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
