### PR TITLE
fix: Fix column order difference between creation and migration in raw_sessions

### DIFF
--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -1758,11 +1758,12 @@
       autocapture_uniq AggregateFunction(uniq, Nullable(UUID)),
       screen_count SimpleAggregateFunction(sum, Int64),
       screen_uniq AggregateFunction(uniq, Nullable(UUID)),
-      -- as a performance optimisation, also keep track of the uniq events for all of these combined, a bounce is a session with <2 of these
-      page_screen_autocapture_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID)),
   
       -- replay
-      maybe_has_session_replay SimpleAggregateFunction(max, Bool) -- will be written False to by the events table mv and True to by the replay table mv
+      maybe_has_session_replay SimpleAggregateFunction(max, Bool), -- will be written False to by the events table mv and True to by the replay table mv
+  
+      -- as a performance optimisation, also keep track of the uniq events for all of these combined, a bounce is a session with <2 of these
+      page_screen_autocapture_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID))
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_raw_sessions', cityHash64(session_id_v7))
   
   '''
@@ -1833,10 +1834,12 @@
       uniqState(if(event='$autocapture', uuid, NULL)) as autocapture_uniq,
       sumIf(1, event='$screen') as screen_count,
       uniqState(if(event='$screen', uuid, NULL)) as screen_uniq,
-      uniqUpToState(1)(if(event='$pageview' OR event='$screen' OR event='$autocapture', uuid, NULL)) as page_screen_autocapture_uniq_up_to,
   
       -- replay
-      false as maybe_has_session_replay
+      false as maybe_has_session_replay,
+  
+      -- perf
+      uniqUpToState(1)(if(event='$pageview' OR event='$screen' OR event='$autocapture', uuid, NULL)) as page_screen_autocapture_uniq_up_to
   FROM posthog_test.sharded_events
   WHERE bitAnd(bitShiftRight(toUInt128(accurateCastOrNull(`$session_id`, 'UUID')), 76), 0xF) == 7 -- has a session id and is valid uuidv7)
   GROUP BY
@@ -2422,11 +2425,12 @@
       autocapture_uniq AggregateFunction(uniq, Nullable(UUID)),
       screen_count SimpleAggregateFunction(sum, Int64),
       screen_uniq AggregateFunction(uniq, Nullable(UUID)),
-      -- as a performance optimisation, also keep track of the uniq events for all of these combined, a bounce is a session with <2 of these
-      page_screen_autocapture_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID)),
   
       -- replay
-      maybe_has_session_replay SimpleAggregateFunction(max, Bool) -- will be written False to by the events table mv and True to by the replay table mv
+      maybe_has_session_replay SimpleAggregateFunction(max, Bool), -- will be written False to by the events table mv and True to by the replay table mv
+  
+      -- as a performance optimisation, also keep track of the uniq events for all of these combined, a bounce is a session with <2 of these
+      page_screen_autocapture_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID))
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.raw_sessions', '{replica}')
   
   PARTITION BY toYYYYMM(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000)))
@@ -2723,11 +2727,12 @@
       autocapture_uniq AggregateFunction(uniq, Nullable(UUID)),
       screen_count SimpleAggregateFunction(sum, Int64),
       screen_uniq AggregateFunction(uniq, Nullable(UUID)),
-      -- as a performance optimisation, also keep track of the uniq events for all of these combined, a bounce is a session with <2 of these
-      page_screen_autocapture_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID)),
   
       -- replay
-      maybe_has_session_replay SimpleAggregateFunction(max, Bool) -- will be written False to by the events table mv and True to by the replay table mv
+      maybe_has_session_replay SimpleAggregateFunction(max, Bool), -- will be written False to by the events table mv and True to by the replay table mv
+  
+      -- as a performance optimisation, also keep track of the uniq events for all of these combined, a bounce is a session with <2 of these
+      page_screen_autocapture_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID))
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_raw_sessions', cityHash64(session_id_v7))
   
   '''
@@ -3533,11 +3538,12 @@
       autocapture_uniq AggregateFunction(uniq, Nullable(UUID)),
       screen_count SimpleAggregateFunction(sum, Int64),
       screen_uniq AggregateFunction(uniq, Nullable(UUID)),
-      -- as a performance optimisation, also keep track of the uniq events for all of these combined, a bounce is a session with <2 of these
-      page_screen_autocapture_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID)),
   
       -- replay
-      maybe_has_session_replay SimpleAggregateFunction(max, Bool) -- will be written False to by the events table mv and True to by the replay table mv
+      maybe_has_session_replay SimpleAggregateFunction(max, Bool), -- will be written False to by the events table mv and True to by the replay table mv
+  
+      -- as a performance optimisation, also keep track of the uniq events for all of these combined, a bounce is a session with <2 of these
+      page_screen_autocapture_uniq_up_to AggregateFunction(uniqUpTo(1), Nullable(UUID))
   ) ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.raw_sessions', '{replica}')
   
   PARTITION BY toYYYYMM(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(session_id_v7, 80)), 1000)))

--- a/posthog/clickhouse/test/test_raw_sessions_model.py
+++ b/posthog/clickhouse/test/test_raw_sessions_model.py
@@ -1,0 +1,27 @@
+from posthog.clickhouse.client import sync_execute
+from posthog.models.raw_sessions.sql import RAW_SESSION_TABLE_BACKFILL_SELECT_SQL
+from posthog.models.utils import uuid7
+from posthog.test.base import (
+    _create_event,
+    ClickhouseTestMixin,
+    BaseTest,
+)
+
+
+class TestRawSessionsModel(ClickhouseTestMixin, BaseTest):
+    def test_backfill_sql(self):
+        distinct_id = str(uuid7())
+        session_id = str(uuid7())
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id=distinct_id,
+            properties={"$current_url": "/", "$session_id": session_id},
+            timestamp="2024-03-08",
+        )
+
+        # just test that the backfill SQL can be run without error
+        sync_execute(
+            "INSERT INTO raw_sessions" + RAW_SESSION_TABLE_BACKFILL_SELECT_SQL() + "AND team_id = %(team_id)s",
+            {"team_id": self.team.id},
+        )

--- a/posthog/models/raw_sessions/migrations.py
+++ b/posthog/models/raw_sessions/migrations.py
@@ -7,6 +7,7 @@ ALTER TABLE {table_name} on CLUSTER '{cluster}'
 ADD COLUMN IF NOT EXISTS
 page_screen_autocapture_uniq_up_to
 AggregateFunction(uniqUpTo(1), Nullable(UUID))
+AFTER maybe_has_session_replay
 """
 
 BASE_RAW_SESSIONS_ADD_PAGEVIEW_AUTOCAPTURE_SCREEN_UP_TO_2_COLUMN_SQL = (


### PR DESCRIPTION
Pulled out from https://github.com/PostHog/posthog/pull/24475 as just the most essential changes

## Problem

The columns as created by the migrations were in a different order to the creation SQL, which broke the backfill script. This was my bad - I included them in the middle of the SQL but didn't include an AFTER expression in the migration.

## Changes

These migrations have already been run on the EU and US cloud instances, so let's treat the order currently live as fixed. This changes the code to match what is running in prod.

It also adds a test to ensure the backfill SQL can run successfully

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Added a test
