### PR TITLE
chore(data-warehouse): ui adjustments

### DIFF
--- a/frontend/src/lib/components/DatabaseTableTree/TreeRow.tsx
+++ b/frontend/src/lib/components/DatabaseTableTree/TreeRow.tsx
@@ -98,6 +98,7 @@ export function TreeFolderRow({ item, depth, onClick, selectedRow, dropdownOverl
                         : undefined
                 }
                 icon={<IconChevronDown className={collapsed ? 'rotate-270' : undefined} />}
+                tooltip={name}
             >
                 {name}
             </LemonButton>

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -129,7 +129,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
     return (
         <div className="DataVisualization flex flex-1 gap-2">
             {!readOnly && showEditingUI && (
-                <div className="flex max-sm:hidden">
+                <div className="max-sm:hidden max-w-xs">
                     <DatabaseTableTreeWithItems inline />
                 </div>
             )}
@@ -142,7 +142,7 @@ function InternalDataTableVisualization(props: DataTableVisualizationProps): JSX
                 {!readOnly && showResultControls && (
                     <>
                         <LemonDivider className="my-0" />
-                        <div className="flex gap-4 justify-between flex-wrap">
+                        <div className="flex gap-4 justify-between flex-wrap px-px">
                             <div className="flex gap-4 items-center">
                                 <Reload />
                                 <ElapsedTime />

--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -249,7 +249,7 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
                         />
                     </div>
                 </div>
-                <div className="flex flex-row">
+                <div className="flex flex-row px-px">
                     {props.editorFooter ? (
                         props.editorFooter(hasErrors, error, isValidView)
                     ) : (

--- a/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
+++ b/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
@@ -229,14 +229,14 @@ export const DatabaseTableTreeWithItems = ({ inline }: DatabaseTableTreeProps): 
         <div
             className={clsx(
                 `bg-bg-light space-y-px rounded border p-2 overflow-y-auto`,
-                !collapsed ? 'min-w-80 flex-1' : 'flex-0'
+                !collapsed ? 'min-w-80 flex-1' : ''
             )}
         >
             {collapsed ? (
                 <LemonButton icon={<IconDatabase />} onClick={() => setCollapsed(false)} />
             ) : (
                 <>
-                    <LemonButton size="xsmall" onClick={() => setCollapsed(true)} fullWidth>
+                    <LemonButton size="xsmall" onClick={() => setCollapsed(true)} fullWidth icon={<IconDatabase />}>
                         <span className="uppercase text-muted-alt tracking-wider">Sources</span>
                     </LemonButton>
                     <DatabaseTableTree onSelectRow={selectRow} items={treeItems()} selectedRow={selectedRow} />


### PR DESCRIPTION
## Problem

- UI issues

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- padding so button isn't cutoff
- max width on table list and max height
- don't extend column whitespace
- add tooltip for long table names
- database icon
<img width="986" alt="Screenshot 2024-08-15 at 12 47 16 PM" src="https://github.com/user-attachments/assets/ca199a75-1091-472f-b710-319061f90a3c">
<img width="831" alt="Screenshot 2024-08-15 at 12 47 26 PM" src="https://github.com/user-attachments/assets/943f9fbf-fcd2-4ee5-97f3-a198a6ebab68">

did not refactor the whole column spacing here as it would require decoupling components
<img width="570" alt="Screenshot 2024-08-15 at 12 47 39 PM" src="https://github.com/user-attachments/assets/b3c67a6f-0a60-4592-a464-8f54f3672cf6">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
