### PR TITLE
fix: Fix TTL to be time.Second based

### DIFF
--- a/livestream/live_stats.go
+++ b/livestream/live_stats.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	COUNTER_TTL = 60
+	COUNTER_TTL = time.Second * 60
 )
 
 type Stats struct {
@@ -20,7 +20,7 @@ type Stats struct {
 func newStatsKeeper() *Stats {
 	return &Stats{
 		Store:       make(map[string]*expirable.LRU[string, string]),
-		GlobalStore: expirable.NewLRU[string, string](0, nil, time.Second*COUNTER_TTL),
+		GlobalStore: expirable.NewLRU[string, string](0, nil, COUNTER_TTL),
 		Counter:     NewSlidingWindowCounter(COUNTER_TTL),
 	}
 }
@@ -34,7 +34,7 @@ func (ts *Stats) keepStats(statsChan chan PostHogEvent) {
 			ts.Counter.Increment()
 			token := event.Token
 			if _, ok := ts.Store[token]; !ok {
-				ts.Store[token] = expirable.NewLRU[string, string](0, nil, time.Second*COUNTER_TTL)
+				ts.Store[token] = expirable.NewLRU[string, string](0, nil, COUNTER_TTL)
 			}
 			ts.Store[token].Add(event.DistinctId, "1")
 			ts.GlobalStore.Add(event.DistinctId, "1")

--- a/livestream/live_stats.go
+++ b/livestream/live_stats.go
@@ -28,16 +28,13 @@ func newStatsKeeper() *Stats {
 func (ts *Stats) keepStats(statsChan chan PostHogEvent) {
 	log.Println("starting stats keeper...")
 
-	for { // ignore the range warning here - it's wrong
-		select {
-		case event := <-statsChan:
-			ts.Counter.Increment()
-			token := event.Token
-			if _, ok := ts.Store[token]; !ok {
-				ts.Store[token] = expirable.NewLRU[string, string](0, nil, COUNTER_TTL)
-			}
-			ts.Store[token].Add(event.DistinctId, "1")
-			ts.GlobalStore.Add(event.DistinctId, "1")
+	for event := range statsChan {
+		ts.Counter.Increment()
+		token := event.Token
+		if _, ok := ts.Store[token]; !ok {
+			ts.Store[token] = expirable.NewLRU[string, string](0, nil, COUNTER_TTL)
 		}
+		ts.Store[token].Add(event.DistinctId, "1")
+		ts.GlobalStore.Add(event.DistinctId, "1")
 	}
 }

--- a/livestream/served.go
+++ b/livestream/served.go
@@ -10,8 +10,8 @@ import (
 )
 
 type Counter struct {
-	EventCount uint32
-	UserCount  uint32
+	EventCount int
+	UserCount  int
 }
 
 func servedHandler(stats *Stats) func(c echo.Context) error {
@@ -19,8 +19,8 @@ func servedHandler(stats *Stats) func(c echo.Context) error {
 		userCount := stats.GlobalStore.Len()
 		count := stats.Counter.Count()
 		resp := Counter{
-			EventCount: uint32(count),
-			UserCount:  uint32(userCount),
+			EventCount: count,
+			UserCount:  userCount,
 		}
 		return c.JSON(http.StatusOK, resp)
 	}


### PR DESCRIPTION
## Problem

Passed the wrong type - needed to be `time.Second` based

## Changes

universally use 60 second time.Second TTL

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
