### PR TITLE
fix: rollback capture concurrency limit

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -641,7 +641,6 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tower",
  "tower-http",
  "tracing",
  "tracing-opentelemetry",

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -36,7 +36,6 @@ thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
 tower-http = { workspace = true }
-tower = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -74,7 +74,6 @@ pub fn router<
                 .get(v0_endpoint::event)
                 .options(v0_endpoint::options),
         )
-        .layer(ConcurrencyLimitLayer::new(BATCH_CONCURRENCY_LIMIT))
         .layer(DefaultBodyLimit::max(BATCH_BODY_SIZE)); // Have to use this, rather than RequestBodyLimitLayer, because we use `Bytes` in the handler (this limit applies specifically to Bytes body types)
 
     let event_router = Router::new()

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -8,7 +8,6 @@ use axum::{
     Router,
 };
 use health::HealthRegistry;
-use tower::limit::ConcurrencyLimitLayer;
 use tower_http::cors::{AllowHeaders, AllowOrigin, CorsLayer};
 use tower_http::trace::TraceLayer;
 

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -19,7 +19,6 @@ use crate::prometheus::{setup_metrics_recorder, track_metrics};
 
 const EVENT_BODY_SIZE: usize = 2 * 1024 * 1024; // 2MB
 const BATCH_BODY_SIZE: usize = 20 * 1024 * 1024; // 20MB, up from the default 2MB used for normal event payloads
-const BATCH_CONCURRENCY_LIMIT: usize = 25; // We deploy these pods with 1G of memory, this and the above lets half of that be used for batch posts
 
 #[derive(Clone)]
 pub struct State {


### PR DESCRIPTION
Turns out most clients use batch, even for small batches.... Maybe we should consider an "import" endpoint that permits very large batches, leave "batch" to permit small ones, and limit concurrency harshly on the "import" endpoint? I'm not sure.