### PR TITLE
fix(surveys): fix multiple select bar chart

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -717,7 +717,7 @@ export function LineGraph_({
                             return tick
                         })
 
-                        const ROW_HEIGHT = 20
+                        const ROW_HEIGHT = inSurveyView ? 30 : 20
                         const height = scale.ticks.length * ROW_HEIGHT
                         const parentNode: any = scale.chart?.canvas?.parentNode
                         parentNode.style.height = `${height}px`

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -495,7 +495,7 @@ export function MultipleChoiceQuestionBarChart({
                     <div className="text-xl font-bold mb-2">{question.question}</div>
 
                     <div
-                        className="border rounded pt-6 pr-10"
+                        className="border rounded pt-8 pr-10"
                         // eslint-disable-next-line react/forbid-dom-props
                         style={{ height: Math.min(chartHeight, 600) }}
                     >

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -495,7 +495,7 @@ export function MultipleChoiceQuestionBarChart({
                     <div className="text-xl font-bold mb-2">{question.question}</div>
 
                     <div
-                        className="border rounded pt-8 pr-10"
+                        className="border rounded pt-8 pr-10 overflow-y-scroll"
                         // eslint-disable-next-line react/forbid-dom-props
                         style={{ height: Math.min(chartHeight, 600) }}
                     >


### PR DESCRIPTION
## Problem
Closes https://github.com/PostHog/posthog/issues/22236

Fixes https://posthog.slack.com/archives/C034XD440RK/p1726479349328929 

## Changes
|Before|After|
|----|----|
|<img width="1201" alt="image" src="https://github.com/user-attachments/assets/e0b97058-ab5a-4f4a-a0c2-c9a3237fddce">|<img width="1200" alt="image" src="https://github.com/user-attachments/assets/841ae973-edd3-44c0-924b-fbda32b0a7a5">|	

This misalignment was probably introduced by https://github.com/PostHog/posthog/pull/21707

A quick n' dirty fix for now, in the future we probably want separate charts for Survey visualizations to avoid these issues.

## How did you test this code?
👀 