### PR TITLE
fix: bump max wait time for flakey cyclotron test, add RUST_BACKTRACE=1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -168,7 +168,7 @@ jobs:
               if: needs.changes.outputs.rust == 'true'
               run: |
                   echo "Starting cargo test"
-                  cargo test --all-features ${{ matrix.package == 'feature-flags' && '--package feature-flags' || '--workspace --exclude feature-flags' }}
+                  RUST_BACKTRACE=1 cargo test --all-features ${{ matrix.package == 'feature-flags' && '--package feature-flags' || '--workspace --exclude feature-flags' }}
                   echo "Cargo test completed"
 
     linting:

--- a/rust/cyclotron-fetch/tests/fetch.rs
+++ b/rust/cyclotron-fetch/tests/fetch.rs
@@ -69,11 +69,11 @@ pub async fn test_returns_failure_after_retries(db: PgPool) {
     // Tick twice for retry
     let started = tick(context.clone()).await.unwrap();
     assert_eq!(started, 1);
-    wait_on_no_running(&db, Duration::milliseconds(100)).await;
+    wait_on_no_running(&db, Duration::milliseconds(500)).await;
     make_immediately_available(&db).await;
     let started = tick(context.clone()).await.unwrap();
     assert_eq!(started, 1);
-    wait_on_no_running(&db, Duration::milliseconds(100)).await;
+    wait_on_no_running(&db, Duration::milliseconds(500)).await;
 
     let returned = wait_on_return(&return_worker, 1, false).await.unwrap();
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
CI (and rarely local) can sometimes choke and take more than 100ms to run the test job. Having a slightly higher max wait (which should rarely be hit) seems like a safe fix.

## Changes

Increase max wait in `test_returns_failure_after_retries`

Additionally, add `RUST_BACKTRACE=1` to CI test runs.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

Improve existing.