### PR TITLE
feat(data-warehouse): integrate model run

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2084,6 +2084,9 @@ const api = {
         ): Promise<DataWarehouseSavedQuery> {
             return await new ApiRequest().dataWarehouseSavedQuery(viewId).update({ data })
         },
+        async run(viewId: DataWarehouseSavedQuery['id']): Promise<void> {
+            return await new ApiRequest().dataWarehouseSavedQuery(viewId).withAction('run').create()
+        },
         async ancestors(viewId: DataWarehouseSavedQuery['id'], level?: number): Promise<Record<string, string[]>> {
             return await new ApiRequest()
                 .dataWarehouseSavedQuery(viewId)

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -529,7 +529,7 @@ export function humanFriendlyDiff(from: dayjs.Dayjs | string, to: dayjs.Dayjs | 
 }
 
 export function humanFriendlyDetailedTime(
-    date: dayjs.Dayjs | string | null,
+    date: dayjs.Dayjs | string | null | undefined,
     formatDate = 'MMMM DD, YYYY',
     formatTime = 'h:mm:ss A'
 ): string {

--- a/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
+++ b/frontend/src/scenes/data-management/database/databaseTableListLogic.ts
@@ -118,6 +118,23 @@ export const databaseTableListLogic = kea<databaseTableListLogicType>([
                     }, {} as Record<string, DatabaseSchemaDataWarehouseTable>)
             },
         ],
+        dataWarehouseTablesMapById: [
+            (s) => [s.database],
+            (database): Record<string, DatabaseSchemaDataWarehouseTable> => {
+                if (!database || !database.tables) {
+                    return {}
+                }
+
+                return Object.values(database.tables)
+                    .filter(
+                        (n): n is DatabaseSchemaDataWarehouseTable => n.type === 'data_warehouse' || n.type == 'view'
+                    )
+                    .reduce((acc, cur) => {
+                        acc[cur.id] = database.tables[cur.name] as DatabaseSchemaDataWarehouseTable
+                        return acc
+                    }, {} as Record<string, DatabaseSchemaDataWarehouseTable>)
+            },
+        ],
         views: [
             (s) => [s.database],
             (database): DatabaseSchemaViewTable[] => {

--- a/frontend/src/scenes/data-model/Node.tsx
+++ b/frontend/src/scenes/data-model/Node.tsx
@@ -10,7 +10,7 @@ function GenericNode({ pref, className = '', children }: NodeProps): JSX.Element
     return (
         <div
             ref={pref}
-            className={`flex max-w-[200px] px-4 py-3 justify-center items-center space-between gap-1 bg-bg-3000 border border-black border-2 rounded-lg truncate ${className}`}
+            className={`flex w-[200px] px-4 py-3 justify-center items-center space-between gap-1 bg-bg-3000 border border-black border-2 rounded-lg ${className}`}
         >
             {children}
         </div>

--- a/frontend/src/scenes/data-model/NodeCanvasWithTable.tsx
+++ b/frontend/src/scenes/data-model/NodeCanvasWithTable.tsx
@@ -397,7 +397,7 @@ const NodeCanvasWithTable = ({
                                             type={
                                                 (dataWarehouseSavedQueryMapById[savedQueryId]?.status &&
                                                     StatusTagSetting[
-                                                        dataWarehouseSavedQueryMapById[savedQueryId]?.status
+                                                        dataWarehouseSavedQueryMapById[savedQueryId].status as string
                                                     ]) ||
                                                 'default'
                                             }

--- a/frontend/src/scenes/data-model/NodeCanvasWithTable.tsx
+++ b/frontend/src/scenes/data-model/NodeCanvasWithTable.tsx
@@ -395,9 +395,11 @@ const NodeCanvasWithTable = ({
                                     <div className="text-xs mt-2 max-w-full">
                                         <LemonTag
                                             type={
-                                                StatusTagSetting[
-                                                    dataWarehouseSavedQueryMapById[savedQueryId]?.status
-                                                ] || 'default'
+                                                (dataWarehouseSavedQueryMapById[savedQueryId]?.status &&
+                                                    StatusTagSetting[
+                                                        dataWarehouseSavedQueryMapById[savedQueryId]?.status
+                                                    ]) ||
+                                                'default'
                                             }
                                             className="break-words"
                                         >

--- a/frontend/src/scenes/data-model/NodeCanvasWithTable.tsx
+++ b/frontend/src/scenes/data-model/NodeCanvasWithTable.tsx
@@ -101,7 +101,9 @@ const calculateNodePositions = (nodesWithDepth: NodeWithDepth[]): NodePosition[]
 
 const calculateTablePosition = (nodePositions: NodePosition[]): Position => {
     // Find the node with the maximum x position
-    const farthestNode = nodePositions.reduce((max, node) => (node.position.x > max.position.x ? node : max))
+    const farthestNode = nodePositions.reduce((max, node) => (node.position.x > max.position.x ? node : max), {
+        position: { x: 0, y: 0 },
+    })
 
     // Calculate the table position to be slightly to the right of the farthest node
     const tablePosition: Position = {

--- a/frontend/src/scenes/data-model/TableFields.tsx
+++ b/frontend/src/scenes/data-model/TableFields.tsx
@@ -31,13 +31,7 @@ export function TableFields({ fixedFields, joinedFields, rowsRefs, tableName }: 
                 </div>
             </div>
             <div className="flex flex-col gap-1">
-                <div
-                    ref={(el) => {
-                        rowsRefs.current[joinedFields.length] = el
-                        rowsRefs.current[joinedFields.length]?.setAttribute('id', 'schema')
-                    }}
-                    className="pl-4 mt-4"
-                >
+                <div className="pl-4 mt-4">
                     <h4>Schema</h4>
                 </div>
                 <LemonTable

--- a/frontend/src/scenes/data-model/dataModelSceneLogic.tsx
+++ b/frontend/src/scenes/data-model/dataModelSceneLogic.tsx
@@ -12,7 +12,7 @@ import { Node } from './types'
 export const dataModelSceneLogic = kea<dataModelSceneLogicType>([
     path(['scenes', 'data-model', 'dataModelSceneLogic']),
     connect(() => ({
-        values: [databaseTableListLogic, ['posthogTablesMap', 'viewsMapById']],
+        values: [databaseTableListLogic, ['posthogTablesMap', 'viewsMapById', 'dataWarehouseTablesMapById']],
     })),
     actions({
         traverseAncestors: (viewId: DataWarehouseSavedQuery['id'], level: number) => ({ viewId, level }),
@@ -35,7 +35,10 @@ export const dataModelSceneLogic = kea<dataModelSceneLogicType>([
                     ...values.nodeMap,
                     [ancestor]: {
                         nodeId: ancestor,
-                        name: values.viewsMapById[ancestor]?.name || ancestor,
+                        name:
+                            values.viewsMapById[ancestor]?.name ||
+                            values.dataWarehouseTablesMapById[ancestor]?.name ||
+                            ancestor,
                         savedQueryId: values.viewsMapById[ancestor]?.id,
                         leaf: [...(values.nodeMap[ancestor]?.leaf || []), viewId],
                     },
@@ -69,17 +72,7 @@ export const dataModelSceneLogic = kea<dataModelSceneLogicType>([
                     table: field.name,
                 })) || [],
         ],
-        allNodes: [
-            (s) => [s.nodeMap],
-            (nodeMap) => [
-                {
-                    nodeId: 'posthog',
-                    name: 'PostHog',
-                    leaf: ['schema'],
-                },
-                ...Object.values(nodeMap),
-            ],
-        ],
+        allNodes: [(s) => [s.nodeMap], (nodeMap) => [...Object.values(nodeMap)]],
     }),
     subscriptions(({ actions, values }) => ({
         joinedFields: (joinedFields) => {
@@ -88,7 +81,10 @@ export const dataModelSceneLogic = kea<dataModelSceneLogicType>([
                     ...values.nodeMap,
                     [field.id]: {
                         nodeId: field.id,
-                        name: values.viewsMapById[field.id]?.name || field.id,
+                        name:
+                            values.viewsMapById[field.id]?.name ||
+                            values.dataWarehouseTablesMapById[field.id]?.name ||
+                            field.id,
                         savedQueryId: values.viewsMapById[field.id]?.id,
                         leaf: [`${field.name}_joined`],
                     },

--- a/frontend/src/scenes/data-model/dataModelSceneLogic.tsx
+++ b/frontend/src/scenes/data-model/dataModelSceneLogic.tsx
@@ -36,6 +36,7 @@ export const dataModelSceneLogic = kea<dataModelSceneLogicType>([
                     [ancestor]: {
                         nodeId: ancestor,
                         name: values.viewsMapById[ancestor]?.name || ancestor,
+                        savedQueryId: values.viewsMapById[ancestor]?.id,
                         leaf: [...(values.nodeMap[ancestor]?.leaf || []), viewId],
                     },
                 })
@@ -88,6 +89,7 @@ export const dataModelSceneLogic = kea<dataModelSceneLogicType>([
                     [field.id]: {
                         nodeId: field.id,
                         name: values.viewsMapById[field.id]?.name || field.id,
+                        savedQueryId: values.viewsMapById[field.id]?.id,
                         leaf: [`${field.name}_joined`],
                     },
                 })

--- a/frontend/src/scenes/data-model/types.ts
+++ b/frontend/src/scenes/data-model/types.ts
@@ -6,6 +6,7 @@ export interface Position {
 export interface Node {
     nodeId: string
     name: string
+    savedQueryId?: string
     leaf: string[]
 }
 

--- a/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
+++ b/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
@@ -4,6 +4,8 @@ import { clsx } from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { DatabaseTableTree, TreeItem } from 'lib/components/DatabaseTableTree/DatabaseTableTree'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { useState } from 'react'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
@@ -15,6 +17,7 @@ import { DatabaseSchemaTable } from '~/queries/schema'
 import { ExternalDataSourceType, InsightLogicProps } from '~/types'
 
 import { SOURCE_DETAILS } from '../new/sourceWizardLogic'
+import { dataWarehouseViewsLogic } from '../saved_queries/dataWarehouseViewsLogic'
 import { dataWarehouseSceneLogic } from '../settings/dataWarehouseSceneLogic'
 import { viewLinkLogic } from '../viewLinkLogic'
 import { ViewLinkModal } from '../ViewLinkModal'
@@ -61,6 +64,8 @@ export const DatabaseTableTreeWithItems = ({ inline }: DatabaseTableTreeProps): 
     const [collapsed, setCollapsed] = useState(false)
     const { toggleJoinTableModal, selectSourceTable } = useActions(viewLinkLogic)
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { runDataWarehouseSavedQuery } = useActions(dataWarehouseViewsLogic)
 
     const deleteButton = (table: DatabaseSchemaTable | null): JSX.Element => {
         if (!table) {
@@ -130,6 +135,17 @@ export const DatabaseTableTreeWithItems = ({ inline }: DatabaseTableTreeProps): 
                     fullWidth
                 >
                     Edit view definition
+                </LemonButton>
+            )}
+            {table.type == 'view' && featureFlags[FEATURE_FLAGS.DATA_MODELING] && (
+                <LemonButton
+                    onClick={() => {
+                        runDataWarehouseSavedQuery(table.id)
+                    }}
+                    data-attr="schema-list-item-materialize"
+                    fullWidth
+                >
+                    Materialize
                 </LemonButton>
             )}
             {deleteButton(table)}

--- a/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
+++ b/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
@@ -4,8 +4,6 @@ import { clsx } from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { DatabaseTableTree, TreeItem } from 'lib/components/DatabaseTableTree/DatabaseTableTree'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { useState } from 'react'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
@@ -17,7 +15,6 @@ import { DatabaseSchemaTable } from '~/queries/schema'
 import { ExternalDataSourceType, InsightLogicProps } from '~/types'
 
 import { SOURCE_DETAILS } from '../new/sourceWizardLogic'
-import { dataWarehouseViewsLogic } from '../saved_queries/dataWarehouseViewsLogic'
 import { dataWarehouseSceneLogic } from '../settings/dataWarehouseSceneLogic'
 import { viewLinkLogic } from '../viewLinkLogic'
 import { ViewLinkModal } from '../ViewLinkModal'
@@ -64,8 +61,6 @@ export const DatabaseTableTreeWithItems = ({ inline }: DatabaseTableTreeProps): 
     const [collapsed, setCollapsed] = useState(false)
     const { toggleJoinTableModal, selectSourceTable } = useActions(viewLinkLogic)
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
-    const { featureFlags } = useValues(featureFlagLogic)
-    const { runDataWarehouseSavedQuery } = useActions(dataWarehouseViewsLogic)
 
     const deleteButton = (table: DatabaseSchemaTable | null): JSX.Element => {
         if (!table) {
@@ -135,17 +130,6 @@ export const DatabaseTableTreeWithItems = ({ inline }: DatabaseTableTreeProps): 
                     fullWidth
                 >
                     Edit view definition
-                </LemonButton>
-            )}
-            {table.type == 'view' && featureFlags[FEATURE_FLAGS.DATA_MODELING] && (
-                <LemonButton
-                    onClick={() => {
-                        runDataWarehouseSavedQuery(table.id)
-                    }}
-                    data-attr="schema-list-item-materialize"
-                    fullWidth
-                >
-                    Materialize
                 </LemonButton>
             )}
             {deleteButton(table)}

--- a/frontend/src/scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic.tsx
@@ -1,5 +1,5 @@
 import { lemonToast } from '@posthog/lemon-ui'
-import { connect, kea, listeners, path, selectors } from 'kea'
+import { actions, connect, events, kea, listeners, path, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
 import api from 'lib/api'
@@ -8,6 +8,7 @@ import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { DatabaseSchemaViewTable } from '~/queries/schema'
+import { DataWarehouseSavedQuery } from '~/types'
 
 import type { dataWarehouseViewsLogicType } from './dataWarehouseViewsLogicType'
 
@@ -17,36 +18,51 @@ export const dataWarehouseViewsLogic = kea<dataWarehouseViewsLogicType>([
         values: [userLogic, ['user'], databaseTableListLogic, ['views', 'databaseLoading']],
         actions: [databaseTableListLogic, ['loadDatabase']],
     })),
-
-    loaders({
+    actions({
+        runDataWarehouseSavedQuery: (viewId: string) => ({ viewId }),
+    }),
+    loaders(({ values }) => ({
         dataWarehouseSavedQueries: [
-            null,
+            [] as DataWarehouseSavedQuery[],
             {
+                loadDataWarehouseSavedQueries: async () => {
+                    const savedQueries = await api.dataWarehouseSavedQueries.list()
+                    return savedQueries.results
+                },
                 createDataWarehouseSavedQuery: async (view: Partial<DatabaseSchemaViewTable>) => {
                     const newView = await api.dataWarehouseSavedQueries.create(view)
 
                     lemonToast.success(`${newView.name ?? 'View'} successfully created`)
                     router.actions.push(urls.dataWarehouseView(newView.id))
 
-                    return null
+                    return [...values.dataWarehouseSavedQueries, newView]
                 },
                 deleteDataWarehouseSavedQuery: async (viewId: string) => {
                     await api.dataWarehouseSavedQueries.delete(viewId)
-                    return null
+                    return values.dataWarehouseSavedQueries.filter((view) => view.id !== viewId)
                 },
                 updateDataWarehouseSavedQuery: async (view: DatabaseSchemaViewTable) => {
-                    await api.dataWarehouseSavedQueries.update(view.id, view)
-                    return null
+                    const newView = await api.dataWarehouseSavedQueries.update(view.id, view)
+                    return values.dataWarehouseSavedQueries.map((savedQuery) => {
+                        if (savedQuery.id === view.id) {
+                            return newView
+                        }
+                        return savedQuery
+                    })
                 },
             },
         ],
-    }),
+    })),
     listeners(({ actions }) => ({
         createDataWarehouseSavedQuerySuccess: () => {
             actions.loadDatabase()
         },
         updateDataWarehouseSavedQuerySuccess: () => {
             actions.loadDatabase()
+        },
+        runDataWarehouseSavedQuery: async ({ viewId }) => {
+            await api.dataWarehouseSavedQueries.run(viewId)
+            actions.loadDataWarehouseSavedQueries()
         },
     })),
     selectors({
@@ -56,5 +72,25 @@ export const dataWarehouseViewsLogic = kea<dataWarehouseViewsLogicType>([
                 return views?.length == 0 && !databaseLoading
             },
         ],
+        dataWarehouseSavedQueryMapById: [
+            (s) => [s.dataWarehouseSavedQueries],
+            (dataWarehouseSavedQueries) => {
+                return dataWarehouseSavedQueries.reduce((acc, cur) => {
+                    acc[cur.id] = cur
+                    return acc
+                }, {} as Record<string, DataWarehouseSavedQuery>)
+            },
+        ],
     }),
+    events(({ actions, cache }) => ({
+        afterMount: () => {
+            actions.loadDataWarehouseSavedQueries()
+            if (!cache.pollingInterval) {
+                cache.pollingInterval = setInterval(actions.loadDataWarehouseSavedQueries, 5000)
+            }
+        },
+        beforeUnmount: () => {
+            clearInterval(cache.pollingInterval)
+        },
+    })),
 ])

--- a/frontend/src/scenes/data-warehouse/settings/DataWarehouseManagedSourcesTable.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/DataWarehouseManagedSourcesTable.tsx
@@ -24,7 +24,7 @@ import { manualLinkSources, PipelineNodeTab, PipelineStage } from '~/types'
 import { SOURCE_DETAILS } from '../new/sourceWizardLogic'
 import { dataWarehouseSettingsLogic } from './dataWarehouseSettingsLogic'
 
-const StatusTagSetting = {
+export const StatusTagSetting = {
     Running: 'primary',
     Completed: 'success',
     Error: 'danger',

--- a/frontend/src/scenes/data-warehouse/settings/DataWarehouseManagedSourcesTable.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/DataWarehouseManagedSourcesTable.tsx
@@ -24,7 +24,7 @@ import { manualLinkSources, PipelineNodeTab, PipelineStage } from '~/types'
 import { SOURCE_DETAILS } from '../new/sourceWizardLogic'
 import { dataWarehouseSettingsLogic } from './dataWarehouseSettingsLogic'
 
-export const StatusTagSetting = {
+export const StatusTagSetting: Record<string, 'primary' | 'success' | 'danger'> = {
     Running: 'primary',
     Completed: 'success',
     Error: 'danger',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3894,6 +3894,8 @@ export interface DataWarehouseSavedQuery {
     name: string
     query: HogQLQuery
     columns: DatabaseSchemaField[]
+    last_run_at?: string
+    status?: string
 }
 
 export interface DataWarehouseViewLink {


### PR DESCRIPTION
## Problem

- no ui for running models

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- add ui
<img width="870" alt="Screenshot 2024-09-19 at 4 02 58 PM" src="https://github.com/user-attachments/assets/cc5fdb24-6c53-4591-9015-28aee3d653db">

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
