### PR TITLE
chore(batch-exports): override email admin only

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -197,6 +197,7 @@ def send_batch_export_run_failure(
     )
     logger.info("Prepared notification email for campaign %s", campaign_key)
 
+    # NOTE: Temporary workaround. This should be a configurable setting
     admin_only = (get_instance_region() == "US") and team.pk in [28956]
 
     memberships_to_email = []


### PR DESCRIPTION
## Problem

- failure emails are sending to everyone

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- only send to organization admins and owners if requested

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
