### PR TITLE
fix(batch-exports): Correctly check for 5 minute bounds

### DIFF
--- a/frontend/src/scenes/pipeline/batchExportRunsLogic.tsx
+++ b/frontend/src/scenes/pipeline/batchExportRunsLogic.tsx
@@ -102,13 +102,15 @@ export const batchExportRunsLogic = kea<batchExportRunsLogicType>([
                 end_at: !end_at ? 'End date is required' : undefined,
             }),
             submit: async ({ start_at, end_at }) => {
-                if (values.batchExportConfig && values.batchExportConfig.interval.endsWith('minutes')) {
+                if (
+                    values.batchExportConfig &&
+                    values.batchExportConfig.interval.endsWith('minutes') &&
+                    start_at?.minute() !== undefined &&
+                    end_at?.minute() !== undefined
+                ) {
                     // TODO: Make this generic for all minute frequencies.
                     // Currently, only 5 minute batch exports are supported.
-                    if (
-                        !(start_at?.minute() && start_at?.minute() % 5 === 0) ||
-                        !(end_at?.minute() && end_at?.minute() % 5 === 0)
-                    ) {
+                    if (!(start_at?.minute() % 5 === 0) || !(end_at?.minute() % 5 === 0)) {
                         lemonToast.error(
                             'Backfilling a 5 minute batch export requires bounds be multiple of five minutes'
                         )


### PR DESCRIPTION
## Problem

This check is not working because I think the minute is a falsy value. 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

So, let's more explicitly check for undefined on the outer check.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Manually.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
