### PR TITLE
fix(replay-capture): replace missing window_id with session_id

### DIFF
--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -348,13 +348,8 @@ pub async fn process_replay_events<'a>(
     let session_id = events[0]
         .properties
         .get("$session_id")
-        .ok_or(CaptureError::MissingSessionId)?
-        .as_str()
-        .ok_or(CaptureError::InvalidSessionId)?;
-    let window_id = events[0]
-        .properties
-        .get("$window_id")
-        .ok_or(CaptureError::MissingWindowId)?;
+        .ok_or(CaptureError::MissingSessionId)?;
+    let window_id = events[0].properties.get("$window_id").unwrap_or(session_id);
     let event = ProcessedEvent {
         data_type: DataType::SnapshotMain,
         uuid: events[0].uuid.unwrap_or_else(uuid_v7),
@@ -373,7 +368,9 @@ pub async fn process_replay_events<'a>(
         now: context.now.clone(),
         sent_at: context.sent_at,
         token: context.token.clone(),
-        session_id: Some(session_id.to_string()),
+        session_id: Some(session_id
+            .as_str()
+            .ok_or(CaptureError::InvalidSessionId)?.to_string()),
     };
 
     sink.send(event).await

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -336,7 +336,9 @@ pub async fn process_replay_events<'a>(
     let snapshot_items: Vec<Value> = events
         .iter()
         .map(|e| match e.properties.get("$snapshot_data") {
+            // We can either have an array or single object
             Some(Value::Array(value)) => Ok(value.to_vec()),
+            // Wrap a single object in a vec to simplify processing.
             Some(Value::Object(value)) => Ok([Value::Object(value.clone())].to_vec()),
             _ => Err(CaptureError::MissingSnapshotData),
         })

--- a/rust/capture/tests/recordings.rs
+++ b/rust/capture/tests/recordings.rs
@@ -93,3 +93,27 @@ async fn it_rejects_bad_session_id() -> Result<()> {
     assert_eq!(StatusCode::BAD_REQUEST, res.status());
     Ok(())
 }
+
+#[tokio::test]
+async fn it_defaults_window_id_to_session_id() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+    let distinct_id = random_string("id", 16);
+    let session_id = random_string("id", 16);
+
+    let main_topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_recordings(&main_topic).await;
+
+    let event = json!({
+        "token": token,
+        "event": "testing",
+        "distinct_id": distinct_id,
+        "properties": {
+            "$session_id": session_id,
+            "$snapshot_data": [],
+        }
+    });
+    let res = server.capture_recording(event.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+    Ok(())
+}


### PR DESCRIPTION
## Problem

I missed that window_id is not required as we replay it with session_id if missing in capture.py, (see https://github.com/PostHog/posthog/blob/5cc4e67850f56a4dea23458022176e3d35ff8032/posthog/session_recordings/session_recording_helpers.py#L146)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
