### PR TITLE
chore(launch.json): Use workspace Python and skip debugging Node deps

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
             "cwd": "${workspaceFolder}",
             "presentation": {
                 "group": "main"
-            }
+            },
+            "skipFiles": ["${workspaceFolder}/node_modules/kea-typegen/**/*.js"]
         },
         {
             "name": "Frontend (https)",
@@ -50,7 +51,6 @@
             },
             "envFile": "${workspaceFolder}/.env",
             "console": "integratedTerminal",
-            "python": "${workspaceFolder}/env/bin/python",
             "cwd": "${workspaceFolder}",
             "presentation": {
                 "group": "main"
@@ -77,7 +77,6 @@
                 "CLOUD_DEPLOYMENT": "dev"
             },
             "console": "integratedTerminal",
-            "python": "${workspaceFolder}/env/bin/python",
             "cwd": "${workspaceFolder}",
             "presentation": {
                 "group": "main"
@@ -96,7 +95,6 @@
             "program": "${workspaceFolder}/manage.py",
             "args": ["run_autoreload_celery", "--type=worker"],
             "console": "integratedTerminal",
-            "python": "${workspaceFolder}/env/bin/python",
             "cwd": "${workspaceFolder}",
             "env": {
                 "SKIP_ASYNC_MIGRATIONS_SETUP": "0",
@@ -146,7 +144,6 @@
                 "PRINT_SQL": "1"
             },
             "console": "integratedTerminal",
-            "python": "${workspaceFolder}/env/bin/python",
             "cwd": "${workspaceFolder}",
             "presentation": {
                 "group": "main"


### PR DESCRIPTION
## Changes

Have finally started the VS Code debugging setup instead of `bin/start`, and it's brilliant, except for two things:
- I'm using `pyenv virtualenv` so `"python": "${workspaceFolder}/env/bin/python"` doesn't point to anything for me. But we shouldn't need to override `"python":` anyway – VS Code's default behavior is to use the Python interpreter selected in the workspace.
- Been seeing the Frontend task trying to step through TypeScript errors bubbled up in kea-typegen, but that's useless. Let's ignore kea-typegen.