### PR TITLE
feat(experiments): set up experiment result query runner

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -505,6 +505,9 @@
                 },
                 {
                     "$ref": "#/definitions/ErrorTrackingQuery"
+                },
+                {
+                    "$ref": "#/definitions/ExperimentResultQuery"
                 }
             ]
         },
@@ -3092,6 +3095,40 @@
                             },
                             "required": ["results"],
                             "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "insight": {
+                                    "const": "TRENDS",
+                                    "type": "string"
+                                },
+                                "results": {
+                                    "additionalProperties": {
+                                        "$ref": "#/definitions/ExperimentVariantTrendResult"
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "required": ["insight", "results"],
+                            "type": "object"
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "insight": {
+                                    "const": "FUNNELS",
+                                    "type": "string"
+                                },
+                                "results": {
+                                    "additionalProperties": {
+                                        "$ref": "#/definitions/ExperimentVariantFunnelResult"
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "required": ["insight", "results"],
+                            "type": "object"
                         }
                     ]
                 },
@@ -3203,6 +3240,9 @@
                         },
                         {
                             "$ref": "#/definitions/ErrorTrackingQuery"
+                        },
+                        {
+                            "$ref": "#/definitions/ExperimentResultQuery"
                         }
                     ],
                     "description": "Source of the events"
@@ -4310,6 +4350,107 @@
                 }
             },
             "required": ["columns", "hogql", "results", "types"],
+            "type": "object"
+        },
+        "ExperimentResultFunnelQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "insight": {
+                    "const": "FUNNELS",
+                    "type": "string"
+                },
+                "results": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ExperimentVariantFunnelResult"
+                    },
+                    "type": "object"
+                }
+            },
+            "required": ["insight", "results"],
+            "type": "object"
+        },
+        "ExperimentResultQuery": {
+            "additionalProperties": false,
+            "properties": {
+                "kind": {
+                    "const": "ExperimentResultQuery",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "response": {
+                    "$ref": "#/definitions/ExperimentResultQueryResponse"
+                },
+                "source": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/TrendsQuery"
+                        },
+                        {
+                            "$ref": "#/definitions/FunnelsQuery"
+                        }
+                    ]
+                },
+                "variants": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["kind", "source", "variants"],
+            "type": "object"
+        },
+        "ExperimentResultQueryResponse": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/ExperimentResultTrendQueryResponse"
+                },
+                {
+                    "$ref": "#/definitions/ExperimentResultFunnelQueryResponse"
+                }
+            ]
+        },
+        "ExperimentResultTrendQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "insight": {
+                    "const": "TRENDS",
+                    "type": "string"
+                },
+                "results": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/ExperimentVariantTrendResult"
+                    },
+                    "type": "object"
+                }
+            },
+            "required": ["insight", "results"],
+            "type": "object"
+        },
+        "ExperimentVariantFunnelResult": {
+            "additionalProperties": false,
+            "properties": {
+                "failure_count": {
+                    "type": "number"
+                },
+                "success_count": {
+                    "type": "number"
+                }
+            },
+            "required": ["success_count", "failure_count"],
+            "type": "object"
+        },
+        "ExperimentVariantTrendResult": {
+            "additionalProperties": false,
+            "properties": {
+                "count": {
+                    "type": "number"
+                }
+            },
+            "required": ["count"],
             "type": "object"
         },
         "ExperimentalAITrendsQuery": {
@@ -6564,6 +6705,7 @@
                 "RecordingsQuery",
                 "SessionAttributionExplorerQuery",
                 "ErrorTrackingQuery",
+                "ExperimentResultQuery",
                 "DataTableNode",
                 "DataVisualizationNode",
                 "SavedInsightNode",
@@ -7775,6 +7917,12 @@
                     "type": "object"
                 },
                 {
+                    "$ref": "#/definitions/ExperimentResultTrendQueryResponse"
+                },
+                {
+                    "$ref": "#/definitions/ExperimentResultFunnelQueryResponse"
+                },
+                {
                     "properties": {},
                     "type": "object"
                 },
@@ -8268,6 +8416,40 @@
                 {
                     "additionalProperties": false,
                     "properties": {
+                        "insight": {
+                            "const": "TRENDS",
+                            "type": "string"
+                        },
+                        "results": {
+                            "additionalProperties": {
+                                "$ref": "#/definitions/ExperimentVariantTrendResult"
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "required": ["insight", "results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "insight": {
+                            "const": "FUNNELS",
+                            "type": "string"
+                        },
+                        "results": {
+                            "additionalProperties": {
+                                "$ref": "#/definitions/ExperimentVariantFunnelResult"
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "required": ["insight", "results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
                         "error": {
                             "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
                             "type": "string"
@@ -8624,6 +8806,9 @@
                 },
                 {
                     "$ref": "#/definitions/ErrorTrackingQuery"
+                },
+                {
+                    "$ref": "#/definitions/ExperimentResultQuery"
                 },
                 {
                     "$ref": "#/definitions/DataVisualizationNode"

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -74,6 +74,7 @@ export enum NodeKind {
     RecordingsQuery = 'RecordingsQuery',
     SessionAttributionExplorerQuery = 'SessionAttributionExplorerQuery',
     ErrorTrackingQuery = 'ErrorTrackingQuery',
+    ExperimentResultQuery = 'ExperimentResultQuery',
 
     // Interface nodes
     DataTableNode = 'DataTableNode',
@@ -120,6 +121,7 @@ export type AnyDataNode =
     | WebGoalsQuery
     | SessionAttributionExplorerQuery
     | ErrorTrackingQuery
+    | ExperimentResultQuery
 
 /**
  * @discriminator kind
@@ -145,6 +147,7 @@ export type QuerySchema =
     | WebGoalsQuery
     | SessionAttributionExplorerQuery
     | ErrorTrackingQuery
+    | ExperimentResultQuery
 
     // Interface nodes
     | DataVisualizationNode
@@ -564,6 +567,7 @@ export interface DataTableNode
                     | WebGoalsQuery
                     | SessionAttributionExplorerQuery
                     | ErrorTrackingQuery
+                    | ExperimentResultQuery
                 )['response']
             >
         >,
@@ -582,6 +586,7 @@ export interface DataTableNode
         | WebGoalsQuery
         | SessionAttributionExplorerQuery
         | ErrorTrackingQuery
+        | ExperimentResultQuery
     /** Columns shown in the table, unless the `source` provides them. */
     columns?: HogQLExpression[]
     /** Columns that aren't shown in the table, even if in columns or returned data */
@@ -1500,6 +1505,33 @@ export type InsightQueryNode =
     | PathsQuery
     | StickinessQuery
     | LifecycleQuery
+
+export interface ExperimentVariantTrendResult {
+    count: number
+}
+
+export interface ExperimentVariantFunnelResult {
+    success_count: number
+    failure_count: number
+}
+
+export interface ExperimentResultTrendQueryResponse {
+    insight: InsightType.TRENDS
+    results: Record<string, ExperimentVariantTrendResult>
+}
+
+export interface ExperimentResultFunnelQueryResponse {
+    insight: InsightType.FUNNELS
+    results: Record<string, ExperimentVariantFunnelResult>
+}
+
+export type ExperimentResultQueryResponse = ExperimentResultTrendQueryResponse | ExperimentResultFunnelQueryResponse
+
+export interface ExperimentResultQuery extends DataNode<ExperimentResultQueryResponse> {
+    kind: NodeKind.ExperimentResultQuery
+    source: TrendsQuery | FunnelsQuery
+    variants: string[]
+}
 
 /**
  * @discriminator kind

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -4,6 +4,7 @@ import {
     IconBrackets,
     IconCorrelationAnalysis,
     IconCursor,
+    IconFlask,
     IconFunnels,
     IconGraph,
     IconHogQL,
@@ -326,6 +327,12 @@ export const QUERY_TYPES_METADATA: Record<NodeKind, InsightTypeMetadata> = {
         name: 'Session Recordings',
         description: 'View available recordings',
         icon: IconVideoCamera,
+        inMenu: false,
+    },
+    [NodeKind.ExperimentResultQuery]: {
+        name: 'Experiment Result',
+        description: 'View experiment result',
+        icon: IconFlask,
         inMenu: false,
     },
 }

--- a/posthog/hogql_queries/experiment_result_query_runner.py
+++ b/posthog/hogql_queries/experiment_result_query_runner.py
@@ -61,10 +61,10 @@ class ExperimentResultQueryRunner(QueryRunner):
 
         for result in funnels_results:
             if result:
-                variant = result[0].get("breakdown_value", [""])[0]
+                variant = result[0].get("breakdown_value")[0]
                 if variant in variants:
-                    total_count = result[0]["count"]
-                    success_count = result[-1]["count"]
+                    total_count = result[0].get("count", 0)
+                    success_count = result[-1].get("count", 0)
                     processed_results[variant].success_count = success_count
                     processed_results[variant].failure_count = total_count - success_count
 

--- a/posthog/hogql_queries/experiment_result_query_runner.py
+++ b/posthog/hogql_queries/experiment_result_query_runner.py
@@ -52,7 +52,7 @@ class ExperimentResultQueryRunner(QueryRunner):
         return processed_results
 
     def _process_funnels_results(
-        self, funnels_results: list[dict[str, Any]]
+        self, funnels_results: list[list[dict[str, Any]]]
     ) -> dict[str, ExperimentVariantFunnelResult]:
         variants = self.query.variants
         processed_results = {
@@ -60,13 +60,15 @@ class ExperimentResultQueryRunner(QueryRunner):
         }
 
         for result in funnels_results:
-            if result:
-                variant = result[0].get("breakdown_value")[0]
-                if variant in variants:
-                    total_count = result[0].get("count", 0)
-                    success_count = result[-1].get("count", 0)
-                    processed_results[variant].success_count = success_count
-                    processed_results[variant].failure_count = total_count - success_count
+            first_step = result[0]
+            last_step = result[-1]
+            variant = first_step.get("breakdown_value")
+            variant_str = variant[0] if isinstance(variant, list) else str(variant)
+            if variant_str in variants:
+                total_count = first_step.get("count", 0)
+                success_count = last_step.get("count", 0) if len(result) > 1 else 0
+                processed_results[variant_str].success_count = success_count
+                processed_results[variant_str].failure_count = total_count - success_count
 
         return processed_results
 

--- a/posthog/hogql_queries/experiment_result_query_runner.py
+++ b/posthog/hogql_queries/experiment_result_query_runner.py
@@ -1,0 +1,74 @@
+from posthog.hogql import ast
+from posthog.hogql_queries.query_runner import QueryRunner, get_query_runner
+from posthog.schema import (
+    ExperimentResultFunnelQueryResponse,
+    ExperimentResultQuery,
+    ExperimentResultTrendQueryResponse,
+    ExperimentVariantTrendResult,
+    ExperimentVariantFunnelResult,
+    TrendsQuery,
+    FunnelsQuery,
+)
+from typing import Any, Union
+
+from posthog.models.filters.mixins.utils import cached_property
+
+
+class ExperimentResultQueryRunner(QueryRunner):
+    query: ExperimentResultQuery
+
+    @cached_property
+    def source_runner(self) -> QueryRunner:
+        return get_query_runner(self.query.source, self.team, self.timings, self.limit_context)
+
+    def calculate(self) -> Union[ExperimentResultTrendQueryResponse, ExperimentResultFunnelQueryResponse]:
+        source_query = self.query.source
+        if isinstance(source_query, TrendsQuery):
+            return self._calculate_trends()
+        elif isinstance(source_query, FunnelsQuery):
+            return self._calculate_funnels()
+        else:
+            raise ValueError(f"Unsupported query type: {type(source_query)}")
+
+    def _calculate_trends(self) -> ExperimentResultTrendQueryResponse:
+        trends_response = self.source_runner.calculate()
+        results = self._process_trends_results(trends_response.results)
+        return ExperimentResultTrendQueryResponse(insight="TRENDS", results=results)
+
+    def _calculate_funnels(self) -> ExperimentResultFunnelQueryResponse:
+        funnels_response = self.source_runner.calculate()
+        results = self._process_funnels_results(funnels_response.results)
+        return ExperimentResultFunnelQueryResponse(insight="FUNNELS", results=results)
+
+    def _process_trends_results(self, trends_results: list[dict[str, Any]]) -> dict[str, ExperimentVariantTrendResult]:
+        variants = self.query.variants
+        processed_results = {variant: ExperimentVariantTrendResult(count=0) for variant in variants}
+
+        for result in trends_results:
+            variant = result.get("breakdown_value")
+            if variant in variants:
+                processed_results[variant].count += result.get("count", 0)
+
+        return processed_results
+
+    def _process_funnels_results(
+        self, funnels_results: list[dict[str, Any]]
+    ) -> dict[str, ExperimentVariantFunnelResult]:
+        variants = self.query.variants
+        processed_results = {
+            variant: ExperimentVariantFunnelResult(success_count=0, failure_count=0) for variant in variants
+        }
+
+        for result in funnels_results:
+            if result:
+                variant = result[0].get("breakdown_value", [""])[0]
+                if variant in variants:
+                    total_count = result[0]["count"]
+                    success_count = result[-1]["count"]
+                    processed_results[variant].success_count = success_count
+                    processed_results[variant].failure_count = total_count - success_count
+
+        return processed_results
+
+    def to_query(self) -> ast.SelectQuery:
+        raise ValueError(f"Cannot convert source query of type {self.query.source.kind} to query")

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -352,6 +352,17 @@ def get_query_runner(
             limit_context=limit_context,
         )
 
+    if kind == "ExperimentResultQuery":
+        from .experiment_result_query_runner import ExperimentResultQueryRunner
+
+        return ExperimentResultQueryRunner(
+            query=query,
+            team=team,
+            timings=timings,
+            modifiers=modifiers,
+            limit_context=limit_context,
+        )
+
     raise ValueError(f"Can't get a runner for an unknown query kind: {kind}")
 
 

--- a/posthog/hogql_queries/test/test_experiment_result_query_runner.py
+++ b/posthog/hogql_queries/test/test_experiment_result_query_runner.py
@@ -1,0 +1,99 @@
+from posthog.hogql_queries.experiment_result_query_runner import ExperimentResultQueryRunner
+from posthog.schema import BreakdownFilter, EventsNode, ExperimentResultQuery, FunnelsQuery, TrendsQuery
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
+from freezegun import freeze_time
+
+
+class TestExperimentResultQueryRunner(ClickhouseTestMixin, APIBaseTest):
+    def setUp(self):
+        super().setUp()
+
+    def test_experiment_result_query_runner_FUNNEL(self):
+        feature_flag_property = f"$feature/test-experiment"
+
+        with freeze_time("2020-01-10 12:00:00"):
+            for variant, purchase_count in [("control", 6), ("test", 8)]:
+                for i in range(10):
+                    _create_person(distinct_ids=[f"user_{variant}_{i}"], team_id=self.team.pk)
+                    _create_event(
+                        team=self.team,
+                        event="$pageview",
+                        distinct_id=f"user_{variant}_{i}",
+                        timestamp="2020-01-02T12:00:00Z",
+                        properties={feature_flag_property: variant},
+                    )
+                    if i < purchase_count:
+                        _create_event(
+                            team=self.team,
+                            event="purchase",
+                            distinct_id=f"user_{variant}_{i}",
+                            timestamp="2020-01-02T12:01:00Z",
+                            properties={feature_flag_property: variant},
+                        )
+
+        flush_persons_and_events()
+
+        funnels_query = FunnelsQuery(
+            series=[EventsNode(event="$pageview"), EventsNode(event="purchase")],
+            dateRange={"date_from": "2020-01-01", "date_to": "2020-01-14"},
+            breakdownFilter=BreakdownFilter(breakdown=feature_flag_property),
+        )
+        experiment_query = ExperimentResultQuery(
+            kind="ExperimentResultQuery", source=funnels_query, variants=["control", "test"]
+        )
+
+        runner = ExperimentResultQueryRunner(query=experiment_query, team=self.team)
+        result = runner.calculate()
+
+        self.assertEqual(result.insight, "FUNNELS")
+        self.assertEqual(len(result.results), 2)
+
+        self.assertIn("control", result.results)
+        self.assertIn("test", result.results)
+
+        control_result = result.results["control"]
+        test_result = result.results["test"]
+
+        self.assertEqual(control_result.success_count, 6)
+        self.assertEqual(control_result.failure_count, 4)
+        self.assertEqual(test_result.success_count, 8)
+        self.assertEqual(test_result.failure_count, 2)
+
+    def test_experiment_result_query_runner_TRENDS(self):
+        feature_flag_property = f"$feature/test-experiment"
+
+        for variant, count in [("control", 11), ("test", 15)]:
+            for i in range(count):
+                with freeze_time("2020-01-10 12:00:00"):
+                    _create_event(
+                        team=self.team,
+                        event="$pageview",
+                        distinct_id=f"user_{variant}_{i}",
+                        properties={feature_flag_property: variant},
+                    )
+        flush_persons_and_events()
+
+        trends_query = TrendsQuery(
+            kind="TrendsQuery",
+            series=[EventsNode(event="$pageview")],
+            dateRange={"date_from": "2020-01-01", "date_to": "2020-01-14"},
+            breakdownFilter=BreakdownFilter(breakdown=feature_flag_property),
+        )
+        experiment_query = ExperimentResultQuery(
+            kind="ExperimentResultQuery", source=trends_query, variants=["control", "test"]
+        )
+
+        runner = ExperimentResultQueryRunner(query=experiment_query, team=self.team)
+        result = runner.calculate()
+
+        self.assertEqual(result.insight, "TRENDS")
+        self.assertEqual(len(result.results), 2)
+
+        self.assertIn("control", result.results)
+        self.assertIn("test", result.results)
+
+        control_result = result.results["control"]
+        test_result = result.results["test"]
+
+        self.assertEqual(control_result.count, 11)
+        self.assertEqual(test_result.count, 15)

--- a/posthog/hogql_queries/test/test_experiment_result_query_runner.py
+++ b/posthog/hogql_queries/test/test_experiment_result_query_runner.py
@@ -1,7 +1,16 @@
 from posthog.hogql_queries.experiment_result_query_runner import ExperimentResultQueryRunner
-from posthog.schema import BreakdownFilter, EventsNode, ExperimentResultQuery, FunnelsQuery, TrendsQuery
+from posthog.schema import (
+    BreakdownFilter,
+    EventsNode,
+    ExperimentResultQuery,
+    FunnelsQuery,
+    TrendsQuery,
+    ExperimentResultFunnelQueryResponse,
+    ExperimentResultTrendQueryResponse,
+)
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
 from freezegun import freeze_time
+from typing import cast
 
 
 class TestExperimentResultQueryRunner(ClickhouseTestMixin, APIBaseTest):
@@ -48,11 +57,13 @@ class TestExperimentResultQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(result.insight, "FUNNELS")
         self.assertEqual(len(result.results), 2)
 
-        self.assertIn("control", result.results)
-        self.assertIn("test", result.results)
+        funnel_result = cast(ExperimentResultFunnelQueryResponse, result)
 
-        control_result = result.results["control"]
-        test_result = result.results["test"]
+        self.assertIn("control", funnel_result.results)
+        self.assertIn("test", funnel_result.results)
+
+        control_result = funnel_result.results["control"]
+        test_result = funnel_result.results["test"]
 
         self.assertEqual(control_result.success_count, 6)
         self.assertEqual(control_result.failure_count, 4)
@@ -89,11 +100,13 @@ class TestExperimentResultQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(result.insight, "TRENDS")
         self.assertEqual(len(result.results), 2)
 
-        self.assertIn("control", result.results)
-        self.assertIn("test", result.results)
+        trend_result = cast(ExperimentResultTrendQueryResponse, result)
 
-        control_result = result.results["control"]
-        test_result = result.results["test"]
+        self.assertIn("control", trend_result.results)
+        self.assertIn("test", trend_result.results)
+
+        control_result = trend_result.results["control"]
+        test_result = trend_result.results["test"]
 
         self.assertEqual(control_result.count, 11)
         self.assertEqual(test_result.count, 15)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -495,6 +495,21 @@ class EventsQueryPersonColumn(BaseModel):
     uuid: str
 
 
+class ExperimentVariantFunnelResult(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    failure_count: float
+    success_count: float
+
+
+class ExperimentVariantTrendResult(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    count: float
+
+
 class FilterLogicalOperator(StrEnum):
     AND_ = "AND"
     OR_ = "OR"
@@ -802,6 +817,7 @@ class NodeKind(StrEnum):
     RECORDINGS_QUERY = "RecordingsQuery"
     SESSION_ATTRIBUTION_EXPLORER_QUERY = "SessionAttributionExplorerQuery"
     ERROR_TRACKING_QUERY = "ErrorTrackingQuery"
+    EXPERIMENT_RESULT_QUERY = "ExperimentResultQuery"
     DATA_TABLE_NODE = "DataTableNode"
     DATA_VISUALIZATION_NODE = "DataVisualizationNode"
     SAVED_INSIGHT_NODE = "SavedInsightNode"
@@ -961,6 +977,22 @@ class QueryResponseAlternative7(BaseModel):
     notices: list[HogQLNotice]
     query: Optional[str] = None
     warnings: list[HogQLNotice]
+
+
+class QueryResponseAlternative24(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    insight: Literal["TRENDS"] = "TRENDS"
+    results: dict[str, ExperimentVariantTrendResult]
+
+
+class QueryResponseAlternative25(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    insight: Literal["FUNNELS"] = "FUNNELS"
+    results: dict[str, ExperimentVariantFunnelResult]
 
 
 class QueryStatus(BaseModel):
@@ -2347,6 +2379,22 @@ class Response8(BaseModel):
     )
 
 
+class Response9(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    insight: Literal["TRENDS"] = "TRENDS"
+    results: dict[str, ExperimentVariantTrendResult]
+
+
+class Response10(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    insight: Literal["FUNNELS"] = "FUNNELS"
+    results: dict[str, ExperimentVariantFunnelResult]
+
+
 class DataWarehousePersonPropertyFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -2473,6 +2521,22 @@ class EventsQueryResponse(BaseModel):
         default=None, description="Measured timings for different parts of the query generation process"
     )
     types: list[str]
+
+
+class ExperimentResultFunnelQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    insight: Literal["FUNNELS"] = "FUNNELS"
+    results: dict[str, ExperimentVariantFunnelResult]
+
+
+class ExperimentResultTrendQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    insight: Literal["TRENDS"] = "TRENDS"
+    results: dict[str, ExperimentVariantTrendResult]
 
 
 class BreakdownFilter1(BaseModel):
@@ -3300,7 +3364,7 @@ class QueryResponseAlternative23(BaseModel):
     )
 
 
-class QueryResponseAlternative24(BaseModel):
+class QueryResponseAlternative26(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3322,7 +3386,7 @@ class QueryResponseAlternative24(BaseModel):
     )
 
 
-class QueryResponseAlternative25(BaseModel):
+class QueryResponseAlternative27(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3344,7 +3408,7 @@ class QueryResponseAlternative25(BaseModel):
     )
 
 
-class QueryResponseAlternative27(BaseModel):
+class QueryResponseAlternative29(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -3365,7 +3429,7 @@ class QueryResponseAlternative27(BaseModel):
     )
 
 
-class QueryResponseAlternative30(BaseModel):
+class QueryResponseAlternative32(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -4364,7 +4428,7 @@ class PropertyGroupFilterValue(BaseModel):
     ]
 
 
-class QueryResponseAlternative26(BaseModel):
+class QueryResponseAlternative28(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -5177,7 +5241,7 @@ class LifecycleQuery(BaseModel):
     )
 
 
-class QueryResponseAlternative31(BaseModel):
+class QueryResponseAlternative33(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -5210,6 +5274,8 @@ class QueryResponseAlternative(
             QueryResponseAlternative12,
             QueryResponseAlternative13,
             QueryResponseAlternative14,
+            ExperimentResultTrendQueryResponse,
+            ExperimentResultFunnelQueryResponse,
             Any,
             QueryResponseAlternative15,
             QueryResponseAlternative16,
@@ -5224,8 +5290,10 @@ class QueryResponseAlternative(
             QueryResponseAlternative25,
             QueryResponseAlternative26,
             QueryResponseAlternative27,
-            QueryResponseAlternative30,
-            QueryResponseAlternative31,
+            QueryResponseAlternative28,
+            QueryResponseAlternative29,
+            QueryResponseAlternative32,
+            QueryResponseAlternative33,
         ]
     ]
 ):
@@ -5245,6 +5313,8 @@ class QueryResponseAlternative(
         QueryResponseAlternative12,
         QueryResponseAlternative13,
         QueryResponseAlternative14,
+        ExperimentResultTrendQueryResponse,
+        ExperimentResultFunnelQueryResponse,
         Any,
         QueryResponseAlternative15,
         QueryResponseAlternative16,
@@ -5259,8 +5329,10 @@ class QueryResponseAlternative(
         QueryResponseAlternative25,
         QueryResponseAlternative26,
         QueryResponseAlternative27,
-        QueryResponseAlternative30,
-        QueryResponseAlternative31,
+        QueryResponseAlternative28,
+        QueryResponseAlternative29,
+        QueryResponseAlternative32,
+        QueryResponseAlternative33,
     ]
 
 
@@ -5277,6 +5349,19 @@ class DatabaseSchemaQueryResponse(BaseModel):
             DatabaseSchemaBatchExportTable,
         ],
     ]
+
+
+class ExperimentResultQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    kind: Literal["ExperimentResultQuery"] = "ExperimentResultQuery"
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    response: Optional[Union[ExperimentResultTrendQueryResponse, ExperimentResultFunnelQueryResponse]] = None
+    source: Union[TrendsQuery, FunnelsQuery]
+    variants: list[str]
 
 
 class FunnelPathsFilter(BaseModel):
@@ -5552,6 +5637,8 @@ class DataTableNode(BaseModel):
             Response6,
             Response7,
             Response8,
+            Response9,
+            Response10,
         ]
     ] = None
     showActions: Optional[bool] = Field(default=None, description="Show the kebab menu at the end of the row")
@@ -5592,6 +5679,7 @@ class DataTableNode(BaseModel):
         WebGoalsQuery,
         SessionAttributionExplorerQuery,
         ErrorTrackingQuery,
+        ExperimentResultQuery,
     ] = Field(..., description="Source of the events")
 
 
@@ -5629,6 +5717,7 @@ class HogQLAutocomplete(BaseModel):
             WebGoalsQuery,
             SessionAttributionExplorerQuery,
             ErrorTrackingQuery,
+            ExperimentResultQuery,
         ]
     ] = Field(default=None, description="Query in whose context to validate.")
     startPosition: int = Field(..., description="Start position of the editor word")
@@ -5670,6 +5759,7 @@ class HogQLMetadata(BaseModel):
             WebGoalsQuery,
             SessionAttributionExplorerQuery,
             ErrorTrackingQuery,
+            ExperimentResultQuery,
         ]
     ] = Field(
         default=None,
@@ -5713,6 +5803,7 @@ class QueryRequest(BaseModel):
         WebGoalsQuery,
         SessionAttributionExplorerQuery,
         ErrorTrackingQuery,
+        ExperimentResultQuery,
         DataVisualizationNode,
         DataTableNode,
         SavedInsightNode,
@@ -5760,6 +5851,7 @@ class QuerySchemaRoot(
             WebGoalsQuery,
             SessionAttributionExplorerQuery,
             ErrorTrackingQuery,
+            ExperimentResultQuery,
             DataVisualizationNode,
             DataTableNode,
             SavedInsightNode,
@@ -5795,6 +5887,7 @@ class QuerySchemaRoot(
         WebGoalsQuery,
         SessionAttributionExplorerQuery,
         ErrorTrackingQuery,
+        ExperimentResultQuery,
         DataVisualizationNode,
         DataTableNode,
         SavedInsightNode,


### PR DESCRIPTION
## Problem
We're migrating experiments to HogQL to allow async querying.

## Changes
Set up a rudimentary query runner for experiment results - returning just simple counts for now. Will add statistical evaluations in a follow up.

## How did you test this code?
tests