### PR TITLE
feat: add concurrency_limit option to rust capture

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -641,6 +641,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-opentelemetry",

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
 tower-http = { workspace = true }
+tower = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -58,6 +58,8 @@ pub struct Config {
 
     #[envconfig(default = "events")]
     pub capture_mode: CaptureMode,
+
+    pub concurrency_limit: Option<usize>,
 }
 
 #[derive(Envconfig, Clone)]

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -35,6 +35,7 @@ async fn index() -> &'static str {
     "capture"
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn router<
     TZ: TimeSource + Send + Sync + 'static,
     S: sinks::Event + Send + Sync + 'static,

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -8,6 +8,7 @@ use axum::{
     Router,
 };
 use health::HealthRegistry;
+use tower::limit::ConcurrencyLimitLayer;
 use tower_http::cors::{AllowHeaders, AllowOrigin, CorsLayer};
 use tower_http::trace::TraceLayer;
 
@@ -46,6 +47,7 @@ pub fn router<
     billing: BillingLimiter,
     metrics: bool,
     capture_mode: CaptureMode,
+    concurrency_limit: Option<usize>,
 ) -> Router {
     let state = State {
         sink: Arc::new(sink),
@@ -124,15 +126,21 @@ pub fn router<
         )
         .layer(DefaultBodyLimit::max(RECORDING_BODY_SIZE));
 
-    let router = match capture_mode {
+    let mut router = match capture_mode {
         CaptureMode::Events => Router::new().merge(batch_router).merge(event_router),
         CaptureMode::Recordings => Router::new().merge(recordings_router),
+    };
+
+    if let Some(limit) = concurrency_limit {
+        router = router.layer(ConcurrencyLimitLayer::new(limit));
     }
-    .merge(status_router)
-    .layer(TraceLayer::new_for_http())
-    .layer(cors)
-    .layer(axum::middleware::from_fn(track_metrics))
-    .with_state(state);
+
+    let router = router
+        .merge(status_router)
+        .layer(TraceLayer::new_for_http())
+        .layer(cors)
+        .layer(axum::middleware::from_fn(track_metrics))
+        .with_state(state);
 
     // Don't install metrics unless asked to
     // Installing a global recorder when capture is used as a library (during tests etc)

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -47,6 +47,7 @@ where
             billing,
             config.export_prometheus,
             config.capture_mode,
+            config.concurrency_limit,
         )
     } else {
         let sink_liveness = liveness
@@ -88,6 +89,7 @@ where
             billing,
             config.export_prometheus,
             config.capture_mode,
+            config.concurrency_limit,
         )
     };
 

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -57,6 +57,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     export_prometheus: false,
     redis_key_prefix: None,
     capture_mode: CaptureMode::Events,
+    concurrency_limit: None,
 });
 
 static TRACING_INIT: Once = Once::new();

--- a/rust/capture/tests/django_compat.rs
+++ b/rust/capture/tests/django_compat.rs
@@ -112,6 +112,7 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
             billing,
             false,
             CaptureMode::Events,
+            None,
         );
 
         let client = TestClient::new(app);


### PR DESCRIPTION

## Problem
large numbers of concurrent requests can cause ram spikes and OOMs

allow us to set concurrency limits to control this

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
