### PR TITLE
fix(data-warehouse): More logging for dwh and fallback to Delta when DeltaS3Wrapper fails

### DIFF
--- a/posthog/hogql/database/s3_table.py
+++ b/posthog/hogql/database/s3_table.py
@@ -60,7 +60,7 @@ def build_function_call(
         return return_expr(expr)
 
     # Delta format
-    if format == "Delta" or format == "DeltaS3Wrapper":
+    if format == "Delta":
         escaped_url = add_param(url)
         if structure:
             escaped_structure = add_param(structure, False)

--- a/posthog/warehouse/data_load/validate_schema.py
+++ b/posthog/warehouse/data_load/validate_schema.py
@@ -141,6 +141,21 @@ async def validate_schema_and_update_table(
 
         assert isinstance(table_created, DataWarehouseTable) and table_created is not None
 
+        # Temp fix #2 for Delta tables without table_format
+        try:
+            await sync_to_async(table_created.get_columns)()
+        except Exception as e:
+            if table_format == DataWarehouseTable.TableFormat.DeltaS3Wrapper:
+                logger.exception("get_columns exception with DeltaS3Wrapper format - trying Delta format", e)
+
+                table_created.format = DataWarehouseTable.TableFormat.Delta
+                await sync_to_async(table_created.get_columns)()
+                table_created.save()
+
+                logger.info("Delta format worked - updating table to use Delta")
+            else:
+                raise
+
         for schema in table_schema.values():
             if schema.get("resource") == _schema_name:
                 schema_columns = schema.get("columns") or {}


### PR DESCRIPTION
## Problem
- There's still a handful of tables not falling back to `Delta` table format - tried debugging but can't get anywhere easily. 

## Changes
- When calling `get_columns` - if DeltaS3Wrapper fails, try again with `Delta` format instead
- Added a lot more logging to figure out whats going on with the above 
