### PR TITLE
chore: expose more kafka settings to capture sink

### DIFF
--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -89,4 +89,8 @@ pub struct KafkaConfig {
     pub kafka_tls: bool,
     #[envconfig(default = "")]
     pub kafka_client_id: String,
+    #[envconfig(default = "60000")]
+    pub kafka_metadata_max_age_ms: u32,
+    #[envconfig(default = "2")]
+    pub kafka_producer_max_retries: u32,
 }

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -129,8 +129,14 @@ impl KafkaSink {
             .set("bootstrap.servers", &config.kafka_hosts)
             .set("statistics.interval.ms", "10000")
             .set("partitioner", "murmur2_random") // Compatibility with python-kafka
-            .set("metadata.max.age.ms", config.kafka_metadata_max_age_ms.to_string())
-            .set("message.send.max.retries", config.kafka_producer_max_retries.to_string())
+            .set(
+                "metadata.max.age.ms",
+                config.kafka_metadata_max_age_ms.to_string(),
+            )
+            .set(
+                "message.send.max.retries",
+                config.kafka_producer_max_retries.to_string(),
+            )
             .set("linger.ms", config.kafka_producer_linger_ms.to_string())
             .set(
                 "message.max.bytes",

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -129,6 +129,8 @@ impl KafkaSink {
             .set("bootstrap.servers", &config.kafka_hosts)
             .set("statistics.interval.ms", "10000")
             .set("partitioner", "murmur2_random") // Compatibility with python-kafka
+            .set("metadata.max.age.ms", config.kafka_metadata_max_age_ms.to_string())
+            .set("message.send.max.retries", config.kafka_producer_max_retries.to_string())
             .set("linger.ms", config.kafka_producer_linger_ms.to_string())
             .set(
                 "message.max.bytes",
@@ -363,6 +365,8 @@ mod tests {
             kafka_heatmaps_topic: "events_plugin_ingestion".to_string(),
             kafka_tls: false,
             kafka_client_id: "".to_string(),
+            kafka_metadata_max_age_ms: 60000,
+            kafka_producer_max_retries: 2,
         };
         let sink = KafkaSink::new(config, handle, limiter).expect("failed to create sink");
         (cluster, sink)

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -51,6 +51,8 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
         kafka_heatmaps_topic: "events_plugin_ingestion".to_string(),
         kafka_tls: false,
         kafka_client_id: "".to_string(),
+        kafka_metadata_max_age_ms: 60000,
+        kafka_producer_max_retries: 2,
     },
     otel_url: None,
     otel_sampling_rate: 0.0,


### PR DESCRIPTION
## Problem

we get quite a few transient errors and these are 2 options for solving them:

1. the metadata refresh means producers stay up to date with brokers coming+going quicker, warpstream recommend this is set to between 20000 and 60000

2. max retries - considering either increasing this to reduce 503s, or decreasing it to reduce memory spikes. 2 is the default

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
