### PR TITLE
chore: fix group filtering in replay

### DIFF
--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_filters.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_filters.ambr
@@ -1282,6 +1282,90 @@
                     max_bytes_before_external_group_by=0
   '''
 # ---
+# name: TestSessionRecordingsListFromFilters.test_event_filter_with_group_filter.1
+  '''
+  SELECT s.session_id AS session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
+         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
+         dateDiff('SECOND', start_time, end_time) AS duration,
+         argMinMerge(s.first_url) AS first_url,
+         sum(s.click_count) AS click_count,
+         sum(s.keypress_count) AS keypress_count,
+         sum(s.mouse_activity_count) AS mouse_activity_count,
+         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
+         minus(duration, active_seconds) AS inactive_seconds,
+         sum(s.console_log_count) AS console_log_count,
+         sum(s.console_warn_count) AS console_warn_count,
+         sum(s.console_error_count) AS console_error_count
+  FROM session_replay_events AS s
+  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
+                                                                                                                                                                                                                                                                                                                                                                                                                        (SELECT events.`$session_id` AS session_id
+                                                                                                                                                                                                                                                                                                                                                                                                                         FROM events
+                                                                                                                                                                                                                                                                                                                                                                                                                         LEFT JOIN
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name, groups.group_type_index AS index, groups.group_key AS key
+                                                                                                                                                                                                                                                                                                                                                                                                                            FROM groups
+                                                                                                                                                                                                                                                                                                                                                                                                                            WHERE and(equals(groups.team_id, 2), ifNull(equals(index, 1), 0))
+                                                                                                                                                                                                                                                                                                                                                                                                                            GROUP BY groups.group_type_index, groups.group_key) AS events__group_1 ON equals(events.`$group_1`, events__group_1.key)
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(equals(events.team_id, 2), notEmpty(events.`$session_id`), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), now64(6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-13 23:58:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), ifNull(equals(events__group_1.properties___name, 'org one'), 0))
+                                                                                                                                                                                                                                                                                                                                                                                                                         GROUP BY events.`$session_id`
+                                                                                                                                                                                                                                                                                                                                                                                                                         HAVING 1)))
+  GROUP BY s.session_id
+  HAVING 1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestSessionRecordingsListFromFilters.test_event_filter_with_group_filter.2
+  '''
+  SELECT s.session_id AS session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
+         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
+         dateDiff('SECOND', start_time, end_time) AS duration,
+         argMinMerge(s.first_url) AS first_url,
+         sum(s.click_count) AS click_count,
+         sum(s.keypress_count) AS keypress_count,
+         sum(s.mouse_activity_count) AS mouse_activity_count,
+         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
+         minus(duration, active_seconds) AS inactive_seconds,
+         sum(s.console_log_count) AS console_log_count,
+         sum(s.console_warn_count) AS console_warn_count,
+         sum(s.console_error_count) AS console_error_count
+  FROM session_replay_events AS s
+  WHERE and(equals(s.team_id, 2), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-14 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), in(s.session_id,
+                                                                                                                                                                                                                                                                                                                                                                                                                        (SELECT events.`$session_id` AS session_id
+                                                                                                                                                                                                                                                                                                                                                                                                                         FROM events
+                                                                                                                                                                                                                                                                                                                                                                                                                         LEFT JOIN
+                                                                                                                                                                                                                                                                                                                                                                                                                           (SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, 'name'), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, 'UTC')) AS properties___name, groups.group_type_index AS index, groups.group_key AS key
+                                                                                                                                                                                                                                                                                                                                                                                                                            FROM groups
+                                                                                                                                                                                                                                                                                                                                                                                                                            WHERE and(equals(groups.team_id, 2), ifNull(equals(index, 2), 0))
+                                                                                                                                                                                                                                                                                                                                                                                                                            GROUP BY groups.group_type_index, groups.group_key) AS events__group_2 ON equals(events.`$group_2`, events__group_2.key)
+                                                                                                                                                                                                                                                                                                                                                                                                                         WHERE and(equals(events.team_id, 2), notEmpty(events.`$session_id`), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), now64(6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-13 23:58:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), ifNull(equals(events__group_2.properties___name, 'org one'), 0))
+                                                                                                                                                                                                                                                                                                                                                                                                                         GROUP BY events.`$session_id`
+                                                                                                                                                                                                                                                                                                                                                                                                                         HAVING 1)))
+  GROUP BY s.session_id
+  HAVING 1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
 # name: TestSessionRecordingsListFromFilters.test_event_filter_with_hogql_event_properties_test_accounts_excluded
   '''
   SELECT s.session_id AS session_id,

--- a/posthog/session_recordings/queries/test/test_session_recording_list_from_filters.py
+++ b/posthog/session_recordings/queries/test/test_session_recording_list_from_filters.py
@@ -3752,6 +3752,36 @@ class TestSessionRecordingsListFromFilters(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual([sr["session_id"] for sr in session_recordings], [session_id])
 
+        (session_recordings, _, _) = self._filter_recordings_by(
+            {
+                "properties": [
+                    {
+                        "key": "name",
+                        "value": ["org one"],
+                        "operator": "exact",
+                        "type": "group",
+                        "group_type_index": 1,
+                    }
+                ],
+            }
+        )
+        self.assertEqual([sr["session_id"] for sr in session_recordings], [session_id])
+
+        (session_recordings, _, _) = self._filter_recordings_by(
+            {
+                "properties": [
+                    {
+                        "key": "name",
+                        "value": ["org one"],
+                        "operator": "exact",
+                        "type": "group",
+                        "group_type_index": 2,
+                    }
+                ],
+            }
+        )
+        self.assertEqual(session_recordings, [])
+
     @freeze_time("2021-01-21T20:00:00.000Z")
     @snapshot_clickhouse_queries
     def test_ordering(self):


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/17925 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/20295)

## Changes

We were not applying group property filters to the events sub query. We had a test around this that checked if the group was a property on the event (which did work / pass) but no test to confirm that it could be added as a property.

Note: we did not actually let you add group properties to replay filters but it was actually possible to include them via internal filters.

Now that I think about it we should include group filters in the actual replay filters now... maybe for a follow up while we unblock the customer for now

## How did you test this code?

Add new tests to filter on group properties in the root `properties` field, rather than the `properties` field in the event filter