### PR TITLE
fix(flags): Remove customer from decide short-circuit block

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1,6 +1,5 @@
 # Web app specific settings/middleware/apps setup
 import os
-from typing import List
 from datetime import timedelta
 
 from corsheaders.defaults import default_headers
@@ -29,7 +28,8 @@ DECIDE_BUCKET_REPLENISH_RATE = get_from_env("DECIDE_BUCKET_REPLENISH_RATE", type
 
 # This is a list of team-ids that are prevented from using the /decide endpoint
 # until they fix an issue with their feature flags causing instability in posthog.
-DECIDE_SHORT_CIRCUITED_TEAM_IDS = []  # type: List[int]
+# DECIDE_SHORT_CIRCUITED_TEAM_IDS = []  # type: List[int]
+
 # Decide db settings
 
 DECIDE_SKIP_POSTGRES_FLAGS = get_from_env("DECIDE_SKIP_POSTGRES_FLAGS", False, type_cast=str_to_bool)

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -28,7 +28,7 @@ DECIDE_BUCKET_REPLENISH_RATE = get_from_env("DECIDE_BUCKET_REPLENISH_RATE", type
 
 # This is a list of team-ids that are prevented from using the /decide endpoint
 # until they fix an issue with their feature flags causing instability in posthog.
-DECIDE_SHORT_CIRCUITED_TEAM_IDS = [15611]
+DECIDE_SHORT_CIRCUITED_TEAM_IDS = []
 # Decide db settings
 
 DECIDE_SKIP_POSTGRES_FLAGS = get_from_env("DECIDE_SKIP_POSTGRES_FLAGS", False, type_cast=str_to_bool)

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1,5 +1,6 @@
 # Web app specific settings/middleware/apps setup
 import os
+from typing import List
 from datetime import timedelta
 
 from corsheaders.defaults import default_headers

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -28,7 +28,7 @@ DECIDE_BUCKET_REPLENISH_RATE = get_from_env("DECIDE_BUCKET_REPLENISH_RATE", type
 
 # This is a list of team-ids that are prevented from using the /decide endpoint
 # until they fix an issue with their feature flags causing instability in posthog.
-DECIDE_SHORT_CIRCUITED_TEAM_IDS = []
+DECIDE_SHORT_CIRCUITED_TEAM_IDS = []  # type: List[int]
 # Decide db settings
 
 DECIDE_SKIP_POSTGRES_FLAGS = get_from_env("DECIDE_SKIP_POSTGRES_FLAGS", False, type_cast=str_to_bool)

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -28,8 +28,7 @@ DECIDE_BUCKET_REPLENISH_RATE = get_from_env("DECIDE_BUCKET_REPLENISH_RATE", type
 
 # This is a list of team-ids that are prevented from using the /decide endpoint
 # until they fix an issue with their feature flags causing instability in posthog.
-# DECIDE_SHORT_CIRCUITED_TEAM_IDS = []  # type: List[int]
-
+DECIDE_SHORT_CIRCUITED_TEAM_IDS = [0]
 # Decide db settings
 
 DECIDE_SKIP_POSTGRES_FLAGS = get_from_env("DECIDE_SKIP_POSTGRES_FLAGS", False, type_cast=str_to_bool)


### PR DESCRIPTION
## Problem

Removes this customer's team from the `/decide` endpoint short circuit settings.


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

- [x] automated tests