### PR TITLE
feat: filter by assigned exceptions

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -3588,6 +3588,16 @@
         "ErrorTrackingQuery": {
             "additionalProperties": false,
             "properties": {
+                "assignee": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
                 },

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1362,6 +1362,7 @@ export interface ErrorTrackingQuery extends DataNode<ErrorTrackingQueryResponse>
     eventColumns?: string[]
     order?: 'last_seen' | 'first_seen' | 'occurrences' | 'users' | 'sessions'
     dateRange: DateRange
+    assignee?: integer | null
     filterGroup?: PropertyGroupFilter
     filterTestAccounts?: boolean
     limit?: integer

--- a/frontend/src/scenes/error-tracking/ErrorTrackingFilters.tsx
+++ b/frontend/src/scenes/error-tracking/ErrorTrackingFilters.tsx
@@ -1,6 +1,7 @@
 import { LemonSelect } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
+import { MemberSelect } from 'lib/components/MemberSelect'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
 import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
@@ -71,57 +72,68 @@ const RecordingsUniversalFilterGroup = (): JSX.Element => {
 }
 
 export const Options = ({ showOrder = true }: { showOrder?: boolean }): JSX.Element => {
-    const { dateRange } = useValues(errorTrackingLogic)
-    const { setDateRange } = useActions(errorTrackingLogic)
+    const { dateRange, assignee } = useValues(errorTrackingLogic)
+    const { setDateRange, setAssignee } = useActions(errorTrackingLogic)
     const { order } = useValues(errorTrackingSceneLogic)
     const { setOrder } = useActions(errorTrackingSceneLogic)
 
     return (
-        <div className="flex gap-4 py-2">
-            <div className="flex items-center gap-1">
-                <span>Date range:</span>
-                <DateFilter
-                    dateFrom={dateRange.date_from}
-                    dateTo={dateRange.date_to}
-                    onChange={(changedDateFrom, changedDateTo) => {
-                        setDateRange({ date_from: changedDateFrom, date_to: changedDateTo })
-                    }}
-                    size="small"
-                />
-            </div>
-            {showOrder && (
+        <div className="flex justify-between">
+            <div className="flex gap-4 py-2">
                 <div className="flex items-center gap-1">
-                    <span>Sort by:</span>
-                    <LemonSelect
-                        onSelect={setOrder}
-                        onChange={setOrder}
-                        value={order}
-                        options={[
-                            {
-                                value: 'last_seen',
-                                label: 'Last seen',
-                            },
-                            {
-                                value: 'first_seen',
-                                label: 'First seen',
-                            },
-                            {
-                                value: 'occurrences',
-                                label: 'Occurrences',
-                            },
-                            {
-                                value: 'users',
-                                label: 'Users',
-                            },
-                            {
-                                value: 'sessions',
-                                label: 'Sessions',
-                            },
-                        ]}
+                    <span>Date range:</span>
+                    <DateFilter
+                        dateFrom={dateRange.date_from}
+                        dateTo={dateRange.date_to}
+                        onChange={(changedDateFrom, changedDateTo) => {
+                            setDateRange({ date_from: changedDateFrom, date_to: changedDateTo })
+                        }}
                         size="small"
                     />
                 </div>
-            )}
+                {showOrder && (
+                    <div className="flex items-center gap-1">
+                        <span>Sort by:</span>
+                        <LemonSelect
+                            onSelect={setOrder}
+                            onChange={setOrder}
+                            value={order}
+                            options={[
+                                {
+                                    value: 'last_seen',
+                                    label: 'Last seen',
+                                },
+                                {
+                                    value: 'first_seen',
+                                    label: 'First seen',
+                                },
+                                {
+                                    value: 'occurrences',
+                                    label: 'Occurrences',
+                                },
+                                {
+                                    value: 'users',
+                                    label: 'Users',
+                                },
+                                {
+                                    value: 'sessions',
+                                    label: 'Sessions',
+                                },
+                            ]}
+                            size="small"
+                        />
+                    </div>
+                )}
+            </div>
+            <div className="flex items-center gap-1">
+                <span>Assigned to:</span>
+                <MemberSelect
+                    value={assignee}
+                    onChange={(user) => {
+                        setAssignee(user?.id || null)
+                    }}
+                />
+            </div>
         </div>
     )
 }

--- a/frontend/src/scenes/error-tracking/errorTrackingLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingLogic.ts
@@ -36,6 +36,7 @@ export const errorTrackingLogic = kea<errorTrackingLogicType>([
 
     actions({
         setDateRange: (dateRange: DateRange) => ({ dateRange }),
+        setAssignee: (assignee: number | null) => ({ assignee }),
         setFilterGroup: (filterGroup: UniversalFiltersGroup) => ({ filterGroup }),
         setFilterTestAccounts: (filterTestAccounts: boolean) => ({ filterTestAccounts }),
         setSparklineSelectedPeriod: (period: string | null) => ({ period }),
@@ -47,6 +48,13 @@ export const errorTrackingLogic = kea<errorTrackingLogicType>([
             { persist: true },
             {
                 setDateRange: (_, { dateRange }) => dateRange,
+            },
+        ],
+        assignee: [
+            null as number | null,
+            { persist: true },
+            {
+                setAssignee: (_, { assignee }) => assignee,
             },
         ],
         filterGroup: [

--- a/frontend/src/scenes/error-tracking/errorTrackingSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingSceneLogic.ts
@@ -11,7 +11,10 @@ export const errorTrackingSceneLogic = kea<errorTrackingSceneLogicType>([
     path(['scenes', 'error-tracking', 'errorTrackingSceneLogic']),
 
     connect({
-        values: [errorTrackingLogic, ['dateRange', 'filterTestAccounts', 'filterGroup', 'sparklineSelectedPeriod']],
+        values: [
+            errorTrackingLogic,
+            ['dateRange', 'assignee', 'filterTestAccounts', 'filterGroup', 'sparklineSelectedPeriod'],
+        ],
     }),
 
     actions({
@@ -36,11 +39,12 @@ export const errorTrackingSceneLogic = kea<errorTrackingSceneLogicType>([
 
     selectors({
         query: [
-            (s) => [s.order, s.dateRange, s.filterTestAccounts, s.filterGroup, s.sparklineSelectedPeriod],
-            (order, dateRange, filterTestAccounts, filterGroup, sparklineSelectedPeriod): DataTableNode =>
+            (s) => [s.order, s.dateRange, s.assignee, s.filterTestAccounts, s.filterGroup, s.sparklineSelectedPeriod],
+            (order, dateRange, assignee, filterTestAccounts, filterGroup, sparklineSelectedPeriod): DataTableNode =>
                 errorTrackingQuery({
                     order,
                     dateRange,
+                    assignee,
                     filterTestAccounts,
                     filterGroup,
                     sparklineSelectedPeriod,

--- a/frontend/src/scenes/error-tracking/queries.ts
+++ b/frontend/src/scenes/error-tracking/queries.ts
@@ -35,19 +35,16 @@ const toStartOfIntervalFn = {
 export const errorTrackingQuery = ({
     order,
     dateRange,
+    assignee,
     filterTestAccounts,
     filterGroup,
     sparklineSelectedPeriod,
     columns,
     limit = 50,
-}: {
-    order: ErrorTrackingQuery['order']
-    dateRange: DateRange
-    filterTestAccounts: boolean
+}: Pick<ErrorTrackingQuery, 'order' | 'dateRange' | 'assignee' | 'filterTestAccounts' | 'limit'> & {
     filterGroup: UniversalFiltersGroup
     sparklineSelectedPeriod: string | null
     columns?: ('error' | 'volume' | 'occurrences' | 'sessions' | 'users' | 'assignee')[]
-    limit?: number
 }): DataTableNode => {
     const select: string[] = []
     if (!columns) {
@@ -69,6 +66,7 @@ export const errorTrackingQuery = ({
             select: select,
             order: order,
             dateRange: dateRange,
+            assignee: assignee,
             filterGroup: filterGroup as PropertyGroupFilter,
             filterTestAccounts: filterTestAccounts,
             limit: limit,

--- a/posthog/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -1,4 +1,27 @@
 # serializer version: 1
+# name: TestErrorTrackingQueryRunner.test_assignee_groups
+  '''
+  SELECT count() AS occurrences,
+         count(DISTINCT events.`$session_id`) AS sessions,
+         count(DISTINCT events.distinct_id) AS users,
+         max(toTimeZone(events.timestamp, 'UTC')) AS last_seen,
+         min(toTimeZone(events.timestamp, 'UTC')) AS first_seen,
+         any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$exception_message'), ''), 'null'), '^"|"$', '')) AS description,
+         any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$exception_type'), ''), 'null'), '^"|"$', '')) AS exception_type,
+         multiIf(has([['SyntaxError']], JSONExtract(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', ''), '[]'), 'Array(String)')), ['SyntaxError'], has([['custom_fingerprint']], JSONExtract(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', ''), '[]'), 'Array(String)')), ['custom_fingerprint'], JSONExtract(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', ''), '[]'), 'Array(String)')) AS fingerprint
+  FROM events
+  WHERE and(equals(events.team_id, 2), equals(events.event, '$exception'), 1, has([['SyntaxError'], ['custom_fingerprint']], JSONExtract(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', ''), '[]'), 'Array(String)')))
+  GROUP BY fingerprint
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
 # name: TestErrorTrackingQueryRunner.test_column_names
   '''
   SELECT count() AS occurrences,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4578,6 +4578,7 @@ class ErrorTrackingQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    assignee: Optional[int] = None
     dateRange: DateRange
     eventColumns: Optional[list[str]] = None
     filterGroup: Optional[PropertyGroupFilter] = None


### PR DESCRIPTION
## Problem

You cannot filter for your exceptions in error tracking

## Changes

Add an "assignee" option to filtering

![assigned](https://github.com/user-attachments/assets/ed553bc7-969e-4609-b617-63c47cccd96c)


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added tests