### PR TITLE
fix: big int in events query

### DIFF
--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -4,7 +4,7 @@ from typing import Optional
 from dateutil.parser import isoparse
 from django.db.models import Prefetch
 from django.utils.timezone import now
-from orjson import orjson
+import orjson
 
 from posthog.api.element import ElementSerializer
 from posthog.api.utils import get_pk_or_uuid

--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -1,10 +1,10 @@
-import json
 from datetime import timedelta
 from typing import Optional
 
 from dateutil.parser import isoparse
 from django.db.models import Prefetch
 from django.utils.timezone import now
+from orjson import orjson
 
 from posthog.api.element import ElementSerializer
 from posthog.api.utils import get_pk_or_uuid
@@ -206,7 +206,7 @@ class EventsQueryRunner(QueryRunner):
                     self.paginator.results[index] = list(result)
                     select = result[star_idx]
                     new_result = dict(zip(SELECT_STAR_FROM_EVENTS_FIELDS, select))
-                    new_result["properties"] = json.loads(new_result["properties"])
+                    new_result["properties"] = orjson.loads(new_result["properties"])
                     if new_result["elements_chain"]:
                         new_result["elements"] = ElementSerializer(
                             chain_to_elements(new_result["elements_chain"]), many=True

--- a/posthog/hogql_queries/test/test_events_query_runner.py
+++ b/posthog/hogql_queries/test/test_events_query_runner.py
@@ -182,5 +182,5 @@ class TestEventsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
             runner = EventsQueryRunner(query=query, team=self.team)
             response = runner.run()
-
+            assert isinstance(response, CachedEventsQueryResponse)
             assert response.results[0][0]["properties"]["bigInt"] == float(BIG_INT)


### PR DESCRIPTION
## Problem

User is having issues with ints larger than 2^64 in properties causing the events page to not display
https://posthoghelp.zendesk.com/agent/tickets/17352 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/20068)

## Changes

orjson doesn't support serializing or deserializing ints bigger than 64 bits.

json allows it.

we were using json to parse the input and then orjson to serialize the output, causing errors.

use orjson for both, which converts the ints to a float, which javascript will be able to use anyways.

(somebody might, in the future, be doing some sort of accounting thing using posthog that requires ints be preserved and kept accurate, but that's a bridge to cross later)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Wrote a test, observed output locally.