### PR TITLE
feat(hogvm): serialize the stack between async operations

### DIFF
--- a/hogvm/typescript/package.json
+++ b/hogvm/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/hogvm",
-    "version": "1.0.32",
+    "version": "1.0.35",
     "description": "PostHog Hog Virtual Machine",
     "types": "dist/index.d.ts",
     "main": "dist/index.js",

--- a/hogvm/typescript/src/__tests__/execute.test.ts
+++ b/hogvm/typescript/src/__tests__/execute.test.ts
@@ -1879,7 +1879,7 @@ describe('hogvm execute', () => {
                 ip: 12,
                 maxMemUsed: 64,
                 ops: 5,
-                stack: [{ key: 'value' }], // not a Map
+                stack: [{ key: 'value' }], // is not a Map
                 syncDuration: 0,
                 throwStack: [],
             },

--- a/hogvm/typescript/src/__tests__/execute.test.ts
+++ b/hogvm/typescript/src/__tests__/execute.test.ts
@@ -1863,4 +1863,26 @@ describe('hogvm execute', () => {
             new UncaughtHogVMException('RetryError', 'Not a good day', { key: 'value' })
         )
     })
+
+    test('returns serialized state', () => {
+        const bytecode = ['_h', op.STRING, 'key', op.STRING, 'value', op.DICT, 1, op.GET_LOCAL, 0, op.CALL, 'fetch', 1]
+        expect(exec(bytecode, { asyncFunctions: { fetch: async () => null } })).toEqual({
+            asyncFunctionArgs: [{ key: 'value' }], // not a Map
+            asyncFunctionName: 'fetch',
+            finished: false,
+            result: undefined,
+            state: {
+                asyncSteps: 1,
+                bytecode: bytecode,
+                callStack: [],
+                declaredFunctions: {},
+                ip: 12,
+                maxMemUsed: 64,
+                ops: 5,
+                stack: [{ key: 'value' }], // not a Map
+                syncDuration: 0,
+                throwStack: [],
+            },
+        })
+    })
 })

--- a/hogvm/typescript/src/execute.ts
+++ b/hogvm/typescript/src/execute.ts
@@ -84,10 +84,10 @@ export async function execAsync(bytecode: any[], options?: ExecOptions): Promise
                 const result = await options?.asyncFunctions[response.asyncFunctionName](
                     ...response.asyncFunctionArgs.map(convertHogToJS)
                 )
-                vmState.stack.push(convertJSToHog(result))
+                vmState.stack.push(result)
             } else if (response.asyncFunctionName in ASYNC_STL) {
                 const result = await ASYNC_STL[response.asyncFunctionName](
-                    response.asyncFunctionArgs,
+                    response.asyncFunctionArgs.map(convertHogToJS),
                     response.asyncFunctionName,
                     options?.timeout ?? DEFAULT_TIMEOUT_MS
                 )
@@ -123,7 +123,7 @@ export function exec(code: any[] | VMState, options?: ExecOptions): ExecResult {
 
     const asyncSteps = vmState ? vmState.asyncSteps : 0
     const syncDuration = vmState ? vmState.syncDuration : 0
-    const stack: any[] = vmState ? vmState.stack : []
+    const stack: any[] = vmState ? vmState.stack.map(convertJSToHog) : []
     const memStack: number[] = stack.map((s) => calculateCost(s))
     const callStack: [number, number, number][] = vmState ? vmState.callStack : []
     const throwStack: [number, number, number][] = vmState ? vmState.throwStack : []
@@ -436,10 +436,10 @@ export function exec(code: any[] | VMState, options?: ExecOptions): ExecResult {
                             result: undefined,
                             finished: false,
                             asyncFunctionName: name,
-                            asyncFunctionArgs: args,
+                            asyncFunctionArgs: args.map(convertHogToJS),
                             state: {
                                 bytecode,
-                                stack,
+                                stack: stack.map(convertHogToJS),
                                 callStack,
                                 throwStack,
                                 declaredFunctions,

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -52,7 +52,7 @@
         "@google-cloud/storage": "^5.8.5",
         "@maxmind/geoip2-node": "^3.4.0",
         "@posthog/clickhouse": "^1.7.0",
-        "@posthog/hogvm": "^1.0.32",
+        "@posthog/hogvm": "^1.0.35",
         "@posthog/plugin-scaffold": "1.4.4",
         "@sentry/node": "^7.49.0",
         "@sentry/profiling-node": "^0.3.0",

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -47,8 +47,8 @@ dependencies:
     specifier: file:../rust/cyclotron-node
     version: file:../rust/cyclotron-node
   '@posthog/hogvm':
-    specifier: ^1.0.32
-    version: 1.0.32(luxon@3.4.4)(re2@1.20.3)
+    specifier: ^1.0.35
+    version: 1.0.35(luxon@3.4.4)(re2@1.20.3)
   '@posthog/plugin-scaffold':
     specifier: 1.4.4
     version: 1.4.4
@@ -3116,8 +3116,8 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /@posthog/hogvm@1.0.32(luxon@3.4.4)(re2@1.20.3):
-    resolution: {integrity: sha512-OjgSzs4fZ1Q0KEiON34/dH9TybfVfallANcgoRiNhUd9KstSm55Ds5cpK6HjGMfRRPpPULuDQ77RH3DBjJ2CCA==}
+  /@posthog/hogvm@1.0.35(luxon@3.4.4)(re2@1.20.3):
+    resolution: {integrity: sha512-Uq3Cpg0CGxwScdgGddfzDCs42opILFhgnM6wqly55PAZGBhXWxVHgVpejLiWLtG1z8aIMLC8HCbQx1rZheCGMQ==}
     peerDependencies:
       luxon: ^3.4.4
       re2: ^1.21.3
@@ -10738,4 +10738,5 @@ packages:
   file:../rust/cyclotron-node:
     resolution: {directory: ../rust/cyclotron-node, type: directory}
     name: '@posthog/cyclotron'
+    version: 0.1.0
     dev: false

--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -1,4 +1,3 @@
-import { convertJSToHog } from '@posthog/hogvm'
 import express from 'express'
 import { DateTime } from 'luxon'
 
@@ -147,7 +146,7 @@ export class CdpApi {
                     })
 
                     // Add the state, simulating what executeAsyncResponse would do
-                    invocation.vmState!.stack.push(convertJSToHog({ status: 200, body: {} }))
+                    invocation.vmState!.stack.push({ status: 200, body: {} })
                 } else {
                     const asyncInvocationRequest: HogFunctionInvocationAsyncRequest = {
                         state: '', // WE don't care about the state for this level of testing
@@ -166,7 +165,7 @@ export class CdpApi {
                             message: 'Failed to execute async function',
                         })
                     }
-                    invocation.vmState!.stack.push(convertJSToHog(asyncRes?.asyncFunctionResponse.response ?? null))
+                    invocation.vmState!.stack.push(asyncRes?.asyncFunctionResponse.response ?? null)
                 }
 
                 logs.push(...response.logs)

--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -1,4 +1,4 @@
-import { calculateCost, convertHogToJS, convertJSToHog, exec, ExecResult } from '@posthog/hogvm'
+import { calculateCost, convertHogToJS, exec, ExecResult } from '@posthog/hogvm'
 import { DateTime } from 'luxon'
 import { Histogram } from 'prom-client'
 
@@ -217,7 +217,7 @@ export class HogExecutor {
         }
 
         // Add the response to the stack to continue execution
-        invocation.vmState.stack.push(convertJSToHog(response))
+        invocation.vmState.stack.push(response)
         invocation.timings.push(...timings)
 
         const res = this.execute(hogFunction, invocation)


### PR DESCRIPTION
## Problem

We can't JSON.stringify Maps.

## Changes

Treat the `stack` as normal JS objects outside of Hog.

## How did you test this code?

Added a test.

~~Tried to test E2E locally, but can't get plugin server running :'(~~

~~I mocked out all `cyclotron` code in the plugin server and this did work well E2E with whatever was remaining:~~

Ran the flow locally. Before headers2 was empty, now it's not.

![image](https://github.com/user-attachments/assets/7e2ab2a3-a36b-4cc7-b034-667a952be322)
