### PR TITLE
fix: annotate person delete with required scope

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -358,6 +358,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             ),
         ],
     )
+    @action(methods=["POST"], detail=False, required_scopes=["person:write"])
     def destroy(self, request: request.Request, pk=None, **kwargs):
         """
         Use this endpoint to delete individual persons. For bulk deletion, use the bulk_delete endpoint instead.


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
This method wasn't annotated, and [users were getting](https://posthoghelp.zendesk.com/agent/tickets/14766) `This action does not support Personal API Key access`

## Changes

I noticed other methods, such as `bulk_delete` (which works with Person API Keys) were annotated, so I'm copying that here: https://github.com/PostHog/posthog/blob/9476c6ed5127d420584316ebb222e8c10d4b39fd/posthog/api/person.py#L418

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
Existing