### PR TITLE
chore: allow exporting mobile recordings while impersonating a user

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerMetaLinks.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerMetaLinks.tsx
@@ -170,7 +170,7 @@ const MenuActions = (): JSX.Element => {
         useActions(sessionRecordingPlayerLogic)
     const { fetchSimilarRecordings } = useActions(sessionRecordingDataLogic(logicProps))
 
-    const hasMobileExport = useFeatureFlag('SESSION_REPLAY_EXPORT_MOBILE_DATA')
+    const hasMobileExport = window.IMPERSONATED_SESSION || useFeatureFlag('SESSION_REPLAY_EXPORT_MOBILE_DATA')
     const hasSimilarRecordings = useFeatureFlag('REPLAY_SIMILAR_RECORDINGS')
 
     const onDelete = (): void => {


### PR DESCRIPTION
We allow ourselves to export mobile recordings to file when debugging

But sometimes we're impersonating a customer and exporting the mobile recording for local testing would be useful

So, let's allow mobile export when impersonated too