### PR TITLE
fix(cdp): Add event id to logs

### DIFF
--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -35,11 +35,6 @@ const hogFunctionFilterDuration = new Histogram({
     buckets: [0, 10, 20, 50, 100, 200],
 })
 
-const hogFunctionFilterErrors = new Counter({
-    name: 'cdp_hog_function_filter_errors',
-    help: 'Errors encountered while filtering functions',
-})
-
 export function execHog(bytecode: any, options?: ExecOptions): ExecResult {
     return exec(bytecode, {
         timeout: DEFAULT_TIMEOUT_MS,
@@ -122,7 +117,6 @@ export class HogExecutor {
                         hogFunctionName: hogFunction.name,
                         error: error.message,
                     })
-                    hogFunctionFilterErrors.inc()
                     erroredFunctions.push(hogFunction)
                     return
                 } finally {
@@ -135,6 +129,7 @@ export class HogExecutor {
                             hogFunctionName: hogFunction.name,
                             teamId: hogFunction.team_id,
                             duration,
+                            eventId: event.event.uuid,
                         })
                     }
                 }


### PR DESCRIPTION
## Problem


## Changes

* Adds event uuid to slow filter logs to aid debugging
* Removes duplicate counter

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
