### PR TITLE
fix(surveys): remove comment from `dataTableQuery` because we were seeing odd behavior where the comment was being stripped on the server response, which was leading to results not being displayed

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -922,12 +922,10 @@ export const surveyLogic = kea<surveyLogicType>([
                                     // Join array items into a string
                                     return `coalesce(arrayStringConcat(JSONExtractArrayRaw(properties, '${getResponseField(
                                         i
-                                    )}'), ', ')) -- ${q.question}`
+                                    )}'), ', ')`
                                 }
 
-                                return `coalesce(JSONExtractString(properties, '${getResponseField(i)}')) -- ${
-                                    q.question
-                                }`
+                                return `coalesce(JSONExtractString(properties, '${getResponseField(i)}'))`
                             }),
                             'timestamp',
                             'person',


### PR DESCRIPTION
## Problem

Does what it says on the title.  Context is here: https://posthog.slack.com/archives/C0113360FFV/p1723750509157379

## Changes

Self-evident

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Note that I wasn't able to reproduce this comment stripping behavior when I ran everything locally; my survey data tables loaded just fine.  It's possible something is funky with this customer's specific configuration, but for the life of me I can't find out why.  Given that I observed this behavior in production and was able to resolve it by removing the comment from the query in the request payload, I think this should be safe.
