### PR TITLE
feat: allow configuring client.id for rust capture

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -85,4 +85,6 @@ pub struct KafkaConfig {
     pub kafka_heatmaps_topic: String,
     #[envconfig(default = "false")]
     pub kafka_tls: bool,
+    #[envconfig(default = "")]
+    pub kafka_client_id: String,
 }

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -362,6 +362,7 @@ mod tests {
             kafka_exceptions_topic: "events_plugin_ingestion".to_string(),
             kafka_heatmaps_topic: "events_plugin_ingestion".to_string(),
             kafka_tls: false,
+            kafka_client_id: "".to_string(),
         };
         let sink = KafkaSink::new(config, handle, limiter).expect("failed to create sink");
         (cluster, sink)

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -144,6 +144,10 @@ impl KafkaSink {
                 (config.kafka_producer_queue_mib * 1024).to_string(),
             );
 
+        if &config.kafka_client_id != "" {
+            client_config.set("client.id", &config.kafka_client_id);
+        }
+
         if config.kafka_tls {
             client_config
                 .set("security.protocol", "ssl")

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -144,7 +144,7 @@ impl KafkaSink {
                 (config.kafka_producer_queue_mib * 1024).to_string(),
             );
 
-        if &config.kafka_client_id != "" {
+        if !&config.kafka_client_id.is_empty() {
             client_config.set("client.id", &config.kafka_client_id);
         }
 

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -50,6 +50,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
         kafka_exceptions_topic: "events_plugin_ingestion".to_string(),
         kafka_heatmaps_topic: "events_plugin_ingestion".to_string(),
         kafka_tls: false,
+        kafka_client_id: "".to_string(),
     },
     otel_url: None,
     otel_sampling_rate: 0.0,


### PR DESCRIPTION
## Problem
this is required for some warpstream features

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
