### PR TITLE
fix(cdp): Over redaction of values

### DIFF
--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -438,7 +438,9 @@ export class HogExecutor {
                 ) {
                     // Assume the values are the sensitive parts
                     Object.values(value).forEach((val: any) => {
-                        values.push(val)
+                        if (typeof val === 'string') {
+                            values.push(val)
+                        }
                     })
                 }
             }

--- a/plugin-server/tests/cdp/examples.ts
+++ b/plugin-server/tests/cdp/examples.ts
@@ -359,7 +359,10 @@ export const HOG_INPUTS_EXAMPLES: Record<string, Pick<HogFunctionType, 'inputs' 
         ],
         inputs: {
             input_1: { value: 'test', bytecode: ['_h', 32, 'test'] },
-            secret_input_2: { value: { foo: 'bar' }, bytecode: { foo: ['_h', 32, 'bar'] } },
+            secret_input_2: {
+                value: { foo: 'bar', null: null, bool: false },
+                bytecode: { foo: ['_h', 32, 'bar'], null: ['_h', 32, null], bool: ['_h', 32, false] },
+            },
             secret_input_3: { value: 'super secret', bytecode: ['_h', 32, 'super secret'] },
         },
     },

--- a/plugin-server/tests/cdp/hog-executor.test.ts
+++ b/plugin-server/tests/cdp/hog-executor.test.ts
@@ -105,11 +105,11 @@ describe('Hog Executor', () => {
                 Array [
                   "Executing function",
                   "test",
-                  "{\\"nested\\":{\\"foo\\":\\"***REDACTED***\\"}}",
-                  "{\\"foo\\":\\"***REDACTED***\\"}",
+                  "{\\"nested\\":{\\"foo\\":\\"***REDACTED***\\",\\"null\\":null,\\"bool\\":false}}",
+                  "{\\"foo\\":\\"***REDACTED***\\",\\"null\\":null,\\"bool\\":false}",
                   "substring: ***REDACTED***",
-                  "{\\"input_1\\":\\"test\\",\\"secret_input_2\\":{\\"foo\\":\\"***REDACTED***\\"},\\"secret_input_3\\":\\"***REDACTED***\\"}",
-                  "Function completed in 0ms. Sync: 0ms. Mem: 129 bytes. Ops: 28.",
+                  "{\\"input_1\\":\\"test\\",\\"secret_input_2\\":{\\"foo\\":\\"***REDACTED***\\",\\"null\\":null,\\"bool\\":false},\\"secret_input_3\\":\\"***REDACTED***\\"}",
+                  "Function completed in 0ms. Sync: 0ms. Mem: 169 bytes. Ops: 28.",
                 ]
             `)
         })


### PR DESCRIPTION
## Problem

We weren't checking the values for being strings which meant null or true/false would get redacted which is super confusing

## Changes

* Check for string value

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
