### PR TITLE
fix(web-analytics): Fix using cohort-based internal test filters in web analytics

### DIFF
--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -58,11 +58,11 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner):
                 """
 SELECT
     breakdown_value AS "context.columns.breakdown_value",
-    uniq(person_id) AS "context.columns.visitors",
+    uniq(filtered_person_id) AS "context.columns.visitors",
     sum(filtered_pageview_count) AS "context.columns.views"
 FROM (
     SELECT
-        any(person_id) AS person_id,
+        any(person_id) AS filtered_person_id,
         count() AS filtered_pageview_count,
         {breakdown_value} AS breakdown_value
     FROM events
@@ -97,11 +97,11 @@ ORDER BY "context.columns.visitors" DESC,
                 """
 SELECT
     breakdown_value AS "context.columns.breakdown_value",
-    uniq(person_id) AS "context.columns.visitors",
+    uniq(filtered_person_id) AS "context.columns.visitors",
     sum(filtered_pageview_count) AS "context.columns.views"
 FROM (
     SELECT
-        any(person_id) AS person_id,
+        any(person_id) AS filtered_person_id,
         count() AS filtered_pageview_count,
         {breakdown_value} AS breakdown_value,
         session.session_id AS session_id
@@ -139,12 +139,12 @@ ORDER BY "context.columns.visitors" DESC,
                 """
 SELECT
     breakdown_value AS "context.columns.breakdown_value",
-    uniq(person_id) AS "context.columns.visitors",
+    uniq(filtered_person_id) AS "context.columns.visitors",
     sum(filtered_pageview_count) AS "context.columns.views",
     avg(is_bounce) AS "context.columns.bounce_rate"
 FROM (
     SELECT
-        any(person_id) AS person_id,
+        any(person_id) AS filtered_person_id,
         count() AS filtered_pageview_count,
         {bounce_breakdown} AS breakdown_value,
         any(session.$is_bounce) AS is_bounce,
@@ -194,11 +194,11 @@ SELECT
 FROM (
     SELECT
         breakdown_value,
-        uniq(person_id) AS visitors,
+        uniq(filtered_person_id) AS visitors,
         sum(filtered_pageview_count) AS views
     FROM (
         SELECT
-            any(person_id) AS person_id,
+            any(person_id) AS filtered_person_id,
             count() AS filtered_pageview_count,
             {breakdown_value} AS breakdown_value,
             session.session_id AS session_id
@@ -301,11 +301,11 @@ SELECT
 FROM (
     SELECT
         breakdown_value,
-        uniq(person_id) AS visitors,
+        uniq(filtered_person_id) AS visitors,
         sum(filtered_pageview_count) AS views
     FROM (
         SELECT
-            any(person_id) AS person_id,
+            any(person_id) AS filtered_person_id,
             count() AS filtered_pageview_count,
             {breakdown_value} AS breakdown_value,
             session.session_id AS session_id
@@ -418,9 +418,10 @@ ORDER BY "context.columns.visitors" DESC,
         return self.query_date_range.date_from_as_hogql()
 
     def calculate(self):
+        query = self.to_query()
         response = self.paginator.execute_hogql_query(
             query_type="stats_table_query",
-            query=self.to_query(),
+            query=query,
             team=self.team,
             timings=self.timings,
             modifiers=self.modifiers,


### PR DESCRIPTION
## Problem

Web analytics queries don't currently support cohort-based internal/test filters, as they re-use the name `person_id`. This breaks the where clause which looks like `person_id in {cohort}`

## Changes

Rename the aggregate field

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

I added a test for this case, which fails without this fix.
