### PR TITLE
fix: timezone display issues

### DIFF
--- a/frontend/src/lib/components/DateDisplay/index.tsx
+++ b/frontend/src/lib/components/DateDisplay/index.tsx
@@ -40,7 +40,7 @@ const dateHighlight = (parsedDate: dayjs.Dayjs, interval: IntervalType): string 
     For example, a single date in a graph will be shown as: `Th` Apr 22.
 */
 export function DateDisplay({ date, secondaryDate, interval, hideWeekRange }: DateDisplayProps): JSX.Element {
-    const parsedDate = dayjs(date)
+    const parsedDate = dayjs.utc(date)
 
     return (
         <>

--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -95,7 +95,7 @@ export function RetentionModal(): JSX.Element | null {
                 </div>
             }
             width={isEmpty ? undefined : '90%'}
-            title={`${dayjs(row.date).format('MMMM D, YYYY')} Cohort`}
+            title={`${dayjs.utc(row.date).format('MMMM D, YYYY')} Cohort`}
         >
             {people && !!people.missing_persons && (
                 <MissingPersonsAlert actorLabel={aggregationTargetLabel} missingActorsCount={people.missing_persons} />


### PR DESCRIPTION
## Problem

When your local machine is behind UTC time, modals pop up as the day before.

![image](https://github.com/user-attachments/assets/8b8decd7-ba30-49e3-ae50-8c3972c7136e)

## Changes

Update the titles in actors modal and retention popups to return the correct date.

![image](https://github.com/user-attachments/assets/ec9e4265-43a0-4170-ac19-8751eefb6bab)


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Locally
