### PR TITLE
fix(dashboards): Make sure loading dashboard items does not `POST /query/`

### DIFF
--- a/cypress/e2e/dashboard-shared.cy.ts
+++ b/cypress/e2e/dashboard-shared.cy.ts
@@ -62,7 +62,6 @@ describe('Shared dashboard', () => {
 
         cy.get('.InsightCard').should('have.length', 6)
         // Make sure no element with text "There are no matching events for this query" exists
-        // TODO this was failing, it shouldn't be but YOLO
-        // cy.get('.insight-empty-state').should('not.exist')
+        cy.get('.insight-empty-state').should('not.exist')
     })
 })

--- a/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
+++ b/frontend/src/queries/nodes/DataNode/dataNodeLogic.ts
@@ -122,7 +122,11 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
         }
     }),
     actions({
-        loadData: (refresh = false, queryId?: string) => ({ refresh, queryId: queryId || uuid() }),
+        loadData: (refresh = false, alreadyRunningQueryId?: string) => ({
+            refresh,
+            queryId: alreadyRunningQueryId || uuid(),
+            pollOnly: !!alreadyRunningQueryId,
+        }),
         abortAnyRunningQuery: true,
         abortQuery: (payload: { queryId: string }) => payload,
         cancelQuery: true,
@@ -142,7 +146,7 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
             {
                 setResponse: (response) => response,
                 clearResponse: () => null,
-                loadData: async ({ refresh: refreshArg, queryId }, breakpoint) => {
+                loadData: async ({ refresh: refreshArg, queryId, pollOnly }, breakpoint) => {
                     const refresh = props.alwaysRefresh || refreshArg
                     if (props.doNotLoad) {
                         return props.cachedResults
@@ -200,7 +204,8 @@ export const dataNodeLogic = kea<dataNodeLogicType>([
                                             methodOptions,
                                             refresh,
                                             queryId,
-                                            actions.setPollResponse
+                                            actions.setPollResponse,
+                                            pollOnly
                                         )) ?? null
                                     const duration = performance.now() - now
                                     return { data, duration }

--- a/frontend/src/queries/nodes/DataTable/dataTableLogic.test.ts
+++ b/frontend/src/queries/nodes/DataTable/dataTableLogic.test.ts
@@ -65,7 +65,8 @@ describe('dataTableLogic', () => {
             expect.anything(),
             false,
             expect.any(String),
-            expect.any(Function)
+            expect.any(Function),
+            false
         )
         expect(performQuery).toHaveBeenCalledTimes(1)
     })

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -204,7 +204,7 @@ export function isQueryForGroup(query: PersonsNode | ActorsQuery): boolean {
 }
 
 export function isAsyncResponse(response: NonNullable<QuerySchema['response']>): response is QueryStatusResponse {
-    return 'query_status' in response
+    return 'query_status' in response && response.query_status
 }
 
 export function isInsightQueryWithSeries(

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -30,6 +30,8 @@ import {
     NodeKind,
     PathsQuery,
     PersonsNode,
+    QuerySchema,
+    QueryStatusResponse,
     RetentionQuery,
     SavedInsightNode,
     SessionAttributionExplorerQuery,
@@ -78,6 +80,7 @@ export function isDataWarehouseNode(node?: Record<string, any> | null): node is 
     return node?.kind === NodeKind.DataWarehouseNode
 }
 
+/** @deprecated `ActorsQuery` is now used instead of `PersonsNode`. */
 export function isPersonsNode(node?: Record<string, any> | null): node is PersonsNode {
     return node?.kind === NodeKind.PersonsNode
 }
@@ -198,6 +201,10 @@ export function isQueryForGroup(query: PersonsNode | ActorsQuery): boolean {
         isRetentionQuery(query.source.source) &&
         query.source.source.aggregation_group_type_index !== undefined
     )
+}
+
+export function isAsyncResponse(response: NonNullable<QuerySchema['response']>): response is QueryStatusResponse {
+    return 'query_status' in response
 }
 
 export function isInsightQueryWithSeries(

--- a/frontend/src/scenes/funnels/funnelUtils.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.ts
@@ -389,7 +389,7 @@ export function flattenedStepsByBreakdown(
                     breakdown_value: 'Baseline',
                 })),
                 conversionRates: {
-                    total: (lastStep?.count ?? 0) / (baseStep?.count ?? 1),
+                    total: (lastStep?.count || 0) / (baseStep?.count || 1),
                 },
             })
         }

--- a/posthog/models/person_overrides/sql.py
+++ b/posthog/models/person_overrides/sql.py
@@ -69,7 +69,7 @@ PERSON_OVERRIDES_CREATE_TABLE_SQL = f"""
     ENGINE = ReplicatedReplacingMergeTree(
         -- NOTE: for testing we use a uuid to ensure that we don't get conflicts
         -- when the tests tear down and recreate the table.
-        '/clickhouse/tables/{'{uuid}' if settings.TEST else ''}noshard/{CLICKHOUSE_DATABASE}.person_overrides',
+        '/clickhouse/tables/{'{uuid}' if settings.TEST or settings.E2E_TESTING else ''}noshard/{CLICKHOUSE_DATABASE}.person_overrides',
         '{{replica}}-{{shard}}',
         version
     )


### PR DESCRIPTION
## Problem

Shared dashboard items without previously cached results have not been loading correctly since we switched to async loading on shared dashboards. See this report: ZEN-17258.
We have a test which should have caught this long ago, but for some reason it was basically disabled in https://github.com/PostHog/posthog/pull/21187.

## Changes

This re-enables the test (it fails as expected on master), and adds a `pollOnly` flag to `executeQuery`, which allows us to use all the existing loading logic, the only change being that when we know the in-progress query ID (as is the case with GETting loading saved insights/dashboards), we don't POST /query/ needlessly – we only poll that known query ID.

## How did you test this code?

E2E test.