### PR TITLE
feat(insights): add missing filter response for StickinessQueryRunner

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -75,6 +75,7 @@ export function InsightTooltip({
     date,
     timezone = 'UTC',
     seriesData = [],
+    title: _title,
     altTitle,
     altRightTitle,
     renderSeries,
@@ -99,13 +100,9 @@ export function InsightTooltip({
 
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
 
-    const title: ReactNode | null =
+    const title: ReactNode =
         getTooltipTitle(seriesData, altTitle, date) ||
-        (date
-            ? `${getFormattedDate(date, seriesData?.[0]?.filter?.interval)} (${
-                  timezone ? shortTimeZone(timezone) : 'UTC'
-              })`
-            : null)
+        `${getFormattedDate(_title)} ${timezone ? shortTimeZone(timezone) : 'UTC'}`
     const rightTitle: ReactNode | null = getTooltipTitle(seriesData, altRightTitle, date) || null
 
     if (itemizeEntitiesAsColumns) {

--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -59,6 +59,7 @@ export interface InsightTooltipProps extends Omit<TooltipConfig, 'renderSeries' 
     breakdownFilter?: BreakdownFilter | undefined | null
     groupTypeLabel?: string
     timezone?: string | null
+    title: string
 }
 
 export const COL_CUTOFF = 4

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -495,6 +495,7 @@ export function LineGraph_({
                             tooltipRoot.render(
                                 <InsightTooltip
                                     date={dataset?.days?.[tooltip.dataPoints?.[0]?.dataIndex]}
+                                    title={tooltip.title[0]}
                                     timezone={timezone}
                                     seriesData={seriesData}
                                     breakdownFilter={breakdownFilter}


### PR DESCRIPTION
## Problem

Fixes issue #22209 by adding `filter` in `query` response

## Changes

Added `_query_to_filter` method in StickinessQueryRunner (Also added TODO comment as similar found in [trends_query_runner.py](https://github.com/PostHog/posthog/blob/8e7c53b20ee3df670a522cfe08c03703426fcfb9/posthog/hogql_queries/insights/trends/trends_query_runner.py#L942-L943))

## Does this work well for both Cloud and self-hosted?

it doesn't have an impact.

## How did you test this code?

tested with updated tests