### PR TITLE
feat(batch-exports): Add setting to start moving teams to async pyarrow

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -19,6 +19,7 @@ BATCH_EXPORT_HTTP_UPLOAD_CHUNK_SIZE_BYTES: int = 1024 * 1024 * 10  # 10MB
 BATCH_EXPORT_HTTP_BATCH_SIZE: int = 1000
 
 UNCONSTRAINED_TIMESTAMP_TEAM_IDS: list[str] = get_list(os.getenv("UNCONSTRAINED_TIMESTAMP_TEAM_IDS", ""))
+ASYNC_ARROW_STREAMING_TEAM_IDS: list[str] = get_list(os.getenv("ASYNC_ARROW_STREAMING_TEAM_IDS", ""))
 DEFAULT_TIMESTAMP_LOOKBACK_DAYS = 7
 # Comma separated list of overrides in the format "team_id:lookback_days"
 OVERRIDE_TIMESTAMP_TEAM_IDS: dict[int, int] = dict(

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -210,11 +210,11 @@ async def iter_records_from_model_view(
             parameters["include_events"] = []
 
         if str(team_id) in settings.UNCONSTRAINED_TIMESTAMP_TEAM_IDS:
-            query = SELECT_FROM_EVENTS_VIEW_UNBOUNDED
+            query_template = SELECT_FROM_EVENTS_VIEW_UNBOUNDED
         elif is_backfill:
-            query = SELECT_FROM_EVENTS_VIEW_BACKFILL
+            query_template = SELECT_FROM_EVENTS_VIEW_BACKFILL
         else:
-            query = SELECT_FROM_EVENTS_VIEW
+            query_template = SELECT_FROM_EVENTS_VIEW
             lookback_days = settings.OVERRIDE_TIMESTAMP_TEAM_IDS.get(team_id, settings.DEFAULT_TIMESTAMP_LOOKBACK_DAYS)
             parameters["lookback_days"] = lookback_days
 
@@ -225,7 +225,7 @@ async def iter_records_from_model_view(
 
         query_fields = ",".join(f"{field['expression']} AS {field['alias']}" for field in fields + control_fields)
 
-        view = query.substitute(fields=query_fields)
+        view = query_template.substitute(fields=query_fields)
 
     parameters["team_id"] = team_id
     parameters["interval_start"] = dt.datetime.fromisoformat(interval_start).strftime("%Y-%m-%d %H:%M:%S")

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -84,7 +84,6 @@ SELECT
 FROM
     events_batch_export_unbounded(
         team_id={team_id},
-        lookback_days={lookback_days},
         interval_start={interval_start},
         interval_end={interval_end},
         include_events={include_events}::Array(String),


### PR DESCRIPTION
## Problem

When we released Persons batch exports we also released a new async implementation to stream ArrowStream chunks from ClickHouse (See https://github.com/PostHog/posthog/blob/master/posthog/temporal/common/asyncpa.py). So far, no errors have been attributed to the async implementation. In particular, no `ConnectionBroken` or similar `IncompleteRead` errors appear in our list of failures for `persons` batch exports. Since these crop up frequently in `events` batch exports, and because having more async code should mean healthier workers, let's start moving batch exports over to asyncpa. We'll start with those teams that are suffering from those errors the most, usually teams with larger exports.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Adds a setting to choose which team_ids will use async streaming for ArrowStream in `events` batch export.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
