### PR TITLE
feat(web-analytics): Fix the query limit not being increased for external clicks / web goals when opened as a modal

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -1085,7 +1085,12 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 }
 
                 const extendQuery = (query: QuerySchema): QuerySchema => {
-                    if (query.kind === NodeKind.DataTableNode && query.source.kind === NodeKind.WebStatsTableQuery) {
+                    if (
+                        query.kind === NodeKind.DataTableNode &&
+                        (query.source.kind === NodeKind.WebStatsTableQuery ||
+                            query.source.kind === NodeKind.WebExternalClicksTableQuery ||
+                            query.source.kind === NodeKind.WebGoalsQuery)
+                    ) {
                         return {
                             ...query,
                             source: {


### PR DESCRIPTION
## Problem

The limit stays at 10 when opening the external clicks query or the web goals query as a model. It should increase to 50

## Changes

Fix the logic so the limit is increased correctly.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Ran it locally, opened the modal