### PR TITLE
fix: tag cohort queries

### DIFF
--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -311,7 +311,7 @@ def recalculate_cohortpeople(
 
     recalcluate_cohortpeople_sql = RECALCULATE_COHORT_BY_ID.format(cohort_filter=cohort_query)
 
-    tag_queries(kind="cohort_calculation", team_id=cohort.team_id, query_type="CohortQuery")
+    tag_queries(kind="cohort_calculation", team_id=cohort.team_id, query_type="CohortsQuery")
     if initiating_user_id:
         tag_queries(user_id=initiating_user_id)
 

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -311,7 +311,7 @@ def recalculate_cohortpeople(
 
     recalcluate_cohortpeople_sql = RECALCULATE_COHORT_BY_ID.format(cohort_filter=cohort_query)
 
-    tag_queries(kind="cohort_calculation", team_id=cohort.team_id)
+    tag_queries(kind="cohort_calculation", team_id=cohort.team_id, query_type="CohortQuery")
     if initiating_user_id:
         tag_queries(user_id=initiating_user_id)
 


### PR DESCRIPTION
## Problem
Cohort queries weren't being tagged in Sentry

## Changes
Tagging them now, can view breakdown of cohort query errors with this
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
