### PR TITLE
fix(bi): Break word on the y series selects when the column name is too long

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -130,7 +130,7 @@ const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number 
     return (
         <div className="flex gap-1 mb-1">
             <LemonSelect
-                className="grow flex-1"
+                className="grow flex-1 break-all"
                 value={series !== null ? series.column.name : 'None'}
                 options={options}
                 disabledReason={responseLoading ? 'Query loading...' : undefined}


### PR DESCRIPTION
## Changes
- In BI, the column name can be too long and thus cause the series to overflow from the side bar onto the chart - make sure to break the word when the column name is too long
