### PR TITLE
fix(projects): Fix project creation when `access_control` set

### DIFF
--- a/ee/api/test/test_team.py
+++ b/ee/api/test/test_team.py
@@ -3,6 +3,7 @@ from rest_framework.status import (
     HTTP_204_NO_CONTENT,
     HTTP_403_FORBIDDEN,
     HTTP_404_NOT_FOUND,
+    HTTP_400_BAD_REQUEST,
 )
 
 from ee.api.test.base import APILicensedTest
@@ -40,6 +41,26 @@ def team_enterprise_api_test_factory():  # type: ignore
             )
             self.assertEqual(self.organization.teams.count(), 2)
 
+        def test_create_team_with_access_control(self):
+            self.organization_membership.level = OrganizationMembership.Level.ADMIN
+            self.organization_membership.save()
+            self.assertEqual(Team.objects.count(), 1)
+            self.assertEqual(Project.objects.count(), 1)
+            response = self.client.post("/api/environments/", {"name": "Test", "access_control": True})
+            self.assertEqual(response.status_code, 201)
+            self.assertEqual(Team.objects.count(), 2)
+            self.assertEqual(Project.objects.count(), 2)
+            response_data = response.json()
+            self.assertDictContainsSubset(
+                {
+                    "name": "Test",
+                    "access_control": True,
+                    "effective_membership_level": OrganizationMembership.Level.ADMIN,
+                },
+                response_data,
+            )
+            self.assertEqual(self.organization.teams.count(), 2)
+
         def test_non_admin_cannot_create_team(self):
             self.organization_membership.level = OrganizationMembership.Level.MEMBER
             self.organization_membership.save()
@@ -50,6 +71,18 @@ def team_enterprise_api_test_factory():  # type: ignore
             self.assertEqual(
                 response.json(),
                 self.permission_denied_response("Your organization access level is insufficient."),
+            )
+
+        def test_cannot_create_team_with_primary_dashboard_id(self):
+            self.organization_membership.level = OrganizationMembership.Level.ADMIN
+            self.organization_membership.save()
+            response = self.client.post("/api/environments/", {"name": "Test", "primary_dashboard": 2137})
+            self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST, response.json())
+            self.assertEqual(
+                response.json(),
+                self.validation_error_response(
+                    "Primary dashboard cannot be set on project creation.", attr="primary_dashboard"
+                ),
             )
 
         def test_create_demo_team(self, *args):

--- a/ee/api/test/test_team.py
+++ b/ee/api/test/test_team.py
@@ -8,6 +8,7 @@ from rest_framework.status import (
 
 from ee.api.test.base import APILicensedTest
 from ee.models.explicit_team_membership import ExplicitTeamMembership
+from posthog.models.dashboard import Dashboard
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.project import Project
 from posthog.models.team import Team
@@ -74,9 +75,10 @@ def team_enterprise_api_test_factory():  # type: ignore
             )
 
         def test_cannot_create_team_with_primary_dashboard_id(self):
+            dashboard_x = Dashboard.objects.create(team=self.team, name="Test")
             self.organization_membership.level = OrganizationMembership.Level.ADMIN
             self.organization_membership.save()
-            response = self.client.post("/api/environments/", {"name": "Test", "primary_dashboard": 2137})
+            response = self.client.post("/api/environments/", {"name": "Test", "primary_dashboard": dashboard_x.id})
             self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST, response.json())
             self.assertEqual(
                 response.json(),

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -43,6 +43,8 @@ from posthog.utils import get_ip_address, get_week_start_for_country_code
 
 
 class ProjectSerializer(ProjectBasicSerializer, UserPermissionsSerializerMixin):
+    instance: Optional[Project]
+
     effective_membership_level = serializers.SerializerMethodField()  # Compat with TeamSerializer
     has_group_types = serializers.SerializerMethodField()  # Compat with TeamSerializer
     live_events_token = serializers.SerializerMethodField()  # Compat with TeamSerializer

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -538,7 +538,7 @@ def team_api_test_factory():
             response = self.client.patch("/api/environments/@current/", {"primary_dashboard": d.id})
             response_data = response.json()
 
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
             self.assertEqual(response_data["name"], self.team.name)
             self.assertEqual(response_data["primary_dashboard"], d.id)
 
@@ -550,11 +550,14 @@ def team_api_test_factory():
             d = Dashboard.objects.create(name="Test", team=team_2)
 
             response = self.client.patch("/api/environments/@current/", {"primary_dashboard": d.id})
-            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
             response = self.client.get("/api/environments/@current/")
             response_data = response.json()
-            self.assertEqual(response_data["primary_dashboard"], None)
+            self.assertEqual(
+                response_data,
+                self.validation_error_response("Dashboard does not belong to this team.", attr="primary_dashboard"),
+            )
 
         def test_is_generating_demo_data(self):
             cache_key = f"is_generating_demo_data_{self.team.pk}"

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -551,11 +551,8 @@ def team_api_test_factory():
 
             response = self.client.patch("/api/environments/@current/", {"primary_dashboard": d.id})
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-            response = self.client.get("/api/environments/@current/")
-            response_data = response.json()
             self.assertEqual(
-                response_data,
+                response.json(),
                 self.validation_error_response("Dashboard does not belong to this team.", attr="primary_dashboard"),
             )
 


### PR DESCRIPTION
## Problem

Brought up in ZEN-18151 (CC @bretthoerner @raquelmsmith):
Since Thursday, project creation has been erroring when `access_control` was specified. This was not an issue in the app, which does not set this param on project creation, but a customer using the API this way experienced disruption.

Sentry issue [POSTHOG-1KFT](https://posthog.sentry.io/issues/5839436142/?project=1899813).

## Changes

The bug appeared after a refactor in #24154 that simplified one path a bit too much. The problem is that we didn't have a test for this path of project creation.

This fixes the bug and adds a few tests to better cover project creation (`access_control` and `primary_dashboard` were lacking coverage).