### PR TITLE
fix(batch-exports): Catch JSONDecodeError, not JSONEncodeError

### DIFF
--- a/posthog/temporal/batch_exports/utils.py
+++ b/posthog/temporal/batch_exports/utils.py
@@ -139,7 +139,7 @@ class JsonScalar(pa.ExtensionScalar):
 
             try:
                 return orjson.loads(value.encode("utf-8"))
-            except orjson.JSONEncodeError:
+            except orjson.JSONDecodeError:
                 pass
 
             try:


### PR DESCRIPTION
## Problem

Small mistake on my part, exception name is `JSONDecodeError`, not `JSONEncodeError`.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
