### PR TITLE
fix(batch-exports): Make Postgres UniqueViolation not retryable

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -658,6 +658,9 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
                 "InsufficientPrivilege",
                 # Issue with exported data compared to schema, retrying won't help.
                 "NotNullViolation",
+                # A user added a unique constraint on their table, but batch exports (particularly events)
+                # can cause duplicates.
+                "UniqueViolation",
             ],
             finish_inputs=finish_inputs,
         )


### PR DESCRIPTION
## Problem

Our events model PostgreSQL batch export does not create any constraints, including primary keys. However, constraints can be added by users. In this case, batch exports can continuously retry on an error that unfortunately will never be fixed.

Ultimately, for Postgres, we should probably `COPY` into a temporary table first, and then do a `INSERT INTO ... ON CONFLICT`. However, our current setup does not make use of temporary tables for the events model. 

In the meantime, at least let's not keep on retrying.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Add `UniqueViolation` as a non-retryable error.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
