### PR TITLE
feat(onboarding-templates): small fixes

### DIFF
--- a/frontend/src/lib/components/IframedToolbarBrowser/IframedToolbarBrowser.tsx
+++ b/frontend/src/lib/components/IframedToolbarBrowser/IframedToolbarBrowser.tsx
@@ -6,16 +6,16 @@ import useResizeObserver from 'use-resize-observer'
 import { ToolbarUserIntent } from '~/types'
 
 import { appEditorUrl } from '../AuthorizedUrlList/authorizedUrlListLogic'
-import { iframedToolbarBrowserLogic } from './iframedToolbarBrowserLogic'
+import { iframedToolbarBrowserLogic, UserIntentVerb } from './iframedToolbarBrowserLogic'
 
-function IframeErrorOverlay(): JSX.Element | null {
+function IframeErrorOverlay({ userIntent }: { userIntent?: string }): JSX.Element | null {
     const logic = iframedToolbarBrowserLogic()
     const { iframeBanner } = useValues(logic)
     return iframeBanner ? (
         <div className="absolute flex flex-col w-full h-full bg-blend-overlay items-start py-4 px-8 pointer-events-none">
             <LemonBanner className="w-full" type={iframeBanner.level}>
                 {iframeBanner.message}. Your site might not allow being embedded in an iframe. You can click "Open in
-                toolbar" above to visit your site and view the heatmap there.
+                toolbar" above to visit your site and {UserIntentVerb[userIntent as ToolbarUserIntent]} there.
             </LemonBanner>
         </div>
     ) : null
@@ -50,7 +50,7 @@ export function IframedToolbarBrowser({
 
     return browserUrl ? (
         <div className="relative flex-1 w-full h-full">
-            <IframeErrorOverlay />
+            <IframeErrorOverlay userIntent={userIntent} />
             <LoadingOverlay />
             <iframe
                 ref={iframeRef}

--- a/frontend/src/lib/components/IframedToolbarBrowser/iframedToolbarBrowserLogic.ts
+++ b/frontend/src/lib/components/IframedToolbarBrowser/iframedToolbarBrowserLogic.ts
@@ -25,6 +25,14 @@ export interface IFrameBanner {
     message: string | JSX.Element
 }
 
+export const UserIntentVerb: {
+    [K in ToolbarUserIntent]: string
+} = {
+    heatmaps: 'view the heatmap',
+    'add-action': 'add actions',
+    'edit-action': 'edit the action',
+}
+
 export const iframedToolbarBrowserLogic = kea<iframedToolbarBrowserLogicType>([
     path(['lib', 'components', 'iframedToolbarBrowser', 'iframedToolbarBrowserLogic']),
     props({} as IframedToolbarBrowserLogicProps),

--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -270,6 +270,10 @@ export const dashboardsModel = kea<dashboardsModelType>([
             }
         },
         addDashboardSuccess: ({ dashboard }) => {
+            if (router.values.location.pathname.includes('onboarding')) {
+                // don't send a toast if we're in onboarding
+                return
+            }
             lemonToast.success(<>Dashboard created</>, {
                 button: {
                     label: 'View',

--- a/frontend/src/scenes/dashboard/DashboardTemplateChooser.tsx
+++ b/frontend/src/scenes/dashboard/DashboardTemplateChooser.tsx
@@ -84,7 +84,7 @@ export function DashboardTemplateChooser({
                                         setActiveDashboardTemplate(template)
                                     }
                                 }
-                                onItemClick?.()
+                                onItemClick?.(template)
                             }}
                             index={index + 1}
                             data-attr="create-dashboard-from-template"

--- a/frontend/src/scenes/dashboard/dashboardTemplateVariablesLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardTemplateVariablesLogic.ts
@@ -158,6 +158,7 @@ export const dashboardTemplateVariablesLogic = kea<dashboardTemplateVariablesLog
                 id: action.id.toString(),
                 math: BaseMathType.UniqueUsers,
                 name: action.name,
+                custom_name: originalVariableName,
                 order: 0,
                 type: EntityTypes.ACTIONS,
                 selector: action.steps?.[0]?.selector,
@@ -177,6 +178,7 @@ export const dashboardTemplateVariablesLogic = kea<dashboardTemplateVariablesLog
                 type: EntityTypes.EVENTS,
                 order: 0,
                 name: '$pageview',
+                custom_name: variableName,
                 properties: [
                     {
                         key: '$current_url',

--- a/frontend/src/scenes/dashboard/dashboardTemplateVariablesLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboardTemplateVariablesLogic.ts
@@ -46,6 +46,7 @@ export const dashboardTemplateVariablesLogic = kea<dashboardTemplateVariablesLog
         resetVariable: (variableId: string) => ({ variableId }),
         goToNextUntouchedActiveVariableIndex: true,
         setIsCurrentlySelectingElement: (isSelecting: boolean) => ({ isSelecting }),
+        setActiveVariableCustomEventName: (customEventName?: string | null) => ({ customEventName }),
     }),
     reducers({
         variables: [
@@ -96,6 +97,12 @@ export const dashboardTemplateVariablesLogic = kea<dashboardTemplateVariablesLog
             {
                 setActiveVariableIndex: (_, { index }) => index,
                 incrementActiveVariableIndex: (state) => state + 1,
+            },
+        ],
+        activeVariableCustomEventName: [
+            null as string | null | undefined,
+            {
+                setActiveVariableCustomEventName: (_, { customEventName }) => customEventName,
             },
         ],
         isCurrentlySelectingElement: [

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplatesLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplatesLogic.tsx
@@ -10,7 +10,7 @@ import type { dashboardTemplatesLogicType } from './dashboardTemplatesLogicType'
 export interface DashboardTemplateProps {
     // default is to present global templates _and_ those visible only in the current team
     scope?: 'default' | DashboardTemplateScope
-    onItemClick?: () => void
+    onItemClick?: (template: DashboardTemplateType) => void
     redirectAfterCreation?: boolean
 }
 

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
@@ -1,7 +1,8 @@
-import { IconArrowRight } from '@posthog/icons'
+import { IconArrowRight, IconCheckCircle } from '@posthog/icons'
 import { LemonButton, LemonCard, LemonInput, LemonInputSelect, LemonSkeleton, Link, Spinner } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { authorizedUrlListLogic, AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
+import { StarHog } from 'lib/components/hedgehogs'
 import { IframedToolbarBrowser } from 'lib/components/IframedToolbarBrowser/IframedToolbarBrowser'
 import { iframedToolbarBrowserLogic } from 'lib/components/IframedToolbarBrowser/iframedToolbarBrowserLogic'
 import { useEffect, useRef, useState } from 'react'
@@ -181,7 +182,7 @@ export const OnboardingDashboardTemplateConfigureStep = ({
     const { variables, allVariablesAreTouched, hasTouchedAnyVariable } = useValues(theDashboardTemplateVariablesLogic)
     const { goToNextStep } = useActions(onboardingLogic)
 
-    const [isSubmitting, setIsSubmitting] = useState(false)
+    const { dashboardCreatedDuringOnboarding } = useValues(onboardingTemplateConfigLogic)
 
     return (
         <OnboardingStep
@@ -191,10 +192,35 @@ export const OnboardingDashboardTemplateConfigureStep = ({
             fullWidth
             continueOverride={<></>}
         >
-            {isSubmitting || isLoading ? (
-                <p>Creating dashboard...</p>
-            ) : (
-                <>
+            <>
+                {dashboardCreatedDuringOnboarding ? (
+                    <div className="mb-8 max-w-screen-md mx-auto">
+                        <div className="bg-success-highlight rounded p-6 flex justify-between items-center">
+                            <div className="flex gap-x-4">
+                                <IconCheckCircle className="text-success text-3xl mb-6" />
+                                <div>
+                                    <h3 className="text-lg font-bold mb-1 text-left">Dashboard created!</h3>
+                                    <p className="mx-0 mb-0">We'll take you there when you're done onboarding.</p>
+                                </div>
+                            </div>
+                            <div className="h-20">
+                                <StarHog className="h-full w-full" />
+                            </div>
+                        </div>
+                        <div className="w-full flex justify-end">
+                            <LemonButton
+                                type="primary"
+                                status="alt"
+                                data-attr="show-plans"
+                                className="mt-4"
+                                onClick={() => goToNextStep()}
+                                icon={<IconArrowRight />}
+                            >
+                                Continue
+                            </LemonButton>
+                        </div>
+                    </div>
+                ) : (
                     <div className="grid grid-cols-6 space-x-6 min-h-[80vh]">
                         <div className="col-span-4 relative">
                             {browserUrl ? (
@@ -225,7 +251,6 @@ export const OnboardingDashboardTemplateConfigureStep = ({
                                         status="alt"
                                         onClick={() => {
                                             if (activeDashboardTemplate) {
-                                                setIsSubmitting(true)
                                                 createDashboardFromTemplate(activeDashboardTemplate, variables, false)
                                             }
                                         }}
@@ -239,17 +264,30 @@ export const OnboardingDashboardTemplateConfigureStep = ({
                                     >
                                         Create dashboard
                                     </LemonButton>
+                                    {/* )} */}
                                 </div>
                                 <div className="max-w-56">
-                                    <LemonButton type="tertiary" onClick={() => goToNextStep()} fullWidth center>
+                                    <LemonButton
+                                        type="tertiary"
+                                        onClick={() => goToNextStep()}
+                                        fullWidth
+                                        center
+                                        disabledReason={
+                                            isLoading
+                                                ? 'Dashboard creating...'
+                                                : dashboardCreatedDuringOnboarding
+                                                ? 'Dashboard already created'
+                                                : undefined
+                                        }
+                                    >
                                         {hasTouchedAnyVariable ? 'Discard dashboard & skip' : 'Skip for now'}
                                     </LemonButton>
                                 </div>
                             </div>
                         </div>
                     </div>
-                </>
-            )}
+                )}
+            </>
         </OnboardingStep>
     )
 }

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
@@ -38,8 +38,9 @@ const UrlInput = ({ iframeRef }: { iframeRef: React.RefObject<HTMLIFrameElement>
     const theDashboardTemplateVariablesLogic = dashboardTemplateVariablesLogic({
         variables: activeDashboardTemplate?.variables || [],
     })
-    const { setVariableForPageview } = useActions(theDashboardTemplateVariablesLogic)
+    const { setVariableForPageview, setActiveVariableCustomEventName } = useActions(theDashboardTemplateVariablesLogic)
     const { activeVariable } = useValues(theDashboardTemplateVariablesLogic)
+    const { hideCustomEventField } = useActions(onboardingTemplateConfigLogic)
 
     useEffect(() => {
         setInputValue(currentPath)
@@ -90,7 +91,11 @@ const UrlInput = ({ iframeRef }: { iframeRef: React.RefObject<HTMLIFrameElement>
                 size="small"
                 type="primary"
                 status="alt"
-                onClick={() => setVariableForPageview(activeVariable.name, currentFullUrl)}
+                onClick={() => {
+                    setVariableForPageview(activeVariable.name, currentFullUrl)
+                    setActiveVariableCustomEventName(null)
+                    hideCustomEventField()
+                }}
             >
                 Select pageview
             </LemonButton>

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateSelectStep.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateSelectStep.tsx
@@ -6,6 +6,7 @@ import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 
 import { onboardingLogic, OnboardingStepKey } from '../onboardingLogic'
 import { OnboardingStep } from '../OnboardingStep'
+import { onboardingTemplateConfigLogic } from './onboardingTemplateConfigLogic'
 
 export const OnboardingDashboardTemplateSelectStep = ({
     stepKey = OnboardingStepKey.DASHBOARD_TEMPLATE,
@@ -14,6 +15,7 @@ export const OnboardingDashboardTemplateSelectStep = ({
 }): JSX.Element => {
     const { goToNextStep } = useActions(onboardingLogic)
     const { clearActiveDashboardTemplate } = useActions(newDashboardLogic)
+    const { setDashboardCreatedDuringOnboarding } = useActions(onboardingTemplateConfigLogic)
 
     // TODO: this is hacky, find a better way to clear the active template when coming back to this screen
     useEffect(() => {
@@ -40,7 +42,13 @@ export const OnboardingDashboardTemplateSelectStep = ({
                 Get useful insights from your events super fast with our dashboard templates. Select one to get started
                 with based on your market and industry.
             </p>
-            <DashboardTemplateChooser onItemClick={goToNextStep} redirectAfterCreation={false} />
+            <DashboardTemplateChooser
+                onItemClick={() => {
+                    setDashboardCreatedDuringOnboarding(null)
+                    goToNextStep()
+                }}
+                redirectAfterCreation={false}
+            />
         </OnboardingStep>
     )
 }

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateSelectStep.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateSelectStep.tsx
@@ -43,9 +43,11 @@ export const OnboardingDashboardTemplateSelectStep = ({
                 with based on your market and industry.
             </p>
             <DashboardTemplateChooser
-                onItemClick={() => {
+                onItemClick={(template) => {
                     setDashboardCreatedDuringOnboarding(null)
-                    goToNextStep()
+                    if (template.variables?.length && template.variables.length > 0) {
+                        goToNextStep()
+                    }
                 }}
                 redirectAfterCreation={false}
             />

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateVariables.tsx
@@ -2,11 +2,13 @@ import { IconCheckCircle, IconInfo, IconTarget, IconTrash } from '@posthog/icons
 import { LemonBanner, LemonButton, LemonCollapse, LemonInput, LemonLabel, Spinner } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { iframedToolbarBrowserLogic } from 'lib/components/IframedToolbarBrowser/iframedToolbarBrowserLogic'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { dashboardTemplateVariablesLogic } from 'scenes/dashboard/dashboardTemplateVariablesLogic'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 
 import { DashboardTemplateVariableType, EntityTypes } from '~/types'
+
+import { onboardingTemplateConfigLogic } from './onboardingTemplateConfigLogic'
 
 function VariableSelector({
     variableName,
@@ -27,12 +29,17 @@ function VariableSelector({
         goToNextUntouchedActiveVariableIndex,
         incrementActiveVariableIndex,
         setIsCurrentlySelectingElement,
+        setActiveVariableCustomEventName,
     } = useActions(theDashboardTemplateVariablesLogic)
-    const { allVariablesAreTouched, variables, activeVariableIndex, isCurrentlySelectingElement } = useValues(
-        theDashboardTemplateVariablesLogic
-    )
-    const [customEventName, setCustomEventName] = useState<string | null>(null)
-    const [showCustomEventField, setShowCustomEventField] = useState(false)
+    const {
+        allVariablesAreTouched,
+        variables,
+        activeVariableIndex,
+        isCurrentlySelectingElement,
+        activeVariableCustomEventName,
+    } = useValues(theDashboardTemplateVariablesLogic)
+    const { customEventFieldShown } = useValues(onboardingTemplateConfigLogic)
+    const { showCustomEventField, hideCustomEventField } = useActions(onboardingTemplateConfigLogic)
     const { enableElementSelector, disableElementSelector, setNewActionName } = useActions(
         iframedToolbarBrowserLogic({ iframeRef, clearBrowserUrlOnUnmount: true })
     )
@@ -49,14 +56,14 @@ function VariableSelector({
                     <IconInfo /> {variable.description}
                 </p>
             </div>
-            {!showCustomEventField && activeVariableIndex == 0 && hasSelectedSite && !variable.touched && (
+            {!customEventFieldShown && activeVariableIndex == 0 && hasSelectedSite && !variable.touched && (
                 <LemonBanner type="info" className="mb-4">
                     <p>
                         <strong>Tip:</strong> Navigate to the page you want before you start selecting.
                     </p>
                 </LemonBanner>
             )}
-            {variable.touched && !customEventName && (
+            {variable.touched && !activeVariableCustomEventName && (
                 <div className="flex justify-between items-center bg-bg-3000-light p-2 pl-3 rounded mb-4">
                     <div>
                         <p className="mb-2">
@@ -96,7 +103,7 @@ function VariableSelector({
                     </div>
                 </div>
             )}
-            {showCustomEventField && (
+            {customEventFieldShown && (
                 <div className="mb-4">
                     <LemonLabel>Custom event name</LemonLabel>
                     <p>
@@ -108,23 +115,23 @@ function VariableSelector({
                             className="grow"
                             onChange={(v) => {
                                 if (v) {
-                                    setCustomEventName(v)
+                                    setActiveVariableCustomEventName(v)
                                     setVariable(variable.name, {
                                         events: [{ id: v, math: 'dau', type: 'events' }],
                                     })
                                 } else {
-                                    setCustomEventName(null)
+                                    setActiveVariableCustomEventName(null)
                                     resetVariable(variable.id)
                                 }
                             }}
                             onBlur={() => {
-                                if (customEventName) {
+                                if (activeVariableCustomEventName) {
                                     setVariable(variable.name, {
-                                        events: [{ id: customEventName, math: 'dau', type: 'events' }],
+                                        events: [{ id: activeVariableCustomEventName, math: 'dau', type: 'events' }],
                                     })
                                 } else {
                                     resetVariable(variable.id)
-                                    setShowCustomEventField(false)
+                                    hideCustomEventField()
                                 }
                             }}
                         />
@@ -137,8 +144,8 @@ function VariableSelector({
                                     disableElementSelector()
                                     setNewActionName(null)
                                     resetVariable(variable.id)
-                                    setCustomEventName(null)
-                                    setShowCustomEventField(false)
+                                    setActiveVariableCustomEventName(null)
+                                    hideCustomEventField()
                                 }}
                             />
                         </div>
@@ -187,7 +194,7 @@ function VariableSelector({
                                 type="primary"
                                 status="alt"
                                 onClick={() => {
-                                    setShowCustomEventField(false)
+                                    hideCustomEventField()
                                     enableElementSelector()
                                     setNewActionName(variable.name)
                                     setIsCurrentlySelectingElement(true)
@@ -205,7 +212,7 @@ function VariableSelector({
                             onClick={() => {
                                 disableElementSelector()
                                 setNewActionName(null)
-                                setShowCustomEventField(true)
+                                showCustomEventField()
                                 setIsCurrentlySelectingElement(false)
                             }}
                             fullWidth

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/onboardingTemplateConfigLogic.ts
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/onboardingTemplateConfigLogic.ts
@@ -8,6 +8,9 @@ import { DashboardType } from '~/types'
 import { onboardingLogic, OnboardingStepKey } from '../onboardingLogic'
 import type { onboardingTemplateConfigLogicType } from './onboardingTemplateConfigLogicType'
 
+// TODO: We should have a variables logic that is keyed for each variable and can handle its state independently.
+// Right now we have fields like customEventFieldShown that, if used outside of onboarding, will impact all variables.
+
 export const onboardingTemplateConfigLogic = kea<onboardingTemplateConfigLogicType>([
     path(['scenes', 'onboarding', 'productAnalyticsSteps', 'onboardingTemplateConfigLogic']),
     connect({
@@ -21,6 +24,8 @@ export const onboardingTemplateConfigLogic = kea<onboardingTemplateConfigLogicTy
     }),
     actions({
         setDashboardCreatedDuringOnboarding: (dashboard: DashboardType | null) => ({ dashboard }),
+        showCustomEventField: true,
+        hideCustomEventField: true,
     }),
     reducers({
         dashboardCreatedDuringOnboarding: [
@@ -29,6 +34,13 @@ export const onboardingTemplateConfigLogic = kea<onboardingTemplateConfigLogicTy
             {
                 submitNewDashboardSuccessWithResult: (_, { result }) => result,
                 setDashboardCreatedDuringOnboarding: (_, { dashboard }) => dashboard,
+            },
+        ],
+        customEventFieldShown: [
+            false,
+            {
+                showCustomEventField: () => true,
+                hideCustomEventField: () => false,
             },
         ],
     }),

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/onboardingTemplateConfigLogic.ts
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/onboardingTemplateConfigLogic.ts
@@ -34,8 +34,9 @@ export const onboardingTemplateConfigLogic = kea<onboardingTemplateConfigLogicTy
     }),
     listeners(({ actions }) => ({
         submitNewDashboardSuccessWithResult: ({ result, variables }) => {
-            if (result && variables?.length && variables.length == 0) {
-                onboardingLogic.actions.goToNextStep(2)
+            if (result && variables?.length == 0) {
+                // dashbboard was created without variables, go to next step for success message
+                onboardingLogic.actions.goToNextStep()
             }
             actions.setOnCompleteOnboardingRedirectUrl(urls.dashboard(result.id))
         },
@@ -43,7 +44,12 @@ export const onboardingTemplateConfigLogic = kea<onboardingTemplateConfigLogicTy
     urlToAction(({ actions, values }) => ({
         '/onboarding/:productKey': (_, { step }) => {
             if (step === OnboardingStepKey.DASHBOARD_TEMPLATE_CONFIGURE) {
-                if (!values.activeDashboardTemplate || !values.activeDashboardTemplate.variables) {
+                if (
+                    (!values.activeDashboardTemplate || !values.activeDashboardTemplate.variables) &&
+                    // we want to use the "success" part of this configure screen, so if we have a dashboard created
+                    // during onboarding, we can view this screen to show the success message. So only go back if we don't have one.
+                    !values.dashboardCreatedDuringOnboarding
+                ) {
                     actions.goToPreviousStep()
                 }
             }

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/onboardingTemplateConfigLogic.ts
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/onboardingTemplateConfigLogic.ts
@@ -23,6 +23,7 @@ export const onboardingTemplateConfigLogic = kea<onboardingTemplateConfigLogicTy
     reducers({
         dashboardCreatedDuringOnboarding: [
             null as DashboardType | null,
+            { persist: true },
             {
                 submitNewDashboardSuccessWithResult: (_, { result }) => result,
             },

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/onboardingTemplateConfigLogic.ts
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/onboardingTemplateConfigLogic.ts
@@ -19,13 +19,16 @@ export const onboardingTemplateConfigLogic = kea<onboardingTemplateConfigLogicTy
             ['goToPreviousStep', 'setOnCompleteOnboardingRedirectUrl'],
         ],
     }),
-    actions({}),
+    actions({
+        setDashboardCreatedDuringOnboarding: (dashboard: DashboardType | null) => ({ dashboard }),
+    }),
     reducers({
         dashboardCreatedDuringOnboarding: [
             null as DashboardType | null,
             { persist: true },
             {
                 submitNewDashboardSuccessWithResult: (_, { result }) => result,
+                setDashboardCreatedDuringOnboarding: (_, { dashboard }) => dashboard,
             },
         ],
     }),

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/onboardingTemplateConfigLogic.ts
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/onboardingTemplateConfigLogic.ts
@@ -1,6 +1,7 @@
 import { actions, connect, kea, listeners, path, reducers } from 'kea'
 import { urlToAction } from 'kea-router'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
+import { urls } from 'scenes/urls'
 
 import { DashboardType } from '~/types'
 
@@ -15,7 +16,7 @@ export const onboardingTemplateConfigLogic = kea<onboardingTemplateConfigLogicTy
             newDashboardLogic,
             ['submitNewDashboardSuccessWithResult', 'setIsLoading'],
             onboardingLogic,
-            ['goToPreviousStep'],
+            ['goToPreviousStep', 'setOnCompleteOnboardingRedirectUrl'],
         ],
     }),
     actions({}),
@@ -27,13 +28,14 @@ export const onboardingTemplateConfigLogic = kea<onboardingTemplateConfigLogicTy
             },
         ],
     }),
-    listeners({
+    listeners(({ actions }) => ({
         submitNewDashboardSuccessWithResult: ({ result, variables }) => {
-            if (result) {
-                onboardingLogic.actions.goToNextStep(variables?.length && variables.length > 0 ? 1 : 2)
+            if (result && variables?.length && variables.length == 0) {
+                onboardingLogic.actions.goToNextStep(2)
             }
+            actions.setOnCompleteOnboardingRedirectUrl(urls.dashboard(result.id))
         },
-    }),
+    })),
     urlToAction(({ actions, values }) => ({
         '/onboarding/:productKey': (_, { step }) => {
             if (step === OnboardingStepKey.DASHBOARD_TEMPLATE_CONFIGURE) {

--- a/frontend/src/toolbar/elements/ElementInfo.tsx
+++ b/frontend/src/toolbar/elements/ElementInfo.tsx
@@ -93,10 +93,26 @@ export function ElementInfo(): JSX.Element | null {
                         )}
                     </>
                 )}
-
-                <LemonButton size="small" type="secondary" onClick={() => createAction(element)} icon={<IconPlus />}>
-                    {automaticActionCreationEnabled ? 'Select element' : 'Create a new action'}
-                </LemonButton>
+                {automaticActionCreationEnabled ? (
+                    <LemonButton
+                        size="small"
+                        type="primary"
+                        status="alt"
+                        onClick={() => createAction(element)}
+                        icon={<IconPlus />}
+                    >
+                        Select element
+                    </LemonButton>
+                ) : (
+                    <LemonButton
+                        size="small"
+                        type="secondary"
+                        onClick={() => createAction(element)}
+                        icon={<IconPlus />}
+                    >
+                        Create a new action
+                    </LemonButton>
+                )}
             </div>
         </>
     )

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2157,6 +2157,7 @@ export interface TemplateVariableStep {
     href?: string | null
     url?: string | null
     properties?: Record<string, any>[]
+    custom_name?: string
 }
 
 export interface PropertiesTimelineFilterType {


### PR DESCRIPTION
## Problem

Onboarding templates flow is functional - now to make it clean!

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- Redirect to the dashboard after onboarding
- Persist dashboard created in case they navigate away (ie when subscribing)
- Add custom error message if the site doesn't load (ie because can't iframe)
- Fix error on creating dashboard with no template
- Fix selecting pageview doesn't hide custom event field
- Make the button more visible
- fix variable name showing as action ID

https://github.com/user-attachments/assets/55dc0b57-7024-4480-8f60-ad93c2dc9c0b

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
