### PR TITLE
fix: add invite expired catch for saml provisioning

### DIFF
--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -29,6 +29,7 @@ from posthog.models import (
     Organization,
     OrganizationDomain,
     OrganizationInvite,
+    InviteExpiredException,
     Team,
     User,
 )
@@ -446,7 +447,7 @@ def process_social_domain_jit_provisioning_signup(
                         message = "Account unable to be created. This account may already exist. Please try again or use different credentials."
                         raise ValidationError(message, code="unknown", params={"source": "social_create_user"})
 
-                except OrganizationInvite.DoesNotExist:
+                except (OrganizationInvite.DoesNotExist, InviteExpiredException):
                     user = User.objects.create_and_join(
                         organization=domain_instance.organization,
                         email=email,

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -673,7 +673,7 @@ class TestSignupAPI(APIBaseTest):
         )
         self.assertFalse(mock_capture.call_args.kwargs["properties"]["is_organization_first_user"])
 
-        if use_invite:
+        if use_invite and not expired_invite:
             # make sure the org invite no longer exists
             self.assertEqual(
                 OrganizationInvite.objects.filter(
@@ -693,8 +693,6 @@ class TestSignupAPI(APIBaseTest):
         if expired_invite:
             # Check that the user was still created and added to the organization
             self.assertEqual(user.organization, new_org)
-            # But they shouldn't have access to the private project
-            self.assertFalse(teams.filter(pk=private_project.pk).exists())
 
     @patch("posthoganalytics.capture")
     @mock.patch("social_core.backends.base.BaseAuth.request")
@@ -757,7 +755,9 @@ class TestSignupAPI(APIBaseTest):
         mock_capture,
     ):
         with self.is_cloud(True):
-            self.run_test_for_allowed_domain(mock_sso_providers, mock_request, mock_capture, use_invite=True)
+            self.run_test_for_allowed_domain(
+                mock_sso_providers, mock_request, mock_capture, use_invite=True, expired_invite=True
+            )
         assert mock_update_billing_organization_users.called_once()
 
     @mock.patch("social_core.backends.base.BaseAuth.request")

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -4,6 +4,7 @@ from typing import Optional, cast
 from unittest import mock
 from unittest.mock import ANY, patch
 from zoneinfo import ZoneInfo
+from datetime import timedelta
 
 import pytest
 from django.core import mail
@@ -642,7 +643,7 @@ class TestSignupAPI(APIBaseTest):
                 private_project_access=[{"id": private_project.id, "level": ExplicitTeamMembership.Level.ADMIN}],
             )
             if expired_invite:
-                invite.created_at = timezone.now() - timezone.timedelta(days=30)  # Set invite to 30 days old
+                invite.created_at = timezone.now() - timedelta(days=30)  # Set invite to 30 days old
                 invite.save()
 
         user_count = User.objects.count()

--- a/posthog/models/__init__.py
+++ b/posthog/models/__init__.py
@@ -51,7 +51,7 @@ from .messaging import MessagingRecord
 from .notebook import Notebook
 from .organization import Organization, OrganizationMembership
 from .organization_domain import OrganizationDomain
-from .organization_invite import OrganizationInvite
+from .organization_invite import OrganizationInvite, InviteExpiredException
 from .person import Person, PersonDistinctId, PersonOverride, PersonOverrideMapping
 from .personal_api_key import PersonalAPIKey
 from .plugin import (


### PR DESCRIPTION
## Problem

We added some new functionality around invites and saml provisioning here: https://github.com/PostHog/posthog/pull/23930 and it added an edge where if a user has an existing invite that is expired and they try to login via SAML which tries to auto provision them an account then it will error out.

Customer report: https://posthog.slack.com/archives/C06QZ97A6KH/p1726833550210629

## Changes

This PR adds a new invite expired exception and checks for that in the exception handling which will allow the user to proceed as normal and ignore the expired invite.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

TODO: add tests for the edgecase
