### PR TITLE
fix(cdp): Customerio destination use person properties for identify

### DIFF
--- a/posthog/cdp/templates/customerio/template_customerio.py
+++ b/posthog/cdp/templates/customerio/template_customerio.py
@@ -141,7 +141,7 @@ if (res.status >= 400) {
             "key": "include_all_properties",
             "type": "boolean",
             "label": "Include all properties as attributes",
-            "description": "If set, all event properties will be included as attributes. Individual attributes can be overridden below.",
+            "description": "If set, all event properties will be included as attributes. Individual attributes can be overridden below. For identify events the Person properties will be used.",
             "default": False,
             "secret": False,
             "required": True,

--- a/posthog/cdp/templates/customerio/template_customerio.py
+++ b/posthog/cdp/templates/customerio/template_customerio.py
@@ -27,8 +27,7 @@ if (action == 'automatic') {
     }
 }
 
-let attributes := inputs.include_all_properties ? event.properties : {}
-
+let attributes := inputs.include_all_properties ? action == 'identify' ? person.properties : event.properties : {}
 let timestamp := toInt(toUnixTimestamp(toDateTime(event.timestamp)))
 
 for (let key, value in inputs.attributes) {

--- a/posthog/cdp/templates/customerio/test_template_customerio.py
+++ b/posthog/cdp/templates/customerio/test_template_customerio.py
@@ -62,6 +62,12 @@ class TestTemplateCustomerio(BaseHogFunctionTemplateTest):
             {"$current_url": "https://example.com", "name": "example"}
         )
 
+        self.run_function(inputs=create_inputs(include_all_properties=True, action="identify"))
+
+        assert self.get_mock_fetch_calls()[0][1]["body"]["attributes"] == snapshot(
+            {"email": "example@posthog.com", "name": "example"}
+        )
+
     def test_automatic_action_mapping(self):
         for event_name, expected_action in [
             ("$identify", "identify"),


### PR DESCRIPTION
## Problem

Identify calls currently adds the event properties if the setting is given where it should really include person properties

## Changes

* Makes the update and adds a test

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
