### PR TITLE
fix: deduplicate navigation requests even more

### DIFF
--- a/frontend/src/scenes/session-recordings/apm/performanceEventDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/apm/performanceEventDataLogic.ts
@@ -181,7 +181,11 @@ function deduplicatePerformanceEvents(events: PerformanceEvent[]): PerformanceEv
     return events
         .reverse()
         .filter((event) => {
-            const key = `${event.entry_type}-${event.name}-${event.timestamp}-${event.window_id}`
+            // the timestamp isn't always exactly the same e.g. they could be one or two milliseconds apart
+            // just because of processing time. So we'll use a range of 10ms
+            const reducedGranularityTimestamp =
+                typeof event.timestamp === 'number' ? Math.floor(event.timestamp / 10) * 10 : event.timestamp
+            const key = `${event.entry_type}-${event.name}-${reducedGranularityTimestamp}-${event.window_id}`
             // we only want to drop is_initial events
             if (seen.has(key) && event.is_initial) {
                 return false

--- a/frontend/src/scenes/session-recordings/apm/performanceEventDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/apm/performanceEventDataLogic.ts
@@ -182,7 +182,8 @@ function deduplicatePerformanceEvents(events: PerformanceEvent[]): PerformanceEv
         .reverse()
         .filter((event) => {
             // the timestamp isn't always exactly the same e.g. they could be one or two milliseconds apart
-            // just because of processing time. So we'll use a range of 10ms
+            // just because of processing time.
+            // So we'll round down to the nearest 10ms
             const reducedGranularityTimestamp =
                 typeof event.timestamp === 'number' ? Math.floor(event.timestamp / 10) * 10 : event.timestamp
             const key = `${event.entry_type}-${event.name}-${reducedGranularityTimestamp}-${event.window_id}`


### PR DESCRIPTION
we sometimes manage to capture a navigation event in the `isInitial` prewrapped check and as a wrapped navigation
we deduplicate those that are exactly the same
but sometimes they are 1 or 2 milliseconds apart while still being duplicate
this deduplicates within 10 milliseconds

|before|after|
|-|-|
|<img width="705" alt="Screenshot 2024-09-16 at 22 19 34" src="https://github.com/user-attachments/assets/3b8866fc-e9ec-4e57-b373-c27b6c27d8ce">|<img width="695" alt="Screenshot 2024-09-16 at 22 19 58" src="https://github.com/user-attachments/assets/e3311833-3ea9-4cfa-b0db-eb7799ce7c72">|
