### PR TITLE
fix: Fix tagging team_id on queries

### DIFF
--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -203,10 +203,9 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):  # TODO: Rename to include "Env" 
 
     @cached_property
     def team_id(self) -> int:
-        team_from_token = self._get_team_from_request()
         if self._is_project_view:
             team_id = self.project_id  # KLUDGE: This is just for the period of transition to project environments
-        elif team_from_token:
+        elif team_from_token := self._get_team_from_request():
             team_id = team_from_token.id
         elif self.param_derived_from_user_current_team == "team_id":
             user = cast(User, self.request.user)
@@ -220,8 +219,7 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):  # TODO: Rename to include "Env" 
 
     @cached_property
     def team(self) -> Team:
-        team_from_token = self._get_team_from_request()
-        if team_from_token:
+        if team_from_token := self._get_team_from_request():
             return team_from_token
 
         if self._is_project_view:
@@ -243,8 +241,7 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):  # TODO: Rename to include "Env" 
 
     @cached_property
     def project_id(self) -> int:
-        team_from_token = self._get_team_from_request()
-        if team_from_token:
+        if team_from_token := self._get_team_from_request():
             assert team_from_token.project_id is not None
             return team_from_token.project_id
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -307,9 +307,6 @@ class CHQueries:
             http_user_agent=request.META.get("HTTP_USER_AGENT"),
         )
 
-        if hasattr(user, "current_team_id") and user.current_team_id:
-            tag_queries(team_id=user.current_team_id)
-
         try:
             response: HttpResponse = self.get_response(request)
 


### PR DESCRIPTION
## Problem

We used the current_team column to set the team_id in the log_comment. Probably fine for people doing queries in the interface, but caused issues with people using the API
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Tag queries with the correct team_id

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
