### PR TITLE
feat: monitoring for endpoint errors

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -23,7 +23,7 @@ from sentry_sdk import set_tag
 QUERY_ERROR_COUNTER = Counter(
     "clickhouse_query_failure",
     "Query execution failure signal is dispatched when a query fails.",
-    labelnames=["exception_type"],
+    labelnames=["exception_type", "query_type"],
 )
 
 QUERY_EXECUTION_TIME_GAUGE = Gauge(
@@ -146,7 +146,9 @@ def sync_execute(
             )
         except Exception as e:
             err = wrap_query_error(e)
-            QUERY_ERROR_COUNTER.labels(exception_type=type(err).__name__).inc()
+            exception_type = type(err).__name__
+            set_tag("clickhouse_exception_type", exception_type)
+            QUERY_ERROR_COUNTER.labels(exception_type=exception_type, query_type=query_type).inc()
 
             raise err from e
         finally:


### PR DESCRIPTION
## Problem
We don't have any monitoring on endpoint failures

## Changes
Update `monitor` decorator to have a counter for endpoint errors
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
