### PR TITLE
fix(data-warehouse): Try lowercase cursor path

### DIFF
--- a/posthog/temporal/data_imports/pipelines/sql_database/helpers.py
+++ b/posthog/temporal/data_imports/pipelines/sql_database/helpers.py
@@ -35,9 +35,12 @@ class TableLoader:
             try:
                 self.cursor_column: Optional[Column[Any]] = table.c[incremental.cursor_path]
             except KeyError as e:
-                raise KeyError(
-                    f"Cursor column '{incremental.cursor_path}' does not exist in table '{table.name}'"
-                ) from e
+                try:
+                    self.cursor_column = table.c[incremental.cursor_path.lower()]
+                except KeyError:
+                    raise KeyError(
+                        f"Cursor column '{incremental.cursor_path}' does not exist in table '{table.name}'"
+                    ) from e
             self.last_value = incremental.last_value
         else:
             self.cursor_column = None


### PR DESCRIPTION
## Problem
- Looks like SQL Alchemy lower cases column names in some scenarios, this is great other than when referencing a cursor path for incremental syncs - sometimes the field can't be found due to casing

## Changes
- If we cant find the cursor path, try again with lower casing it

## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
Tested locally