### PR TITLE
feat(kafka-producer): ping kafka brokers

### DIFF
--- a/rust/common/kafka/src/kafka_producer.rs
+++ b/rust/common/kafka/src/kafka_producer.rs
@@ -58,7 +58,7 @@ pub async fn create_kafka_producer(
     // "Ping" the Kafka brokers by requesting metadata
     match api
         .client()
-        .fetch_metadata(None, std::time::Duration::from_secs(2))
+        .fetch_metadata(None, std::time::Duration::from_secs(15))
     {
         Ok(metadata) => {
             info!(

--- a/rust/common/kafka/src/kafka_producer.rs
+++ b/rust/common/kafka/src/kafka_producer.rs
@@ -2,7 +2,7 @@ use crate::config::KafkaConfig;
 
 use futures::future::join_all;
 use health::HealthHandle;
-use rdkafka::error::{KafkaError, KafkaResult};
+use rdkafka::error::KafkaError;
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
 use rdkafka::ClientConfig;
 use serde::Serialize;


### PR DESCRIPTION
## Problem

Resolve comment: "TODO: ping the kafka brokers to confirm configuration is OK (copy capture)"

## Changes

Ping kafka brokers by requesting metadata.

## Does this work well for both Cloud and self-hosted?

Tested only self-hosted.

## How did you test this code?
1. Ran: `cd rust && docker-compose up`
2. `cargo test`
3. Ran `hook-worker` in debug mode and verified it is getting metadata from Kafka

### Error Case
1. Ran `hook-worker` without Kafka 
<img width="1395" alt="Screenshot 2024-09-06 at 12 30 43 PM" src="https://github.com/user-attachments/assets/ffb66207-e4ea-4266-a5f1-360699f97e17">