### PR TITLE
feat(cdp): Added docs links for hog functions

### DIFF
--- a/frontend/src/lib/lemon-ui/Link/Link.tsx
+++ b/frontend/src/lib/lemon-ui/Link/Link.tsx
@@ -1,7 +1,6 @@
 import './Link.scss'
 
 import clsx from 'clsx'
-import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { isExternalLink } from 'lib/utils'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
@@ -96,9 +95,6 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
             href: typeof to === 'string' ? to : undefined,
         })
 
-        const { sidePanelOpen } = useValues(sidePanelStateLogic)
-        const { openSidePanel } = useActions(sidePanelStateLogic)
-
         const onClick = (event: React.MouseEvent<HTMLElement>): void => {
             if (event.metaKey || event.ctrlKey) {
                 event.stopPropagation()
@@ -112,7 +108,13 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
                 return
             }
 
-            if (typeof to === 'string' && isPostHogComDocs(to)) {
+            const mountedSidePanelLogic = sidePanelStateLogic.findMounted()
+
+            if (typeof to === 'string' && isPostHogComDocs(to) && mountedSidePanelLogic) {
+                // TRICKY: We do this instead of hooks as there is some weird cyclic issue in tests
+                const { sidePanelOpen } = mountedSidePanelLogic.values
+                const { openSidePanel } = mountedSidePanelLogic.actions
+
                 event.preventDefault()
 
                 const target = event.currentTarget

--- a/frontend/src/lib/lemon-ui/Link/Link.tsx
+++ b/frontend/src/lib/lemon-ui/Link/Link.tsx
@@ -1,7 +1,7 @@
 import './Link.scss'
 
 import clsx from 'clsx'
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { isExternalLink } from 'lib/utils'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
@@ -96,6 +96,7 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
             href: typeof to === 'string' ? to : undefined,
         })
 
+        const { sidePanelOpen } = useValues(sidePanelStateLogic)
         const { openSidePanel } = useActions(sidePanelStateLogic)
 
         const onClick = (event: React.MouseEvent<HTMLElement>): void => {
@@ -113,6 +114,18 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
 
             if (typeof to === 'string' && isPostHogComDocs(to)) {
                 event.preventDefault()
+
+                const target = event.currentTarget
+                const container = document.getElementsByTagName('main')[0]
+                const topBar = document.getElementsByClassName('TopBar3000')[0]
+                if (container.contains(target)) {
+                    setTimeout(() => {
+                        // Little delay to allow the rendering of the side panel
+                        const y = container.scrollTop + target.getBoundingClientRect().top - topBar.clientHeight
+                        container.scrollTo({ top: y })
+                    }, 50)
+                }
+
                 openSidePanel(SidePanelTab.Docs, to)
                 return
             }

--- a/frontend/src/lib/lemon-ui/Link/Link.tsx
+++ b/frontend/src/lib/lemon-ui/Link/Link.tsx
@@ -118,7 +118,7 @@ export const Link: React.FC<LinkProps & React.RefAttributes<HTMLElement>> = Reac
                 const target = event.currentTarget
                 const container = document.getElementsByTagName('main')[0]
                 const topBar = document.getElementsByClassName('TopBar3000')[0]
-                if (container.contains(target)) {
+                if (!sidePanelOpen && container.contains(target)) {
                     setTimeout(() => {
                         // Little delay to allow the rendering of the side panel
                         const y = container.scrollTop + target.getBoundingClientRect().top - topBar.clientHeight

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
@@ -317,7 +317,7 @@ export function HogFunctionConfiguration({ templateId, id }: { templateId?: stri
                                                 {({ value, onChange }) => (
                                                     <>
                                                         <div className="flex justify-between gap-2">
-                                                            <LemonLabel>Function source code</LemonLabel>
+                                                            <LemonLabel>Function source code </LemonLabel>
                                                             <LemonButton
                                                                 size="xsmall"
                                                                 type="secondary"
@@ -326,6 +326,14 @@ export function HogFunctionConfiguration({ templateId, id }: { templateId?: stri
                                                                 Hide source code
                                                             </LemonButton>
                                                         </div>
+                                                        <span className="text-xs text-muted-alt">
+                                                            This is the underlying Hog code that will run whenever the
+                                                            filters match.{' '}
+                                                            <Link to="https://posthog.com/docs/cdp/destinations#advanced---custom-code">
+                                                                See the docs
+                                                            </Link>{' '}
+                                                            for more info
+                                                        </span>
                                                         <CodeEditorResizeable
                                                             language="hog"
                                                             value={value ?? ''}

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
@@ -317,7 +317,7 @@ export function HogFunctionConfiguration({ templateId, id }: { templateId?: stri
                                                 {({ value, onChange }) => (
                                                     <>
                                                         <div className="flex justify-between gap-2">
-                                                            <LemonLabel>Function source code </LemonLabel>
+                                                            <LemonLabel>Function source code</LemonLabel>
                                                             <LemonButton
                                                                 size="xsmall"
                                                                 type="secondary"

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
@@ -1,7 +1,7 @@
 import { closestCenter, DndContext } from '@dnd-kit/core'
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { IconGear, IconLock, IconPlus, IconTrash, IconX } from '@posthog/icons'
+import { IconGear, IconInfo, IconLock, IconPlus, IconTrash, IconX } from '@posthog/icons'
 import {
     LemonButton,
     LemonCheckbox,
@@ -344,8 +344,11 @@ export function HogFunctionInputWithSchema({ schema }: HogFunctionInputWithSchem
         }
     }, [showSource])
 
+    const supportsTemplating = ['string', 'json', 'dictionary', 'email'].includes(schema.type)
+
     return (
         <div
+            className="group"
             ref={setNodeRef}
             // eslint-disable-next-line react/forbid-dom-props
             style={{
@@ -378,20 +381,32 @@ export function HogFunctionInputWithSchema({ schema }: HogFunctionInputWithSchem
                                             </Tooltip>
                                         ) : undefined}
                                     </LemonLabel>
-                                    {showSource ? (
-                                        <>
-                                            <LemonTag type="muted" className="font-mono">
-                                                inputs.{schema.key}
-                                            </LemonTag>
-                                            <div className="flex-1" />
-                                            <LemonButton
-                                                size="small"
-                                                noPadding
-                                                icon={<IconGear />}
-                                                onClick={() => setEditing(true)}
-                                            />
-                                        </>
-                                    ) : null}
+                                    {showSource && (
+                                        <LemonTag type="muted" className="font-mono">
+                                            inputs.{schema.key}
+                                        </LemonTag>
+                                    )}
+                                    <div className="flex-1" />
+
+                                    {supportsTemplating && (
+                                        <LemonButton
+                                            size="xsmall"
+                                            to="https://posthog.com/docs/cdp/destinations#input-formatting"
+                                            sideIcon={<IconInfo />}
+                                            noPadding
+                                            className=" opacity-0 group-hover:opacity-100 p-1 transition-opacity"
+                                        >
+                                            Supports templating
+                                        </LemonButton>
+                                    )}
+                                    {showSource && (
+                                        <LemonButton
+                                            size="small"
+                                            noPadding
+                                            icon={<IconGear />}
+                                            onClick={() => setEditing(true)}
+                                        />
+                                    )}
                                 </div>
                                 {value?.secret ? (
                                     <div className="border border-dashed rounded p-1 flex gap-2 items-center">


### PR DESCRIPTION
## Problem

We have some helpful docs so it would be cool to link out to them when we can

## Changes

![2024-08-23 10 06 07](https://github.com/user-attachments/assets/8d531449-21b9-4b4a-b775-e2058ba670c6)


* Adds a description and link to the source code part
* Adds a hover button to the inputs to indicate supporting templating (went for hover as it is already a very busy UI)
* Modified the link interceptor to scroll to the position of the button after opening the sidepanel

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
