### PR TITLE
chore: remove prop from LemonButton

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
+++ b/frontend/src/lib/lemon-ui/LemonButton/LemonButton.tsx
@@ -63,8 +63,6 @@ export interface LemonButtonPropsBase
     disabled?: boolean
     /** Like plain `disabled`, except we enforce a reason to be shown in the tooltip. */
     disabledReason?: string | null | false
-    /** Class for the wrapping div when the button is disabled */
-    disabledReasonWrapperClass?: string
     noPadding?: boolean
     size?: 'xsmall' | 'small' | 'medium' | 'large'
     'data-attr'?: string
@@ -118,7 +116,6 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
                 className,
                 disabled,
                 disabledReason,
-                disabledReasonWrapperClass,
                 loading,
                 type = 'tertiary',
                 status = 'default',
@@ -244,12 +241,7 @@ export const LemonButton: React.FunctionComponent<LemonButtonProps & React.RefAt
             if (tooltipContent) {
                 workingButton = (
                     <Tooltip title={tooltipContent} placement={tooltipPlacement}>
-                        {/* If the button is a `button` element and disabled, wrap it in a div so that the tooltip works */}
-                        {disabled && ButtonComponent === 'button' ? (
-                            <div className={clsx(disabledReasonWrapperClass)}>{workingButton}</div>
-                        ) : (
-                            workingButton
-                        )}
+                        {workingButton}
                     </Tooltip>
                 )
             }

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -169,7 +169,6 @@ const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number 
                     noPadding
                     onClick={() => setSettingsOpen(true)}
                     disabledReason={!canOpenSettings && 'Select a column first'}
-                    disabledReasonWrapperClass="flex"
                 />
             </Popover>
             {!showTableSettings && (


### PR DESCRIPTION
## Problem

We added the `disabledReasonWrapperClass` prop because of an extra div we added to buttons in the disabled state. What if we could remove the wrapping div instead...

## Changes

Confirmed tooltips still attach

![tooltips](https://github.com/user-attachments/assets/954ef20f-8e85-4908-b81a-fc6e2fc8e476)

And button using the prop (gear icon) renders as before

![Screenshot 2024-09-12 at 15 57 09](https://github.com/user-attachments/assets/820c7c2e-4970-46a0-9659-68daa5ee1dae)