### PR TITLE
fix: colors on formula breakdowns

### DIFF
--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -163,13 +163,15 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
                 const uniqSeries = Array.from(
                     // :TRICKY: Stickiness insights don't have an `action` object, despite
                     // types here not reflecting that.
-                    new Set(indexedResults.map((item) => `${item.label}_${item.action?.order}`))
+                    new Set(
+                        indexedResults.map((item) => `${item.label}_${item.action?.order}_${item?.breakdown_value}`)
+                    )
                 )
 
                 // Give current and previous versions of the same dataset the same colorIndex
                 return indexedResults.map((item, index) => {
                     const colorIndex = uniqSeries.findIndex(
-                        (identifier) => identifier === `${item.label}_${item.action?.order}`
+                        (identifier) => identifier === `${item.label}_${item.action?.order}_${item?.breakdown_value}`
                     )
                     return { ...item, colorIndex: colorIndex, id: index }
                 })


### PR DESCRIPTION
## Problem

Colors were all blue for formula breakdowns
<redacted>

## Changes

Fix it!
<img width="1111" alt="Screenshot 2024-08-07 at 11 23 49 AM" src="https://github.com/user-attachments/assets/d4c05322-6465-493b-a587-c0154e89ee34">

## How did you test this code?

Locally
