### PR TITLE
feat(capture): handle empty string UUIDs for `/batch` endpoint

### DIFF
--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -471,14 +471,6 @@ mod tests {
     }
 
     #[test]
-    fn test_none_is_none() {
-        let json = serde_json::json!({});
-        let result = test_deserialize(json);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), None);
-    }
-
-    #[test]
     fn test_valid_uuid_is_some() {
         let valid_uuid = "550e8400-e29b-41d4-a716-446655440000";
         let json = serde_json::json!({"uuid": valid_uuid});

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -66,6 +66,7 @@ pub struct RawEvent {
     pub token: Option<String>,
     #[serde(alias = "$distinct_id", skip_serializing_if = "Option::is_none")]
     pub distinct_id: Option<Value>, // posthog-js accepts arbitrary values as distinct_id
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub uuid: Option<Uuid>,
     pub event: String,
     #[serde(default)]

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -463,7 +463,7 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_string_is_none() {
+    fn test_empty_uuid_string_is_none() {
         let json = serde_json::json!({"uuid": ""});
         let result = test_deserialize(json);
         assert!(result.is_ok());


### PR DESCRIPTION
## Problem

[We tried to make a change to the Go SDK to support passing in client-defined UUIDs to the `/batch` endpoint](https://github.com/PostHog/posthog-go/pull/68), but sometimes those UUIDs were empty strings.  This led to the SDK breaking because, while our batch endpoint _supports_ passing in UUIDs, it doesn't handle the empty string case.  Obviously, we should tell our users to omit UUIDs that are empty, but I think updating our serializer to ignore them is probably a good idea, too.

## Changes

Update the `RawEvent` serializer to treat empty strings in the UUID field as `None`.

## Does this work well for both Cloud and self-hosted?

Yup.

## How did you test this code?

Wrote some tests; maybe overkill, but still seems handy since this is a non-standard deserialization path. Here's a rust playground that shows the fix, too: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=648f9a409cd5c89fdbc4b05c786d5b3a
