### PR TITLE
chore: bring back TK's event properties

### DIFF
--- a/posthog/clickhouse/migrations/0076_add_custom_and_features_property_groups_events_retry2.py
+++ b/posthog/clickhouse/migrations/0076_add_custom_and_features_property_groups_events_retry2.py
@@ -1,0 +1,10 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.property_groups import property_groups
+
+operations = [
+    run_sql_with_exceptions(statement)
+    for statement in [
+        *property_groups.get_alter_create_statements("events", "properties", "custom"),
+        *property_groups.get_alter_create_statements("events", "properties", "feature_flags"),
+    ]
+]


### PR DESCRIPTION
## Problem

We punted on this last night because of a stuck distributed DDL. That is now clear. Let's try again

## Changes

Bring back `0075`'s migrations

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
