### PR TITLE
fix(actions): ignore bytecode error

### DIFF
--- a/frontend/src/scenes/actions/ActionEdit.tsx
+++ b/frontend/src/scenes/actions/ActionEdit.tsx
@@ -1,4 +1,4 @@
-import { IconInfo, IconPlus, IconWarning } from '@posthog/icons'
+import { IconInfo, IconPlus } from '@posthog/icons'
 import { LemonBanner, LemonCheckbox, LemonTextArea } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
@@ -227,19 +227,12 @@ export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): 
                                     <LemonCheckbox
                                         id="webhook-checkbox"
                                         bordered
-                                        checked={action.bytecode_error ? false : !!value}
+                                        checked={!!value}
                                         onChange={onChange}
-                                        disabledReason={
-                                            !slackEnabled
-                                                ? 'Configure webhooks in project settings'
-                                                : action.bytecode_error ?? null
-                                        }
+                                        disabledReason={!slackEnabled ? 'Configure webhooks in project settings' : null}
                                         label={
                                             <>
                                                 <span>Post to webhook when this action is triggered.</span>
-                                                {action.bytecode_error ? (
-                                                    <IconWarning className="text-warning text-xl ml-1" />
-                                                ) : null}
                                             </>
                                         }
                                     />
@@ -251,7 +244,7 @@ export function ActionEdit({ action: loadedAction, id }: ActionEditLogicProps): 
                         </LemonField>
                         {action.post_to_slack && (
                             <>
-                                {!action.bytecode_error && action.post_to_slack && (
+                                {action.post_to_slack && (
                                     <>
                                         <LemonField name="slack_message_format">
                                             {({ value, onChange }) => (


### PR DESCRIPTION
## Problem

This is a patch for users who can't enable webhooks on actions that match autocaptured element text.

The existing plugin server action matching does not use the bytecode field, and neither does the new system.

![Screenshot 2024-08-13 at 14 58 00](https://github.com/user-attachments/assets/9cc44885-59cf-4527-b9ef-bef7f5b3b15b)


## Changes

Ignore bytecode errors.

![Screenshot 2024-08-13 at 15 00 12](https://github.com/user-attachments/assets/ca200cd1-c131-487a-b8df-2a9ca48ad79d)

## How did you test this code?

![Screenshot 2024-08-13 at 15 00 05](https://github.com/user-attachments/assets/b2df62d1-3c2a-4b07-a04c-c04b9596d933)

