### PR TITLE
ci: Upgrade actions/checkout to avoid deprecated Node version

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -18,7 +18,7 @@ jobs:
         if: github.repository == 'PostHog/posthog'
         steps:
             - name: Checkout master
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Notify Sentry
               uses: getsentry/action-release@v1
               env:


### PR DESCRIPTION
fixes #24437.

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
`build-and-deploy-prod.yml` uses `actions/checkout@v3`, which uses a `deprecated` version of `Node.js`.

## Does this work well for both Cloud and self-hosted?
It doesn't have an impact.
<!-- Yes / no / it doesn't have an impact. -->