### PR TITLE
ci(backend): Fix Actions ternary operator faking

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -373,10 +373,8 @@ jobs:
         if: # Run on pull requests to PostHog/posthog + on PostHog/posthog outside of PRs - but never on forks
             needs.changes.outputs.backend == 'true' &&
             (
-            github.event_name == 'pull_request' &&
-            github.event.pull_request.head.repo.full_name == 'PostHog/posthog' ||
-            github.repository == 'PostHog/posthog'
-            )
+            github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository
+            ) == 'PostHog/posthog'
         steps:
             - name: Calculate running time
               run: |


### PR DESCRIPTION
## Problem

Follow-up to #24320.
For some reasons beyond me, GH Actions doesn't have any ternary conditional operator, so we have to do `condition && "foo" || "bar"`, which _almost_ acts like one – e.g. in this example it evaluates to "foo" if `condition` is true. But this breaks down when "foo" can be a falsy value: `true && false || true` evaluates to true.

## Changes

Fixes the comparison that prevents CI running time calculation from failing on forks. Let's only use strings (truthy) inside the pseudo-ternary, and not bools (potentially false).