### PR TITLE
feat(web-analytics): Improve the outbound link clicks tile

### DIFF
--- a/frontend/src/queries/nodes/DataTable/queryFeatures.ts
+++ b/frontend/src/queries/nodes/DataTable/queryFeatures.ts
@@ -5,6 +5,7 @@ import {
     isHogQLQuery,
     isPersonsNode,
     isSessionAttributionExplorerQuery,
+    isWebExternalClicksQuery,
     isWebGoalsQuery,
     isWebOverviewQuery,
     isWebStatsTableQuery,
@@ -62,6 +63,7 @@ export function getQueryFeatures(query: Node): Set<QueryFeature> {
     if (
         isWebOverviewQuery(query) ||
         isWebTopClicksQuery(query) ||
+        isWebExternalClicksQuery(query) ||
         isWebStatsTableQuery(query) ||
         isWebGoalsQuery(query)
     ) {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -495,6 +495,9 @@
                     "$ref": "#/definitions/WebStatsTableQuery"
                 },
                 {
+                    "$ref": "#/definitions/WebExternalClicksTableQuery"
+                },
+                {
                     "$ref": "#/definitions/WebTopClicksQuery"
                 },
                 {
@@ -2035,6 +2038,92 @@
             ],
             "type": "object"
         },
+        "CachedWebExternalClicksTableQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "cache_key": {
+                    "type": "string"
+                },
+                "cache_target_age": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "calculation_trigger": {
+                    "description": "What triggered the calculation of the query, leave empty if user/immediate",
+                    "type": "string"
+                },
+                "columns": {
+                    "items": {},
+                    "type": "array"
+                },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hasMore": {
+                    "type": "boolean"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "is_cached": {
+                    "type": "boolean"
+                },
+                "last_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "next_allowed_client_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "offset": {
+                    "type": "integer"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "results": {
+                    "items": {},
+                    "type": "array"
+                },
+                "samplingRate": {
+                    "$ref": "#/definitions/SamplingRate"
+                },
+                "timezone": {
+                    "type": "string"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                },
+                "types": {
+                    "items": {},
+                    "type": "array"
+                }
+            },
+            "required": [
+                "cache_key",
+                "is_cached",
+                "last_refresh",
+                "next_allowed_client_refresh",
+                "results",
+                "timezone"
+            ],
+            "type": "object"
+        },
         "CachedWebGoalsQueryResponse": {
             "additionalProperties": false,
             "properties": {
@@ -2909,6 +2998,60 @@
                                     "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
                                     "type": "string"
                                 },
+                                "hasMore": {
+                                    "type": "boolean"
+                                },
+                                "hogql": {
+                                    "description": "Generated HogQL query.",
+                                    "type": "string"
+                                },
+                                "limit": {
+                                    "type": "integer"
+                                },
+                                "modifiers": {
+                                    "$ref": "#/definitions/HogQLQueryModifiers",
+                                    "description": "Modifiers used when performing the query"
+                                },
+                                "offset": {
+                                    "type": "integer"
+                                },
+                                "query_status": {
+                                    "$ref": "#/definitions/QueryStatus",
+                                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                                },
+                                "results": {
+                                    "items": {},
+                                    "type": "array"
+                                },
+                                "samplingRate": {
+                                    "$ref": "#/definitions/SamplingRate"
+                                },
+                                "timings": {
+                                    "description": "Measured timings for different parts of the query generation process",
+                                    "items": {
+                                        "$ref": "#/definitions/QueryTiming"
+                                    },
+                                    "type": "array"
+                                },
+                                "types": {
+                                    "items": {},
+                                    "type": "array"
+                                }
+                            },
+                            "required": ["results"],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "columns": {
+                                    "items": {},
+                                    "type": "array"
+                                },
+                                "error": {
+                                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                                    "type": "string"
+                                },
                                 "hogql": {
                                     "description": "Generated HogQL query.",
                                     "type": "string"
@@ -3228,6 +3371,9 @@
                         },
                         {
                             "$ref": "#/definitions/WebStatsTableQuery"
+                        },
+                        {
+                            "$ref": "#/definitions/WebExternalClicksTableQuery"
                         },
                         {
                             "$ref": "#/definitions/WebTopClicksQuery"
@@ -6725,6 +6871,7 @@
                 "WebOverviewQuery",
                 "WebTopClicksQuery",
                 "WebStatsTableQuery",
+                "WebExternalClicksTableQuery",
                 "WebGoalsQuery",
                 "DatabaseSchemaQuery"
             ],
@@ -7732,6 +7879,60 @@
                             "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
                             "type": "string"
                         },
+                        "hasMore": {
+                            "type": "boolean"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "limit": {
+                            "type": "integer"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "offset": {
+                            "type": "integer"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "results": {
+                            "items": {},
+                            "type": "array"
+                        },
+                        "samplingRate": {
+                            "$ref": "#/definitions/SamplingRate"
+                        },
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        },
+                        "types": {
+                            "items": {},
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "columns": {
+                            "items": {},
+                            "type": "array"
+                        },
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
                         "hogql": {
                             "description": "Generated HogQL query.",
                             "type": "string"
@@ -8158,6 +8359,60 @@
                             "items": {
                                 "$ref": "#/definitions/QueryTiming"
                             },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "columns": {
+                            "items": {},
+                            "type": "array"
+                        },
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hasMore": {
+                            "type": "boolean"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "limit": {
+                            "type": "integer"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "offset": {
+                            "type": "integer"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "results": {
+                            "items": {},
+                            "type": "array"
+                        },
+                        "samplingRate": {
+                            "$ref": "#/definitions/SamplingRate"
+                        },
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        },
+                        "types": {
+                            "items": {},
                             "type": "array"
                         }
                     },
@@ -8797,6 +9052,9 @@
                 },
                 {
                     "$ref": "#/definitions/WebStatsTableQuery"
+                },
+                {
+                    "$ref": "#/definitions/WebExternalClicksTableQuery"
                 },
                 {
                     "$ref": "#/definitions/WebTopClicksQuery"
@@ -10418,6 +10676,109 @@
                 "$ref": "#/definitions/WebAnalyticsPropertyFilter"
             },
             "type": "array"
+        },
+        "WebExternalClicksTableQuery": {
+            "additionalProperties": false,
+            "properties": {
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "filterTestAccounts": {
+                    "type": "boolean"
+                },
+                "kind": {
+                    "const": "WebExternalClicksTableQuery",
+                    "type": "string"
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "properties": {
+                    "$ref": "#/definitions/WebAnalyticsPropertyFilters"
+                },
+                "response": {
+                    "$ref": "#/definitions/WebExternalClicksTableQueryResponse"
+                },
+                "sampling": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "forceSamplingRate": {
+                            "$ref": "#/definitions/SamplingRate"
+                        }
+                    },
+                    "type": "object"
+                },
+                "stripQueryParams": {
+                    "type": "boolean"
+                },
+                "useSessionsTable": {
+                    "deprecated": "ignored, always treated as enabled *",
+                    "type": "boolean"
+                }
+            },
+            "required": ["kind", "properties"],
+            "type": "object"
+        },
+        "WebExternalClicksTableQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "columns": {
+                    "items": {},
+                    "type": "array"
+                },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hasMore": {
+                    "type": "boolean"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "offset": {
+                    "type": "integer"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "results": {
+                    "items": {},
+                    "type": "array"
+                },
+                "samplingRate": {
+                    "$ref": "#/definitions/SamplingRate"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                },
+                "types": {
+                    "items": {},
+                    "type": "array"
+                }
+            },
+            "required": ["results"],
+            "type": "object"
         },
         "WebGoalsQuery": {
             "additionalProperties": false,

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -96,6 +96,7 @@ export enum NodeKind {
     WebOverviewQuery = 'WebOverviewQuery',
     WebTopClicksQuery = 'WebTopClicksQuery',
     WebStatsTableQuery = 'WebStatsTableQuery',
+    WebExternalClicksTableQuery = 'WebExternalClicksTableQuery',
     WebGoalsQuery = 'WebGoalsQuery',
 
     // Database metadata
@@ -117,6 +118,7 @@ export type AnyDataNode =
     | HogQLAutocomplete
     | WebOverviewQuery
     | WebStatsTableQuery
+    | WebExternalClicksTableQuery
     | WebTopClicksQuery
     | WebGoalsQuery
     | SessionAttributionExplorerQuery
@@ -143,6 +145,7 @@ export type QuerySchema =
     | HogQLAutocomplete
     | WebOverviewQuery
     | WebStatsTableQuery
+    | WebExternalClicksTableQuery
     | WebTopClicksQuery
     | WebGoalsQuery
     | SessionAttributionExplorerQuery
@@ -563,6 +566,7 @@ export interface DataTableNode
                     | HogQLQuery
                     | WebOverviewQuery
                     | WebStatsTableQuery
+                    | WebExternalClicksTableQuery
                     | WebTopClicksQuery
                     | WebGoalsQuery
                     | SessionAttributionExplorerQuery
@@ -582,6 +586,7 @@ export interface DataTableNode
         | HogQLQuery
         | WebOverviewQuery
         | WebStatsTableQuery
+        | WebExternalClicksTableQuery
         | WebTopClicksQuery
         | WebGoalsQuery
         | SessionAttributionExplorerQuery
@@ -1414,6 +1419,22 @@ export interface WebStatsTableQueryResponse extends AnalyticsQueryResponseBase<u
     offset?: integer
 }
 export type CachedWebStatsTableQueryResponse = CachedQueryResponse<WebStatsTableQueryResponse>
+
+export interface WebExternalClicksTableQuery extends WebAnalyticsQueryBase<WebExternalClicksTableQueryResponse> {
+    kind: NodeKind.WebExternalClicksTableQuery
+    limit?: integer
+    stripQueryParams?: boolean
+}
+export interface WebExternalClicksTableQueryResponse extends AnalyticsQueryResponseBase<unknown[]> {
+    types?: unknown[]
+    columns?: unknown[]
+    hogql?: string
+    samplingRate?: SamplingRate
+    hasMore?: boolean
+    limit?: integer
+    offset?: integer
+}
+export type CachedWebExternalClicksTableQueryResponse = CachedQueryResponse<WebExternalClicksTableQueryResponse>
 
 export interface WebGoalsQuery extends WebAnalyticsQueryBase<WebGoalsQueryResponse> {
     kind: NodeKind.WebGoalsQuery

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -126,6 +126,10 @@ export function isWebStatsTableQuery(node?: Record<string, any> | null): node is
     return node?.kind === NodeKind.WebStatsTableQuery
 }
 
+export function isWebExternalClicksQuery(node?: Record<string, any> | null): boolean {
+    return node?.kind === NodeKind.WebExternalClicksTableQuery
+}
+
 export function isWebTopClicksQuery(node?: Record<string, any> | null): node is WebTopClicksQuery {
     return node?.kind === NodeKind.WebTopClicksQuery
 }

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -305,6 +305,12 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
         icon: IconPieChart,
         inMenu: true,
     },
+    [NodeKind.WebExternalClicksTableQuery]: {
+        name: 'External click urls',
+        description: 'View clicks on external links',
+        icon: IconPieChart,
+        inMenu: true,
+    },
     [NodeKind.HogQuery]: {
         name: 'Hog',
         description: 'Hog query',

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -530,7 +530,7 @@ export const WebExternalClicksTile = ({
                 <div className="flex flex-row items-center space-x-2">
                     <LemonSwitch
                         label="Strip query parameters"
-                        checked={!!shouldStripQueryParams}
+                        checked={shouldStripQueryParams}
                         onChange={setShouldStripQueryParams}
                         className="h-full"
                     />

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -190,6 +190,11 @@ export const webAnalyticsDataTableQueryContext: QueryContext = {
             render: NumericCell,
             align: 'right',
         },
+        clicks: {
+            title: 'Clicks',
+            render: NumericCell,
+            align: 'right',
+        },
         visitors: {
             title: 'Visitors',
             render: NumericCell,
@@ -509,6 +514,37 @@ export const WebGoalsTile = ({
         </div>
     )
 }
+
+export const WebExternalClicksTile = ({
+    query,
+    insightProps,
+}: {
+    query: DataTableNode
+    insightProps: InsightLogicProps
+}): JSX.Element | null => {
+    const { shouldStripQueryParams } = useValues(webAnalyticsLogic)
+    const { setShouldStripQueryParams } = useActions(webAnalyticsLogic)
+    return (
+        <div className="border rounded bg-bg-light flex-1 flex flex-col">
+            <div className="flex flex-row items-center justify-end m-2 mr-4">
+                <div className="flex flex-row items-center space-x-2">
+                    <LemonSwitch
+                        label={
+                            <div className="flex flex-row space-x-2">
+                                <span>Strip query parameters</span>
+                            </div>
+                        }
+                        checked={!!shouldStripQueryParams}
+                        onChange={setShouldStripQueryParams}
+                        className="h-full"
+                    />
+                </div>
+            </div>
+            <Query query={query} readOnly={true} context={{ ...webAnalyticsDataTableQueryContext, insightProps }} />
+        </div>
+    )
+}
+
 export const WebQuery = ({
     query,
     showIntervalSelect,
@@ -529,6 +565,9 @@ export const WebQuery = ({
                 showPathCleaningControls={showPathCleaningControls}
             />
         )
+    }
+    if (query.kind === NodeKind.DataTableNode && query.source.kind === NodeKind.WebExternalClicksTableQuery) {
+        return <WebExternalClicksTile query={query} insightProps={insightProps} />
     }
     if (query.kind === NodeKind.InsightVizNode) {
         return <WebStatsTrendTile query={query} showIntervalTile={showIntervalSelect} insightProps={insightProps} />

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -529,11 +529,7 @@ export const WebExternalClicksTile = ({
             <div className="flex flex-row items-center justify-end m-2 mr-4">
                 <div className="flex flex-row items-center space-x-2">
                     <LemonSwitch
-                        label={
-                            <div className="flex flex-row space-x-2">
-                                <span>Strip query parameters</span>
-                            </div>
-                        }
+                        label="Strip query parameters"
                         checked={!!shouldStripQueryParams}
                         onChange={setShouldStripQueryParams}
                         className="h-full"

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -246,6 +246,9 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         setShouldFilterTestAccounts: (shouldFilterTestAccounts: boolean) => ({
             shouldFilterTestAccounts,
         }),
+        setShouldStripQueryParams: (shouldStripQueryParams: boolean) => ({
+            shouldStripQueryParams,
+        }),
         setStateFromUrl: (state: {
             filters: WebAnalyticsPropertyFilters
             dateFrom: string | null
@@ -457,6 +460,13 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 setShouldFilterTestAccounts: (_, { shouldFilterTestAccounts }) => shouldFilterTestAccounts,
             },
         ],
+        shouldStripQueryParams: [
+            false as boolean,
+            { persist: true },
+            {
+                setShouldStripQueryParams: (_, { shouldStripQueryParams }) => shouldStripQueryParams,
+            },
+        ],
     }),
     selectors(({ actions, values }) => ({
         graphsTab: [(s) => [s._graphsTab], (graphsTab: string | null) => graphsTab || GraphsTab.UNIQUE_USERS],
@@ -486,6 +496,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 () => values.isGreaterThanMd,
                 () => values.shouldShowGeographyTile,
                 () => values.featureFlags,
+                () => values.shouldStripQueryParams,
             ],
             (
                 webAnalyticsFilters,
@@ -497,7 +508,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 _statusCheck,
                 isGreaterThanMd,
                 shouldShowGeographyTile,
-                featureFlags
+                featureFlags,
+                shouldStripQueryParams
             ): WebDashboardTile[] => {
                 const dateRange = {
                     date_from: dateFrom,
@@ -741,20 +753,19 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LAST_CLICK]
                                     ? {
                                           id: PathTab.EXIT_CLICK,
-                                          title: 'Exit clicks',
-                                          linkText: 'Exit clicks',
+                                          title: 'Outbound link clicks',
+                                          linkText: 'Outbound clicks',
                                           query: {
                                               full: true,
                                               kind: NodeKind.DataTableNode,
                                               source: {
-                                                  kind: NodeKind.WebStatsTableQuery,
+                                                  kind: NodeKind.WebExternalClicksTableQuery,
                                                   properties: webAnalyticsFilters,
-                                                  breakdownBy: WebStatsBreakdown.ExitClick,
                                                   dateRange,
-                                                  includeScrollDepth: false,
                                                   sampling,
                                                   limit: 10,
                                                   filterTestAccounts,
+                                                  stripQueryParams: shouldStripQueryParams,
                                               },
                                               embedded: false,
                                           },

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -330,6 +330,17 @@ def get_query_runner(
             limit_context=limit_context,
         )
 
+    if kind == "WebExternalClicksTableQuery":
+        from .web_analytics.external_clicks import WebExternalClicksTableQueryRunner
+
+        return WebExternalClicksTableQueryRunner(
+            query=query,
+            team=team,
+            timings=timings,
+            modifiers=modifiers,
+            limit_context=limit_context,
+        )
+
     if kind == "SessionAttributionExplorerQuery":
         from .web_analytics.session_attribution_explorer_query_runner import SessionAttributionExplorerQueryRunner
 

--- a/posthog/hogql_queries/web_analytics/external_clicks.py
+++ b/posthog/hogql_queries/web_analytics/external_clicks.py
@@ -1,0 +1,119 @@
+from posthog.hogql import ast
+from posthog.hogql.constants import LimitContext
+from posthog.hogql.parser import parse_select
+from posthog.hogql.property import (
+    property_to_expr,
+)
+from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
+from posthog.hogql_queries.web_analytics.web_analytics_query_runner import (
+    WebAnalyticsQueryRunner,
+    map_columns,
+)
+from posthog.schema import (
+    CachedWebStatsTableQueryResponse,
+    WebStatsTableQueryResponse,
+    WebExternalClicksTableQuery,
+    WebExternalClicksTableQueryResponse,
+)
+
+
+class WebExternalClicksTableQueryRunner(WebAnalyticsQueryRunner):
+    query: WebExternalClicksTableQuery
+    response: WebExternalClicksTableQueryResponse
+    cached_response: CachedWebStatsTableQueryResponse
+    paginator: HogQLHasMorePaginator
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.paginator = HogQLHasMorePaginator.from_limit_context(
+            limit_context=LimitContext.QUERY, limit=self.query.limit if self.query.limit else None
+        )
+
+    def to_query(self) -> ast.SelectQuery:
+        if self.query.stripQueryParams:
+            url_expr = ast.Call(
+                name="cutQueryStringAndFragment",
+                args=[ast.Field(chain=["properties", "$external_click_url"])],
+            )
+        else:
+            url_expr = ast.Field(chain=["properties", "$external_click_url"])
+
+        with self.timings.measure("stats_table_query"):
+            query = parse_select(
+                """
+SELECT
+    url AS "context.columns.url",
+    uniq(filtered_person_id) AS "context.columns.visitors",
+    sum(filtered_click_count) AS "context.columns.clicks"
+FROM (
+    SELECT
+        any(person_id) AS filtered_person_id,
+        count() AS filtered_click_count,
+        {url_expr} AS url
+    FROM events
+    WHERE and(
+        timestamp >= {date_from},
+        timestamp < {date_to},
+        events.event == '$autocapture',
+        events.properties.$event_type == 'click',
+        url IS NOT NULL,
+        url != '',
+        {all_properties}
+    )
+    GROUP BY events.`$session_id`, url
+)
+GROUP BY "context.columns.url"
+ORDER BY "context.columns.visitors" DESC,
+"context.columns.url" ASC
+""",
+                timings=self.timings,
+                placeholders={
+                    "url_expr": url_expr,
+                    "all_properties": self._all_properties(),
+                    "date_from": self._date_from(),
+                    "date_to": self._date_to(),
+                },
+            )
+        assert isinstance(query, ast.SelectQuery)
+        return query
+
+    def _all_properties(self) -> ast.Expr:
+        properties = self.query.properties + self._test_account_filters
+        return property_to_expr(properties, team=self.team)
+
+    def _date_to(self) -> ast.Expr:
+        return self.query_date_range.date_to_as_hogql()
+
+    def _date_from(self) -> ast.Expr:
+        return self.query_date_range.date_from_as_hogql()
+
+    def calculate(self):
+        query = self.to_query()
+        response = self.paginator.execute_hogql_query(
+            query_type="stats_table_query",
+            query=query,
+            team=self.team,
+            timings=self.timings,
+            modifiers=self.modifiers,
+        )
+        results = self.paginator.results
+
+        assert results is not None
+
+        results_mapped = map_columns(
+            results,
+            {
+                1: self._unsample,  # views
+                2: self._unsample,  # visitors
+            },
+        )
+
+        return WebStatsTableQueryResponse(
+            columns=response.columns,
+            results=results_mapped,
+            timings=response.timings,
+            types=response.types,
+            hogql=response.hogql,
+            modifiers=self.modifiers,
+            **self.paginator.response_params(),
+        )

--- a/posthog/hogql_queries/web_analytics/external_clicks.py
+++ b/posthog/hogql_queries/web_analytics/external_clicks.py
@@ -31,7 +31,7 @@ class WebExternalClicksTableQueryRunner(WebAnalyticsQueryRunner):
 
     def to_query(self) -> ast.SelectQuery:
         if self.query.stripQueryParams:
-            url_expr = ast.Call(
+            url_expr: ast.Expr = ast.Call(
                 name="cutQueryStringAndFragment",
                 args=[ast.Field(chain=["properties", "$external_click_url"])],
             )

--- a/posthog/hogql_queries/web_analytics/test/test_external_clicks_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_external_clicks_table.py
@@ -1,0 +1,211 @@
+from typing import Optional
+
+from freezegun import freeze_time
+
+from posthog.hogql_queries.web_analytics.external_clicks import WebExternalClicksTableQueryRunner
+from posthog.models.utils import uuid7
+from posthog.schema import (
+    DateRange,
+    SessionTableVersion,
+    HogQLQueryModifiers,
+    WebExternalClicksTableQuery,
+)
+from posthog.test.base import (
+    APIBaseTest,
+    ClickhouseTestMixin,
+    _create_event,
+    _create_person,
+)
+
+
+class TestExternalClicksTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
+    def _create_events(self, data, event="$autocapture"):
+        person_result = []
+        for id, timestamps in data:
+            with freeze_time(timestamps[0][0]):
+                person_result.append(
+                    _create_person(
+                        team_id=self.team.pk,
+                        distinct_ids=[id],
+                        properties={
+                            "name": id,
+                            **({"email": "test@posthog.com"} if id == "test" else {}),
+                        },
+                    )
+                )
+            for timestamp, session_id, pathname, click in timestamps:
+                _create_event(
+                    team=self.team,
+                    event=event,
+                    distinct_id=id,
+                    timestamp=timestamp,
+                    properties={
+                        "$session_id": session_id,
+                        "$pathname": pathname,
+                        "$event_type": "click",
+                        "$external_click_url": click,
+                    },
+                    elements_chain=f'a:href="{click}"',
+                )
+        return person_result
+
+    def _run_external_clicks_table_query(
+        self,
+        date_from,
+        date_to,
+        limit=None,
+        properties=None,
+        session_table_version: SessionTableVersion = SessionTableVersion.V2,
+        filter_test_accounts: Optional[bool] = False,
+        strip_query_params: Optional[bool] = False,
+    ):
+        modifiers = HogQLQueryModifiers(sessionTableVersion=session_table_version)
+        query = WebExternalClicksTableQuery(
+            dateRange=DateRange(date_from=date_from, date_to=date_to),
+            properties=properties or [],
+            limit=limit,
+            filterTestAccounts=filter_test_accounts,
+            stripQueryParams=strip_query_params,
+        )
+        runner = WebExternalClicksTableQueryRunner(team=self.team, query=query, modifiers=modifiers)
+        return runner.calculate()
+
+    def test_no_crash_when_no_data(self):
+        results = self._run_external_clicks_table_query("2023-12-08", "2023-12-15").results
+        self.assertEqual([], results)
+
+    def test_increase_in_users(
+        self,
+    ):
+        s1a = str(uuid7("2023-12-02"))
+        s1b = str(uuid7("2023-12-13"))
+        s2 = str(uuid7("2023-12-10"))
+        self._create_events(
+            [
+                (
+                    "p1",
+                    [
+                        ("2023-12-02", s1a, "/", "https://www.example.com/"),
+                        ("2023-12-03", s1a, "/login", "https://www.example.com/login"),
+                        ("2023-12-13", s1b, "/docs", "https://www.example.com/docs"),
+                    ],
+                ),
+                ("p2", [("2023-12-10", s2, "/", "https://www.example.com/")]),
+            ]
+        )
+
+        results = self._run_external_clicks_table_query("2023-12-01", "2023-12-11").results
+
+        self.assertEqual(
+            [
+                ["https://www.example.com/", 2, 2],
+                ["https://www.example.com/login", 1, 1],
+            ],
+            results,
+        )
+
+    def test_all_time(self):
+        s1a = str(uuid7("2023-12-02"))
+        s1b = str(uuid7("2023-12-13"))
+        s2 = str(uuid7("2023-12-10"))
+        self._create_events(
+            [
+                (
+                    "p1",
+                    [
+                        ("2023-12-02", s1a, "/", "https://www.example.com/"),
+                        ("2023-12-03", s1a, "/login", "https://www.example.com/login"),
+                        ("2023-12-13", s1b, "/docs", "https://www.example.com/docs"),
+                    ],
+                ),
+                ("p2", [("2023-12-10", s2, "/", "https://www.example.com/")]),
+            ]
+        )
+
+        results = self._run_external_clicks_table_query("all", "2023-12-15").results
+
+        self.assertEqual(
+            [
+                ["https://www.example.com/", 2, 2],
+                ["https://www.example.com/docs", 1, 1],
+                ["https://www.example.com/login", 1, 1],
+            ],
+            results,
+        )
+
+    def test_filter_test_accounts(self):
+        s1 = str(uuid7("2023-12-02"))
+        # Create 1 test account
+        self._create_events(
+            [
+                (
+                    "test",
+                    [
+                        ("2023-12-02", s1, "/", "https://www.example.com/"),
+                        ("2023-12-03", s1, "/login", "https://www.example.com/login"),
+                    ],
+                )
+            ]
+        )
+
+        results = self._run_external_clicks_table_query("2023-12-01", "2023-12-03", filter_test_accounts=True).results
+
+        self.assertEqual(
+            [],
+            results,
+        )
+
+    def test_dont_filter_test_accounts(self):
+        s1 = str(uuid7("2023-12-02"))
+        # Create 1 test account
+        self._create_events(
+            [
+                (
+                    "test",
+                    [
+                        ("2023-12-02", s1, "/", "https://www.example.com/"),
+                        ("2023-12-03", s1, "/login", "https://www.example.com/login"),
+                    ],
+                )
+            ]
+        )
+
+        results = self._run_external_clicks_table_query("2023-12-01", "2023-12-03", filter_test_accounts=False).results
+
+        self.assertEqual(
+            [["https://www.example.com/", 1, 1], ["https://www.example.com/login", 1, 1]],
+            results,
+        )
+
+    def test_strip_query_params(self):
+        s1 = str(uuid7("2023-12-02"))
+        # Create 1 test account
+        self._create_events(
+            [
+                (
+                    "test",
+                    [
+                        ("2023-12-02", s1, "/login", "https://www.example.com/login?test=1#foo"),
+                        ("2023-12-03", s1, "/login", "https://www.example.com/login#bar"),
+                    ],
+                )
+            ]
+        )
+
+        results_strip = self._run_external_clicks_table_query(
+            "2023-12-01", "2023-12-03", filter_test_accounts=False, strip_query_params=True
+        ).results
+
+        self.assertEqual(
+            [["https://www.example.com/login", 1, 2]],
+            results_strip,
+        )
+
+        results_no_strip = self._run_external_clicks_table_query(
+            "2023-12-01", "2023-12-03", filter_test_accounts=False, strip_query_params=False
+        ).results
+
+        self.assertEqual(
+            [["https://www.example.com/login#bar", 1, 1], ["https://www.example.com/login?test=1#foo", 1, 1]],
+            results_no_strip,
+        )

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -25,10 +25,13 @@ from posthog.schema import (
     SamplingRate,
     SessionPropertyFilter,
     WebGoalsQuery,
+    WebExternalClicksTableQuery,
 )
 from posthog.utils import generate_cache_key, get_safe_cache
 
-WebQueryNode = Union[WebOverviewQuery, WebTopClicksQuery, WebStatsTableQuery, WebGoalsQuery]
+WebQueryNode = Union[
+    WebOverviewQuery, WebTopClicksQuery, WebStatsTableQuery, WebGoalsQuery, WebExternalClicksTableQuery
+]
 
 
 class WebAnalyticsQueryRunner(QueryRunner, ABC):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -834,6 +834,7 @@ class NodeKind(StrEnum):
     WEB_OVERVIEW_QUERY = "WebOverviewQuery"
     WEB_TOP_CLICKS_QUERY = "WebTopClicksQuery"
     WEB_STATS_TABLE_QUERY = "WebStatsTableQuery"
+    WEB_EXTERNAL_CLICKS_TABLE_QUERY = "WebExternalClicksTableQuery"
     WEB_GOALS_QUERY = "WebGoalsQuery"
     DATABASE_SCHEMA_QUERY = "DatabaseSchemaQuery"
 
@@ -979,7 +980,7 @@ class QueryResponseAlternative7(BaseModel):
     warnings: list[HogQLNotice]
 
 
-class QueryResponseAlternative24(BaseModel):
+class QueryResponseAlternative26(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -987,7 +988,7 @@ class QueryResponseAlternative24(BaseModel):
     results: dict[str, ExperimentVariantTrendResult]
 
 
-class QueryResponseAlternative25(BaseModel):
+class QueryResponseAlternative27(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -1422,6 +1423,33 @@ class Sampling(BaseModel):
     )
     enabled: Optional[bool] = None
     forceSamplingRate: Optional[SamplingRate] = None
+
+
+class WebExternalClicksTableQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: Optional[list] = None
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hasMore: Optional[bool] = None
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    limit: Optional[int] = None
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    offset: Optional[int] = None
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: list
+    samplingRate: Optional[SamplingRate] = None
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: Optional[list] = None
 
 
 class WebGoalsQueryResponse(BaseModel):
@@ -2004,6 +2032,42 @@ class CachedTrendsQueryResponse(BaseModel):
     )
 
 
+class CachedWebExternalClicksTableQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: Optional[AwareDatetime] = None
+    calculation_trigger: Optional[str] = Field(
+        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
+    )
+    columns: Optional[list] = None
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hasMore: Optional[bool] = None
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    is_cached: bool
+    last_refresh: AwareDatetime
+    limit: Optional[int] = None
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    next_allowed_client_refresh: AwareDatetime
+    offset: Optional[int] = None
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: list
+    samplingRate: Optional[SamplingRate] = None
+    timezone: str
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: Optional[list] = None
+
+
 class CachedWebGoalsQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -2277,30 +2341,6 @@ class Response4(BaseModel):
     types: Optional[list] = None
 
 
-class Response5(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    columns: Optional[list] = None
-    error: Optional[str] = Field(
-        default=None,
-        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
-    )
-    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
-    modifiers: Optional[HogQLQueryModifiers] = Field(
-        default=None, description="Modifiers used when performing the query"
-    )
-    query_status: Optional[QueryStatus] = Field(
-        default=None, description="Query status indicates whether next to the provided data, a query is still running."
-    )
-    results: list
-    samplingRate: Optional[SamplingRate] = None
-    timings: Optional[list[QueryTiming]] = Field(
-        default=None, description="Measured timings for different parts of the query generation process"
-    )
-    types: Optional[list] = None
-
-
 class Response6(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -2310,13 +2350,10 @@ class Response6(BaseModel):
         default=None,
         description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
     )
-    hasMore: Optional[bool] = None
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
-    limit: Optional[int] = None
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    offset: Optional[int] = None
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -2347,7 +2384,8 @@ class Response7(BaseModel):
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
-    results: Any
+    results: list
+    samplingRate: Optional[SamplingRate] = None
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
@@ -2355,6 +2393,32 @@ class Response7(BaseModel):
 
 
 class Response8(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: Optional[list] = None
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hasMore: Optional[bool] = None
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    limit: Optional[int] = None
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    offset: Optional[int] = None
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: Any
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: Optional[list] = None
+
+
+class Response9(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -2379,7 +2443,7 @@ class Response8(BaseModel):
     )
 
 
-class Response9(BaseModel):
+class Response10(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -2387,7 +2451,7 @@ class Response9(BaseModel):
     results: dict[str, ExperimentVariantTrendResult]
 
 
-class Response10(BaseModel):
+class Response11(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3027,30 +3091,6 @@ class QueryResponseAlternative10(BaseModel):
     types: Optional[list] = None
 
 
-class QueryResponseAlternative11(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    columns: Optional[list] = None
-    error: Optional[str] = Field(
-        default=None,
-        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
-    )
-    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
-    modifiers: Optional[HogQLQueryModifiers] = Field(
-        default=None, description="Modifiers used when performing the query"
-    )
-    query_status: Optional[QueryStatus] = Field(
-        default=None, description="Query status indicates whether next to the provided data, a query is still running."
-    )
-    results: list
-    samplingRate: Optional[SamplingRate] = None
-    timings: Optional[list[QueryTiming]] = Field(
-        default=None, description="Measured timings for different parts of the query generation process"
-    )
-    types: Optional[list] = None
-
-
 class QueryResponseAlternative12(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -3060,13 +3100,10 @@ class QueryResponseAlternative12(BaseModel):
         default=None,
         description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
     )
-    hasMore: Optional[bool] = None
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
-    limit: Optional[int] = None
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    offset: Optional[int] = None
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
@@ -3097,7 +3134,8 @@ class QueryResponseAlternative13(BaseModel):
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
-    results: Any
+    results: list
+    samplingRate: Optional[SamplingRate] = None
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
@@ -3105,6 +3143,32 @@ class QueryResponseAlternative13(BaseModel):
 
 
 class QueryResponseAlternative14(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: Optional[list] = None
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hasMore: Optional[bool] = None
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    limit: Optional[int] = None
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    offset: Optional[int] = None
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: Any
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: Optional[list] = None
+
+
+class QueryResponseAlternative15(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3129,7 +3193,7 @@ class QueryResponseAlternative14(BaseModel):
     )
 
 
-class QueryResponseAlternative15(BaseModel):
+class QueryResponseAlternative16(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3155,7 +3219,7 @@ class QueryResponseAlternative15(BaseModel):
     types: list[str]
 
 
-class QueryResponseAlternative16(BaseModel):
+class QueryResponseAlternative17(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3182,7 +3246,7 @@ class QueryResponseAlternative16(BaseModel):
     types: list[str]
 
 
-class QueryResponseAlternative17(BaseModel):
+class QueryResponseAlternative18(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3212,7 +3276,7 @@ class QueryResponseAlternative17(BaseModel):
     types: Optional[list] = Field(default=None, description="Types of returned columns")
 
 
-class QueryResponseAlternative18(BaseModel):
+class QueryResponseAlternative19(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3236,58 +3300,7 @@ class QueryResponseAlternative18(BaseModel):
     )
 
 
-class QueryResponseAlternative19(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    columns: Optional[list] = None
-    error: Optional[str] = Field(
-        default=None,
-        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
-    )
-    hasMore: Optional[bool] = None
-    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
-    limit: Optional[int] = None
-    modifiers: Optional[HogQLQueryModifiers] = Field(
-        default=None, description="Modifiers used when performing the query"
-    )
-    offset: Optional[int] = None
-    query_status: Optional[QueryStatus] = Field(
-        default=None, description="Query status indicates whether next to the provided data, a query is still running."
-    )
-    results: list
-    samplingRate: Optional[SamplingRate] = None
-    timings: Optional[list[QueryTiming]] = Field(
-        default=None, description="Measured timings for different parts of the query generation process"
-    )
-    types: Optional[list] = None
-
-
 class QueryResponseAlternative20(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    columns: Optional[list] = None
-    error: Optional[str] = Field(
-        default=None,
-        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
-    )
-    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
-    modifiers: Optional[HogQLQueryModifiers] = Field(
-        default=None, description="Modifiers used when performing the query"
-    )
-    query_status: Optional[QueryStatus] = Field(
-        default=None, description="Query status indicates whether next to the provided data, a query is still running."
-    )
-    results: list
-    samplingRate: Optional[SamplingRate] = None
-    timings: Optional[list[QueryTiming]] = Field(
-        default=None, description="Measured timings for different parts of the query generation process"
-    )
-    types: Optional[list] = None
-
-
-class QueryResponseAlternative21(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3323,6 +3336,57 @@ class QueryResponseAlternative22(BaseModel):
         default=None,
         description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
     )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: list
+    samplingRate: Optional[SamplingRate] = None
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: Optional[list] = None
+
+
+class QueryResponseAlternative23(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: Optional[list] = None
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hasMore: Optional[bool] = None
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    limit: Optional[int] = None
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    offset: Optional[int] = None
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: list
+    samplingRate: Optional[SamplingRate] = None
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+    types: Optional[list] = None
+
+
+class QueryResponseAlternative24(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    columns: Optional[list] = None
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
     hasMore: Optional[bool] = None
     hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
     limit: Optional[int] = None
@@ -3340,7 +3404,7 @@ class QueryResponseAlternative22(BaseModel):
     types: Optional[list] = None
 
 
-class QueryResponseAlternative23(BaseModel):
+class QueryResponseAlternative25(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3365,7 +3429,7 @@ class QueryResponseAlternative23(BaseModel):
     )
 
 
-class QueryResponseAlternative26(BaseModel):
+class QueryResponseAlternative28(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3387,7 +3451,7 @@ class QueryResponseAlternative26(BaseModel):
     )
 
 
-class QueryResponseAlternative27(BaseModel):
+class QueryResponseAlternative29(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3409,7 +3473,7 @@ class QueryResponseAlternative27(BaseModel):
     )
 
 
-class QueryResponseAlternative29(BaseModel):
+class QueryResponseAlternative31(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3430,7 +3494,7 @@ class QueryResponseAlternative29(BaseModel):
     )
 
 
-class QueryResponseAlternative32(BaseModel):
+class QueryResponseAlternative34(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3627,6 +3691,24 @@ class TableSettings(BaseModel):
         extra="forbid",
     )
     columns: Optional[list[ChartAxis]] = None
+
+
+class WebExternalClicksTableQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: Optional[DateRange] = None
+    filterTestAccounts: Optional[bool] = None
+    kind: Literal["WebExternalClicksTableQuery"] = "WebExternalClicksTableQuery"
+    limit: Optional[int] = None
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    properties: list[Union[EventPropertyFilter, PersonPropertyFilter, SessionPropertyFilter]]
+    response: Optional[WebExternalClicksTableQueryResponse] = None
+    sampling: Optional[Sampling] = None
+    stripQueryParams: Optional[bool] = None
+    useSessionsTable: Optional[bool] = None
 
 
 class WebGoalsQuery(BaseModel):
@@ -4429,7 +4511,7 @@ class PropertyGroupFilterValue(BaseModel):
     ]
 
 
-class QueryResponseAlternative28(BaseModel):
+class QueryResponseAlternative30(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -5242,7 +5324,7 @@ class LifecycleQuery(BaseModel):
     )
 
 
-class QueryResponseAlternative33(BaseModel):
+class QueryResponseAlternative35(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -5271,20 +5353,18 @@ class QueryResponseAlternative(
             QueryResponseAlternative8,
             QueryResponseAlternative9,
             QueryResponseAlternative10,
-            QueryResponseAlternative11,
             QueryResponseAlternative12,
             QueryResponseAlternative13,
             QueryResponseAlternative14,
+            QueryResponseAlternative15,
             ExperimentResultTrendQueryResponse,
             ExperimentResultFunnelQueryResponse,
             Any,
-            QueryResponseAlternative15,
             QueryResponseAlternative16,
             QueryResponseAlternative17,
             QueryResponseAlternative18,
             QueryResponseAlternative19,
             QueryResponseAlternative20,
-            QueryResponseAlternative21,
             QueryResponseAlternative22,
             QueryResponseAlternative23,
             QueryResponseAlternative24,
@@ -5293,8 +5373,10 @@ class QueryResponseAlternative(
             QueryResponseAlternative27,
             QueryResponseAlternative28,
             QueryResponseAlternative29,
-            QueryResponseAlternative32,
-            QueryResponseAlternative33,
+            QueryResponseAlternative30,
+            QueryResponseAlternative31,
+            QueryResponseAlternative34,
+            QueryResponseAlternative35,
         ]
     ]
 ):
@@ -5310,20 +5392,18 @@ class QueryResponseAlternative(
         QueryResponseAlternative8,
         QueryResponseAlternative9,
         QueryResponseAlternative10,
-        QueryResponseAlternative11,
         QueryResponseAlternative12,
         QueryResponseAlternative13,
         QueryResponseAlternative14,
+        QueryResponseAlternative15,
         ExperimentResultTrendQueryResponse,
         ExperimentResultFunnelQueryResponse,
         Any,
-        QueryResponseAlternative15,
         QueryResponseAlternative16,
         QueryResponseAlternative17,
         QueryResponseAlternative18,
         QueryResponseAlternative19,
         QueryResponseAlternative20,
-        QueryResponseAlternative21,
         QueryResponseAlternative22,
         QueryResponseAlternative23,
         QueryResponseAlternative24,
@@ -5332,8 +5412,10 @@ class QueryResponseAlternative(
         QueryResponseAlternative27,
         QueryResponseAlternative28,
         QueryResponseAlternative29,
-        QueryResponseAlternative32,
-        QueryResponseAlternative33,
+        QueryResponseAlternative30,
+        QueryResponseAlternative31,
+        QueryResponseAlternative34,
+        QueryResponseAlternative35,
     ]
 
 
@@ -5634,12 +5716,12 @@ class DataTableNode(BaseModel):
             Response2,
             Response3,
             Response4,
-            Response5,
             Response6,
             Response7,
             Response8,
             Response9,
             Response10,
+            Response11,
         ]
     ] = None
     showActions: Optional[bool] = Field(default=None, description="Show the kebab menu at the end of the row")
@@ -5676,6 +5758,7 @@ class DataTableNode(BaseModel):
         HogQLQuery,
         WebOverviewQuery,
         WebStatsTableQuery,
+        WebExternalClicksTableQuery,
         WebTopClicksQuery,
         WebGoalsQuery,
         SessionAttributionExplorerQuery,
@@ -5714,6 +5797,7 @@ class HogQLAutocomplete(BaseModel):
             HogQLAutocomplete,
             WebOverviewQuery,
             WebStatsTableQuery,
+            WebExternalClicksTableQuery,
             WebTopClicksQuery,
             WebGoalsQuery,
             SessionAttributionExplorerQuery,
@@ -5756,6 +5840,7 @@ class HogQLMetadata(BaseModel):
             HogQLAutocomplete,
             WebOverviewQuery,
             WebStatsTableQuery,
+            WebExternalClicksTableQuery,
             WebTopClicksQuery,
             WebGoalsQuery,
             SessionAttributionExplorerQuery,
@@ -5800,6 +5885,7 @@ class QueryRequest(BaseModel):
         HogQLAutocomplete,
         WebOverviewQuery,
         WebStatsTableQuery,
+        WebExternalClicksTableQuery,
         WebTopClicksQuery,
         WebGoalsQuery,
         SessionAttributionExplorerQuery,
@@ -5848,6 +5934,7 @@ class QuerySchemaRoot(
             HogQLAutocomplete,
             WebOverviewQuery,
             WebStatsTableQuery,
+            WebExternalClicksTableQuery,
             WebTopClicksQuery,
             WebGoalsQuery,
             SessionAttributionExplorerQuery,
@@ -5884,6 +5971,7 @@ class QuerySchemaRoot(
         HogQLAutocomplete,
         WebOverviewQuery,
         WebStatsTableQuery,
+        WebExternalClicksTableQuery,
         WebTopClicksQuery,
         WebGoalsQuery,
         SessionAttributionExplorerQuery,


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C05LJK1N3CP/p1725262992141559

## Changes

Changes the query from computing the number of views in sessions with this as the last external clicks, to counting the number of clicks on external links.

Changed some of the text

<img width="1514" alt="Screenshot 2024-09-02 at 16 20 03" src="https://github.com/user-attachments/assets/fe3a1efc-c3dc-44e0-9837-b5385e9338ce">

<img width="1508" alt="Screenshot 2024-09-02 at 16 20 06" src="https://github.com/user-attachments/assets/15f1e2da-2bb0-43fd-8dfb-dd310ddb3320">
(I had a cached version for the second, it should say url in both)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Added some tests for the new query, and ran it locally (see screenshots above).

It's still behind a FF
