### PR TITLE
feat(onboarding-templates): create custom variable selector panel

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonCollapse/LemonCollapse.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCollapse/LemonCollapse.tsx
@@ -96,6 +96,7 @@ interface LemonCollapsePanelProps {
     onChange: (isExpanded: boolean) => void
     className?: string
     dataAttr?: string
+    onHeaderClick?: () => void
 }
 
 function LemonCollapsePanel({
@@ -106,13 +107,17 @@ function LemonCollapsePanel({
     className,
     dataAttr,
     onChange,
+    onHeaderClick,
 }: LemonCollapsePanelProps): JSX.Element {
     const { height: contentHeight, ref: contentRef } = useResizeObserver({ box: 'border-box' })
 
     return (
         <div className="LemonCollapsePanel" aria-expanded={isExpanded}>
             <LemonButton
-                onClick={() => onChange(!isExpanded)}
+                onClick={() => {
+                    onHeaderClick && onHeaderClick()
+                    onChange(!isExpanded)
+                }}
                 icon={isExpanded ? <IconCollapse /> : <IconExpand />}
                 className="LemonCollapsePanel__header"
                 {...(dataAttr ? { 'data-attr': dataAttr } : {})}

--- a/frontend/src/scenes/dashboard/dashboardTemplateVariablesLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardTemplateVariablesLogic.ts
@@ -1,4 +1,4 @@
-import { actions, kea, path, props, propsChanged, reducers } from 'kea'
+import { actions, kea, path, props, propsChanged, reducers, selectors } from 'kea'
 import { isEmptyObject } from 'lib/utils'
 
 import { DashboardTemplateVariableType, FilterType, Optional } from '~/types'
@@ -24,6 +24,9 @@ export const dashboardTemplateVariablesLogic = kea<dashboardTemplateVariablesLog
             variable_name: variableName,
             filterGroup,
         }),
+        setActiveVariableIndex: (index: number) => ({ index }),
+        incrementActiveVariableIndex: true,
+        resetVariable: (variableId: string) => ({ variableId }),
     }),
     reducers({
         variables: [
@@ -41,14 +44,43 @@ export const dashboardTemplateVariablesLogic = kea<dashboardTemplateVariablesLog
                     // TODO: handle actions as well as events
                     return state.map((v: DashboardTemplateVariableType) => {
                         if (v.name === variableName && filterGroup?.events?.length && filterGroup.events[0]) {
-                            return { ...v, default: filterGroup.events[0] }
+                            return { ...v, default: filterGroup.events[0], touched: true }
                         }
-                        return v
+                        return { ...v }
+                    })
+                },
+                resetVariable: (state, { variableId }) => {
+                    return state.map((v: DashboardTemplateVariableType) => {
+                        if (v.id === variableId) {
+                            return { ...v, default: FALLBACK_EVENT, touched: false }
+                        }
+                        return { ...v }
                     })
                 },
             },
         ],
+        activeVariableIndex: [
+            0,
+            {
+                setActiveVariableIndex: (_, { index }) => index,
+                incrementActiveVariableIndex: (state) => state + 1,
+            },
+        ],
     }),
+    selectors(() => ({
+        activeVariable: [
+            (s) => [s.variables, s.activeVariableIndex],
+            (variables: DashboardTemplateVariableType[], activeVariableIndex: number) => {
+                return variables[activeVariableIndex]
+            },
+        ],
+        allVariablesAreTouched: [
+            (s) => [s.variables],
+            (variables: DashboardTemplateVariableType[]) => {
+                return variables.every((v) => v.touched)
+            },
+        ],
+    })),
     propsChanged(({ actions, props }, oldProps) => {
         if (props.variables !== oldProps.variables) {
             actions.setVariables(props.variables)

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
@@ -109,8 +109,8 @@ export const OnboardingDashboardTemplateConfigureStep = ({
                         </div>
                         <div className="col-span-2">
                             <p>
-                                Follow the instructions below to map your data to PostHog events. When complete, we'll
-                                automatically generate a dashboard for your analytics.
+                                For each action below, select an element on your site that indicates when that action is
+                                taken, or enter a custom event name that you'll send from your backend.
                             </p>
                             <DashboardTemplateVariables />
                             <LemonButton

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
@@ -5,13 +5,13 @@ import { authorizedUrlListLogic, AuthorizedUrlListType } from 'lib/components/Au
 import { IframedToolbarBrowser } from 'lib/components/IframedToolbarBrowser/IframedToolbarBrowser'
 import { iframedToolbarBrowserLogic } from 'lib/components/IframedToolbarBrowser/iframedToolbarBrowserLogic'
 import { useRef, useState } from 'react'
-import { DashboardTemplateVariables } from 'scenes/dashboard/DashboardTemplateVariables'
 import { dashboardTemplateVariablesLogic } from 'scenes/dashboard/dashboardTemplateVariablesLogic'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 
 import { OnboardingStepKey } from '../onboardingLogic'
 import { OnboardingStep } from '../OnboardingStep'
 import { sdksLogic } from '../sdks/sdksLogic'
+import { DashboardTemplateVariables } from './DashboardTemplateVariables'
 import { onboardingTemplateConfigLogic } from './onboardingTemplateConfigLogic'
 
 export const OnboardingDashboardTemplateConfigureStep = ({
@@ -23,11 +23,14 @@ export const OnboardingDashboardTemplateConfigureStep = ({
     const { activeDashboardTemplate } = useValues(onboardingTemplateConfigLogic)
     const { createDashboardFromTemplate } = useActions(newDashboardLogic)
     const { isLoading } = useValues(newDashboardLogic)
-    const { variables } = useValues(dashboardTemplateVariablesLogic)
     const { snippetHosts } = useValues(sdksLogic)
     const { addUrl } = useActions(authorizedUrlListLogic({ actionId: null, type: AuthorizedUrlListType.TOOLBAR_URLS }))
     const { setBrowserUrl } = useActions(iframedToolbarBrowserLogic({ iframeRef, clearBrowserUrlOnUnmount: true }))
     const { browserUrl } = useValues(iframedToolbarBrowserLogic({ iframeRef, clearBrowserUrlOnUnmount: true }))
+    const theDashboardTemplateVariablesLogic = dashboardTemplateVariablesLogic({
+        variables: activeDashboardTemplate?.variables || [],
+    })
+    const { variables, allVariablesAreTouched } = useValues(theDashboardTemplateVariablesLogic)
 
     const [isSubmitting, setIsSubmitting] = useState(false)
 
@@ -105,6 +108,10 @@ export const OnboardingDashboardTemplateConfigureStep = ({
                             )}
                         </div>
                         <div className="col-span-2">
+                            <p>
+                                Follow the instructions below to map your data to PostHog events. When complete, we'll
+                                automatically generate a dashboard for your analytics.
+                            </p>
                             <DashboardTemplateVariables />
                             <LemonButton
                                 type="primary"
@@ -119,6 +126,7 @@ export const OnboardingDashboardTemplateConfigureStep = ({
                                 fullWidth
                                 center
                                 className="mt-6"
+                                disabledReason={!allVariablesAreTouched && 'Please select an event for each variable'}
                             >
                                 Create dashboard
                             </LemonButton>

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
@@ -1,5 +1,5 @@
 import { IconArrowRight } from '@posthog/icons'
-import { LemonButton, LemonCard, LemonSkeleton } from '@posthog/lemon-ui'
+import { LemonButton, LemonCard, LemonSkeleton, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { authorizedUrlListLogic, AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
 import { IframedToolbarBrowser } from 'lib/components/IframedToolbarBrowser/IframedToolbarBrowser'
@@ -110,7 +110,11 @@ export const OnboardingDashboardTemplateConfigureStep = ({
                         <div className="col-span-2">
                             <p>
                                 For each action below, select an element on your site that indicates when that action is
-                                taken, or enter a custom event name that you'll send from your backend.
+                                taken, or enter a custom event name that you'll send using{' '}
+                                <Link to="https://posthog.com/docs/product-analytics/capture-events">
+                                    <code>posthog.capture()</code>
+                                </Link>{' '}
+                                (no need to send it now) .
                             </p>
                             <DashboardTemplateVariables hasSelectedSite={!!browserUrl} />
                             <LemonButton

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
@@ -112,7 +112,7 @@ export const OnboardingDashboardTemplateConfigureStep = ({
                                 For each action below, select an element on your site that indicates when that action is
                                 taken, or enter a custom event name that you'll send from your backend.
                             </p>
-                            <DashboardTemplateVariables />
+                            <DashboardTemplateVariables hasSelectedSite={!!browserUrl} />
                             <LemonButton
                                 type="primary"
                                 status="alt"

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
@@ -59,7 +59,7 @@ function VariableSelector({
                     <LemonLabel>Custom event name</LemonLabel>
                     <p>
                         Set the name that you'll use for a custom event (eg. a backend event) instead of selecting an
-                        event from your site.
+                        event from your site. You can change this later if needed.
                     </p>
                     <div className="flex gap-x-2 w-full">
                         <LemonInput

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
@@ -1,5 +1,5 @@
 import { IconCheckCircle, IconInfo, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonCollapse, LemonInput, LemonLabel } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonCollapse, LemonInput, LemonLabel } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { useEffect, useState } from 'react'
 import { dashboardTemplateVariablesLogic } from 'scenes/dashboard/dashboardTemplateVariablesLogic'
@@ -7,7 +7,13 @@ import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 
 import { DashboardTemplateVariableType } from '~/types'
 
-function VariableSelector({ variable }: { variable: DashboardTemplateVariableType }): JSX.Element {
+function VariableSelector({
+    variable,
+    hasSelectedSite,
+}: {
+    variable: DashboardTemplateVariableType
+    hasSelectedSite: boolean
+}): JSX.Element {
     const { activeDashboardTemplate } = useValues(newDashboardLogic)
     const theDashboardTemplateVariablesLogic = dashboardTemplateVariablesLogic({
         variables: activeDashboardTemplate?.variables || [],
@@ -93,34 +99,38 @@ function VariableSelector({ variable }: { variable: DashboardTemplateVariableTyp
                     </div>
                 </div>
             )}
-            <div className="flex">
-                {variable.touched ? (
-                    <LemonButton type="primary" status="alt" onClick={incrementActiveVariableIndex}>
-                        Continue
-                    </LemonButton>
-                ) : (
-                    <div className="flex gap-x-2">
-                        <LemonButton
-                            type="primary"
-                            status="alt"
-                            onClick={() => {
-                                setShowCustomEventField(false)
-                                setVariable(variable.name, { events: [FALLBACK_EVENT] })
-                            }}
-                        >
-                            Select from site
+            {!hasSelectedSite ? (
+                <LemonBanner type="warning">Please select a site to continue. </LemonBanner>
+            ) : (
+                <div className="flex">
+                    {variable.touched ? (
+                        <LemonButton type="primary" status="alt" onClick={incrementActiveVariableIndex}>
+                            Continue
                         </LemonButton>
-                        <LemonButton type="secondary" onClick={() => setShowCustomEventField(true)}>
-                            Use custom event
-                        </LemonButton>
-                    </div>
-                )}
-            </div>
+                    ) : (
+                        <div className="flex gap-x-2">
+                            <LemonButton
+                                type="primary"
+                                status="alt"
+                                onClick={() => {
+                                    setShowCustomEventField(false)
+                                    setVariable(variable.name, { events: [FALLBACK_EVENT] })
+                                }}
+                            >
+                                Select from site
+                            </LemonButton>
+                            <LemonButton type="secondary" onClick={() => setShowCustomEventField(true)}>
+                                Use custom event
+                            </LemonButton>
+                        </div>
+                    )}
+                </div>
+            )}
         </div>
     )
 }
 
-export function DashboardTemplateVariables(): JSX.Element {
+export function DashboardTemplateVariables({ hasSelectedSite }: { hasSelectedSite: boolean }): JSX.Element {
     const { activeDashboardTemplate } = useValues(newDashboardLogic)
     const theDashboardTemplateVariablesLogic = dashboardTemplateVariablesLogic({
         variables: activeDashboardTemplate?.variables || [],
@@ -145,7 +155,7 @@ export function DashboardTemplateVariables(): JSX.Element {
                             {v.touched && <IconCheckCircle className="text-success ml-2 text-base" />}
                         </div>
                     ),
-                    content: <VariableSelector variable={v} {...v} />,
+                    content: <VariableSelector variable={v} {...v} hasSelectedSite={hasSelectedSite} />,
                     className: 'p-4 bg-white',
                     onHeaderClick: () => {
                         setActiveVariableIndex(i)

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
@@ -18,7 +18,9 @@ function VariableSelector({
     const theDashboardTemplateVariablesLogic = dashboardTemplateVariablesLogic({
         variables: activeDashboardTemplate?.variables || [],
     })
-    const { setVariable, resetVariable, incrementActiveVariableIndex } = useActions(theDashboardTemplateVariablesLogic)
+    const { setVariable, resetVariable, goToNextUntouchedActiveVariableIndex, incrementActiveVariableIndex } =
+        useActions(theDashboardTemplateVariablesLogic)
+    const { allVariablesAreTouched, variables, activeVariableIndex } = useValues(theDashboardTemplateVariablesLogic)
     const [customEventName, setCustomEventName] = useState<string | null>(null)
     const [showCustomEventField, setShowCustomEventField] = useState(false)
 
@@ -104,9 +106,24 @@ function VariableSelector({
             ) : (
                 <div className="flex">
                     {variable.touched ? (
-                        <LemonButton type="primary" status="alt" onClick={incrementActiveVariableIndex}>
-                            Continue
-                        </LemonButton>
+                        <>
+                            {!allVariablesAreTouched ||
+                            (allVariablesAreTouched && variables.length !== activeVariableIndex + 1) ? (
+                                <LemonButton
+                                    type="primary"
+                                    status="alt"
+                                    onClick={() =>
+                                        !allVariablesAreTouched
+                                            ? goToNextUntouchedActiveVariableIndex()
+                                            : variables.length !== activeVariableIndex + 1
+                                            ? incrementActiveVariableIndex()
+                                            : null
+                                    }
+                                >
+                                    Continue
+                                </LemonButton>
+                            ) : null}
+                        </>
                     ) : (
                         <div className="flex gap-x-2">
                             <LemonButton

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
@@ -48,9 +48,11 @@ function VariableSelector({ variable }: { variable: DashboardTemplateVariableTyp
             )}
             {showCustomEventField && (
                 <div className="mb-4">
-                    <LemonLabel info="Set the name that you'll use for a custom event (eg a backend event) instead of selecting an event from your site.">
-                        Custom event name
-                    </LemonLabel>
+                    <LemonLabel>Custom event name</LemonLabel>
+                    <p>
+                        Set the name that you'll use for a custom event (eg. a backend event) instead of selecting an
+                        event from your site.
+                    </p>
                     <div className="flex gap-x-2 w-full">
                         <LemonInput
                             className="grow"
@@ -108,8 +110,8 @@ function VariableSelector({ variable }: { variable: DashboardTemplateVariableTyp
                         >
                             Select from site
                         </LemonButton>
-                        <LemonButton type="secondary" status="alt" onClick={() => setShowCustomEventField(true)}>
-                            or use custom event
+                        <LemonButton type="secondary" onClick={() => setShowCustomEventField(true)}>
+                            Use custom event
                         </LemonButton>
                     </div>
                 )}

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
@@ -1,4 +1,4 @@
-import { IconCheckCircle, IconTrash } from '@posthog/icons'
+import { IconCheckCircle, IconInfo, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonCollapse, LemonInput, LemonLabel } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { useEffect, useState } from 'react'
@@ -25,10 +25,9 @@ function VariableSelector({ variable }: { variable: DashboardTemplateVariableTyp
     return (
         <div className="pl-7">
             <div className="mb-2">
-                <p>Select the element that indicates:</p>
-                <LemonLabel showOptional={!variable.required} info={<>{variable.description}</>}>
-                    {variable.name}
-                </LemonLabel>
+                <p>
+                    <IconInfo /> {variable.description}
+                </p>
             </div>
             {variable.touched && !customEventName && (
                 <div className="flex justify-between items-center bg-bg-3000-light p-2 pl-3 rounded mb-4">

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
@@ -125,7 +125,7 @@ export function DashboardTemplateVariables(): JSX.Element {
         variables: activeDashboardTemplate?.variables || [],
     })
     const { variables, activeVariableIndex } = useValues(theDashboardTemplateVariablesLogic)
-    const { setVariables } = useActions(theDashboardTemplateVariablesLogic)
+    const { setVariables, setActiveVariableIndex } = useActions(theDashboardTemplateVariablesLogic)
 
     // TODO: onboarding-dashboard-templates: this is a hack, I'm not sure why it's not set properly initially.
     useEffect(() => {
@@ -136,7 +136,7 @@ export function DashboardTemplateVariables(): JSX.Element {
         <div className="mb-4 DashboardTemplateVariables max-w-192">
             <LemonCollapse
                 activeKey={variables[activeVariableIndex]?.id}
-                panels={variables.map((v) => ({
+                panels={variables.map((v, i) => ({
                     key: v.id,
                     header: (
                         <div>
@@ -146,6 +146,9 @@ export function DashboardTemplateVariables(): JSX.Element {
                     ),
                     content: <VariableSelector variable={v} {...v} />,
                     className: 'p-4 bg-white',
+                    onHeaderClick: () => {
+                        setActiveVariableIndex(i)
+                    },
                 }))}
                 embedded
                 size="small"

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
@@ -1,0 +1,100 @@
+import { IconCheckCircle, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonCollapse, LemonLabel } from '@posthog/lemon-ui'
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+import { dashboardTemplateVariablesLogic } from 'scenes/dashboard/dashboardTemplateVariablesLogic'
+import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
+
+import { DashboardTemplateVariableType } from '~/types'
+
+function VariableSelector({ variable }: { variable: DashboardTemplateVariableType }): JSX.Element {
+    const { activeDashboardTemplate } = useValues(newDashboardLogic)
+    const theDashboardTemplateVariablesLogic = dashboardTemplateVariablesLogic({
+        variables: activeDashboardTemplate?.variables || [],
+    })
+    const { setVariable, resetVariable, incrementActiveVariableIndex } = useActions(theDashboardTemplateVariablesLogic)
+
+    const FALLBACK_EVENT = {
+        id: '$other_event',
+        math: 'dau',
+        type: 'events',
+    }
+
+    return (
+        <div className="pl-7">
+            <div className="mb-2">
+                <p>Select the element that indicates:</p>
+                <LemonLabel showOptional={!variable.required} info={<>{variable.description}</>}>
+                    {variable.name}
+                </LemonLabel>
+            </div>
+            {variable.touched && (
+                <div className="flex justify-between items-center bg-bg-3000-light p-2 pl-3 rounded mb-4">
+                    <div>
+                        <IconCheckCircle className="text-success font-bold" />{' '}
+                        <span className="text-success font-bold">Selected</span>
+                        <p className="italic text-muted mb-0">.md-invite-button</p>
+                    </div>
+                    <div>
+                        <LemonButton
+                            icon={<IconTrash />}
+                            type="tertiary"
+                            size="small"
+                            onClick={() => resetVariable(variable.id)}
+                        />
+                    </div>
+                </div>
+            )}
+            <div className="flex">
+                {variable.touched ? (
+                    <LemonButton type="primary" status="alt" onClick={incrementActiveVariableIndex}>
+                        Continue
+                    </LemonButton>
+                ) : (
+                    <LemonButton
+                        type="primary"
+                        status="alt"
+                        onClick={() => setVariable(variable.name, { events: [FALLBACK_EVENT] })}
+                    >
+                        Select from site
+                    </LemonButton>
+                )}
+            </div>
+        </div>
+    )
+}
+
+export function DashboardTemplateVariables(): JSX.Element {
+    const { activeDashboardTemplate } = useValues(newDashboardLogic)
+    const theDashboardTemplateVariablesLogic = dashboardTemplateVariablesLogic({
+        variables: activeDashboardTemplate?.variables || [],
+    })
+    const { variables, activeVariableIndex } = useValues(theDashboardTemplateVariablesLogic)
+    const { setVariables } = useActions(theDashboardTemplateVariablesLogic)
+
+    // TODO: onboarding-dashboard-templates: this is a hack, I'm not sure why it's not set properly initially.
+    useEffect(() => {
+        setVariables(activeDashboardTemplate?.variables || [])
+    }, [activeDashboardTemplate])
+
+    return (
+        <div className="mb-4 DashboardTemplateVariables max-w-192">
+            <LemonCollapse
+                activeKey={variables[activeVariableIndex]?.id}
+                panels={variables.map((v) => ({
+                    key: v.id,
+                    header: (
+                        <div>
+                            {v.name}
+                            {v.touched && <IconCheckCircle className="text-success ml-2 text-base" />}
+                        </div>
+                    ),
+                    content: <VariableSelector variable={v} {...v} />,
+                    className: 'p-4 bg-white',
+                }))}
+                embedded
+                size="small"
+            />
+        </div>
+    )
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1800,6 +1800,7 @@ export interface DashboardTemplateVariableType {
     type: 'event'
     default: Record<string, JsonType>
     required: boolean
+    touched?: boolean
 }
 
 export type DashboardLayoutSize = 'sm' | 'xs'


### PR DESCRIPTION
## Problem

For #23065

We want the template variable selector process to be as simple as possible for new users - they can always add more complex filters and stuff later. At this point they need two options - select from site, or define a custom event name.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- Simplifies variable select view (makes a completely new component for it)
- Extends variable logic to handle the new component style
- Adds option to use a custom event name for the variable
- When clicking "Select from site" it doesn't actually work yet - that's next


https://github.com/user-attachments/assets/0d3ac1fc-34c1-4a5c-84b5-853234d65fd2


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Clicked around a bunch to handle all the edge cases but LMK if you find any :)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
