### PR TITLE
fix: allow rn and flutter to bypass authorised domains

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -52,7 +52,8 @@ def on_permitted_recording_domain(team: Team, request: HttpRequest) -> bool:
     # TODO this is a short term fix for beta testers
     # TODO we will match on the app identifier in the origin instead and allow users to auth those
     is_authorized_mobile_client: bool = user_agent is not None and any(
-        keyword in user_agent for keyword in ["posthog-android", "posthog-ios"]
+        keyword in user_agent
+        for keyword in ["posthog-android", "posthog-ios", "posthog-ios", "posthog-react-native", "posthog-flutter"]
     )
 
     return is_authorized_web_client or is_authorized_mobile_client

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -53,7 +53,7 @@ def on_permitted_recording_domain(team: Team, request: HttpRequest) -> bool:
     # TODO we will match on the app identifier in the origin instead and allow users to auth those
     is_authorized_mobile_client: bool = user_agent is not None and any(
         keyword in user_agent
-        for keyword in ["posthog-android", "posthog-ios", "posthog-ios", "posthog-react-native", "posthog-flutter"]
+        for keyword in ["posthog-android", "posthog-ios", "posthog-react-native", "posthog-flutter"]
     )
 
     return is_authorized_web_client or is_authorized_mobile_client


### PR DESCRIPTION
## Problem

fix: allow rn and flutter to bypass authorised domains

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
