### PR TITLE
chore: bump the timeout to validate deletes have executed

### DIFF
--- a/posthog/models/async_deletion/delete.py
+++ b/posthog/models/async_deletion/delete.py
@@ -16,7 +16,7 @@ deletions_counter = Counter("deletions_confirmed", "Total number of deletions ma
 
 class AsyncDeletionProcess(ABC):
     CLICKHOUSE_MUTATION_CHUNK_SIZE = 1_000_000
-    CLICKHOUSE_VERIFY_CHUNK_SIZE = 100
+    CLICKHOUSE_VERIFY_CHUNK_SIZE = 300
     DELETION_TYPES: list[DeletionType] = []
 
     def __init__(self) -> None:

--- a/posthog/models/async_deletion/delete.py
+++ b/posthog/models/async_deletion/delete.py
@@ -16,7 +16,7 @@ deletions_counter = Counter("deletions_confirmed", "Total number of deletions ma
 
 class AsyncDeletionProcess(ABC):
     CLICKHOUSE_MUTATION_CHUNK_SIZE = 1_000_000
-    CLICKHOUSE_VERIFY_CHUNK_SIZE = 1_000
+    CLICKHOUSE_VERIFY_CHUNK_SIZE = 100
     DELETION_TYPES: list[DeletionType] = []
 
     def __init__(self) -> None:

--- a/posthog/models/async_deletion/delete_events.py
+++ b/posthog/models/async_deletion/delete_events.py
@@ -15,7 +15,7 @@ deletions_counter = Counter("deletions_executed", "Total number of deletions sen
 # We purposely set this lower than the 256KB limit in ClickHouse to account for the potential overhead of the argument
 # substitution and settings injection. This is a conservative estimate, but it's better to be safe than hit the limit.
 MAX_QUERY_SIZE = 230_000  # 230KB which is less than 256KB limit in ClickHouse
-MAX_SELECT_EXECUTION_TIME = 2 * 60 * 60  # 2 hours
+MAX_SELECT_EXECUTION_TIME = 3 * 60 * 60  # 3 hours
 
 
 # Note: Session recording, dead letter queue, logs deletion will be handled by TTL

--- a/posthog/models/async_deletion/delete_events.py
+++ b/posthog/models/async_deletion/delete_events.py
@@ -15,7 +15,7 @@ deletions_counter = Counter("deletions_executed", "Total number of deletions sen
 # We purposely set this lower than the 256KB limit in ClickHouse to account for the potential overhead of the argument
 # substitution and settings injection. This is a conservative estimate, but it's better to be safe than hit the limit.
 MAX_QUERY_SIZE = 230_000  # 230KB which is less than 256KB limit in ClickHouse
-MAX_SELECT_EXECUTION_TIME = 3 * 60 * 60  # 3 hours
+MAX_SELECT_EXECUTION_TIME = 1 * 60 * 60  # 1 hour(s)
 
 
 # Note: Session recording, dead letter queue, logs deletion will be handled by TTL

--- a/posthog/models/async_deletion/delete_events.py
+++ b/posthog/models/async_deletion/delete_events.py
@@ -15,6 +15,8 @@ deletions_counter = Counter("deletions_executed", "Total number of deletions sen
 # We purposely set this lower than the 256KB limit in ClickHouse to account for the potential overhead of the argument
 # substitution and settings injection. This is a conservative estimate, but it's better to be safe than hit the limit.
 MAX_QUERY_SIZE = 230_000  # 230KB which is less than 256KB limit in ClickHouse
+MAX_SELECT_EXECUTION_TIME = 2 * 60 * 60  # 2 hours
+
 
 # Note: Session recording, dead letter queue, logs deletion will be handled by TTL
 TABLES_TO_DELETE_TEAM_DATA_FROM = [
@@ -127,7 +129,7 @@ class AsyncEventDeletion(AsyncDeletionProcess):
             WHERE {" OR ".join(conditions)}
             """,
             args,
-            settings={"max_execution_time": 30 * 60},
+            settings={"max_execution_time": MAX_SELECT_EXECUTION_TIME},
         )
         return {tuple(row) for row in clickhouse_result}
 


### PR DESCRIPTION
## Problem

Process timed out last week due to execution timeout limit:
```
Code: 160. DB::Exception: Estimated query execution time (6496.488461751246 seconds) is too long. Maximum: 1800. 
```

## Changes

Bump timeout to 1 hour from 30 minutes and also reduce the size of the batches we are running to 300 at a time from 1000 at a time.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
