### PR TITLE
fix(dev-ex): Move pymssql import

### DIFF
--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -357,6 +357,7 @@ def get_mssql_schemas(
     host: str, port: str, database: str, user: str, password: str, schema: str, ssh_tunnel: SSHTunnel
 ) -> dict[str, list[tuple[str, str]]]:
     def get_schemas(postgres_host: str, postgres_port: int):
+        # Importing pymssql requires mssql drivers to be installed locally
         import pymssql
 
         connection = pymssql.connect(

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -9,7 +9,6 @@ from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UUIDModel
 import uuid
 import psycopg2
 import pymysql
-import pymssql
 from .external_data_source import ExternalDataSource
 from posthog.warehouse.data_load.service import (
     external_data_workflow_exists,
@@ -358,6 +357,8 @@ def get_mssql_schemas(
     host: str, port: str, database: str, user: str, password: str, schema: str, ssh_tunnel: SSHTunnel
 ) -> dict[str, list[tuple[str, str]]]:
     def get_schemas(postgres_host: str, postgres_port: int):
+        import pymssql
+
         connection = pymssql.connect(
             server=postgres_host,
             port=str(postgres_port),


### PR DESCRIPTION
## Problem
- Importing `mssql` requires some local dependencies that won't exist on most machines

## Changes
- Move the import to the func that requires it 
