### PR TITLE
feat: Added button to help sidebar to report bug on GitHub

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -14,6 +14,7 @@ import {
     IconToggle,
     IconTrends,
 } from '@posthog/icons'
+import { IconFeedback } from 'lib/lemon-ui/icons'
 import { LemonBanner, LemonButton, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { SupportForm } from 'lib/components/Support/SupportForm'
@@ -288,6 +289,17 @@ export const SidePanelSupport = (): JSX.Element => {
                                             targetBlank
                                         >
                                             Request a feature
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to="https://github.com/PostHog/posthog/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml"
+                                            icon={<IconFeedback />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                 </ul>


### PR DESCRIPTION
Part of the **SuperDay** for Technical Support Engineer role - @joethreepwood 

## Problem
Users are unable to report a bug on GitHub directly from the "Help Sidebar".

## Changes
A button was added, using an existing bug reporting icon from elsewhere on the front end. I was informed a screenshot was not necessary for this task due to timing implications with Codespaces / Ubuntu VM.

## Does this work well for both Cloud and self-hosted?
Yes

