### PR TITLE
fix: horizontal bar chart breakdown label show series name

### DIFF
--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -2,11 +2,8 @@ import { useValues } from 'kea'
 import { getSeriesColor } from 'lib/colors'
 import { useEffect, useState } from 'react'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { datasetToActorsQuery } from 'scenes/trends/viz/datasetToActorsQuery'
 
-import { cohortsModel } from '~/models/cohortsModel'
-import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { ChartParams, GraphType } from '~/types'
 
 import { InsightEmptyState } from '../../insights/EmptyStates'
@@ -20,9 +17,6 @@ export function ActionsHorizontalBar({ showPersonsModal = true }: ChartParams): 
     const [data, setData] = useState<DataSet[] | null>(null)
     const [total, setTotal] = useState(0)
 
-    const { cohorts } = useValues(cohortsModel)
-    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
-
     const { insightProps } = useValues(insightLogic)
     const {
         indexedResults,
@@ -32,7 +26,6 @@ export function ActionsHorizontalBar({ showPersonsModal = true }: ChartParams): 
         showValuesOnSeries,
         isDataWarehouseSeries,
         querySource,
-        breakdownFilter,
         hiddenLegendIndexes,
     } = useValues(trendsDataLogic(insightProps))
 
@@ -47,14 +40,7 @@ export function ActionsHorizontalBar({ showPersonsModal = true }: ChartParams): 
                 actions: _data.map((item) => item.action),
                 personsValues: _data.map((item) => item.persons),
                 breakdownValues: _data.map((item) => item.breakdown_value),
-                breakdownLabels: _data.map((item) => {
-                    return formatBreakdownLabel(
-                        item.breakdown_value,
-                        breakdownFilter,
-                        cohorts,
-                        formatPropertyValueForDisplay
-                    )
-                }),
+                breakdownLabels: _data.map((item) => item.label),
                 compareLabels: _data.map((item) => item.compare_label),
                 backgroundColor: colorList,
                 hoverBackgroundColor: colorList,


### PR DESCRIPTION
## Problem
Fixes https://posthoghelp.zendesk.com/agent/tickets/17200 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/20168)
Where horizontal bar chart labels don't have series names

## Changes
Prepending the item name to the breakdown label

<img width="835" alt="image" src="https://github.com/user-attachments/assets/4b59d0d2-e34d-4001-926e-6a8a9e395e9d">
<img width="836" alt="image" src="https://github.com/user-attachments/assets/25ff89ad-27cb-4a3e-931f-a7c7a6960bfd">

Previous behaviour was this below

<img width="870" alt="image" src="https://github.com/user-attachments/assets/1b204ac5-63c6-4ee6-b382-9909e211c70c">
 
Also works for multiple breakdowns

<img width="821" alt="image" src="https://github.com/user-attachments/assets/ee94cc11-80c7-481a-b835-3ee255744485">


## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
