### PR TITLE
feat(hog): global property access is nullish

### DIFF
--- a/hogvm/python/execute.py
+++ b/hogvm/python/execute.py
@@ -248,7 +248,7 @@ def execute_bytecode(
             case Operation.GET_GLOBAL:
                 chain = [pop_stack() for _ in range(next_token())]
                 if globals and chain[0] in globals:
-                    push_stack(deepcopy(get_nested_value(globals, chain)))
+                    push_stack(deepcopy(get_nested_value(globals, chain, True)))
                 elif functions and chain[0] in functions:
                     push_stack(
                         new_hog_closure(

--- a/hogvm/python/test/test_execute.py
+++ b/hogvm/python/test/test_execute.py
@@ -978,9 +978,15 @@ class TestBytecodeExecute:
         assert self._run_program("let a := {'b': {'d': 2}}; return (((a??{}).b)??{}).c") is None
         assert self._run_program("let a := {'b': {'d': 2}}; return (((a??{}).b)??{}).d") == 2
         assert self._run_program("let a := {'b': {'d': 2}}; return a?.b?.c") is None
+        assert self._run_program("let a := {'b': {'d': 2}}; return a.b.c") is None
         assert self._run_program("let a := {'b': {'d': 2}}; return a?.b?.d") == 2
+        assert self._run_program("let a := {'b': {'d': 2}}; return a.b.d") == 2
         assert self._run_program("let a := {'b': {'d': 2}}; return a?.b?.['c']") is None
+        assert self._run_program("let a := {'b': {'d': 2}}; return a.b['c']") is None
         assert self._run_program("let a := {'b': {'d': 2}}; return a?.b?.['d']") == 2
+        assert self._run_program("let a := {'b': {'d': 2}}; return a.b['d']") == 2
+        assert self._run_program("return properties.foo") == "bar"
+        assert self._run_program("return properties.not.here") is None
 
     def test_bytecode_uncaught_errors(self):
         try:

--- a/hogvm/typescript/package.json
+++ b/hogvm/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/hogvm",
-    "version": "1.0.49",
+    "version": "1.0.50",
     "description": "PostHog Hog Virtual Machine",
     "types": "dist/index.d.ts",
     "source": "src/index.ts",

--- a/hogvm/typescript/src/__tests__/execute.test.ts
+++ b/hogvm/typescript/src/__tests__/execute.test.ts
@@ -1817,6 +1817,15 @@ describe('hogvm execute', () => {
         expect(globals.globalEvent).toEqual({ event: '$pageview', properties: { $browser: 'Chrome' } })
     })
 
+    test('uses nullish access for globals', () => {
+        const globals = { globalVar: { a: { d: 1 } } }
+        expect(
+            exec(['_H', 1, 32, 'c', 32, 'b', 32, 'a', 32, 'globalVar', 1, 4, 38], {
+                globals,
+            }).result
+        ).toEqual(null)
+    })
+
     test('ternary', () => {
         const values: any[] = []
         const functions = {

--- a/hogvm/typescript/src/execute.ts
+++ b/hogvm/typescript/src/execute.ts
@@ -346,9 +346,8 @@ export function exec(code: any[] | VMState, options?: ExecOptions): ExecResult {
                 for (let i = 0; i < count; i++) {
                     chain.push(popStack())
                 }
-
                 if (options?.globals && chain[0] in options.globals && Object.hasOwn(options.globals, chain[0])) {
-                    pushStack(convertJSToHog(getNestedValue(options.globals, chain)))
+                    pushStack(convertJSToHog(getNestedValue(options.globals, chain, true)))
                 } else if (
                     options?.asyncFunctions &&
                     chain.length == 1 &&


### PR DESCRIPTION
## Problem

Accessing CDP filters like `properties.user_info.onboardingCompleted` fails with `Cannot read properties of null`

## Changes

Makes global access nullish, just like it already was for regular property access

## How did you test this code?

Added tests