### PR TITLE
chore: Re-enable Django model order lint rule

### DIFF
--- a/posthog/models/_deprecated_prompts.py
+++ b/posthog/models/_deprecated_prompts.py
@@ -21,11 +21,6 @@ class Prompt(models.Model):
 
 # DEPRECATED - DO NOT USE
 class PromptSequence(models.Model):
-    class Meta:
-        constraints = [
-            models.UniqueConstraint(fields=["key"], name="unique_prompt_sequence"),
-        ]
-
     key = models.CharField(max_length=200)
     type = models.CharField(max_length=200)  # we use this to toggle different behaviors in the frontend
     path_match: ArrayField = ArrayField(models.CharField(max_length=200))  # wildcard path to match the current URL
@@ -36,12 +31,14 @@ class PromptSequence(models.Model):
     prompts = models.ManyToManyField(Prompt)
     autorun = models.BooleanField(default=True)  # whether to run this sequence automatically for all users
 
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(fields=["key"], name="unique_prompt_sequence"),
+        ]
+
 
 # DEPRECATED - DO NOT USE
 class UserPromptState(models.Model):
-    class Meta:
-        constraints = [models.UniqueConstraint(fields=["user", "sequence"], name="unique_user_prompt_state")]
-
     user = models.ForeignKey("User", on_delete=models.CASCADE)
     sequence = models.ForeignKey(PromptSequence, on_delete=models.CASCADE)
 
@@ -49,3 +46,6 @@ class UserPromptState(models.Model):
     step = models.IntegerField(default=None, null=True)
     completed = models.BooleanField(default=False)
     dismissed = models.BooleanField(default=False)
+
+    class Meta:
+        constraints = [models.UniqueConstraint(fields=["user", "sequence"], name="unique_user_prompt_state")]

--- a/posthog/models/action/action.py
+++ b/posthog/models/action/action.py
@@ -30,9 +30,6 @@ class ActionStepJSON:
 
 
 class Action(models.Model):
-    class Meta:
-        indexes = [models.Index(fields=["team_id", "-updated_at"])]
-
     name = models.CharField(max_length=400, null=True, blank=True)
     team = models.ForeignKey("Team", on_delete=models.CASCADE)
     description = models.TextField(blank=True, default="")
@@ -50,6 +47,9 @@ class Action(models.Model):
     # DEPRECATED: these were used before ClickHouse was our database
     is_calculating = models.BooleanField(default=False)
     last_calculated_at = models.DateTimeField(default=timezone.now, blank=True)
+
+    class Meta:
+        indexes = [models.Index(fields=["team_id", "-updated_at"])]
 
     def __str__(self):
         return self.name

--- a/posthog/models/async_deletion/async_deletion.py
+++ b/posthog/models/async_deletion/async_deletion.py
@@ -11,22 +11,6 @@ class DeletionType(models.IntegerChoices):
 
 # This model represents deletions that should delete (other, unrelated) data async
 class AsyncDeletion(models.Model):
-    class Meta:
-        constraints = [
-            # :TRICKY: Postgres does not handle UNIQUE and NULL together well, so create 2 indexes.
-            # See https://dba.stackexchange.com/questions/9759/postgresql-multi-column-unique-constraint-and-null-values for more details
-            models.UniqueConstraint(
-                name="unique deletion",
-                fields=["deletion_type", "key"],
-                condition=models.Q(group_type_index__isnull=True),
-            ),
-            models.UniqueConstraint(
-                name="unique deletion for groups",
-                fields=["deletion_type", "key", "group_type_index"],
-            ),
-        ]
-        indexes = [models.Index(name="delete_verified_at index", fields=["delete_verified_at"])]
-
     id = models.BigAutoField(primary_key=True)
     # Should be one of the DeletionType enum
     deletion_type = models.PositiveSmallIntegerField(null=False, blank=False, choices=DeletionType.choices)
@@ -45,3 +29,19 @@ class AsyncDeletion(models.Model):
 
     # When was the data verified to be deleted - we can skip it in the next round
     delete_verified_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        constraints = [
+            # :TRICKY: Postgres does not handle UNIQUE and NULL together well, so create 2 indexes.
+            # See https://dba.stackexchange.com/questions/9759/postgresql-multi-column-unique-constraint-and-null-values for more details
+            models.UniqueConstraint(
+                name="unique deletion",
+                fields=["deletion_type", "key"],
+                condition=models.Q(group_type_index__isnull=True),
+            ),
+            models.UniqueConstraint(
+                name="unique deletion for groups",
+                fields=["deletion_type", "key", "group_type_index"],
+            ),
+        ]
+        indexes = [models.Index(name="delete_verified_at index", fields=["delete_verified_at"])]

--- a/posthog/models/async_migration.py
+++ b/posthog/models/async_migration.py
@@ -20,9 +20,6 @@ class AsyncMigrationError(models.Model):
 
 
 class AsyncMigration(models.Model):
-    class Meta:
-        constraints = [models.UniqueConstraint(fields=["name"], name="unique name")]
-
     id = models.BigAutoField(primary_key=True)
     name = models.CharField(max_length=50, null=False, blank=False)
     description = models.CharField(max_length=400, null=True, blank=True)
@@ -42,6 +39,9 @@ class AsyncMigration(models.Model):
     posthog_max_version = models.CharField(max_length=20, null=True, blank=True)
 
     parameters = models.JSONField(default=dict)
+
+    class Meta:
+        constraints = [models.UniqueConstraint(fields=["name"], name="unique name")]
 
     def get_name_with_requirements(self) -> str:
         return (

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -96,10 +96,10 @@ class Cohort(models.Model):
 
     is_static = models.BooleanField(default=False)
 
-    objects = CohortManager()
-
     # deprecated in favor of filters
     groups = models.JSONField(default=list)
+
+    objects = CohortManager()
 
     def __str__(self):
         return self.name

--- a/posthog/models/dashboard.py
+++ b/posthog/models/dashboard.py
@@ -77,7 +77,7 @@ class Dashboard(models.Model):
     is_shared = models.BooleanField(default=False)
 
     objects = DashboardManager()
-    objects_including_soft_deleted = models.Manager()
+    objects_including_soft_deleted: models.Manager["Dashboard"] = models.Manager()
 
     __repr__ = sane_repr("team_id", "id", "name")
 

--- a/posthog/models/dashboard_tile.py
+++ b/posthog/models/dashboard_tile.py
@@ -58,7 +58,7 @@ class DashboardTile(models.Model):
     deleted = models.BooleanField(null=True, blank=True)
 
     objects = DashboardTileManager()
-    objects_including_soft_deleted = models.Manager()
+    objects_including_soft_deleted: models.Manager["DashboardTile"] = models.Manager()
 
     class Meta:
         indexes = [models.Index(fields=["filters_hash"], name="query_by_filters_hash_idx")]

--- a/posthog/models/event/event.py
+++ b/posthog/models/event/event.py
@@ -121,18 +121,6 @@ class Selector:
 
 
 class Event(models.Model):
-    class Meta:
-        indexes = [
-            models.Index(fields=["elements_hash"]),
-            models.Index(fields=["timestamp", "team_id", "event"]),
-            # Separately managed:
-            # models.Index(fields=["created_at"]),
-            # NOTE: The below index has been added as a manual migration in
-            # `posthog/migrations/0024_add_event_distinct_id_index.py, but I'm
-            # adding this here to improve visibility.
-            # models.Index(fields=["distinct_id"], name="idx_distinct_id"),
-        ]
-
     created_at = models.DateTimeField(auto_now_add=True, null=True, blank=True)
     team = models.ForeignKey(Team, on_delete=models.CASCADE)
     event = models.CharField(max_length=200, null=True, blank=True)
@@ -144,3 +132,15 @@ class Event(models.Model):
 
     # DEPRECATED: elements are stored against element groups now
     elements = models.JSONField(default=list, null=True, blank=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["elements_hash"]),
+            models.Index(fields=["timestamp", "team_id", "event"]),
+            # Separately managed:
+            # models.Index(fields=["created_at"]),
+            # NOTE: The below index has been added as a manual migration in
+            # `posthog/migrations/0024_add_event_distinct_id_index.py, but I'm
+            # adding this here to improve visibility.
+            # models.Index(fields=["distinct_id"], name="idx_distinct_id"),
+        ]

--- a/posthog/models/exported_asset.py
+++ b/posthog/models/exported_asset.py
@@ -73,7 +73,7 @@ class ExportedAsset(models.Model):
 
     # replace the default manager with one that filters out TTL deleted objects (before their deletion is processed)
     objects = ExportedAssetManager()
-    objects_including_ttl_deleted = models.Manager()
+    objects_including_ttl_deleted: models.Manager["ExportedAsset"] = models.Manager()
 
     @property
     def has_content(self):

--- a/posthog/models/group/group.py
+++ b/posthog/models/group/group.py
@@ -2,14 +2,6 @@ from django.db import models
 
 
 class Group(models.Model):
-    class Meta:
-        constraints = [
-            models.UniqueConstraint(
-                fields=["team_id", "group_key", "group_type_index"],
-                name="unique team_id/group_key/group_type_index combo",
-            )
-        ]
-
     team = models.ForeignKey("Team", on_delete=models.CASCADE)
     group_key = models.CharField(max_length=400, null=False, blank=False)
     group_type_index = models.IntegerField(null=False, blank=False)
@@ -25,3 +17,11 @@ class Group(models.Model):
 
     # current version of the group, used to sync with ClickHouse and collapse rows correctly
     version = models.BigIntegerField(null=False)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["team_id", "group_key", "group_type_index"],
+                name="unique team_id/group_key/group_type_index combo",
+            )
+        ]

--- a/posthog/models/group_type_mapping.py
+++ b/posthog/models/group_type_mapping.py
@@ -4,6 +4,13 @@ from django.db import models
 # This table is responsible for mapping between group types for a Team/Project and event columns
 # to add group keys
 class GroupTypeMapping(models.Model):
+    team = models.ForeignKey("Team", on_delete=models.CASCADE)
+    group_type = models.CharField(max_length=400, null=False, blank=False)
+    group_type_index = models.IntegerField(null=False, blank=False)
+    # Used to display in UI
+    name_singular = models.CharField(max_length=400, null=True, blank=True)
+    name_plural = models.CharField(max_length=400, null=True, blank=True)
+
     class Meta:
         constraints = [
             models.UniqueConstraint(fields=["team", "group_type"], name="unique group types for team"),
@@ -16,10 +23,3 @@ class GroupTypeMapping(models.Model):
                 name="group_type_index is less than or equal 5",
             ),
         ]
-
-    team = models.ForeignKey("Team", on_delete=models.CASCADE)
-    group_type = models.CharField(max_length=400, null=False, blank=False)
-    group_type_index = models.IntegerField(null=False, blank=False)
-    # Used to display in UI
-    name_singular = models.CharField(max_length=400, null=True, blank=True)
-    name_plural = models.CharField(max_length=400, null=True, blank=True)

--- a/posthog/models/insight.py
+++ b/posthog/models/insight.py
@@ -96,7 +96,7 @@ class Insight(models.Model):
     __repr__ = sane_repr("team_id", "id", "short_id", "name")
 
     objects = InsightManager()
-    objects_including_soft_deleted = models.Manager()
+    objects_including_soft_deleted: models.Manager["Insight"] = models.Manager()
 
     class Meta:
         db_table = "posthog_dashboarditem"
@@ -205,16 +205,16 @@ class Insight(models.Model):
 
 
 class InsightViewed(models.Model):
-    class Meta:
-        constraints = [models.UniqueConstraint(fields=["team", "user", "insight"], name="posthog_unique_insightviewed")]
-        indexes = [models.Index(fields=["team_id", "user_id", "-last_viewed_at"])]
-
     # To track views from shared insights, team and user can be null
     team = models.ForeignKey("Team", on_delete=models.CASCADE, null=True, blank=True)
     user = models.ForeignKey("User", on_delete=models.CASCADE, null=True, blank=True)
 
     insight: models.ForeignKey = models.ForeignKey(Insight, on_delete=models.CASCADE)
     last_viewed_at: models.DateTimeField = models.DateTimeField()
+
+    class Meta:
+        constraints = [models.UniqueConstraint(fields=["team", "user", "insight"], name="posthog_unique_insightviewed")]
+        indexes = [models.Index(fields=["team_id", "user_id", "-last_viewed_at"])]
 
 
 @timed("generate_insight_cache_key")

--- a/posthog/models/instance_setting.py
+++ b/posthog/models/instance_setting.py
@@ -9,11 +9,11 @@ from posthog.settings import CONSTANCE_CONFIG, CONSTANCE_DATABASE_PREFIX
 
 
 class InstanceSetting(models.Model):
-    class Meta:
-        constraints = [models.UniqueConstraint(fields=["key"], name="unique key")]
-
     key = models.CharField(max_length=128, null=False, blank=False)
     raw_value = models.CharField(max_length=1024, null=False, blank=True)
+
+    class Meta:
+        constraints = [models.UniqueConstraint(fields=["key"], name="unique key")]
 
     @property
     def value(self):

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -40,13 +40,6 @@ class Integration(models.Model):
         SALESFORCE = "salesforce"
         HUBSPOT = "hubspot"
 
-    class Meta:
-        constraints = [
-            models.UniqueConstraint(
-                fields=["team", "kind", "integration_id"], name="posthog_integration_kind_id_unique"
-            )
-        ]
-
     team = models.ForeignKey("Team", on_delete=models.CASCADE)
 
     # The integration type identifier
@@ -63,6 +56,13 @@ class Integration(models.Model):
     # Meta
     created_at = models.DateTimeField(auto_now_add=True, blank=True)
     created_by = models.ForeignKey("User", on_delete=models.SET_NULL, null=True, blank=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["team", "kind", "integration_id"], name="posthog_integration_kind_id_unique"
+            )
+        ]
 
     @property
     def display_name(self) -> str:

--- a/posthog/models/person/person.py
+++ b/posthog/models/person/person.py
@@ -118,9 +118,6 @@ class Person(models.Model):
 
 
 class PersonDistinctId(models.Model):
-    class Meta:
-        constraints = [models.UniqueConstraint(fields=["team", "distinct_id"], name="unique distinct_id for team")]
-
     team = models.ForeignKey("Team", on_delete=models.CASCADE, db_index=False)
     person = models.ForeignKey(Person, on_delete=models.CASCADE)
     distinct_id = models.CharField(max_length=400)
@@ -128,18 +125,21 @@ class PersonDistinctId(models.Model):
     # current version of the id, used to sync with ClickHouse and collapse rows correctly for new clickhouse table
     version = models.BigIntegerField(null=True, blank=True)
 
+    class Meta:
+        constraints = [models.UniqueConstraint(fields=["team", "distinct_id"], name="unique distinct_id for team")]
+
 
 class PersonlessDistinctId(models.Model):
-    class Meta:
-        constraints = [
-            models.UniqueConstraint(fields=["team", "distinct_id"], name="unique personless distinct_id for team")
-        ]
-
     id = models.BigAutoField(primary_key=True)
     team = models.ForeignKey("Team", on_delete=models.CASCADE, db_index=False)
     distinct_id = models.CharField(max_length=400)
     is_merged = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True, blank=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(fields=["team", "distinct_id"], name="unique personless distinct_id for team")
+        ]
 
 
 class PersonOverrideMapping(models.Model):

--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -275,6 +275,10 @@ class PluginAttachment(models.Model):
 
 
 class PluginStorage(models.Model):
+    plugin_config = models.ForeignKey("PluginConfig", on_delete=models.CASCADE)
+    key = models.CharField(max_length=200)
+    value = models.TextField(blank=True, null=True)
+
     class Meta:
         constraints = [
             models.UniqueConstraint(
@@ -282,10 +286,6 @@ class PluginStorage(models.Model):
                 name="posthog_unique_plugin_storage_key",
             )
         ]
-
-    plugin_config = models.ForeignKey("PluginConfig", on_delete=models.CASCADE)
-    key = models.CharField(max_length=200)
-    value = models.TextField(blank=True, null=True)
 
 
 class PluginLogEntrySource(StrEnum):

--- a/posthog/models/utils.py
+++ b/posthog/models/utils.py
@@ -164,19 +164,19 @@ class DeletedMetaFields(models.Model):
 class UUIDModel(models.Model):
     """Base Django Model with default autoincremented ID field replaced with UUIDT."""
 
+    id = models.UUIDField(primary_key=True, default=UUIDT, editable=False)
+
     class Meta:
         abstract = True
-
-    id = models.UUIDField(primary_key=True, default=UUIDT, editable=False)
 
 
 class UUIDClassicModel(models.Model):
     """Base Django Model with default autoincremented ID field kept and a UUIDT field added."""
 
+    uuid = models.UUIDField(unique=True, default=UUIDT, editable=False)
+
     class Meta:
         abstract = True
-
-    uuid = models.UUIDField(unique=True, default=UUIDT, editable=False)
 
 
 def sane_repr(*attrs: str, include_id=True) -> Callable[[object], str]:

--- a/posthog/session_recordings/models/session_recording_event.py
+++ b/posthog/session_recordings/models/session_recording_event.py
@@ -6,6 +6,14 @@ from posthog.models.team import Team
 
 # DEPRECATED: PostHog model is no longer supported or used
 class SessionRecordingEvent(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True, null=True, blank=True)
+    timestamp = models.DateTimeField(default=timezone.now, blank=True)
+    team = models.ForeignKey(Team, on_delete=models.CASCADE)
+    distinct_id = models.CharField(max_length=200)
+    session_id = models.CharField(max_length=200)
+    window_id = models.CharField(max_length=200, null=True, blank=True)
+    snapshot_data = models.JSONField(default=dict)
+
     class Meta:
         indexes = [
             models.Index(fields=["team_id", "session_id"]),
@@ -15,21 +23,13 @@ class SessionRecordingEvent(models.Model):
             #   models.Index(fields=["team_id", "timestamp"]),
         ]
 
-    created_at = models.DateTimeField(auto_now_add=True, null=True, blank=True)
-    timestamp = models.DateTimeField(default=timezone.now, blank=True)
-    team = models.ForeignKey(Team, on_delete=models.CASCADE)
-    distinct_id = models.CharField(max_length=200)
-    session_id = models.CharField(max_length=200)
-    window_id = models.CharField(max_length=200, null=True, blank=True)
-    snapshot_data = models.JSONField(default=dict)
-
 
 class SessionRecordingViewed(models.Model):
-    class Meta:
-        unique_together = (("team_id", "user_id", "session_id"),)
-        indexes = [models.Index(fields=["team_id", "user_id", "session_id"])]
-
     team = models.ForeignKey(Team, on_delete=models.CASCADE)
     user = models.ForeignKey("User", on_delete=models.CASCADE)
     created_at = models.DateTimeField(auto_now_add=True, null=True, blank=True)
     session_id = models.CharField(max_length=200)
+
+    class Meta:
+        unique_together = (("team_id", "user_id", "session_id"),)
+        indexes = [models.Index(fields=["team_id", "user_id", "session_id"])]

--- a/posthog/session_recordings/models/session_recording_playlist_item.py
+++ b/posthog/session_recordings/models/session_recording_playlist_item.py
@@ -2,9 +2,6 @@ from django.db import models
 
 
 class SessionRecordingPlaylistItem(models.Model):
-    class Meta:
-        unique_together = ("recording", "playlist")
-
     recording = models.ForeignKey(
         "SessionRecording",
         related_name="playlist_items",
@@ -24,3 +21,6 @@ class SessionRecordingPlaylistItem(models.Model):
     deleted = models.BooleanField(null=True, blank=True)
     # DEPRECATED: Use recording_id instead
     session_id = models.CharField(max_length=200, null=True, blank=True)
+
+    class Meta:
+        unique_together = ("recording", "playlist")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ select = [
     "B",
     "C4",
     "C9",
-    #    "DJ012", TODO: Re-enable this
+    "DJ012",
     "E",
     "F",
     "RUF005",


### PR DESCRIPTION
## Problem

After #24500 merged, re-enable the ordering of the Django models rule that I left for a subsequent PR.

## Changes

Turns out the rule was not really working when it was enabled previously.. probably due to typing problem with the stubs or something.
Now it works and the code needs a few fixes.
