### PR TITLE
fix: set created by for dashboards created from templates

### DIFF
--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -515,7 +515,7 @@ class DashboardsViewSet(
     def create_from_template_json(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         dashboard = Dashboard.objects.create(
             team_id=self.team_id,
-            created_by=request.user,
+            created_by=cast(User, request.user),
         )
 
         try:

--- a/posthog/api/dashboards/dashboard.py
+++ b/posthog/api/dashboards/dashboard.py
@@ -513,7 +513,10 @@ class DashboardsViewSet(
         parser_classes=[DashboardTemplateCreationJSONSchemaParser],
     )
     def create_from_template_json(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        dashboard = Dashboard.objects.create(team_id=self.team_id)
+        dashboard = Dashboard.objects.create(
+            team_id=self.team_id,
+            created_by=request.user,
+        )
 
         try:
             dashboard_template = DashboardTemplate(**request.data["template"])

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -1162,6 +1162,9 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
 
         self.assertEqual(dashboard["name"], valid_template["template_name"], dashboard)
         self.assertEqual(dashboard["description"], valid_template["dashboard_description"])
+        self.assertEqual(
+            dashboard["created_by"], dashboard["created_by"] | {"first_name": "", "email": "user1@posthog.com"}
+        )
 
         self.assertEqual(len(dashboard["tiles"]), 1)
 


### PR DESCRIPTION
## Problem
Fixes #24652 

## Changes
Sets created by for dashboards created from templates

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally