### PR TITLE
chore(data-warehouse): Hide the `_dlt` fields from all tables

### DIFF
--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -549,10 +549,8 @@ async def test_postgres_binary_columns(team, postgres_config, postgres_connectio
     columns = res.columns
 
     assert columns is not None
-    assert len(columns) == 3
+    assert len(columns) == 1
     assert columns[0] == "id"
-    assert columns[1] == "_dlt_id"
-    assert columns[2] == "_dlt_load_id"
 
 
 @pytest.mark.django_db(transaction=True)
@@ -662,10 +660,8 @@ async def test_postgres_schema_evolution(team, postgres_config, postgres_connect
     columns = res.columns
 
     assert columns is not None
-    assert len(columns) == 3
+    assert len(columns) == 1
     assert any(x == "id" for x in columns)
-    assert any(x == "_dlt_id" for x in columns)
-    assert any(x == "_dlt_load_id" for x in columns)
 
     # Evole schema
     await postgres_connection.execute(
@@ -683,11 +679,9 @@ async def test_postgres_schema_evolution(team, postgres_config, postgres_connect
     columns = res.columns
 
     assert columns is not None
-    assert len(columns) == 4
+    assert len(columns) == 2
     assert any(x == "id" for x in columns)
     assert any(x == "new_col" for x in columns)
-    assert any(x == "_dlt_id" for x in columns)
-    assert any(x == "_dlt_load_id" for x in columns)
 
 
 @pytest.mark.django_db(transaction=True)
@@ -727,10 +721,8 @@ async def test_sql_database_missing_incremental_values(team, postgres_config, po
     columns = res.columns
 
     assert columns is not None
-    assert len(columns) == 3
+    assert len(columns) == 1
     assert any(x == "id" for x in columns)
-    assert any(x == "_dlt_id" for x in columns)
-    assert any(x == "_dlt_load_id" for x in columns)
 
     # Exclude rows that don't have the incremental cursor key set
     assert len(res.results) == 1
@@ -771,10 +763,8 @@ async def test_sql_database_incremental_initual_value(team, postgres_config, pos
     columns = res.columns
 
     assert columns is not None
-    assert len(columns) == 3
+    assert len(columns) == 1
     assert any(x == "id" for x in columns)
-    assert any(x == "_dlt_id" for x in columns)
-    assert any(x == "_dlt_load_id" for x in columns)
 
     # Include rows that have the same incremental value as the `initial_value`
     assert len(res.results) == 1

--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -237,9 +237,15 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
 
         # Replace fields with any redefined fields if they exist
         external_table_fields = external_tables.get(self.table_name_without_prefix())
+        default_fields = external_tables.get("*", {})
         if external_table_fields is not None:
-            default_fields = external_tables.get("*", {})
             fields = {**external_table_fields, **default_fields}
+        else:
+            # Hide the `_dlt` fields from tables
+            if fields.get("_dlt_id") and fields.get("_dlt_load_id"):
+                del fields["_dlt_id"]
+                del fields["_dlt_load_id"]
+                fields = {**fields, **default_fields}
 
         return S3Table(
             name=self.name,


### PR DESCRIPTION
## Problem
- DLT add two extra fields to all tables: `_dlt_id` and `_dlt_load_id`
- Users have no idea what these are and just confuses them

## Changes
- Hide these fields for all tables (this already happens on tables we've got definitions for)
- I like to hide them instead of removing them as they can be handy when debugging customer issues - the load_id tells us which rows were ingested when
  - (hiding here means they're not in SQL autocomplete, not returned from a `SELECT *` query, and not present in any table schemas across data warehouse

## Does this work well for both Cloud and self-hosted?
Yup

## How did you test this code?
Updated tests