### PR TITLE
chore(insights): improve `Attribution type` tooltip

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -195,7 +195,7 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                                               <div>
                                                   When breaking down funnels, it's possible that the same properties
                                                   don't exist on every event. For example, if you want to break down by
-                                                  browser on a funnel that contains both of frontend and backend events.
+                                                  browser on a funnel that contains both frontend and backend events.
                                               </div>
                                               <div>
                                                   In this case, you can choose from which step the properties should be

--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -1,6 +1,7 @@
 import './EditorFilters.scss'
 
-import { LemonBanner, Link } from '@posthog/lemon-ui'
+import { IconInfo } from '@posthog/icons'
+import { LemonBanner, Link, Tooltip } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useValues } from 'kea'
 import { NON_BREAKDOWN_DISPLAY_TYPES } from 'lib/constants'
@@ -184,24 +185,55 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
                 hasAttribution
                     ? {
                           key: 'attribution',
-                          label: 'Attribution type',
-                          position: 'right',
-                          tooltip: (
-                              <div>
-                                  When breaking funnels down by a property, you can choose how to assign users to the
-                                  various property values. This is useful because property values can change for a
-                                  user/group as someone travels through the funnel.
-                                  <ul className="list-disc pl-4 pt-4">
-                                      <li>First step: the first property value seen from all steps is chosen.</li>
-                                      <li>Last step: last property value seen from all steps is chosen.</li>
-                                      <li>Specific step: the property value seen at that specific step is chosen.</li>
-                                      <li>All steps: the property value must be seen in all steps.</li>
-                                      <li>
-                                          Any step: the property value must be seen on at least one step of the funnel.
-                                      </li>
-                                  </ul>
+                          label: () => (
+                              <div className="flex">
+                                  <span>Attribution type</span>
+                                  <Tooltip
+                                      closeDelayMs={200}
+                                      title={
+                                          <div className="space-y-2">
+                                              <div>
+                                                  When breaking down funnels, it's possible that the same properties
+                                                  don't exist on every event. For example, if you want to break down by
+                                                  browser on a funnel that contains both of frontend and backend events.
+                                              </div>
+                                              <div>
+                                                  In this case, you can choose from which step the properties should be
+                                                  selected from by modifying the attribution type. There are four modes
+                                                  to choose from:
+                                              </div>
+                                              <ul className="list-disc pl-4">
+                                                  <li>
+                                                      First touchpoint: the first property value seen in any of the
+                                                      steps is chosen.
+                                                  </li>
+                                                  <li>
+                                                      Last touchpoint: the last property value seen from all steps is
+                                                      chosen.
+                                                  </li>
+                                                  <li>
+                                                      All steps: the property value must be seen in all steps to be
+                                                      considered in the funnel.
+                                                  </li>
+                                                  <li>
+                                                      Specific step: only the property value seen at the selected step
+                                                      is chosen.
+                                                  </li>
+                                              </ul>
+                                              <div>
+                                                  Read more in the{' '}
+                                                  <Link to="https://posthog.com/docs/product-analytics/funnels#attribution-types">
+                                                      documentation.
+                                                  </Link>
+                                              </div>
+                                          </div>
+                                      }
+                                  >
+                                      <IconInfo className="text-xl text-muted-alt shrink-0 ml-1" />
+                                  </Tooltip>
                               </div>
                           ),
+                          position: 'right',
                           component: Attribution,
                       }
                     : null,

--- a/frontend/src/scenes/experiments/MetricSelector.tsx
+++ b/frontend/src/scenes/experiments/MetricSelector.tsx
@@ -1,7 +1,7 @@
 import './Experiment.scss'
 
 import { IconInfo } from '@posthog/icons'
-import { LemonSelect } from '@posthog/lemon-ui'
+import { LemonSelect, Link } from '@posthog/lemon-ui'
 import { BindLogic, useActions, useValues } from 'kea'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { EXPERIMENT_DEFAULT_DURATION } from 'lib/constants'
@@ -164,22 +164,37 @@ export function AttributionSelect({ insightProps }: EditorFilterProps): JSX.Elem
             <div className="flex">
                 <span>Attribution type</span>
                 <Tooltip
+                    closeDelayMs={200}
                     title={
-                        <div>
-                            When breaking funnels down by a property, you can choose how to assign users to the various
-                            property values. This is useful because property values can change for a user/group as
-                            someone travels through the funnel.
-                            <ul className="list-disc pl-4 pt-4">
-                                <li>First step: the first property value seen from all steps is chosen.</li>
-                                <li>Last step: last property value seen from all steps is chosen.</li>
-                                <li>Specific step: the property value seen at that specific step is chosen.</li>
-                                <li>All steps: the property value must be seen in all steps.</li>
-                                <li>Any step: the property value must be seen on at least one step of the funnel.</li>
+                        <div className="space-y-2">
+                            <div>
+                                When breaking down funnels, it's possible that the same properties don't exist on every
+                                event. For example, if you want to break down by browser on a funnel that contains both
+                                of frontend and backend events.
+                            </div>
+                            <div>
+                                In this case, you can choose from which step the properties should be selected from by
+                                modifying the attribution type. There are four modes to choose from:
+                            </div>
+                            <ul className="list-disc pl-4">
+                                <li>First touchpoint: the first property value seen in any of the steps is chosen.</li>
+                                <li>Last touchpoint: the last property value seen from all steps is chosen.</li>
+                                <li>
+                                    All steps: the property value must be seen in all steps to be considered in the
+                                    funnel.
+                                </li>
+                                <li>Specific step: only the property value seen at the selected step is chosen.</li>
                             </ul>
+                            <div>
+                                Read more in the{' '}
+                                <Link to="https://posthog.com/docs/product-analytics/funnels#attribution-types">
+                                    documentation.
+                                </Link>
+                            </div>
                         </div>
                     }
                 >
-                    <IconInfo className="w-4 info-indicator" />
+                    <IconInfo className="text-xl text-muted-alt shrink-0 ml-1" />
                 </Tooltip>
             </div>
             <Attribution insightProps={insightProps} />

--- a/frontend/src/scenes/experiments/MetricSelector.tsx
+++ b/frontend/src/scenes/experiments/MetricSelector.tsx
@@ -170,7 +170,7 @@ export function AttributionSelect({ insightProps }: EditorFilterProps): JSX.Elem
                             <div>
                                 When breaking down funnels, it's possible that the same properties don't exist on every
                                 event. For example, if you want to break down by browser on a funnel that contains both
-                                of frontend and backend events.
+                                frontend and backend events.
                             </div>
                             <div>
                                 In this case, you can choose from which step the properties should be selected from by


### PR DESCRIPTION
## Changes
- Use naming consistent with the select field options (`touchpoint` vs `step`)
- Port the text from the docs which I find clearer
- Link to the docs

|Before|After|
|----|----|
|<img width="390" alt="image" src="https://github.com/user-attachments/assets/a2713063-bec5-437e-92f0-a51a88a1b7c8">|<img width="390" alt="image" src="https://github.com/user-attachments/assets/38da5a9d-478c-4aef-8fc7-17242ee80540">|	

## How did you test this code?
👀 