### PR TITLE
perf: Optimize `JSONHas` calls when referencing property groups columns

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -255,7 +255,6 @@ posthog/hogql/printer.py:0: error: Argument 1 to "lookup_field_by_name" has inco
 posthog/hogql/printer.py:0: error: Item "TableType" of "TableType | TableAliasType" has no attribute "alias"  [union-attr]
 posthog/hogql/printer.py:0: error: "FieldOrTable" has no attribute "name"  [attr-defined]
 posthog/hogql/printer.py:0: error: "FieldOrTable" has no attribute "name"  [attr-defined]
-posthog/hogql/printer.py:0: error: Argument 2 to "_get_materialized_column" of "_Printer" has incompatible type "str | int"; expected "str"  [arg-type]
 posthog/hogql/printer.py:0: error: Argument 1 to "_print_identifier" of "_Printer" has incompatible type "str | None"; expected "str"  [arg-type]
 posthog/user_permissions.py:0: error: Incompatible return value type (got "int", expected "Level | None")  [return-value]
 posthog/user_permissions.py:0: error: Incompatible return value type (got "int", expected "Level | None")  [return-value]

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -977,23 +977,24 @@ class _Printer(Visitor):
             while isinstance(table, ast.TableAliasType):
                 table = table.table_type
 
-            if self.dialect == "clickhouse":
-                table_name = table.table.to_printed_clickhouse(self.context)
-            else:
-                table_name = table.table.to_printed_hogql()
-            if field is None:
-                raise QueryError(f"Can't resolve field {field_type.name} on table {table_name}")
+            if isinstance(table, ast.TableType):
+                if self.dialect == "clickhouse":
+                    table_name = table.table.to_printed_clickhouse(self.context)
+                else:
+                    table_name = table.table.to_printed_hogql()
+                if field is None:
+                    raise QueryError(f"Can't resolve field {field_type.name} on table {table_name}")
 
-            field_name = cast(str, field.name)
-            for property_group_column in property_groups.get_property_group_columns(
-                table_name, field_name, property_name
-            ):
-                # XXX: this is kind of a hack
-                return PrintableMaterializedPropertyGroupItem(
-                    self.visit(table),
-                    self._print_identifier(property_group_column),
-                    self.context.add_value(property_name),
-                ).has_expr
+                field_name = cast(str, field.name)
+                for property_group_column in property_groups.get_property_group_columns(
+                    table_name, field_name, property_name
+                ):
+                    # XXX: this is kind of a hack
+                    return PrintableMaterializedPropertyGroupItem(
+                        self.visit(table),
+                        self._print_identifier(property_group_column),
+                        self.context.add_value(property_name),
+                    ).has_expr
 
         return None  # nothing to optimize
 

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -958,6 +958,12 @@ class _Printer(Visitor):
                     return property_source.has_expr
                 else:
                     raise ValueError("unexpected node name")
+        elif node.name == "JSONHas":
+            if len(node.args) > 2:
+                # TODO: can probably optimize chained operations here as well
+                return None
+
+            raise NotImplementedError
 
         return None  # nothing to optimize
 

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -944,7 +944,7 @@ class _Printer(Visitor):
             return expr_type
 
         match node:
-            case ast.Call(name="isNull" | "isNotNull", args=[field]):
+            case ast.Call(name="isNull" | "isNotNull" as function_name, args=[field]):
                 # TODO: can probably optimize chained operations, but will need more thought
                 field_type = resolve_field_type(field)
                 if isinstance(field_type, ast.PropertyType) and len(field_type.chain) == 1:
@@ -952,16 +952,16 @@ class _Printer(Visitor):
                     if not isinstance(property_source, PrintableMaterializedPropertyGroupItem):
                         return None
 
-                    match node.name:
+                    match function_name:
                         case "isNull":
                             return f"not({property_source.has_expr})"
                         case "isNotNull":
                             return property_source.has_expr
                         case _:
-                            raise ValueError(f"unexpected node name: {node.name}")
+                            raise ValueError(f"unexpected node name: {function_name}")
             case ast.Call(name="JSONHas", args=[field, ast.Constant(value=property_name)]):
                 # TODO: can probably optimize chained operations here as well
-                field_type = resolve_field_type(node.args[0])
+                field_type = resolve_field_type(field)
                 if not isinstance(field_type, ast.FieldType):
                     return None
 

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -515,6 +515,17 @@ class TestPrinter(BaseTest):
             {"hogql_val_0": "key"},
         )
 
+    def test_property_groups_optimized_has(self) -> None:
+        self._test_property_group_comparison(
+            "JSONHas(properties, 'key')",
+            "mapContains(events.properties_group_custom.keys, %(hogql_val_0)s)",
+            {"hogql_val_0": "key"},
+            expected_skip_indexes_used={"properties_group_custom_keys_bf"},
+        )
+
+        # TODO: Chained operations/path traversal could be optimized further, but is left alone for now.
+        self._test_property_group_comparison("JSONHas(properties, 'foo', 'bar')")
+
     def test_property_groups_optimized_in_comparisons(self) -> None:
         # The IN operator works much like equality when the right hand side of the expression is all constants. Like
         # equality, it also needs to handle the empty string special case.

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -518,13 +518,13 @@ class TestPrinter(BaseTest):
     def test_property_groups_optimized_has(self) -> None:
         self._test_property_group_comparison(
             "JSONHas(properties, 'key')",
-            "mapContains(events.properties_group_custom.keys, %(hogql_val_0)s)",
+            "has(events.properties_group_custom, %(hogql_val_0)s)",
             {"hogql_val_0": "key"},
             expected_skip_indexes_used={"properties_group_custom_keys_bf"},
         )
 
         # TODO: Chained operations/path traversal could be optimized further, but is left alone for now.
-        self._test_property_group_comparison("JSONHas(properties, 'foo', 'bar')")
+        self._test_property_group_comparison("JSONHas(properties, 'foo', 'bar')", None)
 
     def test_property_groups_optimized_in_comparisons(self) -> None:
         # The IN operator works much like equality when the right hand side of the expression is all constants. Like


### PR DESCRIPTION
## Problem

These calls are not currently optimized when using property groups, so "is set" or "is not set" expressions on property keys fall back to the source column for the property values.

This makes queries slower than necessary as they need to read more bytes than they otherwise would. This is especially the case if the property value is also referenced in the query, as both the original property column and the property groups column will be loaded. These queries also cannot currently utilize the skip index to filter out irrelevant rows as-is. In some cases these issues can slow down the query enough that it fails.

Examples (note that time window may need adjustment):

1. https://metabase.prod-us.posthog.dev/question/795-look-up-query-by-query-id?query_id=19279_cache_1a149b25251778d0e99be97cf860a5a3_XeTckTqW
2. https://metabase.prod-us.posthog.dev/question/795-look-up-query-by-query-id?query_id=11653_cache_43cbf427ffe84929fc3c6173e7769bb4_uvBkeo0l

See also:
- #24381
- https://posthog.slack.com/archives/C076E99B152/p1726027964638469

## Changes

Adds an optimization to `JSONHas` calls that reference property group columns to use the equivalent `has(column, key)` expression instead.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Added test.