### PR TITLE
chore(data-warehouse): Dont allow S3 protocol for linking data source

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/dataWarehouseTableLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/dataWarehouseTableLogic.tsx
@@ -92,6 +92,13 @@ export const dataWarehouseTableLogic = kea<dataWarehouseTableLogicType>([
         table: {
             defaults: { ...NEW_WAREHOUSE_TABLE } as DataWarehouseTable,
             errors: ({ name, url_pattern, credential, format }) => {
+                if (url_pattern?.startsWith('s3://')) {
+                    return {
+                        url_pattern:
+                            'Please use the https version of your bucket url e.g. https://your-org.s3.amazonaws.com/airbyte/stripe/invoices/*.pqt',
+                    }
+                }
+
                 return {
                     name: !name && 'Please enter a name.',
                     url_pattern: !url_pattern && 'Please enter a url pattern.',


### PR DESCRIPTION
## Problem
- We get a handful of people trying to use S3 URLs using the `s3` protocol when linking their manual data source to data warehouse
- Because clickhouse doesn't support this, we should reject it to avoid ambiguous errors

## Changes
- Adding an error message for when people use `s3://...` urls
- Not the prettiest, but should reduce some support volume

<img width="856" alt="image" src="https://github.com/user-attachments/assets/5ae7d14e-08f6-4b32-aac4-9406e8e1c0e7">


## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
See above