### PR TITLE
fix(capture): preempt kafka message rejection at unzip time

### DIFF
--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -27,6 +27,7 @@ pub struct State {
     pub timesource: Arc<dyn TimeSource + Send + Sync>,
     pub redis: Arc<dyn Client + Send + Sync>,
     pub billing_limiter: RedisLimiter,
+    pub event_size_limit: usize,
 }
 
 async fn index() -> &'static str {
@@ -47,12 +48,14 @@ pub fn router<
     metrics: bool,
     capture_mode: CaptureMode,
     concurrency_limit: Option<usize>,
+    event_size_limit: usize,
 ) -> Router {
     let state = State {
         sink: Arc::new(sink),
         timesource: Arc::new(timesource),
         redis,
         billing_limiter,
+        event_size_limit,
     };
 
     // Very permissive CORS policy, as old SDK versions

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -31,6 +31,8 @@ where
     )
     .expect("failed to create billing limiter");
 
+    let event_max_bytes = config.kafka.kafka_producer_message_max_bytes as usize;
+
     let app = if config.print_sink {
         // Print sink is only used for local debug, don't allow a container with it to run on prod
         liveness
@@ -48,6 +50,7 @@ where
             config.export_prometheus,
             config.capture_mode,
             config.concurrency_limit,
+            event_max_bytes,
         )
     } else {
         let sink_liveness = liveness
@@ -90,6 +93,7 @@ where
             config.export_prometheus,
             config.capture_mode,
             config.concurrency_limit,
+            event_max_bytes,
         )
     };
 

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -77,12 +77,12 @@ async fn handle_common(
                     tracing::error!("failed to decode form data: {}", e);
                     CaptureError::RequestDecodingError(String::from("missing data field"))
                 })?;
-            RawRequest::from_bytes(payload.into())
+            RawRequest::from_bytes(payload.into(), state.event_size_limit)
         }
         ct => {
             tracing::Span::current().record("content_type", ct);
 
-            RawRequest::from_bytes(body)
+            RawRequest::from_bytes(body, state.event_size_limit)
         }
     }?;
 

--- a/rust/capture/tests/django_compat.rs
+++ b/rust/capture/tests/django_compat.rs
@@ -113,6 +113,7 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
             false,
             CaptureMode::Events,
             None,
+            25 * 1024 * 1024,
         );
 
         let client = TestClient::new(app);


### PR DESCRIPTION
Try not to hold events so large Kafka will drop them anyway, so that if a bunch of those come together memory usage won't spike above what we expect give concurrency and event size limits.