### PR TITLE
fix: partial revert of #23669

### DIFF
--- a/plugin-server/src/worker/ingestion/property-definitions-manager.ts
+++ b/plugin-server/src/worker/ingestion/property-definitions-manager.ts
@@ -134,7 +134,7 @@ export class PropertyDefinitionsManager {
                 this.syncEventDefinitions(team, event),
                 this.syncEventProperties(team, event, properties),
                 this.syncPropertyDefinitions(team, event, properties),
-                this.teamManager.setTeamIngestedEvent(team),
+                this.teamManager.setTeamIngestedEvent(team, properties),
             ])
         } finally {
             clearTimeout(timeout)

--- a/plugin-server/tests/main/process-event.test.ts
+++ b/plugin-server/tests/main/process-event.test.ts
@@ -1224,6 +1224,19 @@ test('capture first team event', async () => {
         new UUIDT().toString()
     )
 
+    expect(posthog.capture).toHaveBeenCalledWith({
+        distinctId: 'plugin_test_user_distinct_id_1001',
+        event: 'first team event ingested',
+        properties: {
+            team: team.uuid,
+        },
+        groups: {
+            project: team.uuid,
+            organization: team.organization_id,
+            instance: 'unknown',
+        },
+    })
+
     team = await getFirstTeam(hub)
     expect(team.ingested_event).toEqual(true)
 


### PR DESCRIPTION
## Problem

Turns out comms and others need this event, whoops. Left a note on #24166 to remember to include firing this event there, when all this code gets yanked from the plugin server.

Only a partial revert because I still left in the reordering of cache updates, hopefully that still helps reduce the spam I was originally tackling