### PR TITLE
fix(cdp): Fixed serialization to not include the hog function

### DIFF
--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -44,6 +44,7 @@ import {
     createInvocation,
     gzipObject,
     prepareLogEntriesForClickhouse,
+    serializeInvocation,
     unGzipObject,
 } from './utils'
 
@@ -217,12 +218,7 @@ abstract class CdpConsumerBase {
         // For now we just enqueue to kafka
         // For kafka style this is overkill to enqueue this way but it simplifies migrating to the new system
 
-        const serializedInvocation: HogFunctionInvocationSerialized = {
-            ...invocation,
-            hogFunctionId: invocation.hogFunction.id,
-        }
-
-        delete (serializedInvocation as any).hogFunction
+        const serializedInvocation = serializeInvocation(invocation)
 
         const request: HogFunctionInvocationSerializedCompressed = {
             state: await gzipObject(serializedInvocation),

--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -548,8 +548,15 @@ export class CdpFunctionCallbackConsumer extends CdpConsumerBase {
                 // NOTE: In the future this service will never do fetching (unless we decide we want to do it in node at some point)
                 // This is just "for now" to support the transition to cyclotron
                 const fetchQueue = invocations.filter((item) => item.queue === 'fetch')
-                const fetchResults = await this.runManyWithHeartbeat(fetchQueue, (item) =>
-                    this.fetchExecutor.execute(item)
+
+                const fetchResults = await Promise.all(
+                    fetchQueue.map((item) => {
+                        return runInstrumentedFunction({
+                            statsKey: `cdpConsumer.handleEachBatch.fetchExecutor.execute`,
+                            func: () => this.fetchExecutor.execute(item),
+                            timeout: 1000,
+                        })
+                    })
                 )
 
                 const hogQueue = invocations.filter((item) => item.queue === 'hog')

--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -229,7 +229,7 @@ abstract class CdpConsumerBase {
         this.messagesToProduce.push({
             topic: KAFKA_CDP_FUNCTION_CALLBACKS,
             value: request,
-            key: invocation.hogFunction.id,
+            key: `${invocation.hogFunction.id}:${invocation.id}`,
         })
     }
 

--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -296,7 +296,7 @@ abstract class CdpConsumerBase {
             // queuedMinMessages: this.hub.KAFKA_QUEUE_SIZE,
             consumerMaxWaitMs: this.hub.KAFKA_CONSUMPTION_MAX_WAIT_MS,
             consumerErrorBackoffMs: this.hub.KAFKA_CONSUMPTION_ERROR_BACKOFF_MS,
-            fetchBatchSize: 10, // this.hub.INGESTION_BATCH_SIZE,
+            fetchBatchSize: this.hub.INGESTION_BATCH_SIZE,
             batchingTimeoutMs: this.hub.KAFKA_CONSUMPTION_BATCHING_TIMEOUT_MS,
             topicCreationTimeoutMs: this.hub.KAFKA_TOPIC_CREATION_TIMEOUT_MS,
             topicMetadataRefreshInterval: this.hub.KAFKA_TOPIC_METADATA_REFRESH_INTERVAL_MS,

--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -296,7 +296,7 @@ abstract class CdpConsumerBase {
             // queuedMinMessages: this.hub.KAFKA_QUEUE_SIZE,
             consumerMaxWaitMs: this.hub.KAFKA_CONSUMPTION_MAX_WAIT_MS,
             consumerErrorBackoffMs: this.hub.KAFKA_CONSUMPTION_ERROR_BACKOFF_MS,
-            fetchBatchSize: this.hub.INGESTION_BATCH_SIZE,
+            fetchBatchSize: 10, // this.hub.INGESTION_BATCH_SIZE,
             batchingTimeoutMs: this.hub.KAFKA_CONSUMPTION_BATCHING_TIMEOUT_MS,
             topicCreationTimeoutMs: this.hub.KAFKA_TOPIC_CREATION_TIMEOUT_MS,
             topicMetadataRefreshInterval: this.hub.KAFKA_TOPIC_METADATA_REFRESH_INTERVAL_MS,
@@ -607,11 +607,11 @@ export class CdpFunctionCallbackConsumer extends CdpConsumerBase {
                                     invocationSerialized.queueParameters = item.asyncFunctionResponse
                                 }
 
-                                const hogFunction =
-                                    invocationSerialized.hogFunction ??
-                                    (invocationSerialized.hogFunctionId
-                                        ? this.hogFunctionManager.getHogFunction(invocationSerialized.hogFunctionId)
-                                        : undefined)
+                                const hogFunctionId =
+                                    invocationSerialized.hogFunctionId ?? invocationSerialized.hogFunction?.id
+                                const hogFunction = hogFunctionId
+                                    ? this.hogFunctionManager.getHogFunction(hogFunctionId)
+                                    : undefined
 
                                 if (!hogFunction) {
                                     status.error('Error finding hog function', {

--- a/plugin-server/src/cdp/fetch-executor.ts
+++ b/plugin-server/src/cdp/fetch-executor.ts
@@ -12,7 +12,7 @@ import {
     HogFunctionQueueParametersFetchRequest,
     HogFunctionQueueParametersFetchResponse,
 } from './types'
-import { gzipObject } from './utils'
+import { gzipObject, serializeInvocation } from './utils'
 
 export const BUCKETS_KB_WRITTEN = [0, 128, 512, 1024, 2024, 4096, 10240, Infinity]
 
@@ -52,7 +52,7 @@ export class FetchExecutor {
             if (this.hogHookEnabledForTeams(invocation.teamId)) {
                 // This is very temporary until we are commited to Cyclotron
                 const payload: HogFunctionInvocationAsyncRequest = {
-                    state: await gzipObject(invocation),
+                    state: await gzipObject(serializeInvocation(invocation)),
                     teamId: invocation.teamId,
                     hogFunctionId: invocation.hogFunction.id,
                     asyncFunctionRequest: {

--- a/plugin-server/src/cdp/utils.ts
+++ b/plugin-server/src/cdp/utils.ts
@@ -12,6 +12,7 @@ import {
     HogFunctionInvocation,
     HogFunctionInvocationGlobals,
     HogFunctionInvocationResult,
+    HogFunctionInvocationSerialized,
     HogFunctionLogEntrySerialized,
     HogFunctionType,
     ParsedClickhouseEvent,
@@ -223,4 +224,14 @@ export function createInvocation(
         queue: 'hog',
         timings: [],
     }
+}
+
+export function serializeInvocation(invocation: HogFunctionInvocation): HogFunctionInvocationSerialized {
+    const serializedInvocation: HogFunctionInvocationSerialized = {
+        ...invocation,
+        hogFunctionId: invocation.hogFunction.id,
+    }
+
+    delete (serializedInvocation as any).hogFunction
+    return invocation
 }


### PR DESCRIPTION
## Problem

The fetch serializer includeed the hog function instead of just the ID.

## Changes

* Change it to include just the ID with a shared function
* Deserialization already supports both options

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
