### PR TITLE
fix(data-warehouse): limiting logic based on schema id

### DIFF
--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -471,7 +471,11 @@ export const billingLogic = kea<billingLogicType>([
                     title: 'Usage limit exceeded',
                     message: `You have exceeded the usage limit for ${productOverLimit.name}. Please 
                         ${productOverLimit.subscribed ? 'increase your billing limit' : 'upgrade your plan'}
-                        or data loss may occur.`,
+                        or ${
+                            productOverLimit.name === 'Data warehouse'
+                                ? 'data will not be synced.'
+                                : 'data loss may occur.'
+                        }.`,
                     dismissKey: 'usage-limit-exceeded',
                 })
                 return

--- a/posthog/tasks/test/test_warehouse.py
+++ b/posthog/tasks/test/test_warehouse.py
@@ -6,7 +6,7 @@ from posthog.tasks.warehouse import (
     validate_data_warehouse_table_columns,
     capture_external_data_rows_synced,
 )
-from posthog.warehouse.models import ExternalDataSource, ExternalDataJob
+from posthog.warehouse.models import ExternalDataSource, ExternalDataJob, ExternalDataSchema
 from freezegun import freeze_time
 import datetime
 
@@ -35,14 +35,29 @@ class TestWarehouse(APIBaseTest):
             source_type="Stripe",
         )
 
+        schema = ExternalDataSchema.objects.create(
+            source=source,
+            name="test_schema",
+            team=self.team,
+            status="Running",
+        )
+
         job = ExternalDataJob.objects.create(
-            pipeline=source, workflow_id="fake_workflow_id", team=self.team, status="Running", rows_synced=100000
+            pipeline=source,
+            workflow_id="fake_workflow_id",
+            team=self.team,
+            status="Running",
+            rows_synced=100000,
+            schema=schema,
         )
 
         check_synced_row_limits_of_team(self.team.pk)
 
         source.refresh_from_db()
         self.assertEqual(source.status, ExternalDataSource.Status.PAUSED)
+
+        schema.refresh_from_db()
+        self.assertEqual(schema.status, ExternalDataSchema.Status.PAUSED)
 
         job.refresh_from_db()
         self.assertEqual(job.status, ExternalDataJob.Status.CANCELLED)
@@ -70,14 +85,29 @@ class TestWarehouse(APIBaseTest):
             source_type="Stripe",
         )
 
+        schema = ExternalDataSchema.objects.create(
+            source=source,
+            name="test_schema",
+            team=self.team,
+            status="Running",
+        )
+
         job = ExternalDataJob.objects.create(
-            pipeline=source, workflow_id="fake_workflow_id", team=self.team, status="Running", rows_synced=100000
+            pipeline=source,
+            workflow_id="fake_workflow_id",
+            team=self.team,
+            status="Running",
+            rows_synced=100000,
+            schema=schema,
         )
 
         check_synced_row_limits_of_team(self.team.pk)
 
         source.refresh_from_db()
         self.assertEqual(source.status, ExternalDataSource.Status.PAUSED)
+
+        schema.refresh_from_db()
+        self.assertEqual(schema.status, ExternalDataSchema.Status.PAUSED)
 
         job.refresh_from_db()
         self.assertEqual(job.status, ExternalDataJob.Status.CANCELLED)

--- a/posthog/tasks/warehouse.py
+++ b/posthog/tasks/warehouse.py
@@ -8,7 +8,7 @@ from posthog.warehouse.data_load.service import (
     pause_external_data_schedule,
     unpause_external_data_schedule,
 )
-from posthog.warehouse.models import ExternalDataJob, ExternalDataSource
+from posthog.warehouse.models import ExternalDataJob, ExternalDataSource, ExternalDataSchema
 from posthog.ph_client import get_ph_client
 from posthog.models import Team
 from django.db.models import Q
@@ -62,6 +62,7 @@ def check_synced_row_limits_of_team(team_id: int) -> None:
     total_rows_synced = sum(rows_synced_list)
 
     if team_model.api_token in limited_team_tokens_rows_synced or total_rows_synced > MONTHLY_LIMIT:
+        # stop active jobs
         running_jobs = ExternalDataJob.objects.filter(team_id=team_id, status=ExternalDataJob.Status.RUNNING)
         for job in running_jobs:
             try:
@@ -77,18 +78,31 @@ def check_synced_row_limits_of_team(team_id: int) -> None:
             job.status = ExternalDataJob.Status.CANCELLED
             job.save()
 
-            job.pipeline.status = ExternalDataSource.Status.PAUSED
-            job.pipeline.save()
-    else:
-        all_sources = ExternalDataSource.objects.filter(team_id=team_id, status=ExternalDataSource.Status.PAUSED)
-        for source in all_sources:
+            job.schema.status = ExternalDataSchema.Status.PAUSED
+            job.schema.save()
+
+        # pause active schemas
+        all_schemas = ExternalDataSchema.objects.filter(
+            team_id=team_id, status__in=[ExternalDataSchema.Status.COMPLETED, ExternalDataSchema.Status.RUNNING]
+        )
+        for schema in all_schemas:
             try:
-                unpause_external_data_schedule(str(source.id))
+                pause_external_data_schedule(str(schema.id))
+            except Exception as e:
+                logger.exception("Could not pause external data schedule", exc_info=e)
+
+            schema.status = ExternalDataSchema.Status.PAUSED
+            schema.save()
+    else:
+        all_schemas = ExternalDataSchema.objects.filter(team_id=team_id, status=ExternalDataSchema.Status.PAUSED)
+        for schema in all_schemas:
+            try:
+                unpause_external_data_schedule(str(schema.id))
             except Exception as e:
                 logger.exception("Could not unpause external data schedule", exc_info=e)
 
-            source.status = ExternalDataSource.Status.COMPLETED
-            source.save()
+            schema.status = ExternalDataSchema.Status.COMPLETED
+            schema.save()
 
 
 @shared_task(ignore_result=True)

--- a/posthog/tasks/warehouse.py
+++ b/posthog/tasks/warehouse.py
@@ -78,8 +78,9 @@ def check_synced_row_limits_of_team(team_id: int) -> None:
             job.status = ExternalDataJob.Status.CANCELLED
             job.save()
 
-            job.schema.status = ExternalDataSchema.Status.PAUSED
-            job.schema.save()
+            if job.schema:
+                job.schema.status = ExternalDataSchema.Status.PAUSED
+                job.schema.save()
 
         # pause active schemas
         all_schemas = ExternalDataSchema.objects.filter(

--- a/posthog/tasks/warehouse.py
+++ b/posthog/tasks/warehouse.py
@@ -78,6 +78,9 @@ def check_synced_row_limits_of_team(team_id: int) -> None:
             job.status = ExternalDataJob.Status.CANCELLED
             job.save()
 
+            job.pipeline.status = ExternalDataSource.Status.PAUSED
+            job.pipeline.save()
+
             if job.schema:
                 job.schema.status = ExternalDataSchema.Status.PAUSED
                 job.schema.save()
@@ -94,6 +97,9 @@ def check_synced_row_limits_of_team(team_id: int) -> None:
 
             schema.status = ExternalDataSchema.Status.PAUSED
             schema.save()
+
+            schema.source.status = ExternalDataSource.Status.PAUSED
+            schema.source.save()
     else:
         all_schemas = ExternalDataSchema.objects.filter(team_id=team_id, status=ExternalDataSchema.Status.PAUSED)
         for schema in all_schemas:
@@ -104,6 +110,9 @@ def check_synced_row_limits_of_team(team_id: int) -> None:
 
             schema.status = ExternalDataSchema.Status.COMPLETED
             schema.save()
+
+            schema.source.status = ExternalDataSource.Status.RUNNING
+            schema.source.save()
 
 
 @shared_task(ignore_result=True)

--- a/posthog/warehouse/api/external_data_schema.py
+++ b/posthog/warehouse/api/external_data_schema.py
@@ -15,7 +15,7 @@ from posthog.api.log_entries import LogEntryMixin
 
 from posthog.warehouse.data_load.service import (
     external_data_workflow_exists,
-    is_any_external_data_job_paused,
+    is_any_external_data_schema_paused,
     sync_external_data_job_workflow,
     pause_external_data_schedule,
     trigger_external_data_workflow,
@@ -213,10 +213,10 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.
     def reload(self, request: Request, *args: Any, **kwargs: Any):
         instance: ExternalDataSchema = self.get_object()
 
-        if is_any_external_data_job_paused(self.team_id):
+        if is_any_external_data_schema_paused(self.team_id):
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
-                data={"message": "Monthly sync limit reached. Please contact PostHog support to increase your limit."},
+                data={"message": "Monthly sync limit reached. Please increase your billing limit to resume syncing."},
             )
 
         try:
@@ -236,10 +236,10 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.
     def resync(self, request: Request, *args: Any, **kwargs: Any):
         instance: ExternalDataSchema = self.get_object()
 
-        if is_any_external_data_job_paused(self.team_id):
+        if is_any_external_data_schema_paused(self.team_id):
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
-                data={"message": "Monthly sync limit reached. Please contact PostHog support to increase your limit."},
+                data={"message": "Monthly sync limit reached. Please increase your billing limit to resume syncing."},
             )
 
         latest_running_job = (

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -16,7 +16,7 @@ from posthog.warehouse.data_load.service import (
     delete_external_data_schedule,
     cancel_external_data_workflow,
     delete_data_import_folder,
-    is_any_external_data_job_paused,
+    is_any_external_data_schema_paused,
     trigger_external_data_source_workflow,
 )
 from posthog.warehouse.models import ExternalDataSource, ExternalDataSchema, ExternalDataJob
@@ -258,10 +258,10 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             elif self.prefix_exists(source_type, prefix):
                 return Response(status=status.HTTP_400_BAD_REQUEST, data={"message": "Prefix already exists"})
 
-        if is_any_external_data_job_paused(self.team_id):
+        if is_any_external_data_schema_paused(self.team_id):
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
-                data={"message": "Monthly sync limit reached. Please contact PostHog support to increase your limit."},
+                data={"message": "Monthly sync limit reached. Please increase your billing limit to resume syncing."},
             )
 
         # TODO: remove dummy vars
@@ -635,10 +635,10 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def reload(self, request: Request, *args: Any, **kwargs: Any):
         instance: ExternalDataSource = self.get_object()
 
-        if is_any_external_data_job_paused(self.team_id):
+        if is_any_external_data_schema_paused(self.team_id):
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
-                data={"message": "Monthly sync limit reached. Please contact PostHog support to increase your limit."},
+                data={"message": "Monthly sync limit reached. Please increase your billing limit to resume syncing."},
             )
 
         try:

--- a/posthog/warehouse/data_load/service.py
+++ b/posthog/warehouse/data_load/service.py
@@ -188,11 +188,11 @@ def delete_data_import_folder(folder_path: str):
     s3.delete(f"{bucket_name}/{folder_path}", recursive=True)
 
 
-def is_any_external_data_job_paused(team_id: int) -> bool:
-    from posthog.warehouse.models import ExternalDataSource
+def is_any_external_data_schema_paused(team_id: int) -> bool:
+    from posthog.warehouse.models import ExternalDataSchema
 
     return (
-        ExternalDataSource.objects.exclude(deleted=True)
-        .filter(team_id=team_id, status=ExternalDataSource.Status.PAUSED)
+        ExternalDataSchema.objects.exclude(deleted=True)
+        .filter(team_id=team_id, status=ExternalDataSchema.Status.PAUSED)
         .exists()
     )


### PR DESCRIPTION
## Problem

- after switching sources to schemas, the limiting logic was not updated

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- limiting logic all based on schema id so the scheduels should be stopped
- triggering reload will be blocked if limits exist and the schedule for the workflow will be paused so no new runs will happen

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
