### PR TITLE
feat: use patched vector to fix 400 responses and to add response body feature

### DIFF
--- a/.github/workflows/vector-docker-build-deploy.yml
+++ b/.github/workflows/vector-docker-build-deploy.yml
@@ -8,6 +8,7 @@ on:
             - '.github/workflows/vector-docker-build-deploy.yml'
         branches:
             - 'master'
+            - frank/test-patched-vector
 
 jobs:
     build:
@@ -76,6 +77,7 @@ jobs:
     deploy:
         runs-on: ubuntu-latest
         needs: build
+        if: github.ref == 'refs/heads/master'
         steps:
             - name: get deployer token
               id: deployer

--- a/.github/workflows/vector-docker-build-deploy.yml
+++ b/.github/workflows/vector-docker-build-deploy.yml
@@ -8,7 +8,6 @@ on:
             - '.github/workflows/vector-docker-build-deploy.yml'
         branches:
             - 'master'
-            - frank/test-patched-vector
 
 jobs:
     build:

--- a/vector/replay-capture/Dockerfile
+++ b/vector/replay-capture/Dockerfile
@@ -7,6 +7,9 @@ COPY vector.yaml .
 # evaluate with yq, basically to expand anchors (which vector doesn't support)
 RUN yq -i e 'explode(.)' vector.yaml
 
+# fork of vector from this branch: https://github.com/frankh/vector/tree/main
+# includes 2 fixed: 1 to make Kafka temporary errors return 500 not 400
+# and 1 to allow us to set response body on the http source
 FROM frankh/vector:0.41.0-patched
 
 COPY --from=config-builder /config/vector.yaml /etc/vector/vector.yaml

--- a/vector/replay-capture/Dockerfile
+++ b/vector/replay-capture/Dockerfile
@@ -7,6 +7,6 @@ COPY vector.yaml .
 # evaluate with yq, basically to expand anchors (which vector doesn't support)
 RUN yq -i e 'explode(.)' vector.yaml
 
-FROM timberio/vector:0.40.X-alpine
+FROM frankh/vector:0.41.0-patched
 
 COPY --from=config-builder /config/vector.yaml /etc/vector/vector.yaml

--- a/vector/replay-capture/tests.yaml
+++ b/vector/replay-capture/tests.yaml
@@ -44,6 +44,8 @@ tests:
                 ."_" = "123456789"
                 %token = "limited_token"
 
+                # we can't properly check things that we verify in the capture decoding vrl sadly :(
+                %quota_limited = true
       outputs:
           - conditions:
                 - source: |

--- a/vector/replay-capture/vector.yaml
+++ b/vector/replay-capture/vector.yaml
@@ -32,6 +32,7 @@ sources:
         query_parameters:
             - _
         host_key: ip
+        response_body_key: '%response'
         decoding:
             codec: vrl
             vrl:
@@ -61,6 +62,8 @@ sources:
                     assert!(is_string(.message[0].distinct_id), "distinct_id is required")
                     assert!(is_string(.message[0].properties."$$session_id"), "$$session_id is required")
                     assert!(is_string(%token), "token is required")
+
+                    %response = {"status": 1}
 
 transforms:
     quota_check:

--- a/vector/replay-capture/vector.yaml
+++ b/vector/replay-capture/vector.yaml
@@ -82,7 +82,7 @@ transforms:
             quota_limited:
                 type: vrl
                 source: |
-                    %quota_limited
+                    %quota_limited == true
 
     events_parsed:
         type: remap

--- a/vector/replay-capture/vector.yaml
+++ b/vector/replay-capture/vector.yaml
@@ -63,7 +63,15 @@ sources:
                     assert!(is_string(.message[0].properties."$$session_id"), "$$session_id is required")
                     assert!(is_string(%token), "token is required")
 
+                    _, err = get_enrichment_table_record("quota_limited_teams", { "token": %token })
+                    # get_enrichment_table_record returns an err if record is not found
+                    # that means err == null iff we found the quota limited record
+                    %quota_limited = err == null
+
                     %response = {"status": 1}
+                    if %quota_limited {
+                      %response.quota_limited = ["recordings"]
+                    }
 
 transforms:
     quota_check:
@@ -74,8 +82,7 @@ transforms:
             quota_limited:
                 type: vrl
                 source: |
-                    _, err = get_enrichment_table_record("quota_limited_teams", { "token": %token })
-                    err == null  # err is not null if row not found, we want to drop where the row _is_ found
+                    %quota_limited
 
     events_parsed:
         type: remap


### PR DESCRIPTION
## Problem

vector has a couple of issues that are annoying for us:

1. it was returning 400 responses on intermittent kafka errors, which is bad as we don't retry 400s on the client. I made this PR to vector to fix this problem: https://github.com/vectordotdev/vector/pull/21036
2. vector doesn't send anything in the response body. I made a PR to add this feature: https://github.com/vectordotdev/vector/pull/21028

I'm hoping we can get these PRs through upstream, but in the meantime i built and pushed a fork to frankh/vector and we'll base our image off that

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
