### PR TITLE
fix: respect decimal places in aggregation axis formats

### DIFF
--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -500,34 +500,45 @@ describe('lib/utils', () => {
         })
     })
     describe('humanFriendlyDuration()', () => {
-        it('returns correct value for <= 60', () => {
-            expect(humanFriendlyDuration(60)).toEqual('1m')
-            expect(humanFriendlyDuration(45)).toEqual('45s')
-            expect(humanFriendlyDuration(44.8)).toEqual('45s')
-            expect(humanFriendlyDuration(45.2)).toEqual('45s')
-        })
-        it('returns correct value for 60 < t < 120', () => {
-            expect(humanFriendlyDuration(90)).toEqual('1m 30s')
-        })
-        it('returns correct value for t > 120', () => {
-            expect(humanFriendlyDuration(360)).toEqual('6m')
-        })
-        it('returns correct value for t >= 3600', () => {
-            expect(humanFriendlyDuration(3600)).toEqual('1h')
-            expect(humanFriendlyDuration(3601)).toEqual('1h 1s')
-            expect(humanFriendlyDuration(3961)).toEqual('1h 6m 1s')
-            expect(humanFriendlyDuration(3961.333)).toEqual('1h 6m 1s')
-            expect(humanFriendlyDuration(3961.666)).toEqual('1h 6m 2s')
-        })
-        it('returns correct value for t >= 86400', () => {
-            expect(humanFriendlyDuration(86400)).toEqual('1d')
-            expect(humanFriendlyDuration(86400.12)).toEqual('1d')
-        })
-        it('truncates to specified # of units', () => {
-            expect(humanFriendlyDuration(3961, 2)).toEqual('1h 6m')
-            expect(humanFriendlyDuration(30, 2)).toEqual('30s') // no change
-            expect(humanFriendlyDuration(30, 0)).toEqual('') // returns no units (useless)
-        })
+        it.each([
+            [10, '10s', undefined, undefined],
+            [9.5, '10s', undefined, undefined],
+            [4, '4s', undefined, undefined],
+            [3.5, '4s', undefined, undefined],
+            [3.5, '3.5s', undefined, 1],
+            [0.4, '0s', undefined, undefined],
+            [0.4, '0.4s', undefined, 1],
+            [0.4, '0.4s', undefined, 2],
+            [0.15, '0s', undefined, undefined],
+            [0.15, '0.2s', undefined, 1],
+            [0.15, '0.15s', undefined, 2],
+            [0.01, '0s', undefined, undefined],
+            [0.01, '0s', undefined, 1],
+            [0.01, '0.01s', undefined, 2],
+            [60, '1m', undefined, undefined],
+            [45, '45s', undefined, undefined],
+            [44.8, '45s', undefined, undefined],
+            [45.2, '45s', undefined, undefined],
+            [90, '1m 30s', undefined, undefined],
+            [360, '6m', undefined, undefined],
+            [360.1, '6m 0.1s', undefined, 2],
+            [3601, '1h 1s', undefined, undefined],
+            [3961, '1h 6m 1s', undefined, undefined],
+            [3961.333, '1h 6m 1s', undefined, undefined],
+            [3961.666, '1h 6m 2s', undefined, undefined],
+            [86400, '1d', undefined, undefined],
+            [86400.12, '1d', undefined, undefined],
+            [3961, '1h 6m', 2, undefined],
+            [3963.5, '1h 6m 3.5s', undefined, 2],
+            [30, '30s', 2, undefined],
+            [30, '30s', 1, undefined],
+            [30, '', 0, undefined],
+        ])(
+            `when duration is %s correctly returns "%s"`,
+            (input: number, expected: string, maxUnits: number | undefined, decimalPlaces: number | undefined) => {
+                expect(humanFriendlyDuration(input, maxUnits, decimalPlaces)).toEqual(expected)
+            }
+        )
         it('returns an empty string for nullish inputs', () => {
             expect(humanFriendlyDuration('', 2)).toEqual('')
             expect(humanFriendlyDuration(null, 2)).toEqual('')

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -313,6 +313,7 @@ export function objectClean<T extends Record<string | number | symbol, unknown>>
     })
     return response
 }
+
 export function objectCleanWithEmpty<T extends Record<string | number | symbol, unknown>>(
     obj: T,
     ignoredKeys: string[] = []
@@ -463,17 +464,38 @@ export const humanFriendlyMilliseconds = (timestamp: number | undefined): string
 
     return `${(timestamp / 1000).toFixed(2)}s`
 }
-export function humanFriendlyDuration(d: string | number | null | undefined, maxUnits?: number): string {
+
+function customRound(value: number, decimalPlaces: number | undefined): number {
+    const factor = Math.pow(10, decimalPlaces ?? 0)
+    return Math.round(value * factor) / factor
+}
+
+/**
+ * Converts a number of seconds to a human-readable duration string.
+ * constructs days, hours, minutes, seconds
+ * returns either the number of days and hours (when over 1 day)
+ * or the number of hours, minutes, and seconds (when under 1 day)
+ *
+ * @param d the number of seconds to convert
+ * @param maxUnits the maximum number of units to display (from the left) (e.g. 2 would display only hours and minutes)
+ * @param decimalPlaces is applied to the right most value this is most useful when dealing with small number of seconds e.g. to distinguish 1.2 and 1.4 seconds instead of showing 1s for both
+ */
+export function humanFriendlyDuration(
+    d: string | number | null | undefined,
+    maxUnits?: number,
+    decimalPlaces?: number
+): string {
     // Convert `d` (seconds) to a human-readable duration string.
     // Example: `1d 10hrs 9mins 8s`
     if (d === '' || d === null || d === undefined) {
         return ''
     }
     d = Number(d)
-    const days = Math.floor(d / 86400)
-    const h = Math.floor((d % 86400) / 3600)
-    const m = Math.floor((d % 3600) / 60)
-    const s = Math.round((d % 3600) % 60)
+    const days = parseFloat(Math.floor(d / 86400).toFixed(decimalPlaces))
+    const h = parseFloat(Math.floor((d % 86400) / 3600).toFixed(decimalPlaces))
+    const m = parseFloat(Math.floor((d % 3600) / 60).toFixed(decimalPlaces))
+
+    const s = customRound((d % 3600) % 60, decimalPlaces)
 
     const dayDisplay = days > 0 ? days + 'd' : ''
     const hDisplay = h > 0 ? h + 'h' : ''
@@ -1108,6 +1130,7 @@ export function is12HoursOrLess(dateFrom: string | undefined | null): boolean {
     }
     return dateFrom.search(/^-([0-9]|1[0-2])h$/) != -1
 }
+
 export function isLessThan2Days(dateFrom: string | undefined | null): boolean {
     if (!dateFrom) {
         return false

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -37,16 +37,16 @@ export const formatAggregationAxisValue = (
     if (aggregationAxisFormat) {
         switch (aggregationAxisFormat) {
             case 'duration':
-                formattedValue = humanFriendlyDuration(value)
+                formattedValue = humanFriendlyDuration(value, undefined, decimalPlaces)
                 break
             case 'duration_ms':
-                formattedValue = humanFriendlyDuration(value / 1000)
+                formattedValue = humanFriendlyDuration(value / 1000, undefined, decimalPlaces)
                 break
             case 'percentage':
-                formattedValue = percentage(value / 100)
+                formattedValue = percentage(value / 100, decimalPlaces, !!decimalPlaces)
                 break
             case 'percentage_scaled':
-                formattedValue = percentage(value)
+                formattedValue = percentage(value, decimalPlaces, !!decimalPlaces)
                 break
             case 'numeric': // numeric is default
             default:

--- a/frontend/src/scenes/insights/aggregationAxisFormat.ts
+++ b/frontend/src/scenes/insights/aggregationAxisFormat.ts
@@ -1,5 +1,5 @@
 import { LemonSelectOptionLeaf } from 'lib/lemon-ui/LemonSelect'
-import { humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/utils'
+import { DEFAULT_DECIMAL_PLACES, humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/utils'
 
 import { TrendsFilter } from '~/queries/schema'
 import { ChartDisplayType, TrendsFilterType } from '~/types'
@@ -23,7 +23,9 @@ export const formatAggregationAxisValue = (
 ): string => {
     value = Number(value)
     const decimalPlaces =
-        (trendsFilter as TrendsFilter)?.decimalPlaces ?? (trendsFilter as Partial<TrendsFilterType>)?.decimal_places
+        (trendsFilter as TrendsFilter)?.decimalPlaces ??
+        (trendsFilter as Partial<TrendsFilterType>)?.decimal_places ??
+        DEFAULT_DECIMAL_PLACES
     const aggregationAxisFormat =
         (trendsFilter as TrendsFilter)?.aggregationAxisFormat ??
         (trendsFilter as Partial<TrendsFilterType>)?.aggregation_axis_format


### PR DESCRIPTION
I noticed that we don't respect the `decimal places` setting when applying a format to an axis, this is particularly noticeable in the web vitals dashboard where you end up with 3s for all values from 2.5s to 3s but might care about increments in between

| before | after |
| - | - |
|<img width="668" alt="Screenshot 2024-09-15 at 16 15 17" src="https://github.com/user-attachments/assets/1983c261-7d19-4d36-8be9-feda817edb22">|<img width="811" alt="Screenshot 2024-09-15 at 16 14 49" src="https://github.com/user-attachments/assets/4a75bee1-4260-4812-a604-68dcd8a02a82">|


### NB

this lifts the default value for decimal precision up a level so it applies to any aggregation format not just bare number
i don't really understand why we only reveal the editor for decimal places in some circumstances so i didn't change that.

without lifting that default up a level you got inconsistent behaviour

![2024-09-15 16 17 11](https://github.com/user-attachments/assets/e2f45f25-e6ec-4860-9d9b-cb190fd1a005)



