### PR TITLE
chore(cyclotron): publish docker images

### DIFF
--- a/.github/workflows/rust-cyclotron-migrator-docker.yml
+++ b/.github/workflows/rust-cyclotron-migrator-docker.yml
@@ -69,7 +69,7 @@ jobs:
               uses: depot/build-push-action@v1
               with:
                   context: ./rust/
-                  file: ./rust/Dockerfile.migrate
+                  file: ./rust/Dockerfile.migrate-cyclotron
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/rust-cyclotron-migrator-docker.yml
+++ b/.github/workflows/rust-cyclotron-migrator-docker.yml
@@ -1,26 +1,20 @@
-name: Build rust container images
+name: Build rust cyclotron-migrator docker image
 
 on:
     workflow_dispatch:
     push:
         paths:
             - 'rust/**'
-            - '.github/workflows/rust-docker-build.yml'
+            - '.github/workflows/rust-cyclotron-migrator-docker.yml'
         branches:
             - 'master'
 
+permissions:
+    packages: write
+
 jobs:
     build:
-        name: Build and publish container image
-        strategy:
-            matrix:
-                image:
-                    - capture
-                    - hook-api
-                    - hook-janitor
-                    - hook-worker
-                    - cyclotron-janitor
-                    - cyclotron-fetch
+        name: build and publish cyclotron-migrator image
         runs-on: depot-ubuntu-22.04-4
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
@@ -44,25 +38,21 @@ jobs:
             - name: Set up Depot CLI
               uses: depot/setup-action@v1
 
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
-              with:
-                  image: tonistiigi/binfmt:latest
-                  platforms: all
-
             - name: Login to ghcr.io
-              uses: docker/login-action@v3
+              uses: docker/login-action@v2
               with:
                   registry: ghcr.io
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
-                  logout: false
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
 
             - name: Docker meta
               id: meta
               uses: docker/metadata-action@v5
               with:
-                  images: ghcr.io/posthog/posthog/${{ matrix.image }}
+                  images: ghcr.io/posthog/posthog/cyclotron-migrator
                   tags: |
                       type=ref,event=pr
                       type=ref,event=branch
@@ -74,19 +64,18 @@ jobs:
               id: buildx
               uses: docker/setup-buildx-action@v2
 
-            - name: Build and push image
-              id: docker_build
+            - name: Build and push migrator
+              id: docker_build_cyclotron_migrator
               uses: depot/build-push-action@v1
               with:
                   context: ./rust/
-                  file: ./rust/Dockerfile
+                  file: ./rust/Dockerfile.migrate
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
-                  platforms: linux/arm64,linux/amd64
+                  platforms: linux/arm64
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
-                  build-args: BIN=${{ matrix.image }}
 
-            - name: Container image digest
-              run: echo ${{ steps.docker_build.outputs.digest }}
+            - name: Cyclotron-migrator image digest
+              run: echo ${{ steps.docker_build_cyclotron_migrator.outputs.digest }}

--- a/.github/workflows/rust-hook-migrator-docker.yml
+++ b/.github/workflows/rust-hook-migrator-docker.yml
@@ -69,7 +69,7 @@ jobs:
               uses: depot/build-push-action@v1
               with:
                   context: ./rust/
-                  file: ./rust/Dockerfile.migrate
+                  file: ./rust/Dockerfile.migrate-hooks
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,7 @@ jobs:
                         - '.github/workflows/rust.yml'
                         - '.github/workflows/rust-docker-build.yml'
                         - '.github/workflows/rust-hook-migrator-docker.yml'
+                        - '.github/workflows/rust-cyclotron-migrator-docker.yml'
                         - 'posthog/management/commands/setup_test_environment.py'
                         - 'posthog/migrations/**'
                         - 'ee/migrations/**'

--- a/rust/Dockerfile.migrate-cyclotron
+++ b/rust/Dockerfile.migrate-cyclotron
@@ -1,0 +1,16 @@
+FROM docker.io/library/rust:1.80.1-bullseye as builder
+
+RUN apt update && apt install build-essential cmake -y
+RUN cargo install sqlx-cli@0.7.3 --no-default-features --features native-tls,postgres --root /app/target/release/
+
+FROM debian:bullseye-20230320-slim AS runtime
+WORKDIR /sqlx
+
+COPY bin /sqlx/bin/
+COPY cyclotron-core/migrations /sqlx/migrations/
+
+COPY --from=builder /app/target/release/bin/sqlx /usr/local/bin
+
+RUN chmod +x ./bin/migrate
+
+CMD ["./bin/migrate"]

--- a/rust/Dockerfile.migrate-hooks
+++ b/rust/Dockerfile.migrate-hooks
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.74.0-buster as builder
+FROM docker.io/library/rust:1.80.1-bullseye as builder
 
 RUN apt update && apt install build-essential cmake -y
 RUN cargo install sqlx-cli@0.7.3 --no-default-features --features native-tls,postgres --root /app/target/release/

--- a/rust/docker-compose.yml
+++ b/rust/docker-compose.yml
@@ -70,7 +70,7 @@ services:
         container_name: setup-test-db
         build:
             context: .
-            dockerfile: Dockerfile.migrate
+            dockerfile: Dockerfile.migrate-hooks
         restart: on-failure
         depends_on:
             db:


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
We need cyclotron images to deploy.

## Changes

Build 'em.

Note that there's a little duplication here. I don't think doing work to make abstractions that work between rusty-hook and cyclotron is worth the time, since we can hopefully delete the rusty-hook/hoghook stuff ASAP.
