### PR TITLE
fix: Removed old heartbeat metric

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -181,7 +181,7 @@ CLICKHOUSE_TABLES = [
     "log_entries",
 ]
 
-HEARTBEAT_EVENT_TO_INGESTION_LAG_METRIC = {"heartbeat": "ingestion", "$heartbeat": "ingestion_api"}
+HEARTBEAT_EVENT_TO_INGESTION_LAG_METRIC = {"$heartbeat": "ingestion_api"}
 
 
 @shared_task(ignore_result=True)


### PR DESCRIPTION
## Problem

The new celery based flow works fine and is what we will rely on now over the scheduled plugins

## Changes

* Removes the old check

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
