### PR TITLE
fix(data-warehouse): Fix missing source icons

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/DataWarehouseManagedSourcesTable.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/DataWarehouseManagedSourcesTable.tsx
@@ -205,7 +205,13 @@ export function RenderDataWarehouseSourceIcon({
                 }
             >
                 <Link to={getDataWarehouseSourceUrl(type)}>
-                    <img src={icon} alt={type} height={sizePx} width={sizePx} className="rounded object-contain" />
+                    <img
+                        src={icon}
+                        alt={type}
+                        height={sizePx}
+                        width={sizePx}
+                        className="rounded object-contain max-w-none"
+                    />
                 </Link>
             </Tooltip>
         </div>


### PR DESCRIPTION
## Problem
Warehouse source icons are missing from prod

<img width="633" alt="image" src="https://github.com/user-attachments/assets/1edb38af-ad3b-483f-a88e-16c114999094">


## Changes
- A style change on the `img` tag fixes this
- No idea why they suddenly went missing, there's not been any changes to the icon component in a while

