### PR TITLE
feat: Track errored filtering for functions better

### DIFF
--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -477,7 +477,8 @@ export class CdpProcessedEventsConsumer extends CdpConsumerBase {
                 await this.groupsManager.enrichGroups(invocationGlobals)
 
                 await this.runManyWithHeartbeat(invocationGlobals, (globals) => {
-                    const { matchingFunctions, nonMatchingFunctions } = this.hogExecutor.findMatchingFunctions(globals)
+                    const { matchingFunctions, nonMatchingFunctions, erroredFunctions } =
+                        this.hogExecutor.findMatchingFunctions(globals)
 
                     possibleInvocations.push(
                         ...matchingFunctions.map((hogFunction) => createInvocation(globals, hogFunction))
@@ -489,6 +490,16 @@ export class CdpProcessedEventsConsumer extends CdpConsumerBase {
                             app_source_id: item.id,
                             metric_kind: 'other',
                             metric_name: 'filtered',
+                            count: 1,
+                        })
+                    )
+
+                    erroredFunctions.forEach((item) =>
+                        this.produceAppMetric({
+                            team_id: item.team_id,
+                            app_source_id: item.id,
+                            metric_kind: 'other',
+                            metric_name: 'filtering_failed',
                             count: 1,
                         })
                     )

--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -112,7 +112,6 @@ export class HogExecutor {
                 const start = performance.now()
                 try {
                     const filterResult = execHog(hogFunction.filters.bytecode, { globals: filtersGlobals })
-                    hogFunctionFilterDuration.observe(performance.now() - start)
                     if (typeof filterResult.result === 'boolean' && filterResult.result) {
                         matchingFunctions.push(hogFunction)
                         return

--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -118,7 +118,6 @@ export class HogExecutor {
                         return
                     }
                 } catch (error) {
-                    // TODO: This should be reported as a log or metric
                     status.error('🦔', `[HogExecutor] Error filtering function`, {
                         hogFunctionId: hogFunction.id,
                         hogFunctionName: hogFunction.name,
@@ -132,7 +131,7 @@ export class HogExecutor {
                     hogFunctionFilterDuration.observe(performance.now() - start)
 
                     if (duration > DEFAULT_TIMEOUT_MS) {
-                        status.warn('🦔', `[HogExecutor] Filter took longer than expected`, {
+                        status.error('🦔', `[HogExecutor] Filter took longer than expected`, {
                             hogFunctionId: hogFunction.id,
                             hogFunctionName: hogFunction.name,
                             teamId: hogFunction.team_id,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -1219,6 +1219,13 @@ export type AppMetric2Type = {
     app_source_id: string
     instance_id?: string
     metric_kind: 'failure' | 'success' | 'other'
-    metric_name: 'succeeded' | 'failed' | 'filtered' | 'disabled_temporarily' | 'disabled_permanently' | 'masked'
+    metric_name:
+        | 'succeeded'
+        | 'failed'
+        | 'filtered'
+        | 'disabled_temporarily'
+        | 'disabled_permanently'
+        | 'masked'
+        | 'filtering_failed'
     count: number
 }


### PR DESCRIPTION
## Problem

Currently we quite quietly error out if filtering fails. would be better to report this to metrics and also indicate the issue in logs for debugging

## Changes

* Pull out filter failures to log app metrics separately
* Time the whole filter even if it fails
* Log a message if it was too long

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
