### PR TITLE
fix: docker was not building for live events

### DIFF
--- a/livestream/Dockerfile
+++ b/livestream/Dockerfile
@@ -5,7 +5,7 @@ RUN go mod download -x
 
 COPY . ./
 RUN go get ./...
-RUN go build -v -o /livestream ./...
+RUN go build -v -o livestream .
 
 # Fetch the GeoLite2-City database that will be used for IP geolocation within Django.
 RUN apt-get update && \

--- a/livestream/Dockerfile
+++ b/livestream/Dockerfile
@@ -5,7 +5,7 @@ RUN go mod download -x
 
 COPY . ./
 RUN go get ./...
-RUN go build -v -o livestream .
+RUN go build -v -o /livestream .
 
 # Fetch the GeoLite2-City database that will be used for IP geolocation within Django.
 RUN apt-get update && \


### PR DESCRIPTION
## Problem

Docker was failing to build new liveevents container

## Changes

This fixes the issue

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
