### PR TITLE
fix(cdp): action filtering fixes

### DIFF
--- a/plugin-server/src/cdp/types.ts
+++ b/plugin-server/src/cdp/types.ts
@@ -96,9 +96,19 @@ export type HogFunctionFilterGlobals = {
     elements_chain_ids: string[]
     elements_chain_elements: string[]
     properties: Record<string, any>
+    distinct_id: string
 
     person?: {
+        id: string
         properties: Record<string, any>
+    }
+    pdi?: {
+        distinct_id: string
+        person_id: string
+        person: {
+            id: string
+            properties: Record<string, any>
+        }
     }
 
     group_0?: {

--- a/plugin-server/src/cdp/utils.ts
+++ b/plugin-server/src/cdp/utils.ts
@@ -151,7 +151,15 @@ export function convertToHogFunctionFilterGlobal(globals: HogFunctionInvocationG
         elements_chain_elements: [] as string[],
         timestamp: globals.event.timestamp,
         properties: globals.event.properties,
-        person: globals.person ? { properties: globals.person.properties } : undefined,
+        person: globals.person ? { id: globals.person.uuid, properties: globals.person.properties } : undefined,
+        pdi: globals.person
+            ? {
+                  distinct_id: globals.event.distinct_id,
+                  person_id: globals.person.uuid,
+                  person: { id: globals.person.uuid, properties: globals.person.properties },
+              }
+            : undefined,
+        distinct_id: globals.event.distinct_id,
         ...groups,
     } satisfies HogFunctionFilterGlobals
 


### PR DESCRIPTION
## Problem

By far the biggest number of errors during filtering come from accessing fields that are not there. Namely `distinct_id` and `pdi.*`

> - Global variable not found: pdi.person.properties.email
> - Global variable not found: distinct_id

## Changes

Adds them to the filter.

## How did you test this code?

👀 