### PR TITLE
fix(popover): use the top placement by default for the person display popover

### DIFF
--- a/frontend/src/scenes/persons/PersonDisplay.tsx
+++ b/frontend/src/scenes/persons/PersonDisplay.tsx
@@ -119,8 +119,8 @@ export function PersonDisplay({
                 }
                 visible={visible}
                 onClickOutside={() => setVisible(false)}
-                placement="right"
-                fallbackPlacements={['bottom', 'top']}
+                placement="top"
+                fallbackPlacements={['bottom', 'right']}
                 showArrow
             >
                 {content}


### PR DESCRIPTION
## Problem

We have an issue where the person display box doesn't render correctly on a few browsers (chrome, arc), and appears off to the right

<img width="951" alt="image" src="https://github.com/user-attachments/assets/a8444b52-4aa6-4db9-a9a9-6bce4b01afcd">

I think it'd be better to appear on the top by default, that way folks can easily see all the person info on popover if they'd like.

e.g.

<img width="968" alt="image" src="https://github.com/user-attachments/assets/cfbce6ed-330c-421a-8fa7-0b6d9a46eb81">


## Changes

https://www.loom.com/share/4379043cb6854a3ca8bc3666e9599066?sid=1a00b0c7-9eca-4092-9c22-68788cf1dc9d


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

👀 
