### PR TITLE
fix: ignore performance events that have no name

### DIFF
--- a/frontend/src/scenes/session-recordings/apm/performanceEventDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/apm/performanceEventDataLogic.ts
@@ -165,7 +165,9 @@ function filterUnwanted(events: PerformanceEvent[]): PerformanceEvent[] {
     // the browser can provide network events that we're not interested in,
     // like a navigation to "about:blank"
     return events.filter((event) => {
-        return !(event.entry_type === 'navigation' && event.name && event.name.startsWith('about:'))
+        return !event.name?.trim() || (event.entry_type === 'navigation' && event.name.startsWith('about:'))
+            ? false
+            : true
     })
 }
 

--- a/frontend/src/scenes/session-recordings/apm/performanceEventDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/apm/performanceEventDataLogic.ts
@@ -165,9 +165,9 @@ function filterUnwanted(events: PerformanceEvent[]): PerformanceEvent[] {
     // the browser can provide network events that we're not interested in,
     // like a navigation to "about:blank"
     return events.filter((event) => {
-        return !event.name?.trim() || (event.entry_type === 'navigation' && event.name.startsWith('about:'))
-            ? false
-            : true
+        const hasNoName = !event.name?.trim().length
+        const isNavigationToAbout = event.entry_type === 'navigation' && !!event.name && event.name.startsWith('about:')
+        return !(hasNoName || isNavigationToAbout)
     })
 }
 


### PR DESCRIPTION
posthog-js 1.160.2 is much better at gathering network events... but it doesn't provide the name/url for those events 👎 

let's hide these invalid entries while we fix the source

![Screenshot 2024-09-03 at 15 47 11](https://github.com/user-attachments/assets/ff68037f-6599-4b3b-b84b-292c79063696)
