### PR TITLE
fix: Add migration timeout parameter (defaults to 60s otherwise)

### DIFF
--- a/posthog/management/commands/migrate_clickhouse.py
+++ b/posthog/management/commands/migrate_clickhouse.py
@@ -16,6 +16,7 @@ from posthog.settings import (
 from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
 
 MIGRATIONS_PACKAGE_NAME = "posthog.clickhouse.migrations"
+MIGRATION_TIMEOUT = 60 * 5  # 5 minutes
 
 
 class Command(BaseCommand):
@@ -61,6 +62,7 @@ class Command(BaseCommand):
             cluster=CLICKHOUSE_CLUSTER,
             verify_ssl_cert=False,
             randomize_replica_paths=settings.TEST or settings.E2E_TESTING,
+            timeout=MIGRATION_TIMEOUT,
         )
         if options["plan"] or options["check"]:
             print("List of clickhouse migrations to be applied:")


### PR DESCRIPTION
## Problem

Deploys are failing in US due to a migration timeing out

## Changes

Default is here:
https://github.com/Infinidat/infi.clickhouse_orm/blob/45a9200ff6e05dd7623219c4731acc14db04bfc5/src/infi/clickhouse_orm/database.py#L90 

increase the timeout on migration from 60s to 300s (5 min)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
