### PR TITLE
fix(data-warehouse): Revert how we read delta s3 wrapped tables

### DIFF
--- a/posthog/hogql/database/s3_table.py
+++ b/posthog/hogql/database/s3_table.py
@@ -35,32 +35,32 @@ def build_function_call(
         return f"{substitute_params(expr, raw_params)})"
 
     # DeltaS3Wrapper format
-    if format == "DeltaS3Wrapper":
-        if url.endswith("/"):
-            escaped_url = add_param(f"{url}*.zstd.parquet")
-        else:
-            escaped_url = add_param(f"{url}/*.zstd.parquet")
+    # if format == "DeltaS3Wrapper":
+    #     if url.endswith("/"):
+    #         escaped_url = add_param(f"{url}*.zstd.parquet")
+    #     else:
+    #         escaped_url = add_param(f"{url}/*.zstd.parquet")
 
-        if structure:
-            escaped_structure = add_param(structure, False)
+    #     if structure:
+    #         escaped_structure = add_param(structure, False)
 
-        expr = f"s3({escaped_url}"
+    #     expr = f"s3({escaped_url}"
 
-        if access_key and access_secret:
-            escaped_access_key = add_param(access_key)
-            escaped_access_secret = add_param(access_secret)
+    #     if access_key and access_secret:
+    #         escaped_access_key = add_param(access_key)
+    #         escaped_access_secret = add_param(access_secret)
 
-            expr += f", {escaped_access_key}, {escaped_access_secret}"
+    #         expr += f", {escaped_access_key}, {escaped_access_secret}"
 
-        expr += ", 'Parquet'"
+    #     expr += ", 'Parquet'"
 
-        if structure:
-            expr += f", {escaped_structure}"
+    #     if structure:
+    #         expr += f", {escaped_structure}"
 
-        return return_expr(expr)
+    #     return return_expr(expr)
 
     # Delta format
-    if format == "Delta":
+    if format == "Delta" or format == "DeltaS3Wrapper":
         escaped_url = add_param(url)
         if structure:
             escaped_structure = add_param(structure, False)

--- a/posthog/hogql/database/test/test_s3_table.py
+++ b/posthog/hogql/database/test/test_s3_table.py
@@ -219,23 +219,23 @@ class TestS3Table(BaseTest):
         res = build_function_call("http://url.com", DataWarehouseTable.TableFormat.Delta, "key", "secret", None, None)
         assert res == "deltaLake('http://url.com', 'key', 'secret')"
 
-    def test_s3_build_function_call_without_context_and_deltaS3Wrapper_format(self):
-        res = build_function_call(
-            "http://url.com", DataWarehouseTable.TableFormat.DeltaS3Wrapper, "key", "secret", None, None
-        )
-        assert res == "s3('http://url.com/*.zstd.parquet', 'key', 'secret', 'Parquet')"
+    # def test_s3_build_function_call_without_context_and_deltaS3Wrapper_format(self):
+    #     res = build_function_call(
+    #         "http://url.com", DataWarehouseTable.TableFormat.DeltaS3Wrapper, "key", "secret", None, None
+    #     )
+    #     assert res == "s3('http://url.com/*.zstd.parquet', 'key', 'secret', 'Parquet')"
 
-    def test_s3_build_function_call_without_context_and_deltaS3Wrapper_format_with_slash(self):
-        res = build_function_call(
-            "http://url.com/", DataWarehouseTable.TableFormat.DeltaS3Wrapper, "key", "secret", None, None
-        )
-        assert res == "s3('http://url.com/*.zstd.parquet', 'key', 'secret', 'Parquet')"
+    # def test_s3_build_function_call_without_context_and_deltaS3Wrapper_format_with_slash(self):
+    #     res = build_function_call(
+    #         "http://url.com/", DataWarehouseTable.TableFormat.DeltaS3Wrapper, "key", "secret", None, None
+    #     )
+    #     assert res == "s3('http://url.com/*.zstd.parquet', 'key', 'secret', 'Parquet')"
 
-    def test_s3_build_function_call_without_context_and_deltaS3Wrapper_format_with_structure(self):
-        res = build_function_call(
-            "http://url.com/", DataWarehouseTable.TableFormat.DeltaS3Wrapper, "key", "secret", "some structure", None
-        )
-        assert res == "s3('http://url.com/*.zstd.parquet', 'key', 'secret', 'Parquet', 'some structure')"
+    # def test_s3_build_function_call_without_context_and_deltaS3Wrapper_format_with_structure(self):
+    #     res = build_function_call(
+    #         "http://url.com/", DataWarehouseTable.TableFormat.DeltaS3Wrapper, "key", "secret", "some structure", None
+    #     )
+    #     assert res == "s3('http://url.com/*.zstd.parquet', 'key', 'secret', 'Parquet', 'some structure')"
 
     def test_s3_build_function_call_without_context_and_delta_format_and_with_structure(self):
         res = build_function_call(


### PR DESCRIPTION
## Problem
- This doesn't work as I was expecting on prod data. We're reading duplicate data via this method 

## Changes
- Revert how we read the new table format until I can look into how to do this properly again 
