### PR TITLE
fix(data-warehouse): Only limit dwh source when actually chunking

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline.py
@@ -48,11 +48,6 @@ class DataImportPipeline:
     ):
         self.inputs = inputs
         self.logger = logger
-        if incremental:
-            # Incremental syncs: Assuming each page is 100 items for now so bound each run at 50_000 items
-            self.source = source.add_limit(500)
-        else:
-            self.source = source
 
         self._incremental = incremental
         self.refresh_dlt = reset_pipeline
@@ -61,6 +56,12 @@ class DataImportPipeline:
             and inputs.job_type != ExternalDataSource.Type.POSTGRES
             and inputs.job_type != ExternalDataSource.Type.SNOWFLAKE
         )
+
+        if self.should_chunk_pipeline:
+            # Incremental syncs: Assuming each page is 100 items for now so bound each run at 50_000 items
+            self.source = source.add_limit(500)
+        else:
+            self.source = source
 
     def _get_pipeline_name(self):
         return f"{self.inputs.job_type}_pipeline_{self.inputs.team_id}_run_{self.inputs.schema_id}"


### PR DESCRIPTION
## Problem
- When we run incremental sync, we want to ensure we're chunking the pipeline when scrolling API's. This has been working great, but we've also accidentally been limiting the amount of rows the `sql_database` source returns
- It's been limited to 500,000 rows per incremental sync `500 * 1000` (the SQL chunk size)

## Changes
Use the correct incremental chunk setting to determine whether we add the source limit

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
👀 