### PR TITLE
fix(data-warehouse): De-nest hubspot tables

### DIFF
--- a/posthog/temporal/data_imports/pipelines/hubspot/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/hubspot/__init__.py
@@ -46,7 +46,7 @@ from .settings import (
 THubspotObjectType = Literal["company", "contact", "deal", "ticket", "quote"]
 
 
-@dlt.source(name="hubspot")
+@dlt.source(name="hubspot", max_table_nesting=0)
 def hubspot(
     api_key: str,
     refresh_token: str,


### PR DESCRIPTION
## Problem
We're creating multiple tables for hubspot tables instead of nesting complex data into a JSON column

## Changes
Set max nesting to zero
