### PR TITLE
feat(cdp): Add migration for Intercom plugin

### DIFF
--- a/posthog/cdp/templates/__init__.py
+++ b/posthog/cdp/templates/__init__.py
@@ -2,7 +2,7 @@ from .webhook.template_webhook import template as webhook
 from .slack.template_slack import template as slack
 from .hubspot.template_hubspot import template as hubspot
 from .customerio.template_customerio import template as customerio, TemplateCustomerioMigrator
-from .intercom.template_intercom import template as intercom
+from .intercom.template_intercom import template as intercom, TemplateIntercomMigrator
 from .sendgrid.template_sendgrid import template as sendgrid
 from .clearbit.template_clearbit import template as clearbit
 from .posthog.template_posthog import template as posthog
@@ -39,6 +39,7 @@ HOG_FUNCTION_TEMPLATES_BY_ID = {template.id: template for template in HOG_FUNCTI
 
 HOG_FUNCTION_MIGRATORS = {
     TemplateCustomerioMigrator.plugin_url: TemplateCustomerioMigrator,
+    TemplateIntercomMigrator.plugin_url: TemplateIntercomMigrator,
 }
 
 __all__ = ["HOG_FUNCTION_TEMPLATES", "HOG_FUNCTION_TEMPLATES_BY_ID"]

--- a/posthog/cdp/templates/intercom/template_intercom.py
+++ b/posthog/cdp/templates/intercom/template_intercom.py
@@ -1,4 +1,6 @@
-from posthog.cdp.templates.hog_function_template import HogFunctionTemplate
+from copy import deepcopy
+import dataclasses
+from posthog.cdp.templates.hog_function_template import HogFunctionTemplate, HogFunctionTemplateMigrator
 
 
 template: HogFunctionTemplate = HogFunctionTemplate(
@@ -8,19 +10,15 @@ template: HogFunctionTemplate = HogFunctionTemplate(
     description="Send events and contact information to Intercom",
     icon_url="/static/services/intercom.png",
     hog="""
-let accessToken := inputs.access_token
-let host := inputs.host
-let email := inputs.email
-
-if (empty(email)) {
+if (empty(inputs.email)) {
     print('`email` input is empty. Skipping.')
     return
 }
 
-let res := fetch(f'https://{host}/events', {
+let res := fetch(f'https://{inputs.host}/events', {
   'method': 'POST',
   'headers': {
-    'Authorization': f'Bearer {accessToken}',
+    'Authorization': f'Bearer {inputs.access_token}',
     'Content-Type': 'application/json',
     'Accept': 'application/json'
   },
@@ -89,3 +87,47 @@ print('Error sending event:', res.status, res.body)
         "filter_test_accounts": True,
     },
 )
+
+
+class TemplateIntercomMigrator(HogFunctionTemplateMigrator):
+    plugin_url = "https://github.com/PostHog/posthog-intercom-plugin"
+
+    @classmethod
+    def migrate(cls, obj):
+        hf = deepcopy(dataclasses.asdict(template))
+
+        useEuropeanDataStorage = obj.config.get("useEuropeanDataStorage", "No")
+        intercomApiKey = obj.config.get("intercomApiKey", "")
+        triggeringEvents = obj.config.get("triggeringEvents", "$identify")
+        ignoredEmailDomains = obj.config.get("ignoredEmailDomains", "")
+
+        hf["filters"] = {}
+
+        events_to_filter = [event.strip() for event in triggeringEvents.split(",") if event.strip()]
+        domains_to_filter = [domain.strip() for domain in ignoredEmailDomains.split(",") if domain.strip()]
+
+        if domains_to_filter:
+            hf["filters"]["properties"] = [
+                {
+                    "key": "email",
+                    "value": domain,
+                    "operator": "not_icontains",
+                    "type": "person",
+                }
+                for domain in domains_to_filter
+            ]
+
+        if events_to_filter:
+            hf["filters"]["events"] = [
+                {"id": event, "name": event, "type": "events", "order": 0} for event in events_to_filter
+            ]
+
+        hf["inputs"] = {
+            "access_token": {"value": intercomApiKey},
+            "host": {"value": "api.eu.intercom.com"}
+            if useEuropeanDataStorage == "Yes"
+            else {"value": "api.intercom.io"},
+            "email": {"value": "{person.properties.email}"},
+        }
+
+        return hf

--- a/posthog/cdp/templates/intercom/test_template_intercom.py
+++ b/posthog/cdp/templates/intercom/test_template_intercom.py
@@ -155,7 +155,7 @@ class TestTemplateMigration(BaseTest):
             {
                 "properties": [
                     {"key": "email", "value": "test.com", "operator": "not_icontains", "type": "person"},
-                    {"key": "email", "value": "other-com", "operator": "not_icontains", "type": "person"},
+                    {"key": "email", "value": "other.com", "operator": "not_icontains", "type": "person"},
                 ],
                 "events": [{"id": "$identify", "name": "$identify", "type": "events", "order": 0}],
             }

--- a/posthog/cdp/templates/intercom/test_template_intercom.py
+++ b/posthog/cdp/templates/intercom/test_template_intercom.py
@@ -1,5 +1,8 @@
+from inline_snapshot import snapshot
 from posthog.cdp.templates.helpers import BaseHogFunctionTemplateTest
-from posthog.cdp.templates.intercom.template_intercom import template as template_intercom
+from posthog.cdp.templates.intercom.template_intercom import template as template_intercom, TemplateIntercomMigrator
+from posthog.models.plugin import PluginConfig
+from posthog.test.base import BaseTest
 
 
 class TestTemplateIntercom(BaseHogFunctionTemplateTest):
@@ -77,3 +80,84 @@ class TestTemplateIntercom(BaseHogFunctionTemplateTest):
                 },
             )
         ]
+
+
+class TestTemplateMigration(BaseTest):
+    def get_plugin_config(self, config: dict):
+        _config = {
+            "intercomApiKey": "INTERCOM_API_KEY",
+            "triggeringEvents": "$identify",
+            "ignoredEmailDomains": "",
+            "useEuropeanDataStorage": "No",
+        }
+
+        _config.update(config)
+        return PluginConfig(enabled=True, order=0, config=_config)
+
+    def test_full_function(self):
+        obj = self.get_plugin_config({})
+
+        template = TemplateIntercomMigrator.migrate(obj)
+        assert template["inputs"] == snapshot(
+            {
+                "access_token": {"value": "INTERCOM_API_KEY"},
+                "host": {"value": "api.intercom.io"},
+                "email": {"value": "{person.properties.email}"},
+            }
+        )
+        assert template["filters"] == snapshot(
+            {"events": [{"id": "$identify", "name": "$identify", "type": "events", "order": 0}]}
+        )
+
+    def test_eu_host(self):
+        obj = self.get_plugin_config(
+            {
+                "useEuropeanDataStorage": "Yes",
+            }
+        )
+
+        template = TemplateIntercomMigrator.migrate(obj)
+        assert template["inputs"] == snapshot(
+            {
+                "access_token": {"value": "INTERCOM_API_KEY"},
+                "host": {"value": "api.eu.intercom.com"},
+                "email": {"value": "{person.properties.email}"},
+            }
+        )
+
+    def test_triggering_events(self):
+        obj = self.get_plugin_config(
+            {
+                "triggeringEvents": "$identify,$pageview, custom event, ",
+            }
+        )
+
+        template = TemplateIntercomMigrator.migrate(obj)
+        assert template["filters"] == snapshot(
+            {
+                "events": [
+                    {"id": "$identify", "name": "$identify", "type": "events", "order": 0},
+                    {"id": "$pageview", "name": "$pageview", "type": "events", "order": 0},
+                    {"id": "custom event", "name": "custom event", "type": "events", "order": 0},
+                ]
+            }
+        )
+
+    def test_ignore_domains(self):
+        obj = self.get_plugin_config(
+            {
+                "ignoredEmailDomains": "test.com, other-com, ",
+            }
+        )
+
+        template = TemplateIntercomMigrator.migrate(obj)
+        assert template["filters"] == snapshot(
+            {
+                "properties": [
+                    {"key": "email", "value": "test.com", "operator": "not_icontains", "type": "person"},
+                    {"key": "email", "value": " other-com", "operator": "not_icontains", "type": "person"},
+                    {"key": "email", "value": " ", "operator": "not_icontains", "type": "person"},
+                ],
+                "events": [{"id": "$identify", "name": "$identify", "type": "events", "order": 0}],
+            }
+        )

--- a/posthog/cdp/templates/intercom/test_template_intercom.py
+++ b/posthog/cdp/templates/intercom/test_template_intercom.py
@@ -146,7 +146,7 @@ class TestTemplateMigration(BaseTest):
     def test_ignore_domains(self):
         obj = self.get_plugin_config(
             {
-                "ignoredEmailDomains": "test.com, other-com, ",
+                "ignoredEmailDomains": "test.com, other.com, ",
             }
         )
 
@@ -155,8 +155,7 @@ class TestTemplateMigration(BaseTest):
             {
                 "properties": [
                     {"key": "email", "value": "test.com", "operator": "not_icontains", "type": "person"},
-                    {"key": "email", "value": " other-com", "operator": "not_icontains", "type": "person"},
-                    {"key": "email", "value": " ", "operator": "not_icontains", "type": "person"},
+                    {"key": "email", "value": "other-com", "operator": "not_icontains", "type": "person"},
                 ],
                 "events": [{"id": "$identify", "name": "$identify", "type": "events", "order": 0}],
             }


### PR DESCRIPTION
## Problem

The Intercom integration looks good so we can prompt for migration.

@MarconLP this is a good example to use for your plugin work. Every existing plugin should have a corresponding Migrator in this way which prompts in the UI for people to migrate and will form the base of automatic migration in the future.

## Changes

* Adds intercom migrator
* Some tidying of where the vars are acccessed

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
