### PR TITLE
chore(data-warehouse): Put bigquery dwh source behind a flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -216,6 +216,7 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_CONVERSION_GOALS: 'web-analytics-conversion-goals', // owner: @robbie-c
     WEB_ANALYTICS_LAST_CLICK: 'web-analytics-last-click', // owner: @robbie-c
     HEDGEHOG_SKIN_SPIDERHOG: 'hedgehog-skin-spiderhog', // owner: @benjackwhite
+    BIGQUERY_DWH: 'bigquery-dwh', // owner: @Gilbert09 #team-data-warehouse
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
+++ b/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
@@ -1,6 +1,8 @@
 import { LemonButton, LemonTable, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useCallback } from 'react'
 import { SceneExport } from 'scenes/sceneTypes'
 
@@ -125,6 +127,7 @@ function FirstStep(): JSX.Element {
     const { connectors, manualConnectors, addToHubspotButtonUrl } = useValues(sourceWizardLogic)
     const { selectConnector, toggleManualLinkFormVisible, onNext, setManualLinkingProvider } =
         useActions(sourceWizardLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const onClick = (sourceConfig: SourceConfig): void => {
         if (sourceConfig.name == 'Hubspot') {
@@ -140,6 +143,14 @@ function FirstStep(): JSX.Element {
         setManualLinkingProvider(manulLinkSource)
     }
 
+    const filteredConnectors = connectors.filter((n) => {
+        if (n.name === 'BigQuery' && !featureFlags[FEATURE_FLAGS.BIGQUERY_DWH]) {
+            return false
+        }
+
+        return true
+    })
+
     return (
         <>
             <h2 className="mt-4">Managed by PostHog</h2>
@@ -149,7 +160,7 @@ function FirstStep(): JSX.Element {
                 <Link to="https://posthog.com/docs/data-warehouse/setup#stripe">Learn more</Link>
             </p>
             <LemonTable
-                dataSource={connectors}
+                dataSource={filteredConnectors}
                 loading={false}
                 disableTableWhileLoading={false}
                 columns={[


### PR DESCRIPTION
## Problem
- bigquery source isn't quite ready yet - need to figure out "destination tables" or something for when the query results are more than 10GB

## Changes
Put adding a BQ source behind a feature flag for now