### PR TITLE
chore: remove property that is too noisy

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -881,12 +881,10 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                 if (everyWindowMissingFullSnapshot) {
                     // video is definitely unplayable
                     posthog.capture('recording_has_no_full_snapshot', {
-                        ...windowsHaveFullSnapshot,
                         sessionId: sessionRecordingId,
                     })
                 } else if (anyWindowMissingFullSnapshot) {
                     posthog.capture('recording_window_missing_full_snapshot', {
-                        ...windowsHaveFullSnapshot,
                         sessionId: sessionRecordingId,
                     })
                 }


### PR DESCRIPTION
We emit `recording_window_missing_full_snapshot` and `recording_has_no_full_snapshot` 

they have properties per window `window-id-$THE_UUID-has-full-snapshot` 

so we're creating very high cardinality property definitions we'll never query... wasteful