### PR TITLE
fix: fix rust image build clashing

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -29,7 +29,7 @@ jobs:
             packages: write # allow push to ghcr.io
 
         outputs:
-            digest: ${{ steps.docker_build.outputs.digest }}
+            capture_digest: ${{ steps.digest.outputs.capture_digest }}
 
         defaults:
             run:
@@ -93,7 +93,10 @@ jobs:
                   build-args: BIN=${{ matrix.image }}
 
             - name: Container image digest
-              run: echo ${{ steps.docker_build.outputs.digest }}
+              id: digest
+              run: |
+                echo ${{ steps.docker_build.outputs.digest }}
+                echo "${{matrix.image}}_digest=${{ steps.docker_build.outputs.digest }}" >> $GITHUB_OUTPUT
 
     deploy:
         name: Deploy capture-replay
@@ -118,7 +121,7 @@ jobs:
                       {
                         "values": {
                           "image": {
-                            "sha": "${{ needs.build.outputs.digest }}"
+                            "sha": "${{ needs.build.outputs.capture_digest }}"
                           }
                         },
                         "release": "capture-replay",


### PR DESCRIPTION

## Problem

all images were publishing to the same output. Split out the outputs to just what we need

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
