### PR TITLE
fix(insights): Expire cache warming tasks at a fixed time

### DIFF
--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -97,7 +97,7 @@ def schedule_warming_for_teams_task():
             | Q(sharingconfiguration__insight__insightviewed__last_viewed_at__gte=threshold)
         ),
         sharingconfiguration__enabled=True,
-    )
+    ).difference(prio_teams)
 
     all_teams = itertools.chain(
         zip(prio_teams, [False] * len(prio_teams)),


### PR DESCRIPTION
## Problem

After monitoring metrics, it seems the expiration is somewhat not working since tasks stay around too long. One issue might be that in chains, the expiry starts counting when the task is delivered to the queue (which is one by one), and not when the whole chain is started. This means if we get to the next task in the chain within 60 minutes (the current expiry) and this then posts the next task it likewise has 60 minutes to expire and so on.

## Changes

Use a fixed expiration time from when we schedule the warming tasks for all teams.
If we load too many tasks into the queue, more than can be done in one hour, the rest should expire before the end of the hour. This can easily be checked in Grafana. If a lot expiry every hour, we can use that information to either scale up or have the system keep less insights warm.
