### PR TITLE
fix: Helper to mark cyclotron changes

### DIFF
--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -48,7 +48,6 @@ jobs:
                         - 'posthog/plugins/**'
                         - 'docker*.yml'
                         - '*Dockerfile'
-                        - 'rust/**'
 
     code-quality:
         name: Code quality

--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -48,6 +48,7 @@ jobs:
                         - 'posthog/plugins/**'
                         - 'docker*.yml'
                         - '*Dockerfile'
+                        - 'rust/**'
 
     code-quality:
         name: Code quality

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -144,5 +144,9 @@
         "patchedDependencies": {
             "node-rdkafka@2.17.0": "patches/node-rdkafka@2.17.0.patch"
         }
+    },
+    "cyclotron": {
+        "//This is a short term workaround to ensure that cyclotron changes trigger a rebuild": true,
+        "version": "0.1.1"
     }
 }

--- a/rust/cyclotron-node/package.json
+++ b/rust/cyclotron-node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/cyclotron",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Node bindings for cyclotron",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
## Problem

We want to have a way of triggering plugin-server tests and deploys when cyclotron code changes.
We will have a better solution soon but short term a manual helper

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
