### PR TITLE
fix(api): fix `KeyError` in _filter_queryset_by_parents_lookups

### DIFF
--- a/ee/api/feature_flag_role_access.py
+++ b/ee/api/feature_flag_role_access.py
@@ -77,7 +77,7 @@ class FeatureFlagRoleAccessViewSet(
     permission_classes = [FeatureFlagRoleAccessPermissions]
     serializer_class = FeatureFlagRoleAccessSerializer
     queryset = FeatureFlagRoleAccess.objects.select_related("feature_flag")
-    filter_rewrite_rules = {"team_id": "feature_flag__team_id"}
+    filter_rewrite_rules = {"project_id": "feature_flag__team__project_id"}
 
     def safely_get_queryset(self, queryset):
         filters = self.request.GET.dict()

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -324,8 +324,9 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):
         parents_query_dict = self.parents_query_dict.copy()
 
         for source, destination in self.filter_rewrite_rules.items():
-            parents_query_dict[destination] = parents_query_dict[source]
-            del parents_query_dict[source]
+            if source in parents_query_dict:
+                parents_query_dict[destination] = parents_query_dict[source]
+                del parents_query_dict[source]
 
         if "project_id" in parents_query_dict:
             # KLUDGE: This rewrite can be removed once the relevant models get that field directly

--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -324,9 +324,8 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):
         parents_query_dict = self.parents_query_dict.copy()
 
         for source, destination in self.filter_rewrite_rules.items():
-            if source in parents_query_dict:
-                parents_query_dict[destination] = parents_query_dict[source]
-                del parents_query_dict[source]
+            parents_query_dict[destination] = parents_query_dict[source]
+            del parents_query_dict[source]
 
         if "project_id" in parents_query_dict:
             # KLUDGE: This rewrite can be removed once the relevant models get that field directly


### PR DESCRIPTION
## Problem
https://posthog.sentry.io/issues/5732669244/?alert_rule_id=4194161&alert_type=issue&notification_uuid=77b8f425-2556-4c84-aec3-bf3b8338ea28&project=1899813&referrer=slack

## Changes
Fixes a `KeyError` that occurs in the `_filter_queryset_by_parents_lookups` method when the method tries to access a key that doesn't exist in `parents_query_dict`.

## How did you test this code?
👀 