### PR TITLE
feat(bi): Use table settings for rendering the big number

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -23,13 +23,13 @@ import { AxisSeries, dataVisualizationLogic } from '../dataVisualizationLogic'
 import { ySeriesLogic, YSeriesLogicProps, YSeriesSettingsTab } from './ySeriesLogic'
 
 export const SeriesTab = (): JSX.Element => {
-    const { columns, numericalColumns, xData, yData, responseLoading, isTableVisualization, tabularColumns } =
+    const { columns, numericalColumns, xData, yData, responseLoading, showTableSettings, tabularColumns } =
         useValues(dataVisualizationLogic)
     const { updateXSeries, addYSeries } = useActions(dataVisualizationLogic)
 
     const hideAddYSeries = yData.length >= numericalColumns.length
 
-    if (isTableVisualization) {
+    if (showTableSettings) {
         return (
             <div className="flex flex-col w-full">
                 <LemonLabel>Columns</LemonLabel>
@@ -87,7 +87,7 @@ export const SeriesTab = (): JSX.Element => {
 }
 
 const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number }): JSX.Element => {
-    const { columns, numericalColumns, responseLoading, dataVisualizationProps, isTableVisualization } =
+    const { columns, numericalColumns, responseLoading, dataVisualizationProps, showTableSettings } =
         useValues(dataVisualizationLogic)
     const { updateSeriesIndex, deleteYSeries } = useActions(dataVisualizationLogic)
 
@@ -100,12 +100,12 @@ const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number 
     const { isDarkModeOn } = useValues(themeLogic)
     const seriesColor = getSeriesColor(index)
 
-    const columnsInOptions = isTableVisualization ? columns : numericalColumns
+    const columnsInOptions = showTableSettings ? columns : numericalColumns
     const options = columnsInOptions.map(({ name, type }) => ({
         value: name,
         label: (
             <div className="items-center flex flex-1">
-                {!isTableVisualization && (
+                {!showTableSettings && (
                     <SeriesGlyph
                         style={{
                             borderColor: seriesColor,
@@ -172,7 +172,7 @@ const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number 
                     disabledReasonWrapperClass="flex"
                 />
             </Popover>
-            {!isTableVisualization && (
+            {!showTableSettings && (
                 <LemonButton
                     key="delete"
                     icon={<IconTrash />}
@@ -216,14 +216,14 @@ const YSeriesFormattingTab = ({ ySeriesLogicProps }: { ySeriesLogicProps: YSerie
 }
 
 const YSeriesDisplayTab = ({ ySeriesLogicProps }: { ySeriesLogicProps: YSeriesLogicProps }): JSX.Element => {
-    const { isTableVisualization } = useValues(dataVisualizationLogic)
+    const { showTableSettings } = useValues(dataVisualizationLogic)
 
     return (
         <Form logic={ySeriesLogic} props={ySeriesLogicProps} formKey="display" className="space-y-4">
             <LemonField name="label" label="Label">
                 <LemonInput />
             </LemonField>
-            {!isTableVisualization && (
+            {!showTableSettings && (
                 <>
                     <LemonField name="trendLine" label="Trend line">
                         {({ value, onChange }) => (

--- a/frontend/src/queries/nodes/DataVisualization/Components/SideBar.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SideBar.tsx
@@ -24,7 +24,8 @@ const TABS_TO_CONTENT: Record<SideBarTab, TabContent> = {
     [SideBarTab.Display]: {
         label: 'Display',
         content: <DisplayTab />,
-        shouldShow: (displayType: ChartDisplayType): boolean => displayType !== ChartDisplayType.ActionsTable,
+        shouldShow: (displayType: ChartDisplayType): boolean =>
+            displayType !== ChartDisplayType.ActionsTable && displayType !== ChartDisplayType.BoldNumber,
     },
 }
 

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -624,6 +624,12 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             (state) => [state.visualizationType],
             (visualizationType): boolean => visualizationType === ChartDisplayType.ActionsTable,
         ],
+        showTableSettings: [
+            (state) => [state.visualizationType],
+            (visualizationType): boolean =>
+                visualizationType === ChartDisplayType.ActionsTable ||
+                visualizationType === ChartDisplayType.BoldNumber,
+        ],
     }),
     listeners(({ props, actions }) => ({
         updateChartSettings: ({ settings }) => {

--- a/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
+++ b/frontend/src/scenes/insights/views/BoldNumber/BoldNumber.tsx
@@ -210,22 +210,21 @@ function BoldNumberComparison({ showPersonsModal }: Pick<ChartParams, 'showPerso
 }
 
 export function HogQLBoldNumber(): JSX.Element {
-    const { response, responseLoading } = useValues(dataVisualizationLogic)
+    const { response, responseLoading, tabularData } = useValues(dataVisualizationLogic)
 
     const displayValue =
         ((!response || responseLoading) && 'Loading...') ||
+        tabularData?.[0]?.[0] ||
         response?.[0]?.[0] ||
         response?.results?.[0]?.[0] ||
         response?.result?.[0]?.[0] ||
         'Error'
 
-    const isNumber = typeof displayValue === 'number'
-
     return (
         <div className="BoldNumber LemonTable HogQL">
             <div className="BoldNumber__value">
                 <Textfit min={32} max={120}>
-                    {`${isNumber ? displayValue.toLocaleString() : displayValue}`}
+                    {displayValue}
                 </Textfit>
             </div>
         </div>


### PR DESCRIPTION
## Problem
The bold number viz in BI doesnt use the chart settings 😱 

## Changes
- Use the settings to render the value (e.g. prefix, number style, etc)

<img width="1178" alt="image" src="https://github.com/user-attachments/assets/1a7eb71d-42b8-4a75-8c2e-f7234368f8e8">


## Does this work well for both Cloud and self-hosted?
Yup

## How did you test this code?
👀 