### PR TITLE
chore(batch-exports): Add SnowflakeConnectionError as non-retryable

### DIFF
--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -758,6 +758,9 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
                 "ProgrammingError",
                 # Raised by Snowflake with an incorrect account name.
                 "ForbiddenError",
+                # Seems to be raised when we can't connect to Snowflake due to invalid parameters like
+                # an invalid account.
+                "OperationalError",
             ],
             finish_inputs=finish_inputs,
         )


### PR DESCRIPTION
## Problem

Another export that's been erroring out constantly for something that's not on us: On invalid configuration Snowflake will raise an `OperationalError`. It seems to be a generic error used in other parts, so instead I'll be catching and re-raising our own exception that we can set safely as non-retryable.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
* Set `SnowflakeConnectionError` as non-retryable.
* Re-raise `OperationalError` as `SnowflakeConnectionError` when calling `connect()` fails.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Manually triggered the error with incorrect parameters trying to connect with the snowflake CLI.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
