### PR TITLE
chore(batch-exports): add non retryable error to bigquery workflow

### DIFF
--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -219,7 +219,7 @@
                       "pdi"
                   ],
                   "hogql_value": "person",
-                  "id": null,
+                  "id": "person",
                   "name": "person",
                   "schema_valid": true,
                   "table": "persons",
@@ -472,7 +472,7 @@
                       "person"
                   ],
                   "hogql_value": "override",
-                  "id": null,
+                  "id": "override",
                   "name": "override",
                   "schema_valid": true,
                   "table": "person_distinct_id_overrides",

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -605,6 +605,8 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
                 # Raised when table_id isn't valid. Sadly, `ValueError` is rather generic, but we
                 # don't anticipate a `ValueError` thrown from our own export code.
                 "ValueError",
+                # Faulty data format from clickhouse to bigquery
+                "JSONDecodeError",
             ],
             finish_inputs=finish_inputs,
         )


### PR DESCRIPTION
## Problem

- jsondecodeerror is nonretryable
- https://cloud.temporal.io/namespaces/posthog-prod-us.usz2o/workflows/0191de17-f2d2-0001-42a8-8c7903de9787-2023-10-18T21%3A00%3A00Z/a508264f-f3d3-427f-b687-9d6b868abe69/pending-activities

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- add to list

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
