### PR TITLE
fix(batch-exports): Do not attempt to decode empty values

### DIFF
--- a/posthog/temporal/batch_exports/utils.py
+++ b/posthog/temporal/batch_exports/utils.py
@@ -121,6 +121,11 @@ class JsonScalar(pa.ExtensionScalar):
 
     def as_py(self) -> dict | None:
         if self.value:
+            value = self.value.as_py()
+
+            if not value:
+                return None
+
             try:
                 return orjson.loads(self.value.as_py().encode("utf-8"))
             except:

--- a/posthog/temporal/batch_exports/utils.py
+++ b/posthog/temporal/batch_exports/utils.py
@@ -127,10 +127,10 @@ class JsonScalar(pa.ExtensionScalar):
                 return None
 
             try:
-                return orjson.loads(self.value.as_py().encode("utf-8"))
+                return orjson.loads(value.encode("utf-8"))
             except:
                 # Fallback if it's something orjson can't handle
-                return json.loads(self.value.as_py())
+                return json.loads(value)
         else:
             return None
 


### PR DESCRIPTION
## Problem

Seeing an error being raised here very rarely:
```
Expecting value: line 1 column 1 (char 0)
```
This usually means we are passing an empty `str` to `json.loads`. In those cases, let's return `None`.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Return `None` if no value to load.
* Do not write any empty values.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
