### PR TITLE
fix: Re ordering transformations

### DIFF
--- a/posthog/api/plugin.py
+++ b/posthog/api/plugin.py
@@ -781,9 +781,9 @@ class PluginConfigViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         orders = request.data.get("orders", {})
 
         plugin_configs = PluginConfig.objects.filter(team_id=self.team.pk, enabled=True)
-        plugin_configs_dict = {p.plugin_id: p for p in plugin_configs}
-        for plugin_id, order in orders.items():
-            plugin_config = plugin_configs_dict.get(int(plugin_id), None)
+        plugin_configs_dict = {p.id: p for p in plugin_configs}
+        for plugin_config_id, order in orders.items():
+            plugin_config = plugin_configs_dict.get(int(plugin_config_id), None)
             if plugin_config and plugin_config.order != order:
                 old_order = plugin_config.order
                 plugin_config.order = order


### PR DESCRIPTION
## Problem

Looks like a regression or just something forgotten as we moved to multiple plugins of the same type. The ordering is keyed on plugin id and not config id

## Changes

* Fixes it

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Manually 