### PR TITLE
feat(cdp): Persist to state instead of url 

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
@@ -102,16 +102,22 @@ export function HogFunctionConfiguration({ templateId, id }: { templateId?: stri
 
     const saveButtons = (
         <>
-            <LemonButton
-                type="secondary"
-                htmlType="reset"
-                onClick={() => resetForm()}
-                disabledReason={
-                    !configurationChanged ? 'No changes' : isConfigurationSubmitting ? 'Saving in progress…' : undefined
-                }
-            >
-                Clear changes
-            </LemonButton>
+            {configurationChanged ? (
+                <LemonButton
+                    type="secondary"
+                    htmlType="reset"
+                    onClick={() => resetForm()}
+                    disabledReason={
+                        !configurationChanged
+                            ? 'No changes'
+                            : isConfigurationSubmitting
+                            ? 'Saving in progress…'
+                            : undefined
+                    }
+                >
+                    Clear changes
+                </LemonButton>
+            ) : null}
             <LemonButton
                 type="primary"
                 htmlType="submit"

--- a/frontend/src/scenes/pipeline/hogfunctions/integrations/HogFunctionInputIntegration.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/integrations/HogFunctionInputIntegration.tsx
@@ -10,13 +10,13 @@ export type HogFunctionInputIntegrationProps = IntegrationConfigureProps & {
 }
 
 export function HogFunctionInputIntegration({ schema, ...props }: HogFunctionInputIntegrationProps): JSX.Element {
-    const { disableBeforeUnload } = useActions(hogFunctionConfigurationLogic)
+    const { persistForUnload } = useActions(hogFunctionConfigurationLogic)
     return (
         <IntegrationChoice
             {...props}
             integration={schema.integration}
             redirectUrl={`${window.location.pathname}?integration_target=${schema.key}`}
-            beforeRedirect={() => disableBeforeUnload()}
+            beforeRedirect={() => persistForUnload()}
         />
     )
 }

--- a/frontend/src/scenes/pipeline/hogfunctions/integrations/HogFunctionInputIntegration.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/integrations/HogFunctionInputIntegration.tsx
@@ -1,5 +1,8 @@
+import { useActions } from 'kea'
+
 import { HogFunctionInputSchemaType } from '~/types'
 
+import { hogFunctionConfigurationLogic } from '../hogFunctionConfigurationLogic'
 import { IntegrationChoice, IntegrationConfigureProps } from './IntegrationChoice'
 
 export type HogFunctionInputIntegrationProps = IntegrationConfigureProps & {
@@ -7,11 +10,13 @@ export type HogFunctionInputIntegrationProps = IntegrationConfigureProps & {
 }
 
 export function HogFunctionInputIntegration({ schema, ...props }: HogFunctionInputIntegrationProps): JSX.Element {
+    const { disableBeforeUnload } = useActions(hogFunctionConfigurationLogic)
     return (
         <IntegrationChoice
             {...props}
             integration={schema.integration}
             redirectUrl={`${window.location.pathname}?integration_target=${schema.key}`}
+            beforeRedirect={() => disableBeforeUnload()}
         />
     )
 }

--- a/frontend/src/scenes/pipeline/hogfunctions/integrations/IntegrationChoice.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/integrations/IntegrationChoice.tsx
@@ -12,6 +12,7 @@ export type IntegrationConfigureProps = {
     onChange?: (value: number | null) => void
     redirectUrl?: string
     integration?: string
+    beforeRedirect?: () => void
 }
 
 export function IntegrationChoice({
@@ -19,6 +20,7 @@ export function IntegrationChoice({
     value,
     integration,
     redirectUrl,
+    beforeRedirect,
 }: IntegrationConfigureProps): JSX.Element | null {
     const { integrationsLoading, integrations } = useValues(integrationsLogic)
     const { newGoogleCloudKey } = useActions(integrationsLogic)
@@ -87,6 +89,7 @@ export function IntegrationChoice({
                                       next: redirectUrl,
                                   }),
                                   disableClientSideRouting: true,
+                                  onClick: beforeRedirect,
                                   label: integrationsOfKind?.length
                                       ? `Connect to a different ${kind} integration`
                                       : `Connect to ${kind}`,


### PR DESCRIPTION
## Problem

The state of the configured hog function was put in the url for new functions but this had a few issues:
1. Redirecting to an integration slack loses the url so the state is gone
2. It only worked for new functions
3. It made doing beforeUnload logic super hard

## Changes

- [x] Moves to using a separate persisted reducer for the state with a timeout to ensure we don't keep it around way too long
- [x] Adds the beforeUnload logic

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
