### PR TITLE
feat: shared dashboards allow viewer to preview filter change

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardEditBar.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBar.tsx
@@ -9,11 +9,9 @@ import { groupsModel } from '~/models/groupsModel'
 import { DashboardMode } from '~/types'
 
 export function DashboardEditBar(): JSX.Element {
-    const { dashboard, canEditDashboard, temporaryFilters, dashboardMode } = useValues(dashboardLogic)
+    const { dashboard, temporaryFilters, dashboardMode } = useValues(dashboardLogic)
     const { setDates, setProperties, setDashboardMode } = useActions(dashboardLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
-
-    const disabledReason = !canEditDashboard ? "You don't have permission to edit this dashboard" : undefined
 
     return (
         <div className="flex gap-2 items-center justify-between flex-wrap">
@@ -27,7 +25,6 @@ export function DashboardEditBar(): JSX.Element {
                     }
                     setDates(from_date, to_date)
                 }}
-                disabledReason={disabledReason}
                 makeLabel={(key) => (
                     <>
                         <IconCalendar />
@@ -36,7 +33,6 @@ export function DashboardEditBar(): JSX.Element {
                 )}
             />
             <PropertyFilters
-                disabledReason={disabledReason}
                 onChange={(properties) => {
                     if (dashboardMode !== DashboardMode.Edit) {
                         setDashboardMode(DashboardMode.Edit, null)

--- a/frontend/src/scenes/dashboard/DashboardHeader.tsx
+++ b/frontend/src/scenes/dashboard/DashboardHeader.tsx
@@ -138,7 +138,13 @@ export function DashboardHeader(): JSX.Element | null {
                                     setDashboardMode(null, DashboardEventSource.DashboardHeaderSaveDashboard)
                                 }
                                 tabIndex={10}
-                                disabled={dashboardLoading}
+                                disabledReason={
+                                    dashboardLoading
+                                        ? 'Wait for dashboard to finish loading'
+                                        : canEditDashboard
+                                        ? undefined
+                                        : 'Not privileged to edit this dashboard'
+                                }
                             >
                                 Save
                             </LemonButton>


### PR DESCRIPTION
## Problem
Fixes #24434 
Allows viewer of shared dashboard to change filters but not save the changes

## Changes

https://github.com/user-attachments/assets/c766daf6-6b61-4842-8bd5-6b28bd19eb78



## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally by inviting a new member and sharing dashboard
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
