### PR TITLE
fix: custom name for horizontal bar chart appears twice

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -743,7 +743,7 @@ export function LineGraph_({
                                     d.compareLabels?.[i],
                                 ]
                             } else if (d.breakdownLabels?.[i]) {
-                                labelDescriptors = [d.breakdownLabels[i], d.compareLabels?.[i]]
+                                labelDescriptors = [d.actions?.[i]?.name, d.breakdownLabels[i], d.compareLabels?.[i]]
                             } else if (d.labels?.[i]) {
                                 labelDescriptors = [d.labels[i], d.compareLabels?.[i]]
                             } else {

--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -48,22 +48,12 @@ export function ActionsHorizontalBar({ showPersonsModal = true }: ChartParams): 
                 personsValues: _data.map((item) => item.persons),
                 breakdownValues: _data.map((item) => item.breakdown_value),
                 breakdownLabels: _data.map((item) => {
-                    const itemLabel = item.action
-                        ? item.action.custom_name ?? item.action.name ?? item.action.id
-                        : item.label
-
-                    if (!item.breakdown_value) {
-                        return itemLabel
-                    }
-
-                    const breakdownLabel = formatBreakdownLabel(
+                    return formatBreakdownLabel(
                         item.breakdown_value,
                         breakdownFilter,
                         cohorts,
                         formatPropertyValueForDisplay
                     )
-
-                    return `${itemLabel} - ${breakdownLabel}`
                 }),
                 compareLabels: _data.map((item) => item.compare_label),
                 backgroundColor: colorList,


### PR DESCRIPTION
## Problem

As described in https://github.com/PostHog/posthog/issues/24699, when a series was given a custom name, the custom name was displayed twice in the horizontal bar chart.  After investigation, it seems that this was a regression introduced by 5a571d7.

This PR reverts that change (which fixes https://github.com/PostHog/posthog/issues/24699), and solves the problem described in https://github.com/PostHog/posthog/pull/24603 in a different manner. As there was already a place in the `<LineGraph />` which was handling the Y axis label rendering, the fix was added there instead.

## Changes

Previous:

![image](https://github.com/user-attachments/assets/892c8212-95a8-445c-bee2-ab36292e8580)

This PR:

![image](https://github.com/user-attachments/assets/7a73ebd4-d549-4eaf-bceb-919508ccd4ad)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Visually tested the following scenarios:

### ✅ no custom name, no breakdown

![image](https://github.com/user-attachments/assets/b340595c-f87f-4f3e-8436-834f39d3f237)

### ✅ no custom name, with breakdown

![image](https://github.com/user-attachments/assets/5b4ab10b-bdd2-4180-afa4-b0283179c18c)

### ✅ custom name, no breakdown

![image](https://github.com/user-attachments/assets/6c7ac2fe-5a44-415a-85c0-f476b6537201)

### ✅ custom name, with breakdown

![image](https://github.com/user-attachments/assets/d7375e98-a8bf-4f80-8b4f-403432f6a940)
