### PR TITLE
feat(web-analytics): Add custom events as conversion goals

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -129,6 +129,16 @@
                 }
             ]
         },
+        "ActionConversionGoal": {
+            "additionalProperties": false,
+            "properties": {
+                "actionId": {
+                    "type": "integer"
+                }
+            },
+            "required": ["actionId"],
+            "type": "object"
+        },
         "ActionsNode": {
             "additionalProperties": false,
             "properties": {
@@ -2661,6 +2671,16 @@
                 "p99_count_per_actor"
             ],
             "type": "string"
+        },
+        "CustomEventConversionGoal": {
+            "additionalProperties": false,
+            "properties": {
+                "customEventName": {
+                    "type": "string"
+                }
+            },
+            "required": ["customEventName"],
+            "type": "object"
         },
         "DashboardFilter": {
             "additionalProperties": false,
@@ -10771,14 +10791,14 @@
             "type": "object"
         },
         "WebAnalyticsConversionGoal": {
-            "additionalProperties": false,
-            "properties": {
-                "actionId": {
-                    "type": "integer"
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/ActionConversionGoal"
+                },
+                {
+                    "$ref": "#/definitions/CustomEventConversionGoal"
                 }
-            },
-            "required": ["actionId"],
-            "type": "object"
+            ]
         },
         "WebAnalyticsPropertyFilter": {
             "anyOf": [

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1354,9 +1354,13 @@ export interface SessionsTimelineQuery extends DataNode<SessionsTimelineQueryRes
 }
 export type WebAnalyticsPropertyFilter = EventPropertyFilter | PersonPropertyFilter | SessionPropertyFilter
 export type WebAnalyticsPropertyFilters = WebAnalyticsPropertyFilter[]
-export type WebAnalyticsConversionGoal = {
+export type ActionConversionGoal = {
     actionId: integer
 }
+export type CustomEventConversionGoal = {
+    customEventName: string
+}
+export type WebAnalyticsConversionGoal = ActionConversionGoal | CustomEventConversionGoal
 interface WebAnalyticsQueryBase<R extends Record<string, any>> extends DataNode<R> {
     dateRange?: DateRange
     properties: WebAnalyticsPropertyFilters

--- a/frontend/src/scenes/web-analytics/WebConversionGoal.tsx
+++ b/frontend/src/scenes/web-analytics/WebConversionGoal.tsx
@@ -1,6 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
+import { useState } from 'react'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 
 import { actionsModel } from '~/models/actionsModel'
@@ -9,26 +10,43 @@ export const WebConversionGoal = (): JSX.Element | null => {
     const { conversionGoal } = useValues(webAnalyticsLogic)
     const { setConversionGoal } = useActions(webAnalyticsLogic)
     const { actions } = useValues(actionsModel)
-
+    const [group, setGroup] = useState(TaxonomicFilterGroupType.CustomEvents)
+    const value =
+        conversionGoal && 'actionId' in conversionGoal ? conversionGoal.actionId : conversionGoal?.customEventName
     return (
-        <TaxonomicPopover<number>
+        <TaxonomicPopover<number | string>
+            groupType={group}
             data-attr="web-analytics-conversion-filter"
-            groupType={TaxonomicFilterGroupType.Actions}
-            value={conversionGoal?.actionId}
-            onChange={(changedValue: number | '') => {
-                if (typeof changedValue === 'number') {
+            value={value}
+            onChange={(changedValue, groupType) => {
+                if (groupType === TaxonomicFilterGroupType.Actions && typeof changedValue === 'number') {
                     setConversionGoal({ actionId: changedValue })
+                    setGroup(TaxonomicFilterGroupType.Actions)
+                } else if (
+                    groupType === TaxonomicFilterGroupType.CustomEvents &&
+                    typeof changedValue === 'string' &&
+                    changedValue
+                ) {
+                    setConversionGoal({ customEventName: changedValue })
+                    setGroup(TaxonomicFilterGroupType.CustomEvents)
                 } else {
                     setConversionGoal(null)
                 }
             }}
-            renderValue={(value) => {
-                const conversionGoalAction = actions.find((a) => a.id === value)
-                return (
-                    <span className="text-overflow max-w-full">{conversionGoalAction?.name ?? 'Conversion goal'}</span>
-                )
+            renderValue={() => {
+                if (!conversionGoal) {
+                    return null
+                } else if ('actionId' in conversionGoal) {
+                    const conversionGoalAction = actions.find((a) => a.id === conversionGoal.actionId)
+                    return (
+                        <span className="text-overflow max-w-full">
+                            {conversionGoalAction?.name ?? 'Conversion goal'}
+                        </span>
+                    )
+                }
+                return <span className="text-overflow max-w-full">{conversionGoal?.customEventName}</span>
             }}
-            groupTypes={[TaxonomicFilterGroupType.Actions]}
+            groupTypes={[TaxonomicFilterGroupType.CustomEvents, TaxonomicFilterGroupType.Actions]}
             placeholder="Add conversion goal"
             placeholderClass=""
             allowClear={true}

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -537,15 +537,23 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     math: BaseMathType.UniqueSessions,
                     custom_name: 'Sessions',
                 }
-                const uniqueConversionsSeries: ActionsNode | undefined = conversionGoal?.actionId
+                const uniqueConversionsSeries: ActionsNode | EventsNode | undefined = !conversionGoal
+                    ? undefined
+                    : 'actionId' in conversionGoal
                     ? {
                           kind: NodeKind.ActionsNode,
-                          id: conversionGoal?.actionId ?? 0,
+                          id: conversionGoal.actionId,
                           math: BaseMathType.UniqueUsers,
                           name: 'Unique conversions',
                           custom_name: 'Unique conversions',
                       }
-                    : undefined
+                    : {
+                          kind: NodeKind.EventsNode,
+                          event: conversionGoal.customEventName,
+                          math: BaseMathType.UniqueUsers,
+                          name: 'Unique conversions',
+                          custom_name: 'Unique conversions',
+                      }
                 const totalConversionSeries = uniqueConversionsSeries
                     ? {
                           ...uniqueConversionsSeries,
@@ -698,7 +706,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                           [totalConversionSeries, uniqueConversionsSeries],
                                           {
                                               formula: 'A / B',
-                                              aggregationAxisFormat: 'percentage_scaled',
+                                              aggregationAxisFormat: 'percentage',
                                           }
                                       )
                                     : null,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -20,6 +20,13 @@ class MathGroupTypeIndex(float, Enum):
     NUMBER_4 = 4
 
 
+class ActionConversionGoal(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    actionId: int
+
+
 class AggregationAxisFormat(StrEnum):
     NUMERIC = "numeric"
     DURATION = "duration"
@@ -274,6 +281,13 @@ class CountPerActorMathType(StrEnum):
     P90_COUNT_PER_ACTOR = "p90_count_per_actor"
     P95_COUNT_PER_ACTOR = "p95_count_per_actor"
     P99_COUNT_PER_ACTOR = "p99_count_per_actor"
+
+
+class CustomEventConversionGoal(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    customEventName: str
 
 
 class DataWarehouseEventsModifier(BaseModel):
@@ -1444,13 +1458,6 @@ class VizSpecificOptions(BaseModel):
     )
     ActionsPie: Optional[ActionsPie] = None
     RETENTION: Optional[RETENTION] = None
-
-
-class WebAnalyticsConversionGoal(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    actionId: int
 
 
 class Sampling(BaseModel):
@@ -3745,7 +3752,7 @@ class WebExternalClicksTableQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    conversionGoal: Optional[WebAnalyticsConversionGoal] = None
+    conversionGoal: Optional[Union[ActionConversionGoal, CustomEventConversionGoal]] = None
     dateRange: Optional[DateRange] = None
     filterTestAccounts: Optional[bool] = None
     kind: Literal["WebExternalClicksTableQuery"] = "WebExternalClicksTableQuery"
@@ -3764,7 +3771,7 @@ class WebGoalsQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    conversionGoal: Optional[WebAnalyticsConversionGoal] = None
+    conversionGoal: Optional[Union[ActionConversionGoal, CustomEventConversionGoal]] = None
     dateRange: Optional[DateRange] = None
     filterTestAccounts: Optional[bool] = None
     kind: Literal["WebGoalsQuery"] = "WebGoalsQuery"
@@ -3783,7 +3790,7 @@ class WebOverviewQuery(BaseModel):
         extra="forbid",
     )
     compare: Optional[bool] = None
-    conversionGoal: Optional[WebAnalyticsConversionGoal] = None
+    conversionGoal: Optional[Union[ActionConversionGoal, CustomEventConversionGoal]] = None
     dateRange: Optional[DateRange] = None
     filterTestAccounts: Optional[bool] = None
     kind: Literal["WebOverviewQuery"] = "WebOverviewQuery"
@@ -3801,7 +3808,7 @@ class WebStatsTableQuery(BaseModel):
         extra="forbid",
     )
     breakdownBy: WebStatsBreakdown
-    conversionGoal: Optional[WebAnalyticsConversionGoal] = None
+    conversionGoal: Optional[Union[ActionConversionGoal, CustomEventConversionGoal]] = None
     dateRange: Optional[DateRange] = None
     doPathCleaning: Optional[bool] = None
     filterTestAccounts: Optional[bool] = None
@@ -3822,7 +3829,7 @@ class WebTopClicksQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    conversionGoal: Optional[WebAnalyticsConversionGoal] = None
+    conversionGoal: Optional[Union[ActionConversionGoal, CustomEventConversionGoal]] = None
     dateRange: Optional[DateRange] = None
     filterTestAccounts: Optional[bool] = None
     kind: Literal["WebTopClicksQuery"] = "WebTopClicksQuery"


### PR DESCRIPTION
## Problem

I'd only implemented conversion goals with Actions, but custom events would work well here

## Changes

Support choosing custom events as conversion goals

<img width="934" alt="Screenshot 2024-09-16 at 19 09 08" src="https://github.com/user-attachments/assets/004b5c72-da35-4f07-80e7-4082eac031a2">

<img width="827" alt="Screenshot 2024-09-16 at 19 09 29" src="https://github.com/user-attachments/assets/65f3f30e-7c7c-4e5c-bb97-c2e0d9184ec4">

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added a new test
