### PR TITLE
fix(data-warehouse): Fixed type error with using in operator

### DIFF
--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -426,7 +426,10 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
         isShowingCachedResults: [
             () => [(_, props) => props.cachedResults ?? null, (_, props) => props.query],
             (cachedResults: AnyResponseType | null, query: DataNode): boolean => {
-                return !!cachedResults || ('query' in query && JSON.stringify(query.query) in cache.localResults)
+                return (
+                    !!cachedResults ||
+                    (cache.localResults && 'query' in query && JSON.stringify(query.query) in cache.localResults)
+                )
             },
         ],
         query: [(_, p) => [p.query], (query) => query],


### PR DESCRIPTION
## Problem
- We're getting a `TypeError` when the local results in cache is `undefined`
- Reported in 2 separate support tickets 

<img width="1269" alt="image" src="https://github.com/user-attachments/assets/96e97d5f-fac0-406b-83c3-102dc36a19f3">

## Changes
- Check `cache.localResults` is a defined value before using the `in` operator on it
