### PR TITLE
fix: refactor the inspector list filtering

### DIFF
--- a/frontend/src/scenes/session-recordings/player/inspector/inspectorListFiltering.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/inspectorListFiltering.ts
@@ -4,6 +4,7 @@ import {
     InspectorListBrowserVisibility,
     InspectorListItem,
     InspectorListItemConsole,
+    InspectorListItemDoctor,
     InspectorListItemEvent,
     InspectorListOfflineStatusChange,
 } from 'scenes/session-recordings/player/inspector/playerInspectorLogic'
@@ -78,6 +79,10 @@ function isException(item: InspectorListItem): boolean {
 
 function isErrorEvent(item: InspectorListItem): boolean {
     return isEvent(item) && item.data.event.toLowerCase().includes('error')
+}
+
+function isDoctorEvent(item: InspectorListItem): item is InspectorListItemDoctor {
+    return item.type === 'doctor'
 }
 
 export function filterInspectorListItems({
@@ -178,11 +183,14 @@ export function filterInspectorListItems({
                     ![...IMAGE_WEB_EXTENSIONS, 'css', 'js'].some((ext) => item.data.name?.includes(`.${ext}`)))
             )
         },
-        [SessionRecordingPlayerTab.DOCTOR]: (item: InspectorListItem) =>
-            isOfflineStatusChange(item) ||
-            isBrowserVisibilityEvent(item) ||
-            (item.type === SessionRecordingPlayerTab.EVENTS && item.data.event === '$exception') ||
-            (item.type === SessionRecordingPlayerTab.CONSOLE && item.data.level === 'error'),
+        [SessionRecordingPlayerTab.DOCTOR]: (item: InspectorListItem) => {
+            return (
+                isOfflineStatusChange(item) ||
+                isBrowserVisibilityEvent(item) ||
+                isException(item) ||
+                isDoctorEvent(item)
+            )
+        },
     }
 
     for (const item of allItems) {

--- a/frontend/src/scenes/session-recordings/player/inspector/inspectorListFiltering.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/inspectorListFiltering.ts
@@ -1,0 +1,215 @@
+import { InspectorListItemPerformance } from 'scenes/session-recordings/apm/performanceEventDataLogic'
+import {
+    IMAGE_WEB_EXTENSIONS,
+    InspectorListBrowserVisibility,
+    InspectorListItem,
+    InspectorListItemConsole,
+    InspectorListItemEvent,
+    InspectorListOfflineStatusChange,
+} from 'scenes/session-recordings/player/inspector/playerInspectorLogic'
+import type { SharedListMiniFilter } from 'scenes/session-recordings/player/playerSettingsLogic'
+
+import { SessionRecordingPlayerTab } from '~/types'
+
+const PostHogMobileEvents = [
+    'Deep Link Opened',
+    'Application Opened',
+    'Application Backgrounded',
+    'Application Updated',
+    'Application Installed',
+    'Application Became Active',
+]
+
+function isMobileEvent(item: InspectorListItem): boolean {
+    return isEvent(item) && PostHogMobileEvents.includes(item.data.event)
+}
+
+function isPostHogEvent(item: InspectorListItem): boolean {
+    return (isEvent(item) && item.data.event.startsWith('$')) || isMobileEvent(item)
+}
+
+function isNetworkEvent(item: InspectorListItem): item is InspectorListItemPerformance {
+    return item.type === SessionRecordingPlayerTab.NETWORK
+}
+
+function isOfflineStatusChange(item: InspectorListItem): item is InspectorListOfflineStatusChange {
+    return item.type === 'offline-status'
+}
+
+function isBrowserVisibilityEvent(item: InspectorListItem): item is InspectorListBrowserVisibility {
+    return item.type === 'browser-visibility'
+}
+
+function isNavigationEvent(item: InspectorListItem): boolean {
+    return isNetworkEvent(item) && ['navigation'].includes(item.data.entry_type || '')
+}
+
+function isNetworkError(item: InspectorListItem): boolean {
+    return isNetworkEvent(item) && (item.data.response_status || -1) >= 400
+}
+
+function isSlowNetwork(item: InspectorListItem): boolean {
+    return isNetworkEvent(item) && (item.data.duration || -1) >= 1000
+}
+
+function isEvent(item: InspectorListItem): item is InspectorListItemEvent {
+    return item.type === SessionRecordingPlayerTab.EVENTS
+}
+
+function isPageviewOrScreen(item: InspectorListItem): boolean {
+    return isEvent(item) && ['$pageview', '$screen'].includes(item.data.event)
+}
+
+function isAutocapture(item: InspectorListItem): boolean {
+    return isEvent(item) && item.data.event === '$autocapture'
+}
+
+function isConsoleEvent(item: InspectorListItem): item is InspectorListItemConsole {
+    return item.type === SessionRecordingPlayerTab.CONSOLE
+}
+
+function isConsoleError(item: InspectorListItem): boolean {
+    return isConsoleEvent(item) && item.data.level === 'error'
+}
+
+function isException(item: InspectorListItem): boolean {
+    return isEvent(item) && item.data.event === '$exception'
+}
+
+function isErrorEvent(item: InspectorListItem): boolean {
+    return isEvent(item) && item.data.event.toLowerCase().includes('error')
+}
+
+export function filterInspectorListItems({
+    allItems,
+    tab,
+    miniFiltersByKey,
+    showMatchingEventsFilter,
+    showOnlyMatching,
+    windowIdFilter,
+}: {
+    allItems: InspectorListItem[]
+    tab: SessionRecordingPlayerTab
+    miniFiltersByKey: {
+        [key: string]: SharedListMiniFilter
+    }
+    showMatchingEventsFilter: boolean
+    showOnlyMatching: boolean
+    windowIdFilter: string | null
+}): InspectorListItem[] {
+    const items: InspectorListItem[] = []
+
+    const shortCircuitExclude = (item: InspectorListItem): boolean =>
+        isNetworkEvent(item) && item.data.entry_type === 'paint'
+
+    const eventsAllowedPerTab: Record<SessionRecordingPlayerTab, (item: InspectorListItem) => boolean> = {
+        [SessionRecordingPlayerTab.ALL]: (item: InspectorListItem) => {
+            const isAllEverything = miniFiltersByKey['all-everything'].enabled === true
+            const isAllAutomatic =
+                !!miniFiltersByKey['all-automatic'].enabled &&
+                (isOfflineStatusChange(item) ||
+                    isBrowserVisibilityEvent(item) ||
+                    isNavigationEvent(item) ||
+                    isNetworkError(item) ||
+                    isSlowNetwork(item) ||
+                    isMobileEvent(item) ||
+                    isPageviewOrScreen(item) ||
+                    isAutocapture(item))
+            const isAllErrors =
+                (!!miniFiltersByKey['all-errors'].enabled && isNetworkError(item)) ||
+                isConsoleError(item) ||
+                isException(item) ||
+                isErrorEvent(item)
+            return isAllEverything || isAllAutomatic || isAllErrors
+        },
+        [SessionRecordingPlayerTab.EVENTS]: (item: InspectorListItem) => {
+            if (item.type !== SessionRecordingPlayerTab.EVENTS) {
+                return false
+            }
+            return (
+                !!miniFiltersByKey['events-all'].enabled ||
+                (!!miniFiltersByKey['events-posthog'].enabled && isPostHogEvent(item)) ||
+                (!!miniFiltersByKey['events-custom'].enabled && !isPostHogEvent(item)) ||
+                (!!miniFiltersByKey['events-pageview'].enabled && ['$pageview', '$screen'].includes(item.data.event)) ||
+                (!!miniFiltersByKey['events-autocapture'].enabled && item.data.event === '$autocapture') ||
+                (!!miniFiltersByKey['events-exceptions'].enabled && item.data.event === '$exception')
+            )
+        },
+        [SessionRecordingPlayerTab.CONSOLE]: (item: InspectorListItem) => {
+            if (item.type !== SessionRecordingPlayerTab.CONSOLE) {
+                return false
+            }
+            return (
+                !!miniFiltersByKey['console-all'].enabled ||
+                (!!miniFiltersByKey['console-info'].enabled && ['log', 'info'].includes(item.data.level)) ||
+                (!!miniFiltersByKey['console-warn'].enabled && item.data.level === 'warn') ||
+                (!!miniFiltersByKey['console-error'].enabled && item.data.level === 'error')
+            )
+        },
+        [SessionRecordingPlayerTab.NETWORK]: (item: InspectorListItem) => {
+            if (item.type !== SessionRecordingPlayerTab.NETWORK) {
+                return false
+            }
+            return (
+                !!miniFiltersByKey['performance-all'].enabled === true ||
+                (!!miniFiltersByKey['performance-document'].enabled &&
+                    ['navigation'].includes(item.data.entry_type || '')) ||
+                (!!miniFiltersByKey['performance-fetch'].enabled &&
+                    item.data.entry_type === 'resource' &&
+                    ['fetch', 'xmlhttprequest'].includes(item.data.initiator_type || '')) ||
+                (!!miniFiltersByKey['performance-assets-js'].enabled &&
+                    item.data.entry_type === 'resource' &&
+                    (item.data.initiator_type === 'script' ||
+                        (['link', 'other'].includes(item.data.initiator_type || '') &&
+                            item.data.name?.includes('.js')))) ||
+                (!!miniFiltersByKey['performance-assets-css'].enabled &&
+                    item.data.entry_type === 'resource' &&
+                    (item.data.initiator_type === 'css' ||
+                        (['link', 'other'].includes(item.data.initiator_type || '') &&
+                            item.data.name?.includes('.css')))) ||
+                (!!miniFiltersByKey['performance-assets-img'].enabled &&
+                    item.data.entry_type === 'resource' &&
+                    (item.data.initiator_type === 'img' ||
+                        (['link', 'other'].includes(item.data.initiator_type || '') &&
+                            !!IMAGE_WEB_EXTENSIONS.some((ext) => item.data.name?.includes(`.${ext}`))))) ||
+                (!!miniFiltersByKey['performance-other'].enabled &&
+                    item.data.entry_type === 'resource' &&
+                    ['other'].includes(item.data.initiator_type || '') &&
+                    ![...IMAGE_WEB_EXTENSIONS, 'css', 'js'].some((ext) => item.data.name?.includes(`.${ext}`)))
+            )
+        },
+        [SessionRecordingPlayerTab.DOCTOR]: (item: InspectorListItem) =>
+            isOfflineStatusChange(item) ||
+            isBrowserVisibilityEvent(item) ||
+            (item.type === SessionRecordingPlayerTab.EVENTS && item.data.event === '$exception') ||
+            (item.type === SessionRecordingPlayerTab.CONSOLE && item.data.level === 'error'),
+    }
+
+    for (const item of allItems) {
+        let include = false
+
+        if (shortCircuitExclude(item)) {
+            continue
+        }
+
+        if (eventsAllowedPerTab[tab](item)) {
+            include = true
+        }
+
+        if (showMatchingEventsFilter && showOnlyMatching) {
+            // Special case - overrides the others
+            include = include && item.highlightColor === 'primary'
+        }
+
+        const itemWindowId = item.windowId // how do we use sometimes properties $window_id... maybe we just shouldn't need to :shrug:
+        const excludedByWindowFilter = !!windowIdFilter && !!itemWindowId && itemWindowId !== windowIdFilter
+
+        if (!include || excludedByWindowFilter) {
+            continue
+        }
+
+        items.push(item)
+    }
+
+    return items
+}

--- a/frontend/src/scenes/session-recordings/player/inspector/inspectorListFiltering.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/inspectorListFiltering.ts
@@ -21,12 +21,12 @@ const PostHogMobileEvents = [
     'Application Became Active',
 ]
 
-function isMobileEvent(item: InspectorListItem): boolean {
+function isPostHogMobileEvent(item: InspectorListItem): boolean {
     return isEvent(item) && PostHogMobileEvents.includes(item.data.event)
 }
 
 function isPostHogEvent(item: InspectorListItem): boolean {
-    return (isEvent(item) && item.data.event.startsWith('$')) || isMobileEvent(item)
+    return (isEvent(item) && item.data.event.startsWith('$')) || isPostHogMobileEvent(item)
 }
 
 function isNetworkEvent(item: InspectorListItem): item is InspectorListItemPerformance {
@@ -117,7 +117,7 @@ export function filterInspectorListItems({
                     isNavigationEvent(item) ||
                     isNetworkError(item) ||
                     isSlowNetwork(item) ||
-                    isMobileEvent(item) ||
+                    isPostHogMobileEvent(item) ||
                     isPageviewOrScreen(item) ||
                     isAutocapture(item))
             const isAllErrors =

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.test.ts
@@ -32,6 +32,30 @@ describe('playerInspectorLogic', () => {
 
     describe('filtering inspector list items', () => {
         describe('the events tab', () => {
+            it('filters by window id', () => {
+                expect(
+                    filterInspectorListItems({
+                        allItems: [
+                            {
+                                type: SessionRecordingPlayerTab.EVENTS,
+                                windowId: 'this window',
+                                data: { event: '$exception' } as unknown as PerformanceEvent,
+                            } as unknown as InspectorListItemEvent,
+                            {
+                                type: SessionRecordingPlayerTab.EVENTS,
+                                windowId: 'a different window',
+                                data: { event: '$exception' } as unknown as PerformanceEvent,
+                            } as unknown as InspectorListItemEvent,
+                        ],
+                        tab: SessionRecordingPlayerTab.EVENTS,
+                        miniFiltersByKey: { 'events-all': { enabled: true } as unknown as SharedListMiniFilter },
+                        showOnlyMatching: false,
+                        showMatchingEventsFilter: false,
+                        windowIdFilter: 'a different window',
+                    })
+                ).toHaveLength(1)
+            })
+
             it('includes browser visibility', () => {
                 expect(
                     filterInspectorListItems({

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.test.ts
@@ -1,7 +1,7 @@
 import { expectLogic } from 'kea-test-utils'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { filterInspectorListItems } from 'scenes/session-recordings/player/inspector/inspectorListFiltering'
 import {
-    filterInspectorListItems,
     InspectorListBrowserVisibility,
     InspectorListItemEvent,
     InspectorListOfflineStatusChange,

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.test.ts
@@ -64,7 +64,7 @@ describe('playerInspectorLogic', () => {
                                 type: 'browser-visibility',
                             } as InspectorListBrowserVisibility,
                         ],
-                        tab: SessionRecordingPlayerTab.EVENTS,
+                        tab: SessionRecordingPlayerTab.ALL,
                         miniFiltersByKey: { 'all-everything': { enabled: true } as unknown as SharedListMiniFilter },
                         showOnlyMatching: false,
                         showMatchingEventsFilter: false,

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -179,20 +179,12 @@ export function filterInspectorListItems({
 
         if (item.type === 'offline-status' || item.type === 'browser-visibility') {
             const allowedMiniFilters = !!(
-                miniFiltersByKey['performance-all']?.enabled ||
-                miniFiltersByKey['all-everything']?.enabled ||
-                miniFiltersByKey['all-automatic']?.enabled ||
-                miniFiltersByKey['console-all']?.enabled ||
-                miniFiltersByKey['events-all']?.enabled
+                miniFiltersByKey['all-everything']?.enabled || miniFiltersByKey['all-automatic']?.enabled
             )
 
             const isCurrentlyShowingFilteredEvents = showMatchingEventsFilter && showOnlyMatching
 
             include = isDoctorTab || (allowedMiniFilters && !isCurrentlyShowingFilteredEvents)
-
-            if (windowIdFilter && item.windowId && item.windowId !== windowIdFilter) {
-                include = false
-            }
         }
 
         if (item.type === SessionRecordingPlayerTab.DOCTOR && isDoctorTab) {
@@ -257,10 +249,6 @@ export function filterInspectorListItems({
                     // Special case - overrides the others
                     include = include && item.highlightColor === 'primary'
                 }
-
-                if (windowIdFilter && item.data.properties?.$window_id !== windowIdFilter) {
-                    include = false
-                }
             }
         }
 
@@ -293,10 +281,6 @@ export function filterInspectorListItems({
                 item.data.level === 'error'
             ) {
                 include = true
-            }
-
-            if (windowIdFilter && item.data.windowId !== windowIdFilter) {
-                include = false
             }
         }
 
@@ -384,7 +368,9 @@ export function filterInspectorListItems({
             }
         }
 
-        if (!include) {
+        const excludedByWindowFilter = !!windowIdFilter && !!item.windowId && item.windowId !== windowIdFilter
+
+        if (!include || excludedByWindowFilter) {
             continue
         }
 

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -336,7 +336,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
                             const customEvent = snapshot as customEvent
                             const tag = customEvent.data.tag
 
-                            if (tag === '$pageview') {
+                            if (['$pageview', 'window hidden', 'browser offline', 'browser online'].includes(tag)) {
                                 return
                             }
 

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -209,7 +209,7 @@ export function filterInspectorListItems({
         // EVENTS
         if (item.type === SessionRecordingPlayerTab.EVENTS) {
             if (tab === SessionRecordingPlayerTab.DOCTOR) {
-                if (item.data.event === '$exception' || item.data.event.toLowerCase().includes('error')) {
+                if (item.data.event === '$exception') {
                     include = true
                 }
             } else {


### PR DESCRIPTION
Figuring out whether an item should be shown and how to change that was breaking my brain

This 

* refactors the inspector filters to be per tab and then per mini filter 
* and de-duplicates some custom events in the doctor tab
* and shows the custom recording events in fewer places
* and doesn't show arbitrary events with error in the name in the doctor tab
