### PR TITLE
fix: Sentry issue with hogql throttle

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -61,7 +61,7 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
         if self.action in ("draft_sql", "chat"):
             return [AIBurstRateThrottle(), AISustainedRateThrottle()]
         if query := self.request.data.get("query"):
-            if query.get("kind") == "HogQLQuery":
+            if isinstance(query, dict) and query.get("kind") == "HogQLQuery":
                 return [HogQLQueryThrottle()]
         return [ClickHouseBurstRateThrottle(), ClickHouseSustainedRateThrottle()]
 


### PR DESCRIPTION
## Problem

https://posthog.sentry.io/issues/5874394486/?project=1899813&referrer=github-pr-bot

The request they're doing (something like `{"query": "select count() from events"}`) isn't valid anyway but the error would be unhelpful

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
