### PR TITLE
fix(dashboards): catch ValueError in BreakdownMixin

### DIFF
--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -219,7 +219,7 @@
                       "pdi"
                   ],
                   "hogql_value": "person",
-                  "id": null,
+                  "id": "person",
                   "name": "person",
                   "schema_valid": true,
                   "table": "persons",
@@ -472,7 +472,7 @@
                       "person"
                   ],
                   "hogql_value": "override",
-                  "id": null,
+                  "id": "override",
                   "name": "override",
                   "schema_valid": true,
                   "table": "person_distinct_id_overrides",

--- a/posthog/models/filters/mixins/common.py
+++ b/posthog/models/filters/mixins/common.py
@@ -3,8 +3,8 @@ import json
 import re
 from math import ceil
 from typing import Any, Literal, Optional, Union, cast
-
 from zoneinfo import ZoneInfo
+
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
@@ -15,6 +15,7 @@ from posthog.constants import (
     BREAKDOWN_ATTRIBUTION_TYPE,
     BREAKDOWN_ATTRIBUTION_VALUE,
     BREAKDOWN_GROUP_TYPE_INDEX,
+    BREAKDOWN_HIDE_OTHER_AGGREGATION,
     BREAKDOWN_HISTOGRAM_BIN_COUNT,
     BREAKDOWN_LIMIT,
     BREAKDOWN_NORMALIZE_URL,
@@ -23,6 +24,7 @@ from posthog.constants import (
     BREAKDOWNS,
     CLIENT_QUERY_ID,
     COMPARE,
+    COMPARE_TO,
     DATA_WAREHOUSE_ENTITIES,
     DATE_FROM,
     DATE_TO,
@@ -47,8 +49,6 @@ from posthog.constants import (
     TREND_FILTER_TYPE_EVENTS,
     TRENDS_WORLD_MAP,
     BreakdownAttributionType,
-    BREAKDOWN_HIDE_OTHER_AGGREGATION,
-    COMPARE_TO,
 )
 from posthog.hogql.constants import BREAKDOWN_VALUES_LIMIT, BREAKDOWN_VALUES_LIMIT_FOR_COUNTRIES
 from posthog.models.entity import Entity, ExclusionEntity, MathType
@@ -191,7 +191,7 @@ class BreakdownMixin(BaseParamMixin):
         if BREAKDOWN_LIMIT in self._data:
             try:
                 return int(self._data[BREAKDOWN_LIMIT])
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
         return None
 
@@ -212,7 +212,7 @@ class BreakdownMixin(BaseParamMixin):
         if BREAKDOWN_HISTOGRAM_BIN_COUNT in self._data:
             try:
                 return int(self._data[BREAKDOWN_HISTOGRAM_BIN_COUNT])
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
         return None
 
@@ -221,7 +221,7 @@ class BreakdownMixin(BaseParamMixin):
         if BREAKDOWN_HIDE_OTHER_AGGREGATION in self._data:
             try:
                 return self._data[BREAKDOWN_HIDE_OTHER_AGGREGATION] in ("True", "true", True)
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
         return None
 


### PR DESCRIPTION
## Problem

Presumably, after migrating filters to query and reverting the migration, we saved nulls in properties where they weren't expected. When someone tries to duplicate a dashboard with an insight with the `breakdown_histogram_bin_count` property set to `None`, the API fails to do that.

[Support Ticket](https://posthoghelp.zendesk.com/agent/tickets/18249)
[Sentry Issue](https://posthog.sentry.io/issues/5748051466/events/de65db9f14cb466b9a57f4189e9a4940/)

## Changes

- Added `ValueError` handling in the BreakdownMixin class.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Unit tests plus a new test to catch it.