### PR TITLE
fix: fix redis key for session replay overflow

### DIFF
--- a/rust/capture/src/limiters/redis.rs
+++ b/rust/capture/src/limiters/redis.rs
@@ -37,7 +37,10 @@ pub const OVERFLOW_LIMITER_CACHE_KEY: &str = "@posthog/capture-overflow/";
 #[derive(Debug)]
 pub enum QuotaResource {
     Events,
+    // due to historical reasons we use different suffixes for quota limits and overflow
+    // hopefully we can unify these in the future
     Recordings,
+    Replay,
 }
 
 impl QuotaResource {
@@ -45,6 +48,7 @@ impl QuotaResource {
         match self {
             Self::Events => "events",
             Self::Recordings => "recordings",
+            Self::Replay => "replay",
         }
     }
 }
@@ -153,7 +157,7 @@ mod tests {
     #[tokio::test]
     async fn test_dynamic_limited() {
         let client = MockRedisClient::new().zrangebyscore_ret(
-            "@posthog/capture-overflow/recordings",
+            "@posthog/capture-overflow/replay",
             vec![String::from("banana")],
         );
         let client = Arc::new(client);
@@ -163,7 +167,7 @@ mod tests {
             client,
             OVERFLOW_LIMITER_CACHE_KEY.to_string(),
             None,
-            QuotaResource::Recordings,
+            QuotaResource::Replay,
         )
         .expect("Failed to create billing limiter");
         tokio::time::sleep(std::time::Duration::from_millis(30)).await;

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -34,7 +34,7 @@ where
                 redis_client.clone(),
                 OVERFLOW_LIMITER_CACHE_KEY.to_string(),
                 config.redis_key_prefix.clone(),
-                QuotaResource::Recordings,
+                QuotaResource::Replay,
             )
             .expect("failed to start replay overflow limiter"),
         ),

--- a/rust/capture/tests/recordings.rs
+++ b/rust/capture/tests/recordings.rs
@@ -139,8 +139,8 @@ async fn it_applies_overflow_limits() -> Result<()> {
     //   - session2 limit is active -> send to overflow
     //   - session3 is not in redis -> accept by default
     let redis = PrefixedRedis::new().await;
-    redis.add_overflow_limit(QuotaResource::Recordings, &session1, Duration::seconds(-60));
-    redis.add_overflow_limit(QuotaResource::Recordings, &session2, Duration::seconds(60));
+    redis.add_overflow_limit(QuotaResource::Replay, &session1, Duration::seconds(-60));
+    redis.add_overflow_limit(QuotaResource::Replay, &session2, Duration::seconds(60));
 
     let mut config = DEFAULT_CONFIG.clone();
     config.redis_key_prefix = redis.key_prefix();


### PR DESCRIPTION
## Problem

we were using "recordings" but it's actually using "replay"

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
