### PR TITLE
feat: Switch batch exports logging to async

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -328,7 +328,7 @@ def bigquery_default_fields() -> list[BatchExportField]:
 async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> RecordsCompleted:
     """Activity streams data from ClickHouse to BigQuery."""
     logger = await bind_temporal_worker_logger(team_id=inputs.team_id, destination="BigQuery")
-    logger.info(
+    await logger.ainfo(
         "Batch exporting range %s - %s to BigQuery: %s.%s.%s",
         inputs.data_interval_start,
         inputs.data_interval_end,
@@ -446,7 +446,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                     last: bool,
                     error: Exception | None,
                 ):
-                    logger.debug(
+                    await logger.adebug(
                         "Loading %s records of size %s bytes",
                         records_since_last_flush,
                         bytes_since_last_flush,

--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -434,7 +434,7 @@ def get_postgres_fields_from_record_schema(
 async def insert_into_postgres_activity(inputs: PostgresInsertInputs) -> RecordsCompleted:
     """Activity streams data from ClickHouse to Postgres."""
     logger = await bind_temporal_worker_logger(team_id=inputs.team_id, destination="PostgreSQL")
-    logger.info(
+    await logger.ainfo(
         "Batch exporting range %s - %s to PostgreSQL: %s.%s.%s",
         inputs.data_interval_start,
         inputs.data_interval_end,
@@ -538,7 +538,7 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs) -> Records
                     last: bool,
                     error: Exception | None,
                 ):
-                    logger.debug(
+                    await logger.adebug(
                         "Copying %s records of size %s bytes",
                         records_since_last_flush,
                         bytes_since_last_flush,

--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -366,7 +366,7 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs) -> Records
             fields.
     """
     logger = await bind_temporal_worker_logger(team_id=inputs.team_id, destination="Redshift")
-    logger.info(
+    await logger.ainfo(
         "Batch exporting range %s - %s to Redshift: %s.%s.%s",
         inputs.data_interval_start,
         inputs.data_interval_end,

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -441,7 +441,7 @@ async def initialize_and_resume_multipart_upload(inputs: S3InsertInputs) -> tupl
     except IndexError:
         # This is the error we expect when no details as the sequence will be empty.
         interval_start = inputs.data_interval_start
-        logger.debug(
+        await logger.adebug(
             "Did not receive details from previous activity Execution. Export will start from the beginning %s",
             interval_start,
         )
@@ -449,12 +449,12 @@ async def initialize_and_resume_multipart_upload(inputs: S3InsertInputs) -> tupl
         # We still start from the beginning, but we make a point to log unexpected errors.
         # Ideally, any new exceptions should be added to the previous block after the first time and we will never land here.
         interval_start = inputs.data_interval_start
-        logger.warning(
+        await logger.awarning(
             "Did not receive details from previous activity Execution due to an unexpected error. Export will start from the beginning %s",
             interval_start,
         )
     else:
-        logger.info(
+        await logger.ainfo(
             "Received details from previous activity. Export will attempt to resume from %s",
             interval_start,
         )
@@ -464,7 +464,7 @@ async def initialize_and_resume_multipart_upload(inputs: S3InsertInputs) -> tupl
             # Even if we receive details we cannot resume a brotli compressed upload as we have lost the compressor state.
             interval_start = inputs.data_interval_start
 
-            logger.info(
+            await logger.ainfo(
                 f"Export will start from the beginning as we are using brotli compression: %s",
                 interval_start,
             )
@@ -502,7 +502,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
     files.
     """
     logger = await bind_temporal_worker_logger(team_id=inputs.team_id, destination="S3")
-    logger.info(
+    await logger.ainfo(
         "Batch exporting range %s - %s to S3: %s",
         inputs.data_interval_start,
         inputs.data_interval_end,
@@ -557,14 +557,14 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
                 error: Exception | None,
             ):
                 if error is not None:
-                    logger.debug("Error while writing part %d", s3_upload.part_number + 1, exc_info=error)
-                    logger.warn(
+                    await logger.adebug("Error while writing part %d", s3_upload.part_number + 1, exc_info=error)
+                    await logger.awarn(
                         "An error was detected while writing part %d. Partial part will not be uploaded in case it can be retried.",
                         s3_upload.part_number + 1,
                     )
                     return
 
-                logger.debug(
+                await logger.adebug(
                     "Uploading %s part %s containing %s records with size %s bytes",
                     "last " if last else "",
                     s3_upload.part_number + 1,

--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -540,7 +540,7 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs) -> Recor
     TODO: We're using JSON here, it's not the most efficient way to do this.
     """
     logger = await bind_temporal_worker_logger(team_id=inputs.team_id, destination="Snowflake")
-    logger.info(
+    await logger.ainfo(
         "Batch exporting range %s - %s to Snowflake: %s.%s.%s",
         inputs.data_interval_start,
         inputs.data_interval_end,

--- a/posthog/temporal/common/utils.py
+++ b/posthog/temporal/common/utils.py
@@ -1,5 +1,5 @@
-import collections.abc
 import abc
+import collections.abc
 import dataclasses
 import datetime as dt
 import typing
@@ -126,23 +126,23 @@ async def should_resume_from_activity_heartbeat(
     except NotEnoughHeartbeatValuesError:
         heartbeat_details = None
         received = False
-        logger.warning("Details from previous activity execution did not contain the expected amount of values")
+        await logger.awarning("Details from previous activity execution did not contain the expected amount of values")
 
     except HeartbeatParseError:
         heartbeat_details = None
         received = False
-        logger.warning("Details from previous activity execution could not be parsed.")
+        await logger.awarning("Details from previous activity execution could not be parsed.")
 
     except Exception:
         # We should start from the beginning, but we make a point to log unexpected errors.
         # Ideally, any new exceptions should be added to the previous blocks after the first time and we will never land here.
         heartbeat_details = None
         received = False
-        logger.exception("Did not receive details from previous activity Execution due to an unexpected error")
+        await logger.aexception("Did not receive details from previous activity Execution due to an unexpected error")
 
     else:
         received = True
-        logger.debug(
+        await logger.adebug(
             f"Received details from previous activity: {heartbeat_details}",
         )
 


### PR DESCRIPTION
## Problem

Had good results with moving file writing to a thread in https://github.com/PostHog/posthog/pull/24792. Inspired by that, I reviewed where we could have more blocking code, and that lead me to our logging (and also to #24804).

Structlog provides async methods that use a thread pool for logging. Our processor chain is not that complex that should be blocking for too long, but occasional timeouts tell us that we still have some blocking code. As little as it may be, Temporal workflows work best when nothing is blocking, so, let's also not block when logging. Our workflows are entirely bound by IO, so the extra computational overhead is not significant for our use case.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Switch all batch export logging calls to async variants (prefixed with `a`).

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Nothing really changed, functionality-wise. So, existing tests should cover this PR.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
