### PR TITLE
Remove top-level `from ee.*` imports to support hobby deployments

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -76,6 +76,9 @@ services:
             OBJECT_STORAGE_ENDPOINT: http://objectstorage:19000
             OBJECT_STORAGE_ENABLED: true
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
+        build:
+            dockerfile: production.Dockerfile
+            context: .
     web:
         extends:
             file: docker-compose.base.yml
@@ -84,6 +87,9 @@ services:
         volumes:
             - ./compose:/compose
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
+        build:
+            dockerfile: production.Dockerfile
+            context: .
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
@@ -104,6 +110,9 @@ services:
             file: docker-compose.base.yml
             service: plugins
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
+        build:
+            dockerfile: production.Dockerfile
+            context: .
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
@@ -147,6 +156,9 @@ services:
             file: docker-compose.base.yml
             service: asyncmigrationscheck
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
+        build:
+            dockerfile: production.Dockerfile
+            context: .
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN
@@ -193,6 +205,9 @@ services:
         volumes:
             - ./compose:/compose
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
+        build:
+            dockerfile: production.Dockerfile
+            context: .
         environment:
             SENTRY_DSN: $SENTRY_DSN
             SITE_URL: https://$DOMAIN

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -24,7 +24,6 @@ from statshog.defaults.django import statsd
 from token_bucket import Limiter, MemoryStorage
 from typing import Any, Optional, Literal
 
-from ee.billing.quota_limiting import QuotaLimitingCaches
 from posthog.api.utils import get_data, get_token, safe_clickhouse_string
 from posthog.cache_utils import cache_for
 from posthog.exceptions import generate_exception_response
@@ -340,7 +339,7 @@ def drop_events_over_quota(token: str, events: list[Any]) -> EventsOverQuotaResu
     if not settings.EE_AVAILABLE:
         return EventsOverQuotaResult(events, False, False)
 
-    from ee.billing.quota_limiting import QuotaResource, list_limited_team_attributes
+    from ee.billing.quota_limiting import QuotaResource, QuotaLimitingCaches, list_limited_team_attributes
 
     results = []
     limited_tokens_events = list_limited_team_attributes(

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -1,5 +1,6 @@
 from typing import Any, Optional, cast
 
+from django.conf import settings
 from rest_framework import (
     exceptions,
     mixins,
@@ -11,7 +12,6 @@ from rest_framework import (
 )
 from rest_framework.decorators import action
 
-from ee.models.explicit_team_membership import ExplicitTeamMembership
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.email import is_email_available
@@ -61,6 +61,12 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
         team_error = "Team does not exist on this organization, or it is private and you do not have access to it."
         if not private_project_access:
             return None
+
+        if not settings.EE_AVAILABLE:
+            return private_project_access
+
+        from ee.models.explicit_team_membership import ExplicitTeamMembership
+
         for item in private_project_access:
             # if the project is private, if user is not an admin of the team, they can't invite to it
             organization: Organization = Organization.objects.get(id=self.context["organization_id"])

--- a/posthog/management/commands/update_billing_quotas.py
+++ b/posthog/management/commands/update_billing_quotas.py
@@ -2,8 +2,6 @@ import pprint
 
 from django.core.management.base import BaseCommand
 
-from ee.billing.quota_limiting import update_all_org_billing_quotas
-
 
 class Command(BaseCommand):
     help = "Update billing rate limiting for all organizations"
@@ -13,6 +11,8 @@ class Command(BaseCommand):
         parser.add_argument("--print-reports", type=bool, help="Print the reports in full")
 
     def handle(self, *args, **options):
+        from ee.billing.quota_limiting import update_all_org_billing_quotas
+
         dry_run = options["dry_run"]
 
         quota_limited_orgs, quota_limiting_suspended_orgs = update_all_org_billing_quotas(dry_run)

--- a/posthog/models/organization_invite.py
+++ b/posthog/models/organization_invite.py
@@ -2,11 +2,13 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Optional
 
 import structlog
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 from rest_framework import exceptions
 
-from ee.models.explicit_team_membership import ExplicitTeamMembership
+if settings.EE_AVAILABLE:
+    from ee.models.explicit_team_membership import ExplicitTeamMembership
 from posthog.constants import INVITE_DAYS_VALIDITY
 from posthog.email import is_email_available
 from posthog.models.organization import OrganizationMembership

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -447,7 +447,6 @@ class Team(UUIDClassicModel):
         return filters
 
     def all_users_with_access(self) -> QuerySet["User"]:
-        from ee.models.explicit_team_membership import ExplicitTeamMembership
         from posthog.models.organization import OrganizationMembership
         from posthog.models.user import User
 
@@ -456,6 +455,7 @@ class Team(UUIDClassicModel):
                 "user_id", flat=True
             )
         else:
+            from ee.models.explicit_team_membership import ExplicitTeamMembership
             user_ids_queryset = (
                 OrganizationMembership.objects.filter(
                     organization_id=self.organization_id, level__gte=OrganizationMembership.Level.ADMIN

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -270,9 +270,8 @@ class User(AbstractUser, UUIDClassicModel):
         self.update_billing_organization_users(organization)
 
     def update_billing_organization_users(self, organization: Organization) -> None:
-        from ee.billing.billing_manager import BillingManager  # avoid circular import
-
         if is_cloud() and get_cached_instance_license() is not None:
+            from ee.billing.billing_manager import BillingManager  # avoid circular import
             BillingManager(get_cached_instance_license()).update_billing_organization_users(organization)
 
     def get_analytics_metadata(self):

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -47,9 +47,10 @@ from posthog.session_recordings.queries.session_recording_properties import (
 from posthog.rate_limit import ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle, PersonalApiKeyRateThrottle
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 from posthog.session_recordings.realtime_snapshots import get_realtime_snapshots, publish_subscription
-from ee.session_recordings.session_summary.summarize_session import summarize_recording
-from ee.session_recordings.ai.similar_recordings import similar_recordings
-from ee.session_recordings.ai.error_clustering import error_clustering
+if settings.EE_AVAILABLE:
+    from ee.session_recordings.session_summary.summarize_session import summarize_recording
+    from ee.session_recordings.ai.similar_recordings import similar_recordings
+    from ee.session_recordings.ai.error_clustering import error_clustering
 from posthog.session_recordings.snapshots.convert_legacy_snapshots import convert_original_version_lts_recording
 from posthog.storage import object_storage
 from prometheus_client import Counter

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -33,7 +33,6 @@ RUN corepack enable && pnpm --version && \
     rm -rf /tmp/pnpm-store
 
 COPY frontend/ frontend/
-COPY ee/frontend/ ee/frontend/
 COPY ./bin/ ./bin/
 COPY babel.config.js tsconfig.json webpack.config.js tailwind.config.js ./
 RUN pnpm build
@@ -113,7 +112,6 @@ ENV PATH=/python-runtime/bin:$PATH \
 COPY manage.py manage.py
 COPY hogvm hogvm/
 COPY posthog posthog/
-COPY ee ee/
 COPY --from=frontend-build /code/frontend/dist /code/frontend/dist
 RUN SKIP_SERVICE_VERSION_REQUIREMENTS=1 SECRET_KEY='unsafe secret key for collectstatic only' DATABASE_URL='postgres:///' REDIS_URL='redis:///' python manage.py collectstatic --noinput
 
@@ -202,7 +200,6 @@ COPY --chown=posthog:posthog gunicorn.config.py ./
 COPY --chown=posthog:posthog ./bin ./bin/
 COPY --chown=posthog:posthog manage.py manage.py
 COPY --chown=posthog:posthog posthog posthog/
-COPY --chown=posthog:posthog ee ee/
 COPY --chown=posthog:posthog hogvm hogvm/
 
 # Keep server command backwards compatible


### PR DESCRIPTION
## Problem
1. The [posthog/posthog](https://hub.docker.com/r/posthog/posthog) image includes the `ee` folder which I don't feel comfortable having since I'm self-hosting
2. The [posthog/posthog-foss](https://hub.docker.com/r/posthog/posthog-foss) image comes without `ee` code, but has not seen updates for over a year

Therefore, building `posthog-foss` from scratch is the only way to get the latest updates _while avoiding non-free code_.

However, `production.Dockerfile` makes references to the `ee/` folder which causes the build to fail.

Furthermore, the code contains several top-level `from ee.*` imports without a corresponding `if settings.EE_AVAILABLE` check, causing runtime exceptions due to absence of `ee` module

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

1. Top-level `from ee.*` imports updated to check for `settings.EE_AVAILABLE`
2. Some `from ee.*` imports moved into the function they are called
3. `production.Dockerfile` updated to remove `ee/` folder references
4. PostHog services in `docker-compose.hobby.yml` updated to include `build:` attributes, to allow local build instead of pulling from Docker Hub

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
I have similar <sup>[1](#myfootnote1)</sup> patches for my self-hosted deployment which I have been regularly updating for >2 months. However, **I have not tested these PR changes on a fresh installation**

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Not tested
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

PS: Love PostHog, you guys rock!

<a name="myfootnote1">1</a>: In my self-hosted deployment I comment out `from ee.*` lines instead of fixing the logic

