### PR TITLE
chore: hide snapshots api

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -359,6 +359,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         return Response({"success": True})
 
+    @extend_schema(exclude=True)
     @action(methods=["GET"], detail=True, renderer_classes=[SurrogatePairSafeJSONRenderer])
     def snapshots(self, request: request.Request, **kwargs):
         """


### PR DESCRIPTION
## Problem

Snapshots are not yet publicly stable (https://github.com/PostHog/posthog/issues/22520)

## Changes

Remove them from the public API