### PR TITLE
fix(infra): Add container hostname to all request logging

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -523,6 +523,7 @@ def per_request_logging_context_middleware(
         # team_id given a host header, and we can't do that with NGINX.
         structlog.contextvars.bind_contextvars(
             host=request.META.get("HTTP_HOST", ""),
+            container_hostname=settings.CONTAINER_HOSTNAME,
             x_forwarded_for=request.META.get("HTTP_X_FORWARDED_FOR", ""),
         )
 


### PR DESCRIPTION
## Problem

While looking at loki logs for the `decide` service I cannot tell which pod / container hostname the error occured on. 
We annotate the request logging with `request host` and the `x-forwarded-for` header, adding `container_hostname` to the logging too.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually running the server locally.