### PR TITLE
fix: cleaner alias check

### DIFF
--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -9,6 +9,7 @@ from django.utils.timezone import now
 from posthog.api.element import ElementSerializer
 from posthog.api.utils import get_pk_or_uuid
 from posthog.hogql import ast
+from posthog.hogql.ast import Alias
 from posthog.hogql.parser import parse_expr, parse_order_expr
 from posthog.hogql.property import action_to_expr, has_aggregation, property_to_expr
 from posthog.hogql.timings import HogQLTimings
@@ -45,6 +46,22 @@ class EventsQueryRunner(QueryRunner):
             limit_context=self.limit_context, limit=self.query.limit, offset=self.query.offset
         )
 
+    def select_cols(self) -> tuple[list[str], list[ast.Expr]]:
+        select_input: list[str] = []
+        person_indices: list[int] = []
+        for index, col in enumerate(self.select_input_raw()):
+            # Selecting a "*" expands the list of columns, resulting in a table that's not what we asked for.
+            # Instead, ask for a tuple with all the columns we want. Later transform this back into a dict.
+            if col == "*":
+                select_input.append(f"tuple({', '.join(SELECT_STAR_FROM_EVENTS_FIELDS)})")
+            elif col.split("--")[0].strip() == "person":
+                # This will be expanded into a followup query
+                select_input.append("distinct_id")
+                person_indices.append(index)
+            else:
+                select_input.append(col)
+        return select_input, [parse_expr(column, timings=self.timings) for column in select_input]
+
     def to_query(self) -> ast.SelectQuery:
         # Note: This code is inefficient and problematic, see https://github.com/PostHog/posthog/issues/13485 for details.
         if self.timings is None:
@@ -53,20 +70,7 @@ class EventsQueryRunner(QueryRunner):
         with self.timings.measure("build_ast"):
             # columns & group_by
             with self.timings.measure("columns"):
-                select_input: list[str] = []
-                person_indices: list[int] = []
-                for index, col in enumerate(self.select_input_raw()):
-                    # Selecting a "*" expands the list of columns, resulting in a table that's not what we asked for.
-                    # Instead, ask for a tuple with all the columns we want. Later transform this back into a dict.
-                    if col == "*":
-                        select_input.append(f"tuple({', '.join(SELECT_STAR_FROM_EVENTS_FIELDS)})")
-                    elif col.split("--")[0].strip() == "person":
-                        # This will be expanded into a followup query
-                        select_input.append("distinct_id")
-                        person_indices.append(index)
-                    else:
-                        select_input.append(col)
-                select: list[ast.Expr] = [parse_expr(column, timings=self.timings) for column in select_input]
+                select_input, select = self.select_cols()
 
             with self.timings.measure("aggregations"):
                 group_by: list[ast.Expr] = [column for column in select if not has_aggregation(column)]
@@ -264,9 +268,10 @@ class EventsQueryRunner(QueryRunner):
             self.query.properties = (self.query.properties or []) + dashboard_filter.properties
 
     def columns(self, result_columns: list | None) -> list[str]:
+        _, select = self.select_cols()
         columns = result_columns or []
         return [
-            columns[idx] if len(columns) > idx and " as " in col else col
+            columns[idx] if len(columns) > idx and isinstance(select[idx], Alias) else col
             for idx, col in enumerate(self.select_input_raw())
         ]
 


### PR DESCRIPTION
## Problem

using the word ' as ' in comments was causing the comment to disappear (and some UI bugs as a result)
https://posthog.slack.com/archives/C0113360FFV/p1723836788738249?thread_ts=1723750509.157379&cid=C0113360FFV

## Changes

Use the parse_expr result to check if it is an alias instead of checking the string directly

## Does this work well for both Cloud and self-hosted?

No Impact

## How did you test this code?

Unit testing
