### PR TITLE
fix: usage is non-zero if has rows_synced

### DIFF
--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -39,7 +39,6 @@ from posthog.utils import (
     get_machine_id,
     get_previous_day,
 )
-
 from posthog.warehouse.models import ExternalDataJob
 
 logger = structlog.get_logger(__name__)
@@ -641,6 +640,7 @@ def has_non_zero_usage(report: FullUsageReport) -> bool:
         or report.decide_requests_count_in_period > 0
         or report.local_evaluation_requests_count_in_period > 0
         or report.survey_responses_count_in_period > 0
+        or report.rows_synced_in_period > 0
     )
 
 


### PR DESCRIPTION
## Problem

DW usage wasn't being counted as billable, so usage reports weren't being sent for companies with non-zero DW usage but zero everything-else usage

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Looks for non-zero rows_synced to determine if report should be sent

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Ya

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

I wonder if anything will fail 😄 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
