### PR TITLE
feat: time to see data metric in PostHog

### DIFF
--- a/frontend/src/lib/internalMetrics.ts
+++ b/frontend/src/lib/internalMetrics.ts
@@ -6,6 +6,7 @@ import { getResponseBytes } from 'scenes/insights/utils'
 import { getCurrentExporterData } from '~/exporter/exporterViewLogic'
 
 export interface TimeToSeeDataPayload {
+    team_id?: number | null
     type: 'dashboard_load' | 'insight_load' | 'properties_timeline_load' | 'property_values_load' | 'properties_load'
     context: 'dashboard' | 'insight' | 'actors_modal' | 'filters'
     time_to_see_data_ms: number

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -10,6 +10,7 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { isActionFilter, isEventFilter } from 'lib/components/UniversalFilters/utils'
 import type { Dayjs } from 'lib/dayjs'
 import { now } from 'lib/dayjs'
+import { TimeToSeeDataPayload } from 'lib/internalMetrics'
 import { isCoreFilter, PROPERTY_KEYS } from 'lib/taxonomy'
 import { objectClean } from 'lib/utils'
 import posthog from 'posthog-js'
@@ -292,6 +293,8 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportPersonsModalViewed: (params: any) => ({
             params,
         }),
+        // timing
+        reportTimeToSeeData: (payload: TimeToSeeDataPayload) => ({ payload }),
         // insights
         reportInsightCreated: (query: Node | null) => ({ query }),
         reportInsightSaved: (query: Node | null, isNewInsight: boolean) => ({ query, isNewInsight }),
@@ -637,6 +640,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 posthog_properties_count,
             }
             posthog.capture('person viewed', properties)
+        },
+        reportTimeToSeeData: async ({ payload }) => {
+            posthog.capture('time to see data', payload)
         },
         reportInsightCreated: async ({ query }, breakpoint) => {
             // "insight created" essentially means that the user clicked "New insight"

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -17,7 +17,7 @@ import { router, urlToAction } from 'kea-router'
 import api, { ApiMethodOptions, getJSONOrNull } from 'lib/api'
 import { DashboardPrivilegeLevel, OrganizationMembershipLevel } from 'lib/constants'
 import { Dayjs, dayjs, now } from 'lib/dayjs'
-import { captureTimeToSeeData, currentSessionId, TimeToSeeDataPayload } from 'lib/internalMetrics'
+import { currentSessionId, TimeToSeeDataPayload } from 'lib/internalMetrics'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { Link } from 'lib/lemon-ui/Link'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -65,6 +65,7 @@ export const DASHBOARD_MIN_REFRESH_INTERVAL_MINUTES = 5
 
 const IS_TEST_MODE = process.env.NODE_ENV === 'test'
 
+const REFRESH_DASHBOARD_ITEM_ACTION = 'refresh_dashboard_item'
 export interface DashboardLogicProps {
     id: number
     dashboard?: DashboardType<QueryBasedInsightModel>
@@ -190,7 +191,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
         refreshAllDashboardItems: (payload: {
             tiles?: DashboardTile<QueryBasedInsightModel>[]
             action: string
-            initialLoad?: boolean
             dashboardQueryId?: string
         }) => payload,
         refreshAllDashboardItemsManual: true,
@@ -953,7 +953,19 @@ export const dashboardLogic = kea<dashboardLogicType>([
         setRefreshError: sharedListeners.reportRefreshTiming,
         setRefreshStatuses: sharedListeners.reportRefreshTiming,
         setRefreshStatus: sharedListeners.reportRefreshTiming,
-        loadDashboardFailure: sharedListeners.reportLoadTiming,
+        loadDashboardFailure: () => {
+            const { action, dashboardQueryId, startTime } = values.dashboardLoadTimerData
+
+            eventUsageLogic.actions.reportTimeToSeeData({
+                team_id: values.currentTeamId,
+                type: 'dashboard_load',
+                context: 'dashboard',
+                status: 'failure',
+                action,
+                primary_interaction_id: dashboardQueryId,
+                time_to_see_data_ms: Math.floor(performance.now() - startTime),
+            })
+        },
         [insightsModel.actionTypes.duplicateInsightSuccess]: () => {
             // TODO this is a bit hacky, but we need to reload the dashboard to get the new insight
             // TODO when duplicated from a dashboard we should carry the context so only one logic needs to reload
@@ -1039,12 +1051,12 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 dashboardsModel.actions.updateDashboardInsight(refreshedInsight!)
                 // Start polling for results
                 tile.insight = refreshedInsight!
-                actions.refreshAllDashboardItems({ tiles: [tile], action: 'refresh' })
+                actions.refreshAllDashboardItems({ tiles: [tile], action: REFRESH_DASHBOARD_ITEM_ACTION })
             } catch (e: any) {
                 actions.setRefreshError(insight.short_id)
             }
         },
-        refreshAllDashboardItems: async ({ tiles, action, initialLoad, dashboardQueryId = uuid() }, breakpoint) => {
+        refreshAllDashboardItems: async ({ tiles, action, dashboardQueryId = uuid() }, breakpoint) => {
             const dashboardId: number = props.id
 
             const insightsToRefresh = (tiles || values.insightTiles || [])
@@ -1058,6 +1070,31 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
             // Don't do anything if there's nothing to refresh
             if (insightsToRefresh.length === 0) {
+                // still report time to see updated data
+                // in case loadDashboard found all cached insights
+                const dashboard = values.dashboard
+                if (dashboard && action !== REFRESH_DASHBOARD_ITEM_ACTION) {
+                    const { action, dashboardQueryId, startTime, responseBytes } = values.dashboardLoadTimerData
+                    const lastRefresh = sortDates(dashboard.tiles.map((tile) => tile.insight?.last_refresh || null))
+
+                    eventUsageLogic.actions.reportTimeToSeeData({
+                        team_id: values.currentTeamId,
+                        type: 'dashboard_load',
+                        context: 'dashboard',
+                        action,
+                        primary_interaction_id: dashboardQueryId,
+                        time_to_see_data_ms: Math.floor(performance.now() - startTime),
+                        api_response_bytes: responseBytes,
+                        insights_fetched: dashboard.tiles.length,
+                        insights_fetched_cached: dashboard.tiles.reduce(
+                            (acc, curr) => acc + (curr.is_cached ? 1 : 0),
+                            0
+                        ),
+                        min_last_refresh: lastRefresh[0],
+                        max_last_refresh: lastRefresh[lastRefresh.length - 1],
+                    })
+                }
+
                 return
             }
 
@@ -1129,6 +1166,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 refreshesFinished += 1
                 if (!cancelled && refreshesFinished === insightsToRefresh.length) {
                     const payload: TimeToSeeDataPayload = {
+                        team_id: values.currentTeamId,
                         type: 'dashboard_load',
                         context: 'dashboard',
                         action,
@@ -1138,20 +1176,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         insights_fetched: insightsToRefresh.length,
                         insights_fetched_cached: 0,
                     }
-                    void captureTimeToSeeData(values.currentTeamId, {
-                        ...payload,
-                        is_primary_interaction: !initialLoad,
-                    })
-                    if (initialLoad) {
-                        const { startTime, responseBytes } = values.dashboardLoadTimerData
-                        void captureTimeToSeeData(values.currentTeamId, {
-                            ...payload,
-                            action: 'initial_load_full',
-                            time_to_see_data_ms: Math.floor(performance.now() - startTime),
-                            api_response_bytes: responseBytes + totalResponseBytes,
-                            is_primary_interaction: true,
-                        })
-                    }
+
+                    eventUsageLogic.actions.reportTimeToSeeData(payload)
                 }
             })
 
@@ -1218,37 +1244,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return // We hit a 404
             }
 
-            const dashboard = values.dashboard
-            const { action, dashboardQueryId, startTime, responseBytes } = values.dashboardLoadTimerData
-            const lastRefresh = sortDates(dashboard.tiles.map((tile) => tile.insight?.last_refresh || null))
-
-            const initialLoad = action === 'initial_load'
-            const allLoaded = false // TODO: Check this
-
-            actions.refreshAllDashboardItems({ action, initialLoad, dashboardQueryId })
-
-            const payload: TimeToSeeDataPayload = {
-                type: 'dashboard_load',
-                context: 'dashboard',
-                action,
-                primary_interaction_id: dashboardQueryId,
-                time_to_see_data_ms: Math.floor(performance.now() - startTime),
-                api_response_bytes: responseBytes,
-                insights_fetched: dashboard.tiles.length,
-                insights_fetched_cached: dashboard.tiles.reduce((acc, curr) => acc + (curr.is_cached ? 1 : 0), 0),
-                min_last_refresh: lastRefresh[0],
-                max_last_refresh: lastRefresh[lastRefresh.length - 1],
-                is_primary_interaction: !initialLoad,
-            }
-
-            void captureTimeToSeeData(values.currentTeamId, payload)
-            if (initialLoad && allLoaded) {
-                void captureTimeToSeeData(values.currentTeamId, {
-                    ...payload,
-                    action: 'initial_load_full',
-                    is_primary_interaction: true,
-                })
-            }
+            const { action, dashboardQueryId } = values.dashboardLoadTimerData
+            actions.refreshAllDashboardItems({ action, dashboardQueryId })
 
             if (values.shouldReportOnAPILoad) {
                 actions.setShouldReportOnAPILoad(false)
@@ -1288,7 +1285,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
             // TRICKY: we cancel just once using the dashboard query id.
             // we can record the queryId that happened to capture the AbortError exception
             // and request the cancellation, but it is probably not particularly relevant
-            await captureTimeToSeeData(values.currentTeamId, {
+            eventUsageLogic.actions.reportTimeToSeeData({
+                team_id: values.currentTeamId,
                 type: 'insight_load',
                 context: 'dashboard',
                 primary_interaction_id: dashboardQueryId,

--- a/frontend/src/scenes/insights/insightDataTimingLogic.ts
+++ b/frontend/src/scenes/insights/insightDataTimingLogic.ts
@@ -1,5 +1,5 @@
 import { actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
-import { captureTimeToSeeData } from 'lib/internalMetrics'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { dataNodeLogic, DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
@@ -24,6 +24,7 @@ export const insightDataTimingLogic = kea<insightDataTimingLogicType>([
             dataNodeLogic({ key: insightVizDataNodeKey(props) } as DataNodeLogicProps),
             ['loadData', 'loadDataSuccess', 'loadDataFailure', 'abortQuery as loadDataCancellation'],
         ],
+        logic: [eventUsageLogic],
     })),
     actions({
         startQuery: (queryId: string) => ({ queryId }),
@@ -52,7 +53,9 @@ export const insightDataTimingLogic = kea<insightDataTimingLogicType>([
             }
 
             const duration = performance.now() - values.queryStartTimes[payload.queryId]
-            void captureTimeToSeeData(values.currentTeamId, {
+
+            eventUsageLogic.actions.reportTimeToSeeData({
+                team_id: values.currentTeamId,
                 type: 'insight_load',
                 context: 'insight',
                 primary_interaction_id: payload.queryId,
@@ -76,7 +79,8 @@ export const insightDataTimingLogic = kea<insightDataTimingLogicType>([
             }
 
             const duration = performance.now() - values.queryStartTimes[errorObject.queryId]
-            void captureTimeToSeeData(values.currentTeamId, {
+            eventUsageLogic.actions.reportTimeToSeeData({
+                team_id: values.currentTeamId,
                 type: 'insight_load',
                 context: 'insight',
                 primary_interaction_id: errorObject.queryId,
@@ -95,7 +99,8 @@ export const insightDataTimingLogic = kea<insightDataTimingLogicType>([
         },
         loadDataCancellation: (payload) => {
             const duration = performance.now() - values.queryStartTimes[payload.queryId]
-            void captureTimeToSeeData(values.currentTeamId, {
+            eventUsageLogic.actions.reportTimeToSeeData({
+                team_id: values.currentTeamId,
                 type: 'insight_load',
                 context: 'insight',
                 primary_interaction_id: payload.queryId,

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1090,6 +1090,7 @@ Using the correct cache and enriching the response with dashboard specific confi
         return activity_page_response(activity_page, limit, page, request)
 
     @action(methods=["POST"], detail=False)
+    @monitor(feature=Feature.INSIGHT, endpoint="insight", method="CANCEL")
     def cancel(self, request: request.Request, **kwargs):
         if "client_query_id" not in request.data:
             raise serializers.ValidationError({"client_query_id": "Field is required."})

--- a/posthog/api/monitoring.py
+++ b/posthog/api/monitoring.py
@@ -2,6 +2,7 @@ from enum import StrEnum
 from prometheus_client import Counter
 from sentry_sdk import set_tag
 from collections.abc import Callable
+from functools import wraps
 
 
 class Feature(StrEnum):
@@ -31,6 +32,7 @@ def monitor(*, feature: Feature | None, endpoint: str, method: str) -> Callable:
     """
 
     def decorator(func: Callable) -> Callable:
+        @wraps(func)
         def wrapper(*args, **kwargs):
             API_REQUESTS_COUNTER.labels(endpoint=endpoint, method=method).inc()
 


### PR DESCRIPTION
## Problem
Moving the time to see metrics to PostHog UI

## Changes
Sends timing metrics for dashboard load/refresh/preview (filter changes) + refresh time for each individual insight
<img width="1136" alt="image" src="https://github.com/user-attachments/assets/9241c63f-9387-4e61-81ae-1d1bce02d106">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Locally looked at the metrics being sent
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
