### PR TITLE
feat: monitoring for cohorts

### DIFF
--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -17,18 +17,15 @@ from posthog.models.property import BehavioralPropertyType, Property, PropertyGr
 from posthog.models.utils import sane_repr
 from posthog.settings.base_variables import TEST
 from prometheus_client import Counter
-from posthog.metrics import LABEL_TEAM_ID
 
 
 COHORT_ERRORED_CALCULATIONS_COUNTER = Counter(
     "cohort_errored_calculations_total",
     "Count of cohort calculations that failed",
-    labelnames=[LABEL_TEAM_ID, "cohort_id"],
 )
 COHORT_SUCCESSFUL_CALCULATIONS_COUNTER = Counter(
     "cohort_successful_calculations_total",
     "Count of cohort calculations that succeeded",
-    labelnames=[LABEL_TEAM_ID, "cohort_id"],
 )
 
 # The empty string literal helps us determine when the cohort is invalid/deleted, when
@@ -230,7 +227,7 @@ class Cohort(models.Model):
             self.last_calculation = timezone.now()
             self.errors_calculating = 0
 
-            COHORT_SUCCESSFUL_CALCULATIONS_COUNTER.labels(team_id=self.team.id, cohort_id=self.id).inc()
+            COHORT_SUCCESSFUL_CALCULATIONS_COUNTER.inc()
         except Exception as err:
             self.errors_calculating = F("errors_calculating") + 1
             logger.warning(
@@ -241,7 +238,7 @@ class Cohort(models.Model):
                 exc_info=True,
             )
 
-            COHORT_ERRORED_CALCULATIONS_COUNTER.labels(team_id=self.team.id, cohort_id=self.id).inc()
+            COHORT_ERRORED_CALCULATIONS_COUNTER.inc()
             capture_exception(
                 Exception(f"Error calculating cohort id = {self.id}, team_id = {self.team.id}"),
                 {"error": str(err)},

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -16,17 +16,7 @@ from posthog.models.person import Person
 from posthog.models.property import BehavioralPropertyType, Property, PropertyGroup
 from posthog.models.utils import sane_repr
 from posthog.settings.base_variables import TEST
-from prometheus_client import Counter
 
-
-COHORT_ERRORED_CALCULATIONS_COUNTER = Counter(
-    "cohort_errored_calculations_total",
-    "Count of cohort calculations that failed",
-)
-COHORT_SUCCESSFUL_CALCULATIONS_COUNTER = Counter(
-    "cohort_successful_calculations_total",
-    "Count of cohort calculations that succeeded",
-)
 
 # The empty string literal helps us determine when the cohort is invalid/deleted, when
 # set in cohorts_cache
@@ -226,8 +216,6 @@ class Cohort(models.Model):
 
             self.last_calculation = timezone.now()
             self.errors_calculating = 0
-
-            COHORT_SUCCESSFUL_CALCULATIONS_COUNTER.inc()
         except Exception as err:
             self.errors_calculating = F("errors_calculating") + 1
             logger.warning(
@@ -238,7 +226,6 @@ class Cohort(models.Model):
                 exc_info=True,
             )
 
-            COHORT_ERRORED_CALCULATIONS_COUNTER.inc()
             capture_exception(
                 Exception(f"Error calculating cohort id = {self.id}, team_id = {self.team.id}"),
                 {"error": str(err)},


### PR DESCRIPTION
## Problem
We don't have any monitoring around cohorts. How many failed/how many left to recalculate.
Even the failure logs don't make it to sentry as of now.

## Changes
Pushing these metrics to Prometheus + capturing the error in Sentry

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally the counter calls were made. 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
