### PR TITLE
fix: Fix empty person response crashing

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -102,6 +102,9 @@ export const personsLogic = kea<personsLogicType>([
             {
                 loadPerson: async ({ id }): Promise<PersonType | null> => {
                     const response = await api.persons.list({ distinct_id: id })
+                    if (!response.results.length) {
+                        return null
+                    }
                     const person = response.results[0]
                     if (person) {
                         actions.reportPersonDetailViewed(person)


### PR DESCRIPTION
## Problem

In #24220 the error handling on the person page was improved to catch backend errors.
This made a problem in the logic surface: We accessed an array that could be empty.

https://posthoghelp.zendesk.com/agent/tickets/16615 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/18883)

## Changes

Add condition.

## How did you test this code?

Tested locally.