### PR TITLE
chore: add rate limit to the sync to billing

### DIFF
--- a/posthog/tasks/sync_to_billing.py
+++ b/posthog/tasks/sync_to_billing.py
@@ -4,7 +4,7 @@ from posthog.models import Organization, OrganizationMembership
 from sentry_sdk import capture_message
 
 
-@shared_task(ignore_result=True, rate_limit="3/s")
+@shared_task(ignore_result=True, rate_limit="4/s")
 def sync_to_billing(organization_id: str) -> None:
     organization = Organization.objects.get(id=organization_id)
 

--- a/posthog/tasks/sync_to_billing.py
+++ b/posthog/tasks/sync_to_billing.py
@@ -4,7 +4,7 @@ from posthog.models import Organization, OrganizationMembership
 from sentry_sdk import capture_message
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, rate_limit="3/s")
 def sync_to_billing(organization_id: str) -> None:
     organization = Organization.objects.get(id=organization_id)
 


### PR DESCRIPTION
## Changes

When we run this sync for all orgs it puts too much pressure on billing. This will limit the number of reqs. The reason for 4 is because this queue can scale up to 24 so it will be a max of 96 reqs/second which billing should be fine to handle. I estimate this will take ~30min to clear the queue and sync all orgs to billing.

Note: this is running in the default queue. 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
