### PR TITLE
feat: use capture-rs and vector replay capture in local compose

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -3,6 +3,45 @@
 #
 
 services:
+    proxy:
+        image: caddy
+        entrypoint: sh
+        restart: always
+        command: -c 'set -x && echo "$$CADDYFILE" > /etc/caddy/Caddyfile && exec caddy run -c /etc/caddy/Caddyfile'
+        volumes:
+            - /root/.caddy
+        environment:
+            CADDYFILE: |
+                http://localhost:8000 {
+                    @replay-capture {
+                        path /s
+                        path /s/*
+                    }
+
+                    @capture {
+                        path /e
+                        path /e/*
+                        path /i/v0/e
+                        path /i/v0/e*
+                        path /batch
+                        path /batch*
+                        path /capture
+                        path /capture*
+                    }
+
+                    handle @capture {
+                        reverse_proxy capture:3000
+                    }
+
+                    handle @replay-capture {
+                        reverse_proxy replay-capture:8000
+                    }
+
+                    handle {
+                        reverse_proxy web:8000
+                    }
+                }
+
     db:
         image: postgres:12-alpine
         restart: on-failure

--- a/docker-compose.dev-full.yml
+++ b/docker-compose.dev-full.yml
@@ -127,10 +127,16 @@ services:
         extends:
             file: docker-compose.base.yml
             service: capture
-        ports:
-            - 3000:3000
         environment:
             - DEBUG=1
+        depends_on:
+            - redis
+            - kafka
+
+    replay-capture:
+        extends:
+            file: docker-compose.base.yml
+            service: replay-capture
         depends_on:
             - redis
             - kafka

--- a/docker-compose.dev-full.yml
+++ b/docker-compose.dev-full.yml
@@ -14,7 +14,7 @@ services:
             file: docker-compose.base.yml
             service: proxy
         ports:
-            - 8001:8000
+            - 8010:8000
         depends_on:
             - replay-capture
             - capture

--- a/docker-compose.dev-full.yml
+++ b/docker-compose.dev-full.yml
@@ -9,6 +9,16 @@
 #
 
 services:
+    proxy:
+        extends:
+            file: docker-compose.base.yml
+            service: proxy
+        ports:
+            - 8001:8000
+        depends_on:
+            - replay-capture
+            - capture
+            - web
     db:
         extends:
             file: docker-compose.base.yml

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,6 +8,17 @@
 #
 
 services:
+    proxy:
+        extends:
+            file: docker-compose.base.yml
+            service: proxy
+        ports:
+            - 8001:8000
+        depends_on:
+            - replay-capture
+            - capture
+        extra_hosts:
+            - 'web:host-gateway'
     db:
         extends:
             file: docker-compose.base.yml
@@ -103,27 +114,22 @@ services:
         environment:
             - LISTEN_PORT=2080
 
-    # Optional capture
+    # capture-rs
     capture:
-        profiles: ['capture-rs']
         extends:
             file: docker-compose.base.yml
             service: capture
-        ports:
-            - 3000:3000
         environment:
             - DEBUG=1
         depends_on:
             - redis
             - kafka
 
-    # Optional capture
+    # vector replay capture
     replay-capture:
         extends:
             file: docker-compose.base.yml
             service: replay-capture
-        ports:
-            - 3001:8000
         depends_on:
             - redis
             - kafka

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,7 @@ services:
             file: docker-compose.base.yml
             service: proxy
         ports:
-            - 8001:8000
+            - 8010:8000
         depends_on:
             - replay-capture
             - capture


### PR DESCRIPTION

## Problem

in production we have replaced (or will soon) most of our capture services with capture-rs and (soon) vector replay capture, but locally we still use the python version.

Add new local service on port 8001 which proxies posthog with the new capture services 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
