### PR TITLE
ci(frontend): Run frontend CI when frontend deps change

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -42,6 +42,8 @@ jobs:
                         - .eslintrc.js
                         - .prettier*
                         - babel.config.js
+                        - package.json
+                        - pnpm-lock.yaml
                         - jest.*.ts
                         - tsconfig.json
                         - tsconfig.*.json

--- a/frontend/src/toolbar/elements/heatmapLogic.ts
+++ b/frontend/src/toolbar/elements/heatmapLogic.ts
@@ -437,7 +437,8 @@ export const heatmapLogic = kea<heatmapLogicType>([
         scrollDepthPosthogJsError: [
             (s) => [s.posthog],
             (posthog: PostHog): 'version' | 'disabled' | null => {
-                const posthogVersion = posthog?._calculate_event_properties('test', {})?.['$lib_version'] ?? '0.0.0'
+                const posthogVersion =
+                    posthog?._calculate_event_properties('test', {}, new Date())?.['$lib_version'] ?? '0.0.0'
                 const majorMinorVersion = posthogVersion.split('.')
                 const majorVersion = parseInt(majorMinorVersion[0], 10)
                 const minorVersion = parseInt(majorMinorVersion[1], 10)


### PR DESCRIPTION
## Problem

A posthog-js upgrade with a typing-breaking change [got into master accidentally](https://github.com/PostHog/posthog/pull/24334), because these days frontend CI only runs when frontend code is changed… and that check hasn't been accounting for `package.json`/`pnpm-lock.yaml`. [See internal Slack thread.](https://posthog.slack.com/archives/C0113360FFV/p1723554147430709)

## Changes

Let's look at `package.json`/`pnpm-lock.yaml` too.