### PR TITLE
fix: Revert bad change to the encrypted fields

### DIFF
--- a/posthog/helpers/encrypted_fields.py
+++ b/posthog/helpers/encrypted_fields.py
@@ -71,9 +71,9 @@ class EncryptedFieldMixin:
         try:
             value = self.f.decrypt(bytes(value, "utf-8")).decode("utf-8")
         except InvalidToken:
-            return None
+            pass
         except UnicodeEncodeError:
-            return None
+            pass
         return super().to_python(value)  # type: ignore
 
     def clean(self, value, model_instance):


### PR DESCRIPTION
## Problem

I meant to revert Marius' change but missed it... This isn't good as we should always pass off to the `to_python` part as that handles all sorts of things like setting defaults etc.

## Changes

* Reverts it

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
