### PR TITLE
fix: #24114 prevent person being clicked on twice if deleted

### DIFF
--- a/frontend/src/scenes/persons/PersonDisplay.tsx
+++ b/frontend/src/scenes/persons/PersonDisplay.tsx
@@ -64,6 +64,17 @@ export function PersonDisplay({
 
     const notebookNode = useNotebookNode()
 
+    const handleClick = (e: React.MouseEvent): void => {
+        if (visible && href && !noLink && person?.properties) {
+            router.actions.push(href)
+        } else if (visible && !person?.properties) {
+            e.preventDefault()
+        } else {
+            setVisible(true)
+        }
+        return
+    }
+
     let content = (
         <span className={clsx('flex items-center', isCentered && 'justify-center')}>
             {withIcon && <PersonIcon person={person} size={typeof withIcon === 'string' ? withIcon : 'md'} />}
@@ -72,26 +83,13 @@ export function PersonDisplay({
     )
 
     content = (
-        <span
-            className="PersonDisplay"
-            onClick={
-                !noPopover
-                    ? () => {
-                          if (visible && href && !noLink) {
-                              router.actions.push(href)
-                          } else {
-                              setVisible(true)
-                          }
-                      }
-                    : undefined
-            }
-        >
-            {noLink || !href ? (
+        <span className="PersonDisplay" onClick={!noPopover ? handleClick : undefined}>
+            {noLink || !href || (visible && !person?.properties) ? (
                 content
             ) : (
                 <Link
                     to={href}
-                    onClick={(e) => {
+                    onClick={(e: React.MouseEvent): void => {
                         if (!noPopover && !notebookNode) {
                             e.preventDefault()
                             return


### PR DESCRIPTION
## Problem

Tackles https://github.com/PostHog/posthog/issues/24114 - Within Activity, if a person has been deleted, then clicking on them twice (whilst the info popover is showing) will result in a page not found.

## Changes

Removed the click action and`<Link>` if person doesn't exist. The popover will display as normal for any user, but the link will disappear if they cannot be clicked on. 

https://www.loom.com/share/8334b37e2e0940238dcd4f1c8ca34f50

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

## How did you test this code?

Self-tested with multiple persons, and ran all front end tests.
