### PR TITLE
feat: Adds support btn to help menu - Ady Superday

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -1,5 +1,6 @@
 import {
     IconAI,
+    IconBug,
     IconChevronDown,
     IconDatabase,
     IconDecisionTree,
@@ -289,6 +290,19 @@ export const SidePanelSupport = (): JSX.Element => {
                                             targetBlank
                                         >
                                             Request a feature
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to={`https://github.com/PostHog/posthog/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&debug-info=${encodeURIComponent(
+                                                getPublicSupportSnippet(region, currentOrganization, currentTeam)
+                                            )}`}
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                 </ul>


### PR DESCRIPTION
## Problem

(Superday task) @MarconLP @joethreepwood 

Add a 'Report a bug' button to the help menu so users can create a GitHub bug report from within PostHog.

## Changes

See bottom of the 'Share feedback' menu:
![Screenshot 2024-08-28 at 09 24 48](https://github.com/user-attachments/assets/6271827c-6553-4321-99db-251983edbc59)

## Does this work well for both Cloud and self-hosted?

Doesn't have an impact.

## How did you test this code?

Clicked link, tested screen widths by reducing/increasing browser size. Ran front-end tests.
