### PR TITLE
fix(propdefs): fix grouptype resolution

### DIFF
--- a/rust/property-defs-rs/src/app_context.rs
+++ b/rust/property-defs-rs/src/app_context.rs
@@ -110,7 +110,6 @@ impl AppContext {
                     name,
                     update.team_id
                 )
-                .bind(name)
                 .fetch_optional(&self.pool)
                 .await?;
 


### PR DESCRIPTION
Seeing high rates of failure to resolve grouptype, think this is why. Surprised sqlx doesn't throw an error for this.