### PR TITLE
fix: Disable observing fetch results for now

### DIFF
--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -265,29 +265,6 @@ abstract class CdpConsumerBase {
                     })
                 })
 
-                // Filter for blocked functions
-                const asyncResponsesToRun: HogFunctionInvocationAsyncResponse[] = []
-
-                for (const item of asyncResponses) {
-                    const functionState = this.hogWatcher.getFunctionState(item.hogFunctionId)
-
-                    if (functionState > HogWatcherState.disabledForPeriod) {
-                        this.produceAppMetric({
-                            team_id: item.teamId,
-                            app_source_id: item.hogFunctionId,
-                            metric_kind: 'failure',
-                            metric_name:
-                                functionState === HogWatcherState.disabledForPeriod
-                                    ? 'disabled_temporarily'
-                                    : 'disabled_permanently',
-                            count: 1,
-                        })
-                        continue
-                    } else {
-                        asyncResponsesToRun.push(item)
-                    }
-                }
-
                 const invocationsWithResponses: [HogFunctionInvocation, HogFunctionAsyncFunctionResponse][] = []
 
                 // Deserialize the compressed data

--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -257,7 +257,8 @@ abstract class CdpConsumerBase {
         return await runInstrumentedFunction({
             statsKey: `cdpConsumer.handleEachBatch.executeAsyncResponses`,
             func: async () => {
-                this.hogWatcher.currentObservations.observeAsyncFunctionResponses(asyncResponses)
+                // NOTE: Disabled for now as it needs some rethinking
+                // this.hogWatcher.currentObservations.observeAsyncFunctionResponses(asyncResponses)
                 asyncResponses.forEach((x) => {
                     counterAsyncFunctionResponse.inc({
                         outcome: x.asyncFunctionResponse.error ? 'failed' : 'succeeded',


### PR DESCRIPTION
## Problem

There's some tweaks that need to be made to the fetch watcher so for now im disabling it.

## Changes

* Comment out the observer

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
