### PR TITLE
feat(cdp): Default to enabled and indicate it in the status

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
@@ -47,7 +47,7 @@ export function HogFunctionConfiguration({ templateId, id }: { templateId?: stri
         loaded,
         hogFunction,
         willReEnableOnSave,
-        willEnableOnSave,
+        willChangeEnabledOnSave,
         globalsWithInputs,
         showPaygate,
         hasAddon,
@@ -120,7 +120,11 @@ export function HogFunctionConfiguration({ templateId, id }: { templateId?: stri
                 loading={isConfigurationSubmitting}
             >
                 {templateId ? 'Create' : 'Save'}
-                {willReEnableOnSave ? ' & re-enable' : willEnableOnSave ? ' & enable' : ''}
+                {willReEnableOnSave
+                    ? ' & re-enable'
+                    : willChangeEnabledOnSave
+                    ? ` & ${configuration.enabled ? 'enable' : 'disable'}`
+                    : ''}
             </LemonButton>
         </>
     )

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
@@ -47,6 +47,7 @@ export function HogFunctionConfiguration({ templateId, id }: { templateId?: stri
         loaded,
         hogFunction,
         willReEnableOnSave,
+        willEnableOnSave,
         globalsWithInputs,
         showPaygate,
         hasAddon,
@@ -118,7 +119,8 @@ export function HogFunctionConfiguration({ templateId, id }: { templateId?: stri
                 onClick={submitConfiguration}
                 loading={isConfigurationSubmitting}
             >
-                {templateId ? 'Create' : willReEnableOnSave ? 'Save & re-enable' : 'Save'}
+                {templateId ? 'Create' : 'Save'}
+                {willReEnableOnSave ? ' & re-enable' : willEnableOnSave ? ' & enable' : ''}
             </LemonButton>
         </>
     )

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.test.ts
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.test.ts
@@ -184,7 +184,7 @@ describe('hogFunctionConfigurationLogic', () => {
                         },
                     },
                 },
-                enabled: false,
+                enabled: true,
             })
         })
 

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -124,7 +124,7 @@ const templateToConfiguration = (
         hog: template.hog,
         icon_url: template.icon_url,
         inputs,
-        enabled: false,
+        enabled: true,
     }
 }
 
@@ -453,6 +453,13 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             (s) => [s.configuration, s.hogFunction],
             (configuration, hogFunction) => {
                 return configuration?.enabled && (hogFunction?.status?.state ?? 0) >= 3
+            },
+        ],
+
+        willEnableOnSave: [
+            (s) => [s.configuration, s.hogFunction],
+            (configuration, hogFunction) => {
+                return configuration?.enabled && (!hogFunction || !hogFunction.enabled)
             },
         ],
         exampleInvocationGlobals: [

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -456,10 +456,10 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             },
         ],
 
-        willEnableOnSave: [
+        willChangeEnabledOnSave: [
             (s) => [s.configuration, s.hogFunction],
             (configuration, hogFunction) => {
-                return configuration?.enabled && (!hogFunction || !hogFunction.enabled)
+                return configuration?.enabled !== (hogFunction?.enabled ?? false)
             },
         ],
         exampleInvocationGlobals: [


### PR DESCRIPTION
## Problem

I always miss that it is not enabled by default but also wan't to be reminded that creating will enable it.


## Changes

![2024-09-20 14 05 34](https://github.com/user-attachments/assets/55f3ef92-26e7-4287-8602-92c488f487e0)

* Default to enabled for a new function
* Indicate this in the save button if the enabled state is changing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
