### PR TITLE
feat: Throw if slack response is bad

### DIFF
--- a/posthog/cdp/templates/slack/template_slack.py
+++ b/posthog/cdp/templates/slack/template_slack.py
@@ -23,7 +23,7 @@ let res := fetch('https://slack.com/api/chat.postMessage', {
 });
 
 if (res.status != 200 or not res.body.ok) {
-  print('Non-ok response:', res)
+  throw Error(f'Failed to post message to Slack: {res.status}: {res.body}');
 }
 """.strip(),
     inputs_schema=[


### PR DESCRIPTION
## Problem

We log but we don't throw which would be better for indicating issues

## Changes

* Throw when the slack response is bad

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
