### PR TITLE
feat(cdp): Additional logging of fetch errors

### DIFF
--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -171,6 +171,7 @@ export class HogExecutor {
         const { logs = [], response = null, error: asyncError, timings = [] } = asyncFunctionResponse
 
         if (response?.status && response.status >= 400) {
+            // Generic warn log for bad status codes
             logs.push({
                 level: 'warn',
                 timestamp: DateTime.now(),

--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -168,11 +168,28 @@ export class HogExecutor {
             throw new Error('No hog function id provided')
         }
 
+        const { logs = [], response = null, error: asyncError, timings = [] } = asyncFunctionResponse
+
+        if (response?.status && response.status >= 400) {
+            logs.push({
+                level: 'warn',
+                timestamp: DateTime.now(),
+                message: `Fetch returned bad status: ${response.status}`,
+            })
+        }
+
         const errorRes = (error = 'Something went wrong'): HogFunctionInvocationResult => ({
             invocation,
             finished: false,
             error,
-            logs: [],
+            logs: [
+                ...logs,
+                {
+                    level: 'error',
+                    timestamp: DateTime.now(),
+                    message: error,
+                },
+            ],
         })
 
         const hogFunction = this.hogFunctionManager.getTeamHogFunction(
@@ -180,29 +197,32 @@ export class HogExecutor {
             invocation.hogFunctionId
         )
 
-        if (!hogFunction) {
-            return errorRes(`Hog Function with ID ${invocation.hogFunctionId} not found`)
+        if (!hogFunction || !invocation.vmState || asyncError) {
+            return errorRes(
+                !hogFunction
+                    ? `Hog Function with ID ${invocation.hogFunctionId} not found`
+                    : asyncError
+                    ? asyncError
+                    : 'No VM state provided for async response'
+            )
         }
 
-        if (!invocation.vmState || !asyncFunctionResponse.response || asyncFunctionResponse.error) {
-            return errorRes(asyncFunctionResponse.error ?? 'No VM state provided for async response')
-        }
-
-        if (asyncFunctionResponse.response?.body && typeof asyncFunctionResponse.response?.body === 'string') {
-            // TODO: Ensure this is done in rusty hook
+        if (typeof response?.body === 'string') {
             try {
-                asyncFunctionResponse.response.body = JSON.parse(asyncFunctionResponse.response.body)
-            } catch (e) {}
+                response.body = JSON.parse(response.body)
+            } catch (e) {
+                // pass - if it isn't json we just pass it on
+            }
         }
 
         // Add the response to the stack to continue execution
-        invocation.vmState.stack.push(convertJSToHog(asyncFunctionResponse.response ?? null))
-        invocation.timings.push(...(asyncFunctionResponse.timings ?? []))
+        invocation.vmState.stack.push(convertJSToHog(response))
+        invocation.timings.push(...timings)
 
         const res = this.execute(hogFunction, invocation)
 
         // Add any timings and logs from the async function
-        res.logs = [...(asyncFunctionResponse.logs ?? []), ...res.logs]
+        res.logs = [...(logs ?? []), ...res.logs]
 
         return res
     }

--- a/plugin-server/src/cdp/hog-watcher/hog-watcher.ts
+++ b/plugin-server/src/cdp/hog-watcher/hog-watcher.ts
@@ -363,6 +363,13 @@ export class HogWatcher {
 
             if (currentState !== newState) {
                 transitionToState(id, newState)
+                // Extra logging to help debugging:
+
+                status.info('👀', `[HogWatcher] Function ${id} changed state`, {
+                    oldState: currentState,
+                    newState: newState,
+                    ratings: newRatings,
+                })
             }
         })
 
@@ -390,9 +397,11 @@ export class HogWatcher {
             return
         }
 
-        status.info('👀', '[HogWatcher] Functions changed state', {
-            changes: stateChanges,
-        })
+        if (Object.keys(stateChanges.states).length) {
+            status.info('👀', '[HogWatcher] Functions changed state', {
+                changes: stateChanges,
+            })
+        }
 
         // Finally write the state summary
         const states: Record<HogFunctionType['id'], HogWatcherState> = Object.fromEntries(

--- a/plugin-server/src/cdp/types.ts
+++ b/plugin-server/src/cdp/types.ts
@@ -172,7 +172,10 @@ export type HogFunctionAsyncFunctionResponse = {
     /** An error message to indicate something went wrong and the invocation should be stopped */
     error?: any
     /** The data to be passed to the Hog function from the response */
-    response: any
+    response?: {
+        status: number
+        body: any
+    }
     timings?: HogFunctionTiming[]
     logs?: LogEntry[]
 }

--- a/plugin-server/src/cdp/types.ts
+++ b/plugin-server/src/cdp/types.ts
@@ -175,7 +175,7 @@ export type HogFunctionAsyncFunctionResponse = {
     response?: {
         status: number
         body: any
-    }
+    } | null
     timings?: HogFunctionTiming[]
     logs?: LogEntry[]
 }


### PR DESCRIPTION
## Problem

Depending on the error case an async function might not be reported back nicely.

## Changes

* Fixes up the logic to ensure we add logs when there is a generic error
* Adds a default log for responses with >=400 status codes

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
