### PR TITLE
fix(frontend): Don't crash on color retrieval error

### DIFF
--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -1,3 +1,5 @@
+import { captureException } from '@sentry/react'
+
 import { LifecycleToggle } from '~/types'
 
 import { LemonTagType } from './lemon-ui/LemonTag'
@@ -39,7 +41,8 @@ export const tagColors: LemonTagType[] = [
 export function getColorVar(variable: string): string {
     const colorValue = getComputedStyle(document.body).getPropertyValue('--' + variable)
     if (!colorValue) {
-        throw new Error(`Couldn't find color variable --${variable}`)
+        captureException(new Error(`Couldn't find color variable --${variable}`))
+        return document.body.getAttribute('theme') === 'light' ? '#000' : '#fff'
     }
     return colorValue.trim()
 }

--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -42,6 +42,7 @@ export function getColorVar(variable: string): string {
     const colorValue = getComputedStyle(document.body).getPropertyValue('--' + variable)
     if (!colorValue) {
         captureException(new Error(`Couldn't find color variable --${variable}`))
+        // Fall back to black or white depending on the theme
         return document.body.getAttribute('theme') === 'light' ? '#000' : '#fff'
     }
     return colorValue.trim()


### PR DESCRIPTION
## Problem

Sometimes JS tries to get color variables before CSS is ready, causing problems. Currently, this means graphs crashing. [See Sentry.](https://posthog.sentry.io/issues/?project=1899813&query=feature:%5BInsightViz,Dashboard,LineGraph%5D&sort=freq&statsPeriod=24h)

## Changes

The problem with colors not being ready is real, but there's no need to crash. We'll still be capturing these problems, but instead of crashing, it's totally fine to return black/white (depending on theme). It's almost guaranteed that subsequent `getColorVar()` will work.