### PR TITLE
fix(batch-exports): Retry up to 5 times on postgres connection

### DIFF
--- a/posthog/temporal/batch_exports/utils.py
+++ b/posthog/temporal/batch_exports/utils.py
@@ -203,7 +203,7 @@ def make_retryable_with_exponential_backoff(
             except retryable_exceptions as err:
                 attempt += 1
 
-                if is_exception_retryable(err) is False or attempt > max_attempts:
+                if is_exception_retryable(err) is False or attempt >= max_attempts:
                     raise
 
                 await asyncio.sleep(

--- a/posthog/temporal/batch_exports/utils.py
+++ b/posthog/temporal/batch_exports/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import collections.abc
 import contextlib
+import functools
 import json
 import typing
 import uuid
@@ -171,3 +172,45 @@ def cast_record_batch_json_columns(
         record_batch.select(remaining_column_names).columns + casted_arrays,
         names=remaining_column_names + list(intersection),
     )
+
+
+_Result = typing.TypeVar("_Result")
+FutureLike = (
+    asyncio.Future[_Result] | collections.abc.Coroutine[None, typing.Any, _Result] | collections.abc.Awaitable[_Result]
+)
+
+
+def make_retryable_with_exponential_backoff(
+    func: typing.Callable[..., collections.abc.Awaitable[_Result]],
+    timeout: float | int | None = None,
+    max_attempts: int = 5,
+    initial_retry_delay: float | int = 2,
+    max_retry_delay: float | int = 32,
+    exponential_backoff_coefficient: int = 2,
+    retryable_exceptions: tuple[type[Exception], ...] = (Exception,),
+    is_exception_retryable: typing.Callable[[Exception], bool] = lambda _: True,
+) -> typing.Callable[..., collections.abc.Awaitable[_Result]]:
+    """Retry the provided async `func` until `max_attempts` is reached."""
+    functools.wraps(func)
+
+    async def inner(*args, **kwargs):
+        attempt = 0
+
+        while True:
+            try:
+                result = await asyncio.wait_for(func(*args, **kwargs), timeout=timeout)
+
+            except retryable_exceptions as err:
+                attempt += 1
+
+                if is_exception_retryable(err) is False or attempt > max_attempts:
+                    raise
+
+                await asyncio.sleep(
+                    min(max_retry_delay, initial_retry_delay * (attempt**exponential_backoff_coefficient))
+                )
+
+            else:
+                return result
+
+    return inner


### PR DESCRIPTION
## Problem

We are seeing some intermittent connection errors that could be caused by slow servers or even psycopg bugs. Regardless, they should be easily solvable with some retrying logic. 

Unfortunately, I am not able to differentiate between connection errors we don't want to retry on (e.g. invalid credentials) and these transient network errors: `psycopg` raises `OperationalError` for both, without any attributes we can check. So, for the time being, we will retry everything 5 times with a similar loop to https://github.com/PostHog/posthog/pull/24416.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Retry on PostgreSQL connection errors.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
