### PR TITLE
feat(experiments HogQL rewrite): prepare funnel query

### DIFF
--- a/posthog/hogql_queries/experiment_funnel_query_runner.py
+++ b/posthog/hogql_queries/experiment_funnel_query_runner.py
@@ -45,17 +45,16 @@ class ExperimentFunnelQueryRunner(QueryRunner):
 
         # Set the date range to match the experiment's duration, using the project's timezone
         if self.team.timezone:
-            start_date = self.experiment.start_date.astimezone(ZoneInfo(self.team.timezone))
-            end_date = (
-                self.experiment.end_date.astimezone(ZoneInfo(self.team.timezone)) if self.experiment.end_date else None
-            )
+            tz = ZoneInfo(self.team.timezone)
+            start_date = self.experiment.start_date.astimezone(tz) if self.experiment.start_date else None
+            end_date = self.experiment.end_date.astimezone(tz) if self.experiment.end_date else None
         else:
             start_date = self.experiment.start_date
             end_date = self.experiment.end_date
 
         prepared_funnel_query.dateRange = InsightDateRange(
-            date_from=start_date.strftime("%Y-%m-%d"),
-            date_to=end_date.strftime("%Y-%m-%d") if end_date else None,
+            date_from=start_date.isoformat() if start_date else None,
+            date_to=end_date.isoformat() if end_date else None,
             explicitDate=True,
         )
 

--- a/posthog/hogql_queries/experiment_funnel_query_runner.py
+++ b/posthog/hogql_queries/experiment_funnel_query_runner.py
@@ -6,8 +6,12 @@ from posthog.schema import (
     ExperimentFunnelQuery,
     ExperimentFunnelQueryResponse,
     ExperimentVariantFunnelResult,
+    FunnelsQuery,
+    InsightDateRange,
+    BreakdownFilter,
 )
 from typing import Any
+from zoneinfo import ZoneInfo
 
 
 class ExperimentFunnelQueryRunner(QueryRunner):
@@ -17,15 +21,51 @@ class ExperimentFunnelQueryRunner(QueryRunner):
         super().__init__(*args, **kwargs)
         self.experiment = Experiment.objects.get(id=self.query.experiment_id)
         self.feature_flag = self.experiment.feature_flag
-
+        self.prepared_funnel_query = self._prepare_funnel_query()
         self.query_runner = FunnelsQueryRunner(
-            query=self.query.source, team=self.team, timings=self.timings, limit_context=self.limit_context
+            query=self.prepared_funnel_query, team=self.team, timings=self.timings, limit_context=self.limit_context
         )
 
     def calculate(self) -> ExperimentFunnelQueryResponse:
         response = self.query_runner.calculate()
         results = self._process_results(response.results)
         return ExperimentFunnelQueryResponse(insight="FUNNELS", results=results)
+
+    def _prepare_funnel_query(self) -> FunnelsQuery:
+        """
+        This method takes the raw funnel query and adapts it
+        for the needs of experiment analysis:
+
+        1. Set the date range to match the experiment's duration, using the project's timezone.
+        2. Configure the breakdown to use the feature flag key, which allows us
+           to separate results for different experiment variants.
+        """
+        # Clone the source query
+        prepared_funnel_query = FunnelsQuery(**self.query.source.model_dump())
+
+        # Set the date range to match the experiment's duration, using the project's timezone
+        if self.team.timezone:
+            start_date = self.experiment.start_date.astimezone(ZoneInfo(self.team.timezone))
+            end_date = (
+                self.experiment.end_date.astimezone(ZoneInfo(self.team.timezone)) if self.experiment.end_date else None
+            )
+        else:
+            start_date = self.experiment.start_date
+            end_date = self.experiment.end_date
+
+        prepared_funnel_query.dateRange = InsightDateRange(
+            date_from=start_date.strftime("%Y-%m-%d"),
+            date_to=end_date.strftime("%Y-%m-%d") if end_date else None,
+            explicitDate=True,
+        )
+
+        # Configure the breakdown to use the feature flag key
+        prepared_funnel_query.breakdownFilter = BreakdownFilter(
+            breakdown=f"$feature/{self.feature_flag.key}",
+            breakdown_type="event",
+        )
+
+        return prepared_funnel_query
 
     def _process_results(self, funnels_results: list[list[dict[str, Any]]]) -> dict[str, ExperimentVariantFunnelResult]:
         variants = self.feature_flag.variants


### PR DESCRIPTION
## Problem
On an experiment, the funnel query is stored in a "raw" format, without the experiment date range or feature flag breakdowns. This allows users to preview the goal in the UI and see the event frequency from the past, where the experiment date range and breakdowns aren't relevant.

## Changes
When calculating experiment results, we need to retrieve the funnel. Before doing so, we modify the query to include:
- experiment date range
- feature flag breakdown

This modification corresponds to the following section of the old method: https://github.com/PostHog/posthog/blob/master/ee/clickhouse/queries/experiments/funnel_experiment_result.py#L75

## How did you test this code?
Updated existing test