### PR TITLE
feat: Better redis pool handling

### DIFF
--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -283,7 +283,7 @@ export interface Hub extends PluginsServerConfig {
     // active connections to Postgres, Redis, ClickHouse, Kafka
     db: DB
     postgres: PostgresRouter
-    redisPool: GenericPool<Redis>
+    redisPool: RedisPool
     clickhouse: ClickHouse
     kafka: Kafka
     kafkaProducer: KafkaProducerWrapper
@@ -1171,7 +1171,9 @@ export interface PipelineEvent extends Omit<PluginEvent, 'team_id'> {
     token?: string
 }
 
-export type RedisPool = GenericPool<Redis>
+export type RedisPool = Pick<GenericPool<Redis>, 'drain' | 'clear'> & {
+    withClient: <T>(name: string, timeout: number, callback: (client: Redis) => Promise<T>) => Promise<T>
+}
 
 export type RRWebEvent = Record<string, any> & {
     timestamp: number

--- a/plugin-server/tests/helpers/redis.ts
+++ b/plugin-server/tests/helpers/redis.ts
@@ -1,12 +1,12 @@
 import { RedisPool } from '../../src/types'
 
 export async function deleteKeysWithPrefix(redisPool: RedisPool, prefix: string) {
-    const redisClient = await redisPool.acquire()
-    const keys = await redisClient.keys(`${prefix}*`)
-    const pipeline = redisClient.pipeline()
-    keys.forEach(function (key) {
-        pipeline.del(key)
+    await redisPool.withClient('deleteKeysWithPrefix', 30 * 1000, async (client) => {
+        const keys = await client.keys(`${prefix}*`)
+        const pipeline = client.pipeline()
+        keys.forEach(function (key) {
+            pipeline.del(key)
+        })
+        await pipeline.exec()
     })
-    await pipeline.exec()
-    await redisPool.release(redisClient)
 }

--- a/plugin-server/tests/main/db.test.ts
+++ b/plugin-server/tests/main/db.test.ts
@@ -25,9 +25,9 @@ describe('DB', () => {
         await resetTestDatabase(undefined, {}, {}, { withExtendedTestData: false })
         db = hub.db
 
-        const redis = await hub.redisPool.acquire()
-        await redis.flushdb()
-        await db.redisPool.release(redis)
+        await hub.redisPool.withClient('test', 1000, async (client) => {
+            await client.flushdb()
+        })
     })
 
     afterEach(async () => {

--- a/plugin-server/tests/main/ingestion-queues/run-async-handlers-event-pipeline.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/run-async-handlers-event-pipeline.test.ts
@@ -15,7 +15,6 @@
 //  2. the KafkaQueue consumer handler will let the error bubble up to the
 //     KafkaJS consumer runner, which we assume will handle retries.
 
-import Redis from 'ioredis'
 import LibrdKafkaError from 'node-rdkafka/lib/error'
 
 import { defaultConfig } from '../../../src/config/config'
@@ -50,19 +49,16 @@ describe('runAppsOnEventPipeline()', () => {
     // way to mock things in subprocesses to test this however.
 
     let hub: Hub
-    let redis: Redis.Redis
     let closeHub: () => Promise<void>
 
     beforeEach(async () => {
         // Use fake timers to ensure that we don't need to wait on e.g. retry logic.
         jest.useFakeTimers({ advanceTimers: true })
         ;[hub, closeHub] = await createHub()
-        redis = await hub.redisPool.acquire()
         await hub.postgres.query(PostgresUse.COMMON_WRITE, POSTGRES_DELETE_TABLES_QUERY, null, 'deleteTables') // Need to clear the DB to avoid unique constraint violations on ids
     })
 
     afterEach(async () => {
-        await hub.redisPool.release(redis)
         await teardownPlugins(hub)
         await closeHub()
         jest.clearAllTimers()

--- a/plugin-server/tests/main/ingestion-queues/run-ingestion-pipeline.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/run-ingestion-pipeline.test.ts
@@ -1,4 +1,3 @@
-import Redis from 'ioredis'
 import { Pool } from 'pg'
 
 import { Hub } from '../../../src/types'
@@ -11,19 +10,16 @@ import { createOrganization, createTeam, POSTGRES_DELETE_TABLES_QUERY } from '..
 
 describe('workerTasks.runEventPipeline()', () => {
     let hub: Hub
-    let redis: Redis.Redis
     let closeHub: () => Promise<void>
     const OLD_ENV = process.env
 
     beforeAll(async () => {
         ;[hub, closeHub] = await createHub()
-        redis = await hub.redisPool.acquire()
         await hub.postgres.query(PostgresUse.COMMON_WRITE, POSTGRES_DELETE_TABLES_QUERY, undefined, '') // Need to clear the DB to avoid unique constraint violations on ids
         process.env = { ...OLD_ENV } // Make a copy
     })
 
     afterAll(async () => {
-        await hub.redisPool.release(redis)
         await closeHub()
         process.env = OLD_ENV // Restore old environment
     })

--- a/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording/session-recordings-consumer.test.ts
@@ -95,7 +95,6 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
         ;[hub, closeHub] = await createHub()
         team = await getFirstTeam(hub)
         teamToken = team.api_token
-        redisConn = await hub.redisPool.acquire(0)
         await redisConn.del(CAPTURE_OVERFLOW_REDIS_KEY)
         await deleteKeys(hub)
 
@@ -108,7 +107,6 @@ describe.each([[true], [false]])('ingester with consumeOverflow=%p', (consumeOve
     afterEach(async () => {
         jest.setTimeout(10000)
         await redisConn.del(CAPTURE_OVERFLOW_REDIS_KEY)
-        await hub.redisPool.release(redisConn)
         await deleteKeys(hub)
         await closeHub()
     })

--- a/plugin-server/tests/sql.test.ts
+++ b/plugin-server/tests/sql.test.ts
@@ -118,20 +118,19 @@ describe('sql', () => {
         })
 
         test('disablePlugin disables a plugin', async () => {
-            const redis = await hub.db.redisPool.acquire()
-            const rowsBefore = await getPluginConfigRows(hub)
-            expect(rowsBefore[0].plugin_id).toEqual(60)
-            expect(rowsBefore[0].enabled).toEqual(true)
+            await hub.db.redisPool.withClient('disablePlugin', 1000, async (client) => {
+                const rowsBefore = await getPluginConfigRows(hub)
+                expect(rowsBefore[0].plugin_id).toEqual(60)
+                expect(rowsBefore[0].enabled).toEqual(true)
 
-            const receivedMessage = redis.subscribe(hub.PLUGINS_RELOAD_PUBSUB_CHANNEL)
-            await disablePlugin(hub, 39)
+                const receivedMessage = client.subscribe(hub.PLUGINS_RELOAD_PUBSUB_CHANNEL)
+                await disablePlugin(hub, 39)
 
-            const rowsAfter = await getPluginConfigRows(hub)
+                const rowsAfter = await getPluginConfigRows(hub)
 
-            expect(rowsAfter).toEqual([])
-            await expect(receivedMessage).resolves.toEqual(1)
+                expect(rowsAfter).toEqual([])
+                await expect(receivedMessage).resolves.toEqual(1)
 
-            await hub.db.redisPool.release(redis)
         })
     })
 })


### PR DESCRIPTION
## Problem

We manually acquire and release the locks on the redis pool with a tonne of boilerplate around this.

## Changes

* Modify the redis pool to have a helper method for exactly this

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
