### PR TITLE
fix(data-warehouse): Use better mechanics for resyncing a table

### DIFF
--- a/posthog/warehouse/api/external_data_schema.py
+++ b/posthog/warehouse/api/external_data_schema.py
@@ -21,7 +21,6 @@ from posthog.warehouse.data_load.service import (
     trigger_external_data_workflow,
     unpause_external_data_schedule,
     cancel_external_data_workflow,
-    delete_data_import_folder,
 )
 from posthog.warehouse.models.external_data_schema import (
     filter_mysql_incremental_fields,
@@ -251,17 +250,9 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.
         if latest_running_job and latest_running_job.workflow_id and latest_running_job.status == "Running":
             cancel_external_data_workflow(latest_running_job.workflow_id)
 
-        all_jobs = ExternalDataJob.objects.filter(
-            schema_id=instance.pk, team_id=instance.team_id, status="Completed"
-        ).all()
-
-        # Unnecessary to iterate for incremental jobs since they'll all by identified by the schema_id. Be over eager just to clear remnants
-        for job in all_jobs:
-            try:
-                delete_data_import_folder(job.folder_path())
-            except Exception as e:
-                logger.exception(f"Could not clean up data import folder: {job.folder_path()}", exc_info=e)
-                pass
+        source: ExternalDataSource = instance.source
+        source.job_inputs.update({"reset_pipeline": True})
+        source.save()
 
         try:
             trigger_external_data_workflow(instance)


### PR DESCRIPTION
## Problem
When resyncing a table, we relying on deleting the folder contents in S3 before syncing again - this doesn't always work. We have purpose built mechanics for dealing with this 

## Changes
Use the proper functionality to do the resync instead

## Does this work well for both Cloud and self-hosted?
Yup

## How did you test this code?
Tested locally