### PR TITLE
fix(persons): Display error when person API fails

### DIFF
--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -101,6 +101,7 @@ export function PersonScene(): JSX.Element | null {
         feedEnabled,
         person,
         personLoading,
+        personError,
         currentTab,
         splitMergeModalShown,
         urlId,
@@ -113,6 +114,9 @@ export function PersonScene(): JSX.Element | null {
     const { groupsEnabled } = useValues(groupsAccessLogic)
     const { currentTeam } = useValues(teamLogic)
 
+    if (personError) {
+        throw new Error(personError)
+    }
     if (!person) {
         return personLoading ? <SpinnerOverlay sceneLevel /> : <NotFound object="Person" />
     }

--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -202,6 +202,15 @@ export const personsLogic = kea<personsLogicType>([
             loadPerson: () => null,
             setPerson: (_, { person }): PersonType | null => person,
         },
+        personError: [
+            null as string | null,
+            {
+                loadPerson: () => null,
+                setPerson: () => null,
+                loadPersonUUID: () => null,
+                loadPersonFailure: (_, { error }) => error,
+            },
+        ],
         distinctId: [
             null as string | null,
             {


### PR DESCRIPTION
## Problem

If person API responds with an error, the page shows 404

Fixes #23671

## Changes

It would be nice to get the failure state in KEA for all loaders in general, but to quick fix it I'm using the `loadPersonFailure` to get the error.

## How did you test this code?

Tested locally with simulated error from backend.