### PR TITLE
fix(batch-exports): use 1MB payload limit for http batch exports

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -15,7 +15,10 @@ BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES: int = 1024 * 1024 * 50  # 50MB
 BATCH_EXPORT_SNOWFLAKE_UPLOAD_CHUNK_SIZE_BYTES: int = 1024 * 1024 * 100  # 100MB
 BATCH_EXPORT_POSTGRES_UPLOAD_CHUNK_SIZE_BYTES: int = 1024 * 1024 * 50  # 50MB
 BATCH_EXPORT_BIGQUERY_UPLOAD_CHUNK_SIZE_BYTES: int = 1024 * 1024 * 100  # 100MB
-BATCH_EXPORT_HTTP_UPLOAD_CHUNK_SIZE_BYTES: int = 1024 * 1024 * 10  # 10MB
+# This is set to 1MB to stay under Axum's 2MB default limit. We could raise the Capture max body
+# size limit, but that would put as at more risk of OOMing Capture. There isn't a rush on HTTP
+# Batch Exports, so this is a safe path forward for now.
+BATCH_EXPORT_HTTP_UPLOAD_CHUNK_SIZE_BYTES: int = 1024 * 1024 * 1  # 1MB
 BATCH_EXPORT_HTTP_BATCH_SIZE: int = 1000
 
 UNCONSTRAINED_TIMESTAMP_TEAM_IDS: list[str] = get_list(os.getenv("UNCONSTRAINED_TIMESTAMP_TEAM_IDS", ""))


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
[We are getting HTTP 413 from Capture when trying to migrate a user.](https://posthog.slack.com/archives/C019RAX2XBN/p1723793450157419)
[[Zendesk Ticket]](https://posthoghelp.zendesk.com/agent/tickets/16395)

*NOTE*: Ugh, actually. We don't calculate the size until we write to disk. We could go over 2MB (because of the last event being >1MB) before we detect and flush... Probably should also bump Capture's max body size a bit like we did for rusty-hook: https://github.com/PostHog/posthog/blob/8ddcb3b76a2541db4e0eae25dc5b2cfc61289328/rust/hook-api/src/handlers/app.rs#L29 ... But maybe this is worth trying out first.

## Changes

Use 1MB limit, see comment in code.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
Existing