### PR TITLE
fix(data-warehouse): Upgraded DLT and added test for schema evolution

### DIFF
--- a/posthog/temporal/data_imports/pipelines/salesforce/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/salesforce/__init__.py
@@ -1,3 +1,4 @@
+from typing import Any, Optional
 import dlt
 from dlt.sources.helpers.rest_client.paginators import BasePaginator
 from dlt.sources.helpers.requests import Response, Request
@@ -157,7 +158,7 @@ class SalesforceEndpointPaginator(BasePaginator):
         super().__init__()
         self.instance_url = instance_url
 
-    def update_state(self, response: Response) -> None:
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
         res = response.json()
 
         self._next_page = None

--- a/posthog/temporal/data_imports/pipelines/stripe/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/stripe/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 import dlt
 from dlt.sources.helpers.rest_client.paginators import BasePaginator
 from dlt.sources.helpers.requests import Response, Request
@@ -264,7 +264,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
 
 
 class StripePaginator(BasePaginator):
-    def update_state(self, response: Response) -> None:
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
         res = response.json()
 
         self._starting_after = None

--- a/posthog/temporal/data_imports/pipelines/zendesk/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/zendesk/__init__.py
@@ -1,4 +1,5 @@
 import base64
+from typing import Any, Optional
 import dlt
 from dlt.sources.helpers.rest_client.paginators import BasePaginator, JSONLinkPaginator
 from dlt.sources.helpers.requests import Response, Request
@@ -235,7 +236,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
 
 
 class ZendeskTicketsIncrementalEndpointPaginator(BasePaginator):
-    def update_state(self, response: Response) -> None:
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
         res = response.json()
 
         self._next_start_time = None
@@ -260,7 +261,7 @@ class ZendeskTicketsIncrementalEndpointPaginator(BasePaginator):
 
 
 class ZendeskIncrementalEndpointPaginator(BasePaginator):
-    def update_state(self, response: Response) -> None:
+    def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
         res = response.json()
 
         self._next_page = None

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -106,7 +106,7 @@ async def _run(
         team_id=team.pk,
         source_id=source.pk,
         sync_type=sync_type,
-        sync_type_config=sync_type_config,
+        sync_type_config=sync_type_config or {},
     )
 
     workflow_id = str(uuid.uuid4())

--- a/posthog/temporal/tests/external_data/test_external_data_job.py
+++ b/posthog/temporal/tests/external_data/test_external_data_job.py
@@ -511,7 +511,7 @@ async def test_run_stripe_job(activity_environment, team, minio_client, **kwargs
             Bucket=BUCKET_NAME, Prefix=f"{folder_path}/customer/"
         )
 
-        assert len(job_1_customer_objects["Contents"]) == 3
+        assert len(job_1_customer_objects["Contents"]) == 2
 
     with (
         mock.patch.object(RESTClient, "paginate", mock_charges_paginate),
@@ -536,7 +536,7 @@ async def test_run_stripe_job(activity_environment, team, minio_client, **kwargs
         job_2_charge_objects = await minio_client.list_objects_v2(
             Bucket=BUCKET_NAME, Prefix=f"{job_2.folder_path()}/charge/"
         )
-        assert len(job_2_charge_objects["Contents"]) == 3
+        assert len(job_2_charge_objects["Contents"]) == 2
 
 
 @pytest.mark.django_db(transaction=True)
@@ -749,7 +749,7 @@ async def test_run_stripe_job_row_count_update(activity_environment, team, minio
             Bucket=BUCKET_NAME, Prefix=f"{folder_path}/customer/"
         )
 
-        assert len(job_1_customer_objects["Contents"]) == 3
+        assert len(job_1_customer_objects["Contents"]) == 2
 
         await sync_to_async(job_1.refresh_from_db)()
         assert job_1.rows_synced == 1
@@ -914,7 +914,7 @@ async def test_run_postgres_job(
         job_1_team_objects = await minio_client.list_objects_v2(
             Bucket=BUCKET_NAME, Prefix=f"{folder_path}/posthog_test/"
         )
-        assert len(job_1_team_objects["Contents"]) == 3
+        assert len(job_1_team_objects["Contents"]) == 2
 
 
 @pytest.mark.django_db(transaction=True)

--- a/requirements.in
+++ b/requirements.in
@@ -33,8 +33,8 @@ djangorestframework==3.15.1
 djangorestframework-csv==2.1.1
 djangorestframework-dataclasses==1.2.0
 django-fernet-encrypted-fields==0.1.3
-dlt==0.5.3
-dlt[deltalake]==0.5.3
+dlt==0.5.4
+dlt[deltalake]==0.5.4
 dnspython==2.2.1
 drf-exceptions-hog==0.4.0
 drf-extensions==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -129,7 +129,7 @@ defusedxml==0.6.0
     # via
     #   python3-openid
     #   social-auth-core
-deltalake==0.18.2
+deltalake==0.19.1
     # via dlt
 distro==1.9.0
     # via openai
@@ -206,7 +206,7 @@ djangorestframework-csv==2.1.1
     # via -r requirements.in
 djangorestframework-dataclasses==1.2.0
     # via -r requirements.in
-dlt==0.5.3
+dlt==0.5.4
     # via -r requirements.in
 dnspython==2.2.1
     # via -r requirements.in
@@ -214,7 +214,7 @@ drf-exceptions-hog==0.4.0
     # via -r requirements.in
 drf-extensions==0.7.0
     # via -r requirements.in
-drf-spectacular==0.27.1
+drf-spectacular==0.27.2
     # via -r requirements.in
 et-xmlfile==1.1.0
     # via openpyxl
@@ -258,8 +258,6 @@ googleapis-common-protos==1.60.0
     # via
     #   google-api-core
     #   grpcio-status
-greenlet==3.0.3
-    # via sqlalchemy
 grpcio==1.57.0
     # via
     #   google-api-core
@@ -434,8 +432,6 @@ pyarrow==17.0.0
     #   -r requirements.in
     #   deltalake
     #   dlt
-pyarrow-hotfix==0.6
-    # via deltalake
 pyasn1==0.5.0
     # via
     #   pyasn1-modules


### PR DESCRIPTION
## Problem
- When the underlying schema for a postgres database updates, we don't add the new columns to our parquet files

## Changes
- Upgrades DLT to 0.5.4 - this adds schema evolution to the delta format
- Added a test that fails on 0.5.3 but passes on 0.5.4

## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
- Unit test