### PR TITLE
fix(insights): applying a formula with multiple breakdowns

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -4735,3 +4735,60 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert len(response.results) == 1
         assert response.results[0]["count"] == 2
         assert response.results[0]["data"] == [1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+    def test_multiple_breakdowns_work_with_formula(self):
+        self._create_test_events()
+        flush_persons_and_events()
+
+        response = self._run_trends_query(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.DAY,
+            [EventsNode(event="$pageview")],
+            TrendsFilter(display=ChartDisplayType.ACTIONS_LINE_GRAPH, formula="A*10"),
+            BreakdownFilter(breakdowns=[Breakdown(property="$browser", type=MultipleBreakdownType.EVENT)]),
+        )
+
+        breakdown_labels = [result["breakdown_value"] for result in response.results]
+
+        assert len(response.results) == 4
+        assert breakdown_labels == [["Chrome"], ["Firefox"], ["Edge"], ["Safari"]]
+        assert [result["data"] for result in response.results] == [
+            [0, 0, 10, 10, 10, 0, 10, 0, 10, 0, 10, 0],
+            [10, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0],
+        ]
+
+    def test_multiple_series_and_multiple_breakdowns_work_with_formula(self):
+        self._create_test_events()
+        flush_persons_and_events()
+
+        response = self._run_trends_query(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.DAY,
+            [EventsNode(event="$pageview"), EventsNode(event="$pageview")],
+            TrendsFilter(display=ChartDisplayType.ACTIONS_LINE_GRAPH, formula="A/B*100"),
+            BreakdownFilter(
+                breakdowns=[
+                    Breakdown(property="$browser", type=MultipleBreakdownType.EVENT),
+                    Breakdown(property="prop", type=MultipleBreakdownType.EVENT, histogram_bin_count=2),
+                ]
+            ),
+        )
+
+        breakdown_labels = [result["breakdown_value"] for result in response.results]
+        assert len(response.results) == 4
+        assert breakdown_labels == [
+            ["Chrome", "[10,25]"],
+            ["Firefox", "[10,25]"],
+            ["Edge", "[25,40.01]"],
+            ["Safari", "[25,40.01]"],
+        ]
+        assert [result["data"] for result in response.results] == [
+            [0, 0, 100, 100, 100, 0, 100, 0, 100, 0, 100, 0],
+            [100, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0],
+        ]

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -1,26 +1,25 @@
-from natsort import natsorted, ns
+import threading
 from copy import deepcopy
 from datetime import timedelta
 from math import ceil
 from operator import itemgetter
-import threading
-from typing import Optional, Any, Union
-from django.conf import settings
+from typing import Any, Optional, Union
 
+from django.conf import settings
 from django.utils.timezone import datetime
+from natsort import natsorted, ns
+
 from posthog.caching.insights_api import (
     BASE_MINIMUM_INSIGHT_REFRESH_INTERVAL,
-    REDUCED_MINIMUM_INSIGHT_REFRESH_INTERVAL,
     REAL_TIME_INSIGHT_REFRESH_INTERVAL,
+    REDUCED_MINIMUM_INSIGHT_REFRESH_INTERVAL,
 )
 from posthog.clickhouse import query_tagging
-
 from posthog.hogql import ast
-from posthog.hogql.constants import LimitContext, MAX_SELECT_RETURNED_ROWS, BREAKDOWN_VALUES_LIMIT
+from posthog.hogql.constants import BREAKDOWN_VALUES_LIMIT, MAX_SELECT_RETURNED_ROWS, LimitContext
 from posthog.hogql.printer import to_printed_hogql
 from posthog.hogql.query import execute_hogql_query
 from posthog.hogql.timings import HogQLTimings
-from posthog.hogql_queries.insights.trends.display import TrendsDisplay
 from posthog.hogql_queries.insights.trends.breakdown import (
     BREAKDOWN_NULL_DISPLAY,
     BREAKDOWN_NULL_STRING_LABEL,
@@ -28,9 +27,10 @@ from posthog.hogql_queries.insights.trends.breakdown import (
     BREAKDOWN_OTHER_DISPLAY,
     BREAKDOWN_OTHER_STRING_LABEL,
 )
-from posthog.hogql_queries.insights.trends.trends_query_builder import TrendsQueryBuilder
-from posthog.hogql_queries.insights.trends.trends_actors_query_builder import TrendsActorsQueryBuilder
+from posthog.hogql_queries.insights.trends.display import TrendsDisplay
 from posthog.hogql_queries.insights.trends.series_with_extras import SeriesWithExtras
+from posthog.hogql_queries.insights.trends.trends_actors_query_builder import TrendsActorsQueryBuilder
+from posthog.hogql_queries.insights.trends.trends_query_builder import TrendsQueryBuilder
 from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.hogql_queries.utils.formula_ast import FormulaAST
 from posthog.hogql_queries.utils.query_compare_to_date_range import QueryCompareToDateRange
@@ -47,30 +47,30 @@ from posthog.queries.util import correct_result_for_sampling
 from posthog.schema import (
     ActionsNode,
     BreakdownItem,
+    BreakdownType,
     CachedTrendsQueryResponse,
     ChartDisplayType,
     Compare,
     CompareItem,
     DashboardFilter,
+    DataWarehouseEventsModifier,
+    DataWarehouseNode,
     DayItem,
     EventsNode,
-    DataWarehouseNode,
+    HogQLQueryModifiers,
     HogQLQueryResponse,
     InCohortVia,
     InsightActorsQueryOptionsResponse,
+    IntervalType,
     MultipleBreakdownOptions,
     MultipleBreakdownType,
     QueryTiming,
     Series,
     TrendsQuery,
     TrendsQueryResponse,
-    HogQLQueryModifiers,
-    DataWarehouseEventsModifier,
-    BreakdownType,
-    IntervalType,
 )
-from posthog.warehouse.models import DataWarehouseTable
 from posthog.utils import format_label_date, multisort
+from posthog.warehouse.models import DataWarehouseTable
 
 
 class TrendsQueryRunner(QueryRunner):
@@ -782,13 +782,19 @@ class TrendsQueryRunner(QueryRunner):
             for result in results:
                 if isinstance(result, list):
                     for item in result:
-                        all_breakdown_values.add(itemgetter(*keys)(item))
+                        data = itemgetter(*keys)(item)
+                        all_breakdown_values.add(tuple(data) if isinstance(data, list) else data)
 
             # sort the results so that the breakdown values are in the correct order
             sorted_breakdown_values = natsorted(list(all_breakdown_values), alg=ns.IGNORECASE)
 
             computed_results = []
-            for breakdown_value in sorted_breakdown_values:
+            for single_or_multiple_breakdown_value in sorted_breakdown_values:
+                breakdown_value = (
+                    list(single_or_multiple_breakdown_value)
+                    if isinstance(single_or_multiple_breakdown_value, tuple)
+                    else single_or_multiple_breakdown_value
+                )
                 any_result: Optional[dict[str, Any]] = None
                 for result in results:
                     matching_result = [item for item in result if itemgetter(*keys)(item) == breakdown_value]


### PR DESCRIPTION
## Problem

A trends query would throw an exception if you applied a formula and multiple breakdowns.

## Changes

Fix applying a formula by using hashable tuples instead of lists.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added additional tests.

[Related support ticket](https://posthoghelp.zendesk.com/agent/tickets/16519)