### PR TITLE
fix: fix bad response due to enrichment table not available in decoding

### DIFF
--- a/vector/replay-capture/tests.yaml
+++ b/vector/replay-capture/tests.yaml
@@ -43,9 +43,6 @@ tests:
                 .timestamp = now()
                 ."_" = "123456789"
                 %token = "limited_token"
-
-                # we can't properly check things that we verify in the capture decoding vrl sadly :(
-                %quota_limited = true
       outputs:
           - conditions:
                 - source: |

--- a/vector/replay-capture/vector.yaml
+++ b/vector/replay-capture/vector.yaml
@@ -63,15 +63,7 @@ sources:
                     assert!(is_string(.message[0].properties."$$session_id"), "$$session_id is required")
                     assert!(is_string(%token), "token is required")
 
-                    _, err = get_enrichment_table_record("quota_limited_teams", { "token": %token })
-                    # get_enrichment_table_record returns an err if record is not found
-                    # that means err == null iff we found the quota limited record
-                    %quota_limited = err == null
-
                     %response = {"status": 1}
-                    if %quota_limited {
-                      %response.quota_limited = ["recordings"]
-                    }
 
 transforms:
     quota_check:
@@ -82,7 +74,8 @@ transforms:
             quota_limited:
                 type: vrl
                 source: |
-                    %quota_limited == true
+                    _, err = get_enrichment_table_record("quota_limited_teams", { "token": %token })
+                    err == null  # err is not null if row not found, we want to drop where the row _is_ found
 
     events_parsed:
         type: remap


### PR DESCRIPTION


## Problem
sadly the enrichment tables are not present in VRL decoding which means we can't use it to change our HTTP response

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
