### PR TITLE
chore: Bump aiohttp

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -427,7 +427,7 @@ async def get_client(
             team_id, settings.CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT
         )
 
-    with aiohttp.TCPConnector(ssl=False) as connector:
+    with aiohttp.TCPConnector(ssl=False, keepalive_timeout=0) as connector:
         async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
             async with ClickHouseClient(
                 session,

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@
 # - `uv pip compile requirements.in -o requirements.txt`
 # - `uv pip compile requirements-dev.in -o requirements-dev.txt`
 #
-aiohttp>=3.9.0
+aiohttp==3.10.4
 aioboto3==12.0.0
 aiokafka>=0.8
 antlr4-python3-runtime==4.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@ aiobotocore==2.7.0
     # via
     #   aioboto3
     #   s3fs
-aiohttp==3.9.3
+aiohappyeyeballs==2.4.0
+    # via aiohttp
+aiohttp==3.10.4
     # via
     #   -r requirements.in
     #   aiobotocore


### PR DESCRIPTION
## Problem

Trying to find the root cause for occasional network disconnects on long-running batch exports. I think it's client side as the ClickHouse error logs seem to point out that it's the client disconnecting. This puts the focus on aiohttp.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
