### PR TITLE
fix(data-warehouse): include views props in insights

### DIFF
--- a/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
+++ b/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
@@ -109,7 +109,9 @@ export const databaseTableListLogic = kea<databaseTableListLogicType>([
                 }
 
                 return Object.values(database.tables)
-                    .filter((n): n is DatabaseSchemaDataWarehouseTable => n.type === 'data_warehouse')
+                    .filter(
+                        (n): n is DatabaseSchemaDataWarehouseTable => n.type === 'data_warehouse' || n.type == 'view'
+                    )
                     .reduce((acc, cur) => {
                         acc[cur.name] = database.tables[cur.name] as DatabaseSchemaDataWarehouseTable
                         return acc


### PR DESCRIPTION
## Problem

- when using views in insights, the views props aren't populated

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- populate view props

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
