### PR TITLE
fix: exclude push from auto-generated snippet

### DIFF
--- a/frontend/src/lib/components/JSSnippet.tsx
+++ b/frontend/src/lib/components/JSSnippet.tsx
@@ -13,7 +13,7 @@ export function snippetFunctions(): string {
         if (
             typeof posthogPrototype[key] === 'function' &&
             !key.startsWith('_') &&
-            !['constructor', 'toString'].includes(key)
+            !['constructor', 'toString', 'push'].includes(key)
         ) {
             methods.push(key)
         }


### PR DESCRIPTION
closes #24797 

"push" certainly wasn't there in the pre-auto-generated-snippet snippet

and the auto-generation is only intended to catch _new_ methods

so without pulling on the thread of why `push` exists it is safe to remove this