### PR TITLE
refactor(insights): remove query-based-insights-saving flag

### DIFF
--- a/frontend/src/layout/navigation-3000/sidebars/insights.ts
+++ b/frontend/src/layout/navigation-3000/sidebars/insights.ts
@@ -1,7 +1,5 @@
 import { afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { subscriptions } from 'kea-subscriptions'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { insightsApi } from 'scenes/insights/utils/api'
 import { INSIGHTS_PER_PAGE, savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
@@ -28,8 +26,6 @@ export const insightsSidebarLogic = kea<insightsSidebarLogicType>([
             ['activeScene', 'sceneParams'],
             navigation3000Logic,
             ['searchTerm'],
-            featureFlagLogic,
-            ['featureFlags'],
         ],
         actions: [savedInsightsLogic, ['loadInsights', 'setSavedInsightsFilters', 'duplicateInsight']],
     })),
@@ -49,10 +45,6 @@ export const insightsSidebarLogic = kea<insightsSidebarLogicType>([
         ],
     })),
     selectors(({ actions, values, cache }) => ({
-        queryBasedInsightSaving: [
-            (s) => [s.featureFlags],
-            (featureFlags) => !!featureFlags[FEATURE_FLAGS.QUERY_BASED_INSIGHTS_SAVING],
-        ],
         contents: [
             (s) => [s.insights, s.infiniteInsights, s.insightsLoading, teamLogic.selectors.currentTeamId],
             (insights, infiniteInsights, insightsLoading, currentTeamId) => [
@@ -103,7 +95,7 @@ export const insightsSidebarLogic = kea<insightsSidebarLogicType>([
                                                     endpoint: `projects/${currentTeamId}/insights`,
                                                     callback: actions.loadInsights,
                                                     options: {
-                                                        writeAsQuery: values.queryBasedInsightSaving,
+                                                        writeAsQuery: true,
                                                     },
                                                 })
                                             },
@@ -117,7 +109,7 @@ export const insightsSidebarLogic = kea<insightsSidebarLogicType>([
                                 const updatedItem = await insightsApi.update(
                                     insight.id,
                                     { name: newName },
-                                    { writeAsQuery: values.queryBasedInsightSaving }
+                                    { writeAsQuery: true }
                                 )
                                 insightsModel.actions.renameInsightSuccess(updatedItem)
                             },

--- a/frontend/src/layout/navigation-3000/sidebars/insights.ts
+++ b/frontend/src/layout/navigation-3000/sidebars/insights.ts
@@ -94,9 +94,6 @@ export const insightsSidebarLogic = kea<insightsSidebarLogicType>([
                                                     object: insight,
                                                     endpoint: `projects/${currentTeamId}/insights`,
                                                     callback: actions.loadInsights,
-                                                    options: {
-                                                        writeAsQuery: true,
-                                                    },
                                                 })
                                             },
                                             status: 'danger',
@@ -106,11 +103,7 @@ export const insightsSidebarLogic = kea<insightsSidebarLogicType>([
                                 },
                             ],
                             onRename: async (newName) => {
-                                const updatedItem = await insightsApi.update(
-                                    insight.id,
-                                    { name: newName },
-                                    { writeAsQuery: true }
-                                )
+                                const updatedItem = await insightsApi.update(insight.id, { name: newName })
                                 insightsModel.actions.renameInsightSuccess(updatedItem)
                             },
                         } as BasicListItem

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -162,7 +162,6 @@ export const FEATURE_FLAGS = {
     PRODUCT_SPECIFIC_ONBOARDING: 'product-specific-onboarding', // owner: @raquelmsmith
     REDIRECT_SIGNUPS_TO_INSTANCE: 'redirect-signups-to-instance', // owner: @raquelmsmith
     APPS_AND_EXPORTS_UI: 'apps-and-exports-ui', // owner: @benjackwhite
-    QUERY_BASED_INSIGHTS_SAVING: 'query-based-insights-saving', // owner: @thmsobrmlr
     HOGQL_DASHBOARD_ASYNC: 'hogql-dashboard-async', // owner: @webjunkie
     WEBHOOKS_DENYLIST: 'webhooks-denylist', // owner: #team-pipeline
     PIPELINE_UI: 'pipeline-ui', // owner: #team-pipeline

--- a/frontend/src/lib/utils/deleteWithUndo.tsx
+++ b/frontend/src/lib/utils/deleteWithUndo.tsx
@@ -1,6 +1,5 @@
 import { lemonToast } from '@posthog/lemon-ui'
 import api from 'lib/api'
-import { getInsightModel, InsightsApiOptions } from 'scenes/insights/utils/api'
 
 import { QueryBasedInsightModel } from '~/types'
 
@@ -40,7 +39,6 @@ export async function deleteWithUndo<T extends Record<string, any>>({
  * when given a query based insight */
 export async function deleteInsightWithUndo({
     undo = false,
-    options,
     ...props
 }: {
     undo?: boolean
@@ -48,10 +46,9 @@ export async function deleteInsightWithUndo({
     object: QueryBasedInsightModel
     idField?: keyof QueryBasedInsightModel
     callback?: (undo: boolean, object: QueryBasedInsightModel) => void
-    options: InsightsApiOptions
 }): Promise<void> {
     await api.update(`api/${props.endpoint}/${props.object[props.idField || 'id']}`, {
-        ...getInsightModel(props.object, options.writeAsQuery),
+        ...props.object,
         deleted: !undo,
     })
     props.callback?.(undo, props.object)
@@ -66,7 +63,7 @@ export async function deleteInsightWithUndo({
                 ? undefined
                 : {
                       label: 'Undo',
-                      action: () => deleteInsightWithUndo({ undo: true, options, ...props }),
+                      action: () => deleteInsightWithUndo({ undo: true, ...props }),
                   },
         }
     )

--- a/frontend/src/models/insightsModel.tsx
+++ b/frontend/src/models/insightsModel.tsx
@@ -1,9 +1,7 @@
 import { LemonDialog, LemonInput } from '@posthog/lemon-ui'
-import { actions, connect, kea, listeners, path, selectors } from 'kea'
-import { FEATURE_FLAGS } from 'lib/constants'
+import { actions, connect, kea, listeners, path } from 'kea'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightsApi } from 'scenes/insights/utils/api'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -13,7 +11,7 @@ import type { insightsModelType } from './insightsModelType'
 
 export const insightsModel = kea<insightsModelType>([
     path(['models', 'insightsModel']),
-    connect({ values: [featureFlagLogic, ['featureFlags']], logic: [teamLogic] }),
+    connect({ logic: [teamLogic] }),
     actions(() => ({
         renameInsight: (item: QueryBasedInsightModel) => ({ item }),
         renameInsightSuccess: (item: QueryBasedInsightModel) => ({ item }),
@@ -25,13 +23,7 @@ export const insightsModel = kea<insightsModelType>([
             insightIds,
         }),
     })),
-    selectors({
-        queryBasedInsightSaving: [
-            (s) => [s.featureFlags],
-            (featureFlags) => !!featureFlags[FEATURE_FLAGS.QUERY_BASED_INSIGHTS_SAVING],
-        ],
-    }),
-    listeners(({ actions, values }) => ({
+    listeners(({ actions }) => ({
         renameInsight: async ({ item }) => {
             LemonDialog.openForm({
                 title: 'Rename insight',
@@ -45,11 +37,7 @@ export const insightsModel = kea<insightsModelType>([
                     insightName: (name) => (!name ? 'You must enter a name' : undefined),
                 },
                 onSubmit: async ({ insightName }) => {
-                    const updatedItem = await insightsApi.update(
-                        item.id,
-                        { name: insightName },
-                        { writeAsQuery: values.queryBasedInsightSaving }
-                    )
+                    const updatedItem = await insightsApi.update(item.id, { name: insightName }, { writeAsQuery: true })
                     lemonToast.success(
                         <>
                             Renamed insight from <b>{item.name}</b> to <b>{insightName}</b>
@@ -61,7 +49,7 @@ export const insightsModel = kea<insightsModelType>([
         },
         duplicateInsight: async ({ item }) => {
             const addedItem = await insightsApi.duplicate(item, {
-                writeAsQuery: values.queryBasedInsightSaving,
+                writeAsQuery: true,
             })
 
             actions.duplicateInsightSuccess(addedItem)

--- a/frontend/src/models/insightsModel.tsx
+++ b/frontend/src/models/insightsModel.tsx
@@ -37,7 +37,7 @@ export const insightsModel = kea<insightsModelType>([
                     insightName: (name) => (!name ? 'You must enter a name' : undefined),
                 },
                 onSubmit: async ({ insightName }) => {
-                    const updatedItem = await insightsApi.update(item.id, { name: insightName }, { writeAsQuery: true })
+                    const updatedItem = await insightsApi.update(item.id, { name: insightName })
                     lemonToast.success(
                         <>
                             Renamed insight from <b>{item.name}</b> to <b>{insightName}</b>
@@ -48,9 +48,7 @@ export const insightsModel = kea<insightsModelType>([
             })
         },
         duplicateInsight: async ({ item }) => {
-            const addedItem = await insightsApi.duplicate(item, {
-                writeAsQuery: true,
-            })
+            const addedItem = await insightsApi.duplicate(item)
 
             actions.duplicateInsightSuccess(addedItem)
             lemonToast.success('Insight duplicated')

--- a/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
+++ b/frontend/src/queries/nodes/InsightQuery/utils/queryNodeToFilter.ts
@@ -10,7 +10,6 @@ import {
     InsightNodeKind,
     InsightQueryNode,
     LifecycleFilterLegacy,
-    Node,
     NodeKind,
     PathsFilterLegacy,
     RetentionFilterLegacy,
@@ -22,14 +21,13 @@ import {
     isDataWarehouseNode,
     isEventsNode,
     isFunnelsQuery,
-    isInsightVizNode,
     isLifecycleQuery,
     isPathsQuery,
     isRetentionQuery,
     isStickinessQuery,
     isTrendsQuery,
 } from '~/queries/utils'
-import { ActionFilter, EntityTypes, FilterType, InsightType, QueryBasedInsightModel } from '~/types'
+import { ActionFilter, EntityTypes, FilterType, InsightType } from '~/types'
 
 type FilterTypeActionsAndEvents = {
     events?: ActionFilter[]
@@ -121,28 +119,6 @@ const nodeKindToFilterKey: Record<InsightNodeKind, string> = {
     [NodeKind.PathsQuery]: 'pathsFilter',
     [NodeKind.StickinessQuery]: 'stickinessFilter',
     [NodeKind.LifecycleQuery]: 'lifecycleFilter',
-}
-
-/** Returns a `query` or converted `filters` for a query based insight,
- * depending on the feature flag. This is necessary as we want to
- * transition to query based insights on the frontend, while the backend
- * still has filter based insights (and or conversion function is frontend side).
- *
- * The feature flag can be enabled once we want to persist query based insights
- * backend side. Once the flag is rolled out 100% this function becomes obsolete.
- */
-export const getInsightFilterOrQueryForPersistance = (
-    insight: QueryBasedInsightModel,
-    queryBasedInsightSavingFlag: boolean
-): { filters: Partial<FilterType> | undefined; query: Node<Record<string, any>> | null | undefined } => {
-    let filters
-    let query
-    if (!queryBasedInsightSavingFlag && isInsightVizNode(insight.query)) {
-        filters = queryNodeToFilter(insight.query.source)
-    } else {
-        query = insight.query
-    }
-    return { filters, query }
 }
 
 export const queryNodeToFilter = (query: InsightQueryNode): Partial<FilterType> => {

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -46,15 +46,9 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     const { setInsightMode } = useActions(insightSceneLogic)
 
     // insightLogic
-    const {
-        insightProps,
-        canEditInsight,
-        insight,
-        queryBasedInsightSaving,
-        insightChanged,
-        insightSaving,
-        hasDashboardItemId,
-    } = useValues(insightLogic(insightLogicProps))
+    const { insightProps, canEditInsight, insight, insightChanged, insightSaving, hasDashboardItemId } = useValues(
+        insightLogic(insightLogicProps)
+    )
     const { setInsightMetadata, saveAs, saveInsight } = useActions(insightLogic(insightLogicProps))
 
     // savedInsightsLogic
@@ -249,7 +243,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                             push(urls.savedInsights())
                                                         },
                                                         options: {
-                                                            writeAsQuery: queryBasedInsightSaving,
+                                                            writeAsQuery: true,
                                                         },
                                                     })
                                                 }

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -242,9 +242,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                             loadInsights()
                                                             push(urls.savedInsights())
                                                         },
-                                                        options: {
-                                                            writeAsQuery: true,
-                                                        },
                                                     })
                                                 }
                                                 fullWidth

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -28,7 +28,7 @@ import { teamLogic } from '../teamLogic'
 import { insightDataLogic } from './insightDataLogic'
 import type { insightLogicType } from './insightLogicType'
 import { getInsightId } from './utils'
-import { insightsApi, InsightsApiOptions } from './utils/api'
+import { insightsApi } from './utils/api'
 
 export const UNSAVED_INSIGHT_MIN_REFRESH_INTERVAL_MINUTES = 3
 
@@ -110,9 +110,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                         return values.insight
                     }
 
-                    const response = await insightsApi.update(values.insight.id as number, insightUpdate, {
-                        writeAsQuery: true,
-                    })
+                    const response = await insightsApi.update(values.insight.id as number, insightUpdate)
                     breakpoint()
                     const updatedInsight: QueryBasedInsightModel = {
                         ...response,
@@ -141,9 +139,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                         beforeUpdates[key] = values.savedInsight[key]
                     }
 
-                    const response = await insightsApi.update(values.insight.id as number, metadataUpdate, {
-                        writeAsQuery: true,
-                    })
+                    const response = await insightsApi.update(values.insight.id as number, metadataUpdate)
                     breakpoint()
 
                     savedInsightsLogic.findMounted()?.actions.loadInsights()
@@ -155,9 +151,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                             label: 'Undo',
                             dataAttr: 'edit-insight-undo',
                             action: async () => {
-                                const response = await insightsApi.update(values.insight.id as number, beforeUpdates, {
-                                    writeAsQuery: true,
-                                })
+                                const response = await insightsApi.update(values.insight.id as number, beforeUpdates)
                                 savedInsightsLogic.findMounted()?.actions.loadInsights()
                                 dashboardsModel.actions.updateDashboardInsight(response)
                                 actions.setInsight(response, { overrideQuery: false, fromPersistentApi: true })
@@ -326,12 +320,9 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                     tags,
                 }
 
-                const options: InsightsApiOptions = {
-                    writeAsQuery: true,
-                }
                 savedInsight = insightNumericId
-                    ? await insightsApi.update(insightNumericId, insightRequest, options)
-                    : await insightsApi.create(insightRequest, options)
+                    ? await insightsApi.update(insightNumericId, insightRequest)
+                    : await insightsApi.create(insightRequest)
                 savedInsightsLogic.findMounted()?.actions.loadInsights() // Load insights afresh
                 actions.saveInsightSuccess()
             } catch (e) {
@@ -400,16 +391,11 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             })
         },
         saveAsConfirmation: async ({ name, redirectToViewMode, persist }) => {
-            const insight = await insightsApi.create(
-                {
-                    name,
-                    query: values.query,
-                    saved: true,
-                },
-                {
-                    writeAsQuery: true,
-                }
-            )
+            const insight = await insightsApi.create({
+                name,
+                query: values.query,
+                saved: true,
+            })
             lemonToast.info(
                 `You're now working on a copy of ${values.insight.name || values.insight.derived_name || name}`
             )

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -2,10 +2,9 @@ import { LemonDialog, LemonInput } from '@posthog/lemon-ui'
 import { actions, connect, events, kea, key, listeners, LogicWrapper, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
-import { DashboardPrivilegeLevel, FEATURE_FLAGS } from 'lib/constants'
+import { DashboardPrivilegeLevel } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectsEqual } from 'lib/utils'
 import { eventUsageLogic, InsightEventSource } from 'lib/utils/eventUsageLogic'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
@@ -59,8 +58,6 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             ['mathDefinitions'],
             userLogic,
             ['user'],
-            featureFlagLogic,
-            ['featureFlags'],
         ],
         actions: [tagsModel, ['loadTags']],
         logic: [eventUsageLogic, dashboardsModel],
@@ -114,7 +111,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                     }
 
                     const response = await insightsApi.update(values.insight.id as number, insightUpdate, {
-                        writeAsQuery: values.queryBasedInsightSaving,
+                        writeAsQuery: true,
                     })
                     breakpoint()
                     const updatedInsight: QueryBasedInsightModel = {
@@ -145,7 +142,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                     }
 
                     const response = await insightsApi.update(values.insight.id as number, metadataUpdate, {
-                        writeAsQuery: values.queryBasedInsightSaving,
+                        writeAsQuery: true,
                     })
                     breakpoint()
 
@@ -159,7 +156,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                             dataAttr: 'edit-insight-undo',
                             action: async () => {
                                 const response = await insightsApi.update(values.insight.id as number, beforeUpdates, {
-                                    writeAsQuery: values.queryBasedInsightSaving,
+                                    writeAsQuery: true,
                                 })
                                 savedInsightsLogic.findMounted()?.actions.loadInsights()
                                 dashboardsModel.actions.updateDashboardInsight(response)
@@ -267,10 +264,6 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             (s) => [(state) => insightDataLogic.findMounted(s.insightProps(state))?.values.query || null],
             (node): Node | null => node,
         ],
-        queryBasedInsightSaving: [
-            (s) => [s.featureFlags],
-            (featureFlags) => !!featureFlags[FEATURE_FLAGS.QUERY_BASED_INSIGHTS_SAVING],
-        ],
         insightProps: [() => [(_, props) => props], (props): InsightLogicProps => props],
         isInDashboardContext: [() => [(_, props) => props], ({ dashboardId }) => !!dashboardId],
         hasDashboardItemId: [
@@ -334,7 +327,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                 }
 
                 const options: InsightsApiOptions = {
-                    writeAsQuery: values.queryBasedInsightSaving,
+                    writeAsQuery: true,
                 }
                 savedInsight = insightNumericId
                     ? await insightsApi.update(insightNumericId, insightRequest, options)
@@ -414,7 +407,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                     saved: true,
                 },
                 {
-                    writeAsQuery: values.queryBasedInsightSaving,
+                    writeAsQuery: true,
                 }
             )
             lemonToast.info(

--- a/frontend/src/scenes/insights/utils/api.ts
+++ b/frontend/src/scenes/insights/utils/api.ts
@@ -1,35 +1,16 @@
 import api from 'lib/api'
 
-import { getInsightFilterOrQueryForPersistance } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
 import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
 import { RefreshType } from '~/queries/schema'
 import { InsightShortId, QueryBasedInsightModel } from '~/types'
 
-export type InsightsApiOptions = {
-    writeAsQuery: boolean
-}
-
-export function getInsightModel<Flag extends boolean>(
-    insight: QueryBasedInsightModel,
-    asQuery: Flag
-): QueryBasedInsightModel {
-    return {
-        ...insight,
-        ...getInsightFilterOrQueryForPersistance(insight, asQuery),
-    } as QueryBasedInsightModel
-}
-
 async function _perform(
     method: 'create' | 'update',
     insight: Partial<QueryBasedInsightModel>,
-    options: InsightsApiOptions,
     id?: number
 ): Promise<QueryBasedInsightModel> {
-    const { writeAsQuery } = options
-
-    const data = getInsightModel(insight as QueryBasedInsightModel, writeAsQuery)
-    const legacyInsight = method === 'create' ? await api.insights[method](data) : await api.insights[method](id!, data)
-
+    const legacyInsight =
+        method === 'create' ? await api.insights[method](insight) : await api.insights[method](id!, insight)
     return getQueryBasedInsightModel(legacyInsight)
 }
 
@@ -54,20 +35,13 @@ export const insightsApi = {
         }
         return getQueryBasedInsightModel(legacyInsight)
     },
-    async create(
-        insight: Partial<QueryBasedInsightModel>,
-        options: InsightsApiOptions
-    ): Promise<QueryBasedInsightModel> {
-        return this._perform('create', insight, options)
+    async create(insight: Partial<QueryBasedInsightModel>): Promise<QueryBasedInsightModel> {
+        return this._perform('create', insight)
     },
-    async update(
-        id: number,
-        insightUpdate: Partial<QueryBasedInsightModel>,
-        options: InsightsApiOptions
-    ): Promise<QueryBasedInsightModel> {
-        return this._perform('update', insightUpdate, options, id)
+    async update(id: number, insightUpdate: Partial<QueryBasedInsightModel>): Promise<QueryBasedInsightModel> {
+        return this._perform('update', insightUpdate, id)
     },
-    async duplicate(insight: QueryBasedInsightModel, options: InsightsApiOptions): Promise<QueryBasedInsightModel> {
-        return this.create({ ...insight, name: insight.name ? `${insight.name} (copy)` : insight.name }, options)
+    async duplicate(insight: QueryBasedInsightModel): Promise<QueryBasedInsightModel> {
+        return this.create({ ...insight, name: insight.name ? `${insight.name} (copy)` : insight.name })
     },
 }

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -374,7 +374,7 @@ export function NewInsightButton({ dataAttr }: NewInsightButtonProps): JSX.Eleme
 
 function SavedInsightsGrid(): JSX.Element {
     const { loadInsights, renameInsight, duplicateInsight } = useActions(savedInsightsLogic)
-    const { insights, insightsLoading, pagination, queryBasedInsightSaving } = useValues(savedInsightsLogic)
+    const { insights, insightsLoading, pagination } = useValues(savedInsightsLogic)
     const { currentTeamId } = useValues(teamLogic)
 
     const paginationState = usePagination(insights?.results || [], pagination)
@@ -395,7 +395,7 @@ function SavedInsightsGrid(): JSX.Element {
                                     endpoint: `projects/${currentTeamId}/insights`,
                                     callback: loadInsights,
                                     options: {
-                                        writeAsQuery: queryBasedInsightSaving,
+                                        writeAsQuery: true,
                                     },
                                 })
                             }
@@ -418,8 +418,7 @@ function SavedInsightsGrid(): JSX.Element {
 export function SavedInsights(): JSX.Element {
     const { loadInsights, updateFavoritedInsight, renameInsight, duplicateInsight, setSavedInsightsFilters } =
         useActions(savedInsightsLogic)
-    const { insights, count, insightsLoading, filters, sorting, pagination, queryBasedInsightSaving } =
-        useValues(savedInsightsLogic)
+    const { insights, count, insightsLoading, filters, sorting, pagination } = useValues(savedInsightsLogic)
     const { hasTagging } = useValues(organizationLogic)
     const { currentTeamId } = useValues(teamLogic)
     const summarizeInsight = useSummarizeInsight()
@@ -542,7 +541,7 @@ export function SavedInsights(): JSX.Element {
                                             endpoint: `projects/${currentTeamId}/insights`,
                                             callback: loadInsights,
                                             options: {
-                                                writeAsQuery: queryBasedInsightSaving,
+                                                writeAsQuery: true,
                                             },
                                         })
                                     }

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -394,9 +394,6 @@ function SavedInsightsGrid(): JSX.Element {
                                     object: insight,
                                     endpoint: `projects/${currentTeamId}/insights`,
                                     callback: loadInsights,
-                                    options: {
-                                        writeAsQuery: true,
-                                    },
                                 })
                             }
                             placement="SavedInsightGrid"
@@ -540,9 +537,6 @@ export function SavedInsights(): JSX.Element {
                                             object: insight,
                                             endpoint: `projects/${currentTeamId}/insights`,
                                             callback: loadInsights,
-                                            options: {
-                                                writeAsQuery: true,
-                                            },
                                         })
                                     }
                                     data-attr={`insight-item-${insight.short_id}-dropdown-remove`}

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -2,12 +2,10 @@ import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea
 import { loaders } from 'kea-loaders'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 import api, { CountedPaginatedResponse } from 'lib/api'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { Sorting } from 'lib/lemon-ui/LemonTable'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { PaginationManual } from 'lib/lemon-ui/PaginationControl'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectDiffShallow, objectsEqual, toParams } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { deleteDashboardLogic } from 'scenes/dashboard/deleteDashboardLogic'
@@ -69,7 +67,7 @@ function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsightFilters
 export const savedInsightsLogic = kea<savedInsightsLogicType>([
     path(['scenes', 'saved-insights', 'savedInsightsLogic']),
     connect(() => ({
-        values: [teamLogic, ['currentTeamId'], featureFlagLogic, ['featureFlags'], sceneLogic, ['activeScene']],
+        values: [teamLogic, ['currentTeamId'], sceneLogic, ['activeScene']],
         logic: [eventUsageLogic],
     })),
     actions({
@@ -146,7 +144,7 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
                     {
                         favorited,
                     },
-                    { writeAsQuery: values.queryBasedInsightSaving }
+                    { writeAsQuery: true }
                 )
                 const updatedInsights = values.insights.results.map((i) =>
                     i.short_id === insight.short_id ? response : i
@@ -181,10 +179,6 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
         ],
     }),
     selectors({
-        queryBasedInsightSaving: [
-            (s) => [s.featureFlags],
-            (featureFlags) => !!featureFlags[FEATURE_FLAGS.QUERY_BASED_INSIGHTS_SAVING],
-        ],
         filters: [(s) => [s.rawFilters], (rawFilters): SavedInsightFilters => cleanFilters(rawFilters || {})],
         count: [(s) => [s.insights], (insights) => insights.count],
         usingFilters: [
@@ -288,7 +282,7 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
         },
         duplicateInsight: async ({ insight, redirectToInsight }) => {
             const newInsight = await insightsApi.duplicate(insight, {
-                writeAsQuery: values.queryBasedInsightSaving,
+                writeAsQuery: true,
             })
             actions.addInsight(newInsight)
             redirectToInsight && router.actions.push(urls.insightEdit(newInsight.short_id))

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -139,13 +139,9 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
                 } as CountedPaginatedResponse<QueryBasedInsightModel> & { offset: number }
             },
             updateFavoritedInsight: async ({ insight, favorited }) => {
-                const response = await insightsApi.update(
-                    insight.id,
-                    {
-                        favorited,
-                    },
-                    { writeAsQuery: true }
-                )
+                const response = await insightsApi.update(insight.id, {
+                    favorited,
+                })
                 const updatedInsights = values.insights.results.map((i) =>
                     i.short_id === insight.short_id ? response : i
                 )
@@ -281,9 +277,7 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
             insightsModel.actions.renameInsight(insight)
         },
         duplicateInsight: async ({ insight, redirectToInsight }) => {
-            const newInsight = await insightsApi.duplicate(insight, {
-                writeAsQuery: true,
-            })
+            const newInsight = await insightsApi.duplicate(insight)
             actions.addInsight(newInsight)
             redirectToInsight && router.actions.push(urls.insightEdit(newInsight.short_id))
         },


### PR DESCRIPTION
## Problem

The feature flag for query based saving is rolled out to 100% of users https://us.posthog.com/project/2/feature_flags/62829.

## Changes

This PR removes the flag, alongside with the `writeAsQuery` flag.

## How did you test this code?

CI run