### PR TITLE
feat(web-analytics): Default onto sessions v2

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -82,7 +82,6 @@ from posthog.schema import (
     PersonsOnEventsMode,
     SessionTableVersion,
 )
-from posthog.utils import get_instance_region
 from posthog.warehouse.models.external_data_job import ExternalDataJob
 from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 from posthog.warehouse.models.external_data_source import ExternalDataSource
@@ -249,8 +248,9 @@ def create_hogql_database(
             join_function=join_with_persons_table,
         )
 
-    if modifiers.sessionTableVersion == SessionTableVersion.V2 or (
-        get_instance_region() == "EU" and modifiers.sessionTableVersion == SessionTableVersion.AUTO
+    if (
+        modifiers.sessionTableVersion == SessionTableVersion.V2
+        or modifiers.sessionTableVersion == SessionTableVersion.AUTO
     ):
         raw_sessions = RawSessionsTableV2()
         database.raw_sessions = raw_sessions

--- a/posthog/hogql/database/schema/test/__snapshots__/test_session_replay_events.ambr
+++ b/posthog/hogql/database/schema/test/__snapshots__/test_session_replay_events.ambr
@@ -333,12 +333,12 @@
   SELECT DISTINCT session_replay_events.session_id AS session_id
   FROM session_replay_events
   LEFT JOIN
-    (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS duration,
-            sessions.session_id AS session_id
-     FROM sessions
-     WHERE equals(sessions.team_id, 2)
-     GROUP BY sessions.session_id,
-              sessions.session_id) AS raw_session_replay_events__session ON equals(session_replay_events.session_id, raw_session_replay_events__session.session_id)
+    (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS duration,
+            raw_sessions.session_id_v7 AS session_id_v7
+     FROM raw_sessions
+     WHERE equals(raw_sessions.team_id, 2)
+     GROUP BY raw_sessions.session_id_v7,
+              raw_sessions.session_id_v7) AS raw_session_replay_events__session ON equals(toUInt128(accurateCastOrNull(session_replay_events.session_id, 'UUID')), raw_session_replay_events__session.session_id_v7)
   WHERE and(equals(session_replay_events.team_id, 2), ifNull(greater(raw_session_replay_events__session.duration, 3600), 0))
   GROUP BY session_replay_events.session_id
   HAVING ifNull(equals(dateDiff('second', min(toTimeZone(session_replay_events.min_first_timestamp, 'UTC')), max(toTimeZone(session_replay_events.max_last_timestamp, 'UTC'))), 3600), 0)

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -346,6 +346,7 @@
                   "fields": [
                       "id",
                       "session_id",
+                      "session_id_v7",
                       "team_id",
                       "distinct_id",
                       "$start_timestamp",
@@ -354,8 +355,8 @@
                       "$num_uniq_urls",
                       "$entry_current_url",
                       "$entry_pathname",
-                      "$exit_current_url",
-                      "$exit_pathname",
+                      "$end_current_url",
+                      "$end_pathname",
                       "$entry_utm_source",
                       "$entry_utm_campaign",
                       "$entry_utm_medium",
@@ -364,13 +365,15 @@
                       "$entry_referring_domain",
                       "$entry_gclid",
                       "$entry_gad_source",
-                      "$event_count_map",
                       "$pageview_count",
                       "$autocapture_count",
+                      "$screen_count",
                       "$channel_type",
                       "$session_duration",
                       "duration",
-                      "$is_bounce"
+                      "$is_bounce",
+                      "$last_external_click_url",
+                      "$page_screen_autocapture_count_up_to"
                   ],
                   "hogql_value": "session",
                   "name": "session",
@@ -832,6 +835,7 @@
                   "fields": [
                       "id",
                       "session_id",
+                      "session_id_v7",
                       "team_id",
                       "distinct_id",
                       "$start_timestamp",
@@ -840,8 +844,8 @@
                       "$num_uniq_urls",
                       "$entry_current_url",
                       "$entry_pathname",
-                      "$exit_current_url",
-                      "$exit_pathname",
+                      "$end_current_url",
+                      "$end_pathname",
                       "$entry_utm_source",
                       "$entry_utm_campaign",
                       "$entry_utm_medium",
@@ -850,13 +854,15 @@
                       "$entry_referring_domain",
                       "$entry_gclid",
                       "$entry_gad_source",
-                      "$event_count_map",
                       "$pageview_count",
                       "$autocapture_count",
+                      "$screen_count",
                       "$channel_type",
                       "$session_duration",
                       "duration",
-                      "$is_bounce"
+                      "$is_bounce",
+                      "$last_external_click_url",
+                      "$page_screen_autocapture_count_up_to"
                   ],
                   "hogql_value": "session",
                   "name": "session",
@@ -1054,6 +1060,15 @@
                   "table": null,
                   "type": "string"
               },
+              "session_id_v7": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "session_id_v7",
+                  "name": "session_id_v7",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
               "distinct_id": {
                   "chain": null,
                   "fields": null,
@@ -1117,20 +1132,20 @@
                   "table": null,
                   "type": "string"
               },
-              "$exit_current_url": {
+              "$end_current_url": {
                   "chain": null,
                   "fields": null,
-                  "hogql_value": "`$exit_current_url`",
-                  "name": "$exit_current_url",
+                  "hogql_value": "`$end_current_url`",
+                  "name": "$end_current_url",
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
               },
-              "$exit_pathname": {
+              "$end_pathname": {
                   "chain": null,
                   "fields": null,
-                  "hogql_value": "`$exit_pathname`",
-                  "name": "$exit_pathname",
+                  "hogql_value": "`$end_pathname`",
+                  "name": "$end_pathname",
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
@@ -1225,6 +1240,15 @@
                   "table": null,
                   "type": "integer"
               },
+              "$screen_count": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$screen_count`",
+                  "name": "$screen_count",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
               "$channel_type": {
                   "chain": null,
                   "fields": null,
@@ -1260,6 +1284,15 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "boolean"
+              },
+              "$last_external_click_url": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$last_external_click_url`",
+                  "name": "$last_external_click_url",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
               }
           },
           "id": "sessions",
@@ -1703,6 +1736,7 @@
                   "fields": [
                       "id",
                       "session_id",
+                      "session_id_v7",
                       "team_id",
                       "distinct_id",
                       "$start_timestamp",
@@ -1711,8 +1745,8 @@
                       "$num_uniq_urls",
                       "$entry_current_url",
                       "$entry_pathname",
-                      "$exit_current_url",
-                      "$exit_pathname",
+                      "$end_current_url",
+                      "$end_pathname",
                       "$entry_utm_source",
                       "$entry_utm_campaign",
                       "$entry_utm_medium",
@@ -1721,13 +1755,15 @@
                       "$entry_referring_domain",
                       "$entry_gclid",
                       "$entry_gad_source",
-                      "$event_count_map",
                       "$pageview_count",
                       "$autocapture_count",
+                      "$screen_count",
                       "$channel_type",
                       "$session_duration",
                       "duration",
-                      "$is_bounce"
+                      "$is_bounce",
+                      "$last_external_click_url",
+                      "$page_screen_autocapture_count_up_to"
                   ],
                   "hogql_value": "session",
                   "name": "session",
@@ -2189,6 +2225,7 @@
                   "fields": [
                       "id",
                       "session_id",
+                      "session_id_v7",
                       "team_id",
                       "distinct_id",
                       "$start_timestamp",
@@ -2197,8 +2234,8 @@
                       "$num_uniq_urls",
                       "$entry_current_url",
                       "$entry_pathname",
-                      "$exit_current_url",
-                      "$exit_pathname",
+                      "$end_current_url",
+                      "$end_pathname",
                       "$entry_utm_source",
                       "$entry_utm_campaign",
                       "$entry_utm_medium",
@@ -2207,13 +2244,15 @@
                       "$entry_referring_domain",
                       "$entry_gclid",
                       "$entry_gad_source",
-                      "$event_count_map",
                       "$pageview_count",
                       "$autocapture_count",
+                      "$screen_count",
                       "$channel_type",
                       "$session_duration",
                       "duration",
-                      "$is_bounce"
+                      "$is_bounce",
+                      "$last_external_click_url",
+                      "$page_screen_autocapture_count_up_to"
                   ],
                   "hogql_value": "session",
                   "name": "session",
@@ -2411,6 +2450,15 @@
                   "table": null,
                   "type": "string"
               },
+              "session_id_v7": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "session_id_v7",
+                  "name": "session_id_v7",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
               "distinct_id": {
                   "chain": null,
                   "fields": null,
@@ -2474,20 +2522,20 @@
                   "table": null,
                   "type": "string"
               },
-              "$exit_current_url": {
+              "$end_current_url": {
                   "chain": null,
                   "fields": null,
-                  "hogql_value": "`$exit_current_url`",
-                  "name": "$exit_current_url",
+                  "hogql_value": "`$end_current_url`",
+                  "name": "$end_current_url",
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
               },
-              "$exit_pathname": {
+              "$end_pathname": {
                   "chain": null,
                   "fields": null,
-                  "hogql_value": "`$exit_pathname`",
-                  "name": "$exit_pathname",
+                  "hogql_value": "`$end_pathname`",
+                  "name": "$end_pathname",
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
@@ -2582,6 +2630,15 @@
                   "table": null,
                   "type": "integer"
               },
+              "$screen_count": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$screen_count`",
+                  "name": "$screen_count",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
               "$channel_type": {
                   "chain": null,
                   "fields": null,
@@ -2617,6 +2674,15 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "boolean"
+              },
+              "$last_external_click_url": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "`$last_external_click_url`",
+                  "name": "$last_external_click_url",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
               }
           },
           "id": "sessions",

--- a/posthog/hogql/test/__snapshots__/test_query.ambr
+++ b/posthog/hogql/test/__snapshots__/test_query.ambr
@@ -105,10 +105,10 @@
   
   SELECT sessions.session_id AS session_id, sessions.`$entry_current_url` AS `$entry_current_url` 
   FROM (
-  SELECT sessions.session_id AS session_id, nullIf(nullIf(argMinMerge(sessions.entry_url), %(hogql_val_0)s), %(hogql_val_1)s) AS `$entry_current_url`, min(toTimeZone(sessions.min_timestamp, %(hogql_val_2)s)) AS `$start_timestamp` 
-  FROM sessions 
-  WHERE and(equals(sessions.team_id, 420), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, %(hogql_val_3)s), toIntervalDay(3)), toDateTime64('2024-07-06 00:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, %(hogql_val_4)s), toIntervalDay(3)), toDateTime64('2024-07-04 00:00:00.000000', 6, 'UTC')), 0)) 
-  GROUP BY sessions.session_id, sessions.session_id) AS sessions 
+  SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id, nullIf(nullIf(argMinMerge(raw_sessions.entry_url), %(hogql_val_0)s), %(hogql_val_1)s) AS `$entry_current_url`, min(toTimeZone(raw_sessions.min_timestamp, %(hogql_val_2)s)) AS `$start_timestamp`, raw_sessions.session_id_v7 AS session_id_v7 
+  FROM raw_sessions 
+  WHERE equals(raw_sessions.team_id, 420) 
+  GROUP BY raw_sessions.session_id_v7, raw_sessions.session_id_v7) AS sessions 
   WHERE and(ifNull(less(sessions.`$start_timestamp`, toDateTime64('2024-07-06 00:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(sessions.`$start_timestamp`, toDateTime64('2024-07-04 00:00:00.000000', 6, 'UTC')), 0)) 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0
@@ -136,10 +136,10 @@
   
   SELECT sessions.session_id AS session_id, sessions.`$entry_current_url` AS `$entry_current_url` 
   FROM (
-  SELECT sessions.session_id AS session_id, nullIf(nullIf(argMinMerge(sessions.entry_url), %(hogql_val_0)s), %(hogql_val_1)s) AS `$entry_current_url` 
-  FROM sessions 
-  WHERE equals(sessions.team_id, 420) 
-  GROUP BY sessions.session_id, sessions.session_id) AS sessions 
+  SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id, nullIf(nullIf(argMinMerge(raw_sessions.entry_url), %(hogql_val_0)s), %(hogql_val_1)s) AS `$entry_current_url`, raw_sessions.session_id_v7 AS session_id_v7 
+  FROM raw_sessions 
+  WHERE equals(raw_sessions.team_id, 420) 
+  GROUP BY raw_sessions.session_id_v7, raw_sessions.session_id_v7) AS sessions 
   WHERE and(ifNull(equals(sessions.`$entry_current_url`, %(hogql_val_2)s), 0), 1) 
   LIMIT 100 
   SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -3726,12 +3726,12 @@
                      ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value
               FROM events AS e SAMPLE 1
               LEFT JOIN
-                (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
-                        sessions.session_id AS session_id
-                 FROM sessions
-                 WHERE and(equals(sessions.team_id, 2), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
-                 GROUP BY sessions.session_id,
-                          sessions.session_id) AS e__session ON equals(e.`$session_id`, e__session.session_id)
+                (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+                        raw_sessions.session_id_v7 AS session_id_v7
+                 FROM raw_sessions
+                 WHERE and(equals(raw_sessions.team_id, 2), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
+                 GROUP BY raw_sessions.session_id_v7,
+                          raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')), e__session.session_id_v7)
               WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
               GROUP BY e.`$session_id`,
                        breakdown_value)
@@ -3772,12 +3772,12 @@
                      ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value
               FROM events AS e SAMPLE 1
               LEFT JOIN
-                (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
-                        sessions.session_id AS session_id
-                 FROM sessions
-                 WHERE and(equals(sessions.team_id, 2), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
-                 GROUP BY sessions.session_id,
-                          sessions.session_id) AS e__session ON equals(e.`$session_id`, e__session.session_id)
+                (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+                        raw_sessions.session_id_v7 AS session_id_v7
+                 FROM raw_sessions
+                 WHERE and(equals(raw_sessions.team_id, 2), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
+                 GROUP BY raw_sessions.session_id_v7,
+                          raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')), e__session.session_id_v7)
               WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
               GROUP BY e.`$session_id`,
                        breakdown_value)
@@ -3818,12 +3818,12 @@
                      ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value_1
               FROM events AS e SAMPLE 1
               LEFT JOIN
-                (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
-                        sessions.session_id AS session_id
-                 FROM sessions
-                 WHERE and(equals(sessions.team_id, 2), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
-                 GROUP BY sessions.session_id,
-                          sessions.session_id) AS e__session ON equals(e.`$session_id`, e__session.session_id)
+                (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+                        raw_sessions.session_id_v7 AS session_id_v7
+                 FROM raw_sessions
+                 WHERE and(equals(raw_sessions.team_id, 2), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
+                 GROUP BY raw_sessions.session_id_v7,
+                          raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')), e__session.session_id_v7)
               WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
               GROUP BY e.`$session_id`,
                        breakdown_value_1)
@@ -3864,12 +3864,12 @@
                      ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value_1
               FROM events AS e SAMPLE 1
               LEFT JOIN
-                (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
-                        sessions.session_id AS session_id
-                 FROM sessions
-                 WHERE and(equals(sessions.team_id, 2), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
-                 GROUP BY sessions.session_id,
-                          sessions.session_id) AS e__session ON equals(e.`$session_id`, e__session.session_id)
+                (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+                        raw_sessions.session_id_v7 AS session_id_v7
+                 FROM raw_sessions
+                 WHERE and(equals(raw_sessions.team_id, 2), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
+                 GROUP BY raw_sessions.session_id_v7,
+                          raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')), e__session.session_id_v7)
               WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
               GROUP BY e.`$session_id`,
                        breakdown_value_1)

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -4297,12 +4297,12 @@
                      ifNull(nullIf(toString(e__pdi__person.`properties___$some_prop`), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value
               FROM events AS e SAMPLE 1
               LEFT JOIN
-                (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
-                        sessions.session_id AS session_id
-                 FROM sessions
-                 WHERE and(equals(sessions.team_id, 2), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
-                 GROUP BY sessions.session_id,
-                          sessions.session_id) AS e__session ON equals(e.`$session_id`, e__session.session_id)
+                (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+                        raw_sessions.session_id_v7 AS session_id_v7
+                 FROM raw_sessions
+                 WHERE and(equals(raw_sessions.team_id, 2), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
+                 GROUP BY raw_sessions.session_id_v7,
+                          raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')), e__session.session_id_v7)
               INNER JOIN
                 (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS e__pdi___person_id,
                         argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
@@ -4361,12 +4361,12 @@
                      ifNull(nullIf(toString(e__pdi__person.`properties___$some_prop`), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value_1
               FROM events AS e SAMPLE 1
               LEFT JOIN
-                (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
-                        sessions.session_id AS session_id
-                 FROM sessions
-                 WHERE and(equals(sessions.team_id, 2), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
-                 GROUP BY sessions.session_id,
-                          sessions.session_id) AS e__session ON equals(e.`$session_id`, e__session.session_id)
+                (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+                        raw_sessions.session_id_v7 AS session_id_v7
+                 FROM raw_sessions
+                 WHERE and(equals(raw_sessions.team_id, 2), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
+                 GROUP BY raw_sessions.session_id_v7,
+                          raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')), e__session.session_id_v7)
               INNER JOIN
                 (SELECT argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS e__pdi___person_id,
                         argMax(person_distinct_id2.person_id, person_distinct_id2.version) AS person_id,
@@ -4438,12 +4438,12 @@
     (SELECT any(e__session.`$session_duration`) AS session_duration
      FROM events AS e SAMPLE 1
      LEFT JOIN
-       (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
-               sessions.session_id AS session_id
-        FROM sessions
-        WHERE and(equals(sessions.team_id, 2), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
-        GROUP BY sessions.session_id,
-                 sessions.session_id) AS e__session ON equals(e.`$session_id`, e__session.session_id)
+       (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 2), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')), e__session.session_id_v7)
      WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
      GROUP BY e.`$session_id`
      ORDER BY 1 DESC)
@@ -4463,12 +4463,12 @@
     (SELECT any(e__session.`$session_duration`) AS session_duration
      FROM events AS e SAMPLE 1
      LEFT JOIN
-       (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
-               sessions.session_id AS session_id
-        FROM sessions
-        WHERE and(equals(sessions.team_id, 2), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
-        GROUP BY sessions.session_id,
-                 sessions.session_id) AS e__session ON equals(e.`$session_id`, e__session.session_id)
+       (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 2), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')), e__session.session_id_v7)
      WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
      GROUP BY e.`$session_id`
      ORDER BY 1 DESC)
@@ -4497,12 +4497,12 @@
                   toStartOfWeek(toTimeZone(e.timestamp, 'UTC'), 0) AS day_start
            FROM events AS e SAMPLE 1
            LEFT JOIN
-             (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
-                     sessions.session_id AS session_id
-              FROM sessions
-              WHERE and(equals(sessions.team_id, 2), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')), 0)), 0), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
-              GROUP BY sessions.session_id,
-                       sessions.session_id) AS e__session ON equals(e.`$session_id`, e__session.session_id)
+             (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+                     raw_sessions.session_id_v7 AS session_id_v7
+              FROM raw_sessions
+              WHERE and(equals(raw_sessions.team_id, 2), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')), 0)), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
+              GROUP BY raw_sessions.session_id_v7,
+                       raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')), e__session.session_id_v7)
            WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')), 0)), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
            GROUP BY day_start,
                     e.`$session_id`,
@@ -4536,12 +4536,12 @@
                   toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
            FROM events AS e SAMPLE 1
            LEFT JOIN
-             (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
-                     sessions.session_id AS session_id
-              FROM sessions
-              WHERE and(equals(sessions.team_id, 2), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
-              GROUP BY sessions.session_id,
-                       sessions.session_id) AS e__session ON equals(e.`$session_id`, e__session.session_id)
+             (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+                     raw_sessions.session_id_v7 AS session_id_v7
+              FROM raw_sessions
+              WHERE and(equals(raw_sessions.team_id, 2), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
+              GROUP BY raw_sessions.session_id_v7,
+                       raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')), e__session.session_id_v7)
            WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
            GROUP BY day_start,
                     e.`$session_id`,
@@ -4584,12 +4584,12 @@
                      toStartOfWeek(toTimeZone(e.timestamp, 'UTC'), 0) AS day_start
               FROM events AS e SAMPLE 1
               LEFT JOIN
-                (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
-                        sessions.session_id AS session_id
-                 FROM sessions
-                 WHERE and(equals(sessions.team_id, 2), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')), 0)), 0), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
-                 GROUP BY sessions.session_id,
-                          sessions.session_id) AS e__session ON equals(e.`$session_id`, e__session.session_id)
+                (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+                        raw_sessions.session_id_v7 AS session_id_v7
+                 FROM raw_sessions
+                 WHERE and(equals(raw_sessions.team_id, 2), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')), 0)), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
+                 GROUP BY raw_sessions.session_id_v7,
+                          raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')), e__session.session_id_v7)
               WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')), 0)), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
               GROUP BY day_start,
                        e.`$session_id`,
@@ -4639,12 +4639,12 @@
                      toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
               FROM events AS e SAMPLE 1
               LEFT JOIN
-                (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
-                        sessions.session_id AS session_id
-                 FROM sessions
-                 WHERE and(equals(sessions.team_id, 2), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
-                 GROUP BY sessions.session_id,
-                          sessions.session_id) AS e__session ON equals(e.`$session_id`, e__session.session_id)
+                (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+                        raw_sessions.session_id_v7 AS session_id_v7
+                 FROM raw_sessions
+                 WHERE and(equals(raw_sessions.team_id, 2), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
+                 GROUP BY raw_sessions.session_id_v7,
+                          raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')), e__session.session_id_v7)
               WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
               GROUP BY day_start,
                        e.`$session_id`,
@@ -4694,12 +4694,12 @@
                      toStartOfWeek(toTimeZone(e.timestamp, 'UTC'), 0) AS day_start
               FROM events AS e SAMPLE 1
               LEFT JOIN
-                (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
-                        sessions.session_id AS session_id
-                 FROM sessions
-                 WHERE and(equals(sessions.team_id, 2), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')), 0)), 0), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
-                 GROUP BY sessions.session_id,
-                          sessions.session_id) AS e__session ON equals(e.`$session_id`, e__session.session_id)
+                (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+                        raw_sessions.session_id_v7 AS session_id_v7
+                 FROM raw_sessions
+                 WHERE and(equals(raw_sessions.team_id, 2), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')), 0)), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
+                 GROUP BY raw_sessions.session_id_v7,
+                          raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')), e__session.session_id_v7)
               WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfWeek(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')), 0)), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
               GROUP BY day_start,
                        e.`$session_id`,
@@ -4749,12 +4749,12 @@
                      toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
               FROM events AS e SAMPLE 1
               LEFT JOIN
-                (SELECT dateDiff('second', min(toTimeZone(sessions.min_timestamp, 'UTC')), max(toTimeZone(sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
-                        sessions.session_id AS session_id
-                 FROM sessions
-                 WHERE and(equals(sessions.team_id, 2), ifNull(greaterOrEquals(plus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(toTimeZone(sessions.min_timestamp, 'UTC'), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
-                 GROUP BY sessions.session_id,
-                          sessions.session_id) AS e__session ON equals(e.`$session_id`, e__session.session_id)
+                (SELECT dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+                        raw_sessions.session_id_v7 AS session_id_v7
+                 FROM raw_sessions
+                 WHERE and(equals(raw_sessions.team_id, 2), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), 0))
+                 GROUP BY raw_sessions.session_id_v7,
+                          raw_sessions.session_id_v7) AS e__session ON equals(toUInt128(accurateCastOrNull(e.`$session_id`, 'UUID')), e__session.session_id_v7)
               WHERE and(equals(e.team_id, 2), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
               GROUP BY day_start,
                        e.`$session_id`,


### PR DESCRIPTION
## Problem

We want to switch people over to sessions v2 by default. It's already default on EU, this makes it default on US too

## Changes

Make anyone set to "auto" use v2.

The next step after this is to just delete v1.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

n/a
