### PR TITLE
fix: make the version checker banner team aware

### DIFF
--- a/frontend/src/lib/components/VersionChecker/VersionCheckerBanner.tsx
+++ b/frontend/src/lib/components/VersionChecker/VersionCheckerBanner.tsx
@@ -1,10 +1,12 @@
 import { useValues } from 'kea'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { teamLogic } from 'scenes/teamLogic'
 
 import { versionCheckerLogic } from './versionCheckerLogic'
 
 export function VersionCheckerBanner(): JSX.Element | null {
-    const { versionWarning } = useValues(versionCheckerLogic)
+    const { currentTeamId } = useValues(teamLogic)
+    const { versionWarning } = useValues(versionCheckerLogic({ teamId: currentTeamId }))
     if (!versionWarning) {
         return null
     }

--- a/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
+++ b/frontend/src/lib/components/VersionChecker/versionCheckerLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, kea, listeners, path, reducers, sharedListeners } from 'kea'
+import { actions, afterMount, kea, key, listeners, path, props, reducers, sharedListeners } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { isNotNil } from 'lib/utils'
@@ -45,8 +45,14 @@ export interface AvailableVersions {
     deprecation?: PosthogJSDeprecation
 }
 
+export interface VersionCheckerLogicProps {
+    teamId: number | null
+}
+
 export const versionCheckerLogic = kea<versionCheckerLogicType>([
-    path(['components', 'VersionChecker', 'versionCheckerLogic']),
+    props({ teamId: null } as VersionCheckerLogicProps),
+    key(({ teamId }) => teamId || 'no-team-id'),
+    path((key) => ['components', 'VersionChecker', 'versionCheckerLogic', key]),
     actions({
         setVersionWarning: (versionWarning: SDKVersionWarning | null) => ({ versionWarning }),
         setSdkVersions: (sdkVersions: SDKVersion[]) => ({ sdkVersions }),


### PR DESCRIPTION
I was switching between teams and the first team had a version warning.

Every subsequent team I visited showed the warning as if they had ingested the same old version that the first team was warning about

That's because the `versionCheckerLogic` persists its data but isn't team aware.

Well, now it is!

# proof if proof be need be

here you can see two records for the version checker. the old one that has no team id in it, and the new one that does have a team id

<img width="574" alt="Screenshot 2024-09-09 at 12 50 38" src="https://github.com/user-attachments/assets/51874031-4ed5-4403-8c87-15d0faee803b">

now if you have three project and one of them has an old version of posthog-js we won't complain on all three