### PR TITLE
chore: Remove 3600 timeout in backfill for raw_sessions

### DIFF
--- a/posthog/management/commands/backfill_raw_sessions_table.py
+++ b/posthog/management/commands/backfill_raw_sessions_table.py
@@ -81,7 +81,7 @@ AND and(
         for i in reversed(range(num_days)):
             date = self.start_date + timedelta(days=i)
             logging.info("Writing the sessions for day %s", date.strftime("%Y-%m-%d"))
-            insert_query = f"""INSERT INTO {TARGET_TABLE} {select_query(select_date=date, team_id=self.team_id)} SETTINGS max_execution_time=3600"""
+            insert_query = f"""INSERT INTO {TARGET_TABLE} {select_query(select_date=date, team_id=self.team_id)}"""
             for retries in range(self.num_retries + 1):
                 try:
                     sync_execute(


### PR DESCRIPTION
## Problem

This doesn't need to be present as we pass `SETTINGS` in to `sync_execute` later.

Additionally, the value of 3600 is wrong, and it should be 7200.

## Changes

Remove the 3600 seconds timeout from the insert query

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran the backfill command in my local dev environment
