### PR TITLE
feat: show absolute time in seekbar preview

### DIFF
--- a/frontend/src/scenes/session-recordings/player/controller/Seekbar.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/Seekbar.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef } from 'react'
 import { RecordingSegment } from '~/types'
 
 import { playerInspectorLogic } from '../inspector/playerInspectorLogic'
+import { playerSettingsLogic } from '../playerSettingsLogic'
 import { sessionRecordingDataLogic } from '../sessionRecordingDataLogic'
 import { sessionRecordingPlayerLogic } from '../sessionRecordingPlayerLogic'
 import { PlayerSeekbarPreview } from './PlayerSeekbarPreview'
@@ -18,6 +19,7 @@ export function Seekbar(): JSX.Element {
     const { seekToTime } = useActions(sessionRecordingPlayerLogic)
     const { seekbarItems } = useValues(playerInspectorLogic(logicProps))
     const { endTimeMs, thumbLeftPos, bufferPercent, isScrubbing } = useValues(seekbarLogic(logicProps))
+    const { timestampFormat } = useValues(playerSettingsLogic)
 
     const { handleDown, setSlider, setThumb } = useActions(seekbarLogic(logicProps))
     const { sessionPlayerData, sessionPlayerMetaData } = useValues(sessionRecordingDataLogic(logicProps))
@@ -84,6 +86,8 @@ export function Seekbar(): JSX.Element {
                         activeMs={
                             sessionPlayerMetaData?.active_seconds ? sessionPlayerMetaData.active_seconds * 1000 : null
                         }
+                        timestampFormat={timestampFormat}
+                        startTime={sessionPlayerData.start}
                     />
                 </div>
             </div>


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C03PB072FMJ/p1725483868252729

We should show the matching timestamp in the preview when in absolute timestamp format

## Changes

(Because of recomputation cost we do not pass `currentTimestamp` into the memoized function, hence the logic couldn't really be shared)

![previewtime](https://github.com/user-attachments/assets/662132ed-1c98-47b4-92a6-5152b8669a59)