### PR TITLE
feat: tag cohort errors in Sentry

### DIFF
--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -216,19 +216,15 @@ class Cohort(models.Model):
 
             self.last_calculation = timezone.now()
             self.errors_calculating = 0
-        except Exception as err:
+        except Exception:
             self.errors_calculating = F("errors_calculating") + 1
+
             logger.warning(
                 "cohort_calculation_failed",
                 id=self.pk,
                 current_version=self.version,
                 new_version=pending_version,
                 exc_info=True,
-            )
-
-            capture_exception(
-                Exception(f"Error calculating cohort id = {self.id}, team_id = {self.team.id}"),
-                {"error": str(err)},
             )
 
             raise

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -13,6 +13,7 @@ from posthog.models.cohort import get_and_update_pending_version
 from posthog.models.cohort.util import clear_stale_cohortpeople
 from posthog.models.user import User
 from prometheus_client import Gauge
+from sentry_sdk import set_tag
 
 COHORT_RECALCULATIONS_BACKLOG_GAUGE = Gauge(
     "cohort_recalculations_backlog",
@@ -54,6 +55,10 @@ def calculate_cohorts() -> None:
 
 
 def update_cohort(cohort: Cohort, *, initiating_user: Optional[User]) -> None:
+    set_tag("component", "cohort")
+    set_tag("cohort_id", cohort.id)
+    set_tag("team_id", cohort.team.id)
+
     pending_version = get_and_update_pending_version(cohort)
     calculate_cohort_ch.delay(cohort.id, pending_version, initiating_user.id if initiating_user else None)
 


### PR DESCRIPTION
## Problem
Current cohort errors can't be classified on sentry.

## Changes
Added tags around the cohort logic.
Added a `component` tag which later can be used to classify where errors are coming from (cohorts, trends, exports...)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally that it hits this code path
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
