### PR TITLE
fix(queries): Increase max retries when async queries hit concurrency

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -45,7 +45,7 @@ def redis_heartbeat() -> None:
     ),
     retry_backoff=1,
     retry_backoff_max=10,
-    max_retries=3,
+    max_retries=10,
     expires=60 * 10,  # Do not run queries that got stuck for more than this
     reject_on_worker_lost=True,
 )


### PR DESCRIPTION
## Problem

We removed the chaining for dashboard queries in #24057 but this is causing an increase of queries hitting the concurrency threshold (as to be expected).
Grafana/Loki shows something like close to a thirds of requests that need to retry ultimately failing, either because they retry too fast or when they retry still there is no capacity.

## Changes

Increase the maximum number of retries.