### PR TITLE
feat(dashboards): Allow interaction with dashboard items in edit mode

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.scss
@@ -16,14 +16,6 @@
         outline: 1px solid var(--primary-3000);
     }
 
-    &.react-draggable::after {
-        // During dashboard layout editing, we need an overlay to prevent accidental interaction with card content
-        position: absolute;
-        inset: 0;
-        z-index: var(--z-content-overlay);
-        content: '';
-    }
-
     .ErrorBoundary {
         width: 100%;
         height: 100%;

--- a/frontend/src/lib/components/Cards/handles.tsx
+++ b/frontend/src/lib/components/Cards/handles.tsx
@@ -5,8 +5,8 @@ export function ResizeHandle1D({ orientation }: { orientation: 'horizontal' | 'v
     return (
         <div className={clsx('handle', orientation)}>
             <svg fill="none" height="24" viewBox="0 0 16 24" width="16" xmlns="http://www.w3.org/2000/svg">
-                <rect fill="#fff" height="23" rx="3.5" width="15" x=".5" y=".5" />
-                <g fill="#5375ff">
+                <rect fill="var(--bg-light)" height="23" rx="3.5" width="15" x=".5" y=".5" />
+                <g fill="var(--primary)">
                     <rect height="2" rx=".25" width="2" x="5" y="5" />
                     <rect height="2" rx=".25" width="2" x="9" y="5" />
                     <rect height="2" rx=".25" width="2" x="5" y="9" />
@@ -16,7 +16,7 @@ export function ResizeHandle1D({ orientation }: { orientation: 'horizontal' | 'v
                     <rect height="2" rx=".25" width="2" x="5" y="13" />
                     <rect height="2" rx=".25" width="2" x="5" y="17" />
                 </g>
-                <rect height="23" rx="3.5" stroke="#d9d9d9" width="15" x=".5" y=".5" />
+                <rect height="23" rx="3.5" stroke="var(--border)" width="15" x=".5" y=".5" />
             </svg>
         </div>
     )
@@ -27,8 +27,8 @@ export function ResizeHandle2D(): JSX.Element {
     return (
         <div className="handle corner">
             <svg fill="none" height="18" viewBox="0 0 18 18" width="18" xmlns="http://www.w3.org/2000/svg">
-                <rect fill="#fff" height="17" rx="3.5" width="17" x=".5" y=".5" />
-                <g fill="#5375ff">
+                <rect fill="var(--bg-light)" height="17" rx="3.5" width="17" x=".5" y=".5" />
+                <g fill="var(--primary)">
                     <rect height="2" rx=".25" width="2" x="8" y="8" />
                     <rect height="2" rx=".25" width="2" x="8" y="12" />
                     <rect height="2" rx=".25" width="2" x="12" y="4" />
@@ -36,7 +36,7 @@ export function ResizeHandle2D(): JSX.Element {
                     <rect height="2" rx=".25" width="2" x="12" y="8" />
                     <rect height="2" rx=".25" width="2" x="12" y="12" />
                 </g>
-                <rect height="17" rx="3.5" stroke="#d9d9d9" width="17" x=".5" y=".5" />
+                <rect height="17" rx="3.5" stroke="var(--border)" width="17" x=".5" y=".5" />
             </svg>
         </div>
     )

--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -23,8 +23,10 @@
     will-change: width, height;
 }
 
-.react-grid-item.react-draggable {
+.react-grid-item.react-draggable .CardMeta {
+    // .CardMeta is the draggable handle
     cursor: move;
+    user-select: none; // Prevent accidental text selection while dragging
 }
 
 .react-grid-item.react-draggable-dragging {

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -59,6 +59,7 @@ export function DashboardItems(): JSX.Element {
                 <ReactGridLayout
                     width={gridWrapperWidth}
                     className={className}
+                    draggableHandle=".CardMeta"
                     isDraggable={dashboardMode === DashboardMode.Edit}
                     isResizable={dashboardMode === DashboardMode.Edit}
                     layouts={layouts}
@@ -98,7 +99,7 @@ export function DashboardItems(): JSX.Element {
                             isDragging.current = false
                         }, 250)
                     }}
-                    draggableCancel=".anticon,table,button,.Popover"
+                    draggableCancel="a,table,button,.Popover"
                 >
                     {tiles?.map((tile) => {
                         const { insight, text } = tile


### PR DESCRIPTION
## Problem

People would like to interact with their graphs while in dashboard edit mode – a very reasonable expectation.

## Changes

Here's one way to do it:

![2024-09-03 15 40 54](https://github.com/user-attachments/assets/c5cd63fc-1c1c-4e73-b170-c81caba6acb9)

Also fixed resize handle colors, they were all hard-coded to legacy light mode.

## How did you test this code?

Manual QA so far. Please do your own take on this too!