### PR TITLE
Update SidePanelSupport.tsx to include a 'Report a bug' button -SuperDay

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -281,6 +281,19 @@ export const SidePanelSupport = (): JSX.Element => {
                                         <LemonButton
                                             type="secondary"
                                             status="alt"
+                                            to={`https://github.com/PostHog/posthog/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&debug-info=${encodeURIComponent(
+                                                getPublicSupportSnippet(region, currentOrganization, currentTeam)
+                                            )}`}
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Report a bug
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
                                             to={`https://github.com/PostHog/posthog/issues/new?&labels=enhancement&template=feature_request.yml&debug-info=${encodeURIComponent(
                                                 getPublicSupportSnippet(region, currentOrganization, currentTeam)
                                             )}`}


### PR DESCRIPTION
Add a 'Report a bug' button that will allow users to report a bug directly in GitHub (Superday task).

## Problem

Users are unable to report a bug directly on GitHub.

## Changes

Added a 'Report a bug' button that allows PostHog users to report a bug directly on GitHub.
