### PR TITLE
feat: Added check for no identifiers

### DIFF
--- a/posthog/cdp/templates/customerio/template_customerio.py
+++ b/posthog/cdp/templates/customerio/template_customerio.py
@@ -12,6 +12,19 @@ template: HogFunctionTemplate = HogFunctionTemplate(
 let action := inputs.action
 let name := event.name
 
+let hasIdentifier := false
+
+for (let key, value in inputs.identifiers) {
+    if (not empty(value)) {
+        hasIdentifier := true
+    }
+}
+
+if (not hasIdentifier) {
+    print('No identifier set. Skipping as at least 1 identifier is needed.')
+    return
+}
+
 if (action == 'automatic') {
     if (event.name == '$identify') {
         action := 'identify'

--- a/posthog/cdp/templates/customerio/test_template_customerio.py
+++ b/posthog/cdp/templates/customerio/test_template_customerio.py
@@ -102,3 +102,11 @@ class TestTemplateCustomerio(BaseHogFunctionTemplateTest):
 
             assert self.get_mock_fetch_calls()[0][1]["body"]["action"] == "event"
             assert self.get_mock_fetch_calls()[0][1]["body"]["name"] == event_name
+
+    def test_function_requires_identifier(self):
+        self.run_function(inputs=create_inputs(identifiers={"email": None, "id": ""}))
+
+        assert not self.get_mock_fetch_calls()
+        assert self.get_mock_print_calls() == snapshot(
+            [("No identifier set. Skipping as at least 1 identifier is needed.",)]
+        )


### PR DESCRIPTION
## Problem

The customer.io destination requires identifiers to be set but if they aren't it currently still calls the api and fails

## Changes

* Fix this to make it clearer in the log why a message wasn't sent.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
