### PR TITLE
chore: update the dismissed survey logic

### DIFF
--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -302,13 +302,8 @@ export const billingProductLogic = kea<billingProductLogicType>([
             actions.setSurveyID('')
         },
         deactivateProductSuccess: async (_, breakpoint) => {
-            if (!values.unsubscribeError) {
-                const hasSurveyReasons = values.surveyResponse['$survey_response_2']?.length > 0
-                const textAreaNotEmpty = values.surveyResponse['$survey_response']?.length > 0
-                const shouldReportSurvey = hasSurveyReasons || textAreaNotEmpty
-                shouldReportSurvey
-                    ? actions.reportSurveySent(values.surveyID, values.surveyResponse)
-                    : actions.reportSurveyDismissed(values.surveyID)
+            if (!values.unsubscribeError && values.surveyID) {
+                actions.reportSurveySent(values.surveyID, values.surveyResponse)
             }
             await breakpoint(200)
             location.reload()


### PR DESCRIPTION
## Problem

We've got two issues:
1. We have an instance of the billing product logic for each product, so when we use kea listener success callbacks, they trigger multiple times (one for each instance) and, in this case, ten times. This was a problem for two reasons - first, we were triggered survey dismissed calls ten times for every unsubscribe modal submission, and second, there was no Survey ID since the Survey ID is only set on the logic for the product being unsubscribed.
2. We are submitting the survey dismissed event when the unsubscription modal is submitted without an answer from the customer - this seems wrong. We still want to track the subscription and pipe it into Slack even if there is no answer. 

## Changes

This PR fixes the multiple callback firing by checking for the Survey ID. Note that there's probably a deeper fix that should occur where listener callbacks are not used in logic with multiple instances. This PR also updates the unsubscription submission with no answers to use the survey sent—this will pip those in Slack through Zapier. 