### PR TITLE
fix(batch-exports): Add response content to error message

### DIFF
--- a/posthog/temporal/batch_exports/http_batch_export.py
+++ b/posthog/temporal/batch_exports/http_batch_export.py
@@ -48,8 +48,8 @@ class RetryableResponseError(Exception):
 class NonRetryableResponseError(Exception):
     """Error for HTTP status >= 400 and < 500 (excluding 429)."""
 
-    def __init__(self, status):
-        super().__init__(f"NonRetryableResponseError status: {status}")
+    def __init__(self, status, content):
+        super().__init__(f"NonRetryableResponseError (status: {status}): {content}")
 
 
 def raise_for_status(response: aiohttp.ClientResponse):
@@ -59,7 +59,7 @@ def raise_for_status(response: aiohttp.ClientResponse):
         if response.status >= 500 or response.status == 429:
             raise RetryableResponseError(response.status)
         else:
-            raise NonRetryableResponseError(response.status)
+            raise NonRetryableResponseError(response.status, response.text())
 
 
 def http_default_fields() -> list[BatchExportField]:

--- a/posthog/temporal/batch_exports/http_batch_export.py
+++ b/posthog/temporal/batch_exports/http_batch_export.py
@@ -52,14 +52,15 @@ class NonRetryableResponseError(Exception):
         super().__init__(f"NonRetryableResponseError (status: {status}): {content}")
 
 
-def raise_for_status(response: aiohttp.ClientResponse):
+async def raise_for_status(response: aiohttp.ClientResponse):
     """Like aiohttp raise_for_status, but it distinguishes between retryable and non-retryable
     errors."""
     if not response.ok:
         if response.status >= 500 or response.status == 429:
             raise RetryableResponseError(response.status)
         else:
-            raise NonRetryableResponseError(response.status, response.text())
+            text = await response.text()
+            raise NonRetryableResponseError(response.status, text)
 
 
 def http_default_fields() -> list[BatchExportField]:
@@ -155,7 +156,7 @@ async def post_json_file_to_url(url, batch_file, session: aiohttp.ClientSession)
     data_reader.close = lambda: None  # type: ignore
 
     async with session.post(url, data=data_reader, headers=headers) as response:
-        raise_for_status(response)
+        await raise_for_status(response)
 
     data_reader.detach()
     return response


### PR DESCRIPTION
## Problem

HTTP batch exports are failing with a 400 status from our API. Trying to dig into the problem by adding response content to error.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add response text to error message.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Current unit tests cover raising retryable errors, so if there's something in the response we'll see it.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
