### PR TITLE
fix(hogql): use new hogql parser version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -97,7 +97,7 @@ phonenumberslite==8.13.6
 openai==1.10.0
 tiktoken==0.6.0
 nh3==0.2.14
-hogql-parser==1.0.36
+hogql-parser==1.0.38
 zxcvbn==4.4.28
 zstd==1.5.5.1
 xmlsec==1.3.13 # Do not change this version - it will break SAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -275,7 +275,7 @@ h11==0.13.0
     #   wsproto
 hexbytes==1.0.0
     # via dlt
-hogql-parser==1.0.36
+hogql-parser==1.0.38
     # via -r requirements.in
 httpcore==1.0.2
     # via httpx


### PR DESCRIPTION
## Problem

These errors ended up in master:
```
=========================== short test summary info ============================
FAILED posthog/hogql/test/test_parser_cpp.py::TestParserCpp::test_call_expr - posthog.hogql.errors.SyntaxError: mismatched input '(' expecting <EOF>
FAILED posthog/hogql/test/test_parser_cpp.py::TestParserCpp::test_lambda_blocks - posthog.hogql.errors.SyntaxError: mismatched input '->' expecting <EOF>
FAILED posthog/hogql/test/test_parser_cpp.py::TestParserCpp::test_lambdas - posthog.hogql.errors.SyntaxError: mismatched input '->' expecting <EOF>
FAILED posthog/hogql/test/test_printer.py::TestPrinter::test_expr_parse_errors - AssertionError: Expected 'Aggregation 'quantile' expects 1 parameter, found 0' in 'Aggregation 'quantile' requires parameters in addition to arguments'
FAILED posthog/hogql/test/test_printer.py::TestPrinter::test_expr_syntax_errors - AssertionError: Expected 'mismatched input ')' expecting '->'' in 'no viable alternative at input '()''
==== 5 failed, 1157 passed, 3 skipped, 5511 deselected in 399.05s (0:06:39) ====
```

## Changes

Use the new `hogql-parser` version that was shipped with https://github.com/PostHog/posthog/pull/24575

## How did you test this code?

Tests locally