### PR TITLE
fix: command results can be drowned in open URL results

### DIFF
--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -716,35 +716,47 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                 scope: GLOBAL_COMMAND_SCOPE,
                 prefixes: ['open', 'visit'],
                 resolver: (argument) => {
-                    if (argument && isURL(argument)) {
+                    const words = argument?.split(' ')
+                    const url = words?.find((word) => isURL(word))
+                    if (url) {
                         return {
-                            icon: IconExternal,
-                            display: `Open ${argument}`,
-                            synonyms: [`Visit ${argument}`],
-                            executor: () => {
-                                open(argument)
-                            },
-                        }
-                    }
-                    const results: CommandResultTemplate[] = (teamLogic.values.currentTeam?.app_urls ?? []).map(
-                        (url: string) => ({
                             icon: IconExternal,
                             display: `Open ${url}`,
                             synonyms: [`Visit ${url}`],
                             executor: () => {
                                 open(url)
                             },
+                        }
+                    }
+
+                    if (
+                        words &&
+                        words.length > 0 &&
+                        words[0].toLowerCase() === 'open' &&
+                        words[0].toLowerCase() === 'visit'
+                    ) {
+                        const results: CommandResultTemplate[] = (teamLogic.values.currentTeam?.app_urls ?? []).map(
+                            (url: string) => ({
+                                icon: IconExternal,
+                                display: `Open ${url}`,
+                                synonyms: [`Visit ${url}`],
+                                executor: () => {
+                                    open(url)
+                                },
+                            })
+                        )
+                        results.push({
+                            icon: IconExternal,
+                            display: 'Open PostHog Docs',
+                            synonyms: ['technical documentation'],
+                            executor: () => {
+                                open('https://posthog.com/docs')
+                            },
                         })
-                    )
-                    results.push({
-                        icon: IconExternal,
-                        display: 'Open PostHog Docs',
-                        synonyms: ['technical documentation'],
-                        executor: () => {
-                            open('https://posthog.com/docs')
-                        },
-                    })
-                    return results
+                        return results
+                    }
+
+                    return null
                 },
             }
 

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -716,6 +716,16 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                 scope: GLOBAL_COMMAND_SCOPE,
                 prefixes: ['open', 'visit'],
                 resolver: (argument) => {
+                    if (argument && isURL(argument)) {
+                        return {
+                            icon: IconExternal,
+                            display: `Open ${argument}`,
+                            synonyms: [`Visit ${argument}`],
+                            executor: () => {
+                                open(argument)
+                            },
+                        }
+                    }
                     const results: CommandResultTemplate[] = (teamLogic.values.currentTeam?.app_urls ?? []).map(
                         (url: string) => ({
                             icon: IconExternal,
@@ -726,16 +736,6 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                             },
                         })
                     )
-                    if (argument && isURL(argument)) {
-                        results.push({
-                            icon: IconExternal,
-                            display: `Open ${argument}`,
-                            synonyms: [`Visit ${argument}`],
-                            executor: () => {
-                                open(argument)
-                            },
-                        })
-                    }
                     results.push({
                         icon: IconExternal,
                         display: 'Open PostHog Docs',

--- a/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
+++ b/frontend/src/lib/components/CommandPalette/commandPaletteLogic.tsx
@@ -729,12 +729,7 @@ export const commandPaletteLogic = kea<commandPaletteLogicType>([
                         }
                     }
 
-                    if (
-                        words &&
-                        words.length > 0 &&
-                        words[0].toLowerCase() === 'open' &&
-                        words[0].toLowerCase() === 'visit'
-                    ) {
+                    if (words && words.length > 0 && ['open', 'visit'].includes(words[0].toLowerCase())) {
                         const results: CommandResultTemplate[] = (teamLogic.values.currentTeam?.app_urls ?? []).map(
                             (url: string) => ({
                                 icon: IconExternal,


### PR DESCRIPTION
the new replay omni search never shows in prod because we add a tonne of "open app url" commands and then take the top 5 commands so you only ever see those open commands

instead lets only add those generic commands when there is no URL in the provided search and someone starts by typing open or visit

and show only the specific open command when there is a URL