### PR TITLE
feat: monitoring for endpoints

### DIFF
--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -29,6 +29,7 @@ from posthog.models.dashboard_templates import DashboardTemplate
 from posthog.models.tagged_item import TaggedItem
 from posthog.models.user import User
 from posthog.user_permissions import UserPermissionsSerializerMixin
+from posthog.api.monitoring import monitor, Feature
 
 logger = structlog.get_logger(__name__)
 
@@ -161,6 +162,7 @@ class DashboardSerializer(DashboardBasicSerializer):
 
         return value
 
+    @monitor(feature=Feature.DASHBOARD, endpoint="dashboard", method="POST")
     def create(self, validated_data: dict, *args: Any, **kwargs: Any) -> Dashboard:
         request = self.context["request"]
         validated_data["created_by"] = request.user
@@ -260,6 +262,7 @@ class DashboardSerializer(DashboardBasicSerializer):
                 color=existing_tile.color,
             )
 
+    @monitor(feature=Feature.DASHBOARD, endpoint="update", method="PATCH")
     def update(self, instance: Dashboard, validated_data: dict, *args: Any, **kwargs: Any) -> Dashboard:
         can_user_restrict = self.user_permissions.dashboard(instance).can_restrict
         if "restriction_level" in validated_data and not can_user_restrict:
@@ -451,6 +454,7 @@ class DashboardsViewSet(
 
         return queryset
 
+    @monitor(feature=Feature.DASHBOARD, endpoint="dashboard", method="GET")
     def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         pk = kwargs["pk"]
         queryset = self.get_queryset()

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -103,6 +103,7 @@ from posthog.utils import (
     relative_date_parse,
     str_to_bool,
 )
+from posthog.api.monitoring import monitor, Feature
 
 logger = structlog.get_logger(__name__)
 
@@ -329,6 +330,7 @@ class InsightSerializer(InsightBasicSerializer, UserPermissionsSerializerMixin):
             "is_cached",
         )
 
+    @monitor(feature=Feature.INSIGHT, endpoint="insight", method="POST")
     def create(self, validated_data: dict, *args: Any, **kwargs: Any) -> Insight:
         request = self.context["request"]
         tags = validated_data.pop("tags", None)  # tags are created separately as global tag relationships
@@ -368,6 +370,7 @@ class InsightSerializer(InsightBasicSerializer, UserPermissionsSerializerMixin):
         return insight
 
     @transaction.atomic()
+    @monitor(feature=Feature.INSIGHT, endpoint="insight", method="POST")
     def update(self, instance: Insight, validated_data: dict, **kwargs) -> Insight:
         dashboards_before_change: list[Union[str, dict]] = []
         try:
@@ -786,6 +789,7 @@ Using the correct cache and enriching the response with dashboard specific confi
             ),
         ],
     )
+    @monitor(feature=Feature.INSIGHT, endpoint="insight", method="GET")
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
         serializer_context = self.get_serializer_context()

--- a/posthog/api/monitoring.py
+++ b/posthog/api/monitoring.py
@@ -1,0 +1,37 @@
+from enum import StrEnum
+from prometheus_client import Counter
+from sentry_sdk import set_tag
+
+
+class Feature(StrEnum):
+    COHORT = "cohort"
+    DASHBOARD = "dashboard"
+    INSIGHT = "insight"
+    QUERY = "query"
+
+
+API_REQUESTS_COUNTER = Counter(
+    "api_requests",
+    "Number of API requests",
+    labelnames=["endpoint", "method"],
+)
+
+
+def monitor(*, feature: Feature | None, endpoint: str, method: str) -> callable:
+    """
+    Decorator to increment the API requests counter
+    Sets sentry tags for the endpoint and method
+    """
+
+    def decorator(func: callable) -> callable:
+        def wrapper(*args, **kwargs):
+            API_REQUESTS_COUNTER.labels(endpoint=endpoint, method=method).inc()
+
+            if feature:
+                set_tag("feature", feature.value)
+
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/posthog/api/monitoring.py
+++ b/posthog/api/monitoring.py
@@ -1,6 +1,7 @@
 from enum import StrEnum
 from prometheus_client import Counter
 from sentry_sdk import set_tag
+from collections.abc import Callable
 
 
 class Feature(StrEnum):
@@ -17,13 +18,13 @@ API_REQUESTS_COUNTER = Counter(
 )
 
 
-def monitor(*, feature: Feature | None, endpoint: str, method: str) -> callable:
+def monitor(*, feature: Feature | None, endpoint: str, method: str) -> Callable:
     """
     Decorator to increment the API requests counter
     Sets sentry tags for the endpoint and method
     """
 
-    def decorator(func: callable) -> callable:
+    def decorator(func: Callable) -> Callable:
         def wrapper(*args, **kwargs):
             API_REQUESTS_COUNTER.labels(endpoint=endpoint, method=method).inc()
 

--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -32,6 +32,7 @@ from posthog.rate_limit import (
     TeamRateThrottle,
 )
 from posthog.schema import QueryRequest, QueryResponseAlternative, QueryStatusResponse
+from posthog.api.monitoring import monitor, Feature
 
 
 class QueryThrottle(TeamRateThrottle):
@@ -59,6 +60,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             200: QueryResponseAlternative,
         },
     )
+    @monitor(feature=Feature.QUERY, endpoint="query", method="POST")
     def create(self, request, *args, **kwargs) -> Response:
         data = self.get_model(request.data, QueryRequest)
         client_query_id = data.client_query_id or uuid.uuid4().hex
@@ -99,6 +101,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         description="(Experimental)",
         responses={200: QueryStatusResponse},
     )
+    @monitor(feature=Feature.QUERY, endpoint="query", method="GET")
     def retrieve(self, request: Request, pk=None, *args, **kwargs) -> JsonResponse:
         show_progress: bool = request.query_params.get("show_progress", False) == "true"
         show_progress = (
@@ -124,6 +127,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
             204: OpenApiResponse(description="Query cancelled"),
         },
     )
+    @monitor(feature=Feature.QUERY, endpoint="query", method="DELETE")
     def destroy(self, request, pk=None, *args, **kwargs):
         cancel_query(self.team.pk, pk)
         return Response(status=204)

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -10,7 +10,6 @@ from collections.abc import Sequence
 import sqlparse
 from clickhouse_driver import Client as SyncClient
 from django.conf import settings as app_settings
-from statshog.defaults.django import statsd
 
 from posthog.clickhouse.client.connection import Workload, get_pool
 from posthog.clickhouse.client.escape import substitute_params
@@ -18,6 +17,18 @@ from posthog.clickhouse.query_tagging import get_query_tag_value, get_query_tags
 from posthog.errors import wrap_query_error
 from posthog.settings import TEST
 from posthog.utils import generate_short_id, patchable
+from prometheus_client import Counter, Gauge
+
+QUERY_ERROR_COUNTER = Counter(
+    "clickhouse_query_failure",
+    "Query execution failure signal is dispatched when a query fails.",
+    labelnames=["exception_type"],
+)
+
+QUERY_EXECUTION_TIME_GAUGE = Gauge(
+    "clickhouse_query_execution_time",
+    "Clickhouse query execution time",
+)
 
 InsertParams = Union[list, tuple, types.GeneratorType]
 NonInsertParams = dict[str, Any]
@@ -128,16 +139,13 @@ def sync_execute(
             )
         except Exception as e:
             err = wrap_query_error(e)
-            statsd.incr(
-                "clickhouse_sync_execution_failure",
-                tags={"failed": True, "reason": type(err).__name__},
-            )
+            QUERY_ERROR_COUNTER.labels(exception_type=type(err).__name__).inc()
 
             raise err from e
         finally:
             execution_time = perf_counter() - start_time
 
-            statsd.timing("clickhouse_sync_execution_time", execution_time * 1000.0)
+            QUERY_EXECUTION_TIME_GAUGE.set(execution_time * 1000.0)
 
             if query_counter := getattr(thread_local_storage, "query_counter", None):
                 query_counter.total_query_time += execution_time

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -542,6 +542,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         tag_queries(cache_key=cache_key)
         tag_queries(sentry_trace=get_traceparent())
         set_tag("cache_key", cache_key)
+        set_tag("query_type", self.query.__name__)
         if insight_id:
             tag_queries(insight_id=insight_id)
             set_tag("insight_id", str(insight_id))

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -542,7 +542,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         tag_queries(cache_key=cache_key)
         tag_queries(sentry_trace=get_traceparent())
         set_tag("cache_key", cache_key)
-        set_tag("query_type", self.query.__name__)
+        set_tag("query_type", self.query.__class__.__name__)
         if insight_id:
             tag_queries(insight_id=insight_id)
             set_tag("insight_id", str(insight_id))


### PR DESCRIPTION
## Problem
Don't have visibility on load to our endpoint. Can't detect spikes/falls in requests

## Changes
Added monitoring to some endpoints for which we will want to have alerting setup.
Also setting the sentry tag for each of the requests so that we can categories errors/sentry issues according to the feature (have more context which parts of our stack are broken/cause users more issues)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested the decorator is hit/doesn't error out locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
