### PR TITLE
chore: stop using forked vector now that they merged upstream

### DIFF
--- a/vector/replay-capture/Dockerfile
+++ b/vector/replay-capture/Dockerfile
@@ -7,9 +7,7 @@ COPY vector.yaml .
 # evaluate with yq, basically to expand anchors (which vector doesn't support)
 RUN yq -i e 'explode(.)' vector.yaml
 
-# fork of vector from this branch: https://github.com/frankh/vector/tree/main
-# includes 2 fixed: 1 to make Kafka temporary errors return 500 not 400
-# and 1 to allow us to set response body on the http source
-FROM frankh/vector:0.41.0-patched
+# nightly vector to include this fix https://github.com/vectordotdev/vector/commit/dc0b4087095b4968cca0201e233919de8cff9918
+FROM timberio/vector@sha256:f30cba5e4efcf554aea09a3f970fc75a140750ded0095840a47a8b9c9571100c
 
 COPY --from=config-builder /config/vector.yaml /etc/vector/vector.yaml

--- a/vector/replay-capture/vector.yaml
+++ b/vector/replay-capture/vector.yaml
@@ -32,7 +32,6 @@ sources:
         query_parameters:
             - _
         host_key: ip
-        response_body_key: '%response'
         decoding:
             codec: vrl
             vrl:
@@ -62,8 +61,6 @@ sources:
                     assert!(is_string(.message[0].distinct_id), "distinct_id is required")
                     assert!(is_string(.message[0].properties."$$session_id"), "$$session_id is required")
                     assert!(is_string(%token), "token is required")
-
-                    %response = {"status": 1}
 
 transforms:
     quota_check:


### PR DESCRIPTION
## Problem

we were forking for this: https://github.com/vectordotdev/vector/commit/dc0b4087095b4968cca0201e233919de8cff9918

now merged upstream so switch to nightly build of vector which has this fix in

removed the response_body stuff as it wasn't useful as we can't access the enrichment tables in decoding which means we can't set the quota response, which was the only point in it

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
