### PR TITLE
fix: we document a batch import limit of 20MB, but rust capture dropped anything over 2MB

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -641,6 +641,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-opentelemetry",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1480,7 +1480,6 @@ dependencies = [
  "sqlx",
  "tokio",
  "tower",
- "tower-http",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
 tower-http = { workspace = true }
+tower = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -1,12 +1,14 @@
 use std::future::ready;
 use std::sync::Arc;
 
+use axum::extract::DefaultBodyLimit;
 use axum::http::Method;
 use axum::{
     routing::{get, post},
     Router,
 };
 use health::HealthRegistry;
+use tower::limit::ConcurrencyLimitLayer;
 use tower_http::cors::{AllowHeaders, AllowOrigin, CorsLayer};
 use tower_http::trace::TraceLayer;
 
@@ -15,6 +17,10 @@ use crate::{
 };
 
 use crate::prometheus::{setup_metrics_recorder, track_metrics};
+
+const EVENT_BODY_SIZE: usize = 2 * 1024 * 1024; // 2MB
+const BATCH_BODY_SIZE: usize = 20 * 1024 * 1024; // 20MB, up from the default 2MB used for normal event payloads
+const BATCH_CONCURRENCY_LIMIT: usize = 25; // We deploy these pods with 1G of memory, this and the above lets half of that be used for batch posts
 
 #[derive(Clone)]
 pub struct State {
@@ -55,23 +61,7 @@ pub fn router<
         .allow_credentials(true)
         .allow_origin(AllowOrigin::mirror_request());
 
-    let router = Router::new()
-        // TODO: use NormalizePathLayer::trim_trailing_slash
-        .route("/", get(index))
-        .route("/_readiness", get(index))
-        .route("/_liveness", get(move || ready(liveness.get_status())))
-        .route(
-            "/e",
-            post(v0_endpoint::event)
-                .get(v0_endpoint::event)
-                .options(v0_endpoint::options),
-        )
-        .route(
-            "/e/",
-            post(v0_endpoint::event)
-                .get(v0_endpoint::event)
-                .options(v0_endpoint::options),
-        )
+    let batch_router = Router::new()
         .route(
             "/batch",
             post(v0_endpoint::event)
@@ -80,6 +70,22 @@ pub fn router<
         )
         .route(
             "/batch/",
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
+                .options(v0_endpoint::options),
+        )
+        .layer(ConcurrencyLimitLayer::new(BATCH_CONCURRENCY_LIMIT))
+        .layer(DefaultBodyLimit::max(BATCH_BODY_SIZE)); // Have to use this, rather than RequestBodyLimitLayer, because we use `Bytes` in the handler (this limit applies specifically to Bytes body types)
+
+    let event_router = Router::new()
+        .route(
+            "/e",
+            post(v0_endpoint::event)
+                .get(v0_endpoint::event)
+                .options(v0_endpoint::options),
+        )
+        .route(
+            "/e/",
             post(v0_endpoint::event)
                 .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
@@ -96,6 +102,17 @@ pub fn router<
                 .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
         )
+        .layer(DefaultBodyLimit::max(EVENT_BODY_SIZE));
+
+    let status_router = Router::new()
+        .route("/", get(index))
+        .route("/_readiness", get(index))
+        .route("/_liveness", get(move || ready(liveness.get_status())));
+
+    let router = Router::new()
+        .merge(batch_router)
+        .merge(event_router)
+        .merge(status_router)
         .layer(TraceLayer::new_for_http())
         .layer(cors)
         .layer(axum::middleware::from_fn(track_metrics))

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -98,6 +98,16 @@ impl ServerHandle {
             .await
             .expect("failed to send request")
     }
+
+    pub async fn capture_to_batch<T: Into<reqwest::Body>>(&self, body: T) -> reqwest::Response {
+        let client = reqwest::Client::new();
+        client
+            .post(format!("http://{:?}/batch", self.addr))
+            .body(body)
+            .send()
+            .await
+            .expect("failed to send request")
+    }
 }
 
 impl Drop for ServerHandle {

--- a/rust/hook-api/Cargo.toml
+++ b/rust/hook-api/Cargo.toml
@@ -19,7 +19,6 @@ serde_json = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }
-tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }

--- a/rust/hook-api/src/handlers/app.rs
+++ b/rust/hook-api/src/handlers/app.rs
@@ -1,8 +1,7 @@
 use std::convert::Infallible;
 
-use axum::{routing, Router};
+use axum::{extract::DefaultBodyLimit, routing, Router};
 use tower::limit::ConcurrencyLimitLayer;
-use tower_http::limit::RequestBodyLimitLayer;
 
 use hook_common::pgqueue::PgQueue;
 
@@ -26,7 +25,7 @@ pub fn add_routes(
             routing::post(webhook::post_hoghook)
                 .with_state(pg_pool)
                 .layer::<_, Infallible>(ConcurrencyLimitLayer::new(concurrency_limit))
-                .layer(RequestBodyLimitLayer::new(max_body_size)),
+                .layer(DefaultBodyLimit::max(max_body_size)),
         )
     } else {
         router.route(
@@ -34,7 +33,7 @@ pub fn add_routes(
             routing::post(webhook::post_webhook)
                 .with_state(pg_pool)
                 .layer::<_, Infallible>(ConcurrencyLimitLayer::new(concurrency_limit))
-                .layer(RequestBodyLimitLayer::new(max_body_size)),
+                .layer(DefaultBodyLimit::max(max_body_size)),
         )
     }
 }


### PR DESCRIPTION
Also fixed hook-api using the wrong kind of tower layer for limiting body size - axums internal default limits override towers generic ones, for Bytes (and things that use Bytes)