### PR TITLE
feat(web-analytics): Add page-level conversion goals, part 1

### DIFF
--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -40,6 +40,8 @@ export function WebOverview(props: {
 
     const samplingRate = webOverviewQueryResponse?.samplingRate
 
+    const numSkeletons = props.query.conversionGoal ? 4 : 5
+
     return (
         <>
             <EvenlyDistributedRows
@@ -47,7 +49,7 @@ export function WebOverview(props: {
                 minWidthRems={OVERVIEW_ITEM_CELL_MIN_WIDTH_REMS + 2}
             >
                 {responseLoading
-                    ? range(5).map((i) => <WebOverviewItemCellSkeleton key={i} />)
+                    ? range(numSkeletons).map((i) => <WebOverviewItemCellSkeleton key={i} />)
                     : webOverviewQueryResponse?.results?.map((item) => (
                           <WebOverviewItemCell key={item.key} item={item} />
                       )) || []}
@@ -170,6 +172,12 @@ const labelFromKey = (key: string): string => {
             return 'Session duration'
         case 'bounce rate':
             return 'Bounce rate'
+        case 'conversion rate':
+            return 'Conversion rate'
+        case 'total conversions':
+            return 'Total conversions'
+        case 'unique conversions':
+            return 'Unique conversions'
         default:
             return key
                 .split(' ')

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10658,6 +10658,16 @@
             },
             "type": "object"
         },
+        "WebAnalyticsConversionGoal": {
+            "additionalProperties": false,
+            "properties": {
+                "actionId": {
+                    "type": "integer"
+                }
+            },
+            "required": ["actionId"],
+            "type": "object"
+        },
         "WebAnalyticsPropertyFilter": {
             "anyOf": [
                 {
@@ -10680,6 +10690,9 @@
         "WebExternalClicksTableQuery": {
             "additionalProperties": false,
             "properties": {
+                "conversionGoal": {
+                    "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
                 },
@@ -10783,6 +10796,9 @@
         "WebGoalsQuery": {
             "additionalProperties": false,
             "properties": {
+                "conversionGoal": {
+                    "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
                 },
@@ -10912,6 +10928,9 @@
                 "compare": {
                     "type": "boolean"
                 },
+                "conversionGoal": {
+                    "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
                 },
@@ -11026,6 +11045,9 @@
                 "breakdownBy": {
                     "$ref": "#/definitions/WebStatsBreakdown"
                 },
+                "conversionGoal": {
+                    "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
                 },
@@ -11135,6 +11157,9 @@
         "WebTopClicksQuery": {
             "additionalProperties": false,
             "properties": {
+                "conversionGoal": {
+                    "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
                 },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -10691,7 +10691,14 @@
             "additionalProperties": false,
             "properties": {
                 "conversionGoal": {
-                    "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
@@ -10797,7 +10804,14 @@
             "additionalProperties": false,
             "properties": {
                 "conversionGoal": {
-                    "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
@@ -10929,7 +10943,14 @@
                     "type": "boolean"
                 },
                 "conversionGoal": {
-                    "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
@@ -11046,7 +11067,14 @@
                     "$ref": "#/definitions/WebStatsBreakdown"
                 },
                 "conversionGoal": {
-                    "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"
@@ -11158,7 +11186,14 @@
             "additionalProperties": false,
             "properties": {
                 "conversionGoal": {
-                    "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "dateRange": {
                     "$ref": "#/definitions/DateRange"

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1330,10 +1330,13 @@ export interface SessionsTimelineQuery extends DataNode<SessionsTimelineQueryRes
 }
 export type WebAnalyticsPropertyFilter = EventPropertyFilter | PersonPropertyFilter | SessionPropertyFilter
 export type WebAnalyticsPropertyFilters = WebAnalyticsPropertyFilter[]
-
+export type WebAnalyticsConversionGoal = {
+    actionId: integer
+}
 interface WebAnalyticsQueryBase<R extends Record<string, any>> extends DataNode<R> {
     dateRange?: DateRange
     properties: WebAnalyticsPropertyFilters
+    conversionGoal?: WebAnalyticsConversionGoal
     sampling?: {
         enabled?: boolean
         forceSamplingRate?: SamplingRate

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1336,7 +1336,7 @@ export type WebAnalyticsConversionGoal = {
 interface WebAnalyticsQueryBase<R extends Record<string, any>> extends DataNode<R> {
     dateRange?: DateRange
     properties: WebAnalyticsPropertyFilters
-    conversionGoal?: WebAnalyticsConversionGoal
+    conversionGoal?: WebAnalyticsConversionGoal | null
     sampling?: {
         enabled?: boolean
         forceSamplingRate?: SamplingRate

--- a/frontend/src/scenes/web-analytics/WebConversionGoal.tsx
+++ b/frontend/src/scenes/web-analytics/WebConversionGoal.tsx
@@ -1,14 +1,21 @@
 import { useActions, useValues } from 'kea'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 
 import { actionsModel } from '~/models/actionsModel'
 
-export const WebConversionGoal = (): JSX.Element => {
+export const WebConversionGoal = (): JSX.Element | null => {
     const { conversionGoal } = useValues(webAnalyticsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
     const { setConversionGoal } = useActions(webAnalyticsLogic)
     const { actions } = useValues(actionsModel)
+
+    if (!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_CONVERSION_GOALS] && !conversionGoal) {
+        return null
+    }
     return (
         <TaxonomicPopover<number>
             data-attr="web-analytics-conversion-filter"

--- a/frontend/src/scenes/web-analytics/WebConversionGoal.tsx
+++ b/frontend/src/scenes/web-analytics/WebConversionGoal.tsx
@@ -1,0 +1,36 @@
+import { useActions, useValues } from 'kea'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
+import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
+
+import { actionsModel } from '~/models/actionsModel'
+
+export const WebConversionGoal = (): JSX.Element => {
+    const { conversionGoal } = useValues(webAnalyticsLogic)
+    const { setConversionGoal } = useActions(webAnalyticsLogic)
+    const { actions } = useValues(actionsModel)
+    return (
+        <>
+            <TaxonomicPopover<number>
+                data-attr="web-analytics-conversion-filter"
+                groupType={TaxonomicFilterGroupType.Actions}
+                value={conversionGoal?.actionId}
+                onChange={(changedValue) => {
+                    setConversionGoal({ actionId: changedValue })
+                }}
+                renderValue={(value) => {
+                    const conversionGoalAction = actions.find((a) => a.id === value)
+                    return (
+                        <span className="text-overflow max-w-full">
+                            {conversionGoalAction?.name ?? 'Conversion goal'}
+                        </span>
+                    )
+                }}
+                groupTypes={[TaxonomicFilterGroupType.Actions]}
+                placeholder="Add conversion goal"
+                placeholderClass=""
+                allowClear={true}
+            />
+        </>
+    )
+}

--- a/frontend/src/scenes/web-analytics/WebConversionGoal.tsx
+++ b/frontend/src/scenes/web-analytics/WebConversionGoal.tsx
@@ -1,21 +1,15 @@
 import { useActions, useValues } from 'kea'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 
 import { actionsModel } from '~/models/actionsModel'
 
 export const WebConversionGoal = (): JSX.Element | null => {
     const { conversionGoal } = useValues(webAnalyticsLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
     const { setConversionGoal } = useActions(webAnalyticsLogic)
     const { actions } = useValues(actionsModel)
 
-    if (!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_CONVERSION_GOALS] && !conversionGoal) {
-        return null
-    }
     return (
         <TaxonomicPopover<number>
             data-attr="web-analytics-conversion-filter"

--- a/frontend/src/scenes/web-analytics/WebConversionGoal.tsx
+++ b/frontend/src/scenes/web-analytics/WebConversionGoal.tsx
@@ -10,27 +10,28 @@ export const WebConversionGoal = (): JSX.Element => {
     const { setConversionGoal } = useActions(webAnalyticsLogic)
     const { actions } = useValues(actionsModel)
     return (
-        <>
-            <TaxonomicPopover<number>
-                data-attr="web-analytics-conversion-filter"
-                groupType={TaxonomicFilterGroupType.Actions}
-                value={conversionGoal?.actionId}
-                onChange={(changedValue) => {
+        <TaxonomicPopover<number>
+            data-attr="web-analytics-conversion-filter"
+            groupType={TaxonomicFilterGroupType.Actions}
+            value={conversionGoal?.actionId}
+            onChange={(changedValue: number | '') => {
+                if (typeof changedValue === 'number') {
                     setConversionGoal({ actionId: changedValue })
-                }}
-                renderValue={(value) => {
-                    const conversionGoalAction = actions.find((a) => a.id === value)
-                    return (
-                        <span className="text-overflow max-w-full">
-                            {conversionGoalAction?.name ?? 'Conversion goal'}
-                        </span>
-                    )
-                }}
-                groupTypes={[TaxonomicFilterGroupType.Actions]}
-                placeholder="Add conversion goal"
-                placeholderClass=""
-                allowClear={true}
-            />
-        </>
+                } else {
+                    setConversionGoal(null)
+                }
+            }}
+            renderValue={(value) => {
+                const conversionGoalAction = actions.find((a) => a.id === value)
+                return (
+                    <span className="text-overflow max-w-full">{conversionGoalAction?.name ?? 'Conversion goal'}</span>
+                )
+            }}
+            groupTypes={[TaxonomicFilterGroupType.Actions]}
+            placeholder="Add conversion goal"
+            placeholderClass=""
+            allowClear={true}
+            size="small"
+        />
     )
 }

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -23,6 +23,7 @@ import {
     webAnalyticsLogic,
 } from 'scenes/web-analytics/webAnalyticsLogic'
 import { WebAnalyticsModal } from 'scenes/web-analytics/WebAnalyticsModal'
+import { WebConversionGoal } from 'scenes/web-analytics/WebConversionGoal'
 import { WebPropertyFilters } from 'scenes/web-analytics/WebPropertyFilters'
 
 import { navigationLogic } from '~/layout/navigation/navigationLogic'
@@ -53,6 +54,7 @@ const Filters = (): JSX.Element => {
                     setWebAnalyticsFilters={setWebAnalyticsFilters}
                     webAnalyticsFilters={webAnalyticsFilters}
                 />
+                <WebConversionGoal />
                 <ReloadAll />
             </div>
             <div className="bg-border h-px w-full mt-2" />

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -3,12 +3,14 @@ import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { VersionCheckerBanner } from 'lib/components/VersionChecker/VersionCheckerBanner'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 import { PostHogComDocsURL } from 'lib/lemon-ui/Link/Link'
 import { Popover } from 'lib/lemon-ui/Popover'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { isNotNil } from 'lib/utils'
 import React, { useState } from 'react'
 import { WebAnalyticsErrorTrackingTile } from 'scenes/web-analytics/tiles/WebAnalyticsErrorTracking'
@@ -40,6 +42,8 @@ const Filters = (): JSX.Element => {
     } = useValues(webAnalyticsLogic)
     const { setWebAnalyticsFilters, setDates } = useActions(webAnalyticsLogic)
     const { mobileLayout } = useValues(navigationLogic)
+    const { conversionGoal } = useValues(webAnalyticsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     return (
         <div
@@ -54,7 +58,9 @@ const Filters = (): JSX.Element => {
                     setWebAnalyticsFilters={setWebAnalyticsFilters}
                     webAnalyticsFilters={webAnalyticsFilters}
                 />
-                <WebConversionGoal />
+                {featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_CONVERSION_GOALS] || conversionGoal ? (
+                    <WebConversionGoal />
+                ) : null}
                 <ReloadAll />
             </div>
             <div className="bg-border h-px w-full mt-2" />

--- a/frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
@@ -12,18 +12,16 @@ export const WebPropertyFilters = ({
     setWebAnalyticsFilters: (filters: WebAnalyticsPropertyFilters) => void
 }): JSX.Element => {
     return (
-        <>
-            <PropertyFilters
-                taxonomicGroupTypes={[
-                    TaxonomicFilterGroupType.EventProperties,
-                    TaxonomicFilterGroupType.PersonProperties,
-                    TaxonomicFilterGroupType.SessionProperties,
-                ]}
-                onChange={(filters) => setWebAnalyticsFilters(filters.filter(isEventPersonOrSessionPropertyFilter))}
-                propertyFilters={webAnalyticsFilters}
-                pageKey="web-analytics"
-                eventNames={['$pageview']}
-            />
-        </>
+        <PropertyFilters
+            taxonomicGroupTypes={[
+                TaxonomicFilterGroupType.EventProperties,
+                TaxonomicFilterGroupType.PersonProperties,
+                TaxonomicFilterGroupType.SessionProperties,
+            ]}
+            onChange={(filters) => setWebAnalyticsFilters(filters.filter(isEventPersonOrSessionPropertyFilter))}
+            propertyFilters={webAnalyticsFilters}
+            pageKey="web-analytics"
+            eventNames={['$pageview']}
+        />
     )
 }

--- a/frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
+++ b/frontend/src/scenes/web-analytics/WebPropertyFilters.tsx
@@ -12,16 +12,18 @@ export const WebPropertyFilters = ({
     setWebAnalyticsFilters: (filters: WebAnalyticsPropertyFilters) => void
 }): JSX.Element => {
     return (
-        <PropertyFilters
-            taxonomicGroupTypes={[
-                TaxonomicFilterGroupType.EventProperties,
-                TaxonomicFilterGroupType.PersonProperties,
-                TaxonomicFilterGroupType.SessionProperties,
-            ]}
-            onChange={(filters) => setWebAnalyticsFilters(filters.filter(isEventPersonOrSessionPropertyFilter))}
-            propertyFilters={webAnalyticsFilters}
-            pageKey="web-analytics"
-            eventNames={['$pageview']}
-        />
+        <>
+            <PropertyFilters
+                taxonomicGroupTypes={[
+                    TaxonomicFilterGroupType.EventProperties,
+                    TaxonomicFilterGroupType.PersonProperties,
+                    TaxonomicFilterGroupType.SessionProperties,
+                ]}
+                onChange={(filters) => setWebAnalyticsFilters(filters.filter(isEventPersonOrSessionPropertyFilter))}
+                propertyFilters={webAnalyticsFilters}
+                pageKey="web-analytics"
+                eventNames={['$pageview']}
+            />
+        </>
     )
 }

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -517,7 +517,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 webAnalyticsFilters,
                 replayFilters,
                 dateFilter,
-                conversionGoal: conversionGoal ?? undefined,
+                conversionGoal,
             }),
         ],
         tiles: [
@@ -1748,9 +1748,11 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             }
         },
     })),
-    listeners(({ values, actions }) => ({
-        setGraphsTab: ({ tab }) => {
-            const conversionGoal = values.conversionGoal
+    listeners(({ values, actions }) => {
+        const checkGraphsTabIsCompatibleWithConversionGoal = (
+            tab: string,
+            conversionGoal: WebAnalyticsConversionGoal | null
+        ): void => {
             if (conversionGoal) {
                 if (tab === GraphsTab.PAGE_VIEWS || tab === GraphsTab.NUM_SESSION) {
                     actions.setGraphsTab(GraphsTab.UNIQUE_USERS)
@@ -1764,24 +1766,16 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     actions.setGraphsTab(GraphsTab.UNIQUE_USERS)
                 }
             }
-        },
-        setConversionGoal: ({ conversionGoal }) => {
-            const tab = values.graphsTab
-            if (conversionGoal) {
-                if (tab === GraphsTab.PAGE_VIEWS || tab === GraphsTab.NUM_SESSION) {
-                    actions.setGraphsTab(GraphsTab.UNIQUE_USERS)
-                }
-            } else {
-                if (
-                    tab === GraphsTab.TOTAL_CONVERSIONS ||
-                    tab === GraphsTab.CONVERSION_RATE ||
-                    tab === GraphsTab.UNIQUE_CONVERSIONS
-                ) {
-                    actions.setGraphsTab(GraphsTab.UNIQUE_USERS)
-                }
-            }
-        },
-    })),
+        }
+        return {
+            setGraphsTab: ({ tab }) => {
+                checkGraphsTabIsCompatibleWithConversionGoal(tab, values.conversionGoal)
+            },
+            setConversionGoal: ({ conversionGoal }) => {
+                checkGraphsTabIsCompatibleWithConversionGoal(values.graphsTab, conversionGoal)
+            },
+        }
+    }),
 ])
 
 const isDefinitionStale = (definition: EventDefinition | PropertyDefinition): boolean => {

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -1635,6 +1635,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         const stateToUrl = (): string => {
             const {
                 webAnalyticsFilters,
+                conversionGoal,
                 dateFilter: { dateTo, dateFrom, interval },
                 _sourceTab,
                 _deviceTab,
@@ -1648,6 +1649,9 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             const urlParams = new URLSearchParams()
             if (webAnalyticsFilters.length > 0) {
                 urlParams.set('filters', JSON.stringify(webAnalyticsFilters))
+            }
+            if (conversionGoal) {
+                urlParams.set('conversionGoal', JSON.stringify(conversionGoal))
             }
             if (dateFrom !== initialDateFrom || dateTo !== initialDateTo || interval !== initialInterval) {
                 urlParams.set('date_from', dateFrom ?? '')
@@ -1681,6 +1685,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         return {
             setWebAnalyticsFilters: stateToUrl,
             togglePropertyFilter: stateToUrl,
+            setConversionGoal: stateToUrl,
             setDates: stateToUrl,
             setInterval: stateToUrl,
             setDeviceTab: stateToUrl,
@@ -1696,6 +1701,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             _,
             {
                 filters,
+                conversionGoal,
                 date_from,
                 date_to,
                 interval,
@@ -1712,6 +1718,9 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 
             if (parsedFilters) {
                 actions.setWebAnalyticsFilters(parsedFilters)
+            }
+            if (conversionGoal) {
+                actions.setConversionGoal(conversionGoal)
             }
             if (date_from || date_to || interval) {
                 actions.setDatesAndInterval(date_from, date_to, interval)

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -182,6 +182,10 @@ export interface WebAnalyticsStatusCheck {
     isSendingPageLeavesScroll: boolean
 }
 
+export type WebAnalyticsConversionGoal = {
+    actionId: number
+}
+
 export const GEOIP_PLUGIN_URLS = [
     'https://github.com/PostHog/posthog-plugin-geoip',
     'https://www.npmjs.com/package/@posthog/geoip-plugin',
@@ -249,6 +253,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         setShouldStripQueryParams: (shouldStripQueryParams: boolean) => ({
             shouldStripQueryParams,
         }),
+        setConversionGoal: (conversionGoal: WebAnalyticsConversionGoal) => ({ conversionGoal }),
         setStateFromUrl: (state: {
             filters: WebAnalyticsPropertyFilters
             dateFrom: string | null
@@ -465,6 +470,12 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             { persist: true },
             {
                 setShouldStripQueryParams: (_, { shouldStripQueryParams }) => shouldStripQueryParams,
+            },
+        ],
+        conversionGoal: [
+            null as WebAnalyticsConversionGoal | null,
+            {
+                setConversionGoal: (_, { conversionGoal }) => conversionGoal,
             },
         ],
     }),

--- a/posthog/hogql_queries/web_analytics/test/test_web_overview.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_overview.py
@@ -115,7 +115,7 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         assert [item.key for item in results] == [
             "visitors",
-            "conversions",
+            "total conversions",
             "unique conversions",
             "conversion rate",
         ]

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -40,7 +40,7 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner):
         if self.query.conversionGoal:
             results = [
                 to_data("visitors", "unit", self._unsample(row[0]), self._unsample(row[1])),
-                to_data("conversions", "unit", self._unsample(row[2]), self._unsample(row[3])),
+                to_data("total conversions", "unit", self._unsample(row[2]), self._unsample(row[3])),
                 to_data("unique conversions", "unit", self._unsample(row[4]), self._unsample(row[5])),
                 to_data("conversion rate", "percentage", row[6], row[7]),
             ]

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -1,4 +1,5 @@
 from typing import Optional
+import math
 
 from django.utils.timezone import datetime
 
@@ -21,115 +22,7 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner):
     cached_response: CachedWebOverviewQueryResponse
 
     def to_query(self) -> ast.SelectQuery | ast.SelectUnionQuery:
-        with self.timings.measure("date_expr"):
-            start = self.query_date_range.previous_period_date_from_as_hogql()
-            mid = self.query_date_range.date_from_as_hogql()
-            end = self.query_date_range.date_to_as_hogql()
-
-        if self.query.compare:
-            return parse_select(
-                """
-SELECT
-    uniq(if(start_timestamp >= {mid} AND start_timestamp < {end}, person_id, NULL)) AS unique_users,
-    uniq(if(start_timestamp >= {start} AND start_timestamp < {mid}, person_id, NULL)) AS previous_unique_users,
-    sumIf(filtered_pageview_count, start_timestamp >= {mid} AND start_timestamp < {end}) AS current_pageviews,
-    sumIf(filtered_pageview_count, start_timestamp >= {start} AND start_timestamp < {mid}) AS previous_pageviews,
-    uniq(if(start_timestamp >= {mid} AND start_timestamp < {end}, session_id, NULL)) AS unique_sessions,
-    uniq(if(start_timestamp >= {start} AND start_timestamp < {mid}, session_id, NULL)) AS previous_unique_sessions,
-    avg(if(start_timestamp >= {mid}, session_duration, NULL)) AS avg_duration_s,
-    avg(if(start_timestamp < {mid}, session_duration, NULL)) AS prev_avg_duration_s,
-    avg(if(start_timestamp >= {mid}, is_bounce, NULL)) AS bounce_rate,
-    avg(if(start_timestamp < {mid}, is_bounce, NULL)) AS prev_bounce_rate,
-    uniq(if(start_timestamp >= {mid} AND start_timestamp < {end}, conversion_person_id, NULL)) / unique_users AS unique_converting_people,
-    uniq(if(start_timestamp >= {start} AND start_timestamp < {mid}, conversion_person_id, NULL)) / previous_unique_users AS previous_unique_converting_people
-FROM (
-    SELECT
-        any(events.person_id) as person_id,
-        session.session_id as session_id,
-        min(session.$start_timestamp) as start_timestamp,
-        any(session.$session_duration) as session_duration,
-        {pageview_count_expression} as filtered_pageview_count,
-        {conversion_person_id_expr} as conversion_person_id,
-        any(session.$is_bounce) as is_bounce
-    FROM events
-    WHERE and(
-        events.`$session_id` IS NOT NULL,
-        {event_type_expr},
-        timestamp >= {start},
-        timestamp < {end},
-        {event_properties},
-        {session_properties}
-    )
-    GROUP BY session_id
-    HAVING and(
-        start_timestamp >= {start},
-        start_timestamp < {end}
-    )
-)
-
-    """,
-                placeholders={
-                    "start": start,
-                    "mid": mid,
-                    "end": end,
-                    "event_properties": self.event_properties(),
-                    "session_properties": self.session_properties(),
-                    "pageview_count_expression": self.pageview_count_expression,
-                    "conversion_person_id_expr": self.conversion_person_id_expr,
-                    "event_type_expr": self.event_type_expr,
-                },
-            )
-        else:
-            return parse_select(
-                """
-                SELECT
-    uniq(person_id) AS unique_users,
-    NULL as previous_unique_users,
-    sum(filtered_pageview_count) AS current_pageviews,
-    NULL as previous_pageviews,
-    uniq(session_id) AS unique_sessions,
-    NULL as previous_unique_sessions,
-    avg(session_duration) AS avg_duration_s,
-    NULL as prev_avg_duration_s,
-    avg(is_bounce) AS bounce_rate,
-    NULL as prev_bounce_rate,
-    uniq(conversion_person_id) / unique_users AS unique_converting_users,
-    NULL AS previous_unique_converting_users
-FROM (
-    SELECT
-        any(events.person_id) as person_id,
-        session.session_id as session_id,
-        min(session.$start_timestamp) as start_timestamp,
-        any(session.$session_duration) as session_duration,
-        {pageview_count_expression} as filtered_pageview_count,
-        {conversion_person_id_expr} as conversion_person_id,
-        any(session.$is_bounce) as is_bounce
-    FROM events
-    WHERE and(
-        events.`$session_id` IS NOT NULL,
-        {event_type_expr},
-        timestamp >= {mid},
-        timestamp < {end},
-        {event_properties},
-        {session_properties}
-    )
-    GROUP BY session_id
-    HAVING and(
-        start_timestamp >= {mid},
-        start_timestamp < {end}
-    )
-)
-                """,
-                placeholders={
-                    "mid": mid,
-                    "end": end,
-                    "event_properties": self.event_properties(),
-                    "session_properties": self.session_properties(),
-                    "pageview_count_expression": self.pageview_count_expression,
-                    "conversion_person_id_expr": self.conversion_person_id_expr,
-                    "event_type_expr": self.event_type_expr,
-                },
-            )
+        return self.outer_select
 
     def calculate(self):
         response = execute_hogql_query(
@@ -144,15 +37,21 @@ FROM (
 
         row = response.results[0]
 
-        results = [
+        if self.query.conversionGoal:
+            results = [
+                to_data("visitors", "unit", self._unsample(row[0]), self._unsample(row[1])),
+                to_data("conversions", "unit", self._unsample(row[2]), self._unsample(row[3])),
+                to_data("unique conversions", "unit", self._unsample(row[4]), self._unsample(row[5])),
+                to_data("conversion rate", "percentage", row[6], row[7]),
+            ]
+        else:
+            results = [
                 to_data("visitors", "unit", self._unsample(row[0]), self._unsample(row[1])),
                 to_data("views", "unit", self._unsample(row[2]), self._unsample(row[3])),
                 to_data("sessions", "unit", self._unsample(row[4]), self._unsample(row[5])),
                 to_data("session duration", "duration_s", row[6], row[7]),
                 to_data("bounce rate", "percentage", row[8], row[9], is_increase_bad=True),
             ]
-        if self.query.conversionGoal:
-            results.append(to_data("conversion rate", "percentage", row[10], row[11]))
 
         return WebOverviewQueryResponse(
             results=results,
@@ -188,7 +87,7 @@ FROM (
         return property_to_expr(properties, team=self.team, scope="event")
 
     @cached_property
-    def conversion_goal_action (self)-> Optional[Action]:
+    def conversion_goal_action(self) -> Optional[Action]:
         if self.query.conversionGoal:
             return Action.objects.get(pk=self.query.conversionGoal.actionId)
         else:
@@ -198,30 +97,223 @@ FROM (
     def conversion_person_id_expr(self) -> ast.Expr:
         if self.conversion_goal_action:
             action_expr = action_to_expr(self.conversion_goal_action)
-            return ast.Call(name='any', args=[ast.Call(name="if", args=[action_expr, ast.Field(chain=['events', 'person_id']), ast.Constant(value=None)])])
+            return ast.Call(
+                name="any",
+                args=[
+                    ast.Call(
+                        name="if",
+                        args=[action_expr, ast.Field(chain=["events", "person_id"]), ast.Constant(value=None)],
+                    )
+                ],
+            )
         else:
             return ast.Constant(value=None)
 
     @cached_property
     def pageview_count_expression(self) -> ast.Expr:
         if self.conversion_goal_action:
-            return ast.Call(name='countIf', args=[ast.CompareOperation(left=ast.Field(chain=['event']), op=ast.CompareOperationOp.Eq, right=ast.Constant(value='$pageview'))])
+            return ast.Call(
+                name="countIf",
+                args=[
+                    ast.CompareOperation(
+                        left=ast.Field(chain=["event"]),
+                        op=ast.CompareOperationOp.Eq,
+                        right=ast.Constant(value="$pageview"),
+                    )
+                ],
+            )
         else:
-            return ast.Call(name='count', args=[])
+            return ast.Call(name="count", args=[])
+
+    @cached_property
+    def conversion_count_expr(self) -> ast.Expr:
+        if self.conversion_goal_action:
+            action_expr = action_to_expr(self.conversion_goal_action)
+            return ast.Call(name="countIf", args=[action_expr])
+        else:
+            return ast.Constant(value=None)
 
     @cached_property
     def event_type_expr(self) -> ast.Expr:
-        pageview_expr = ast.CompareOperation(op=ast.CompareOperationOp.Eq, left=ast.Field(chain=['event']), right=ast.Constant(value='$pageview'))
+        pageview_expr = ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq, left=ast.Field(chain=["event"]), right=ast.Constant(value="$pageview")
+        )
 
         if self.conversion_goal_action:
-            return ast.Call(name='or', args=[
-                pageview_expr,
-                action_to_expr(self.conversion_goal_action)
-            ])
+            return ast.Call(name="or", args=[pageview_expr, action_to_expr(self.conversion_goal_action)])
         else:
             return pageview_expr
 
-import math
+    @cached_property
+    def inner_select(self) -> ast.SelectQuery:
+        start = self.query_date_range.previous_period_date_from_as_hogql()
+        mid = self.query_date_range.date_from_as_hogql()
+        end = self.query_date_range.date_to_as_hogql()
+
+        parsed_select = parse_select(
+            """
+SELECT
+    any(events.person_id) as person_id,
+    session.session_id as session_id,
+    min(session.$start_timestamp) as start_timestamp
+FROM events
+WHERE and(
+    events.`$session_id` IS NOT NULL,
+    {event_type_expr},
+    timestamp >= {date_range_start},
+    timestamp < {date_range_end},
+    {event_properties},
+    {session_properties}
+)
+GROUP BY session_id
+HAVING and(
+    start_timestamp >= {date_range_start},
+    start_timestamp < {date_range_end}
+)
+        """,
+            placeholders={
+                "date_range_start": start if self.query.compare else mid,
+                "date_range_end": end,
+                "event_properties": self.event_properties(),
+                "session_properties": self.session_properties(),
+                "conversion_person_id_expr": self.conversion_person_id_expr,
+                "event_type_expr": self.event_type_expr,
+            },
+        )
+        assert isinstance(parsed_select, ast.SelectQuery)
+
+        if self.query.conversionGoal:
+            parsed_select.select.append(ast.Alias(alias="conversion_count", expr=self.conversion_count_expr))
+            parsed_select.select.append(ast.Alias(alias="conversion_person_id", expr=self.conversion_person_id_expr))
+        else:
+            parsed_select.select.append(
+                ast.Alias(
+                    alias="session_duration",
+                    expr=ast.Call(name="any", args=[ast.Field(chain=["session", "$session_duration"])]),
+                )
+            )
+            parsed_select.select.append(
+                ast.Alias(alias="filtered_pageview_count", expr=ast.Call(name="count", args=[]))
+            )
+            parsed_select.select.append(
+                ast.Alias(
+                    alias="is_bounce", expr=ast.Call(name="any", args=[ast.Field(chain=["session", "$is_bounce"])])
+                )
+            )
+
+        return parsed_select
+
+    @cached_property
+    def outer_select(self) -> ast.SelectQuery:
+        start = self.query_date_range.previous_period_date_from_as_hogql()
+        mid = self.query_date_range.date_from_as_hogql()
+        end = self.query_date_range.date_to_as_hogql()
+
+        def current_period_aggregate(function_name, column_name, alias):
+            if self.query.compare:
+                return ast.Alias(
+                    alias=alias,
+                    expr=ast.Call(
+                        name=function_name + "If",
+                        args=[
+                            ast.Field(chain=[column_name]),
+                            ast.Call(
+                                name="and",
+                                args=[
+                                    ast.CompareOperation(
+                                        op=ast.CompareOperationOp.GtEq,
+                                        left=ast.Field(chain=["start_timestamp"]),
+                                        right=mid,
+                                    ),
+                                    ast.CompareOperation(
+                                        op=ast.CompareOperationOp.Lt,
+                                        left=ast.Field(chain=["start_timestamp"]),
+                                        right=end,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                )
+            else:
+                return ast.Alias(alias=alias, expr=ast.Call(name=function_name, args=[ast.Field(chain=[column_name])]))
+
+        def previous_period_aggregate(function_name, column_name, alias):
+            if self.query.compare:
+                return ast.Alias(
+                    alias=alias,
+                    expr=ast.Call(
+                        name=function_name + "If",
+                        args=[
+                            ast.Field(chain=[column_name]),
+                            ast.Call(
+                                name="and",
+                                args=[
+                                    ast.CompareOperation(
+                                        op=ast.CompareOperationOp.GtEq,
+                                        left=ast.Field(chain=["start_timestamp"]),
+                                        right=start,
+                                    ),
+                                    ast.CompareOperation(
+                                        op=ast.CompareOperationOp.Lt,
+                                        left=ast.Field(chain=["start_timestamp"]),
+                                        right=mid,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                )
+            else:
+                return ast.Alias(alias=alias, expr=ast.Constant(value=None))
+
+        if self.query.conversionGoal:
+            select = [
+                current_period_aggregate("uniq", "person_id", "unique_users"),
+                previous_period_aggregate("uniq", "person_id", "previous_unique_users"),
+                current_period_aggregate("sum", "conversion_count", "total_conversion_count"),
+                previous_period_aggregate("sum", "conversion_count", "previous_total_conversion_count"),
+                current_period_aggregate("uniq", "conversion_person_id", "unique_conversions"),
+                previous_period_aggregate("uniq", "conversion_person_id", "previous_unique_conversions"),
+                ast.Alias(
+                    alias="conversion_rate",
+                    expr=ast.Call(
+                        name="divide", args=[ast.Field(chain=["unique_conversions"]), ast.Field(chain=["unique_users"])]
+                    ),
+                ),
+                ast.Alias(
+                    alias="previous_conversion_rate",
+                    expr=ast.Call(
+                        name="divide",
+                        args=[
+                            ast.Field(chain=["previous_unique_conversions"]),
+                            ast.Field(chain=["previous_unique_users"]),
+                        ],
+                    ),
+                ),
+            ]
+        else:
+            select = [
+                current_period_aggregate("uniq", "person_id", "unique_users"),
+                previous_period_aggregate("uniq", "person_id", "previous_unique_users"),
+                current_period_aggregate("sum", "filtered_pageview_count", "total_filtered_pageview_count"),
+                previous_period_aggregate("sum", "filtered_pageview_count", "previous_filtered_pageview_count"),
+                current_period_aggregate("uniq", "session_id", "unique_sessions"),
+                previous_period_aggregate("uniq", "session_id", "previous_unique_sessions"),
+                current_period_aggregate("avg", "session_duration", "avg_duration_s"),
+                previous_period_aggregate("avg", "session_duration", "prev_avg_duration_s"),
+                current_period_aggregate("avg", "is_bounce", "bounce_rate"),
+                previous_period_aggregate("avg", "is_bounce", "prev_bounce_rate"),
+            ]
+
+        query = ast.SelectQuery(
+            select=select,
+            select_from=ast.JoinExpr(table=self.inner_select),
+        )
+        assert isinstance(query, ast.SelectQuery)
+        return query
+
+
 def to_data(
     key: str,
     kind: str,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1417,6 +1417,13 @@ class VizSpecificOptions(BaseModel):
     RETENTION: Optional[RETENTION] = None
 
 
+class WebAnalyticsConversionGoal(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    actionId: int
+
+
 class Sampling(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -3697,6 +3704,7 @@ class WebExternalClicksTableQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    conversionGoal: Optional[WebAnalyticsConversionGoal] = None
     dateRange: Optional[DateRange] = None
     filterTestAccounts: Optional[bool] = None
     kind: Literal["WebExternalClicksTableQuery"] = "WebExternalClicksTableQuery"
@@ -3715,6 +3723,7 @@ class WebGoalsQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    conversionGoal: Optional[WebAnalyticsConversionGoal] = None
     dateRange: Optional[DateRange] = None
     filterTestAccounts: Optional[bool] = None
     kind: Literal["WebGoalsQuery"] = "WebGoalsQuery"
@@ -3733,6 +3742,7 @@ class WebOverviewQuery(BaseModel):
         extra="forbid",
     )
     compare: Optional[bool] = None
+    conversionGoal: Optional[WebAnalyticsConversionGoal] = None
     dateRange: Optional[DateRange] = None
     filterTestAccounts: Optional[bool] = None
     kind: Literal["WebOverviewQuery"] = "WebOverviewQuery"
@@ -3750,6 +3760,7 @@ class WebStatsTableQuery(BaseModel):
         extra="forbid",
     )
     breakdownBy: WebStatsBreakdown
+    conversionGoal: Optional[WebAnalyticsConversionGoal] = None
     dateRange: Optional[DateRange] = None
     doPathCleaning: Optional[bool] = None
     filterTestAccounts: Optional[bool] = None
@@ -3770,6 +3781,7 @@ class WebTopClicksQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    conversionGoal: Optional[WebAnalyticsConversionGoal] = None
     dateRange: Optional[DateRange] = None
     filterTestAccounts: Optional[bool] = None
     kind: Literal["WebTopClicksQuery"] = "WebTopClicksQuery"


### PR DESCRIPTION
## Problem

Conversion goals are an often-requested feature of web analytics.

## Changes

Added a button to add conversion goals
<img width="1386" alt="Screenshot 2024-09-11 at 12 14 04" src="https://github.com/user-attachments/assets/b83ffceb-ba67-4bc9-affd-a0adff84a34e">

Uses Actions: 
<img width="1386" alt="Screenshot 2024-09-11 at 12 15 11" src="https://github.com/user-attachments/assets/c98c1562-290f-4d93-9b38-5a0c544a26cc">

If a conversion goal is set, the overview shows conversion-related metrics
<img width="1363" alt="Screenshot 2024-09-11 at 12 19 08" src="https://github.com/user-attachments/assets/b26a831f-8a50-492b-a9cc-c56a3e1ad56b">


If a conversion goal is set, the graphs tile shows conversion-related metrics
<img width="1367" alt="Screenshot 2024-09-11 at 12 17 52" src="https://github.com/user-attachments/assets/7351f717-00d7-45a6-ac9f-db7fdafaccc2">

<img width="1373" alt="Screenshot 2024-09-11 at 12 17 25" src="https://github.com/user-attachments/assets/ff7d5059-280e-495f-a9c3-47483318583e">


Still to do (not in this PR, in a follow-up PR):
* Make the stats table queries (e.g. the Path queries) calculate conversion rate instead of bounce rate if a goal is set
* Make the conversion goal chooser UI match the filter chooser UI, rather than the just being the default action picker UI
* Make the goals clickable in the goals query

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Added some tests for the new query