### PR TITLE
feat(web-analytics): Some UI tweaks

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -81,7 +81,7 @@ export function InsightVizDisplay({
     const BlockingEmptyState = (() => {
         if (insightDataLoading) {
             return (
-                <div className="flex flex-col flex-1 justify-center items-center">
+                <div className="flex flex-col flex-1 justify-center items-center p-2">
                     <InsightLoadingState queryId={queryId} key={queryId} insightProps={insightProps} />
                 </div>
             )

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -371,7 +371,7 @@ export const WebStatsTableTile = ({
 
     const pathCleaningSettingsUrl = urls.settings('project-product-analytics', 'path-cleaning')
     return (
-        <div className="border rounded bg-bg-light flex-1">
+        <div className="border rounded bg-bg-light flex-1 flex flex-col">
             {showPathCleaningControls && (
                 <div className="flex flex-row items-center justify-end m-2 mr-4">
                     <div className="flex flex-row items-center space-x-2">

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -639,7 +639,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             [
                                 {
                                     id: PathTab.PATH,
-                                    title: 'Top paths',
+                                    title: 'Paths',
                                     linkText: 'Path',
                                     query: {
                                         full: true,
@@ -664,7 +664,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 },
                                 {
                                     id: PathTab.INITIAL_PATH,
-                                    title: 'Top entry paths',
+                                    title: 'Entry paths',
                                     linkText: 'Entry path',
                                     query: {
                                         full: true,
@@ -688,8 +688,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 },
                                 {
                                     id: PathTab.EXIT_PATH,
-                                    title: 'Top exit paths',
-                                    linkText: 'Exit path',
+                                    title: 'End paths',
+                                    linkText: 'End path',
                                     query: {
                                         full: true,
                                         kind: NodeKind.DataTableNode,
@@ -725,7 +725,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         tabs: [
                             {
                                 id: SourceTab.CHANNEL,
-                                title: 'Top channels',
+                                title: 'Channels',
                                 linkText: 'Channel',
                                 query: {
                                     full: true,
@@ -763,7 +763,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: SourceTab.REFERRING_DOMAIN,
-                                title: 'Top referrers',
+                                title: 'Referrers',
                                 linkText: 'Referring domain',
                                 query: {
                                     full: true,
@@ -784,7 +784,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 
                             {
                                 id: SourceTab.UTM_SOURCE,
-                                title: 'Top sources',
+                                title: 'UTM sources',
                                 linkText: 'UTM source',
                                 query: {
                                     full: true,
@@ -804,7 +804,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: SourceTab.UTM_MEDIUM,
-                                title: 'Top UTM medium',
+                                title: 'UTM medium',
                                 linkText: 'UTM medium',
                                 query: {
                                     full: true,
@@ -824,7 +824,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: SourceTab.UTM_CAMPAIGN,
-                                title: 'Top UTM campaigns',
+                                title: 'UTM campaigns',
                                 linkText: 'UTM campaign',
                                 query: {
                                     full: true,
@@ -844,7 +844,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: SourceTab.UTM_CONTENT,
-                                title: 'Top UTM content',
+                                title: 'UTM content',
                                 linkText: 'UTM content',
                                 query: {
                                     full: true,
@@ -864,7 +864,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: SourceTab.UTM_TERM,
-                                title: 'Top UTM terms',
+                                title: 'UTM terms',
                                 linkText: 'UTM term',
                                 query: {
                                     full: true,
@@ -916,7 +916,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         tabs: [
                             {
                                 id: DeviceTab.DEVICE_TYPE,
-                                title: 'Device types',
+                                title: 'Device type',
                                 linkText: 'Device type',
                                 query: {
                                     kind: NodeKind.InsightVizNode,
@@ -953,7 +953,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: DeviceTab.BROWSER,
-                                title: 'Top browsers',
+                                title: 'Browsers',
                                 linkText: 'Browser',
                                 query: {
                                     full: true,
@@ -973,7 +973,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             {
                                 id: DeviceTab.OS,
-                                title: 'Top OSs',
+                                title: 'OS',
                                 linkText: 'OS',
                                 query: {
                                     full: true,
@@ -1040,7 +1040,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                   },
                                   {
                                       id: GeographyTab.COUNTRIES,
-                                      title: 'Top countries',
+                                      title: 'Countries',
                                       linkText: 'Countries',
                                       query: {
                                           full: true,
@@ -1060,7 +1060,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                   },
                                   {
                                       id: GeographyTab.REGIONS,
-                                      title: 'Top regions',
+                                      title: 'Regions',
                                       linkText: 'Regions',
                                       query: {
                                           full: true,
@@ -1080,7 +1080,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                   },
                                   {
                                       id: GeographyTab.CITIES,
-                                      title: 'Top cities',
+                                      title: 'Cities',
                                       linkText: 'Cities',
                                       query: {
                                           full: true,

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -919,37 +919,20 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 title: 'Device type',
                                 linkText: 'Device type',
                                 query: {
-                                    kind: NodeKind.InsightVizNode,
+                                    full: true,
+                                    kind: NodeKind.DataTableNode,
                                     source: {
-                                        kind: NodeKind.TrendsQuery,
-                                        breakdownFilter: { breakdown: '$device_type', breakdown_type: 'event' },
-                                        dateRange,
-                                        series: [
-                                            {
-                                                event: '$pageview',
-                                                name: 'Pageview',
-                                                kind: NodeKind.EventsNode,
-                                                math: BaseMathType.UniqueUsers,
-                                            },
-                                        ],
-                                        trendsFilter: {
-                                            display: ChartDisplayType.ActionsPie,
-                                            showLabelsOnSeries: true,
-                                        },
-                                        filterTestAccounts,
+                                        kind: NodeKind.WebStatsTableQuery,
                                         properties: webAnalyticsFilters,
+                                        breakdownBy: WebStatsBreakdown.DeviceType,
+                                        dateRange,
+                                        sampling,
+                                        limit: 10,
+                                        filterTestAccounts,
                                     },
-                                    hidePersonsModal: true,
-                                    vizSpecificOptions: {
-                                        [ChartDisplayType.ActionsPie]: {
-                                            disableHoverOffset: true,
-                                            hideAggregation: true,
-                                        },
-                                    },
-                                    embedded: true,
                                 },
                                 insightProps: createInsightProps(TileId.DEVICES, DeviceTab.DEVICE_TYPE),
-                                canOpenInsight: true,
+                                canOpenModal: true,
                             },
                             {
                                 id: DeviceTab.BROWSER,


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C05LJK1N3CP/p1724862413691769

Fixes everything except for the loading state.

## Changes

Add margin to loading state:
<img width="1047" alt="Screenshot 2024-08-29 at 18 10 38" src="https://github.com/user-attachments/assets/7709933f-244a-40f7-9257-f0662f7bf676">

Tile background doesn't overflow:
<img width="1039" alt="Screenshot 2024-08-29 at 18 10 57" src="https://github.com/user-attachments/assets/75345225-4252-4ba1-81c3-eb2c1efe1e42">

Device type is a table:
<img width="525" alt="Screenshot 2024-08-29 at 18 13 08" src="https://github.com/user-attachments/assets/f5bb21b5-0ea9-4c81-8a01-0993646ba151">

Plus, I removed "Top" from the titles

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

See screenshots
