### PR TITLE
chore: change funnel errors to ExposedHogQLError

### DIFF
--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 import sentry_sdk
 import structlog
 from prometheus_client import Histogram
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, APIException
 
 from posthog import celery, redis
 from posthog.clickhouse.client.async_task_chain import add_task_to_on_commit
@@ -198,7 +198,7 @@ def execute_process_query(
         raise
     except Exception as err:
         query_status.results = None  # Clear results in case they are faulty
-        if isinstance(err, ExposedHogQLError | ExposedCHQueryError) or is_staff_user:
+        if isinstance(err, APIException | ExposedHogQLError | ExposedCHQueryError) or is_staff_user:
             # We can only expose the error message if it's a known safe error OR if the user is PostHog staff
             query_status.error_message = str(err)
         logger.exception("Error processing query async", team_id=team_id, query_id=query_id, exc_info=True)


### PR DESCRIPTION
## Problem

Realized through development environment that non posthog users couldn't see useful funnel errors (this was likely an async query change)

![image](https://github.com/user-attachments/assets/4567c86f-10ca-4b82-8742-79ae9ce7f2b6)


## Changes

Change all validation errors in funnels to ExposedHogQLError

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Made sure errors surfaced when you weren't a staff user.
