### PR TITLE
chore: abstract property methods

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -78,7 +78,7 @@ class AggregationFinder(TraversingVisitor):
                 self.visit(arg)
 
 
-def _handle_bool_values(value: ValueT, field: ast.Field, property: Property, team: Team) -> ValueT | bool:
+def _handle_bool_values(value: ValueT, expr: ast.Expr, property: Property, team: Team) -> ValueT | bool:
     if value != "true" and value != "false":
         return value
     if property.type == "person":
@@ -95,7 +95,10 @@ def _handle_bool_values(value: ValueT, field: ast.Field, property: Property, tea
             group_type_index=property.group_type_index,
         )
     elif property.type == "data_warehouse_person_property":
-        key = field.chain[-2]
+        if not isinstance(expr, ast.Field):
+            raise Exception(f"Requires a Field expression")
+
+        key = expr.chain[-2]
 
         # TODO: pass id of table item being filtered on instead of searching through joins
         current_join: DataWarehouseJoin | None = (
@@ -156,54 +159,57 @@ def _handle_bool_values(value: ValueT, field: ast.Field, property: Property, tea
     return value
 
 
-def _field_to_compare_op(
-    field: ast.Field, value: ValueT, operator: PropertyOperator, property: Property, is_json_field: bool, team: Team
+def _expr_to_compare_op(
+    expr: ast.Expr, value: ValueT, operator: PropertyOperator, property: Property, is_json_field: bool, team: Team
 ) -> ast.Expr:
     if operator == PropertyOperator.IS_SET:
         return ast.CompareOperation(
             op=ast.CompareOperationOp.NotEq,
-            left=field,
+            left=expr,
             right=ast.Constant(value=None),
         )
     elif operator == PropertyOperator.IS_NOT_SET:
-        return ast.Or(
-            exprs=[
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Eq,
-                    left=field,
-                    right=ast.Constant(value=None),
-                )
-            ]
-            + (
-                [
-                    ast.Not(
-                        expr=ast.Call(
-                            name="JSONHas",
-                            args=[ast.Field(chain=field.chain[:-1]), ast.Constant(value=property.key)],
-                        )
-                    )
-                ]
-                if is_json_field
-                else []
+        exprs: list[ast.Expr] = [
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.Eq,
+                left=expr,
+                right=ast.Constant(value=None),
             )
-        )
+        ]
+
+        if is_json_field:
+            if not isinstance(expr, ast.Field):
+                raise Exception(f"Requires a Field expression")
+
+            field = ast.Field(chain=expr.chain[:-1])
+
+            exprs.append(
+                ast.Not(
+                    expr=ast.Call(
+                        name="JSONHas",
+                        args=[field, ast.Constant(value=property.key)],
+                    )
+                )
+            )
+
+        return ast.Or(exprs=exprs)
     elif operator == PropertyOperator.ICONTAINS:
         return ast.CompareOperation(
             op=ast.CompareOperationOp.ILike,
-            left=field,
+            left=expr,
             right=ast.Constant(value=f"%{value}%"),
         )
     elif operator == PropertyOperator.NOT_ICONTAINS:
         return ast.CompareOperation(
             op=ast.CompareOperationOp.NotILike,
-            left=field,
+            left=expr,
             right=ast.Constant(value=f"%{value}%"),
         )
     elif operator == PropertyOperator.REGEX:
         return ast.Call(
             name="ifNull",
             args=[
-                ast.Call(name="match", args=[ast.Call(name="toString", args=[field]), ast.Constant(value=value)]),
+                ast.Call(name="match", args=[ast.Call(name="toString", args=[expr]), ast.Constant(value=value)]),
                 ast.Constant(value=0),
             ],
         )
@@ -214,9 +220,7 @@ def _field_to_compare_op(
                 ast.Call(
                     name="not",
                     args=[
-                        ast.Call(
-                            name="match", args=[ast.Call(name="toString", args=[field]), ast.Constant(value=value)]
-                        )
+                        ast.Call(name="match", args=[ast.Call(name="toString", args=[expr]), ast.Constant(value=value)])
                     ],
                 ),
                 ast.Constant(value=1),
@@ -225,47 +229,49 @@ def _field_to_compare_op(
     elif operator == PropertyOperator.EXACT or operator == PropertyOperator.IS_DATE_EXACT:
         return ast.CompareOperation(
             op=ast.CompareOperationOp.Eq,
-            left=field,
-            right=ast.Constant(value=_handle_bool_values(value, field, property, team)),
+            left=expr,
+            right=ast.Constant(value=_handle_bool_values(value, expr, property, team)),
         )
     elif operator == PropertyOperator.IS_NOT:
         return ast.CompareOperation(
             op=ast.CompareOperationOp.NotEq,
-            left=field,
-            right=ast.Constant(value=_handle_bool_values(value, field, property, team)),
+            left=expr,
+            right=ast.Constant(value=_handle_bool_values(value, expr, property, team)),
         )
     elif operator == PropertyOperator.LT or operator == PropertyOperator.IS_DATE_BEFORE:
-        return ast.CompareOperation(op=ast.CompareOperationOp.Lt, left=field, right=ast.Constant(value=value))
+        return ast.CompareOperation(op=ast.CompareOperationOp.Lt, left=expr, right=ast.Constant(value=value))
     elif operator == PropertyOperator.GT or operator == PropertyOperator.IS_DATE_AFTER:
-        return ast.CompareOperation(op=ast.CompareOperationOp.Gt, left=field, right=ast.Constant(value=value))
+        return ast.CompareOperation(op=ast.CompareOperationOp.Gt, left=expr, right=ast.Constant(value=value))
     elif operator == PropertyOperator.LTE:
-        return ast.CompareOperation(op=ast.CompareOperationOp.LtEq, left=field, right=ast.Constant(value=value))
+        return ast.CompareOperation(op=ast.CompareOperationOp.LtEq, left=expr, right=ast.Constant(value=value))
     elif operator == PropertyOperator.GTE:
-        return ast.CompareOperation(op=ast.CompareOperationOp.GtEq, left=field, right=ast.Constant(value=value))
+        return ast.CompareOperation(op=ast.CompareOperationOp.GtEq, left=expr, right=ast.Constant(value=value))
     else:
         raise NotImplementedError(f"PropertyOperator {operator} not implemented")
 
 
 def property_to_expr(
-    property: list
-    | dict
-    | PropertyGroup
-    | PropertyGroupFilter
-    | PropertyGroupFilterValue
-    | Property
-    | ast.Expr
-    | EventPropertyFilter
-    | PersonPropertyFilter
-    | ElementPropertyFilter
-    | SessionPropertyFilter
-    | CohortPropertyFilter
-    | RecordingPropertyFilter
-    | GroupPropertyFilter
-    | FeaturePropertyFilter
-    | HogQLPropertyFilter
-    | EmptyPropertyFilter
-    | DataWarehousePropertyFilter
-    | DataWarehousePersonPropertyFilter,
+    property: (
+        list
+        | dict
+        | PropertyGroup
+        | PropertyGroupFilter
+        | PropertyGroupFilterValue
+        | Property
+        | ast.Expr
+        | EventPropertyFilter
+        | PersonPropertyFilter
+        | ElementPropertyFilter
+        | SessionPropertyFilter
+        | CohortPropertyFilter
+        | RecordingPropertyFilter
+        | GroupPropertyFilter
+        | FeaturePropertyFilter
+        | HogQLPropertyFilter
+        | EmptyPropertyFilter
+        | DataWarehousePropertyFilter
+        | DataWarehousePersonPropertyFilter
+    ),
     team: Team,
     scope: Literal["event", "person", "session", "replay", "replay_entity", "replay_pdi"] = "event",
 ) -> ast.Expr:
@@ -367,7 +373,7 @@ def property_to_expr(
         else:
             chain = ["properties"]
 
-        field = ast.Field(chain=[*chain, property.key])
+        expr: ast.Expr = ast.Field(chain=[*chain, property.key])
 
         if isinstance(value, list):
             if len(value) == 0:
@@ -398,8 +404,8 @@ def property_to_expr(
                     return ast.And(exprs=exprs)
                 return ast.Or(exprs=exprs)
 
-        return _field_to_compare_op(
-            field=field,
+        return _expr_to_compare_op(
+            expr=expr,
             value=value,
             operator=operator,
             team=team,
@@ -449,8 +455,8 @@ def property_to_expr(
             return expr
 
         if property.key == "href":
-            return _field_to_compare_op(
-                field=ast.Field(chain=["elements_chain_href"]),
+            return _expr_to_compare_op(
+                expr=ast.Field(chain=["elements_chain_href"]),
                 value=value,
                 operator=operator,
                 team=team,
@@ -462,8 +468,8 @@ def property_to_expr(
             return parse_expr(
                 "arrayExists(text -> {compare}, elements_chain_texts)",
                 {
-                    "compare": _field_to_compare_op(
-                        field=ast.Field(chain=["text"]),
+                    "compare": _expr_to_compare_op(
+                        expr=ast.Field(chain=["text"]),
                         value=value,
                         operator=operator,
                         team=team,

--- a/posthog/models/filters/mixins/property.py
+++ b/posthog/models/filters/mixins/property.py
@@ -15,8 +15,37 @@ from posthog.models.property import Property, PropertyGroup
 
 class PropertyMixin(BaseParamMixin):
     @cached_property
-    def old_properties(self) -> list[Property]:
-        _props = self._data.get(PROPERTIES)
+    def property_groups(self) -> PropertyGroup:
+        return self._parse_data(key=PROPERTIES)
+
+    def _parse_data(self, key: str) -> PropertyGroup:
+        _props = self._data.get(key)
+
+        if isinstance(_props, str):
+            try:
+                loaded_props = json.loads(_props)
+            except json.decoder.JSONDecodeError:
+                raise ValidationError("Data is unparsable!")
+        else:
+            loaded_props = _props
+
+        # if grouped properties
+        if isinstance(loaded_props, dict) and "type" in loaded_props and "values" in loaded_props:
+            try:
+                return self._parse_property_group(loaded_props)
+            except ValidationError:
+                raise
+            except ValueError as e:
+                raise ValidationError(f"PropertyGroup is unparsable: {e}")
+        # already a PropertyGroup just return
+        elif isinstance(loaded_props, PropertyGroup):
+            return loaded_props
+
+        # old properties
+        return PropertyGroup(type=PropertyOperatorType.AND, values=self.old_properties(key=key))
+
+    def old_properties(self, key: str) -> list[Property]:
+        _props = self._data.get(key)
 
         if isinstance(_props, str):
             try:
@@ -36,33 +65,6 @@ class PropertyMixin(BaseParamMixin):
         else:
             # old style dict properties or a list of properties
             return self._parse_properties(loaded_props)
-
-    @cached_property
-    def property_groups(self) -> PropertyGroup:
-        _props = self._data.get(PROPERTIES)
-
-        if isinstance(_props, str):
-            try:
-                loaded_props = json.loads(_props)
-            except json.decoder.JSONDecodeError:
-                raise ValidationError("Properties are unparsable!")
-        else:
-            loaded_props = _props
-
-        # if grouped properties
-        if isinstance(loaded_props, dict) and "type" in loaded_props and "values" in loaded_props:
-            try:
-                return self._parse_property_group(loaded_props)
-            except ValidationError:
-                raise
-            except ValueError as e:
-                raise ValidationError(f"PropertyGroup is unparsable: {e}")
-        # already a PropertyGroup just return
-        elif isinstance(loaded_props, PropertyGroup):
-            return loaded_props
-
-        # old properties
-        return PropertyGroup(type=PropertyOperatorType.AND, values=self.old_properties)
 
     def _parse_properties(self, properties: Optional[Any]) -> list[Property]:
         if isinstance(properties, list):


### PR DESCRIPTION
## Problem

Abstracted from https://github.com/PostHog/posthog/pull/24292

## Changes

#### 1. expr not field
Recordings require a function expression to be passed to their compare operation e.g.
```
if property.type == "recording" and property.key == "snapshot_source":
    expr = ast.Call(name="argMinMerge", args=[field])
```
There is no reason we should limit the compare construction function to only accept field expressions

#### 2. Property group parsing
We have two sets of "properties" denoted by the `properties` and `console_logs` keys in the query. We do not want to use a single set of properties because we lookup the `console_logs` in a separate sub query for performance reasons. Therefore, I abstracted the logic to create property groups and allowed it to accept any key via the `_parse_data` method. The `property_groups` method returns exactly as before 

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

No functional changes expected