### PR TITLE
fix(onboarding-templates): wait for team to be updated with authorized urls

### DIFF
--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
@@ -87,9 +87,20 @@ const UrlInput = ({ iframeRef }: { iframeRef: React.RefObject<HTMLIFrameElement>
 export const SiteChooser = (): JSX.Element => {
     const iframeRef = useRef<HTMLIFrameElement>(null)
     const { snippetHosts, hasSnippetEventsLoading } = useValues(sdksLogic)
-    const { addUrl } = useActions(authorizedUrlListLogic({ actionId: null, type: AuthorizedUrlListType.TOOLBAR_URLS }))
-    const { setBrowserUrl } = useActions(iframedToolbarBrowserLogic({ iframeRef, clearBrowserUrlOnUnmount: true }))
-    const { iframeBanner } = useValues(iframedToolbarBrowserLogic({ iframeRef, clearBrowserUrlOnUnmount: true }))
+    const { setProposedBrowserUrl } = useActions(
+        iframedToolbarBrowserLogic({
+            iframeRef,
+            clearBrowserUrlOnUnmount: true,
+            automaticallyAuthorizeBrowserUrl: true,
+        })
+    )
+    const { iframeBanner, proposedBrowserUrl } = useValues(
+        iframedToolbarBrowserLogic({
+            iframeRef,
+            clearBrowserUrlOnUnmount: true,
+            automaticallyAuthorizeBrowserUrl: true,
+        })
+    )
     const { setStepKey } = useActions(onboardingLogic)
 
     return (
@@ -125,10 +136,10 @@ export const SiteChooser = (): JSX.Element => {
                                         type="tertiary"
                                         status="default"
                                         onClick={() => {
-                                            addUrl(host)
-                                            setBrowserUrl(host)
+                                            setProposedBrowserUrl(host)
                                         }}
                                         sideIcon={<IconArrowRight />}
+                                        disabledReason={proposedBrowserUrl && 'Loading...'}
                                     >
                                         {host}
                                     </LemonButton>


### PR DESCRIPTION
## Problem

When someone selected their URL, it was automatically being added to the authorized URLs list. However, we were then attempting to visit the browser URL before that addition was completed, so the backend would throw an error saying it wasn't authorized.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Due to logic dependencies I tried a few ways to go about this, and the one I landed on was:

- in iFrameBrowser logic, say if we want to automatically authorize proposed URLs
- If so, when we propose a URL, either set it as the browser URL if already auth'd or add it to the list of auth'd URLs
- When we hear that the team was updated successfully, check the list of authorized URLs with the proposed URL - if they match, then we can set the browser URL

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

manually

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
