### PR TITLE
feat(insights): Remove insight cache tasks from schedule

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -40,12 +40,10 @@ from posthog.tasks.tasks import (
     redis_celery_queue_depth,
     redis_heartbeat,
     schedule_all_subscriptions,
-    schedule_cache_updates_task,
     send_org_usage_reports,
     start_poll_query_performance,
     stop_surveys_reached_target,
     sync_all_organization_available_product_features,
-    sync_insight_cache_states_task,
     update_event_partitions,
     update_quota_limiting,
     verify_persons_data_in_sync,
@@ -147,21 +145,6 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
 
     # Sync all Organization.available_product_features every hour, only for billing v1 orgs
     sender.add_periodic_task(crontab(minute="30", hour="*"), sync_all_organization_available_product_features.s())
-
-    sync_insight_cache_states_schedule = get_crontab(settings.SYNC_INSIGHT_CACHE_STATES_SCHEDULE)
-    if sync_insight_cache_states_schedule:
-        sender.add_periodic_task(
-            sync_insight_cache_states_schedule,
-            sync_insight_cache_states_task.s(),
-            name="sync insight cache states",
-        )
-
-    add_periodic_task_with_expiry(
-        sender,
-        settings.UPDATE_CACHED_DASHBOARD_ITEMS_INTERVAL_SECONDS,
-        schedule_cache_updates_task.s(),
-        "check dashboard items",
-    )
 
     sender.add_periodic_task(crontab(minute="*/15"), check_async_migration_health.s())
 


### PR DESCRIPTION
## Problem

After #24388 we can disable the legacy cache warming and see if it's missed somewhere 🤭

## Changes

- remove from schedule
- this way we can re-add it if necessary
- otherwise full code removal in subsequent step
