### PR TITLE
fix: Move all spread pushes to safer concats or manual pushes

### DIFF
--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -115,7 +115,7 @@ export class CdpApi {
             await this.hogFunctionManager.enrichWithIntegrations([compoundConfiguration])
 
             let lastResponse: HogFunctionInvocationResult | null = null
-            const logs: LogEntry[] = []
+            let logs: LogEntry[] = []
 
             let count = 0
 
@@ -177,7 +177,7 @@ export class CdpApi {
                     response = this.hogExecutor.execute(invocation)
                 }
 
-                logs.push(...response.logs)
+                logs = logs.concat(response.logs)
                 lastResponse = response
             }
 

--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -227,7 +227,7 @@ export class HogExecutor {
                     status,
                     body: response?.body,
                 })
-                invocation.timings.push(...timings)
+                invocation.timings = invocation.timings.concat(timings)
                 result.logs = [...logs, ...result.logs]
             }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/console-logs-ingester.ts
@@ -51,7 +51,9 @@ export class ConsoleLogsIngester {
         for (const message of messages) {
             const results = await retryOnDependencyUnavailableError(() => this.consume(message))
             if (results) {
-                pendingProduceRequests.push(...results)
+                results.forEach((result) => {
+                    pendingProduceRequests.push(result)
+                })
             }
         }
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
@@ -35,7 +35,9 @@ export class ReplayEventsIngester {
         for (const message of messages) {
             const results = await retryOnDependencyUnavailableError(() => this.consume(message))
             if (results) {
-                pendingProduceRequests.push(...results)
+                results.forEach((result) => {
+                    pendingProduceRequests.push(result)
+                })
             }
         }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -95,7 +95,7 @@ export class EventPipelineRunner {
         )
 
         if (heatmapKafkaAcks.length > 0) {
-            kafkaAcks.push(...heatmapKafkaAcks)
+            heatmapKafkaAcks.forEach((ack) => kafkaAcks.push(ack))
         }
 
         return this.registerLastStep('extractHeatmapDataStep', [preparedEventWithoutHeatmaps], kafkaAcks)
@@ -248,7 +248,7 @@ export class EventPipelineRunner {
         )
 
         if (heatmapKafkaAcks.length > 0) {
-            kafkaAcks.push(...heatmapKafkaAcks)
+            heatmapKafkaAcks.forEach((ack) => kafkaAcks.push(ack))
         }
 
         const enrichedIfErrorEvent = await this.runStep(


### PR DESCRIPTION
## Problem

We found out that `.push(...arr)` can cause stack overflows and fixed it in a couple of places but not all

## Changes

* Found all cases in the plugin server and moved to an alternative.
* Need to find a linting rule way for this @pauldambra maybe you know how?

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
