### PR TITLE
fix(hog): bytecode starts with _H as well

### DIFF
--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -30,9 +30,9 @@ const hogExecutionDuration = new Histogram({
 export const formatInput = (bytecode: any, globals: HogFunctionInvocation['globals']): any => {
     // Similar to how we generate the bytecode by iterating over the values,
     // here we iterate over the object and replace the bytecode with the actual values
-    // bytecode is indicated as an array beginning with ["_h"]
+    // bytecode is indicated as an array beginning with ["_H"] (versions 1+) or ["_h"] (version 0)
 
-    if (Array.isArray(bytecode) && bytecode[0] === '_h') {
+    if (Array.isArray(bytecode) && (bytecode[0] === '_h' || bytecode[0] === '_H')) {
         const res = exec(bytecode, {
             globals,
             timeout: DEFAULT_TIMEOUT_MS,


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C06GG249PR6/p1724772235488799

## Changes

Bytecode can start with `_H`


## How did you test this code?

WIP