### PR TITLE
feat: disable replay in decide if over quota

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -1,5 +1,5 @@
 from random import random
-from typing import Union
+from typing import Union, cast
 
 import structlog
 from django.conf import settings
@@ -140,6 +140,7 @@ def get_decide(request: HttpRequest):
             team = user.teams.get(id=project_id)
 
         if team:
+            token = cast(str, token)  # we know it's not None if we found a team
             structlog.contextvars.bind_contextvars(team_id=team.id)
 
             disable_flags = process_bool(data.get("disable_flags")) is True

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -248,7 +248,7 @@ def get_decide(request: HttpRequest):
 
             response["sessionRecording"] = _session_recording_config_response(request, team, token)
 
-            if response["sessionRecording"] and settings.DECIDE_SESSION_REPLAY_QUOTA_CHECK:
+            if settings.DECIDE_SESSION_REPLAY_QUOTA_CHECK:
                 from ee.billing.quota_limiting import QuotaLimitingCaches, QuotaResource, list_limited_team_attributes
 
                 limited_tokens_recordings = list_limited_team_attributes(
@@ -256,7 +256,7 @@ def get_decide(request: HttpRequest):
                 )
 
                 if token in limited_tokens_recordings:
-                    response["quotaLimited"] = ["sessionRecording"]
+                    response["quotaLimited"] = ["recordings"]
                     response["sessionRecording"] = False
 
             response["surveys"] = True if team.surveys_opt_in else False

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -248,6 +248,17 @@ def get_decide(request: HttpRequest):
 
             response["sessionRecording"] = _session_recording_config_response(request, team, token)
 
+            if response["sessionRecording"] and settings.DECIDE_SESSION_REPLAY_QUOTA_CHECK:
+                from ee.billing.quota_limiting import QuotaLimitingCaches, QuotaResource, list_limited_team_attributes
+
+                limited_tokens_recordings = list_limited_team_attributes(
+                    QuotaResource.RECORDINGS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
+                )
+
+                if token in limited_tokens_recordings:
+                    response["quotaLimited"] = ["sessionRecording"]
+                    response["sessionRecording"] = False
+
             response["surveys"] = True if team.surveys_opt_in else False
             response["heatmaps"] = True if team.heatmaps_opt_in else False
 
@@ -299,16 +310,6 @@ def _session_recording_config_response(request: HttpRequest, team: Team, token: 
         if team.session_recording_opt_in and (
             on_permitted_recording_domain(team, request) or not team.recording_domains
         ):
-            if settings.DECIDE_SESSION_REPLAY_QUOTA_CHECK:
-                from ee.billing.quota_limiting import QuotaLimitingCaches, QuotaResource, list_limited_team_attributes
-
-                limited_tokens_recordings = list_limited_team_attributes(
-                    QuotaResource.RECORDINGS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
-                )
-
-                if token in limited_tokens_recordings:
-                    return False
-
             capture_console_logs = True if team.capture_console_log_opt_in else False
             sample_rate = team.session_recording_sample_rate or None
             if sample_rate == "1.00":

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -3173,6 +3173,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
 
             response = self._post_decide().json()
             assert response["sessionRecording"] is False
+            self.assertEqual(response["quotaLimited"], ["sessionRecording"])
 
     @patch("ee.billing.quota_limiting.list_limited_team_attributes")
     def test_quota_limited_recordings_other_token(self, _fake_token_limiting, *args):

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -3154,6 +3154,28 @@ class TestDecide(BaseTest, QueryMatchingTest):
             response = self._post_decide(api_version=3, data={"token": new_token, "distinct_id": "other id"})
             self.assertEqual(response.status_code, 429)
 
+    @patch("ee.billing.quota_limiting.list_limited_team_attributes")
+    def test_quota_limited_recordings_return_retry_after_header_when_enabled(
+        self, _kafka_produce, _fake_token_limiting
+    ) -> None:
+        from ee.billing.quota_limiting import QuotaResource
+
+        with self.settings(DECIDE_SESSION_REPLAY_QUOTA_CHECK=True):
+
+            def fake_limiter(*args, **kwargs):
+                return [self.team.api_token] if args[0] == QuotaResource.RECORDINGS else []
+
+            _fake_token_limiting.side_effect = fake_limiter
+
+            self._update_team(
+                {
+                    "session_recording_opt_in": True,
+                }
+            )
+
+            response = self._post_decide().json()
+            assert response["sessionRecording"] is False
+
     @patch("posthog.models.feature_flag.flag_analytics.CACHE_BUCKET_SIZE", 10)
     def test_decide_analytics_only_fires_when_enabled(self, *args):
         FeatureFlag.objects.create(

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -3173,7 +3173,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
 
             response = self._post_decide().json()
             assert response["sessionRecording"] is False
-            self.assertEqual(response["quotaLimited"], ["sessionRecording"])
+            assert response["quotaLimited"] == ["recordings"]
 
     @patch("ee.billing.quota_limiting.list_limited_team_attributes")
     def test_quota_limited_recordings_other_token(self, _fake_token_limiting, *args):
@@ -3194,6 +3194,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
 
             response = self._post_decide().json()
             assert response["sessionRecording"] is not False
+            assert not response["quotaLimited"]
 
     @patch("posthog.models.feature_flag.flag_analytics.CACHE_BUCKET_SIZE", 10)
     def test_decide_analytics_only_fires_when_enabled(self, *args):

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -3194,7 +3194,7 @@ class TestDecide(BaseTest, QueryMatchingTest):
 
             response = self._post_decide().json()
             assert response["sessionRecording"] is not False
-            assert not response["quotaLimited"]
+            assert not response.get("quotaLimited")
 
     @patch("posthog.models.feature_flag.flag_analytics.CACHE_BUCKET_SIZE", 10)
     def test_decide_analytics_only_fires_when_enabled(self, *args):

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -45,6 +45,9 @@ DECIDE_SKIP_HASH_KEY_OVERRIDE_WRITES = get_from_env(
     "DECIDE_SKIP_HASH_KEY_OVERRIDE_WRITES", False, type_cast=str_to_bool
 )
 
+# if `true` we disable session replay if over quota
+DECIDE_SESSION_REPLAY_QUOTA_CHECK = get_from_env("DECIDE_SESSION_REPLAY_QUOTA_CHECK", False, type_cast=str_to_bool)
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
## Problem

When session replay is over the billing limit the client JS continues sending requests which we drop silently.

We recently added a change to change the capture response to include that it was over quota and to stop subsequent sends, but we still send the first one.

Include it in the decide check to prevent this (this also means we can be more flexible with our capture response and not necessarily need to include the quota limit there)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
