### PR TITLE
fix: horizontal bar chart formula mode label

### DIFF
--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -48,7 +48,10 @@ export function ActionsHorizontalBar({ showPersonsModal = true }: ChartParams): 
                 personsValues: _data.map((item) => item.persons),
                 breakdownValues: _data.map((item) => item.breakdown_value),
                 breakdownLabels: _data.map((item) => {
-                    const itemLabel = item.action.custom_name ?? item.action.name ?? item.action.id
+                    const itemLabel = item.action
+                        ? item.action.custom_name ?? item.action.name ?? item.action.id
+                        : item.label
+
                     if (!item.breakdown_value) {
                         return itemLabel
                     }


### PR DESCRIPTION
## Problem
Fixes #24632 
## Changes
Formula mode doesn't have `item.action` so using the label in this scenario

<img width="869" alt="image" src="https://github.com/user-attachments/assets/480e901a-8910-4fff-aed2-f0c31f41a287">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
