### PR TITLE
refactor(backfills): Use Heartbeater and handle cancellation

### DIFF
--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -551,7 +551,7 @@ async def check_if_over_failure_threshold(batch_export_id: str, check_window: in
     """Check if a given batch export is over failure threshold.
 
     A 'check_window' was added to account for batch exports that have a history of failures but have some
-    occassional successes in the middle. This is relevant particularly for low-volume exports:
+    occasional successes in the middle. This is relevant particularly for low-volume exports:
     A batch export without rows to export always succeeds, even if it's not properly configured. So, the failures
     could be scattered between these successes.
 

--- a/posthog/temporal/common/heartbeat.py
+++ b/posthog/temporal/common/heartbeat.py
@@ -29,7 +29,7 @@ class Heartbeater:
     @property
     def details(self) -> tuple[typing.Any, ...]:
         """Return details if available, otherwise an empty tuple."""
-        return self._details
+        return self._details or ()
 
     @details.setter
     def details(self, details: tuple[typing.Any, ...]) -> None:


### PR DESCRIPTION
## Problem

Backfills can timeout if any of the operations not covered by a heartbeat takes too long (mostly the I/O tasks like checking if a schedule exists, connecting to temporal).

Backfills are not cancelled fast enough if a batch export fails too much. Batch exports cancel ongoing backfills upon finishing a run, but there's a lot more clean-up going on that can slow this process down. This leads to backfills running much longer than they should given that the failure threshold has been reached.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Use `Heartbeater` to cover everything with a heartbeat.
Move cancellation logic to backfill. Now, every backfill is responsible to cancel itself. Since a backfill tracks only its own failure rate, the threshold was reduced.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
