### PR TITLE
feat(propdefs): per-worker compaction, cache back to main thread

### DIFF
--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -37,6 +37,11 @@ pub struct Config {
     #[envconfig(default = "100000")]
     pub cache_capacity: usize,
 
+    // Each worker thread internally batches up to this number, then de-dupes
+    // across this batch before releasing to the main thread
+    #[envconfig(default = "50000")]
+    pub compaction_batch_size: usize,
+
     #[envconfig(default = "100")]
     pub channel_slots_per_worker: usize,
 

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -68,8 +68,8 @@ async fn spawn_producer_loop(
     skip_threshold: usize,
     compaction_batch_size: usize,
 ) {
-    let mut batch = Vec::with_capacity(compaction_batch_size + skip_threshold);
-    let mut sent = HashSet::with_capacity(compaction_batch_size + skip_threshold);
+    let mut batch = Vec::with_capacity(compaction_batch_size);
+    let mut sent = HashSet::with_capacity(compaction_batch_size);
     loop {
         let message = consumer
             .recv()

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -14,3 +14,4 @@ pub const PERMIT_WAIT_TIME: &str = "prop_defs_permit_wait_time_ms";
 pub const UPDATE_ISSUE_TIME: &str = "prop_defs_update_issue_time_ms";
 pub const CACHE_CONSUMED: &str = "prop_defs_cache_space";
 pub const RECV_DEQUEUED: &str = "prop_defs_recv_dequeued";
+pub const COMPACTED_UPDATES: &str = "prop_defs_compaction_ratio";

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -14,4 +14,4 @@ pub const PERMIT_WAIT_TIME: &str = "prop_defs_permit_wait_time_ms";
 pub const UPDATE_ISSUE_TIME: &str = "prop_defs_update_issue_time_ms";
 pub const CACHE_CONSUMED: &str = "prop_defs_cache_space";
 pub const RECV_DEQUEUED: &str = "prop_defs_recv_dequeued";
-pub const COMPACTED_UPDATES: &str = "prop_defs_compaction_ratio";
+pub const COMPACTED_UPDATES: &str = "prop_defs_compaction_dropped_updates";


### PR DESCRIPTION
Distributing cache probing to workers didn't help the "throughput scales inversely with cache size" problem.