### PR TITLE
fix: properties table early render

### DIFF
--- a/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
+++ b/frontend/src/lib/components/PropertiesTable/PropertiesTable.tsx
@@ -175,7 +175,7 @@ function ValueDisplay({
     )
 }
 interface PropertiesTableType extends BasePropertyType {
-    properties?: Record<string, any>
+    properties?: Record<string, any> | Array<Record<string, any>>
     sortProperties?: boolean
     searchable?: boolean
     filterable?: boolean
@@ -210,32 +210,8 @@ export function PropertiesTable({
     const { hidePostHogPropertiesInTable } = useValues(userPreferencesLogic)
     const { setHidePostHogPropertiesInTable } = useActions(userPreferencesLogic)
 
-    if (Array.isArray(properties)) {
-        return (
-            <div>
-                {properties.length ? (
-                    properties.map((item, index) => (
-                        <PropertiesTable
-                            key={index}
-                            type={type}
-                            properties={item}
-                            nestingLevel={nestingLevel + 1}
-                            useDetectedPropertyType={
-                                ['$set', '$set_once'].some((s) => s === rootKey) ? false : useDetectedPropertyType
-                            }
-                        />
-                    ))
-                ) : (
-                    <LemonTag type="muted" className="font-mono uppercase">
-                        Array (empty)
-                    </LemonTag>
-                )}
-            </div>
-        )
-    }
-
     const objectProperties = useMemo(() => {
-        if (!properties || !(properties instanceof Object)) {
+        if (!properties || Array.isArray(properties)) {
             return []
         }
         let entries = Object.entries(properties)
@@ -281,6 +257,30 @@ export function PropertiesTable({
         }
         return entries
     }, [properties, sortProperties, searchTerm, hidePostHogPropertiesInTable])
+
+    if (Array.isArray(properties)) {
+        return (
+            <div>
+                {properties.length ? (
+                    properties.map((item, index) => (
+                        <PropertiesTable
+                            key={index}
+                            type={type}
+                            properties={item}
+                            nestingLevel={nestingLevel + 1}
+                            useDetectedPropertyType={
+                                ['$set', '$set_once'].some((s) => s === rootKey) ? false : useDetectedPropertyType
+                            }
+                        />
+                    ))
+                ) : (
+                    <LemonTag type="muted" className="font-mono uppercase">
+                        Array (empty)
+                    </LemonTag>
+                )}
+            </div>
+        )
+    }
 
     if (properties instanceof Object) {
         const columns: LemonTableColumns<Record<string, any>> = [
@@ -446,6 +446,7 @@ export function PropertiesTable({
             </>
         )
     }
+
     // if none of above, it's a value
     return (
         <ValueDisplay

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarPersonTab.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarPersonTab.tsx
@@ -1,6 +1,7 @@
 import { PersonDisplay } from '@posthog/apps-common'
 import { useValues } from 'kea'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 
 import { PropertyDefinitionType } from '~/types'
 
@@ -9,19 +10,25 @@ import { sessionRecordingPlayerLogic } from '../sessionRecordingPlayerLogic'
 
 export function PlayerSidebarPersonTab(): JSX.Element {
     const { logicProps } = useValues(sessionRecordingPlayerLogic)
-    const { sessionPerson } = useValues(playerMetaLogic(logicProps))
+    const { sessionPerson, sessionPlayerMetaDataLoading } = useValues(playerMetaLogic(logicProps))
 
     return (
         <div className="flex flex-col overflow-auto bg-bg-3000">
             <div className="font-bold bg-bg-light px-2 border-b py-3">
                 <PersonDisplay person={sessionPerson} withIcon noPopover />
             </div>
-            <PropertiesTable
-                properties={sessionPerson?.properties || []}
-                type={PropertyDefinitionType.Person}
-                sortProperties
-                embedded
-            />
+            {sessionPlayerMetaDataLoading ? (
+                <div className="space-y-2">
+                    <LemonSkeleton.Row repeat={60} fade={true} className="h-3 w-full" />
+                </div>
+            ) : (
+                <PropertiesTable
+                    properties={sessionPerson?.properties || []}
+                    type={PropertyDefinitionType.Person}
+                    sortProperties
+                    embedded
+                />
+            )}
         </div>
     )
 }


### PR DESCRIPTION
users are reporting an error using the person tab
if you provide an array as input we return early skipping a hook 
and react say no bueno

well, not any more
(and adds a loading state)

see: https://posthoghelp.zendesk.com/agent/tickets/18351 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/20433)

|Before|After|
|-|-|
|![2024-09-18 23 15 53](https://github.com/user-attachments/assets/70f4196f-5136-440d-a942-9cd547eca19c)|![2024-09-18 23 12 48](https://github.com/user-attachments/assets/00b7e852-d474-49da-9980-813f763c57f5)|

