### PR TITLE
fix: use murmur2 random in vector capture for compatibility with django

### DIFF
--- a/vector/replay-capture/vector.yaml
+++ b/vector/replay-capture/vector.yaml
@@ -214,7 +214,7 @@ sinks:
             sticky.partitioning.linger.ms: '25'
             enable.idempotence: 'false'
             max.in.flight.requests.per.connection: '1000000'
-            partitioner: 'consistent_random'
+            partitioner: 'murmur2_random'
         message_timeout_ms: 10000
         socket_timeout_ms: 5000
     kafka_overflow:


### PR DESCRIPTION
## Problem

we do the same thing in rust capture (see https://github.com/PostHog/posthog/blob/dee5ca103cb51a3180398de05a6b956f9298f01c/rust/capture/src/sinks/kafka.rs#L130)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
