### PR TITLE
fix(queries): Reduce cardinality of counter labels

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -43,7 +43,7 @@ CELERY_TASK_FAILURE_COUNTER = Counter(
 CELERY_TASK_RETRY_COUNTER = Counter(
     "posthog_celery_task_retry",
     "task retry signal is dispatched when a task will be retried.",
-    labelnames=["task_name", "reason"],
+    labelnames=["task_name", "reason"],  # Attention: Keep reason as low cardinality as possible
 )
 
 
@@ -146,7 +146,9 @@ def failure_signal_handler(sender, **kwargs):
 
 @task_retry.connect
 def retry_signal_handler(sender, reason, **kwargs):
-    CELERY_TASK_RETRY_COUNTER.labels(task_name=sender.name, reason=str(reason)).inc()
+    # Make reason low cardinality (e.g. only the exception type)
+    reason = reason.__class__.__name__
+    CELERY_TASK_RETRY_COUNTER.labels(task_name=sender.name, reason=reason).inc()
 
 
 @app.on_after_finalize.connect

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -11,7 +11,7 @@ from posthog import redis
 CONCURRENT_TASKS_LIMIT_EXCEEDED_COUNTER = Counter(
     "posthog_celery_task_concurrency_limit_exceeded",
     "Number of times a Celery task exceeded the concurrency limit",
-    ["task_name", "limit", "key"],
+    ["task_name", "limit"],
 )
 
 # Lua script for atomic check, remove expired if limit hit, and increment with TTL
@@ -64,9 +64,7 @@ def limit_concurrency(max_concurrent_tasks: int, key: Optional[Callable] = None,
                 redis_client.eval(lua_script, 1, running_tasks_key, current_time, task_id, max_concurrent_tasks, ttl)
                 == 0
             ):
-                CONCURRENT_TASKS_LIMIT_EXCEEDED_COUNTER.labels(
-                    task_name=task_name, limit=max_concurrent_tasks, key=dynamic_key
-                ).inc()
+                CONCURRENT_TASKS_LIMIT_EXCEEDED_COUNTER.labels(task_name=task_name, limit=max_concurrent_tasks).inc()
 
                 raise CeleryConcurrencyLimitExceeded(
                     f"Exceeded maximum concurrent tasks limit: {max_concurrent_tasks} for key: {dynamic_key}"


### PR DESCRIPTION
## Problem

After writing https://github.com/PostHog/posthog/pull/24310#discussion_r1714058407 I realized I did put Prometheus counter labels with too high cardinality.

## Changes

Reduce number of possible values or remove altogether.

## How did you test this code?

n/a