### PR TITLE
chore: Ensure sqlx is present for migrations

### DIFF
--- a/rust/bin/migrate-cyclotron
+++ b/rust/bin/migrate-cyclotron
@@ -6,5 +6,7 @@ CYCLOTRON_DATABASE_URL=${CYCLOTRON_DATABASE_URL:-postgres://posthog:posthog@loca
 
 echo "Performing cyclotron migrations for $CYCLOTRON_DATABASE_URL (DATABASE_NAME=$CYCLOTRON_DATABASE_NAME)"
 
+cargo install sqlx-cli
+
 sqlx database create -D "$CYCLOTRON_DATABASE_URL"
 sqlx migrate run -D "$CYCLOTRON_DATABASE_URL" --source $SCRIPT_DIR/../cyclotron-core/migrations


### PR DESCRIPTION
## Changes

Looks like the `sqlx` CLI is now necessary to run `bin/migrate`, which is an addition uniquely requiring separate installation right now. This change ensures `sqlx` gets installed automatically. Now, I'm not 100% that we don't also run `rust/bin/migrate-cyclotron` somewhere in prod, so I ask for a sanity check on this.