### PR TITLE
fix(web-analytics): Fix infinite loop when setting the date range to the last 180 days

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -237,6 +237,11 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         setGeographyTab: (tab: string) => ({ tab }),
         setDates: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
         setInterval: (interval: IntervalType) => ({ interval }),
+        setDatesAndInterval: (dateFrom: string | null, dateTo: string | null, interval: IntervalType) => ({
+            dateFrom,
+            dateTo,
+            interval,
+        }),
         setIsPathCleaningEnabled: (isPathCleaningEnabled: boolean) => ({ isPathCleaningEnabled }),
         setShouldFilterTestAccounts: (shouldFilterTestAccounts: boolean) => ({
             shouldFilterTestAccounts,
@@ -419,6 +424,17 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         dateTo,
                         dateFrom,
                         interval,
+                    }
+                },
+                setDatesAndInterval: (_, { dateTo, dateFrom, interval }) => {
+                    if (!dateFrom && !dateTo) {
+                        dateFrom = initialDateFrom
+                        dateTo = initialDateTo
+                    }
+                    return {
+                        dateTo,
+                        dateFrom,
+                        interval: interval || getDefaultInterval(dateFrom, dateTo),
                     }
                 },
                 setStateFromUrl: (_, { state: { dateTo, dateFrom, interval } }) => {
@@ -1541,11 +1557,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             if (parsedFilters) {
                 actions.setWebAnalyticsFilters(parsedFilters)
             }
-            if (date_from || date_to) {
-                actions.setDates(date_from, date_to)
-            }
-            if (interval) {
-                actions.setInterval(interval)
+            if (date_from || date_to || interval) {
+                actions.setDatesAndInterval(date_from, date_to, interval)
             }
             if (device_tab) {
                 actions.setDeviceTab(device_tab)


### PR DESCRIPTION
## Problem

When setting the date filter to last 180 days, the page gets stuck into an infinite loop.

To reproduce:
Go to web analytics.
Change the date range to the last 180 days.

## Changes
Set the date range and interval together, so that updating one does not trigger an update of the other.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Spin up posthog locally and run the steps to reproduce, bug doesn't occur
