### PR TITLE
fix: retention query returns wrong results with target_first_time

### DIFF
--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -170,7 +170,12 @@ class RetentionQueryRunner(QueryRunner):
                 {
                     "target_timestamps": target_timestamps,
                     "min_timestamp": self.query_date_range.date_to_start_of_interval_hogql(
-                        parse_expr("min(events.timestamp)")
+                        parse_expr(
+                            "minIf(events.timestamp, {target_entity_expr})",
+                            {
+                                "target_entity_expr": target_entity_expr,
+                            },
+                        )
                     ),
                 },
             )


### PR DESCRIPTION
## Problem

the retention query is returning the wrong results for target_first_time

The first image shows retention from "downloaded file" to "all events" 
The second image shows retention from "downloaded file" to "downloaded file"

The retention of the first image should be equal or greater than retention for the second image.

(1)
![image](https://github.com/user-attachments/assets/de4c038a-be62-4536-bc42-e00bc074a1b7)

(2)
![image](https://github.com/user-attachments/assets/83bda43d-4ca7-4a73-8de2-1c5ed397e90d)



## Changes

Make this work properly:

![image](https://github.com/user-attachments/assets/bb2dc1a8-3bcb-4fcd-8f76-f7dc392096ee)

## How did you test this code?

Tested in dev, as shown above. Wrote a test.