### PR TITLE
fix: add cache_key tag to capture loaded tokens metric

### DIFF
--- a/rust/capture/src/limiters/redis.rs
+++ b/rust/capture/src/limiters/redis.rs
@@ -102,7 +102,10 @@ impl RedisLimiter {
                 match RedisLimiter::fetch_limited(&redis, &key).await {
                     Ok(set) => {
                         let set = HashSet::from_iter(set.iter().cloned());
-                        gauge!("capture_billing_limits_loaded_tokens",).set(set.len() as f64);
+                        gauge!(
+                            "capture_billing_limits_loaded_tokens",
+                            "cache_key" => key.clone(),
+                        ).set(set.len() as f64);
 
                         let mut limited_lock = limited.write().await;
                         *limited_lock = set;

--- a/rust/capture/src/limiters/redis.rs
+++ b/rust/capture/src/limiters/redis.rs
@@ -105,7 +105,8 @@ impl RedisLimiter {
                         gauge!(
                             "capture_billing_limits_loaded_tokens",
                             "cache_key" => key.clone(),
-                        ).set(set.len() as f64);
+                        )
+                        .set(set.len() as f64);
 
                         let mut limited_lock = limited.write().await;
                         *limited_lock = set;


### PR DESCRIPTION
## Problem
the metrics for quota limits and replay overflows were colliding, split them by cache_key

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
