### PR TITLE
fix(insights): check in the breakdown_value to find the "other" breakdown

### DIFF
--- a/posthog/hogql_queries/insights/trends/breakdown.py
+++ b/posthog/hogql_queries/insights/trends/breakdown.py
@@ -22,6 +22,8 @@ from posthog.schema import (
     InCohortVia,
     MultipleBreakdownType,
     TrendsQuery,
+)
+from posthog.schema import (
     Breakdown as BreakdownSchema,
 )
 
@@ -168,14 +170,6 @@ class Breakdown:
         Type checking
         """
         return cast(BreakdownFilter, self.query.breakdownFilter)
-
-    @property
-    def hide_other_aggregation(self) -> bool:
-        return (
-            self.query.breakdownFilter.breakdown_hide_other_aggregation or False
-            if self.query.breakdownFilter
-            else False
-        )
 
     def _get_cohort_filter(self, breakdowns: list[str | int] | list[str] | str | int):
         if breakdowns == "all":

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -423,9 +423,9 @@ class TrendsQueryRunner(QueryRunner):
                 timings.extend(timing)
 
         has_more = False
-        if self.breakdown_enabled and any(item["label"] == BREAKDOWN_OTHER_STRING_LABEL for item in final_result):
+        if self.breakdown_enabled and any(self._is_other_breakdown(item["breakdown_value"]) for item in final_result):
             if self.query.breakdownFilter and self.query.breakdownFilter.breakdown_hide_other_aggregation:
-                final_result = [item for item in final_result if item["label"] != BREAKDOWN_OTHER_STRING_LABEL]
+                final_result = [item for item in final_result if not self._is_other_breakdown(item["breakdown_value"])]
             has_more = True
 
         return TrendsQueryResponse(
@@ -802,6 +802,7 @@ class TrendsQueryRunner(QueryRunner):
                     if isinstance(single_or_multiple_breakdown_value, tuple)
                     else single_or_multiple_breakdown_value
                 )
+
                 any_result: Optional[dict[str, Any]] = None
                 for result in results:
                     matching_result = [item for item in result if itemgetter(*keys)(item) == breakdown_value]
@@ -1059,3 +1060,10 @@ class TrendsQueryRunner(QueryRunner):
                 res_breakdown.append(item)
 
         return res_breakdown
+
+    def _is_other_breakdown(self, breakdown: BreakdownItem | list[BreakdownItem]) -> bool:
+        return (
+            breakdown == BREAKDOWN_OTHER_STRING_LABEL
+            or isinstance(breakdown, list)
+            and BREAKDOWN_OTHER_STRING_LABEL in breakdown
+        )


### PR DESCRIPTION
## Problem

The "Label" field of a Trends response is not an optimal way to look for the "Other" breakdown. For example, when a formula is applied, the label becomes `Formula (A+B)`.

[Related Ticket](https://posthoghelp.zendesk.com/agent/tickets/16938)

## Changes

Check for the "Other" breakdown using breakdown values including single and multiple breakdowns.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unit tests, manual testing and added a test to catch regressions.