### PR TITLE
feat: add dry run to delete process for testing in prod

### DIFF
--- a/posthog/management/commands/start_delete_mutation.py
+++ b/posthog/management/commands/start_delete_mutation.py
@@ -15,11 +15,16 @@ class Command(BaseCommand):
         "Useful when you need data deleted asap (cannot wait for the scheduled job)"
     )
 
-    def handle(self, *args, **options):
-        run()
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run", default=False, type=bool, help="Don't run the delete, just print out the delete statement"
+        )
+
+    def handle(self, *args, **kwargs):
+        run(**kwargs)
 
 
-def run():
+def run(dry_run):
     logger.info("Starting deletion of data for teams")
-    clickhouse_clear_removed_data()
+    clickhouse_clear_removed_data(dry_run)
     logger.info("Finished deletion of data for teams")

--- a/posthog/models/async_deletion/delete_cohorts.py
+++ b/posthog/models/async_deletion/delete_cohorts.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from posthog.client import sync_execute
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.async_deletion.delete import AsyncDeletionProcess, logger
 
@@ -23,7 +22,7 @@ class AsyncCohortDeletion(AsyncDeletionProcess):
 
         conditions, args = self._conditions(deletions)
 
-        sync_execute(
+        self._sync_execute(
             f"""
             DELETE FROM cohortpeople
             WHERE {" OR ".join(conditions)}
@@ -43,7 +42,7 @@ class AsyncCohortDeletion(AsyncDeletionProcess):
 
     def _verify_by_column(self, distinct_columns: str, async_deletions: list[AsyncDeletion]) -> set[tuple[Any, ...]]:
         conditions, args = self._conditions(async_deletions)
-        clickhouse_result = sync_execute(
+        clickhouse_result = self._query(
             f"""
             SELECT DISTINCT {distinct_columns}
             FROM cohortpeople

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -481,12 +481,12 @@ def clickhouse_mutation_count() -> None:
 
 
 @shared_task(ignore_result=True)
-def clickhouse_clear_removed_data() -> None:
+def clickhouse_clear_removed_data(dry_run=False) -> None:
     from posthog.models.async_deletion.delete_cohorts import AsyncCohortDeletion
     from posthog.models.async_deletion.delete_events import AsyncEventDeletion
     from posthog.pagerduty.pd import create_incident
 
-    runner = AsyncEventDeletion()
+    runner = AsyncEventDeletion(dry_run)
 
     try:
         runner.mark_deletions_done()


### PR DESCRIPTION
feat: add dry run to delete process for testing in prod

## Problem

The delete job is failing in prod, but is working locally. It's hard to test this without the scale of prod. This allows us to run the job manually with a `--dry-run` flag which will print out the statements to debug.

## Changes

add `--dry-run` flag to the deletion logic

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
