### PR TITLE
feat(web-analytics): Exclude subdomains in external click

### DIFF
--- a/posthog/hogql_queries/web_analytics/external_clicks.py
+++ b/posthog/hogql_queries/web_analytics/external_clicks.py
@@ -58,6 +58,7 @@ FROM (
         events.properties.$event_type == 'click',
         url IS NOT NULL,
         url != '',
+        cutToFirstSignificantSubdomain(properties.`$external_click_url`) != cutToFirstSignificantSubdomain(properties.`$host`),
         {all_properties}
     )
     GROUP BY events.`$session_id`, url


### PR DESCRIPTION
## Problem

More discussion here https://posthog.slack.com/archives/C05LJK1N3CP/p1726477850174519

We're trying to count external clicks. posthog-js already skips anything on the same subdomain, but we need a little more logic here to skip anything on the same domain.

## Changes

Add a check using the clickhouse function `cutToFirstSignificantSubdomain`

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added 2 tests
