### PR TITLE
feat(cdp): remove duplicate global fields

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -149,12 +149,10 @@ export function convertToHogFunctionInvocationGlobals(
             properties: event.properties,
             timestamp: event.timestamp,
 
-            name: event.event,
             url: `${projectUrl}/events/${encodeURIComponent(event.uuid ?? '')}/${encodeURIComponent(event.timestamp)}`,
         },
         person: {
-            id: person.uuid ?? person.id ?? '',
-            uuid: person.uuid ?? person.id ?? '', // TODO: remove
+            id: person.id ?? '',
             properties: person.properties,
 
             name: asDisplay(person),
@@ -474,12 +472,10 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                             $current_url: currentUrl,
                             $browser: 'Chrome',
                         },
-                        name: '$pageview',
                         url: `${window.location.origin}/project/${currentTeam?.id}/events/`,
                     },
                     person: {
                         id: personId,
-                        uuid: personId, // TODO: remove
                         properties: {
                             email: 'example@posthog.com',
                         },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4517,13 +4517,11 @@ export type HogFunctionInvocationGlobals = {
         distinct_id: string
         properties: Record<string, any>
         timestamp: string
-        name: string
         url: string
     }
     person?: {
         id: string
         properties: Record<string, any>
-        uuid: string
         name: string
         url: string
     }

--- a/plugin-server/src/cdp/types.ts
+++ b/plugin-server/src/cdp/types.ts
@@ -75,7 +75,6 @@ export type HogFunctionInvocationGlobals = {
         timestamp: string
 
         /* Special fields in Hog */
-        name: string
         url: string
     }
     person?: {
@@ -84,7 +83,6 @@ export type HogFunctionInvocationGlobals = {
         properties: Record<string, any>
 
         /** Special fields in Hog */
-        uuid: string // TODO: remove?
         name: string
         url: string
     }

--- a/plugin-server/src/cdp/utils.ts
+++ b/plugin-server/src/cdp/utils.ts
@@ -61,7 +61,6 @@ export function convertToHogFunctionInvocationGlobals(
         person = {
             id: event.person_id,
             properties: personProperties,
-            uuid: event.person_id,
             name: personDisplayName,
             url: `${projectUrl}/person/${encodeURIComponent(event.distinct_id)}`,
         }
@@ -82,7 +81,6 @@ export function convertToHogFunctionInvocationGlobals(
             distinct_id: event.distinct_id,
             properties,
             timestamp: eventTimestamp,
-            name: event.event!,
             url: `${projectUrl}/events/${encodeURIComponent(event.uuid)}/${encodeURIComponent(eventTimestamp)}`,
         },
         person,
@@ -142,7 +140,7 @@ export function convertToHogFunctionFilterGlobal(globals: HogFunctionInvocationG
 
     const elementsChain = globals.event.elements_chain ?? globals.event.properties['$elements_chain']
     const response = {
-        event: globals.event.name,
+        event: globals.event.event,
         elements_chain: elementsChain,
         elements_chain_href: '',
         elements_chain_texts: [] as string[],
@@ -150,12 +148,12 @@ export function convertToHogFunctionFilterGlobal(globals: HogFunctionInvocationG
         elements_chain_elements: [] as string[],
         timestamp: globals.event.timestamp,
         properties: globals.event.properties,
-        person: globals.person ? { id: globals.person.uuid, properties: globals.person.properties } : undefined,
+        person: globals.person ? { id: globals.person.id, properties: globals.person.properties } : undefined,
         pdi: globals.person
             ? {
                   distinct_id: globals.event.distinct_id,
-                  person_id: globals.person.uuid,
-                  person: { id: globals.person.uuid, properties: globals.person.properties },
+                  person_id: globals.person.id,
+                  person: { id: globals.person.id, properties: globals.person.properties },
               }
             : undefined,
         distinct_id: globals.event.distinct_id,

--- a/plugin-server/tests/cdp/cdp-api.test.ts
+++ b/plugin-server/tests/cdp/cdp-api.test.ts
@@ -105,7 +105,7 @@ describe('CDP API', () => {
         const globals: Partial<HogFunctionInvocationGlobals> = {
             groups: {},
             person: {
-                uuid: '123',
+                id: '123',
                 name: 'Jane Doe',
                 url: 'https://example.com/person/123',
                 properties: {
@@ -114,7 +114,8 @@ describe('CDP API', () => {
             },
             event: {
                 uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',
-                name: '$pageview',
+                event: '$pageview',
+                elements_chain: '',
                 distinct_id: '123',
                 timestamp: '2021-09-28T14:00:00Z',
                 url: 'https://example.com/events/b3a1fe86-b10c-43cc-acaf-d208977608d0/2021-09-28T14:00:00Z',

--- a/plugin-server/tests/cdp/cdp-api.test.ts
+++ b/plugin-server/tests/cdp/cdp-api.test.ts
@@ -174,7 +174,7 @@ describe('CDP API', () => {
                     },
                     {
                         level: 'debug',
-                        message: "Suspending function due to async function call 'fetch'. Payload: 2010 bytes",
+                        message: "Suspending function due to async function call 'fetch'. Payload: 2039 bytes",
                     },
                     {
                         level: 'info',
@@ -222,7 +222,7 @@ describe('CDP API', () => {
                     },
                     {
                         level: 'debug',
-                        message: "Suspending function due to async function call 'fetch'. Payload: 2010 bytes",
+                        message: "Suspending function due to async function call 'fetch'. Payload: 2039 bytes",
                     },
                     {
                         level: 'debug',

--- a/plugin-server/tests/cdp/cdp-e2e.test.ts
+++ b/plugin-server/tests/cdp/cdp-e2e.test.ts
@@ -82,7 +82,7 @@ describe('CDP E2E', () => {
                 } as any,
                 event: {
                     uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',
-                    name: '$pageview',
+                    event: '$pageview',
                     properties: {
                         $current_url: 'https://posthog.com',
                         $lib_version: '1.0.0',

--- a/plugin-server/tests/cdp/cdp-e2e.test.ts
+++ b/plugin-server/tests/cdp/cdp-e2e.test.ts
@@ -131,7 +131,7 @@ describe('CDP E2E', () => {
                 Array [
                   "https://example.com/posthog-webhook",
                   Object {
-                    "body": "{\\"event\\":{\\"uuid\\":\\"b3a1fe86-b10c-43cc-acaf-d208977608d0\\",\\"event\\":\\"$pageview\\",\\"elements_chain\\":\\"\\",\\"distinct_id\\":\\"distinct_id\\",\\"url\\":\\"http://localhost:8000/events/1\\",\\"properties\\":{\\"$current_url\\":\\"https://posthog.com\\",\\"$lib_version\\":\\"1.0.0\\"},\\"timestamp\\":\\"2024-09-03T09:00:00Z\\"},\\"groups\\":{},\\"nested\\":{\\"foo\\":\\"http://localhost:8000/events/1\\"},\\"person\\":{\\"uuid\\":\\"uuid\\",\\"name\\":\\"test\\",\\"url\\":\\"http://localhost:8000/persons/1\\",\\"properties\\":{\\"email\\":\\"test@posthog.com\\"}},\\"event_url\\":\\"http://localhost:8000/events/1-test\\"}",
+                    "body": "{\\"event\\":{\\"uuid\\":\\"b3a1fe86-b10c-43cc-acaf-d208977608d0\\",\\"event\\":\\"$pageview\\",\\"elements_chain\\":\\"\\",\\"distinct_id\\":\\"distinct_id\\",\\"url\\":\\"http://localhost:8000/events/1\\",\\"properties\\":{\\"$current_url\\":\\"https://posthog.com\\",\\"$lib_version\\":\\"1.0.0\\"},\\"timestamp\\":\\"2024-09-03T09:00:00Z\\"},\\"groups\\":{},\\"nested\\":{\\"foo\\":\\"http://localhost:8000/events/1\\"},\\"person\\":{\\"id\\":\\"uuid\\",\\"name\\":\\"test\\",\\"url\\":\\"http://localhost:8000/persons/1\\",\\"properties\\":{\\"email\\":\\"test@posthog.com\\"}},\\"event_url\\":\\"http://localhost:8000/events/1-test\\"}",
                     "headers": Object {
                       "version": "v=1.0.0",
                     },

--- a/plugin-server/tests/cdp/cdp-e2e.test.ts
+++ b/plugin-server/tests/cdp/cdp-e2e.test.ts
@@ -131,7 +131,7 @@ describe('CDP E2E', () => {
                 Array [
                   "https://example.com/posthog-webhook",
                   Object {
-                    "body": "{\\"event\\":{\\"uuid\\":\\"b3a1fe86-b10c-43cc-acaf-d208977608d0\\",\\"name\\":\\"$pageview\\",\\"distinct_id\\":\\"distinct_id\\",\\"url\\":\\"http://localhost:8000/events/1\\",\\"properties\\":{\\"$current_url\\":\\"https://posthog.com\\",\\"$lib_version\\":\\"1.0.0\\"},\\"timestamp\\":\\"2024-09-03T09:00:00Z\\"},\\"groups\\":{},\\"nested\\":{\\"foo\\":\\"http://localhost:8000/events/1\\"},\\"person\\":{\\"uuid\\":\\"uuid\\",\\"name\\":\\"test\\",\\"url\\":\\"http://localhost:8000/persons/1\\",\\"properties\\":{\\"email\\":\\"test@posthog.com\\"}},\\"event_url\\":\\"http://localhost:8000/events/1-test\\"}",
+                    "body": "{\\"event\\":{\\"uuid\\":\\"b3a1fe86-b10c-43cc-acaf-d208977608d0\\",\\"event\\":\\"$pageview\\",\\"distinct_id\\":\\"distinct_id\\",\\"url\\":\\"http://localhost:8000/events/1\\",\\"properties\\":{\\"$current_url\\":\\"https://posthog.com\\",\\"$lib_version\\":\\"1.0.0\\"},\\"timestamp\\":\\"2024-09-03T09:00:00Z\\"},\\"groups\\":{},\\"nested\\":{\\"foo\\":\\"http://localhost:8000/events/1\\"},\\"person\\":{\\"uuid\\":\\"uuid\\",\\"name\\":\\"test\\",\\"url\\":\\"http://localhost:8000/persons/1\\",\\"properties\\":{\\"email\\":\\"test@posthog.com\\"}},\\"event_url\\":\\"http://localhost:8000/events/1-test\\"}",
                     "headers": Object {
                       "version": "v=1.0.0",
                     },

--- a/plugin-server/tests/cdp/cdp-e2e.test.ts
+++ b/plugin-server/tests/cdp/cdp-e2e.test.ts
@@ -131,7 +131,7 @@ describe('CDP E2E', () => {
                 Array [
                   "https://example.com/posthog-webhook",
                   Object {
-                    "body": "{\\"event\\":{\\"uuid\\":\\"b3a1fe86-b10c-43cc-acaf-d208977608d0\\",\\"event\\":\\"$pageview\\",\\"distinct_id\\":\\"distinct_id\\",\\"url\\":\\"http://localhost:8000/events/1\\",\\"properties\\":{\\"$current_url\\":\\"https://posthog.com\\",\\"$lib_version\\":\\"1.0.0\\"},\\"timestamp\\":\\"2024-09-03T09:00:00Z\\"},\\"groups\\":{},\\"nested\\":{\\"foo\\":\\"http://localhost:8000/events/1\\"},\\"person\\":{\\"uuid\\":\\"uuid\\",\\"name\\":\\"test\\",\\"url\\":\\"http://localhost:8000/persons/1\\",\\"properties\\":{\\"email\\":\\"test@posthog.com\\"}},\\"event_url\\":\\"http://localhost:8000/events/1-test\\"}",
+                    "body": "{\\"event\\":{\\"uuid\\":\\"b3a1fe86-b10c-43cc-acaf-d208977608d0\\",\\"event\\":\\"$pageview\\",\\"elements_chain\\":\\"\\",\\"distinct_id\\":\\"distinct_id\\",\\"url\\":\\"http://localhost:8000/events/1\\",\\"properties\\":{\\"$current_url\\":\\"https://posthog.com\\",\\"$lib_version\\":\\"1.0.0\\"},\\"timestamp\\":\\"2024-09-03T09:00:00Z\\"},\\"groups\\":{},\\"nested\\":{\\"foo\\":\\"http://localhost:8000/events/1\\"},\\"person\\":{\\"uuid\\":\\"uuid\\",\\"name\\":\\"test\\",\\"url\\":\\"http://localhost:8000/persons/1\\",\\"properties\\":{\\"email\\":\\"test@posthog.com\\"}},\\"event_url\\":\\"http://localhost:8000/events/1-test\\"}",
                     "headers": Object {
                       "version": "v=1.0.0",
                     },

--- a/plugin-server/tests/cdp/cdp-function-processor.test.ts
+++ b/plugin-server/tests/cdp/cdp-function-processor.test.ts
@@ -145,7 +145,7 @@ describe('CDP Function Processor', () => {
                 } as any,
                 event: {
                     uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',
-                    name: '$pageview',
+                    event: '$pageview',
                     properties: {
                         $current_url: 'https://posthog.com',
                         $lib_version: '1.0.0',

--- a/plugin-server/tests/cdp/cdp-function-processor.test.ts
+++ b/plugin-server/tests/cdp/cdp-function-processor.test.ts
@@ -209,7 +209,7 @@ describe('CDP Function Processor', () => {
             ])
             expect(kafkaMessages.logs.map((x) => x.value.message)).toEqual([
                 'Executing function',
-                "Suspending function due to async function call 'fetch'. Payload: 1902 bytes",
+                "Suspending function due to async function call 'fetch'. Payload: 1931 bytes",
                 'Resuming function',
                 'Fetch response:, {"status":200,"body":{"success":true}}',
                 expect.stringContaining('Function completed'),

--- a/plugin-server/tests/cdp/cdp-processed-events-consumer.test.ts
+++ b/plugin-server/tests/cdp/cdp-processed-events-consumer.test.ts
@@ -132,7 +132,7 @@ describe('CDP Processed Events Consumer', () => {
                     } as any,
                     event: {
                         uuid: 'b3a1fe86-b10c-43cc-acaf-d208977608d0',
-                        name: '$pageview',
+                        event: '$pageview',
                         properties: {
                             $current_url: 'https://posthog.com',
                             $lib_version: '1.0.0',

--- a/plugin-server/tests/cdp/cdp-processed-events-consumer.test.ts
+++ b/plugin-server/tests/cdp/cdp-processed-events-consumer.test.ts
@@ -173,7 +173,7 @@ describe('CDP Processed Events Consumer', () => {
                     {
                         topic: 'log_entries_test',
                         value: {
-                            message: "Suspending function due to async function call 'fetch'. Payload: 1902 bytes",
+                            message: "Suspending function due to async function call 'fetch'. Payload: 1931 bytes",
                             log_source_id: fnFetchNoFilters.id,
                         },
                     },

--- a/plugin-server/tests/cdp/examples.ts
+++ b/plugin-server/tests/cdp/examples.ts
@@ -244,7 +244,7 @@ export const HOG_EXAMPLES: Record<string, Pick<HogFunctionType, 'hog' | 'bytecod
         ],
     },
     posthog_capture: {
-        hog: "postHogCapture({\n    'event': f'{event.name} (copy)',\n    'distinct_id': event.distinct_id,\n    'properties': {}\n})",
+        hog: "postHogCapture({\n    'event': f'{event.event} (copy)',\n    'distinct_id': event.distinct_id,\n    'properties': {}\n})",
         bytecode: [
             '_h',
             32,
@@ -252,7 +252,7 @@ export const HOG_EXAMPLES: Record<string, Pick<HogFunctionType, 'hog' | 'bytecod
             32,
             ' (copy)',
             32,
-            'name',
+            'event',
             32,
             'event',
             1,

--- a/plugin-server/tests/cdp/fixtures.ts
+++ b/plugin-server/tests/cdp/fixtures.ts
@@ -32,6 +32,10 @@ export const createIntegration = (integration: Partial<IntegrationType>) => {
         errors: '',
         created_at: new Date().toISOString(),
         created_by_id: 1001,
+        id: integration.id ?? 1,
+        kind: integration.kind ?? 'slack',
+        config: {},
+        sensitive_config: {},
         ...integration,
     }
 
@@ -50,6 +54,7 @@ export const createIncomingEvent = (teamId: number, data: Partial<RawClickHouseE
         event: '$pageview',
         timestamp: new Date().toISOString() as ClickHouseTimestamp,
         properties: '{}',
+        person_mode: 'full',
         ...data,
     }
 }
@@ -110,7 +115,7 @@ export const createHogExecutionGlobals = (
         groups: {},
         ...data,
         person: {
-            uuid: 'uuid',
+            id: 'uuid',
             name: 'test',
             url: 'http://localhost:8000/persons/1',
             properties: {
@@ -126,7 +131,8 @@ export const createHogExecutionGlobals = (
         },
         event: {
             uuid: 'uuid',
-            name: 'test',
+            event: 'test',
+            elements_chain: '',
             distinct_id: 'distinct_id',
             url: 'http://localhost:8000/events/1',
             properties: {
@@ -160,5 +166,6 @@ export const createInvocation = (
         hogFunction,
         queue: 'hog',
         timings: [],
+        priority: 0,
     }
 }

--- a/plugin-server/tests/cdp/hog-executor.test.ts
+++ b/plugin-server/tests/cdp/hog-executor.test.ts
@@ -60,6 +60,7 @@ describe('Hog Executor', () => {
                 invocation: {
                     id: expect.any(String),
                     teamId: 1,
+                    priority: 0,
                     globals: invocation.globals,
                     hogFunction: invocation.hogFunction,
                     queue: 'fetch',
@@ -89,7 +90,7 @@ describe('Hog Executor', () => {
                 {
                     timestamp: expect.any(DateTime),
                     level: 'debug',
-                    message: "Suspending function due to async function call 'fetch'. Payload: 1818 bytes",
+                    message: "Suspending function due to async function call 'fetch'. Payload: 1847 bytes",
                 },
             ])
         })
@@ -170,10 +171,10 @@ describe('Hog Executor', () => {
             expect(logs.map((log) => log.message)).toMatchInlineSnapshot(`
                 Array [
                   "Executing function",
-                  "Suspending function due to async function call 'fetch'. Payload: 1818 bytes",
+                  "Suspending function due to async function call 'fetch'. Payload: 1847 bytes",
                   "Resuming function",
                   "Fetch response:, {\\"status\\":200,\\"body\\":\\"success\\"}",
-                  "Function completed in 100ms. Sync: 0ms. Mem: 750 bytes. Ops: 22.",
+                  "Function completed in 100ms. Sync: 0ms. Mem: 779 bytes. Ops: 22.",
                 ]
             `)
         })
@@ -189,10 +190,10 @@ describe('Hog Executor', () => {
             expect(logs.map((log) => log.message)).toMatchInlineSnapshot(`
                 Array [
                   "Executing function",
-                  "Suspending function due to async function call 'fetch'. Payload: 1818 bytes",
+                  "Suspending function due to async function call 'fetch'. Payload: 1847 bytes",
                   "Resuming function",
                   "Fetch response:, {\\"status\\":200,\\"body\\":{\\"foo\\":\\"bar\\"}}",
-                  "Function completed in 100ms. Sync: 0ms. Mem: 750 bytes. Ops: 22.",
+                  "Function completed in 100ms. Sync: 0ms. Mem: 779 bytes. Ops: 22.",
                 ]
             `)
         })
@@ -243,12 +244,11 @@ describe('Hog Executor', () => {
                 event: {
                     uuid: 'uuid',
                     event: '$autocapture',
-                    elements_chain: '',
+                    elements_chain: elementsChain('Not our text'),
                     distinct_id: 'distinct_id',
                     url: 'http://localhost:8000/events/1',
                     properties: {
                         $lib_version: '1.2.3',
-                        $elements_chain: elementsChain('Not our text'),
                     },
                     timestamp: new Date().toISOString(),
                 },
@@ -263,12 +263,11 @@ describe('Hog Executor', () => {
                 event: {
                     uuid: 'uuid',
                     event: '$autocapture',
-                    elements_chain: '',
+                    elements_chain: elementsChain('Reload'),
                     distinct_id: 'distinct_id',
                     url: 'http://localhost:8000/events/1',
                     properties: {
                         $lib_version: '1.2.3',
-                        $elements_chain: elementsChain('Reload'),
                     },
                     timestamp: new Date().toISOString(),
                 },
@@ -295,12 +294,11 @@ describe('Hog Executor', () => {
                 event: {
                     uuid: 'uuid',
                     event: '$autocapture',
-                    elements_chain: '',
+                    elements_chain: elementsChain('/project/1/not-a-link'),
                     distinct_id: 'distinct_id',
                     url: 'http://localhost:8000/events/1',
                     properties: {
                         $lib_version: '1.2.3',
-                        $elements_chain: elementsChain('/project/1/not-a-link'),
                     },
                     timestamp: new Date().toISOString(),
                 },
@@ -315,12 +313,11 @@ describe('Hog Executor', () => {
                 event: {
                     uuid: 'uuid',
                     event: '$autocapture',
-                    elements_chain: '',
+                    elements_chain: elementsChain('/project/1/activity/explore'),
                     distinct_id: 'distinct_id',
                     url: 'http://localhost:8000/events/1',
                     properties: {
                         $lib_version: '1.2.3',
-                        $elements_chain: elementsChain('/project/1/activity/explore'),
                     },
                     timestamp: new Date().toISOString(),
                 },
@@ -347,12 +344,11 @@ describe('Hog Executor', () => {
                 event: {
                     uuid: 'uuid',
                     event: '$autocapture',
-                    elements_chain: '',
+                    elements_chain: elementsChain('notfound'),
                     distinct_id: 'distinct_id',
                     url: 'http://localhost:8000/events/1',
                     properties: {
                         $lib_version: '1.2.3',
-                        $elements_chain: elementsChain('notfound'),
                     },
                     timestamp: new Date().toISOString(),
                 },
@@ -367,12 +363,11 @@ describe('Hog Executor', () => {
                 event: {
                     uuid: 'uuid',
                     event: '$autocapture',
-                    elements_chain: '',
+                    elements_chain: elementsChain('homelink'),
                     distinct_id: 'distinct_id',
                     url: 'http://localhost:8000/events/1',
                     properties: {
                         $lib_version: '1.2.3',
-                        $elements_chain: elementsChain('homelink'),
                     },
                     timestamp: new Date().toISOString(),
                 },

--- a/plugin-server/tests/cdp/hog-executor.test.ts
+++ b/plugin-server/tests/cdp/hog-executor.test.ts
@@ -132,7 +132,8 @@ describe('Hog Executor', () => {
             expect(body).toEqual({
                 event: {
                     uuid: 'uuid',
-                    name: 'test',
+                    event: 'test',
+                    elements_chain: '',
                     distinct_id: 'distinct_id',
                     url: 'http://localhost:8000/events/1',
                     properties: { $lib_version: '1.2.3' },
@@ -141,7 +142,7 @@ describe('Hog Executor', () => {
                 groups: {},
                 nested: { foo: 'http://localhost:8000/events/1' },
                 person: {
-                    uuid: 'uuid',
+                    id: 'uuid',
                     name: 'test',
                     url: 'http://localhost:8000/persons/1',
                     properties: { email: 'test@posthog.com' },
@@ -215,7 +216,7 @@ describe('Hog Executor', () => {
                 createHogExecutionGlobals({
                     groups: {},
                     event: {
-                        name: '$pageview',
+                        event: '$pageview',
                         properties: {
                             $current_url: 'https://posthog.com',
                         },
@@ -241,7 +242,8 @@ describe('Hog Executor', () => {
                 groups: {},
                 event: {
                     uuid: 'uuid',
-                    name: '$autocapture',
+                    event: '$autocapture',
+                    elements_chain: '',
                     distinct_id: 'distinct_id',
                     url: 'http://localhost:8000/events/1',
                     properties: {
@@ -260,7 +262,8 @@ describe('Hog Executor', () => {
                 groups: {},
                 event: {
                     uuid: 'uuid',
-                    name: '$autocapture',
+                    event: '$autocapture',
+                    elements_chain: '',
                     distinct_id: 'distinct_id',
                     url: 'http://localhost:8000/events/1',
                     properties: {
@@ -291,7 +294,8 @@ describe('Hog Executor', () => {
                 groups: {},
                 event: {
                     uuid: 'uuid',
-                    name: '$autocapture',
+                    event: '$autocapture',
+                    elements_chain: '',
                     distinct_id: 'distinct_id',
                     url: 'http://localhost:8000/events/1',
                     properties: {
@@ -310,7 +314,8 @@ describe('Hog Executor', () => {
                 groups: {},
                 event: {
                     uuid: 'uuid',
-                    name: '$autocapture',
+                    event: '$autocapture',
+                    elements_chain: '',
                     distinct_id: 'distinct_id',
                     url: 'http://localhost:8000/events/1',
                     properties: {
@@ -341,7 +346,8 @@ describe('Hog Executor', () => {
                 groups: {},
                 event: {
                     uuid: 'uuid',
-                    name: '$autocapture',
+                    event: '$autocapture',
+                    elements_chain: '',
                     distinct_id: 'distinct_id',
                     url: 'http://localhost:8000/events/1',
                     properties: {
@@ -360,7 +366,8 @@ describe('Hog Executor', () => {
                 groups: {},
                 event: {
                     uuid: 'uuid',
-                    name: '$autocapture',
+                    event: '$autocapture',
+                    elements_chain: '',
                     distinct_id: 'distinct_id',
                     url: 'http://localhost:8000/events/1',
                     properties: {


### PR DESCRIPTION
## Problem

We have a few duplicate fields in the CDP/Hog globals, e.g. `person.id` and `person.uuid`.

## Changes

- Removes the duplicates, preferring the same names as used in the database.
- Should only be merged after we make sure all existing functions do not use the new names.

## How did you test this code?

Changed all functions in production to not use the removed fields. Made all the tests pass.