### PR TITLE
chore: add credit modal events

### DIFF
--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -83,6 +83,8 @@ export const billingLogic = kea<billingLogicType>([
         setShowLicenseDirectInput: (show: boolean) => ({ show }),
         reportBillingAlertShown: (alertConfig: BillingAlertConfig) => ({ alertConfig }),
         reportBillingAlertActionClicked: (alertConfig: BillingAlertConfig) => ({ alertConfig }),
+        reportCreditsFormSubmitted: (creditInput: number) => ({ creditInput }),
+        reportCreditsModalShown: true,
         reportBillingShown: true,
         registerInstrumentationProps: true,
         setRedirectPath: true,
@@ -466,6 +468,7 @@ export const billingLogic = kea<billingLogicType>([
 
                 actions.showPurchaseCreditsModal(false)
                 actions.loadCreditOverview()
+                actions.reportCreditsFormSubmitted(+creditInput)
 
                 LemonDialog.open({
                     title: 'Your credit purchase has been submitted',
@@ -519,6 +522,14 @@ export const billingLogic = kea<billingLogicType>([
         reportBillingAlertActionClicked: ({ alertConfig }) => {
             posthog.capture('billing alert action clicked', {
                 ...alertConfig,
+            })
+        },
+        reportCreditsModalShown: () => {
+            posthog.capture('credits modal shown')
+        },
+        reportCreditsFormSubmitted: ({ creditInput }) => {
+            posthog.capture('credits modal credit form submitted', {
+                creditInput,
             })
         },
         loadBillingSuccess: () => {
@@ -663,6 +674,11 @@ export const billingLogic = kea<billingLogicType>([
                     payload['billing_period_end'] = values.billing.billing_period.current_period_end
                 }
                 posthog.register(payload)
+            }
+        },
+        showPurchaseCreditsModal: ({ isOpen }) => {
+            if (isOpen) {
+                actions.reportCreditsModalShown()
             }
         },
     })),


### PR DESCRIPTION
## Changes

Adding events for opening and submitting the credits modal 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
