### PR TITLE
perf(dashboards): Increase dashboards list API page size

### DIFF
--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -92,7 +92,7 @@ export const dashboardsModel = kea<dashboardsModelType>([
                         return { count: 0, next: null, previous: null, results: [] }
                     }
                     const dashboards: PaginatedResponse<DashboardType> = await api.get(
-                        url || `api/projects/${teamLogic.values.currentTeamId}/dashboards/?limit=100`
+                        url || `api/projects/${teamLogic.values.currentTeamId}/dashboards/?limit=2000`
                     )
 
                     return {


### PR DESCRIPTION
## Problem

Following #25024, listing dashboards scales better, but there are some major unaccounted for startup costs. `limit=1` takes ~700ms, but `limit=1000` (with 1000 items actually returned) takes just ~2.5s.

## Changes

Currently with 1000 projects in production we load 10 pages, taking around 10 seconds with all the overhead. We need some better tracing to actually dig into the overhead we're seeing, but for now: big pages for ~2.5s of time to interactive.

`/dashboards/` page size:

![stonks](https://i.insider.com/601448566dfbe10018e00c5d)
