### PR TITLE
chore(data-warehouse): Drop local pipeline files after the DLT pipeline is done

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline.py
@@ -224,6 +224,9 @@ class DataImportPipeline:
                     row_count=total_counts.total(),
                 )
 
+        # Delete local state from the file system
+        pipeline.drop()
+
         return dict(total_counts)
 
     async def run(self) -> dict[str, int]:


### PR DESCRIPTION
## Problem
- Long living temporal workers are filling up with local DLT files and getting killed due to running out of space

## Changes
Drop the local pipeline files after the pipeline has finished

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested locally