### PR TITLE
feat(experiments): ship winning variant from Experiment UI

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -210,7 +210,7 @@ export const FEATURE_FLAGS = {
     MULTITAB_EDITOR: 'multitab-editor', // owner: @EDsCODE #team-data-warehouse
     WEB_ANALYTICS_REPLAY: 'web-analytics-replay', // owner: @robbie-c
     BATCH_EXPORTS_POSTHOG_HTTP: 'posthog-http-batch-exports',
-    EXPERIMENT_MAKE_DECISION: 'experiment-make-decision', // owner: @jurajmajerik #team-data-warehouse
+    EXPERIMENT_MAKE_DECISION: 'experiment-make-decision', // owner: @jurajmajerik #team-feature-success
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -210,6 +210,7 @@ export const FEATURE_FLAGS = {
     MULTITAB_EDITOR: 'multitab-editor', // owner: @EDsCODE #team-data-warehouse
     WEB_ANALYTICS_REPLAY: 'web-analytics-replay', // owner: @robbie-c
     BATCH_EXPORTS_POSTHOG_HTTP: 'posthog-http-batch-exports',
+    EXPERIMENT_MAKE_DECISION: 'experiment-make-decision', // owner: @jurajmajerik #team-data-warehouse
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -10,7 +10,7 @@ import { experimentLogic } from '../experimentLogic'
 import { VariantTag } from './components'
 
 export function DistributionTable(): JSX.Element {
-    const { experiment, experimentResults } = useValues(experimentLogic)
+    const { experimentId, experiment, experimentResults } = useValues(experimentLogic)
 
     const columns: LemonTableColumns<MultivariateFlagVariant> = [
         {
@@ -21,7 +21,7 @@ export function DistributionTable(): JSX.Element {
                 if (!experimentResults || !experimentResults.insight) {
                     return <span className="font-semibold">{item.key}</span>
                 }
-                return <VariantTag variantKey={item.key} />
+                return <VariantTag experimentId={experimentId} variantKey={item.key} />
             },
         },
         {

--- a/frontend/src/scenes/experiments/ExperimentView/Overview.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Overview.tsx
@@ -9,6 +9,7 @@ import { VariantTag } from './components'
 
 export function Overview(): JSX.Element {
     const {
+        experimentId,
         experimentResults,
         getIndexForVariant,
         experimentInsightType,
@@ -43,13 +44,13 @@ export function Overview(): JSX.Element {
 
             return (
                 <div className="items-center inline-flex flex-wrap">
-                    <VariantTag variantKey={winningVariant.key} />
+                    <VariantTag experimentId={experimentId} variantKey={winningVariant.key} />
                     <span>&nbsp;is winning with a conversion rate&nbsp;</span>
                     <span className="font-semibold text-success items-center">
                         increase of {`${difference.toFixed(2)}%`}
                     </span>
                     <span>&nbsp;percentage points (vs&nbsp;</span>
-                    <VariantTag variantKey={comparisonVariant.key} />
+                    <VariantTag experimentId={experimentId} variantKey={comparisonVariant.key} />
                     <span>).&nbsp;</span>
                 </div>
             )
@@ -62,7 +63,7 @@ export function Overview(): JSX.Element {
 
             return (
                 <div className="items-center inline-flex flex-wrap">
-                    <VariantTag variantKey={highestProbabilityVariant} />
+                    <VariantTag experimentId={experimentId} variantKey={highestProbabilityVariant} />
                     <span>&nbsp;is winning with a&nbsp;</span>
                     <span className="font-semibold text-success items-center">
                         {`${(probability[highestProbabilityVariant] * 100).toFixed(2)}% probability`}&nbsp;

--- a/frontend/src/scenes/experiments/ExperimentView/SecondaryMetricsTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SecondaryMetricsTable.tsx
@@ -146,7 +146,7 @@ export function SecondaryMetricsTable({
                         }
                         return (
                             <div className="flex items-center py-2">
-                                <VariantTag variantKey={item.variant} />
+                                <VariantTag experimentId={experimentId} variantKey={item.variant} />
                             </div>
                         )
                     },

--- a/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
@@ -19,6 +19,7 @@ import { VariantTag } from './components'
 
 export function SummaryTable(): JSX.Element {
     const {
+        experimentId,
         experimentResults,
         tabularExperimentResults,
         experimentInsightType,
@@ -43,7 +44,7 @@ export function SummaryTable(): JSX.Element {
             render: function Key(_, item): JSX.Element {
                 return (
                     <div className="flex items-center">
-                        <VariantTag variantKey={item.key} />
+                        <VariantTag experimentId={experimentId} variantKey={item.key} />
                     </div>
                 )
             },

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -1,11 +1,13 @@
 import '../Experiment.scss'
 
-import { IconArchive, IconCheck, IconX } from '@posthog/icons'
+import { IconArchive, IconCheck, IconMagicWand, IconX } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
     LemonDialog,
     LemonDivider,
+    LemonModal,
+    LemonSelect,
     LemonSkeleton,
     LemonTag,
     LemonTagType,
@@ -16,23 +18,38 @@ import { useActions, useValues } from 'kea'
 import { AnimationType } from 'lib/animations/animations'
 import { Animation } from 'lib/components/Animation/Animation'
 import { PageHeader } from 'lib/components/PageHeader'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { IconAreaChart } from 'lib/lemon-ui/icons'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { useEffect, useState } from 'react'
 import { urls } from 'scenes/urls'
 
+import { groupsModel } from '~/models/groupsModel'
 import { filtersToQueryNode } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
 import { Query } from '~/queries/Query/Query'
 import { InsightVizNode, NodeKind } from '~/queries/schema'
-import { Experiment as ExperimentType, ExperimentResults, FilterType, InsightShortId, InsightType } from '~/types'
+import {
+    Experiment,
+    Experiment as ExperimentType,
+    ExperimentResults,
+    FilterType,
+    InsightShortId,
+    InsightType,
+} from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
 import { getExperimentStatus, getExperimentStatusColor } from '../experimentsLogic'
 import { getExperimentInsightColour, transformResultFilters } from '../utils'
 
-export function VariantTag({ variantKey }: { variantKey: string }): JSX.Element {
-    const { experimentResults, getIndexForVariant } = useValues(experimentLogic)
+export function VariantTag({
+    experimentId,
+    variantKey,
+}: {
+    experimentId: number | 'new'
+    variantKey: string
+}): JSX.Element {
+    const { experimentResults, getIndexForVariant } = useValues(experimentLogic({ experimentId }))
 
     return (
         <span className="flex items-center space-x-1">
@@ -307,7 +324,15 @@ export function ExperimentLoadingAnimation(): JSX.Element {
 }
 
 export function PageHeaderCustom(): JSX.Element {
-    const { experiment, isExperimentRunning, isExperimentStopped } = useValues(experimentLogic)
+    const {
+        experimentId,
+        experiment,
+        isExperimentRunning,
+        isExperimentStopped,
+        areResultsSignificant,
+        isSingleVariantShipped,
+        featureFlags,
+    } = useValues(experimentLogic)
     const {
         launchExperiment,
         resetRunningExperiment,
@@ -317,8 +342,8 @@ export function PageHeaderCustom(): JSX.Element {
         loadExperimentResults,
         loadSecondaryMetricResults,
         createExposureCohort,
+        openMakeDecisionModal,
     } = useActions(experimentLogic)
-
     const exposureCohortId = experiment?.exposure_cohort
 
     return (
@@ -472,9 +497,93 @@ export function PageHeaderCustom(): JSX.Element {
                             )}
                         </div>
                     )}
+                    {featureFlags[FEATURE_FLAGS.EXPERIMENT_MAKE_DECISION] &&
+                        areResultsSignificant &&
+                        !isSingleVariantShipped && (
+                            <>
+                                <LemonButton
+                                    type="primary"
+                                    status="alt"
+                                    icon={<IconMagicWand />}
+                                    onClick={() => openMakeDecisionModal()}
+                                >
+                                    <b>Make decision</b>
+                                </LemonButton>
+                                <MakeDecisionModal experimentId={experimentId} />
+                            </>
+                        )}
                 </>
             }
         />
+    )
+}
+
+export function MakeDecisionModal({ experimentId }: { experimentId: Experiment['id'] }): JSX.Element {
+    const { experiment, sortedWinProbabilities, isMakeDecisionModalOpen } = useValues(experimentLogic({ experimentId }))
+    const { closeMakeDecisionModal, shipVariant } = useActions(experimentLogic({ experimentId }))
+    const { aggregationLabel } = useValues(groupsModel)
+
+    const [selectedVariantKey, setSelectedVariantKey] = useState<string | null>()
+    useEffect(() => setSelectedVariantKey(sortedWinProbabilities[0]?.key), [sortedWinProbabilities])
+
+    const aggregationTargetName =
+        experiment.filters.aggregation_group_type_index != null
+            ? aggregationLabel(experiment.filters.aggregation_group_type_index).plural
+            : 'users'
+
+    return (
+        <LemonModal
+            isOpen={isMakeDecisionModalOpen}
+            onClose={closeMakeDecisionModal}
+            width={600}
+            title="Make decision"
+            footer={
+                <div className="flex items-center gap-2">
+                    <LemonButton type="secondary" onClick={closeMakeDecisionModal}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton onClick={() => shipVariant(selectedVariantKey)} type="primary">
+                        Ship variant
+                    </LemonButton>
+                </div>
+            }
+        >
+            <div className="space-y-4">
+                <div className="text-sm">
+                    This action will roll out the selected variant to <b>100% of {aggregationTargetName}.</b>
+                </div>
+                <LemonSelect
+                    data-attr="metrics-selector"
+                    value={selectedVariantKey}
+                    onChange={(variantKey) => setSelectedVariantKey(variantKey)}
+                    options={sortedWinProbabilities.map(({ key }) => ({
+                        value: key,
+                        label: (
+                            <div className="space-x-2 inline-flex">
+                                <VariantTag experimentId={experimentId} variantKey={key} />
+                                {key === sortedWinProbabilities[0]?.key && (
+                                    <LemonTag type="success">
+                                        <b className="uppercase">Winning</b>
+                                    </LemonTag>
+                                )}
+                            </div>
+                        ),
+                    }))}
+                />
+                <LemonBanner type="info" className="mb-4">
+                    For a more precise control over your release, adjust the rollout percentage and release conditions
+                    in the{' '}
+                    <Link
+                        target="_blank"
+                        className="font-semibold"
+                        to={experiment.feature_flag ? urls.featureFlag(experiment.feature_flag.id) : undefined}
+                    >
+                        {experiment.feature_flag?.key}
+                    </Link>{' '}
+                    feature flag.
+                </LemonBanner>
+            </div>
+        </LemonModal>
     )
 }
 
@@ -491,15 +600,49 @@ export function ActionBanner(): JSX.Element {
         funnelResultsPersonsTotal,
         actualRunningTime,
         getHighestProbabilityVariant,
+        isSingleVariantShipped,
+        featureFlags,
     } = useValues(experimentLogic)
 
     const { archiveExperiment } = useActions(experimentLogic)
+
+    const { aggregationLabel } = useValues(groupsModel)
+    const aggregationTargetName =
+        experiment.filters.aggregation_group_type_index != null
+            ? aggregationLabel(experiment.filters.aggregation_group_type_index).plural
+            : 'users'
 
     const recommendedRunningTime = experiment?.parameters?.recommended_running_time || 1
     const recommendedSampleSize = experiment?.parameters?.recommended_sample_size || 100
 
     if (!experiment || experimentLoading || experimentResultsLoading) {
         return <></>
+    }
+
+    if (featureFlags[FEATURE_FLAGS.EXPERIMENT_MAKE_DECISION]) {
+        if (isSingleVariantShipped) {
+            const shippedVariant = experiment.feature_flag?.filters.multivariate?.variants.find(
+                ({ rollout_percentage }) => rollout_percentage === 100
+            )
+            if (!shippedVariant) {
+                return <></>
+            }
+
+            return (
+                <LemonBanner type="info" className="mt-4">
+                    <span className="inline-flex items-center">
+                        <span
+                            className="border rounded px-2"
+                            // eslint-disable-next-line react/forbid-dom-props
+                            style={{ backgroundColor: 'var(--bg-table)' }}
+                        >
+                            <VariantTag experimentId={experiment.id} variantKey={shippedVariant.key} />
+                        </span>
+                        &nbsp; has been released to 100% of {aggregationTargetName}.
+                    </span>
+                </LemonBanner>
+            )
+        }
     }
 
     // Draft

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -571,8 +571,8 @@ export function MakeDecisionModal({ experimentId }: { experimentId: Experiment['
                     }))}
                 />
                 <LemonBanner type="info" className="mb-4">
-                    For a more precise control over your release, adjust the rollout percentage and release conditions
-                    in the{' '}
+                    For more precise control over your release, adjust the rollout percentage and release conditions in
+                    the{' '}
                     <Link
                         target="_blank"
                         className="font-semibold"


### PR DESCRIPTION
feature flag: `experiment-make-decision`

## Changes
Add the ability to roll out the winning variant to 100% of users/groups from the Experiment UI.

https://github.com/user-attachments/assets/f940ec7c-b955-4721-b320-06aab609e4ce

Follow-ups:
- add a checkbox to stop the experiment from the same modal
- add a logic test for the `shipVariant` method (no time left today but want to keep moving)
- add event tracking

## How did you test this code?
👀 