### PR TITLE
fix: Improve property group optimized comparisons to boolean values

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -656,6 +656,14 @@ class _Printer(Visitor):
                     # the ``values`` subcolumn of the map.
                     return f"not({property_source.has_expr})"
 
+                # Equality comparisons to boolean constants can skip NULL checks while maintaining our desired result
+                # (i.e. comparisons with NULL evaluate to false) since the value expression will return an empty string
+                # if the property doesn't exist in the map.
+                if constant_expr.value is True:
+                    return f"equals({property_source.value_expr}, 'true')"
+                elif constant_expr.value is False:
+                    return f"equals({property_source.value_expr}, 'false')"
+
                 printed_expr = f"equals({property_source.value_expr}, {self.visit(constant_expr)})"
                 if constant_expr.value == "":
                     # If we're comparing to an empty string literal, we need to disambiguate this from the default value

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -468,6 +468,10 @@ class TestPrinter(BaseTest):
         self._test_property_group_comparison("properties.key = lower(NULL)", None)
 
     def test_property_groups_optimized_boolean_equality_comparisons(self) -> None:
+        PropertyDefinition.objects.create(
+            team=self.team, name="is_boolean", property_type="Boolean", type=PropertyDefinition.Type.EVENT
+        )
+
         self._test_property_group_comparison(
             "properties.is_boolean = true",
             "equals(events.properties_group_custom[%(hogql_val_0)s], 'true')",
@@ -484,8 +488,8 @@ class TestPrinter(BaseTest):
 
         # Don't try to optimize not equals comparisons: NULL handling here is tricky, and we wouldn't get any benefit
         # from using the indexes anyway.
-        self._test_property_group_comparison("properties.is_boolean != true", None, expected_skip_indexes_used={})
-        self._test_property_group_comparison("properties.is_boolean != false", None, expected_skip_indexes_used={})
+        self._test_property_group_comparison("properties.is_boolean != true", None, expected_skip_indexes_used=set())
+        self._test_property_group_comparison("properties.is_boolean != false", None, expected_skip_indexes_used=set())
 
     def test_property_groups_optimized_empty_string_equality_comparisons(self) -> None:
         # Keys that don't exist in a map return default values for the type -- in our case empty strings -- so we need

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -403,7 +403,7 @@ class TestPrinter(BaseTest):
         if expected_context_values is not None:
             self.assertDictContainsSubset(expected_context_values, context.values)
 
-        if expected_skip_indexes_used:
+        if expected_skip_indexes_used is not None:
             # The table needs some data to be able get a `EXPLAIN` result that includes index information -- otherwise
             # the query is optimized to read from `NullSource` which doesn't do us much good here...
             for _ in range(10):


### PR DESCRIPTION
## Problem

Property group comparisons to boolean constants were not being special cased during expression optimization (see #24381 for background.) This caused those expressions to be rewritten to `equals(group[key], 0)` or `equals(group[key], 1)`, and caused to errors due to the type mismatch between argument types.

Example: https://metabase.prod-us.posthog.dev/question/904-query-history?lookback_window=24%20hours&team_id=&normalized_query_hash=&insight_id=1555939&workload=

## Changes

This fixes the expression rewriting so that the types are consistent on both sides of the expression.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Added test.