### PR TITLE
chore(batch-exports): Do not retry on endpoint errors

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -725,6 +725,8 @@ class S3BatchExportWorkflow(PostHogWorkflow):
                 "ClientError",
                 # An S3 bucket doesn't exist.
                 "NoSuchBucket",
+                # Couldn't connect to custom S3 endpoint
+                "EndpointConnectionError",
             ],
             finish_inputs=finish_inputs,
         )


### PR DESCRIPTION
## Problem

Custom S3 endpoints can raise this error that we can't retry on.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Do not retry when we can't connect to custom S3 endpoint.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
