### PR TITLE
fix: label query execution time with query kind

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -28,6 +28,7 @@ QUERY_ERROR_COUNTER = Counter(
 QUERY_EXECUTION_TIME_GAUGE = Gauge(
     "clickhouse_query_execution_time",
     "Clickhouse query execution time",
+    labelnames=["query_type"],
 )
 
 InsertParams = Union[list, tuple, types.GeneratorType]
@@ -145,7 +146,9 @@ def sync_execute(
         finally:
             execution_time = perf_counter() - start_time
 
-            QUERY_EXECUTION_TIME_GAUGE.set(execution_time * 1000.0)
+            query_type = tags.get("query_type", "Other")
+
+            QUERY_EXECUTION_TIME_GAUGE.labels(query_type=query_type).set(execution_time * 1000.0)
 
             if query_counter := getattr(thread_local_storage, "query_counter", None):
                 query_counter.total_query_time += execution_time

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -542,7 +542,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         tag_queries(cache_key=cache_key)
         tag_queries(sentry_trace=get_traceparent())
         set_tag("cache_key", cache_key)
-        set_tag("query_type", self.query.__class__.__name__)
+        set_tag("query_type", getattr(self.query, "kind", "Other"))
         if insight_id:
             tag_queries(insight_id=insight_id)
             set_tag("insight_id", str(insight_id))


### PR DESCRIPTION
## Problem
Want to split up our [query execution time](https://grafana.prod-us.posthog.dev/d/edvegyvt4u8sge/requests?from=now-24h&to=now&timezone=browser) by query type

## Changes
Add query type label to the gauge
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested code path locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
