### PR TITLE
feat(batch-exports): Send file write to thread

### DIFF
--- a/posthog/temporal/batch_exports/temporary_file.py
+++ b/posthog/temporal/batch_exports/temporary_file.py
@@ -1,6 +1,7 @@
 """This module contains a temporary file to stage data in batch exports."""
 
 import abc
+import asyncio
 import collections.abc
 import contextlib
 import csv
@@ -390,7 +391,7 @@ class BatchExportWriter(abc.ABC):
         column_names = record_batch.column_names
         column_names.pop(column_names.index("_inserted_at"))
 
-        self._write_record_batch(record_batch.select(column_names))
+        await asyncio.to_thread(self._write_record_batch, record_batch.select(column_names))
 
         self.last_inserted_at = last_inserted_at
         self.track_records_written(record_batch)


### PR DESCRIPTION
## Problem

We are still seeing heartbeat timeouts, which means that something is still blocking the event loop and not allowing heartbeats to go out. File writing seems to be the only sync call remaining, and the GIL should be released when file writing.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Send file writing to thread, release the GIL, hopefully heartbeat on time?

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
