### PR TITLE
feat: Add soft delete column to events

### DIFF
--- a/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
+++ b/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
@@ -14,11 +14,17 @@ ALTER TABLE {table} ON CLUSTER {cluster}
 ADD COLUMN IF NOT EXISTS is_deleted Boolean False
 """
 
+ADD_COLUMNS_INDEX_EVENTS = """
+ALTER TABLE {table} ON CLUSTER {cluster}
+ADD INDEX IF NOT EXISTS is_deleted_idx (is_deleted) TYPE minmax GRANULARITY 1
+"""
+
 
 def add_columns_to_required_tables(_):
     with ch_pool.get_client() as client:
         client.execute(DROP_COLUMNS_SHARDED_EVENTS.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
         client.execute(ADD_COLUMNS_SHARDED_EVENTS.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
+        client.execute(ADD_COLUMNS_INDEX_EVENTS.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
 
 
 operations = [

--- a/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
+++ b/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
@@ -11,7 +11,7 @@ DROP COLUMN IF EXISTS is_deleted
 
 ADD_COLUMNS_SHARDED_EVENTS = """
 ALTER TABLE {table} ON CLUSTER {cluster}
-ADD COLUMN IF NOT EXISTS is_deleted DEFAULT Boolean False
+ADD COLUMN IF NOT EXISTS is_deleted Boolean DEFAULT False
 """
 
 ADD_COLUMNS_EVENTS = """

--- a/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
+++ b/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
@@ -4,7 +4,7 @@ from posthog.clickhouse.client.connection import ch_pool
 from posthog.settings import CLICKHOUSE_CLUSTER
 
 
-DROP_COLUMNS_SHARDED_EVENTS = """
+DROP_COLUMNS_EVENTS = """
 ALTER TABLE {table} ON CLUSTER {cluster}
 DROP COLUMN IF EXISTS is_deleted
 """
@@ -12,6 +12,11 @@ DROP COLUMN IF EXISTS is_deleted
 ADD_COLUMNS_SHARDED_EVENTS = """
 ALTER TABLE {table} ON CLUSTER {cluster}
 ADD COLUMN IF NOT EXISTS is_deleted DEFAULT Boolean False
+"""
+
+ADD_COLUMNS_EVENTS = """
+ALTER TABLE {table} ON CLUSTER {cluster}
+ADD COLUMN IF NOT EXISTS is_deleted
 """
 
 ADD_COLUMNS_INDEX_EVENTS = """
@@ -22,8 +27,10 @@ ADD INDEX IF NOT EXISTS is_deleted_idx (is_deleted) TYPE minmax GRANULARITY 1
 
 def add_columns_to_required_tables(_):
     with ch_pool.get_client() as client:
-        client.execute(DROP_COLUMNS_SHARDED_EVENTS.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
+        client.execute(DROP_COLUMNS_EVENTS.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
+        client.execute(DROP_COLUMNS_EVENTS.format(table="events", cluster=CLICKHOUSE_CLUSTER))
         client.execute(ADD_COLUMNS_SHARDED_EVENTS.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
+        client.execute(ADD_COLUMNS_EVENTS.format(table="events", cluster=CLICKHOUSE_CLUSTER))
         client.execute(ADD_COLUMNS_INDEX_EVENTS.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
 
 

--- a/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
+++ b/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
@@ -11,7 +11,7 @@ DROP COLUMN IF EXISTS is_deleted
 
 ADD_COLUMNS_SHARDED_EVENTS = """
 ALTER TABLE {table} ON CLUSTER {cluster}
-ADD COLUMN IF NOT EXISTS is_deleted Boolean DEFAULT False
+ADD COLUMN IF NOT EXISTS is_deleted Boolean
 """
 
 ADD_COLUMNS_EVENTS = """

--- a/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
+++ b/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
@@ -1,0 +1,26 @@
+from infi.clickhouse_orm import migrations
+
+from posthog.clickhouse.client.connection import ch_pool
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+
+DROP_COLUMNS_SHARDED_EVENTS = """
+ALTER TABLE {table} ON CLUSTER {cluster}
+DROP COLUMN IF EXISTS is_deleted
+"""
+
+ADD_COLUMNS_SHARDED_EVENTS = """
+ALTER TABLE {table} ON CLUSTER {cluster}
+ADD COLUMN IF NOT EXISTS is_deleted Boolean DEFAULT False
+"""
+
+
+def add_columns_to_required_tables(_):
+    with ch_pool.get_client() as client:
+        client.execute(DROP_COLUMNS_SHARDED_EVENTS.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
+        client.execute(ADD_COLUMNS_SHARDED_EVENTS.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
+
+
+operations = [
+    migrations.RunPython(add_columns_to_required_tables),
+]

--- a/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
+++ b/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
@@ -11,7 +11,7 @@ DROP COLUMN IF EXISTS is_deleted
 
 ADD_COLUMNS_SHARDED_EVENTS = """
 ALTER TABLE {table} ON CLUSTER {cluster}
-ADD COLUMN IF NOT EXISTS is_deleted Boolean False
+ADD COLUMN IF NOT EXISTS is_deleted DEFAULT Boolean False
 """
 
 ADD_COLUMNS_INDEX_EVENTS = """

--- a/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
+++ b/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
@@ -9,14 +9,9 @@ ALTER TABLE {table} ON CLUSTER {cluster}
 DROP COLUMN IF EXISTS is_deleted
 """
 
-ADD_COLUMNS_SHARDED_EVENTS = """
-ALTER TABLE {table} ON CLUSTER {cluster}
-ADD COLUMN IF NOT EXISTS is_deleted Boolean
-"""
-
 ADD_COLUMNS_EVENTS = """
 ALTER TABLE {table} ON CLUSTER {cluster}
-ADD COLUMN IF NOT EXISTS is_deleted
+ADD COLUMN IF NOT EXISTS is_deleted Boolean
 """
 
 ADD_COLUMNS_INDEX_EVENTS = """
@@ -29,7 +24,7 @@ def add_columns_to_required_tables(_):
     with ch_pool.get_client() as client:
         client.execute(DROP_COLUMNS_EVENTS.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
         client.execute(DROP_COLUMNS_EVENTS.format(table="events", cluster=CLICKHOUSE_CLUSTER))
-        client.execute(ADD_COLUMNS_SHARDED_EVENTS.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
+        client.execute(ADD_COLUMNS_EVENTS.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
         client.execute(ADD_COLUMNS_EVENTS.format(table="events", cluster=CLICKHOUSE_CLUSTER))
         client.execute(ADD_COLUMNS_INDEX_EVENTS.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
 

--- a/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
+++ b/posthog/clickhouse/migrations/0078_add_soft_delete_column_on_events.py
@@ -11,7 +11,7 @@ DROP COLUMN IF EXISTS is_deleted
 
 ADD_COLUMNS_SHARDED_EVENTS = """
 ALTER TABLE {table} ON CLUSTER {cluster}
-ADD COLUMN IF NOT EXISTS is_deleted Boolean DEFAULT False
+ADD COLUMN IF NOT EXISTS is_deleted Boolean False
 """
 
 


### PR DESCRIPTION
## Problem

We can't use lightweight deletes because the implementation is riddled with gotchas

## Changes

So why don't we create our own version of the soft delete? We will re-emit the events (using an insert as select statement) with all of the interesting details omitted and the `is_deleted` flag set to `true`. We will also increment the version so that the old versions are cleaned up by the `ReplacingMergeTree` at some point leaving behind only the `is_deleted` rows as ghosts 👻.

As a follow up we will need to add this predicate to all queries being created by hogql and other query facilities

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
