### PR TITLE
chore(bump latest posthog-js): need to support this bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
         "pmtiles": "^2.11.0",
         "postcss": "^8.4.31",
         "postcss-preset-env": "^9.3.0",
-        "posthog-js": "1.154.4",
+        "posthog-js": "1.154.5",
         "posthog-js-lite": "3.0.0",
         "prettier": "^2.8.8",
         "prop-types": "^15.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,8 +272,8 @@ dependencies:
     specifier: ^9.3.0
     version: 9.3.0(postcss@8.4.31)
   posthog-js:
-    specifier: 1.154.4
-    version: 1.154.4
+    specifier: 1.154.5
+    version: 1.154.5
   posthog-js-lite:
     specifier: 3.0.0
     version: 3.0.0
@@ -17766,8 +17766,8 @@ packages:
     resolution: {integrity: sha512-dyajjnfzZD1tht4N7p7iwf7nBnR1MjVaVu+MKr+7gBgA39bn28wizCIJZztZPtHy4PY0YwtSGgwfBCuG/hnHgA==}
     dev: false
 
-  /posthog-js@1.154.4:
-    resolution: {integrity: sha512-J6SvhjNGOqkL8uH/sL3h4rXN7bUz9MnCJ1bu/D9Vkf6Enft8LlkOnzackUwR8EpKdM/dhA0dUjDk5Fz/6dovbw==}
+  /posthog-js@1.154.5:
+    resolution: {integrity: sha512-YYhWckDIRObfCrQpiLq+fdcDTIbQp8ebiKi0ueGohMRgugIG9LJVSpBgCeCHZm2C7sOxDUNcAr3T5VBDUSQoOg==}
     dependencies:
       fflate: 0.4.8
       preact: 10.23.1


### PR DESCRIPTION
## Problem

I thought these bumps were auto-created, sigh.  Need to bump posthog-js to support this fix: https://github.com/PostHog/posthog-js/pull/1343
