### PR TITLE
fix: Start non-worker celery command with app.start()

### DIFF
--- a/.run/Celery Beat.run.xml
+++ b/.run/Celery Beat.run.xml
@@ -1,0 +1,31 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Celery Beat" type="PythonConfigurationType" factoryName="Python">
+    <module name="posthog" />
+    <option name="ENV_FILES" value="$PROJECT_DIR$/bin/celery-queues.env" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="CLICKHOUSE_SECURE" value="False" />
+      <env name="DATABASE_URL" value="postgres://posthog:posthog@localhost:5432/posthog" />
+      <env name="DEBUG" value="1" />
+      <env name="KAFKA_HOSTS" value="localhost" />
+      <env name="SKIP_SERVICE_VERSION_REQUIREMENTS" value="1" />
+      <env name="REPLAY_EMBEDDINGS_ALLOWED_TEAM" value="1,2,3" />
+    </envs>
+    <option name="SDK_HOME" value="$PROJECT_DIR$/env/bin/python" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/manage.py" />
+    <option name="PARAMETERS" value="run_autoreload_celery --type=beat" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Dev.run.xml
+++ b/.run/Dev.run.xml
@@ -3,6 +3,7 @@
     <toRun name="PostHog" type="Python.DjangoServer" />
     <toRun name="Frontend" type="js.build_tools.npm" />
     <toRun name="Plugin Server" type="js.build_tools.npm" />
+    <toRun name="Celery Beat" type="PythonConfigurationType" />
     <toRun name="Celery Threads" type="PythonConfigurationType" />
     <method v="2" />
   </configuration>

--- a/posthog/management/commands/run_autoreload_celery.py
+++ b/posthog/management/commands/run_autoreload_celery.py
@@ -1,4 +1,5 @@
 from typing import Literal
+
 import django
 from django.core.management.base import BaseCommand
 
@@ -41,4 +42,7 @@ class Command(BaseCommand):
             ]
         )
 
-        celery_app.worker_main(args)
+        if type == "worker":
+            celery_app.worker_main(args)
+        else:
+            celery_app.start(args)


### PR DESCRIPTION
## Problem

Getting the following error when trying to run PostHog locally:

```
Traceback (most recent call last):
  File "/.../threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/.../threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/.../site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/.../posthog/management/commands/run_autoreload_celery.py", line 20, in <lambda>
    autoreload.run_with_reloader(lambda: self.run_celery_worker(options["type"]))
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.../posthog/management/commands/run_autoreload_celery.py", line 44, in run_celery_worker
    celery_app.worker_main(args)
  File "/.../site-packages/celery/app/base.py", line 383, in worker_main
    raise ValueError(
ValueError: The worker sub-command must be specified in argv.
Use app.start() to programmatically start other commands.
```

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Follow the recommendation to use `app.start()` when worker is not specified.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

It runs on my machine :shipit: 
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
