### PR TITLE
fix: Added rewrite rule for activity log

### DIFF
--- a/posthog/api/activity_log.py
+++ b/posthog/api/activity_log.py
@@ -76,6 +76,7 @@ class ActivityLogViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, mixins
     queryset = ActivityLog.objects.all()
     serializer_class = ActivityLogSerializer
     pagination_class = ActivityLogPagination
+    filter_rewrite_rules = {"project_id": "team_id"}
 
     def safely_get_queryset(self, queryset) -> QuerySet:
         params = self.request.GET.dict()


### PR DESCRIPTION
## Problem

Activity log broke due to it not having the proper model relations for teams and orgs.

## Changes

* Fixes it with a rewrite path which is good enough for now
* Adds tests to actually catch this endpoint

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
