### PR TITLE
fix: rrweb player now has a destroy method

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -1063,7 +1063,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
         cache.hasInitialized = false
         document.removeEventListener('fullscreenchange', cache.fullScreenListener)
         cache.pausedMediaElements = []
-        values.player?.replayer?.pause()
+        values.player?.replayer?.destroy()
         actions.setPlayer(null)
         cache.unmountConsoleWarns?.()
 


### PR DESCRIPTION
While reading the rrweb docs because I only do fun, exciting things I saw the replayer has a destroy method

I wondered if we call it

We do... but only for preview panes.

When we unmount the player logic we only pause the replayer

We also periodically get hard-to-recreate reports that the site slows down over long watching sessions. That has always felt like a leak. And not destroying the player feels like a leaky thing

| before | after |
| --| -- |
|<img width="537" alt="current-pause" src="https://github.com/user-attachments/assets/f5b83cc5-0f55-459f-96b8-de897ee68cd7">|<img width="543" alt="proposed-destroy" src="https://github.com/user-attachments/assets/1d7645fe-08d0-4991-8d94-7f037603e3b0">|

clicking around the site appears to behave the same before and after but the captured performance monitors look less leaky to me (who could just be seeing patterns in noise)
