### PR TITLE
feat: add sdk target area to support form

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -104,6 +104,11 @@ export const TARGET_AREA_TO_NAME = [
                 label: 'Onboarding',
             },
             {
+                value: 'sdk',
+                'data-attr': `support-form-target-area-onboarding`,
+                label: 'SDK / Implementation',
+            },
+            {
                 value: 'cohorts',
                 'data-attr': `support-form-target-area-cohorts`,
                 label: 'Cohorts',


### PR DESCRIPTION

![2024-09-06 at 00 53 46@2x](https://github.com/user-attachments/assets/8b0c6cc8-edd3-4442-801f-224db0aa606d)

## Changes

- Added a new target area `SDK / Implementation` to the support form
- We'll automatically assign those tickets to the product analytics queue using [this trigger](https://posthoghelp.zendesk.com/admin/objects-rules/rules/triggers/14505275311387)