### PR TITLE
fix(flags): Add a setting to prevent certain teams from abusing decide endpoint

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -140,6 +140,17 @@ def get_decide(request: HttpRequest):
             team = user.teams.get(id=project_id)
 
         if team:
+            if team.id in settings.DECIDE_SHORT_CIRCUITED_TEAM_IDS:
+                return cors_response(
+                    request,
+                    generate_exception_response(
+                        "decide",
+                        f"Team with ID {team.id} cannot access the /decide endpoint."
+                        f"Please contact us at hey@posthog.com",
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    ),
+                )
+
             token = cast(str, token)  # we know it's not None if we found a team
             structlog.contextvars.bind_contextvars(team_id=team.id)
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -24,6 +24,11 @@ DECIDE_RATE_LIMIT_ENABLED = get_from_env("DECIDE_RATE_LIMIT_ENABLED", False, typ
 DECIDE_BUCKET_CAPACITY = get_from_env("DECIDE_BUCKET_CAPACITY", type_cast=int, default=500)
 DECIDE_BUCKET_REPLENISH_RATE = get_from_env("DECIDE_BUCKET_REPLENISH_RATE", type_cast=float, default=10.0)
 
+# Prevent decide abuse
+
+# This is a list of team-ids that are prevented from using the /decide endpoint
+# until they fix an issue with their feature flags causing instability in posthog.
+DECIDE_SHORT_CIRCUITED_TEAM_IDS = [15611]
 # Decide db settings
 
 DECIDE_SKIP_POSTGRES_FLAGS = get_from_env("DECIDE_SKIP_POSTGRES_FLAGS", False, type_cast=str_to_bool)


### PR DESCRIPTION
## Problem

This PR adds a setting to provide team-ids that can be disabled from accessing the `/decide` endpoint. 
A need for this setting came out of our recent issues with certain feature flags having very large property values causing decide pods to crash.

## Changes

Adds a `DECIDE_SHORT_CIRCUITED_TEAM_IDS` property `settings/web.py` which is then used by the `/decide` endpoint to disable access to the endpoint. 

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

* Automated tests.