### PR TITLE
chore: sans fonts for buttons

### DIFF
--- a/frontend/src/lib/components/DatabaseTableTree/TreeRow.tsx
+++ b/frontend/src/lib/components/DatabaseTableTree/TreeRow.tsx
@@ -24,6 +24,7 @@ export function TreeRow({ item }: TreeRowProps): JSX.Element {
                 size="xsmall"
                 fullWidth
                 icon={item.icon ? <>{item.icon}</> : null}
+                className="font-normal"
             >
                 <span className="flex-1 flex justify-between">
                     <span className="truncate">{item.name}</span>
@@ -50,6 +51,7 @@ export function TreeTableRow({ item, onClick, selected }: TreeTableRowProps): JS
         <li>
             <LemonButton
                 size="xsmall"
+                className="font-normal"
                 fullWidth
                 onClick={_onClick}
                 active={selected}
@@ -84,6 +86,7 @@ export function TreeFolderRow({ item, depth, onClick, selectedRow, dropdownOverl
         <li className="overflow-hidden">
             <LemonButton
                 size="small"
+                className="font-normal"
                 fullWidth
                 onClick={_onClick}
                 sideAction={

--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.scss
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.scss
@@ -76,7 +76,8 @@
     outline: none;
     transition: var(--lemon-button-transition);
 
-    .font-normal {
+    .font-normal,
+    &.font-normal {
         font-family: var(--font-sans);
     }
 

--- a/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
+++ b/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
@@ -236,7 +236,13 @@ export const DatabaseTableTreeWithItems = ({ inline }: DatabaseTableTreeProps): 
                 <LemonButton icon={<IconDatabase />} onClick={() => setCollapsed(false)} />
             ) : (
                 <>
-                    <LemonButton size="xsmall" onClick={() => setCollapsed(true)} fullWidth icon={<IconDatabase />}>
+                    <LemonButton
+                        size="xsmall"
+                        onClick={() => setCollapsed(true)}
+                        fullWidth
+                        icon={<IconDatabase />}
+                        className="font-normal"
+                    >
                         <span className="uppercase text-muted-alt tracking-wider">Sources</span>
                     </LemonButton>
                     <DatabaseTableTree onSelectRow={selectRow} items={treeItems()} selectedRow={selectedRow} />

--- a/frontend/src/scenes/session-recordings/apm/playerInspector/ItemPerformanceEvent.tsx
+++ b/frontend/src/scenes/session-recordings/apm/playerInspector/ItemPerformanceEvent.tsx
@@ -173,7 +173,13 @@ export function ItemPerformanceEvent({
 
     return (
         <div>
-            <LemonButton noPadding onClick={() => setExpanded(!expanded)} fullWidth data-attr="item-performance-event">
+            <LemonButton
+                noPadding
+                onClick={() => setExpanded(!expanded)}
+                fullWidth
+                data-attr="item-performance-event"
+                className="font-normal"
+            >
                 <div className="flex-1 overflow-hidden">
                     <div
                         className="absolute bg-primary rounded-sm opacity-75"

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemConsoleLog.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemConsoleLog.tsx
@@ -13,7 +13,13 @@ export interface ItemConsoleLogProps {
 export function ItemConsoleLog({ item, expanded, setExpanded }: ItemConsoleLogProps): JSX.Element {
     return (
         <>
-            <LemonButton noPadding onClick={() => setExpanded(!expanded)} fullWidth data-attr="item-console-log">
+            <LemonButton
+                noPadding
+                onClick={() => setExpanded(!expanded)}
+                fullWidth
+                data-attr="item-console-log"
+                className="font-normal"
+            >
                 <div className="p-2 text-xs cursor-pointer truncate font-mono flex-1">{item.data.content}</div>
                 {(item.data.count || 1) > 1 ? (
                     <span

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemDoctor.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemDoctor.tsx
@@ -12,7 +12,13 @@ export interface ItemDoctorProps {
 export function ItemDoctor({ item, expanded, setExpanded }: ItemDoctorProps): JSX.Element {
     return (
         <>
-            <LemonButton noPadding onClick={() => setExpanded(!expanded)} fullWidth data-attr="item-doctor-item">
+            <LemonButton
+                noPadding
+                onClick={() => setExpanded(!expanded)}
+                fullWidth
+                data-attr="item-doctor-item"
+                className="font-normal"
+            >
                 <div className="p-2 text-xs cursor-pointer truncate font-mono flex-1">{item.tag}</div>
             </LemonButton>
 

--- a/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.tsx
+++ b/frontend/src/scenes/session-recordings/player/inspector/components/ItemEvent.tsx
@@ -83,7 +83,7 @@ export function ItemEvent({ item, expanded, setExpanded }: ItemEventProps): JSX.
 
     return (
         <div data-attr="item-event">
-            <LemonButton noPadding onClick={() => setExpanded(!expanded)} fullWidth>
+            <LemonButton noPadding onClick={() => setExpanded(!expanded)} fullWidth className="font-normal">
                 <div className="flex flex-row w-full justify-between gap-2 items-center p-2 text-xs cursor-pointer truncate">
                     <div>
                         <PropertyKeyInfo


### PR DESCRIPTION
## Problem

We should only use Matter as the fonts on buttons that look like buttons

## Changes

Making the change for the Replay inspector and Data Warehouse

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Snapshots!