### PR TITLE
fix(batch-exports): Use existing schema in merge query

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -205,6 +205,7 @@ class BigQueryClient(bigquery.Client):
         final_table: bigquery.Table,
         stage_table: bigquery.Table,
         merge_key: collections.abc.Iterable[bigquery.SchemaField],
+        update_fields: collections.abc.Iterable[bigquery.SchemaField] | None = None,
         person_version_key: str = "person_version",
         person_distinct_id_version_key: str = "person_distinct_id_version",
     ):
@@ -221,7 +222,11 @@ class BigQueryClient(bigquery.Client):
         update_clause = ""
         values = ""
         field_names = ""
-        for n, field in enumerate(final_table.schema):
+
+        if not update_fields:
+            update_fields = final_table.schema
+
+        for n, field in enumerate(update_fields):
             if n > 0:
                 update_clause += ", "
                 values += ", "
@@ -481,6 +486,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                         final_table=bigquery_table,
                         stage_table=bigquery_stage_table,
                         merge_key=merge_key,
+                        update_fields=schema,
                     )
 
                 return writer.records_total

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -224,9 +224,11 @@ class BigQueryClient(bigquery.Client):
         field_names = ""
 
         if not update_fields:
-            update_fields = final_table.schema
+            update_clause_fields = final_table.schema
+        else:
+            update_clause_fields = update_fields
 
-        for n, field in enumerate(update_fields):
+        for n, field in enumerate(update_clause_fields):
             if n > 0:
                 update_clause += ", "
                 values += ", "

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -238,6 +238,9 @@ class BigQueryClient(bigquery.Client):
             field_names += f"`{field.name}`"
             values += f"stage.`{field.name}`"
 
+        if not update_clause:
+            raise ValueError("Empty update clause")
+
         merge_query = f"""
         MERGE `{final_table.full_table_id.replace(":", ".", 1)}` final
         USING `{stage_table.full_table_id.replace(":", ".", 1)}` stage

--- a/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
@@ -5,6 +5,7 @@ import operator
 import os
 import typing
 import uuid
+import warnings
 
 import pyarrow as pa
 import pytest
@@ -213,7 +214,12 @@ def bigquery_dataset(bigquery_config, bigquery_client) -> typing.Generator[bigqu
 
     yield dataset
 
-    # bigquery_client.delete_dataset(dataset_id, delete_contents=True, not_found_ok=True)
+    try:
+        bigquery_client.delete_dataset(dataset_id, delete_contents=True, not_found_ok=True)
+    except Exception as exc:
+        warnings.warn(
+            f"Failed to clean up dataset: {dataset_id} due to '{exc.__class__.__name__}': {str(exc)}", stacklevel=1
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

Occasionally, we see syntax errors being raised in BigQuery batch export pointing to the line right after where the `{update_clause}` should be. One theory is that the schema fields of a table are returned empty, which would cause the `{update_clause}` to be empty and thus a syntax error. Let's control for that scenario.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
* Use our existing schema in the merge query of persons batch export, which we know is set.
* Raise an error if `{update_clause}` is empty.
* Clean-up dataset after tests.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Ran bigquery unit tests. All passing.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
