### PR TITLE
chore(batch-exports): Bump pyscopg

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -58,7 +58,7 @@ pdpyras==5.2.0
 posthoganalytics==3.5.0
 psycopg2-binary==2.9.7
 PyMySQL==1.1.1
-psycopg[binary]==3.1.18
+psycopg[binary]==3.1.20
 pyarrow==17.0.0
 pydantic==2.5.3
 pyjwt==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -258,6 +258,8 @@ googleapis-common-protos==1.60.0
     # via
     #   google-api-core
     #   grpcio-status
+greenlet==3.0.3
+    # via sqlalchemy
 grpcio==1.57.0
     # via
     #   google-api-core
@@ -419,9 +421,9 @@ protobuf==4.22.1
     #   grpcio-status
     #   proto-plus
     #   temporalio
-psycopg==3.1.18
+psycopg==3.1.20
     # via -r requirements.in
-psycopg-binary==3.1.18
+psycopg-binary==3.1.20
     # via psycopg
 psycopg2-binary==2.9.7
     # via -r requirements.in


### PR DESCRIPTION
## Problem

Seeing a strange connection error in PostgreSQL batch exports:
```
  "message": "connection failed: SSL SYSCALL error: Success",
```

Not much I could find except for [this psycopg2 issue](https://www.github.com/psycopg/psycopg2/issues/1550). Since it could be SSL-related, I'm bumping our psycopg package a couple of patch versions to 3.1.20 from 3.1.18 as it includes a newer version of OpenSSL

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Bump psycopg to 3.1.20.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Existing tests in CI cover postgres batch exports, and they are passing.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
