### PR TITLE
fix: we should identify the user on `$set` events as well

### DIFF
--- a/posthog/cdp/templates/customerio/template_customerio.py
+++ b/posthog/cdp/templates/customerio/template_customerio.py
@@ -26,7 +26,7 @@ if (not hasIdentifier) {
 }
 
 if (action == 'automatic') {
-    if (event.name == '$identify') {
+    if (event.name in ('$identify', '$set')) {
         action := 'identify'
         name := null
     } else if (event.name == '$pageview') {

--- a/posthog/cdp/templates/customerio/test_template_customerio.py
+++ b/posthog/cdp/templates/customerio/test_template_customerio.py
@@ -71,6 +71,7 @@ class TestTemplateCustomerio(BaseHogFunctionTemplateTest):
     def test_automatic_action_mapping(self):
         for event_name, expected_action in [
             ("$identify", "identify"),
+            ("$set", "identify"),
             ("$pageview", "page"),
             ("$screen", "screen"),
             ("$autocapture", "event"),


### PR DESCRIPTION
## Problem

the identify action should also be triggered by `$set` events

context: https://posthoghelp.zendesk.com/agent/tickets/16535 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/19261)