### PR TITLE
chore(sessions-v2): Increase timeout to 2 hours

### DIFF
--- a/posthog/management/commands/backfill_raw_sessions_table.py
+++ b/posthog/management/commands/backfill_raw_sessions_table.py
@@ -20,7 +20,7 @@ logger = structlog.get_logger(__name__)
 TARGET_TABLE = "raw_sessions"
 
 SETTINGS = {
-    "max_execution_time": 3600  # 1 hour
+    "max_execution_time": 7200  # 2 hours
 }
 
 


### PR DESCRIPTION
## Problem

We're starting to run into the 1 hour time limit. This system sucks and should probably be rewritten but in the meantime let's just increase the timeout

## Changes

Increase the timeout to 2 hours

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
n/a
