### PR TITLE
fix: correctly lookup log entry fields

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -326,6 +326,8 @@ export function propertyFilterTypeToPropertyDefinitionType(
         ? PropertyDefinitionType.Session
         : filterType === PropertyFilterType.Recording
         ? PropertyDefinitionType.Session
+        : filterType === PropertyFilterType.LogEntry
+        ? PropertyDefinitionType.LogEntry
         : PropertyDefinitionType.Event
 }
 

--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -1155,6 +1155,17 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
             description: 'URL a user visited during their session',
         },
     },
+    log_entries: {
+        level: {
+            label: 'Console log level',
+            description: 'Level of the ',
+            examples: ['info', 'warn', 'error'],
+        },
+        message: {
+            label: 'Console log message',
+            description: 'The contents of the log message',
+        },
+    },
 } satisfies Partial<Record<TaxonomicFilterGroupType, Record<string, CoreFilterDefinition>>>
 
 CORE_FILTER_DEFINITIONS_BY_GROUP.numerical_event_properties = CORE_FILTER_DEFINITIONS_BY_GROUP.event_properties

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -345,6 +345,8 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
                 return
             }
 
+            console.log(getPropertyKey(type, propertyKey))
+
             if (localOptions[getPropertyKey(type, propertyKey)]) {
                 actions.setOptions(propertyKey, localOptions[getPropertyKey(type, propertyKey)], false)
                 return

--- a/frontend/src/models/propertyDefinitionsModel.ts
+++ b/frontend/src/models/propertyDefinitionsModel.ts
@@ -59,7 +59,7 @@ const localOptions: Record<string, PropValue[]> = {
         { id: 0, name: 'web' },
         { id: 1, name: 'mobile' },
     ],
-    'session/console_log_level': [
+    'log_entry/level': [
         { id: 0, name: 'info' },
         { id: 1, name: 'warn' },
         { id: 2, name: 'error' },
@@ -344,8 +344,6 @@ export const propertyDefinitionsModel = kea<propertyDefinitionsModelType>([
             if (!propertyKey || values.currentTeamId === null) {
                 return
             }
-
-            console.log(getPropertyKey(type, propertyKey))
 
             if (localOptions[getPropertyKey(type, propertyKey)]) {
                 actions.setOptions(propertyKey, localOptions[getPropertyKey(type, propertyKey)], false)

--- a/frontend/src/scenes/session-recordings/filters/ReplayTaxonomicFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/ReplayTaxonomicFilters.tsx
@@ -5,6 +5,7 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterGroupType, TaxonomicFilterValue } from 'lib/components/TaxonomicFilter/types'
 import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
+import { getFilterLabel } from 'lib/taxonomy'
 import { useState } from 'react'
 
 import { PropertyFilterType } from '~/types'
@@ -26,24 +27,24 @@ export function ReplayTaxonomicFilters({ onChange }: ReplayTaxonomicFiltersProps
 
     const properties = [
         {
-            label: 'Visited page',
             key: 'visited_page',
             propertyFilterType: PropertyFilterType.Recording,
+            taxonomicFilterGroup: TaxonomicFilterGroupType.Replay,
         },
         {
-            label: 'Platform',
             key: 'snapshot_source',
             propertyFilterType: PropertyFilterType.Recording,
+            taxonomicFilterGroup: TaxonomicFilterGroupType.Replay,
         },
         {
-            label: 'Console log level',
-            key: 'console_log_level',
+            key: 'level',
             propertyFilterType: PropertyFilterType.LogEntry,
+            taxonomicFilterGroup: TaxonomicFilterGroupType.LogEntries,
         },
         {
-            label: 'Console log text',
-            key: 'console_log_query',
+            key: 'message',
             propertyFilterType: PropertyFilterType.LogEntry,
+            taxonomicFilterGroup: TaxonomicFilterGroupType.LogEntries,
         },
     ]
 
@@ -52,17 +53,20 @@ export function ReplayTaxonomicFilters({ onChange }: ReplayTaxonomicFiltersProps
             <section>
                 <h5 className="mt-1 mb-0">Replay properties</h5>
                 <ul className="space-y-px">
-                    {properties.map(({ key, label, propertyFilterType }) => (
-                        <LemonButton
-                            key={key}
-                            size="small"
-                            fullWidth
-                            onClick={() => onChange(key, { propertyFilterType: propertyFilterType })}
-                            disabledReason={hasFilter(key) ? `${label} filter already added` : undefined}
-                        >
-                            {label}
-                        </LemonButton>
-                    ))}
+                    {properties.map(({ key, taxonomicFilterGroup, propertyFilterType }) => {
+                        const label = getFilterLabel(key, taxonomicFilterGroup)
+                        return (
+                            <LemonButton
+                                key={key}
+                                size="small"
+                                fullWidth
+                                onClick={() => onChange(key, { propertyFilterType: propertyFilterType })}
+                                disabledReason={hasFilter(key) ? `${label} filter already added` : undefined}
+                            >
+                                {label}
+                            </LemonButton>
+                        )
+                    })}
                 </ul>
             </section>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3066,6 +3066,7 @@ export enum PropertyDefinitionType {
     Person = 'person',
     Group = 'group',
     Session = 'session',
+    LogEntry = 'log_entry',
 }
 
 export interface PropertyDefinition {

--- a/posthog/session_recordings/queries/session_recording_list_from_filters.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_filters.py
@@ -208,12 +208,22 @@ class SessionRecordingListFromFilters:
             optional_exprs.append(property_to_expr(remaining_properties, team=self._team, scope="replay"))
 
         if self._filter.console_log_filters.values:
-            # print(self._filter.console_log_filters.type)
             console_logs_subquery = ast.SelectQuery(
                 select=[ast.Field(chain=["log_source_id"])],
                 select_from=ast.JoinExpr(table=ast.Field(chain=["console_logs_log_entries"])),
-                where=self._filter.ast_operand(
-                    exprs=[property_to_expr(self._filter.console_log_filters, team=self._team)]
+                where=ast.And(
+                    exprs=[
+                        self._filter.ast_operand(
+                            exprs=[
+                                property_to_expr(self._filter.console_log_filters, team=self._team),
+                            ]
+                        ),
+                        ast.CompareOperation(
+                            op=ast.CompareOperationOp.Eq,
+                            left=ast.Field(chain=["log_source"]),
+                            right=ast.Constant(value="session_replay"),
+                        ),
+                    ]
                 ),
             )
 

--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_filters.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_filters.ambr
@@ -2484,6 +2484,120 @@
                     max_bytes_before_external_group_by=0
   '''
 # ---
+# name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_by_console_text
+  '''
+  SELECT s.session_id AS session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
+         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
+         dateDiff('SECOND', start_time, end_time) AS duration,
+         argMinMerge(s.first_url) AS first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
+         minus(duration, active_seconds) AS inactive_seconds,
+         sum(s.console_log_count) AS console_log_count,
+         sum(s.console_warn_count) AS console_warn_count,
+         sum(s.console_error_count) AS console_error_count
+  FROM session_replay_events AS s
+  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
+                                                                                                                                                                                                                                                                                                                                                                                                                        (SELECT console_logs_log_entries.log_source_id AS log_source_id
+                                                                                                                                                                                                                                                                                                                                                                                                                         FROM
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.message AS message, log_entries.log_source AS log_source
+                                                                                                                                                                                                                                                                                                                                                                                                                            FROM log_entries
+                                                                                                                                                                                                                                                                                                                                                                                                                            WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(or(or(ifNull(equals(console_logs_log_entries.level, 'warn'), 0), ifNull(equals(console_logs_log_entries.level, 'error'), 0)), ifNull(equals(console_logs_log_entries.message, 'message 4'), 0)), ifNull(equals(console_logs_log_entries.log_source, 'session_replay'), 0)))))
+  GROUP BY s.session_id
+  HAVING 1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_by_console_text.1
+  '''
+  SELECT s.session_id AS session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
+         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
+         dateDiff('SECOND', start_time, end_time) AS duration,
+         argMinMerge(s.first_url) AS first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
+         minus(duration, active_seconds) AS inactive_seconds,
+         sum(s.console_log_count) AS console_log_count,
+         sum(s.console_warn_count) AS console_warn_count,
+         sum(s.console_error_count) AS console_error_count
+  FROM session_replay_events AS s
+  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
+                                                                                                                                                                                                                                                                                                                                                                                                                        (SELECT console_logs_log_entries.log_source_id AS log_source_id
+                                                                                                                                                                                                                                                                                                                                                                                                                         FROM
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.message AS message, log_entries.log_source AS log_source
+                                                                                                                                                                                                                                                                                                                                                                                                                            FROM log_entries
+                                                                                                                                                                                                                                                                                                                                                                                                                            WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(and(or(ifNull(equals(console_logs_log_entries.level, 'warn'), 0), ifNull(equals(console_logs_log_entries.level, 'error'), 0)), ifNull(ilike(console_logs_log_entries.message, '%message 5%'), 0)), ifNull(equals(console_logs_log_entries.log_source, 'session_replay'), 0)))))
+  GROUP BY s.session_id
+  HAVING 1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_by_console_text.2
+  '''
+  SELECT s.session_id AS session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
+         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
+         dateDiff('SECOND', start_time, end_time) AS duration,
+         argMinMerge(s.first_url) AS first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
+         minus(duration, active_seconds) AS inactive_seconds,
+         sum(s.console_log_count) AS console_log_count,
+         sum(s.console_warn_count) AS console_warn_count,
+         sum(s.console_error_count) AS console_error_count
+  FROM session_replay_events AS s
+  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
+                                                                                                                                                                                                                                                                                                                                                                                                                        (SELECT console_logs_log_entries.log_source_id AS log_source_id
+                                                                                                                                                                                                                                                                                                                                                                                                                         FROM
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.message AS message, log_entries.log_source AS log_source
+                                                                                                                                                                                                                                                                                                                                                                                                                            FROM log_entries
+                                                                                                                                                                                                                                                                                                                                                                                                                            WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(and(ifNull(equals(console_logs_log_entries.level, 'info'), 0), ifNull(ilike(console_logs_log_entries.message, '%message 5%'), 0)), ifNull(equals(console_logs_log_entries.log_source, 'session_replay'), 0)))))
+  GROUP BY s.session_id
+  HAVING 1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_by_snapshot_source
   '''
   SELECT s.session_id AS session_id,
@@ -2739,6 +2853,82 @@
   '''
 # ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_with_console_warns.1
+  '''
+  SELECT s.session_id AS session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
+         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
+         dateDiff('SECOND', start_time, end_time) AS duration,
+         argMinMerge(s.first_url) AS first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
+         minus(duration, active_seconds) AS inactive_seconds,
+         sum(s.console_log_count) AS console_log_count,
+         sum(s.console_warn_count) AS console_warn_count,
+         sum(s.console_error_count) AS console_error_count
+  FROM session_replay_events AS s
+  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
+                                                                                                                                                                                                                                                                                                                                                                                                                        (SELECT console_logs_log_entries.log_source_id AS log_source_id
+                                                                                                                                                                                                                                                                                                                                                                                                                         FROM
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.log_source AS log_source
+                                                                                                                                                                                                                                                                                                                                                                                                                            FROM log_entries
+                                                                                                                                                                                                                                                                                                                                                                                                                            WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(ifNull(equals(console_logs_log_entries.level, 'info'), 0), ifNull(equals(console_logs_log_entries.log_source, 'session_replay'), 0)))))
+  GROUP BY s.session_id
+  HAVING 1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_with_mixed_console_counts
+  '''
+  SELECT s.session_id AS session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
+         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
+         dateDiff('SECOND', start_time, end_time) AS duration,
+         argMinMerge(s.first_url) AS first_url,
+         sum(s.click_count),
+         sum(s.keypress_count),
+         sum(s.mouse_activity_count),
+         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
+         minus(duration, active_seconds) AS inactive_seconds,
+         sum(s.console_log_count) AS console_log_count,
+         sum(s.console_warn_count) AS console_warn_count,
+         sum(s.console_error_count) AS console_error_count
+  FROM session_replay_events AS s
+  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
+                                                                                                                                                                                                                                                                                                                                                                                                                        (SELECT console_logs_log_entries.log_source_id AS log_source_id
+                                                                                                                                                                                                                                                                                                                                                                                                                         FROM
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.log_source AS log_source
+                                                                                                                                                                                                                                                                                                                                                                                                                            FROM log_entries
+                                                                                                                                                                                                                                                                                                                                                                                                                            WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(or(ifNull(equals(console_logs_log_entries.level, 'warn'), 0), ifNull(equals(console_logs_log_entries.level, 'error'), 0)), ifNull(equals(console_logs_log_entries.log_source, 'session_replay'), 0)))))
+  GROUP BY s.session_id
+  HAVING 1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_with_mixed_console_counts.1
   '''
   SELECT s.session_id AS session_id,
          any(s.team_id),

--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_filters.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_filters.ambr
@@ -2484,120 +2484,6 @@
                     max_bytes_before_external_group_by=0
   '''
 # ---
-# name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_by_console_text
-  '''
-  SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
-         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
-         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
-         dateDiff('SECOND', start_time, end_time) AS duration,
-         argMinMerge(s.first_url) AS first_url,
-         sum(s.click_count),
-         sum(s.keypress_count),
-         sum(s.mouse_activity_count),
-         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
-         minus(duration, active_seconds) AS inactive_seconds,
-         sum(s.console_log_count) AS console_log_count,
-         sum(s.console_warn_count) AS console_warn_count,
-         sum(s.console_error_count) AS console_error_count
-  FROM session_replay_events AS s
-  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
-                                                                                                                                                                                                                                                                                                                                                                                                                        (SELECT console_logs_log_entries.log_source_id AS log_source_id
-                                                                                                                                                                                                                                                                                                                                                                                                                         FROM
-                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.message AS message
-                                                                                                                                                                                                                                                                                                                                                                                                                            FROM log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                            WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE or(or(ifNull(equals(console_logs_log_entries.level, 'warn'), 0), ifNull(equals(console_logs_log_entries.level, 'error'), 0)), ifNull(equals(console_logs_log_entries.message, 'message 4'), 0)))))
-  GROUP BY s.session_id
-  HAVING 1
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0
-  '''
-# ---
-# name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_by_console_text.1
-  '''
-  SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
-         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
-         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
-         dateDiff('SECOND', start_time, end_time) AS duration,
-         argMinMerge(s.first_url) AS first_url,
-         sum(s.click_count),
-         sum(s.keypress_count),
-         sum(s.mouse_activity_count),
-         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
-         minus(duration, active_seconds) AS inactive_seconds,
-         sum(s.console_log_count) AS console_log_count,
-         sum(s.console_warn_count) AS console_warn_count,
-         sum(s.console_error_count) AS console_error_count
-  FROM session_replay_events AS s
-  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
-                                                                                                                                                                                                                                                                                                                                                                                                                        (SELECT console_logs_log_entries.log_source_id AS log_source_id
-                                                                                                                                                                                                                                                                                                                                                                                                                         FROM
-                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.message AS message
-                                                                                                                                                                                                                                                                                                                                                                                                                            FROM log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                            WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(or(ifNull(equals(console_logs_log_entries.level, 'warn'), 0), ifNull(equals(console_logs_log_entries.level, 'error'), 0)), ifNull(ilike(console_logs_log_entries.message, '%message 5%'), 0)))))
-  GROUP BY s.session_id
-  HAVING 1
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0
-  '''
-# ---
-# name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_by_console_text.2
-  '''
-  SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
-         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
-         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
-         dateDiff('SECOND', start_time, end_time) AS duration,
-         argMinMerge(s.first_url) AS first_url,
-         sum(s.click_count),
-         sum(s.keypress_count),
-         sum(s.mouse_activity_count),
-         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
-         minus(duration, active_seconds) AS inactive_seconds,
-         sum(s.console_log_count) AS console_log_count,
-         sum(s.console_warn_count) AS console_warn_count,
-         sum(s.console_error_count) AS console_error_count
-  FROM session_replay_events AS s
-  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
-                                                                                                                                                                                                                                                                                                                                                                                                                        (SELECT console_logs_log_entries.log_source_id AS log_source_id
-                                                                                                                                                                                                                                                                                                                                                                                                                         FROM
-                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.message AS message
-                                                                                                                                                                                                                                                                                                                                                                                                                            FROM log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                            WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(ifNull(equals(console_logs_log_entries.level, 'info'), 0), ifNull(ilike(console_logs_log_entries.message, '%message 5%'), 0)))))
-  GROUP BY s.session_id
-  HAVING 1
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0
-  '''
-# ---
 # name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_by_snapshot_source
   '''
   SELECT s.session_id AS session_id,
@@ -2683,10 +2569,10 @@
   WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
                                                                                                                                                                                                                                                                                                                                                                                                                         (SELECT console_logs_log_entries.log_source_id AS log_source_id
                                                                                                                                                                                                                                                                                                                                                                                                                          FROM
-                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.log_source AS log_source
                                                                                                                                                                                                                                                                                                                                                                                                                             FROM log_entries
                                                                                                                                                                                                                                                                                                                                                                                                                             WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE ifNull(equals(console_logs_log_entries.level, 'error'), 0))))
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(ifNull(equals(console_logs_log_entries.level, 'error'), 0), ifNull(equals(console_logs_log_entries.log_source, 'session_replay'), 0)))))
   GROUP BY s.session_id
   HAVING 1
   ORDER BY start_time DESC
@@ -2721,10 +2607,10 @@
   WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
                                                                                                                                                                                                                                                                                                                                                                                                                         (SELECT console_logs_log_entries.log_source_id AS log_source_id
                                                                                                                                                                                                                                                                                                                                                                                                                          FROM
-                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.log_source AS log_source
                                                                                                                                                                                                                                                                                                                                                                                                                             FROM log_entries
                                                                                                                                                                                                                                                                                                                                                                                                                             WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE ifNull(equals(console_logs_log_entries.level, 'info'), 0))))
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(ifNull(equals(console_logs_log_entries.level, 'info'), 0), ifNull(equals(console_logs_log_entries.log_source, 'session_replay'), 0)))))
   GROUP BY s.session_id
   HAVING 1
   ORDER BY start_time DESC
@@ -2759,10 +2645,10 @@
   WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
                                                                                                                                                                                                                                                                                                                                                                                                                         (SELECT console_logs_log_entries.log_source_id AS log_source_id
                                                                                                                                                                                                                                                                                                                                                                                                                          FROM
-                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.log_source AS log_source
                                                                                                                                                                                                                                                                                                                                                                                                                             FROM log_entries
                                                                                                                                                                                                                                                                                                                                                                                                                             WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE ifNull(equals(console_logs_log_entries.level, 'info'), 0))))
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(ifNull(equals(console_logs_log_entries.level, 'info'), 0), ifNull(equals(console_logs_log_entries.log_source, 'session_replay'), 0)))))
   GROUP BY s.session_id
   HAVING 1
   ORDER BY start_time DESC
@@ -2797,10 +2683,10 @@
   WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
                                                                                                                                                                                                                                                                                                                                                                                                                         (SELECT console_logs_log_entries.log_source_id AS log_source_id
                                                                                                                                                                                                                                                                                                                                                                                                                          FROM
-                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.log_source AS log_source
                                                                                                                                                                                                                                                                                                                                                                                                                             FROM log_entries
                                                                                                                                                                                                                                                                                                                                                                                                                             WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE ifNull(equals(console_logs_log_entries.level, 'warn'), 0))))
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(ifNull(equals(console_logs_log_entries.level, 'warn'), 0), ifNull(equals(console_logs_log_entries.log_source, 'session_replay'), 0)))))
   GROUP BY s.session_id
   HAVING 1
   ORDER BY start_time DESC
@@ -2835,10 +2721,10 @@
   WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
                                                                                                                                                                                                                                                                                                                                                                                                                         (SELECT console_logs_log_entries.log_source_id AS log_source_id
                                                                                                                                                                                                                                                                                                                                                                                                                          FROM
-                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.log_source AS log_source
                                                                                                                                                                                                                                                                                                                                                                                                                             FROM log_entries
                                                                                                                                                                                                                                                                                                                                                                                                                             WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE ifNull(equals(console_logs_log_entries.level, 'warn'), 0))))
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(ifNull(equals(console_logs_log_entries.level, 'warn'), 0), ifNull(equals(console_logs_log_entries.log_source, 'session_replay'), 0)))))
   GROUP BY s.session_id
   HAVING 1
   ORDER BY start_time DESC
@@ -2873,86 +2759,10 @@
   WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
                                                                                                                                                                                                                                                                                                                                                                                                                         (SELECT console_logs_log_entries.log_source_id AS log_source_id
                                                                                                                                                                                                                                                                                                                                                                                                                          FROM
-                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.log_source AS log_source
                                                                                                                                                                                                                                                                                                                                                                                                                             FROM log_entries
                                                                                                                                                                                                                                                                                                                                                                                                                             WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE ifNull(equals(console_logs_log_entries.level, 'info'), 0))))
-  GROUP BY s.session_id
-  HAVING 1
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0
-  '''
-# ---
-# name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_with_mixed_console_counts
-  '''
-  SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
-         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
-         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
-         dateDiff('SECOND', start_time, end_time) AS duration,
-         argMinMerge(s.first_url) AS first_url,
-         sum(s.click_count),
-         sum(s.keypress_count),
-         sum(s.mouse_activity_count),
-         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
-         minus(duration, active_seconds) AS inactive_seconds,
-         sum(s.console_log_count) AS console_log_count,
-         sum(s.console_warn_count) AS console_warn_count,
-         sum(s.console_error_count) AS console_error_count
-  FROM session_replay_events AS s
-  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
-                                                                                                                                                                                                                                                                                                                                                                                                                        (SELECT console_logs_log_entries.log_source_id AS log_source_id
-                                                                                                                                                                                                                                                                                                                                                                                                                         FROM
-                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level
-                                                                                                                                                                                                                                                                                                                                                                                                                            FROM log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                            WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE or(ifNull(equals(console_logs_log_entries.level, 'warn'), 0), ifNull(equals(console_logs_log_entries.level, 'error'), 0)))))
-  GROUP BY s.session_id
-  HAVING 1
-  ORDER BY start_time DESC
-  LIMIT 51
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    format_csv_allow_double_quotes=0,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0
-  '''
-# ---
-# name: TestSessionRecordingsListFromFilters.test_filter_for_recordings_with_mixed_console_counts.1
-  '''
-  SELECT s.session_id AS session_id,
-         any(s.team_id),
-         any(s.distinct_id),
-         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
-         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
-         dateDiff('SECOND', start_time, end_time) AS duration,
-         argMinMerge(s.first_url) AS first_url,
-         sum(s.click_count),
-         sum(s.keypress_count),
-         sum(s.mouse_activity_count),
-         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
-         minus(duration, active_seconds) AS inactive_seconds,
-         sum(s.console_log_count) AS console_log_count,
-         sum(s.console_warn_count) AS console_warn_count,
-         sum(s.console_error_count) AS console_error_count
-  FROM session_replay_events AS s
-  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
-                                                                                                                                                                                                                                                                                                                                                                                                                        (SELECT console_logs_log_entries.log_source_id AS log_source_id
-                                                                                                                                                                                                                                                                                                                                                                                                                         FROM
-                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level
-                                                                                                                                                                                                                                                                                                                                                                                                                            FROM log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                            WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE ifNull(equals(console_logs_log_entries.level, 'info'), 0))))
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(ifNull(equals(console_logs_log_entries.level, 'info'), 0), ifNull(equals(console_logs_log_entries.log_source, 'session_replay'), 0)))))
   GROUP BY s.session_id
   HAVING 1
   ORDER BY start_time DESC
@@ -3631,10 +3441,10 @@
   WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-11 13:46:23.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-25 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-01 13:46:23.000000', 6, 'UTC')), 0), in(s.session_id,
                                                                                                                                                                                                                                                                                                                                                                                                                         (SELECT console_logs_log_entries.log_source_id AS log_source_id
                                                                                                                                                                                                                                                                                                                                                                                                                          FROM
-                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.message AS message
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.message AS message, log_entries.log_source AS log_source
                                                                                                                                                                                                                                                                                                                                                                                                                             FROM log_entries
                                                                                                                                                                                                                                                                                                                                                                                                                             WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(ifNull(equals(console_logs_log_entries.level, 'warn'), 0), ifNull(equals(console_logs_log_entries.message, 'random'), 0)))))
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(and(ifNull(equals(console_logs_log_entries.level, 'warn'), 0), ifNull(equals(console_logs_log_entries.message, 'random'), 0)), ifNull(equals(console_logs_log_entries.log_source, 'session_replay'), 0)))))
   GROUP BY s.session_id
   HAVING 1
   ORDER BY start_time DESC
@@ -3669,10 +3479,10 @@
   WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-11 13:46:23.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-25 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-01 13:46:23.000000', 6, 'UTC')), 0), in(s.session_id,
                                                                                                                                                                                                                                                                                                                                                                                                                         (SELECT console_logs_log_entries.log_source_id AS log_source_id
                                                                                                                                                                                                                                                                                                                                                                                                                          FROM
-                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.message AS message
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT log_entries.log_source_id AS log_source_id, log_entries.level AS level, log_entries.message AS message, log_entries.log_source AS log_source
                                                                                                                                                                                                                                                                                                                                                                                                                             FROM log_entries
                                                                                                                                                                                                                                                                                                                                                                                                                             WHERE and(equals(log_entries.team_id, 2), equals(log_entries.log_source, 'session_replay'))) AS console_logs_log_entries
-                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE or(ifNull(equals(console_logs_log_entries.level, 'warn'), 0), ifNull(equals(console_logs_log_entries.message, 'random'), 0)))))
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(or(ifNull(equals(console_logs_log_entries.level, 'warn'), 0), ifNull(equals(console_logs_log_entries.message, 'random'), 0)), ifNull(equals(console_logs_log_entries.log_source, 'session_replay'), 0)))))
   GROUP BY s.session_id
   HAVING 1
   ORDER BY start_time DESC


### PR DESCRIPTION
## Problem

Originally reported in https://posthog.com/questions/a-server-error-cccured-when-filtering-in-session-replay

## Changes

I think I missed some things during a bad merge around https://github.com/PostHog/posthog/pull/24292

- We should be using the names of the columns in the `log_entries` DB

Noticed a couple of other things as I went:
- Better handling of the names for events so that they are centralised in `taxonomy.tsx`
- Limit the DB query to `log_source = 'session_replay'`

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Updated the query snapshots