### PR TITLE
fix: time to convert funnel bug

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -84,13 +84,6 @@ def add_query_params(url: str, params: dict[str, str]) -> str:
 def _convert_response_to_csv_data(data: Any) -> Generator[Any, None, None]:
     if isinstance(data.get("results"), list):
         results = data.get("results")
-    elif isinstance(data.get("result"), list):
-        results = data.get("result")
-    else:
-        return None
-
-    if isinstance(data.get("results"), list):
-        # query like
         if len(results) > 0 and (isinstance(results[0], list) or isinstance(results[0], tuple)) and data.get("types"):
             # e.g. {'columns': ['count()'], 'hasMore': False, 'results': [[1775]], 'types': ['UInt64']}
             # or {'columns': ['count()', 'event'], 'hasMore': False, 'results': [[551, '$feature_flag_called'], [265, '$autocapture']], 'types': ['UInt64', 'String']}
@@ -111,6 +104,13 @@ def _convert_response_to_csv_data(data: Any) -> Generator[Any, None, None]:
                         row_dict[data["columns"][idx]] = x
                 yield row_dict
             return
+
+    if isinstance(data.get("results"), list) or isinstance(data.get("results"), dict):
+        results = data.get("results")
+    elif isinstance(data.get("results"), list) or isinstance(data.get("results"), dict):
+        results = data.get("result")
+    else:
+        return None
 
     if isinstance(results, list):
         first_result = next(iter(results), None)

--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -107,7 +107,7 @@ def _convert_response_to_csv_data(data: Any) -> Generator[Any, None, None]:
 
     if isinstance(data.get("results"), list) or isinstance(data.get("results"), dict):
         results = data.get("results")
-    elif isinstance(data.get("results"), list) or isinstance(data.get("results"), dict):
+    elif isinstance(data.get("result"), list) or isinstance(data.get("result"), dict):
         results = data.get("result")
     else:
         return None

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -560,42 +560,44 @@ class TestCSVExporter(APIBaseTest):
 
     def test_funnel_time_to_convert(self) -> None:
         data = {
-            "average_conversion_time": 1.45,
-            "bins": [
-                [1, 1],
-                [2, 3],
-                [3, 5],
-                [4, 17],
-                [5, 29],
-                [6, 44],
-                [7, 38],
-                [8, 24],
-                [9, 10],
-                [10, 7],
-                [11, 3],
-                [12, 1],
-                [13, 1],
-                [14, 1],
-                [15, 0],
-                [16, 0],
-                [17, 0],
-                [18, 0],
-                [19, 0],
-                [20, 0],
-                [21, 1],
-                [22, 0],
-                [23, 1],
-                [24, 0],
-                [25, 0],
-                [26, 0],
-            ],
+            "results": {
+                "average_conversion_time": 1.45,
+                "bins": [
+                    [1, 1],
+                    [2, 3],
+                    [3, 5],
+                    [4, 17],
+                    [5, 29],
+                    [6, 44],
+                    [7, 38],
+                    [8, 24],
+                    [9, 10],
+                    [10, 7],
+                    [11, 3],
+                    [12, 1],
+                    [13, 1],
+                    [14, 1],
+                    [15, 0],
+                    [16, 0],
+                    [17, 0],
+                    [18, 0],
+                    [19, 0],
+                    [20, 0],
+                    [21, 1],
+                    [22, 0],
+                    [23, 1],
+                    [24, 0],
+                    [25, 0],
+                    [26, 0],
+                ],
+            }
         }
-        csv_data = yield _convert_response_to_csv_data(data)
-        assert 1 == csv_data["bin"]
-        assert 1 == csv_data["value"]
-        csv_data = yield _convert_response_to_csv_data(data)
-        assert 2 == csv_data["bin"]
-        assert 3 == csv_data["value"]
+        csv_list = list(_convert_response_to_csv_data(data))
+        bins = data["results"]["bins"]
+        assert len(bins) == len(csv_list)
+        for bin, csv in zip(bins, csv_list):
+            assert bin[0] == csv["bin"]
+            assert bin[1] == csv["value"]
 
     @patch("posthog.models.exported_asset.UUIDT")
     def test_csv_exporter_empty_result(self, mocked_uuidt: Any) -> None:

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -559,41 +559,41 @@ class TestCSVExporter(APIBaseTest):
             )
 
     def test_funnel_time_to_convert(self) -> None:
+        bins = [
+            [1, 1],
+            [2, 3],
+            [3, 5],
+            [4, 17],
+            [5, 29],
+            [6, 44],
+            [7, 38],
+            [8, 24],
+            [9, 10],
+            [10, 7],
+            [11, 3],
+            [12, 1],
+            [13, 1],
+            [14, 1],
+            [15, 0],
+            [16, 0],
+            [17, 0],
+            [18, 0],
+            [19, 0],
+            [20, 0],
+            [21, 1],
+            [22, 0],
+            [23, 1],
+            [24, 0],
+            [25, 0],
+            [26, 0],
+        ]
         data = {
             "results": {
                 "average_conversion_time": 1.45,
-                "bins": [
-                    [1, 1],
-                    [2, 3],
-                    [3, 5],
-                    [4, 17],
-                    [5, 29],
-                    [6, 44],
-                    [7, 38],
-                    [8, 24],
-                    [9, 10],
-                    [10, 7],
-                    [11, 3],
-                    [12, 1],
-                    [13, 1],
-                    [14, 1],
-                    [15, 0],
-                    [16, 0],
-                    [17, 0],
-                    [18, 0],
-                    [19, 0],
-                    [20, 0],
-                    [21, 1],
-                    [22, 0],
-                    [23, 1],
-                    [24, 0],
-                    [25, 0],
-                    [26, 0],
-                ],
+                "bins": bins,
             }
         }
         csv_list = list(_convert_response_to_csv_data(data))
-        bins = data["results"]["bins"]
         assert len(bins) == len(csv_list)
         for bin, csv in zip(bins, csv_list):
             assert bin[0] == csv["bin"]

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -27,6 +27,7 @@ from posthog.tasks.exports import csv_exporter
 from posthog.tasks.exports.csv_exporter import (
     UnexpectedEmptyJsonResponse,
     add_query_params,
+    _convert_response_to_csv_data,
 )
 from posthog.hogql.constants import CSV_EXPORT_BREAKDOWN_LIMIT_INITIAL
 from posthog.test.base import APIBaseTest, _create_event, flush_persons_and_events, _create_person
@@ -556,6 +557,45 @@ class TestCSVExporter(APIBaseTest):
                     "$pageview,test'123,$pageview,1,60.0,60.0",
                 ],
             )
+
+    def test_funnel_time_to_convert(self) -> None:
+        data = {
+            "average_conversion_time": 1.45,
+            "bins": [
+                [1, 1],
+                [2, 3],
+                [3, 5],
+                [4, 17],
+                [5, 29],
+                [6, 44],
+                [7, 38],
+                [8, 24],
+                [9, 10],
+                [10, 7],
+                [11, 3],
+                [12, 1],
+                [13, 1],
+                [14, 1],
+                [15, 0],
+                [16, 0],
+                [17, 0],
+                [18, 0],
+                [19, 0],
+                [20, 0],
+                [21, 1],
+                [22, 0],
+                [23, 1],
+                [24, 0],
+                [25, 0],
+                [26, 0],
+            ],
+        }
+        csv_data = yield _convert_response_to_csv_data(data)
+        assert 1 == csv_data["bin"]
+        assert 1 == csv_data["value"]
+        csv_data = yield _convert_response_to_csv_data(data)
+        assert 2 == csv_data["bin"]
+        assert 3 == csv_data["value"]
 
     @patch("posthog.models.exported_asset.UUIDT")
     def test_csv_exporter_empty_result(self, mocked_uuidt: Any) -> None:


### PR DESCRIPTION
## Problem

Time to convert funnel export is failing because its result format isn't a list.

## Changes

Fix logic and add test

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Wrote a test. Download one locally.
