### PR TITLE
fix: Downgrade unit docker base

### DIFF
--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -141,7 +141,8 @@ RUN apt-get update && \
 #
 # ---------------------------------------------------------
 #
-FROM unit:python3.11
+# NOTE: newer images change the base image from bullseye to bookworm which makes compiled openssl versions have all sorts of issues
+FROM unit:1.32.0-python3.11 
 WORKDIR /code
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
## Problem

The updated docker image base has caused issues with openssl libs. This hardcodes the older version

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Tested in a different PR that ran E2E tests. This is just a pure version that only has what we need.