### PR TITLE
feat(hogvm): log when error in filter

### DIFF
--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -328,7 +328,8 @@ abstract class CdpConsumerBase {
 
                 // Find all functions that could need running
                 invocationGlobals.forEach((globals) => {
-                    const { matchingFunctions, nonMatchingFunctions } = this.hogExecutor.findMatchingFunctions(globals)
+                    const { matchingFunctions, nonMatchingFunctions, logs } =
+                        this.hogExecutor.findMatchingFunctions(globals)
 
                     possibleInvocations.push(
                         ...matchingFunctions.map((hogFunction) => ({
@@ -346,6 +347,14 @@ abstract class CdpConsumerBase {
                             count: 1,
                         })
                     )
+
+                    logs.forEach((log) => {
+                        this.messagesToProduce.push({
+                            topic: KAFKA_LOG_ENTRIES,
+                            value: log,
+                            key: log.instance_id,
+                        })
+                    })
                 })
 
                 const states = await this.hogWatcher.getStates(possibleInvocations.map((x) => x.hogFunction.id))


### PR DESCRIPTION
## Problem

If HogVM throws any error during CDP event filtering, it's lost (except for pod logs).

## Changes

Logs an error each time something in the filter throws.

## How did you test this code?

I'm not sure how to test it. I couldn't come up with a HogQL expression that would throw... and would prefer to fix any that actually do manage to throw. Thus there's no actual test either :/.

I added a manual throw in the middle here:

![Screenshot 2024-08-13 at 16 20 44](https://github.com/user-attachments/assets/1595b3bd-f034-4a3b-9ac0-598863f1f5a4)

and got it to show up in the logs:

![Screenshot 2024-08-13 at 16 20 37](https://github.com/user-attachments/assets/4a0933df-bd48-4b70-a9a8-fb2a0cfb47e4)
