### PR TITLE
feat(queries): Adjust cache warming schedule

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -96,7 +96,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     add_periodic_task_with_expiry(sender, 20, start_poll_query_performance.s(), "20 sec query performance heartbeat")
 
     sender.add_periodic_task(
-        crontab(hour="*", minute="*/30"),
+        crontab(hour="*", minute="0"),
         schedule_warming_for_teams_task.s(),
         name="schedule warming for largest teams",
     )


### PR DESCRIPTION
## Problem

Working on cache warming v2... monitoring and adjusting load.
Once per hour might be better: We have a full hour to go through all insights to warm. Slightly more insights to warm probably, but double the time for them.

## Changes

Adjust schedule
