### PR TITLE
feat(hog): escape curlies properly

### DIFF
--- a/hogql_parser/setup.py
+++ b/hogql_parser/setup.py
@@ -32,7 +32,7 @@ module = Extension(
 
 setup(
     name="hogql_parser",
-    version="1.0.35",
+    version="1.0.36",
     url="https://github.com/PostHog/posthog/tree/master/hogql_parser",
     author="PostHog Inc.",
     author_email="hey@posthog.com",

--- a/hogql_parser/string.cpp
+++ b/hogql_parser/string.cpp
@@ -68,6 +68,7 @@ string parse_string_text_ctx(antlr4::tree::TerminalNode* node, bool escape_quote
       boost::replace_all(text, "''", "'");
       boost::replace_all(text, "\\'", "'");
     }
+    boost::replace_all(text, "\\{", "{");
     return replace_common_escape_characters(text);
   } catch (SyntaxError& e) {
     throw SyntaxError(e.what(), node->getSymbol()->getStartIndex(), node->getSymbol()->getStopIndex() + 1);

--- a/posthog/hogql/parse_string.py
+++ b/posthog/hogql/parse_string.py
@@ -53,4 +53,5 @@ def parse_string_text_ctx(ctx: ParserRuleContext, escape_quotes=True) -> str:
     if escape_quotes:
         text = text.replace("''", "'")
         text = text.replace("\\'", "'")
+    text = text.replace("\\{", "{")
     return replace_common_escape_characters(text)

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -1843,6 +1843,13 @@ def parser_test_factory(backend: Literal["python", "cpp"]):
             node2 = self._expr("f'strings\\' to {'strings'}'")
             assert node2 == node
 
+            node = self._string_template("strings\\{ to {'strings'}")
+            assert node == ast.Call(
+                name="concat", args=[ast.Constant(value="strings{ to "), ast.Constant(value="strings")]
+            )
+            node2 = self._expr("f'strings\\{ to {'strings'}'")
+            assert node2 == node
+
         def test_template_strings_full_multiline(self):
             node = self._string_template("hello \n{event}")
             assert node == ast.Call(name="concat", args=[ast.Constant(value="hello \n"), ast.Field(chain=["event"])])

--- a/requirements.in
+++ b/requirements.in
@@ -96,7 +96,7 @@ phonenumberslite==8.13.6
 openai==1.10.0
 tiktoken==0.6.0
 nh3==0.2.14
-hogql-parser==1.0.35
+hogql-parser==1.0.36
 zxcvbn==4.4.28
 zstd==1.5.5.1
 xmlsec==1.3.13 # Do not change this version - it will break SAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -275,7 +275,7 @@ h11==0.13.0
     #   wsproto
 hexbytes==1.0.0
     # via dlt
-hogql-parser==1.0.35
+hogql-parser==1.0.36
     # via -r requirements.in
 httpcore==1.0.2
     # via httpx


### PR DESCRIPTION
## Problem

Escaped curly brackets in f-strings are returned with the `\` symbol attached.

```
f'\{' = '\\{'
```


## Changes

Now this works:

```
f'\{' == '{'
```

## How did you test this code?

Added a test