### PR TITLE
fix: All events filter 

### DIFF
--- a/posthog/cdp/filters.py
+++ b/posthog/cdp/filters.py
@@ -28,8 +28,14 @@ def hog_function_filters_to_expr(filters: dict, team: Team, actions: dict[int, A
         exprs.extend(common_filters_expr)
 
         # Events
-        if filter.get("type") == "events" and filter.get("name"):
-            exprs.append(parse_expr("event = {event}", {"event": ast.Constant(value=filter["name"])}))
+        if filter.get("type") == "events" and filter.get("id"):
+            event_name = filter["id"]
+
+            if event_name is None:
+                # all events
+                exprs.append(ast.Constant(value=1))
+            else:
+                exprs.append(parse_expr("event = {event}", {"event": ast.Constant(value=event_name)}))
 
         # Actions
         if filter.get("type") == "actions":

--- a/posthog/cdp/test/test_filters.py
+++ b/posthog/cdp/test/test_filters.py
@@ -65,6 +65,20 @@ class TestHogFunctionFilters(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest
     def test_filters_empty(self):
         assert self.filters_to_bytecode(filters={}) == snapshot(["_h", 29])
 
+    def test_filters_all_events(self):
+        assert self.filters_to_bytecode(
+            filters={
+                "events": [
+                    {
+                        "id": None,
+                        "name": "All events",
+                        "type": "events",
+                        "order": 0,
+                    }
+                ]
+            }
+        ) == snapshot(["_h", 3, 0, 29, 4, 2])
+
     def test_filters_events(self):
         assert self.filters_to_bytecode(filters={"events": self.filters["events"]}) == snapshot(
             [


### PR DESCRIPTION
## Problem

There was a missing condition for the all events filter.

## Changes

* fixes it
* Also checks the id of an event rather than a name. This happened to work because they are almost always the same...

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
