### PR TITLE
feat: Add ci/cd for capture-replay

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -1,4 +1,4 @@
-name: Build rust container images
+name: Build and deploy rust container images
 
 on:
     workflow_dispatch:
@@ -27,6 +27,9 @@ jobs:
             id-token: write # allow issuing OIDC tokens for this workflow run
             contents: read # allow reading the repo contents
             packages: write # allow push to ghcr.io
+
+        outputs:
+            digest: ${{ steps.docker_build.outputs.digest }}
 
         defaults:
             run:
@@ -91,3 +94,36 @@ jobs:
 
             - name: Container image digest
               run: echo ${{ steps.docker_build.outputs.digest }}
+
+
+    deploy:
+        name: Deploy capture-replay
+        runs-on: ubuntu-latest
+        needs: build
+        if: github.ref == 'refs/heads/master'
+        steps:
+            - name: get deployer token
+              id: deployer
+              uses: getsentry/action-github-app-token@v3
+              with:
+                  app_id: ${{ secrets.DEPLOYER_APP_ID }}
+                  private_key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
+
+            - name: Trigger livestream deployment
+              uses: peter-evans/repository-dispatch@v3
+              with:
+                  token: ${{ steps.deployer.outputs.token }}
+                  repository: PostHog/charts
+                  event-type: commit_state_update
+                  client-payload: |
+                      {
+                        "values": {
+                          "image": {
+                            "sha": "${{ needs.build.outputs.digest }}"
+                          }
+                        },
+                        "release": "capture-replay",
+                        "commit": ${{ toJson(github.event.head_commit) }},
+                        "repository": ${{ toJson(github.repository) }},
+                        "labels": []
+                      }


### PR DESCRIPTION
## Problem

auto deploy capture-replay with latest code

we will set up automatic canary deploy/rollbacks so this is less risky before we roll this out to events capture too

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
