### PR TITLE
fix(integrations): load double the number of slack channels

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -322,7 +322,7 @@ class SlackIntegration:
         return sorted(channels, key=lambda x: x["name"])
 
     def _list_channels_by_type(self, type: Literal["public_channel", "private_channel"]) -> list[dict]:
-        max_page = 10
+        max_page = 20
         channels = []
         cursor = None
 


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/17106 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/19376)

The Slack endpoint is limited to 11 pages, so users with more than 1100 channels can't add theirs. Screenshot by @MarconLP:

![](https://posthoghelp.zendesk.com/attachments/token/VaoPigNeH72jCk67Da3BwivY5/?name=2024-08-21+at+13.52.07.gif)

## Changes

Loads double the number of channels. It looks like Slack might have added an endpoint for searching channels as well https://api.slack.com/methods/admin.conversations.search. Seeing if I can do that in a follow up...

## How did you test this code?

Didn't