### PR TITLE
chore: fix hobby plugin server, again (#24750)

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -121,6 +121,7 @@ services:
             OBJECT_STORAGE_ENDPOINT: http://objectstorage:19000
             OBJECT_STORAGE_ENABLED: true
             CDP_REDIS_HOST: redis7
+            CDP_REDIS_PORT: 6379
         depends_on:
             - db
             - redis


### PR DESCRIPTION
Follwing up to #24750 I noticed that the self-hosted installation would not start - as the plugin server is per-default configured to connect to redis 6479, but docker-compose networking makes it available at the default port 6379