### PR TITLE
feat(web-analytics): Add a setting to use the uniq_page_screen_autocaptures mode

### DIFF
--- a/frontend/src/scenes/settings/project/BounceRatePageViewMode.tsx
+++ b/frontend/src/scenes/settings/project/BounceRatePageViewMode.tsx
@@ -33,6 +33,18 @@ const bounceRatePageViewModeOptions: LemonRadioOption<BounceRatePageViewMode>[] 
             </>
         ),
     },
+    {
+        value: 'uniq_page_screen_autocaptures',
+        label: (
+            <>
+                <div>Use uniqUpTo</div>
+                <div className="text-muted">
+                    Uses the <code>uniqUpTo</code> function to count if the total unique pageviews + screen events +
+                    autocaptures is &gte; 2
+                </div>
+            </>
+        ),
+    },
 ]
 
 export function BounceRatePageViewModeSetting(): JSX.Element {


### PR DESCRIPTION
## Problem

I want to be able to turn this on this setting for us and some customers, to measure perf improvement easily on prod.

The code is already live, and this setting is hidden behind a feature flag, just that the new mode is not in the settings UI. I'm not expecting customers to use this without our help

## Changes
Add the new mode to the settings UI
## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually, but it's behind a FF anyway
