### PR TITLE
fix: add concurrency limiter

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -73,7 +73,7 @@ time = { version = "0.3.36", features = [
 ] }
 thiserror = { version = "1.0" }
 tokio = { version = "1.34.0", features = ["full"] }
-tower = "0.4.13"
+tower = { version = "0.4.13", features = ["default", "limit"] }
 tower-http = { version = "0.5.2", features = ["cors", "limit", "trace"] }
 tracing = "0.1.40"
 tracing-opentelemetry = "0.23.0"

--- a/rust/hook-api/src/config.rs
+++ b/rust/hook-api/src/config.rs
@@ -20,6 +20,9 @@ pub struct Config {
     #[envconfig(default = "5000000")]
     pub max_body_size: usize,
 
+    #[envconfig(default = "100")]
+    pub concurrency_limit: usize,
+
     #[envconfig(default = "false")]
     pub hog_mode: bool,
 }

--- a/rust/hook-api/src/handlers/webhook.rs
+++ b/rust/hook-api/src/handlers/webhook.rs
@@ -243,13 +243,20 @@ mod tests {
     use crate::handlers::app::add_routes;
 
     const MAX_BODY_SIZE: usize = 1_000_000;
+    const CONCURRENCY_LIMIT: usize = 10;
 
     #[sqlx::test(migrations = "../migrations")]
     async fn webhook_success(db: PgPool) {
         let pg_queue = PgQueue::new_from_pool("test_index", db).await;
         let hog_mode = false;
 
-        let app = add_routes(Router::new(), pg_queue, hog_mode, MAX_BODY_SIZE);
+        let app = add_routes(
+            Router::new(),
+            pg_queue,
+            hog_mode,
+            MAX_BODY_SIZE,
+            CONCURRENCY_LIMIT,
+        );
 
         let mut headers = collections::HashMap::new();
         headers.insert("Content-Type".to_owned(), "application/json".to_owned());
@@ -292,7 +299,13 @@ mod tests {
         let pg_queue = PgQueue::new_from_pool("test_index", db).await;
         let hog_mode = false;
 
-        let app = add_routes(Router::new(), pg_queue, hog_mode, MAX_BODY_SIZE);
+        let app = add_routes(
+            Router::new(),
+            pg_queue,
+            hog_mode,
+            MAX_BODY_SIZE,
+            CONCURRENCY_LIMIT,
+        );
 
         let response = app
             .oneshot(
@@ -330,7 +343,13 @@ mod tests {
         let pg_queue = PgQueue::new_from_pool("test_index", db).await;
         let hog_mode = false;
 
-        let app = add_routes(Router::new(), pg_queue, hog_mode, MAX_BODY_SIZE);
+        let app = add_routes(
+            Router::new(),
+            pg_queue,
+            hog_mode,
+            MAX_BODY_SIZE,
+            CONCURRENCY_LIMIT,
+        );
 
         let response = app
             .oneshot(
@@ -352,7 +371,13 @@ mod tests {
         let pg_queue = PgQueue::new_from_pool("test_index", db).await;
         let hog_mode = false;
 
-        let app = add_routes(Router::new(), pg_queue, hog_mode, MAX_BODY_SIZE);
+        let app = add_routes(
+            Router::new(),
+            pg_queue,
+            hog_mode,
+            MAX_BODY_SIZE,
+            CONCURRENCY_LIMIT,
+        );
 
         let response = app
             .oneshot(
@@ -374,7 +399,13 @@ mod tests {
         let pg_queue = PgQueue::new_from_pool("test_index", db).await;
         let hog_mode = false;
 
-        let app = add_routes(Router::new(), pg_queue, hog_mode, MAX_BODY_SIZE);
+        let app = add_routes(
+            Router::new(),
+            pg_queue,
+            hog_mode,
+            MAX_BODY_SIZE,
+            CONCURRENCY_LIMIT,
+        );
 
         let bytes: Vec<u8> = vec![b'a'; MAX_BODY_SIZE + 1];
         let long_string = String::from_utf8_lossy(&bytes);
@@ -422,7 +453,13 @@ mod tests {
         let pg_queue = PgQueue::new_from_pool("test_index", db.clone()).await;
         let hog_mode = true;
 
-        let app = add_routes(Router::new(), pg_queue, hog_mode, MAX_BODY_SIZE);
+        let app = add_routes(
+            Router::new(),
+            pg_queue,
+            hog_mode,
+            MAX_BODY_SIZE,
+            CONCURRENCY_LIMIT,
+        );
 
         let valid_payloads = vec![
             (
@@ -507,7 +544,13 @@ mod tests {
         let pg_queue = PgQueue::new_from_pool("test_index", db.clone()).await;
         let hog_mode = true;
 
-        let app = add_routes(Router::new(), pg_queue, hog_mode, MAX_BODY_SIZE);
+        let app = add_routes(
+            Router::new(),
+            pg_queue,
+            hog_mode,
+            MAX_BODY_SIZE,
+            CONCURRENCY_LIMIT,
+        );
 
         let invalid_payloads = vec![
             r#"{}"#,

--- a/rust/hook-api/src/main.rs
+++ b/rust/hook-api/src/main.rs
@@ -39,6 +39,7 @@ async fn main() {
         pg_queue,
         config.hog_mode,
         config.max_body_size,
+        config.concurrency_limit,
     );
     let app = setup_metrics_routes(app);
 


### PR DESCRIPTION
It's trivial for hooks to have more requests in flight than it can handle in memory, if it's being sent requests faster than it's able to push them into PG. This adds a backpressure mechanism, with a default limit of 100 because our max request size defaults to 5MB and we deploy hooks with a limit of 500. We can tune this later, once we stop crashing.