### PR TITLE
fix(batch-exports): Escape unicode characters

### DIFF
--- a/posthog/temporal/batch_exports/utils.py
+++ b/posthog/temporal/batch_exports/utils.py
@@ -2,6 +2,7 @@ import asyncio
 import collections.abc
 import contextlib
 import functools
+import json
 import typing
 import uuid
 
@@ -154,7 +155,12 @@ class JsonScalar(pa.ExtensionScalar):
             try:
                 return orjson.loads(value.encode("utf-8", "replace"))
             except orjson.JSONDecodeError:
-                logger.exception("Failed to decode: %s", value)
+                logger.exception("Failed to decode with orjson: %s", value)
+
+            try:
+                return json.loads(value.encode("utf-8", "replace"))
+            except json.JSONDecodeError:
+                logger.exception("Failed to decode with stdlib: %s", value)
                 raise
 
         else:

--- a/posthog/temporal/batch_exports/utils.py
+++ b/posthog/temporal/batch_exports/utils.py
@@ -2,7 +2,6 @@ import asyncio
 import collections.abc
 import contextlib
 import functools
-import json
 import typing
 import uuid
 
@@ -127,7 +126,7 @@ class JsonScalar(pa.ExtensionScalar):
 
         We attempt to decode the value returned by `as_py` as JSON 3 times:
         1. As returned by `as_py`, without changes.
-        2. By replacing any encoding errors.
+        2. By escaping and replacing any encoding errors.
         3. By treating the value as a string and surrouding it with quotes.
 
         If all else fails, we will log the offending value and re-raise the decoding error.
@@ -138,29 +137,28 @@ class JsonScalar(pa.ExtensionScalar):
             if not value:
                 return None
 
+            json_bytes = value.encode("utf-8")
+
             try:
-                return orjson.loads(value.encode("utf-8"))
+                return orjson.loads(json_bytes)
             except orjson.JSONDecodeError:
                 pass
 
+            json_bytes = value.encode("unicode-escape").decode("utf-8", "replace").encode("utf-8")
             try:
-                return orjson.loads(value.encode("utf-8", "replace"))
+                return orjson.loads(json_bytes)
             except orjson.JSONDecodeError:
                 pass
 
-            if isinstance(value, str) and len(value) > 0:
-                # Handles `"$set": "Something"`
+            if isinstance(value, str) and len(value) > 0 and not value.startswith("{") and not value.endswith("}"):
+                # Handles non-valid JSON strings like `'"$set": "Something"'` by quoting them.
                 value = f'"{value}"'
 
+            json_bytes = value.encode("unicode-escape").decode("utf-8", "replace").encode("utf-8")
             try:
-                return orjson.loads(value.encode("utf-8", "replace"))
+                return orjson.loads(json_bytes)
             except orjson.JSONDecodeError:
                 logger.exception("Failed to decode with orjson: %s", value)
-
-            try:
-                return json.loads(value.encode("utf-8", "replace"))
-            except json.JSONDecodeError:
-                logger.exception("Failed to decode with stdlib: %s", value)
                 raise
 
         else:


### PR DESCRIPTION
## Problem

Still seeing very occasional `JSONDecodeError`s being raised. Appears to be some invalid UTF-8 encoding that orjson is too strict to handle.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
* Escape any unicode characters and replace errors as a fallback.

Also, still logging when this happens to see if we can figure out why the JSON is not valid UTF-8 in the first place.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
