### PR TITLE
feat(insights): Lower staleness times for extended caches

### DIFF
--- a/posthog/caching/utils.py
+++ b/posthog/caching/utils.py
@@ -140,8 +140,8 @@ staleness_threshold_map = {
         None: timedelta(hours=1),
         "minute": timedelta(hours=1),
         "hour": timedelta(hours=6),
-        "day": timedelta(hours=24),
-        "week": timedelta(days=2),
+        "day": timedelta(hours=6),
+        "week": timedelta(days=1),
         "month": timedelta(days=2),
     },
 }

--- a/posthog/caching/utils.py
+++ b/posthog/caching/utils.py
@@ -139,7 +139,7 @@ staleness_threshold_map = {
     ThresholdMode.LAZY: {
         None: timedelta(hours=1),
         "minute": timedelta(hours=1),
-        "hour": timedelta(hours=6),
+        "hour": timedelta(hours=1),
         "day": timedelta(hours=6),
         "week": timedelta(days=1),
         "month": timedelta(days=2),


### PR DESCRIPTION
## Problem

For shared dashboards, we only refresh daily stats after 24 hours.
If the case is someone looking at the shared dashboard Monday at 8 am, then not having updates all Monday is too long.

Context in https://posthoghelp.zendesk.com/agent/tickets/15783 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/18849)

## Changes

Lower the times.

## How did you test this code?

n/a