### PR TITLE
chore: remove unnaccessible api endpoints and rate limit snapshots

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -44,10 +44,7 @@ from posthog.session_recordings.queries.session_recording_list_from_filters impo
 from posthog.session_recordings.queries.session_recording_properties import (
     SessionRecordingProperties,
 )
-from posthog.rate_limit import (
-    ClickHouseBurstRateThrottle,
-    ClickHouseSustainedRateThrottle,
-)
+from posthog.rate_limit import ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle, PersonalApiKeyRateThrottle
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 from posthog.session_recordings.realtime_snapshots import get_realtime_snapshots, publish_subscription
 from ee.session_recordings.session_summary.summarize_session import summarize_recording
@@ -250,9 +247,20 @@ def stream_from(url: str, headers: dict | None = None) -> Generator[requests.Res
         session.close()
 
 
+class SnapshotsBurstRateThrottle(PersonalApiKeyRateThrottle):
+    scope = "snapshots_burst"
+    rate = "120/minute"
+
+
+class SnapshotsSustainedRateThrottle(PersonalApiKeyRateThrottle):
+    scope = "snapshots_sustained"
+    rate = "600/hour"
+
+
 # NOTE: Could we put the sharing stuff in the shared mixin :thinking:
 class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object = "session_recording"
+    scope_object_read_actions = ["list", "retrieve", "snapshots"]
     throttle_classes = [ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle]
     serializer_class = SessionRecordingSerializer
     # We don't use this
@@ -279,11 +287,12 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         return list_recordings_response(filter, request, self.get_serializer_context())
 
     @extend_schema(
+        exclude=True,
         description="""
         Gets a list of event ids that match the given session recording filter.
         The filter must include a single session ID.
         And must include at least one event or action filter.
-        This API is intended for internal use and might have unannounced breaking changes."""
+        This API is intended for internal use and might have unannounced breaking changes.""",
     )
     @action(methods=["GET"], detail=False)
     def matching_events(self, request: request.Request, *args: Any, **kwargs: Any) -> JsonResponse:
@@ -345,6 +354,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         return Response({"success": True}, status=204)
 
+    @extend_schema(exclude=True)
     @action(methods=["POST"], detail=True)
     def persist(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
         recording = self.get_object()
@@ -360,7 +370,12 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         return Response({"success": True})
 
     @extend_schema(exclude=True)
-    @action(methods=["GET"], detail=True, renderer_classes=[SurrogatePairSafeJSONRenderer])
+    @action(
+        methods=["GET"],
+        detail=True,
+        renderer_classes=[SurrogatePairSafeJSONRenderer],
+        throttle_classes=[SnapshotsBurstRateThrottle, SnapshotsSustainedRateThrottle],
+    )
     def snapshots(self, request: request.Request, **kwargs):
         """
         Snapshots can be loaded from multiple places:
@@ -497,6 +512,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             return "anonymous"
 
     # Returns properties given a list of session recording ids
+    @extend_schema(exclude=True)
     @action(methods=["GET"], detail=False)
     def properties(self, request: request.Request, **kwargs):
         filter = SessionRecordingsFilter(request=request, team=self.team)
@@ -521,6 +537,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         return Response({"results": session_recording_serializer.data})
 
+    @extend_schema(exclude=True)
     @action(methods=["POST"], detail=True)
     def summarize(self, request: request.Request, **kwargs):
         if not request.user.is_authenticated:
@@ -561,6 +578,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             )
         return r
 
+    @extend_schema(exclude=True)
     @action(methods=["GET"], detail=True)
     def similar_sessions(self, request: request.Request, **kwargs):
         if not request.user.is_authenticated:
@@ -590,6 +608,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         r = Response(recordings, headers={"Cache-Control": "max-age=15"})
         return r
 
+    @extend_schema(exclude=True)
     @action(methods=["GET"], detail=False)
     def error_clusters(self, request: request.Request, **kwargs):
         if not request.user.is_authenticated:


### PR DESCRIPTION
## Problem

1. We have a bunch of API endpoints on https://posthog.com/docs/api/session-recordings that are not actually accessible via the public API
2. We want to allow limited public access to the snapshots API so let's rate limit it

## Changes

1. Add `exclude` to any endpoint not accessible publicly (public endpoints defined by `scope_object_read_actions`)
2. Add two burst and sustained limits to the `snapshots` API