### PR TITLE
fix(capture-replay): try using jemalloc

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -639,6 +639,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "thiserror",
+ "tikv-jemallocator",
  "time",
  "tokio",
  "tower",
@@ -3978,6 +3979,26 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.6"
+
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }

--- a/rust/capture/src/main.rs
+++ b/rust/capture/src/main.rs
@@ -16,6 +16,13 @@ use tracing_subscriber::{EnvFilter, Layer};
 use capture::config::Config;
 use capture::server::serve;
 
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 async fn shutdown() {
     let mut term = signal::unix::signal(signal::unix::SignalKind::terminate())
         .expect("failed to register SIGTERM handler");


### PR DESCRIPTION
## Problem

Capture replay _looks_ like it's leaking memory, but it's possible that what's actually happening is heap fragmentation. One way to test this is to use an allocator that's heap-fragmentation focused, and see if that helps things at all.

This commit should be reverted after testing in production - even if we want to switch to jemalloc, we should integrate it in a less hacky manner.