### PR TITLE
revert: "stop using forked vector now that they merged upstream"

### DIFF
--- a/vector/replay-capture/Dockerfile
+++ b/vector/replay-capture/Dockerfile
@@ -7,7 +7,9 @@ COPY vector.yaml .
 # evaluate with yq, basically to expand anchors (which vector doesn't support)
 RUN yq -i e 'explode(.)' vector.yaml
 
-# nightly vector to include this fix https://github.com/vectordotdev/vector/commit/dc0b4087095b4968cca0201e233919de8cff9918
-FROM timberio/vector@sha256:f30cba5e4efcf554aea09a3f970fc75a140750ded0095840a47a8b9c9571100c
+# fork of vector from this branch: https://github.com/frankh/vector/tree/main
+# includes 2 fixed: 1 to make Kafka temporary errors return 500 not 400
+# and 1 to allow us to set response body on the http source
+FROM frankh/vector:0.41.0-patched
 
 COPY --from=config-builder /config/vector.yaml /etc/vector/vector.yaml

--- a/vector/replay-capture/vector.yaml
+++ b/vector/replay-capture/vector.yaml
@@ -32,6 +32,7 @@ sources:
         query_parameters:
             - _
         host_key: ip
+        response_body_key: '%response'
         decoding:
             codec: vrl
             vrl:
@@ -61,6 +62,8 @@ sources:
                     assert!(is_string(.message[0].distinct_id), "distinct_id is required")
                     assert!(is_string(.message[0].properties."$$session_id"), "$$session_id is required")
                     assert!(is_string(%token), "token is required")
+
+                    %response = {"status": 1}
 
 transforms:
     quota_check:


### PR DESCRIPTION
Reverts PostHog/posthog#24325

the json response is actually important as we json parse it in the client so it errors out if empty, revert back to the fork until we can get this merged upstream or find another solution