### PR TITLE
fix(insights): legacy funnels didn't work with personless events

### DIFF
--- a/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
+++ b/ee/clickhouse/models/test/__snapshots__/test_cohort.ambr
@@ -89,7 +89,7 @@
                        AND event = '$pageview'
                        AND 1=1) > 0 AS performed_event_condition_X_level_level_0_level_0_level_0_0
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -157,7 +157,7 @@
                                    AND event = '$pageview'
                                    AND 1=1) > 0 AS performed_event_condition_X_level_level_0_level_0_level_0_0
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
@@ -205,7 +205,7 @@
                minIf(timestamp, event = 'signup') >= now() - INTERVAL 15 day
         AND minIf(timestamp, event = 'signup') < now() as first_time_condition_X_level_level_0_level_0_0
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -252,7 +252,7 @@
                minIf(timestamp, event = 'signup') >= now() - INTERVAL 15 day
         AND minIf(timestamp, event = 'signup') < now() as first_time_condition_X_level_level_0_level_1_level_0_level_0_level_0_0
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -397,6 +397,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -528,6 +535,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -664,6 +678,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -800,6 +821,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -936,6 +964,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -1363,6 +1398,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -1475,6 +1517,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1589,6 +1637,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1703,6 +1757,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1817,6 +1877,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2241,6 +2307,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -2397,6 +2470,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2456,6 +2536,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2515,6 +2602,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2676,6 +2770,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2735,6 +2836,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2794,6 +2902,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2955,6 +3070,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -3014,6 +3136,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -3073,6 +3202,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -3234,6 +3370,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -3293,6 +3436,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -3352,6 +3502,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -380,8 +380,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -511,8 +511,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -647,8 +647,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -783,8 +783,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -919,8 +919,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -1346,8 +1346,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -1458,8 +1458,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1572,8 +1572,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1686,8 +1686,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1800,8 +1800,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -2224,8 +2224,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -2380,8 +2380,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -2439,8 +2439,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'play movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -2498,8 +2498,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'sign up', 1, 0) as step_1,
@@ -2659,8 +2659,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -2718,8 +2718,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'play movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -2777,8 +2777,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'sign up', 1, 0) as step_1,
@@ -2938,8 +2938,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -2997,8 +2997,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'play movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -3056,8 +3056,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'sign up', 1, 0) as step_1,
@@ -3217,8 +3217,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -3276,8 +3276,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'play movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -3335,8 +3335,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'sign up', 1, 0) as step_1,

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -380,8 +380,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -392,18 +392,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -518,8 +511,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -530,18 +523,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -661,8 +647,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -673,18 +659,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -804,8 +783,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -816,18 +795,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -947,8 +919,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -959,18 +931,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -1381,8 +1346,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -1393,18 +1358,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -1500,8 +1458,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1512,17 +1470,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1620,8 +1572,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1632,17 +1584,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1740,8 +1686,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1752,17 +1698,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1860,8 +1800,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1872,17 +1812,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2290,8 +2224,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -2302,18 +2236,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -2453,8 +2380,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -2465,18 +2392,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2519,8 +2439,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'play movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -2531,18 +2451,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2585,8 +2498,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'sign up', 1, 0) as step_1,
@@ -2597,18 +2510,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2753,8 +2659,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -2765,18 +2671,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2819,8 +2718,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'play movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -2831,18 +2730,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2885,8 +2777,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'sign up', 1, 0) as step_1,
@@ -2897,18 +2789,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -3053,8 +2938,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -3065,18 +2950,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -3119,8 +2997,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'play movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -3131,18 +3009,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -3185,8 +3056,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'sign up', 1, 0) as step_1,
@@ -3197,18 +3068,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -3353,8 +3217,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -3365,18 +3229,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -3419,8 +3276,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'play movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -3431,18 +3288,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -3485,8 +3335,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'sign up', 1, 0) as step_1,
@@ -3497,18 +3347,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -35,8 +35,8 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(((event = 'user signed up'
                                 AND (has(['val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))))) , 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
@@ -131,8 +131,8 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
@@ -220,8 +220,8 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
@@ -305,8 +305,8 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
@@ -390,8 +390,8 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
@@ -475,8 +475,8 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
@@ -560,8 +560,8 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
@@ -649,8 +649,8 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
@@ -734,8 +734,8 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
@@ -819,8 +819,8 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
@@ -904,8 +904,8 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -35,8 +35,8 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(((event = 'user signed up'
                                 AND (has(['val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))))) , 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
@@ -44,18 +44,11 @@
                                 AND (has(['val'], replaceRegexpAll(JSONExtractRaw(properties, 'key'), '^"|"$', ''))))) , 1, 0) as step_1,
                            if(step_1 = 1, timestamp, null) as latest_1
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['paid', 'user signed up', 'user signed up', 'paid']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -138,25 +131,18 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
                            if(step_1 = 1, timestamp, null) as latest_1
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['paid', 'user signed up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -234,25 +220,18 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
                            if(step_1 = 1, timestamp, null) as latest_1
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['paid', 'user signed up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -326,25 +305,18 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
                            if(step_1 = 1, timestamp, null) as latest_1
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['paid', 'user signed up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -418,25 +390,18 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
                            if(step_1 = 1, timestamp, null) as latest_1
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['paid', 'user signed up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -510,25 +475,18 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
                            if(step_1 = 1, timestamp, null) as latest_1
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['paid', 'user signed up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -602,25 +560,18 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
                            if(step_1 = 1, timestamp, null) as latest_1
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['paid', 'user signed up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -698,25 +649,18 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
                            if(step_1 = 1, timestamp, null) as latest_1
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['paid', 'user signed up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -790,25 +734,18 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
                            if(step_1 = 1, timestamp, null) as latest_1
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['paid', 'user signed up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -882,25 +819,18 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
                            if(step_1 = 1, timestamp, null) as latest_1
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['paid', 'user signed up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -974,25 +904,18 @@
                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'paid', 1, 0) as step_1,
                            if(step_1 = 1, timestamp, null) as latest_1
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['paid', 'user signed up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlation.ambr
@@ -49,6 +49,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['paid', 'user signed up', 'user signed up', 'paid']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -143,6 +150,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['paid', 'user signed up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -232,6 +246,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['paid', 'user signed up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -317,6 +338,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['paid', 'user signed up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -402,6 +430,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['paid', 'user signed up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -487,6 +522,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['paid', 'user signed up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -572,6 +614,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['paid', 'user signed up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -661,6 +710,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['paid', 'user signed up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -746,6 +802,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['paid', 'user signed up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -831,6 +894,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['paid', 'user signed up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -916,6 +986,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['paid', 'user signed up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -66,9 +66,9 @@
                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1"
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                            e.uuid AS uuid,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -80,18 +80,11 @@
                            if(step_1 = 1, "$session_id", null) as "$session_id_1",
                            if(step_1 = 1, "$window_id", null) as "$window_id_1"
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['$pageview', 'insight analyzed']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -276,9 +269,9 @@
                                                                                                                                                                                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                                  e.uuid AS uuid,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = '$pageview', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -295,18 +288,11 @@
                                  if(step_2 = 1, "$session_id", null) as "$session_id_2",
                                  if(step_2 = 1, "$window_id", null) as "$window_id_2"
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['$pageview', 'insight analyzed', 'insight updated']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -430,9 +416,9 @@
                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1"
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                            e.uuid AS uuid,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -444,18 +430,11 @@
                            if(step_1 = 1, "$session_id", null) as "$session_id_1",
                            if(step_1 = 1, "$window_id", null) as "$window_id_1"
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['$pageview', 'insight analyzed']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -572,9 +551,9 @@
                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$window_id_1"
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                            e.uuid AS uuid,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -586,17 +565,11 @@
                            if(step_1 = 1, "$session_id", null) as "$session_id_1",
                            if(step_1 = 1, "$window_id", null) as "$window_id_1"
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -711,9 +684,9 @@
                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$window_id_1"
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                            e.uuid AS uuid,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -725,17 +698,11 @@
                            if(step_1 = 1, "$session_id", null) as "$session_id_1",
                            if(step_1 = 1, "$window_id", null) as "$window_id_1"
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -85,6 +85,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['$pageview', 'insight analyzed']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -293,6 +300,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['$pageview', 'insight analyzed', 'insight updated']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -435,6 +449,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['$pageview', 'insight analyzed']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -570,6 +591,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -703,6 +730,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN

--- a/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
+++ b/ee/clickhouse/queries/funnels/test/__snapshots__/test_funnel_correlations_persons.ambr
@@ -66,9 +66,9 @@
                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1"
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                            e.uuid AS uuid,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -269,9 +269,9 @@
                                                                                                                                                                                                                                                                                           ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                                  e.uuid AS uuid,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = '$pageview', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -416,9 +416,9 @@
                                                                                                                                                                       ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_1"
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                            e.uuid AS uuid,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -551,9 +551,9 @@
                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$window_id_1"
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                            e.uuid AS uuid,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -684,9 +684,9 @@
                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING) "$window_id_1"
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                            e.uuid AS uuid,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(step_0 = 1, "uuid", null) as "uuid_0",

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -73,7 +73,7 @@
                                                                   min(event_1_latest_1) over (PARTITION by person_id
                                                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_1_latest_1
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                   event,
                   properties,
                   distinct_id, timestamp, if(event = '$pageview'
@@ -221,7 +221,7 @@
                                        min(event_0_latest_1) over (PARTITION by person_id
                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                   event,
                   properties,
                   distinct_id, timestamp, if(event = '$pageview'
@@ -269,7 +269,7 @@
                                        min(event_0_latest_1) over (PARTITION by person_id
                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                   event,
                   properties,
                   distinct_id, timestamp, if(event = '$pageview'
@@ -318,7 +318,7 @@
                                        min(event_0_latest_1) over (PARTITION by person_id
                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                   event,
                   properties,
                   distinct_id, timestamp, if(event = '$pageview'

--- a/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_cohort_query.ambr
@@ -18,7 +18,7 @@
      AND minIf(timestamp, ((replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') = 'https://posthog.com/feedback/123'
                             AND event = '$autocapture'))) < now() as first_time_condition_None_level_level_0_level_1_level_0_0
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
@@ -73,7 +73,7 @@
                                                                   min(event_1_latest_1) over (PARTITION by person_id
                                                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_1_latest_1
         FROM
-          (SELECT pdi.person_id AS person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                   event,
                   properties,
                   distinct_id, timestamp, if(event = '$pageview'
@@ -89,7 +89,7 @@
                                              AND timestamp > now() - INTERVAL 8 day, 1, 0) AS event_1_step_1,
                                           if(event_1_step_1 = 1, timestamp, null) AS event_1_latest_1
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -133,7 +133,7 @@
                     AND event = '$pageview'
                     AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_0_0
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
@@ -176,7 +176,7 @@
                     AND event = '$pageview'
                     AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_1_level_0_0
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
@@ -221,7 +221,7 @@
                                        min(event_0_latest_1) over (PARTITION by person_id
                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1
         FROM
-          (SELECT pdi.person_id AS person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                   event,
                   properties,
                   distinct_id, timestamp, if(event = '$pageview'
@@ -231,7 +231,7 @@
                                              AND timestamp > now() - INTERVAL 7 day, 1, 0) AS event_0_step_1,
                                           if(event_0_step_1 = 1, timestamp, null) AS event_0_latest_1
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -269,7 +269,7 @@
                                        min(event_0_latest_1) over (PARTITION by person_id
                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1
         FROM
-          (SELECT pdi.person_id AS person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                   event,
                   properties,
                   distinct_id, timestamp, if(event = '$pageview'
@@ -279,7 +279,7 @@
                                              AND timestamp > now() - INTERVAL 7 day, 1, 0) AS event_0_step_1,
                                           if(event_0_step_1 = 1, timestamp, null) AS event_0_latest_1
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -318,7 +318,7 @@
                                        min(event_0_latest_1) over (PARTITION by person_id
                                                                    ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) event_0_latest_1
         FROM
-          (SELECT pdi.person_id AS person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                   event,
                   properties,
                   distinct_id, timestamp, if(event = '$pageview'
@@ -328,7 +328,7 @@
                                              AND timestamp > now() - INTERVAL 7 day, 1, 0) AS event_0_step_1,
                                           if(event_0_step_1 = 1, timestamp, null) AS event_0_latest_1
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -372,7 +372,7 @@
                     AND event = '$pageview'
                     AND (has(['something'], replaceRegexpAll(JSONExtractRaw(properties, '$filter_prop'), '^"|"$', '')))) > 0 AS performed_event_condition_None_level_level_0_level_0_0
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
@@ -400,7 +400,7 @@
                     AND event = '$pageview'
                     AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_0_0
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
@@ -439,7 +439,7 @@
                     AND event = '$pageview'
                     AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_0_0
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
@@ -486,7 +486,7 @@
      AND minIf(timestamp, ((replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', '') = 'https://posthog.com/feedback/123'
                             AND event = '$autocapture'))) < now() as first_time_condition_None_level_level_0_level_1_level_0_0
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
@@ -631,7 +631,7 @@
                     AND event = '$pageview'
                     AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_1_0
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
@@ -673,7 +673,7 @@
                     AND event = '$pageview'
                     AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_1_level_0_0
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
@@ -728,7 +728,7 @@
                     AND event = '$pageview'
                     AND 1=1) > 0 AS performed_event_condition_None_level_level_0_level_1_0
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -22,20 +22,13 @@
 # name: TestEventQuery.test_account_filters.2
   '''
   SELECT e.timestamp as timestamp,
-         pdi.person_id as person_id
+         if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id
   FROM events e
-  INNER JOIN
+  LEFT OUTER JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
-       AND distinct_id IN
-         (SELECT distinct_id
-          FROM events
-          WHERE team_id = 2
-            AND event = 'event_name'
-            AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-01-14 00:00:00', 'UTC')), 'UTC')
-            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-21 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
@@ -69,20 +62,13 @@
 # name: TestEventQuery.test_cohort_filter
   '''
   SELECT e.timestamp as timestamp,
-         pdi.person_id as person_id
+         if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id
   FROM events e
-  INNER JOIN
+  LEFT OUTER JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
-       AND distinct_id IN
-         (SELECT distinct_id
-          FROM events
-          WHERE team_id = 2
-            AND event = 'viewed'
-            AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
-            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
@@ -95,7 +81,7 @@
     AND event = 'viewed'
     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-    AND (pdi.person_id IN
+    AND (if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) IN
            (SELECT id
             FROM person
             WHERE team_id = 2
@@ -147,20 +133,13 @@
 # name: TestEventQuery.test_entity_filtered_by_cohort
   '''
   SELECT e.timestamp as timestamp,
-         pdi.person_id as person_id
+         if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id
   FROM events e
-  INNER JOIN
+  LEFT OUTER JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
-       AND distinct_id IN
-         (SELECT distinct_id
-          FROM events
-          WHERE team_id = 2
-            AND event = '$pageview'
-            AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
-            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
@@ -173,7 +152,7 @@
     AND event = '$pageview'
     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-    AND (pdi.person_id IN
+    AND (if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) IN
            (SELECT id
             FROM person
             WHERE team_id = 2
@@ -284,20 +263,13 @@
 # name: TestEventQuery.test_groups_filters_mixed
   '''
   SELECT e.timestamp as timestamp,
-         pdi.person_id as person_id
+         if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id
   FROM events e
-  INNER JOIN
+  LEFT OUTER JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
-       AND distinct_id IN
-         (SELECT distinct_id
-          FROM events
-          WHERE team_id = 2
-            AND event = '$pageview'
-            AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
@@ -329,20 +301,13 @@
 # name: TestEventQuery.test_static_cohort_filter
   '''
   SELECT e.timestamp as timestamp,
-         pdi.person_id as person_id
+         if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id
   FROM events e
-  INNER JOIN
+  LEFT OUTER JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
-       AND distinct_id IN
-         (SELECT distinct_id
-          FROM events
-          WHERE team_id = 2
-            AND event = 'viewed'
-            AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
-            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
@@ -355,7 +320,7 @@
     AND event = 'viewed'
     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-    AND (pdi.person_id IN
+    AND (if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) IN
            (SELECT person_id as id
             FROM person_static_cohort
             WHERE cohort_id = 2

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -29,6 +29,13 @@
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
+       AND distinct_id IN
+         (SELECT distinct_id
+          FROM events
+          WHERE team_id = 2
+            AND event = 'event_name'
+            AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-01-14 00:00:00', 'UTC')), 'UTC')
+            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-21 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
@@ -69,6 +76,13 @@
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
+       AND distinct_id IN
+         (SELECT distinct_id
+          FROM events
+          WHERE team_id = 2
+            AND event = 'viewed'
+            AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
+            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
@@ -140,6 +154,13 @@
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
+       AND distinct_id IN
+         (SELECT distinct_id
+          FROM events
+          WHERE team_id = 2
+            AND event = '$pageview'
+            AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
+            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
@@ -270,6 +291,13 @@
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
+       AND distinct_id IN
+         (SELECT distinct_id
+          FROM events
+          WHERE team_id = 2
+            AND event = '$pageview'
+            AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN
@@ -308,6 +336,13 @@
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
+       AND distinct_id IN
+         (SELECT distinct_id
+          FROM events
+          WHERE team_id = 2
+            AND event = 'viewed'
+            AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
+            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   INNER JOIN

--- a/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_event_query.ambr
@@ -22,7 +22,7 @@
 # name: TestEventQuery.test_account_filters.2
   '''
   SELECT e.timestamp as timestamp,
-         if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id
+         if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id
   FROM events e
   LEFT OUTER JOIN
     (SELECT distinct_id,
@@ -62,7 +62,7 @@
 # name: TestEventQuery.test_cohort_filter
   '''
   SELECT e.timestamp as timestamp,
-         if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id
+         if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id
   FROM events e
   LEFT OUTER JOIN
     (SELECT distinct_id,
@@ -81,7 +81,7 @@
     AND event = 'viewed'
     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-    AND (if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) IN
+    AND (if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) IN
            (SELECT id
             FROM person
             WHERE team_id = 2
@@ -133,7 +133,7 @@
 # name: TestEventQuery.test_entity_filtered_by_cohort
   '''
   SELECT e.timestamp as timestamp,
-         if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id
+         if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id
   FROM events e
   LEFT OUTER JOIN
     (SELECT distinct_id,
@@ -152,7 +152,7 @@
     AND event = '$pageview'
     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-    AND (if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) IN
+    AND (if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) IN
            (SELECT id
             FROM person
             WHERE team_id = 2
@@ -263,7 +263,7 @@
 # name: TestEventQuery.test_groups_filters_mixed
   '''
   SELECT e.timestamp as timestamp,
-         if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id
+         if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id
   FROM events e
   LEFT OUTER JOIN
     (SELECT distinct_id,
@@ -301,7 +301,7 @@
 # name: TestEventQuery.test_static_cohort_filter
   '''
   SELECT e.timestamp as timestamp,
-         if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id
+         if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id
   FROM events e
   LEFT OUTER JOIN
     (SELECT distinct_id,
@@ -320,7 +320,7 @@
     AND event = 'viewed'
     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-    AND (if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) IN
+    AND (if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) IN
            (SELECT person_id as id
             FROM person_static_cohort
             WHERE cohort_id = 2

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -28,7 +28,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT pdi.person_id as person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -43,7 +43,7 @@
                   period_status_pairs.2 as status,
                   toDateTime(min(person.created_at), 'UTC') AS created_at
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -61,7 +61,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))) + INTERVAL 1 day
-           GROUP BY pdi.person_id)
+           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))
@@ -101,7 +101,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT pdi.person_id as person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('month', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('month', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('month', toDateTime('1970-01-01')))) as following_activity,
@@ -116,7 +116,7 @@
                   period_status_pairs.2 as status,
                   toDateTime(min(person.created_at), 'UTC') AS created_at
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -134,7 +134,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('month', toDateTime('2021-02-04 00:00:00', 'UTC'))) - INTERVAL 1 month
              AND timestamp < toDateTime(dateTrunc('month', toDateTime('2021-05-05 23:59:59', 'UTC'))) + INTERVAL 1 month
-           GROUP BY pdi.person_id)
+           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('month', toDateTime('2021-05-05 23:59:59', 'UTC'))
@@ -174,7 +174,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT pdi.person_id as person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('week', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('week', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('week', toDateTime('1970-01-01')))) as following_activity,
@@ -189,7 +189,7 @@
                   period_status_pairs.2 as status,
                   toDateTime(min(person.created_at), 'UTC') AS created_at
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -207,7 +207,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('week', toDateTime('2021-04-06 00:00:00', 'UTC'))) - INTERVAL 1 week
              AND timestamp < toDateTime(dateTrunc('week', toDateTime('2021-05-06 23:59:59', 'UTC'))) + INTERVAL 1 week
-           GROUP BY pdi.person_id)
+           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('week', toDateTime('2021-05-06 23:59:59', 'UTC'))
@@ -247,7 +247,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT pdi.person_id as person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -262,7 +262,7 @@
                   period_status_pairs.2 as status,
                   toDateTime(min(person.created_at), 'UTC') AS created_at
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -280,7 +280,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-11 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2020-01-18 23:59:59', 'UTC'))) + INTERVAL 1 day
-           GROUP BY pdi.person_id)
+           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2020-01-18 23:59:59', 'UTC'))
@@ -320,7 +320,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT pdi.person_id as person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -335,7 +335,7 @@
                   period_status_pairs.2 as status,
                   toDateTime(min(person.created_at), 'UTC') AS created_at
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -354,7 +354,7 @@
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))) + INTERVAL 1 day
              AND (and(ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%example%'), 0), 1))
-           GROUP BY pdi.person_id)
+           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))
@@ -394,7 +394,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT pdi.person_id as person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -409,7 +409,7 @@
                   period_status_pairs.2 as status,
                   toDateTime(min(person.created_at), 'UTC') AS created_at
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -428,7 +428,7 @@
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))) + INTERVAL 1 day
              AND (and(ifNull(like(nullIf(nullIf(events.`mat_$current_url`, ''), 'null'), '%example%'), 0), 1))
-           GROUP BY pdi.person_id)
+           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))
@@ -468,7 +468,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT pdi.person_id as person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -483,7 +483,7 @@
                   period_status_pairs.2 as status,
                   toDateTime(min(person.created_at), 'UTC') AS created_at
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -503,7 +503,7 @@
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))) + INTERVAL 1 day
              AND (ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), '%test.com'), 0))
-           GROUP BY pdi.person_id)
+           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))
@@ -543,7 +543,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT pdi.person_id as person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -558,7 +558,7 @@
                   period_status_pairs.2 as status,
                   toDateTime(min(person.created_at), 'UTC') AS created_at
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -578,7 +578,7 @@
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))) + INTERVAL 1 day
              AND (ifNull(like(nullIf(nullIf(pmat_email, ''), 'null'), '%test.com'), 0))
-           GROUP BY pdi.person_id)
+           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))
@@ -618,7 +618,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT pdi.person_id as person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -633,7 +633,7 @@
                   period_status_pairs.2 as status,
                   toDateTime(min(person.created_at), 'UTC') AS created_at
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -659,7 +659,7 @@
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-12 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'UTC'))) + INTERVAL 1 day
              AND (has(['value'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'key'), '^"|"$', '')))
-           GROUP BY pdi.person_id)
+           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'UTC'))

--- a/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_lifecycle.ambr
@@ -28,7 +28,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -61,7 +61,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))) + INTERVAL 1 day
-           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
+           GROUP BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))
@@ -101,7 +101,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('month', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('month', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('month', toDateTime('1970-01-01')))) as following_activity,
@@ -134,7 +134,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('month', toDateTime('2021-02-04 00:00:00', 'UTC'))) - INTERVAL 1 month
              AND timestamp < toDateTime(dateTrunc('month', toDateTime('2021-05-05 23:59:59', 'UTC'))) + INTERVAL 1 month
-           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
+           GROUP BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('month', toDateTime('2021-05-05 23:59:59', 'UTC'))
@@ -174,7 +174,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('week', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('week', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('week', toDateTime('1970-01-01')))) as following_activity,
@@ -207,7 +207,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('week', toDateTime('2021-04-06 00:00:00', 'UTC'))) - INTERVAL 1 week
              AND timestamp < toDateTime(dateTrunc('week', toDateTime('2021-05-06 23:59:59', 'UTC'))) + INTERVAL 1 week
-           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
+           GROUP BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('week', toDateTime('2021-05-06 23:59:59', 'UTC'))
@@ -247,7 +247,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -280,7 +280,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-11 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2020-01-18 23:59:59', 'UTC'))) + INTERVAL 1 day
-           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
+           GROUP BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2020-01-18 23:59:59', 'UTC'))
@@ -320,7 +320,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -354,7 +354,7 @@
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))) + INTERVAL 1 day
              AND (and(ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), '%example%'), 0), 1))
-           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
+           GROUP BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))
@@ -394,7 +394,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -428,7 +428,7 @@
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))) + INTERVAL 1 day
              AND (and(ifNull(like(nullIf(nullIf(events.`mat_$current_url`, ''), 'null'), '%example%'), 0), 1))
-           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
+           GROUP BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))
@@ -468,7 +468,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -503,7 +503,7 @@
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))) + INTERVAL 1 day
              AND (ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'email'), ''), 'null'), '^"|"$', ''), '%test.com'), 0))
-           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
+           GROUP BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))
@@ -543,7 +543,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -578,7 +578,7 @@
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2021-04-28 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))) + INTERVAL 1 day
              AND (ifNull(like(nullIf(nullIf(pmat_email, ''), 'null'), '%test.com'), 0))
-           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
+           GROUP BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2021-05-05 23:59:59', 'UTC'))
@@ -618,7 +618,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -659,7 +659,7 @@
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-12 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'UTC'))) + INTERVAL 1 day
              AND (has(['value'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'key'), '^"|"$', '')))
-           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
+           GROUP BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'UTC'))

--- a/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
@@ -144,6 +144,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -309,6 +315,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -472,6 +484,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -635,6 +653,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -798,6 +822,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -964,6 +994,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  LEFT JOIN
@@ -1137,6 +1173,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  LEFT JOIN
@@ -1308,6 +1350,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  LEFT JOIN
@@ -1479,6 +1527,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  LEFT JOIN
@@ -1650,6 +1704,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  LEFT JOIN
@@ -1824,6 +1884,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -1992,6 +2058,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -2160,6 +2232,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -2328,6 +2406,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -2497,6 +2581,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -2664,6 +2754,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -2829,6 +2925,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -2994,6 +3096,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -3159,6 +3267,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -3324,6 +3438,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
@@ -3403,6 +3523,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -3482,6 +3608,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -3561,6 +3693,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -3640,6 +3778,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -3719,6 +3863,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -3799,6 +3950,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -3879,6 +4037,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -3958,6 +4123,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$screen')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -4037,6 +4209,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (NOT event LIKE '$%')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -4116,6 +4295,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event IN ['/custom1', '/custom2'])
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -4195,6 +4381,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event IN ['/custom3', 'blah'])
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -4274,6 +4467,15 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview'
+                                OR event = '$screen'
+                                OR NOT event LIKE '$%')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -4355,6 +4557,15 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview'
+                                OR event = '$screen'
+                                OR NOT event LIKE '$%')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -4437,6 +4648,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (NOT event LIKE '$%')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-03 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -4766,6 +4984,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -4843,6 +5068,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (NOT event LIKE '$%')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -4917,6 +5149,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (NOT event LIKE '$%')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -4990,6 +5229,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (NOT event LIKE '$%')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -5063,6 +5309,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (NOT event LIKE '$%')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -5137,6 +5390,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (NOT event LIKE '$%')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -5210,6 +5470,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (NOT event LIKE '$%')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -5283,6 +5550,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (NOT event LIKE '$%')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -5357,6 +5631,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (NOT event LIKE '$%')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -5430,6 +5711,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (NOT event LIKE '$%')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -5629,6 +5917,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -5749,6 +6044,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -5870,6 +6172,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -5991,6 +6300,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -6118,6 +6434,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -6208,6 +6531,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -6289,6 +6618,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -6368,6 +6703,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -6449,6 +6790,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -6528,6 +6875,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -6609,6 +6962,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -6688,6 +7047,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -6769,6 +7134,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -6848,6 +7219,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -6926,6 +7303,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -7005,6 +7388,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -7084,6 +7474,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -7159,6 +7555,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -7232,6 +7634,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -7308,6 +7716,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -7383,6 +7797,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -7459,6 +7879,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -7534,6 +7960,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -7607,6 +8039,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -7680,6 +8118,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -7758,6 +8202,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -7839,6 +8290,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -7920,6 +8378,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -7999,6 +8464,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -8079,6 +8551,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -8158,6 +8637,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -8236,6 +8721,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -8315,6 +8807,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -8394,6 +8892,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -8473,6 +8977,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -8553,6 +9063,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND (event = '$pageview')
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -8632,6 +9149,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2

--- a/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
@@ -59,8 +59,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -68,18 +68,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -140,31 +133,25 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= target_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -240,8 +227,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -249,18 +236,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -318,31 +298,25 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= target_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -416,8 +390,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -425,18 +399,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -494,31 +461,25 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= target_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -592,8 +553,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -601,18 +562,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -670,31 +624,25 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= target_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -768,8 +716,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -777,18 +725,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -846,31 +787,25 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= target_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -944,8 +879,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -953,18 +888,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -1025,23 +953,17 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  LEFT JOIN
@@ -1051,13 +973,13 @@
                     WHERE team_id = 2
                       AND group_type_index = 0
                     GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -1133,8 +1055,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -1142,18 +1064,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -1211,23 +1126,17 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  LEFT JOIN
@@ -1237,13 +1146,13 @@
                     WHERE team_id = 2
                       AND group_type_index = 0
                     GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -1317,8 +1226,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -1326,18 +1235,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -1395,23 +1297,17 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  LEFT JOIN
@@ -1421,13 +1317,13 @@
                     WHERE team_id = 2
                       AND group_type_index = 0
                     GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -1501,8 +1397,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -1510,18 +1406,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -1579,23 +1468,17 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  LEFT JOIN
@@ -1605,13 +1488,13 @@
                     WHERE team_id = 2
                       AND group_type_index = 0
                     GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -1685,8 +1568,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -1694,18 +1577,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -1763,23 +1639,17 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  LEFT JOIN
@@ -1789,13 +1659,13 @@
                     WHERE team_id = 2
                       AND group_type_index = 0
                     GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -1869,8 +1739,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -1878,18 +1748,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -1950,31 +1813,25 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= target_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -2050,8 +1907,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -2059,18 +1916,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -2131,31 +1981,25 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= target_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -2231,8 +2075,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -2240,18 +2084,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -2312,31 +2149,25 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp <= target_timestamp + INTERVAL 7 DAY
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -2412,8 +2243,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -2421,18 +2252,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -2493,31 +2317,25 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp <= target_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -2593,8 +2411,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -2602,18 +2420,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -2674,33 +2485,27 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.min_timestamp as min_timestamp,
                         funnel_actors.max_timestamp as max_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= min_timestamp
                    AND e.timestamp <= max_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -2776,8 +2581,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -2785,18 +2590,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -2854,33 +2652,27 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.min_timestamp as min_timestamp,
                         funnel_actors.max_timestamp as max_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= min_timestamp
                    AND e.timestamp <= max_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -2954,8 +2746,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -2963,18 +2755,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -3032,33 +2817,27 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.min_timestamp as min_timestamp,
                         funnel_actors.max_timestamp as max_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= min_timestamp
                    AND e.timestamp <= max_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3132,8 +2911,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -3141,18 +2920,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -3210,33 +2982,27 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.min_timestamp as min_timestamp,
                         funnel_actors.max_timestamp as max_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= min_timestamp
                    AND e.timestamp <= max_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3310,8 +3076,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -3319,18 +3085,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -3388,33 +3147,27 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.min_timestamp as min_timestamp,
                         funnel_actors.max_timestamp as max_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= min_timestamp
                    AND e.timestamp <= max_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3488,8 +3241,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -3497,18 +3250,11 @@
                                  if(event = 'step three', 1, 0) as step_2,
                                  if(step_2 = 1, timestamp, null) as latest_2
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['step one', 'step three', 'step two']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -3566,33 +3312,27 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.min_timestamp as min_timestamp,
                         funnel_actors.max_timestamp as max_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = pdi.person_id
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= min_timestamp
                    AND e.timestamp <= max_timestamp
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3653,28 +3393,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3738,28 +3472,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3823,28 +3551,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), nullIf(nullIf(e.`mat_$screen_name`, ''), 'null'), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(nullIf(nullIf(e.`mat_$current_url`, ''), 'null'), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3908,28 +3630,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), nullIf(nullIf(e.`mat_$screen_name`, ''), 'null'), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(nullIf(nullIf(e.`mat_$current_url`, ''), 'null'), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3993,23 +3709,16 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['/bar/.*/foo']) AS group_index,
                         if(group_index > 0, ['/bar/*/foo'][group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -4017,7 +3726,7 @@
                    AND NOT path_item IN ['/bar/*/foo']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4080,23 +3789,16 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['/xxx/invalid/.*']) AS group_index,
                         if(group_index > 0, ['/xxx/invalid/*'][group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -4104,7 +3806,7 @@
                    AND NOT path_item IN ['/bar/*/foo']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4167,30 +3869,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4253,30 +3948,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$screen')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$screen')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4339,30 +4027,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (NOT event LIKE '$%')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4425,30 +4106,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event IN ['/custom1', '/custom2'])
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event IN ['/custom1', '/custom2'])
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4511,30 +4185,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event IN ['/custom3', 'blah'])
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event IN ['/custom3', 'blah'])
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4597,25 +4264,16 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview'
-                                OR event = '$screen'
-                                OR NOT event LIKE '$%')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -4624,7 +4282,7 @@
                         OR NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4687,25 +4345,16 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview'
-                                OR event = '$screen'
-                                OR NOT event LIKE '$%')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -4715,7 +4364,7 @@
                    AND NOT path_item IN ['/custom1', '/1', '/2', '/3']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4778,30 +4427,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (NOT event LIKE '$%')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-03 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-03 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5113,31 +4755,24 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         replaceRegexpAll(path_item_ungrouped, '\\?(.*)', '?<param>') AS path_item_cleaned,
                         multiMatchAnyIndex(path_item_cleaned, ['/step1']) AS group_index,
                         if(group_index > 0, ['/step1'][group_index], path_item_cleaned) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5198,30 +4833,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (NOT event LIKE '$%')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5279,30 +4907,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (NOT event LIKE '$%')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5359,30 +4980,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (NOT event LIKE '$%')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5439,30 +5053,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (NOT event LIKE '$%')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5520,30 +5127,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (NOT event LIKE '$%')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5600,30 +5200,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (NOT event LIKE '$%')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5680,30 +5273,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (NOT event LIKE '$%')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5761,30 +5347,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (NOT event LIKE '$%')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5841,30 +5420,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (NOT event LIKE '$%')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6043,7 +5615,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         e.uuid AS uuid,
                         e.timestamp AS timestamp,
                         e."$session_id" as $session_id,
@@ -6052,25 +5624,18 @@
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6170,7 +5735,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         e.uuid AS uuid,
                         e.timestamp AS timestamp,
                         e."$session_id" as $session_id,
@@ -6179,25 +5744,18 @@
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6298,7 +5856,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         e.uuid AS uuid,
                         e.timestamp AS timestamp,
                         e."$session_id" as $session_id,
@@ -6307,25 +5865,18 @@
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6426,7 +5977,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         e.uuid AS uuid,
                         e.timestamp AS timestamp,
                         e."$session_id" as $session_id,
@@ -6435,25 +5986,18 @@
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6560,7 +6104,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         e.uuid AS uuid,
                         e.timestamp AS timestamp,
                         e."$session_id" as $session_id,
@@ -6569,25 +6113,18 @@
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6661,28 +6198,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6748,28 +6279,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6833,28 +6358,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6920,28 +6439,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7005,28 +6518,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7092,28 +6599,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), nullIf(nullIf(e.`mat_$screen_name`, ''), 'null'), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(nullIf(nullIf(e.`mat_$current_url`, ''), 'null'), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7177,28 +6678,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), nullIf(nullIf(e.`mat_$screen_name`, ''), 'null'), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(nullIf(nullIf(e.`mat_$current_url`, ''), 'null'), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7264,28 +6759,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), nullIf(nullIf(e.`mat_$screen_name`, ''), 'null'), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(nullIf(nullIf(e.`mat_$current_url`, ''), 'null'), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7349,28 +6838,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), nullIf(nullIf(e.`mat_$screen_name`, ''), 'null'), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(nullIf(nullIf(e.`mat_$current_url`, ''), 'null'), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7433,28 +6916,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7518,30 +6995,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7604,28 +7074,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7685,28 +7149,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7764,28 +7222,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7846,28 +7298,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7927,28 +7373,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8009,28 +7449,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8090,28 +7524,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8169,28 +7597,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8248,28 +7670,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8330,32 +7746,25 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         replaceRegexpAll(path_item_ungrouped, '\\?(.*)', '?<param>') AS path_item_0,
                         replaceRegexpAll(path_item_0, '/\\d+(/|\\?)?', '/<id>') AS path_item_cleaned,
                         multiMatchAnyIndex(path_item_cleaned, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_cleaned) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8418,32 +7827,25 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         replaceRegexpAll(path_item_ungrouped, '\\?(.*)', '?<param>') AS path_item_0,
                         replaceRegexpAll(path_item_0, '/\\d+(/|\\?)?', '/<id>') AS path_item_cleaned,
                         multiMatchAnyIndex(path_item_cleaned, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_cleaned) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8506,32 +7908,25 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         replaceRegexpAll(path_item_ungrouped, '\\?(.*)', '?<param>') AS path_item_0,
                         replaceRegexpAll(path_item_0, '/\\d+(/|\\?)?', '/<id>') AS path_item_cleaned,
                         multiMatchAnyIndex(path_item_cleaned, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_cleaned) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8594,30 +7989,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8680,31 +8068,24 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         replaceRegexpAll(path_item_ungrouped, '\\?(.*)', '?<param>') AS path_item_cleaned,
                         multiMatchAnyIndex(path_item_cleaned, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_cleaned) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8767,28 +8148,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
                         if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8851,30 +8226,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['/bar/.*/foo']) AS group_index,
                         if(group_index > 0, ['/bar/*/foo'][group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8937,28 +8305,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
                         if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -9022,28 +8384,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
                         if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -9107,28 +8463,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
                         if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -9193,30 +8543,23 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['\\(a\\+\\)\\+', '\\[aaa\\|aaaa\\]\\+', '1\\..*', '\\..*', '/3\\?q=1', '/3.*']) AS group_index,
                         if(group_index > 0, ['(a+)+', '[aaa|aaaa]+', '1.*', '.*', '/3?q=1', '/3*'][group_index], path_item_ungrouped) AS path_item
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND (event = '$pageview')
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -9279,28 +8622,22 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        pdi.person_id AS person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
                         if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
                  FROM events e SAMPLE 1.0
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY pdi.person_id,
+                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,

--- a/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
@@ -73,6 +73,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -247,6 +254,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -416,6 +430,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -585,6 +606,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -754,6 +782,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -923,6 +958,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -1105,6 +1147,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -1282,6 +1331,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -1459,6 +1515,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -1636,6 +1699,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -1813,6 +1883,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -1987,6 +2064,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -2161,6 +2245,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -2335,6 +2426,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -2509,6 +2607,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -2685,6 +2790,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -2856,6 +2968,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -3027,6 +3146,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -3198,6 +3324,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2
@@ -3369,6 +3502,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['step one', 'step three', 'step two']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           WHERE team_id = 2

--- a/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_paths.ambr
@@ -59,8 +59,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -133,7 +133,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
@@ -146,12 +146,12 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= target_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -227,8 +227,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -298,7 +298,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
@@ -311,12 +311,12 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= target_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -390,8 +390,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -461,7 +461,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
@@ -474,12 +474,12 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= target_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -553,8 +553,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -624,7 +624,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
@@ -637,12 +637,12 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= target_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -716,8 +716,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -787,7 +787,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
@@ -800,12 +800,12 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= target_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -879,8 +879,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -953,7 +953,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
@@ -973,13 +973,13 @@
                     WHERE team_id = 2
                       AND group_type_index = 0
                     GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -1055,8 +1055,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -1126,7 +1126,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
@@ -1146,13 +1146,13 @@
                     WHERE team_id = 2
                       AND group_type_index = 0
                     GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -1226,8 +1226,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -1297,7 +1297,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
@@ -1317,13 +1317,13 @@
                     WHERE team_id = 2
                       AND group_type_index = 0
                     GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -1397,8 +1397,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -1468,7 +1468,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
@@ -1488,13 +1488,13 @@
                     WHERE team_id = 2
                       AND group_type_index = 0
                     GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -1568,8 +1568,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -1639,7 +1639,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
@@ -1659,13 +1659,13 @@
                     WHERE team_id = 2
                       AND group_type_index = 0
                     GROUP BY group_key) groups_0 ON "$group_0" == groups_0.group_key
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND (has(['technology'], replaceRegexpAll(JSONExtractRaw(group_properties_0, 'industry'), '^"|"$', '')))
                    AND e.timestamp >= target_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -1739,8 +1739,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -1813,7 +1813,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
@@ -1826,12 +1826,12 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= target_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -1907,8 +1907,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -1981,7 +1981,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
@@ -1994,12 +1994,12 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= target_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -2075,8 +2075,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -2149,7 +2149,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
@@ -2162,12 +2162,12 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp <= target_timestamp + INTERVAL 7 DAY
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -2243,8 +2243,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -2317,7 +2317,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.timestamp AS target_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
@@ -2330,12 +2330,12 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp <= target_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -2411,8 +2411,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -2485,7 +2485,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.min_timestamp as min_timestamp,
                         funnel_actors.max_timestamp as max_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
@@ -2499,13 +2499,13 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= min_timestamp
                    AND e.timestamp <= max_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -2581,8 +2581,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -2652,7 +2652,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.min_timestamp as min_timestamp,
                         funnel_actors.max_timestamp as max_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
@@ -2666,13 +2666,13 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= min_timestamp
                    AND e.timestamp <= max_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -2746,8 +2746,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -2817,7 +2817,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.min_timestamp as min_timestamp,
                         funnel_actors.max_timestamp as max_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
@@ -2831,13 +2831,13 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= min_timestamp
                    AND e.timestamp <= max_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -2911,8 +2911,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -2982,7 +2982,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.min_timestamp as min_timestamp,
                         funnel_actors.max_timestamp as max_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
@@ -2996,13 +2996,13 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= min_timestamp
                    AND e.timestamp <= max_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3076,8 +3076,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -3147,7 +3147,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.min_timestamp as min_timestamp,
                         funnel_actors.max_timestamp as max_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
@@ -3161,13 +3161,13 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= min_timestamp
                    AND e.timestamp <= max_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3241,8 +3241,8 @@
                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                                 if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'step one', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'step two', 1, 0) as step_1,
@@ -3312,7 +3312,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         funnel_actors.min_timestamp as min_timestamp,
                         funnel_actors.max_timestamp as max_timestamp,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
@@ -3326,13 +3326,13 @@
                     WHERE team_id = 2
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-                 JOIN funnel_actors ON funnel_actors.actor_id = if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id)
+                 JOIN funnel_actors ON funnel_actors.actor_id = if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id)
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
                    AND e.timestamp >= min_timestamp
                    AND e.timestamp <= max_timestamp
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3393,7 +3393,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -3408,7 +3408,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3472,7 +3472,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -3487,7 +3487,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3551,7 +3551,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), nullIf(nullIf(e.`mat_$screen_name`, ''), 'null'), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(nullIf(nullIf(e.`mat_$current_url`, ''), 'null'), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -3566,7 +3566,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3630,7 +3630,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), nullIf(nullIf(e.`mat_$screen_name`, ''), 'null'), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(nullIf(nullIf(e.`mat_$current_url`, ''), 'null'), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -3645,7 +3645,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3709,7 +3709,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['/bar/.*/foo']) AS group_index,
                         if(group_index > 0, ['/bar/*/foo'][group_index], path_item_ungrouped) AS path_item
@@ -3726,7 +3726,7 @@
                    AND NOT path_item IN ['/bar/*/foo']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3789,7 +3789,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['/xxx/invalid/.*']) AS group_index,
                         if(group_index > 0, ['/xxx/invalid/*'][group_index], path_item_ungrouped) AS path_item
@@ -3806,7 +3806,7 @@
                    AND NOT path_item IN ['/bar/*/foo']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3869,7 +3869,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -3885,7 +3885,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -3948,7 +3948,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -3964,7 +3964,7 @@
                    AND (event = '$screen')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4027,7 +4027,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -4043,7 +4043,7 @@
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4106,7 +4106,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -4122,7 +4122,7 @@
                    AND (event IN ['/custom1', '/custom2'])
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4185,7 +4185,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -4201,7 +4201,7 @@
                    AND (event IN ['/custom3', 'blah'])
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4264,7 +4264,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -4282,7 +4282,7 @@
                         OR NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4345,7 +4345,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -4364,7 +4364,7 @@
                    AND NOT path_item IN ['/custom1', '/1', '/2', '/3']
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4427,7 +4427,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -4443,7 +4443,7 @@
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-03 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4755,7 +4755,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         replaceRegexpAll(path_item_ungrouped, '\\?(.*)', '?<param>') AS path_item_cleaned,
                         multiMatchAnyIndex(path_item_cleaned, ['/step1']) AS group_index,
@@ -4772,7 +4772,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4833,7 +4833,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -4849,7 +4849,7 @@
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4907,7 +4907,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -4923,7 +4923,7 @@
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -4980,7 +4980,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -4996,7 +4996,7 @@
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5053,7 +5053,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -5069,7 +5069,7 @@
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5127,7 +5127,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -5143,7 +5143,7 @@
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5200,7 +5200,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -5216,7 +5216,7 @@
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5273,7 +5273,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -5289,7 +5289,7 @@
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5347,7 +5347,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -5363,7 +5363,7 @@
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5420,7 +5420,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(event, '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -5436,7 +5436,7 @@
                    AND (NOT event LIKE '$%')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5615,7 +5615,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         e.uuid AS uuid,
                         e.timestamp AS timestamp,
                         e."$session_id" as $session_id,
@@ -5635,7 +5635,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5735,7 +5735,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         e.uuid AS uuid,
                         e.timestamp AS timestamp,
                         e."$session_id" as $session_id,
@@ -5755,7 +5755,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5856,7 +5856,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         e.uuid AS uuid,
                         e.timestamp AS timestamp,
                         e."$session_id" as $session_id,
@@ -5876,7 +5876,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -5977,7 +5977,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         e.uuid AS uuid,
                         e.timestamp AS timestamp,
                         e."$session_id" as $session_id,
@@ -5997,7 +5997,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6104,7 +6104,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         e.uuid AS uuid,
                         e.timestamp AS timestamp,
                         e."$session_id" as $session_id,
@@ -6124,7 +6124,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-02 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6198,7 +6198,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -6213,7 +6213,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6279,7 +6279,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -6294,7 +6294,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6358,7 +6358,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -6373,7 +6373,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6439,7 +6439,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -6454,7 +6454,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6518,7 +6518,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -6533,7 +6533,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6599,7 +6599,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), nullIf(nullIf(e.`mat_$screen_name`, ''), 'null'), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(nullIf(nullIf(e.`mat_$current_url`, ''), 'null'), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -6614,7 +6614,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6678,7 +6678,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), nullIf(nullIf(e.`mat_$screen_name`, ''), 'null'), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(nullIf(nullIf(e.`mat_$current_url`, ''), 'null'), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -6693,7 +6693,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6759,7 +6759,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), nullIf(nullIf(e.`mat_$screen_name`, ''), 'null'), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(nullIf(nullIf(e.`mat_$current_url`, ''), 'null'), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -6774,7 +6774,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6838,7 +6838,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), nullIf(nullIf(e.`mat_$screen_name`, ''), 'null'), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(nullIf(nullIf(e.`mat_$current_url`, ''), 'null'), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -6853,7 +6853,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6916,7 +6916,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -6931,7 +6931,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -6995,7 +6995,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -7011,7 +7011,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7074,7 +7074,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -7089,7 +7089,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7149,7 +7149,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -7164,7 +7164,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7222,7 +7222,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -7237,7 +7237,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7298,7 +7298,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -7313,7 +7313,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7373,7 +7373,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -7388,7 +7388,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7449,7 +7449,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -7464,7 +7464,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7524,7 +7524,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -7539,7 +7539,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7597,7 +7597,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -7612,7 +7612,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7670,7 +7670,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -7685,7 +7685,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2011-12-31 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7746,7 +7746,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         replaceRegexpAll(path_item_ungrouped, '\\?(.*)', '?<param>') AS path_item_0,
                         replaceRegexpAll(path_item_0, '/\\d+(/|\\?)?', '/<id>') AS path_item_cleaned,
@@ -7764,7 +7764,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7827,7 +7827,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         replaceRegexpAll(path_item_ungrouped, '\\?(.*)', '?<param>') AS path_item_0,
                         replaceRegexpAll(path_item_0, '/\\d+(/|\\?)?', '/<id>') AS path_item_cleaned,
@@ -7845,7 +7845,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7908,7 +7908,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         replaceRegexpAll(path_item_ungrouped, '\\?(.*)', '?<param>') AS path_item_0,
                         replaceRegexpAll(path_item_0, '/\\d+(/|\\?)?', '/<id>') AS path_item_cleaned,
@@ -7926,7 +7926,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -7989,7 +7989,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, NULL) AS group_index,
                         if(group_index > 0, NULL[group_index], path_item_ungrouped) AS path_item
@@ -8005,7 +8005,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8068,7 +8068,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         replaceRegexpAll(path_item_ungrouped, '\\?(.*)', '?<param>') AS path_item_cleaned,
                         multiMatchAnyIndex(path_item_cleaned, NULL) AS group_index,
@@ -8085,7 +8085,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8148,7 +8148,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
                         if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
@@ -8163,7 +8163,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8226,7 +8226,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['/bar/.*/foo']) AS group_index,
                         if(group_index > 0, ['/bar/*/foo'][group_index], path_item_ungrouped) AS path_item
@@ -8242,7 +8242,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8305,7 +8305,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
                         if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
@@ -8320,7 +8320,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8384,7 +8384,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
                         if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
@@ -8399,7 +8399,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8463,7 +8463,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
                         if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
@@ -8478,7 +8478,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8543,7 +8543,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['\\(a\\+\\)\\+', '\\[aaa\\|aaaa\\]\\+', '1\\..*', '\\..*', '/3\\?q=1', '/3.*']) AS group_index,
                         if(group_index > 0, ['(a+)+', '[aaa|aaaa]+', '1.*', '.*', '/3?q=1', '/3*'][group_index], path_item_ungrouped) AS path_item
@@ -8559,7 +8559,7 @@
                    AND (event = '$pageview')
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2023-05-23 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,
@@ -8622,7 +8622,7 @@
                      groupArray(path_item) as paths
               FROM
                 (SELECT e.timestamp AS timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS person_id,
                         ifNull(if(equals(event, '$screen'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$screen_name'), ''), 'null'), '^"|"$', ''), if(equals(event, '$pageview'), replaceRegexpAll(ifNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), ''), '(.)/$', '\\1'), event)), '') AS path_item_ungrouped,
                         multiMatchAnyIndex(path_item_ungrouped, ['between_step_1_.*', 'between_step_2_.*', 'step\\ drop.*']) AS group_index,
                         if(group_index > 0, ['between_step_1_*', 'between_step_2_*', 'step drop*'][group_index], path_item_ungrouped) AS path_item
@@ -8637,7 +8637,7 @@
                  WHERE team_id = 2
                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC')
-                 ORDER BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id),
+                 ORDER BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id),
                           e.timestamp)
               GROUP BY person_id) ARRAY
            JOIN session_paths AS path_time_tuple,

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
@@ -146,8 +146,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview_funnel', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = '$pageleave_funnel', 1, 0) as step_1,
@@ -156,18 +156,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['$pageleave_funnel', '$pageview_funnel']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
@@ -146,8 +146,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview_funnel', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = '$pageleave_funnel', 1, 0) as step_1,

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiment_secondary_results.ambr
@@ -161,6 +161,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['$pageleave_funnel', '$pageview_funnel']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -68,8 +68,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = '$pageleave', 1, 0) as step_1,
@@ -78,18 +78,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['$pageleave', '$pageview']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -175,8 +168,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = '$pageleave', 1, 0) as step_1,
@@ -185,18 +178,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['$pageleave', '$pageview']
-                              AND toTimeZone(timestamp, 'Europe/Amsterdam') >= toDateTime('2020-01-01 14:20:21', 'Europe/Amsterdam')
-                              AND toTimeZone(timestamp, 'Europe/Amsterdam') <= toDateTime('2020-01-06 10:00:00', 'Europe/Amsterdam') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -282,8 +268,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = '$pageleave', 1, 0) as step_1,
@@ -292,18 +278,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['$pageleave', '$pageview']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -390,7 +369,7 @@
                  FROM
                    (SELECT e.timestamp as timestamp,
                            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$account_id'), ''), 'null'), '^"|"$', '') as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = '$pageleave', 1, 0) as step_1,
@@ -399,18 +378,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['$pageleave', '$pageview']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -1083,7 +1055,7 @@
                        AND (has(['bonk'], replaceRegexpAll(JSONExtractRaw(properties, 'bonk'), '^"|"$', ''))
                             AND ifNull(in(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$current_url'), ''), 'null'), '^"|"$', ''), tuple('x', 'y')), 0))) > 0 AS performed_event_condition_X_level_level_0_level_0_0
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -68,8 +68,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = '$pageleave', 1, 0) as step_1,
@@ -168,8 +168,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = '$pageleave', 1, 0) as step_1,
@@ -268,8 +268,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = '$pageleave', 1, 0) as step_1,
@@ -369,7 +369,7 @@
                  FROM
                    (SELECT e.timestamp as timestamp,
                            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$account_id'), ''), 'null'), '^"|"$', '') as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = '$pageview', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = '$pageleave', 1, 0) as step_1,

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -83,6 +83,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['$pageleave', '$pageview']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -183,6 +190,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['$pageleave', '$pageview']
+                              AND toTimeZone(timestamp, 'Europe/Amsterdam') >= toDateTime('2020-01-01 14:20:21', 'Europe/Amsterdam')
+                              AND toTimeZone(timestamp, 'Europe/Amsterdam') <= toDateTime('2020-01-06 10:00:00', 'Europe/Amsterdam') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -283,6 +297,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['$pageleave', '$pageview']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -383,6 +404,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['$pageleave', '$pageview']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -69,9 +69,9 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               pdi.person_id as target
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -86,7 +86,7 @@
                  event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))) as event_date,
-               pdi.person_id as target,
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
                [
                           dateDiff(
                               'Day',
@@ -95,7 +95,7 @@
                           )
                       ] as breakdown_values
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -141,9 +141,9 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               pdi.person_id as target
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -158,7 +158,7 @@
                  event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))) as event_date,
-               pdi.person_id as target,
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
                [
                           dateDiff(
                               'Day',
@@ -167,7 +167,7 @@
                           )
                       ] as breakdown_values
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -210,9 +210,9 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               pdi.person_id as target
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -239,7 +239,7 @@
                  event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))) as event_date,
-               pdi.person_id as target,
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
                [
                           dateDiff(
                               'Day',
@@ -248,7 +248,7 @@
                           )
                       ] as breakdown_values
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -310,9 +310,9 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               pdi.person_id as target
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -339,7 +339,7 @@
                  event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))) as event_date,
-               pdi.person_id as target,
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
                [
                           dateDiff(
                               'Day',
@@ -348,7 +348,7 @@
                           )
                       ] as breakdown_values
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -406,9 +406,9 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               pdi.person_id as target
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -435,7 +435,7 @@
                  event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))) as event_date,
-               pdi.person_id as target,
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
                [
                           dateDiff(
                               'Day',
@@ -444,7 +444,7 @@
                           )
                       ] as breakdown_values
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_retention.ambr
@@ -69,7 +69,7 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target
         FROM events e
         LEFT OUTER JOIN
           (SELECT distinct_id,
@@ -86,7 +86,7 @@
                  event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))) as event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target,
                [
                           dateDiff(
                               'Day',
@@ -141,7 +141,7 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target
         FROM events e
         LEFT OUTER JOIN
           (SELECT distinct_id,
@@ -158,7 +158,7 @@
                  event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))) as event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target,
                [
                           dateDiff(
                               'Day',
@@ -210,7 +210,7 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target
         FROM events e
         LEFT OUTER JOIN
           (SELECT distinct_id,
@@ -239,7 +239,7 @@
                  event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))) as event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target,
                [
                           dateDiff(
                               'Day',
@@ -310,7 +310,7 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target
         FROM events e
         LEFT OUTER JOIN
           (SELECT distinct_id,
@@ -339,7 +339,7 @@
                  event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))) as event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target,
                [
                           dateDiff(
                               'Day',
@@ -406,7 +406,7 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target
         FROM events e
         LEFT OUTER JOIN
           (SELECT distinct_id,
@@ -435,7 +435,7 @@
                  event_date),
           target_event_query as
        (SELECT min(toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'))) as event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target,
                [
                           dateDiff(
                               'Day',

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
@@ -113,7 +113,7 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
+    (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
      LEFT OUTER JOIN
@@ -139,7 +139,7 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
+    (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
      LEFT OUTER JOIN
@@ -165,7 +165,7 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
+    (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfWeek(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'), 0)) as num_intervals
      FROM events e
      LEFT OUTER JOIN
@@ -198,7 +198,7 @@
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT aggregation_target AS actor_id
   FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
+    (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfWeek(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'), 0)) as num_intervals
      FROM events e
      LEFT OUTER JOIN
@@ -231,7 +231,7 @@
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT aggregation_target AS actor_id
   FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
+    (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfWeek(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'), 0)) as num_intervals
      FROM events e
      LEFT OUTER JOIN
@@ -264,7 +264,7 @@
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT aggregation_target AS actor_id
   FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
+    (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfWeek(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'), 0)) as num_intervals
      FROM events e
      LEFT OUTER JOIN
@@ -309,7 +309,7 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
+    (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
      LEFT OUTER JOIN
@@ -346,7 +346,7 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
+    (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e SAMPLE 1.0
      LEFT OUTER JOIN
@@ -372,7 +372,7 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
+    (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
      LEFT OUTER JOIN
@@ -397,7 +397,7 @@
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT aggregation_target AS actor_id
   FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
+    (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
      LEFT OUTER JOIN
@@ -422,7 +422,7 @@
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT aggregation_target AS actor_id
   FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
+    (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
      LEFT OUTER JOIN
@@ -447,7 +447,7 @@
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT aggregation_target AS actor_id
   FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
+    (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
      LEFT OUTER JOIN
@@ -509,7 +509,7 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
+    (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
      LEFT OUTER JOIN
@@ -535,7 +535,7 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
+    (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'US/Pacific'))) as num_intervals
      FROM events e
      LEFT OUTER JOIN

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
@@ -8,18 +8,11 @@
     (SELECT e."$group_0" AS aggregation_target,
             countDistinct(toStartOfWeek(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'), 0)) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'watched movie'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -41,18 +34,11 @@
     (SELECT e."$group_0" AS aggregation_target,
             countDistinct(toStartOfWeek(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'), 0)) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'watched movie'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -75,18 +61,11 @@
     (SELECT e."$group_0" AS aggregation_target,
             countDistinct(toStartOfWeek(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'), 0)) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'watched movie'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -109,18 +88,11 @@
     (SELECT e."$group_0" AS aggregation_target,
             countDistinct(toStartOfWeek(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'), 0)) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'watched movie'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -141,21 +113,14 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT pdi.person_id AS aggregation_target,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'watched movie'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -174,21 +139,14 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT pdi.person_id AS aggregation_target,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'watched movie'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -207,21 +165,14 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT pdi.person_id AS aggregation_target,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfWeek(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'), 0)) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'watched movie'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      LEFT JOIN
@@ -247,21 +198,14 @@
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT aggregation_target AS actor_id
   FROM
-    (SELECT pdi.person_id AS aggregation_target,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfWeek(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'), 0)) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'watched movie'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      LEFT JOIN
@@ -287,21 +231,14 @@
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT aggregation_target AS actor_id
   FROM
-    (SELECT pdi.person_id AS aggregation_target,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfWeek(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'), 0)) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'watched movie'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      LEFT JOIN
@@ -327,21 +264,14 @@
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT aggregation_target AS actor_id
   FROM
-    (SELECT pdi.person_id AS aggregation_target,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfWeek(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'), 0)) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'watched movie'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      LEFT JOIN
@@ -379,21 +309,14 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT pdi.person_id AS aggregation_target,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'watched movie'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -423,21 +346,14 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT pdi.person_id AS aggregation_target,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e SAMPLE 1.0
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'watched movie'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -456,21 +372,14 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT pdi.person_id AS aggregation_target,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'watched movie'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-01 12:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-01 20:00:00', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -488,21 +397,14 @@
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT aggregation_target AS actor_id
   FROM
-    (SELECT pdi.person_id AS aggregation_target,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND ((event = 'watched movie'))
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -520,21 +422,14 @@
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT aggregation_target AS actor_id
   FROM
-    (SELECT pdi.person_id AS aggregation_target,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND ((event = 'watched movie'))
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -552,21 +447,14 @@
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT aggregation_target AS actor_id
   FROM
-    (SELECT pdi.person_id AS aggregation_target,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND ((event = 'watched movie'))
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -621,21 +509,14 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT pdi.person_id AS aggregation_target,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC'))) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = '$pageview'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -654,21 +535,14 @@
   SELECT countDistinct(aggregation_target),
          num_intervals
   FROM
-    (SELECT pdi.person_id AS aggregation_target,
+    (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) AS aggregation_target,
             countDistinct(toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'US/Pacific'))) as num_intervals
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = '$pageview'
-               AND toTimeZone(timestamp, 'US/Pacific') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'US/Pacific')), 'US/Pacific')
-               AND toTimeZone(timestamp, 'US/Pacific') <= toDateTime('2021-05-15 23:59:59', 'US/Pacific') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_stickiness.ambr
@@ -13,6 +13,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'watched movie'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -39,6 +46,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'watched movie'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -66,6 +80,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'watched movie'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -93,6 +114,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'watched movie'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -121,6 +149,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'watched movie'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -147,6 +182,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'watched movie'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -173,6 +215,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'watched movie'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      LEFT JOIN
@@ -206,6 +255,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'watched movie'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      LEFT JOIN
@@ -239,6 +295,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'watched movie'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      LEFT JOIN
@@ -272,6 +335,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'watched movie'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfWeek(toDateTime('2020-01-01 00:00:00', 'UTC'), 0), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      LEFT JOIN
@@ -317,6 +387,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'watched movie'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -354,6 +431,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'watched movie'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -380,6 +464,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'watched movie'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-01 12:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-01 20:00:00', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -405,6 +496,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND ((event = 'watched movie'))
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -430,6 +528,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND ((event = 'watched movie'))
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -455,6 +560,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND ((event = 'watched movie'))
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -517,6 +629,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = '$pageview'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-15 23:59:59', 'UTC') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -543,6 +662,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = '$pageview'
+               AND toTimeZone(timestamp, 'US/Pacific') >= toDateTime(toStartOfDay(toDateTime('2021-05-01 00:00:00', 'US/Pacific')), 'US/Pacific')
+               AND toTimeZone(timestamp, 'US/Pacific') <= toDateTime('2021-05-15 23:59:59', 'US/Pacific') )
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -26,6 +26,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = '$pageview'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -61,6 +68,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = '$pageview'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -88,6 +102,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = '$pageview'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-14 00:00:00', 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -145,6 +166,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = '$pageview'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-14 00:00:00', 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -201,6 +229,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = '$pageview'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -307,6 +342,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = '$pageview'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -346,6 +388,13 @@
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
               WHERE team_id = 2
+                AND distinct_id IN
+                  (SELECT distinct_id
+                   FROM events
+                   WHERE team_id = 2
+                     AND event = '$pageview'
+                     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
+                     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
               GROUP BY distinct_id
               HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
            WHERE team_id = 2
@@ -374,6 +423,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = '$pageview'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -465,6 +521,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = '$pageview'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -622,6 +685,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = '$pageview'
+               AND toDateTime(timestamp, 'UTC') >= toDateTime('2011-12-25 00:00:00', 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
@@ -672,6 +742,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = '$pageview'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -705,6 +782,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = '$pageview'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-14 00:00:00', 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -738,6 +822,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = '$pageview'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2011-12-31 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -771,6 +862,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = '$pageview'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-02 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-16 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -876,6 +974,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = '$pageview'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-02 00:00:00', 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-02 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -17,7 +17,7 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
@@ -79,7 +79,7 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
@@ -136,7 +136,7 @@
   FROM
     (SELECT e.timestamp as timestamp,
             e."properties" as "properties",
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
@@ -192,7 +192,7 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
@@ -298,7 +298,7 @@
   FROM
     (SELECT e.timestamp as timestamp,
             e."properties" as "properties",
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
@@ -365,7 +365,7 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
@@ -456,7 +456,7 @@
   FROM
     (SELECT e.timestamp as timestamp,
             e."properties" as "properties",
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
@@ -613,7 +613,7 @@
   FROM
     (SELECT e.timestamp as timestamp,
             e."properties" as "properties",
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
@@ -867,7 +867,7 @@
   FROM
     (SELECT e.timestamp as timestamp,
             e."$session_id" as "$session_id",
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_trends.ambr
@@ -17,22 +17,15 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = '$pageview'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -63,18 +56,11 @@
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = '$pageview'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -93,22 +79,15 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = '$pageview'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-14 00:00:00', 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -157,22 +136,15 @@
   FROM
     (SELECT e.timestamp as timestamp,
             e."properties" as "properties",
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = '$pageview'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-14 00:00:00', 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -220,22 +192,15 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = '$pageview'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -333,22 +298,15 @@
   FROM
     (SELECT e.timestamp as timestamp,
             e."properties" as "properties",
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = '$pageview'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -383,18 +341,11 @@
           (SELECT pdi.person_id AS actor_id,
                   min(timestamp) AS first_seen_timestamp
            FROM events e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
               WHERE team_id = 2
-                AND distinct_id IN
-                  (SELECT distinct_id
-                   FROM events
-                   WHERE team_id = 2
-                     AND event = '$pageview'
-                     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
-                     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
               GROUP BY distinct_id
               HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
            WHERE team_id = 2
@@ -414,22 +365,15 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = '$pageview'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -512,22 +456,15 @@
   FROM
     (SELECT e.timestamp as timestamp,
             e."properties" as "properties",
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = '$pageview'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -676,22 +613,15 @@
   FROM
     (SELECT e.timestamp as timestamp,
             e."properties" as "properties",
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = '$pageview'
-               AND toDateTime(timestamp, 'UTC') >= toDateTime('2011-12-25 00:00:00', 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
@@ -737,18 +667,11 @@
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = '$pageview'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-01 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -777,18 +700,11 @@
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = '$pageview'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-14 00:00:00', 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -817,18 +733,11 @@
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = '$pageview'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2011-12-31 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-14 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -857,18 +766,11 @@
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = '$pageview'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-02 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-16 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -965,22 +867,15 @@
   FROM
     (SELECT e.timestamp as timestamp,
             e."$session_id" as "$session_id",
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = '$pageview'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-02 00:00:00', 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-02 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
@@ -238,8 +238,8 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up'
                            AND (has(['org:5'], "$group_0")), 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
@@ -293,8 +293,8 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up'
                            AND (has(['org:5'], "$group_0")), 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
@@ -356,8 +356,8 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,
@@ -418,8 +418,8 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
@@ -238,26 +238,19 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up'
                            AND (has(['org:5'], "$group_0")), 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['paid', 'user signed up']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -300,26 +293,19 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up'
                            AND (has(['org:5'], "$group_0")), 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['paid', 'user signed up']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -370,25 +356,18 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['paid', 'user signed up']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  LEFT JOIN
@@ -439,25 +418,18 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['paid', 'user signed up']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  LEFT JOIN

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel.ambr
@@ -251,6 +251,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['paid', 'user signed up']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -306,6 +313,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['paid', 'user signed up']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -368,6 +382,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['paid', 'user signed up']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  LEFT JOIN
@@ -430,6 +451,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['paid', 'user signed up']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  LEFT JOIN

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -54,7 +54,7 @@
                     FROM
                       (SELECT e.timestamp as timestamp,
                               e."$group_0" as aggregation_target,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
@@ -63,18 +63,11 @@
                               if(event = 'step three', 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['step one', 'step three', 'step two']
-                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -54,7 +54,7 @@
                     FROM
                       (SELECT e.timestamp as timestamp,
                               e."$group_0" as aggregation_target,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,

--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -68,6 +68,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['step one', 'step three', 'step two']
+                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN

--- a/posthog/api/test/__snapshots__/test_cohort.ambr
+++ b/posthog/api/test/__snapshots__/test_cohort.ambr
@@ -27,7 +27,7 @@
                        AND event = '$pageview'
                        AND 1=1) > 0 AS performed_event_condition_X_level_level_0_level_1_level_0_0
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -71,8 +71,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            person.person_props as person_props,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
@@ -142,8 +142,8 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         person.person_props as person_props,
                         if(event = 'user signed up', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
@@ -209,8 +209,8 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         person.person_props as person_props,
                         if(event = 'user signed up'
                            AND (and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), 1)

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -71,8 +71,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            person.person_props as person_props,
                            if(event = 'user signed up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
@@ -82,18 +82,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['user did things', 'user signed up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -149,26 +142,19 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         person.person_props as person_props,
                         if(event = 'user signed up', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'user did things', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['user did things', 'user signed up']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
@@ -223,8 +209,8 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         person.person_props as person_props,
                         if(event = 'user signed up'
                            AND (and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), 1)
@@ -235,18 +221,11 @@
                                 AND ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person_props, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)), 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['user did things', 'user signed up']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
@@ -433,18 +412,11 @@
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = '$pageview'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -508,18 +480,11 @@
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = '$pageview'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -557,18 +522,11 @@
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = '$pageview'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -606,18 +564,11 @@
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = '$pageview'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -417,6 +417,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = '$pageview'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -485,6 +492,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = '$pageview'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -527,6 +541,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = '$pageview'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -569,6 +590,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = '$pageview'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2012-01-08 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN

--- a/posthog/api/test/__snapshots__/test_insight.ambr
+++ b/posthog/api/test/__snapshots__/test_insight.ambr
@@ -87,6 +87,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['user did things', 'user signed up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     INNER JOIN
@@ -155,6 +162,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['user did things', 'user signed up']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
@@ -226,6 +240,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['user did things', 'user signed up']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2012-01-08 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2012-01-15 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN

--- a/posthog/api/test/__snapshots__/test_insight_funnels.ambr
+++ b/posthog/api/test/__snapshots__/test_insight_funnels.ambr
@@ -51,8 +51,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              pdi.person_id as aggregation_target,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -60,18 +60,11 @@
                               if(event = 'step three', 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['step one', 'step three', 'step two']
-                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
-                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -163,8 +156,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step two', 1, 0) as step_1,
@@ -172,17 +165,11 @@
                         if(event = 'step three', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -269,8 +256,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step two', 1, 0) as step_1,
@@ -278,18 +265,11 @@
                         if(event = 'step three', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['step one', 'step three', 'step two']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -319,8 +299,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step two', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step three', 1, 0) as step_1,
@@ -328,18 +308,11 @@
                         if(event = 'step one', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['step one', 'step three', 'step two']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -369,8 +342,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step three', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step one', 1, 0) as step_1,
@@ -378,18 +351,11 @@
                         if(event = 'step two', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['step one', 'step three', 'step two']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2

--- a/posthog/api/test/__snapshots__/test_insight_funnels.ambr
+++ b/posthog/api/test/__snapshots__/test_insight_funnels.ambr
@@ -51,8 +51,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -156,8 +156,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step two', 1, 0) as step_1,
@@ -256,8 +256,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step two', 1, 0) as step_1,
@@ -299,8 +299,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step two', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step three', 1, 0) as step_1,
@@ -342,8 +342,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step three', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step one', 1, 0) as step_1,

--- a/posthog/api/test/__snapshots__/test_insight_funnels.ambr
+++ b/posthog/api/test/__snapshots__/test_insight_funnels.ambr
@@ -65,6 +65,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['step one', 'step three', 'step two']
+                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
+                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -170,6 +177,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -270,6 +283,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['step one', 'step three', 'step two']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -313,6 +333,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['step one', 'step three', 'step two']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -356,6 +383,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['step one', 'step three', 'step two']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2

--- a/posthog/api/test/__snapshots__/test_persons_trends.ambr
+++ b/posthog/api/test/__snapshots__/test_persons_trends.ambr
@@ -12,23 +12,16 @@
             e."properties" as "properties",
             e."$window_id" as $window_id,
             e."$session_id" as $session_id,
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id,
             e.uuid as uuid
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = '$pageview'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-08 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -67,23 +60,16 @@
             e."properties" as "properties",
             e."$window_id" as $window_id,
             e."$session_id" as $session_id,
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id,
             e.uuid as uuid
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = '$pageview'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-08 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
@@ -132,23 +118,16 @@
             e."properties" as "properties",
             e."$window_id" as $window_id,
             e."$session_id" as $session_id,
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id,
             e.uuid as uuid
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = '$pageview'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-08 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2

--- a/posthog/api/test/__snapshots__/test_persons_trends.ambr
+++ b/posthog/api/test/__snapshots__/test_persons_trends.ambr
@@ -12,7 +12,7 @@
             e."properties" as "properties",
             e."$window_id" as $window_id,
             e."$session_id" as $session_id,
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id,
             e.uuid as uuid
@@ -60,7 +60,7 @@
             e."properties" as "properties",
             e."$window_id" as $window_id,
             e."$session_id" as $session_id,
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id,
             e.uuid as uuid
@@ -118,7 +118,7 @@
             e."properties" as "properties",
             e."$window_id" as $window_id,
             e."$session_id" as $session_id,
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id,
             e.uuid as uuid

--- a/posthog/api/test/__snapshots__/test_persons_trends.ambr
+++ b/posthog/api/test/__snapshots__/test_persons_trends.ambr
@@ -22,6 +22,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = '$pageview'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-08 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -70,6 +77,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = '$pageview'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-08 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
@@ -128,6 +142,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = '$pageview'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-08 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
@@ -1807,8 +1807,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -1819,18 +1819,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -1950,8 +1943,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -1962,18 +1955,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -2093,8 +2079,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -2105,18 +2091,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -2236,8 +2215,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -2248,18 +2227,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel.ambr
@@ -1824,6 +1824,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -1960,6 +1967,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -2096,6 +2110,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -2232,6 +2253,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -717,8 +717,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -729,17 +729,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -837,8 +831,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -849,17 +843,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -957,8 +945,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -969,17 +957,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1077,8 +1059,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1089,17 +1071,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1844,8 +1820,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1856,17 +1832,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1964,8 +1934,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1976,17 +1946,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2084,8 +2048,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -2096,17 +2060,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2204,8 +2162,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -2216,17 +2174,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -717,8 +717,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -831,8 +831,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -945,8 +945,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1059,8 +1059,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1820,8 +1820,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1934,8 +1934,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -2048,8 +2048,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -2162,8 +2162,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -734,6 +734,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -848,6 +854,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -962,6 +974,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1076,6 +1094,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1837,6 +1861,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1951,6 +1981,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2065,6 +2101,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2179,6 +2221,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_udf.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_udf.ambr
@@ -734,6 +734,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -848,6 +854,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -962,6 +974,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1076,6 +1094,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1648,6 +1672,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1762,6 +1792,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1876,6 +1912,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1990,6 +2032,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_udf.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_udf.ambr
@@ -717,8 +717,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -729,17 +729,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -837,8 +831,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -849,17 +843,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -957,8 +945,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -969,17 +957,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1077,8 +1059,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1089,17 +1071,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1655,8 +1631,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1667,17 +1643,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1775,8 +1745,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1787,17 +1757,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1895,8 +1859,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1907,17 +1871,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2015,8 +1973,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -2027,17 +1985,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_udf.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict_udf.ambr
@@ -717,8 +717,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -831,8 +831,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -945,8 +945,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1059,8 +1059,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1631,8 +1631,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1745,8 +1745,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1859,8 +1859,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1973,8 +1973,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends.ambr
@@ -682,8 +682,8 @@
                                                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'step one', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'step two', 1, 0) as step_1,
@@ -691,18 +691,11 @@
                            if(event = 'step three', 1, 0) as step_2,
                            if(step_2 = 1, timestamp, null) as latest_2
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['step one', 'step three', 'step two']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends.ambr
@@ -696,6 +696,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['step one', 'step three', 'step two']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends.ambr
@@ -682,8 +682,8 @@
                                                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'step one', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'step two', 1, 0) as step_1,

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_udf.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_udf.ambr
@@ -197,8 +197,8 @@
                                                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'step one', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'step two', 1, 0) as step_1,
@@ -206,18 +206,11 @@
                            if(event = 'step three', 1, 0) as step_2,
                            if(step_2 = 1, timestamp, null) as latest_2
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['step one', 'step three', 'step two']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_udf.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_udf.ambr
@@ -211,6 +211,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['step one', 'step three', 'step two']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_udf.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_udf.ambr
@@ -1416,6 +1416,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -1552,6 +1559,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -1688,6 +1702,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -1824,6 +1845,13 @@
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
+                               AND distinct_id IN
+                                 (SELECT distinct_id
+                                  FROM events
+                                  WHERE team_id = 2
+                                    AND event IN ['buy', 'play movie', 'sign up']
+                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_udf.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_udf.ambr
@@ -1399,8 +1399,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -1411,18 +1411,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -1542,8 +1535,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -1554,18 +1547,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -1685,8 +1671,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -1697,18 +1683,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN
@@ -1828,8 +1807,8 @@
                               prop_vals as prop
                        FROM
                          (SELECT e.timestamp as timestamp,
-                                 pdi.person_id as aggregation_target,
-                                 pdi.person_id as person_id,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                                 if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                                  if(event = 'sign up', 1, 0) as step_0,
                                  if(step_0 = 1, timestamp, null) as latest_0,
                                  if(event = 'play movie', 1, 0) as step_1,
@@ -1840,18 +1819,11 @@
                                  prop_basic as prop,
                                  argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                           FROM events e
-                          INNER JOIN
+                          LEFT OUTER JOIN
                             (SELECT distinct_id,
                                     argMax(person_id, version) as person_id
                              FROM person_distinct_id2
                              WHERE team_id = 2
-                               AND distinct_id IN
-                                 (SELECT distinct_id
-                                  FROM events
-                                  WHERE team_id = 2
-                                    AND event IN ['buy', 'play movie', 'sign up']
-                                    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                              GROUP BY distinct_id
                              HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                           LEFT JOIN

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -1334,8 +1334,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1346,18 +1346,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1400,8 +1393,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'play movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -1412,18 +1405,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1466,8 +1452,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'sign up', 1, 0) as step_1,
@@ -1478,18 +1464,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1634,8 +1613,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1646,18 +1625,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1700,8 +1672,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'play movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -1712,18 +1684,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1766,8 +1731,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'sign up', 1, 0) as step_1,
@@ -1778,18 +1743,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1911,8 +1869,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -1923,18 +1881,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1977,8 +1928,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'play movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -1989,18 +1940,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2043,8 +1987,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'sign up', 1, 0) as step_1,
@@ -2055,18 +1999,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2211,8 +2148,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'play movie', 1, 0) as step_1,
@@ -2223,18 +2160,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2277,8 +2207,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'play movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -2289,18 +2219,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2343,8 +2266,8 @@
                         prop_vals as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'sign up', 1, 0) as step_1,
@@ -2355,18 +2278,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, isNotNull(prop)) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'play movie', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -1351,6 +1351,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1410,6 +1417,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1469,6 +1483,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1630,6 +1651,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1689,6 +1717,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1748,6 +1783,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1886,6 +1928,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -1945,6 +1994,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2004,6 +2060,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2165,6 +2228,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2224,6 +2294,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN
@@ -2283,6 +2360,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'play movie', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     LEFT JOIN

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel.py
@@ -4105,17 +4105,19 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             self.assertEqual(results[1]["count"], 1)
 
         def test_funnel_personless_events_are_supported(self):
-            # person 1
+            user_id = uuid.uuid4()
             _create_event(
                 team=self.team,
                 event="$pageview",
-                distinct_id="user_1",
+                distinct_id=user_id,
+                person_id=user_id,
                 timestamp="2024-03-22T13:00:00Z",
             )
             _create_event(
                 team=self.team,
                 event="sign up",
-                distinct_id="user_1",
+                distinct_id=user_id,
+                person_id=user_id,
                 timestamp="2024-03-22T14:00:00Z",
             )
 

--- a/posthog/queries/event_query/event_query.py
+++ b/posthog/queries/event_query/event_query.py
@@ -17,12 +17,12 @@ from posthog.models.property.util import parse_prop_grouped_clauses
 from posthog.models.team import Team
 from posthog.queries.column_optimizer.column_optimizer import ColumnOptimizer
 from posthog.queries.person_distinct_id_query import get_team_distinct_ids_query
+from posthog.queries.person_on_events_v2_sql import PERSON_DISTINCT_ID_OVERRIDES_JOIN_SQL
 from posthog.queries.person_query import PersonQuery
 from posthog.queries.query_date_range import QueryDateRange
+from posthog.queries.util import PersonPropertiesMode, alias_poe_mode_for_legacy
 from posthog.schema import PersonsOnEventsMode
 from posthog.session_recordings.queries.session_query import SessionQuery
-from posthog.queries.util import PersonPropertiesMode, alias_poe_mode_for_legacy
-from posthog.queries.person_on_events_v2_sql import PERSON_DISTINCT_ID_OVERRIDES_JOIN_SQL
 
 
 class EventQuery(metaclass=ABCMeta):
@@ -139,7 +139,7 @@ class EventQuery(metaclass=ABCMeta):
         elif person_on_events_mode == PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS:
             return f"{self.EVENT_TABLE_ALIAS}.person_id"
 
-        return f"{self.DISTINCT_ID_TABLE_ALIAS}.person_id"
+        return f"if(not(empty({self.DISTINCT_ID_TABLE_ALIAS}.distinct_id)), {self.DISTINCT_ID_TABLE_ALIAS}.person_id, {self.EVENT_TABLE_ALIAS}.person_id)"
 
     def _get_person_ids_query(self, *, relevant_events_conditions: str = "") -> str:
         if not self._should_join_distinct_ids:
@@ -152,8 +152,8 @@ class EventQuery(metaclass=ABCMeta):
             )
 
         return f"""
-            INNER JOIN (
-                {get_team_distinct_ids_query(self._team_id, relevant_events_conditions=relevant_events_conditions)}
+            LEFT OUTER JOIN (
+                {get_team_distinct_ids_query(self._team_id)}
             ) AS {self.DISTINCT_ID_TABLE_ALIAS}
             ON {self.EVENT_TABLE_ALIAS}.distinct_id = {self.DISTINCT_ID_TABLE_ALIAS}.distinct_id
         """

--- a/posthog/queries/event_query/event_query.py
+++ b/posthog/queries/event_query/event_query.py
@@ -153,7 +153,7 @@ class EventQuery(metaclass=ABCMeta):
 
         return f"""
             LEFT OUTER JOIN (
-                {get_team_distinct_ids_query(self._team_id)}
+                {get_team_distinct_ids_query(self._team_id, relevant_events_conditions=relevant_events_conditions)}
             ) AS {self.DISTINCT_ID_TABLE_ALIAS}
             ON {self.EVENT_TABLE_ALIAS}.distinct_id = {self.DISTINCT_ID_TABLE_ALIAS}.distinct_id
         """

--- a/posthog/queries/event_query/event_query.py
+++ b/posthog/queries/event_query/event_query.py
@@ -139,7 +139,7 @@ class EventQuery(metaclass=ABCMeta):
         elif person_on_events_mode == PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS:
             return f"{self.EVENT_TABLE_ALIAS}.person_id"
 
-        return f"if(not(empty({self.DISTINCT_ID_TABLE_ALIAS}.distinct_id)), {self.DISTINCT_ID_TABLE_ALIAS}.person_id, {self.EVENT_TABLE_ALIAS}.person_id)"
+        return f"if(notEmpty({self.DISTINCT_ID_TABLE_ALIAS}.distinct_id), {self.DISTINCT_ID_TABLE_ALIAS}.person_id, {self.EVENT_TABLE_ALIAS}.person_id)"
 
     def _get_person_ids_query(self, *, relevant_events_conditions: str = "") -> str:
         if not self._should_join_distinct_ids:

--- a/posthog/queries/funnels/funnel_event_query.py
+++ b/posthog/queries/funnels/funnel_event_query.py
@@ -111,7 +111,7 @@ class FunnelEventQuery(EventQuery):
             SELECT {all_fields}
             FROM events {self.EVENT_TABLE_ALIAS}
             {sample_clause}
-            {self._get_person_ids_query()}
+            {self._get_person_ids_query(relevant_events_conditions=f"{entity_query} {date_query} {prop_query}")}
             {person_query}
             {groups_query}
             {{extra_join}}

--- a/posthog/queries/funnels/funnel_event_query.py
+++ b/posthog/queries/funnels/funnel_event_query.py
@@ -111,7 +111,7 @@ class FunnelEventQuery(EventQuery):
             SELECT {all_fields}
             FROM events {self.EVENT_TABLE_ALIAS}
             {sample_clause}
-            {self._get_person_ids_query(relevant_events_conditions=f"{entity_query} {date_query}")}
+            {self._get_person_ids_query()}
             {person_query}
             {groups_query}
             {{extra_join}}

--- a/posthog/queries/funnels/funnel_event_query.py
+++ b/posthog/queries/funnels/funnel_event_query.py
@@ -111,7 +111,7 @@ class FunnelEventQuery(EventQuery):
             SELECT {all_fields}
             FROM events {self.EVENT_TABLE_ALIAS}
             {sample_clause}
-            {self._get_person_ids_query(relevant_events_conditions=f"{entity_query} {date_query} {prop_query}")}
+            {self._get_person_ids_query(relevant_events_conditions=f"{entity_query} {date_query}")}
             {person_query}
             {groups_query}
             {{extra_join}}

--- a/posthog/queries/funnels/test/__snapshots__/test_breakdowns_by_current_url.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_breakdowns_by_current_url.ambr
@@ -58,8 +58,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'watched movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'terminate funnel', 1, 0) as step_1,
@@ -70,18 +70,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['terminate funnel', 'watched movie']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-02 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -157,8 +150,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'watched movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'terminate funnel', 1, 0) as step_1,
@@ -169,18 +162,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['terminate funnel', 'watched movie']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-02 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_breakdowns_by_current_url.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_breakdowns_by_current_url.ambr
@@ -75,6 +75,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['terminate funnel', 'watched movie']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-02 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -167,6 +174,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['terminate funnel', 'watched movie']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-02 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_breakdowns_by_current_url.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_breakdowns_by_current_url.ambr
@@ -58,8 +58,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'watched movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'terminate funnel', 1, 0) as step_1,
@@ -150,8 +150,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'watched movie', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'terminate funnel', 1, 0) as step_1,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -73,6 +73,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['step one', 'step three', 'step two']
+                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-14 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -156,6 +163,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['step one', 'step three', 'step two']
+                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-14 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -334,6 +348,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['paid', 'user signed up']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
@@ -423,6 +444,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['paid', 'user signed up']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
@@ -519,6 +547,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['$pageview', 'user signed up']
+                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-07-01 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
@@ -622,6 +657,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['$pageview', 'user signed up']
+                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-07-01 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
@@ -730,6 +772,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['$pageview', 'user signed up']
+                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-07-01 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
@@ -838,6 +887,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['$pageview', 'user signed up']
+                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-07-01 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
@@ -933,6 +989,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['paid', 'user signed up']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
@@ -996,6 +1059,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['paid', 'user signed up']
+                           AND toTimeZone(timestamp, 'US/Pacific') >= toDateTime('2020-01-01 00:00:00', 'US/Pacific')
+                           AND toTimeZone(timestamp, 'US/Pacific') <= toDateTime('2020-01-14 23:59:59', 'US/Pacific') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -1083,6 +1153,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -1175,6 +1252,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -1265,6 +1349,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -59,8 +59,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -142,8 +142,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -310,8 +310,8 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up'
                            AND (person_id IN
                                   (SELECT id
@@ -405,8 +405,8 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up'
                            AND (person_id IN
                                   (SELECT DISTINCT person_id
@@ -503,8 +503,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               if(event = 'user signed up', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = '$pageview'
@@ -606,8 +606,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               if(event = 'user signed up', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = '$pageview'
@@ -714,8 +714,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               if(event = 'user signed up', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = '$pageview'
@@ -822,8 +822,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               if(event = 'user signed up', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = '$pageview'
@@ -916,8 +916,8 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up'
                            AND (person_id IN
                                   (SELECT person_id as id
@@ -984,8 +984,8 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,
@@ -1067,8 +1067,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy'
@@ -1157,8 +1157,8 @@
                         prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy'
@@ -1250,8 +1250,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['','']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel.ambr
@@ -59,8 +59,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              pdi.person_id as aggregation_target,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -68,18 +68,11 @@
                               if(event = 'step three', 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['step one', 'step three', 'step two']
-                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-14 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -149,8 +142,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              pdi.person_id as aggregation_target,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -158,18 +151,11 @@
                               if(event = 'step three', 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['step one', 'step three', 'step two']
-                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-14 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -324,8 +310,8 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up'
                            AND (person_id IN
                                   (SELECT id
@@ -343,18 +329,11 @@
                         if(event = 'paid', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['paid', 'user signed up']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
@@ -426,8 +405,8 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up'
                            AND (person_id IN
                                   (SELECT DISTINCT person_id
@@ -439,18 +418,11 @@
                         if(event = 'paid', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['paid', 'user signed up']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
@@ -531,8 +503,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              pdi.person_id as aggregation_target,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               if(event = 'user signed up', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = '$pageview'
@@ -542,18 +514,11 @@
                                  AND (has(['aloha2.com'], replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''))), 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['$pageview', 'user signed up']
-                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-07-01 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
@@ -641,8 +606,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              pdi.person_id as aggregation_target,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               if(event = 'user signed up', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = '$pageview'
@@ -652,18 +617,11 @@
                                  AND (has(['aloha2.com'], replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''))), 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['$pageview', 'user signed up']
-                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-07-01 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
@@ -756,8 +714,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              pdi.person_id as aggregation_target,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               if(event = 'user signed up', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = '$pageview'
@@ -767,18 +725,11 @@
                                  AND (has(['aloha2.com'], replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''))), 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['$pageview', 'user signed up']
-                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-07-01 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
@@ -871,8 +822,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              pdi.person_id as aggregation_target,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               if(event = 'user signed up', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = '$pageview'
@@ -882,18 +833,11 @@
                                  AND (has(['aloha2.com'], replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''))), 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['$pageview', 'user signed up']
-                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-07-01 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
@@ -972,8 +916,8 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up'
                            AND (person_id IN
                                   (SELECT person_id as id
@@ -984,18 +928,11 @@
                         if(event = 'paid', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['paid', 'user signed up']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-14 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  INNER JOIN
@@ -1047,25 +984,18 @@
                                                                         ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'user signed up', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'paid', 1, 0) as step_1,
                         if(step_1 = 1, timestamp, null) as latest_1
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['paid', 'user signed up']
-                           AND toTimeZone(timestamp, 'US/Pacific') >= toDateTime('2020-01-01 00:00:00', 'US/Pacific')
-                           AND toTimeZone(timestamp, 'US/Pacific') <= toDateTime('2020-01-14 23:59:59', 'US/Pacific') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -1137,8 +1067,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy'
@@ -1148,18 +1078,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -1234,8 +1157,8 @@
                         prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy'
@@ -1247,18 +1170,11 @@
                            prop_1 as prop,
                            groupUniqArray(prop) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -1334,8 +1250,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['','']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -1344,18 +1260,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_persons.ambr
@@ -120,9 +120,9 @@
                                                                                                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                               e.uuid AS uuid,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -296,9 +296,9 @@
                                                                                                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                               e.uuid AS uuid,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -472,9 +472,9 @@
                                                                                                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                               e.uuid AS uuid,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(step_0 = 1, "uuid", null) as "uuid_0",

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_persons.ambr
@@ -144,6 +144,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['step one', 'step three', 'step two']
+                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
+                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -320,6 +327,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['step one', 'step three', 'step two']
+                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
+                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -496,6 +510,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['step one', 'step three', 'step two']
+                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
+                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_persons.ambr
@@ -120,9 +120,9 @@
                                                                                                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              pdi.person_id as aggregation_target,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                               e.uuid AS uuid,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -139,18 +139,11 @@
                               if(step_2 = 1, "$session_id", null) as "$session_id_2",
                               if(step_2 = 1, "$window_id", null) as "$window_id_2"
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['step one', 'step three', 'step two']
-                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
-                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -303,9 +296,9 @@
                                                                                                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              pdi.person_id as aggregation_target,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                               e.uuid AS uuid,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -322,18 +315,11 @@
                               if(step_2 = 1, "$session_id", null) as "$session_id_2",
                               if(step_2 = 1, "$window_id", null) as "$window_id_2"
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['step one', 'step three', 'step two']
-                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
-                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -486,9 +472,9 @@
                                                                                                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              pdi.person_id as aggregation_target,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                               e.uuid AS uuid,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -505,18 +491,11 @@
                               if(step_2 = 1, "$session_id", null) as "$session_id_2",
                               if(step_2 = 1, "$window_id", null) as "$window_id_2"
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['step one', 'step three', 'step two']
-                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
-                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -55,8 +55,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy'
@@ -66,17 +66,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -148,8 +142,8 @@
                         prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy'
@@ -161,17 +155,11 @@
                            prop_1 as prop,
                            groupUniqArray(prop) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -244,8 +232,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['','']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -254,17 +242,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -55,8 +55,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy'
@@ -142,8 +142,8 @@
                         prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy'
@@ -232,8 +232,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['','']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -71,6 +71,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -160,6 +166,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -247,6 +259,12 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
@@ -84,9 +84,9 @@
                                                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                         e.uuid AS uuid,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -221,9 +221,9 @@
                                                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                         e.uuid AS uuid,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -358,9 +358,9 @@
                                                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                         e.uuid AS uuid,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(step_0 = 1, "uuid", null) as "uuid_0",

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
@@ -108,6 +108,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -245,6 +251,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -382,6 +394,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_strict_persons.ambr
@@ -84,9 +84,9 @@
                                                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                         e.uuid AS uuid,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -103,17 +103,11 @@
                         if(step_2 = 1, "$session_id", null) as "$session_id_2",
                         if(step_2 = 1, "$window_id", null) as "$window_id_2"
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -227,9 +221,9 @@
                                                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                         e.uuid AS uuid,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -246,17 +240,11 @@
                         if(step_2 = 1, "$session_id", null) as "$session_id_2",
                         if(step_2 = 1, "$window_id", null) as "$window_id_2"
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -370,9 +358,9 @@
                                                                                                                                                                                                                                        ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                         e.uuid AS uuid,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -389,17 +377,11 @@
                         if(step_2 = 1, "$session_id", null) as "$session_id_2",
                         if(step_2 = 1, "$window_id", null) as "$window_id_2"
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
@@ -51,8 +51,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -410,8 +410,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step two', 1, 0) as step_1,
@@ -510,8 +510,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step two', 1, 0) as step_1,
@@ -553,8 +553,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step two', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step three', 1, 0) as step_1,
@@ -596,8 +596,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step three', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step one', 1, 0) as step_1,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
@@ -65,6 +65,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['step one', 'step three', 'step two']
+                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
+                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -424,6 +431,12 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -524,6 +537,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['step one', 'step three', 'step two']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -567,6 +587,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['step one', 'step three', 'step two']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -610,6 +637,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['step one', 'step three', 'step two']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_time_to_convert.ambr
@@ -51,8 +51,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              pdi.person_id as aggregation_target,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -60,18 +60,11 @@
                               if(event = 'step three', 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['step one', 'step three', 'step two']
-                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
-                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -417,8 +410,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step two', 1, 0) as step_1,
@@ -426,17 +419,11 @@
                         if(event = 'step three', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -523,8 +510,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step two', 1, 0) as step_1,
@@ -532,18 +519,11 @@
                         if(event = 'step three', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['step one', 'step three', 'step two']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -573,8 +553,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step two', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step three', 1, 0) as step_1,
@@ -582,18 +562,11 @@
                         if(event = 'step one', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['step one', 'step three', 'step two']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -623,8 +596,8 @@
                                                                                            ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step three', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(event = 'step one', 1, 0) as step_1,
@@ -632,18 +605,11 @@
                         if(event = 'step two', 1, 0) as step_2,
                         if(step_2 = 1, timestamp, null) as latest_2
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['step one', 'step three', 'step two']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-06-07 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-06-13 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_trends.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_trends.ambr
@@ -51,8 +51,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              pdi.person_id as aggregation_target,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -60,18 +60,11 @@
                               if(event = 'step three', 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['step one', 'step three', 'step two']
-                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-04-30 00:00:00', 'UTC')
-                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -143,8 +136,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              pdi.person_id as aggregation_target,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -152,18 +145,11 @@
                               if(event = 'step three', 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['step one', 'step three', 'step two']
-                                 AND toTimeZone(timestamp, 'US/Pacific') >= toDateTime('2021-04-30 00:00:00', 'US/Pacific')
-                                 AND toTimeZone(timestamp, 'US/Pacific') <= toDateTime('2021-05-07 23:59:59', 'US/Pacific') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -235,8 +221,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              pdi.person_id as aggregation_target,
-                              pdi.person_id as person_id,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -244,18 +230,11 @@
                               if(event = 'step three', 1, 0) as step_2,
                               if(step_2 = 1, timestamp, null) as latest_2
                        FROM events e
-                       INNER JOIN
+                       LEFT OUTER JOIN
                          (SELECT distinct_id,
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
-                            AND distinct_id IN
-                              (SELECT distinct_id
-                               FROM events
-                               WHERE team_id = 2
-                                 AND event IN ['step one', 'step three', 'step two']
-                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -320,8 +299,8 @@
                                                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'step one', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'step two', 1, 0) as step_1,
@@ -329,18 +308,11 @@
                            if(event = 'step three', 1, 0) as step_2,
                            if(step_2 = 1, timestamp, null) as latest_2
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['step one', 'step three', 'step two']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_trends.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_trends.ambr
@@ -65,6 +65,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['step one', 'step three', 'step two']
+                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-04-30 00:00:00', 'UTC')
+                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -150,6 +157,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['step one', 'step three', 'step two']
+                                 AND toTimeZone(timestamp, 'US/Pacific') >= toDateTime('2021-04-30 00:00:00', 'US/Pacific')
+                                 AND toTimeZone(timestamp, 'US/Pacific') <= toDateTime('2021-05-07 23:59:59', 'US/Pacific') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -235,6 +249,13 @@
                                  argMax(person_id, version) as person_id
                           FROM person_distinct_id2
                           WHERE team_id = 2
+                            AND distinct_id IN
+                              (SELECT distinct_id
+                               FROM events
+                               WHERE team_id = 2
+                                 AND event IN ['step one', 'step three', 'step two']
+                                 AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                                 AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                           GROUP BY distinct_id
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        WHERE team_id = 2
@@ -313,6 +334,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['step one', 'step three', 'step two']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_trends.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_trends.ambr
@@ -51,8 +51,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -136,8 +136,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -221,8 +221,8 @@
                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                     FROM
                       (SELECT e.timestamp as timestamp,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                              if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                              if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -299,8 +299,8 @@
                                                                                               ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_2
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'step one', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'step two', 1, 0) as step_1,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
@@ -98,9 +98,9 @@
                                                                                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                            e.uuid AS uuid,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'step one', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -117,18 +117,11 @@
                            if(step_2 = 1, "$session_id", null) as "$session_id_2",
                            if(step_2 = 1, "$window_id", null) as "$window_id_2"
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['step one', 'step three', 'step two']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -259,9 +252,9 @@
                                                                                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                            e.uuid AS uuid,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'step one', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -278,18 +271,11 @@
                            if(step_2 = 1, "$session_id", null) as "$session_id_2",
                            if(step_2 = 1, "$window_id", null) as "$window_id_2"
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['step one', 'step three', 'step two']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -421,9 +407,9 @@
                                                                                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                            e.uuid AS uuid,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'step one', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -440,18 +426,11 @@
                            if(step_2 = 1, "$session_id", null) as "$session_id_2",
                            if(step_2 = 1, "$window_id", null) as "$window_id_2"
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['step one', 'step three', 'step two']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
@@ -122,6 +122,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['step one', 'step three', 'step two']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -276,6 +283,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['step one', 'step three', 'step two']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -431,6 +445,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['step one', 'step three', 'step two']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-07 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_trends_persons.ambr
@@ -98,9 +98,9 @@
                                                                                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                            e.uuid AS uuid,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'step one', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -252,9 +252,9 @@
                                                                                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                            e.uuid AS uuid,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'step one', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -407,9 +407,9 @@
                                                                                                                                                                                                                                                                                     ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                            e.uuid AS uuid,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'step one', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(step_0 = 1, "uuid", null) as "uuid_0",

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -72,8 +72,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy'
@@ -116,8 +116,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy'
                               AND (has(['xyz'], replaceRegexpAll(JSONExtractRaw(properties, '$version'), '^"|"$', ''))), 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
@@ -221,8 +221,8 @@
                         prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy'
@@ -269,8 +269,8 @@
                         prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy'
                               AND (has(['xyz'], replaceRegexpAll(JSONExtractRaw(properties, '$version'), '^"|"$', ''))), 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
@@ -378,8 +378,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['','']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -421,8 +421,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['','']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
-                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'sign up', 1, 0) as step_1,

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -88,6 +88,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -132,6 +139,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -239,6 +253,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -287,6 +308,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -393,6 +421,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -436,6 +471,13 @@
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 2
+                              AND event IN ['buy', 'sign up']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered.ambr
@@ -72,8 +72,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy'
@@ -83,18 +83,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -123,8 +116,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy'
                               AND (has(['xyz'], replaceRegexpAll(JSONExtractRaw(properties, '$version'), '^"|"$', ''))), 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
@@ -134,18 +127,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -235,8 +221,8 @@
                         prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy'
@@ -248,18 +234,11 @@
                            prop_1 as prop,
                            groupUniqArray(prop) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -290,8 +269,8 @@
                         prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy'
                               AND (has(['xyz'], replaceRegexpAll(JSONExtractRaw(properties, '$version'), '^"|"$', ''))), 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
@@ -303,18 +282,11 @@
                            prop_1 as prop,
                            groupUniqArray(prop) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -406,8 +378,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['','']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'sign up', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'buy', 1, 0) as step_1,
@@ -416,18 +388,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2
@@ -456,8 +421,8 @@
                         if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['','']) as prop
                  FROM
                    (SELECT e.timestamp as timestamp,
-                           pdi.person_id as aggregation_target,
-                           pdi.person_id as person_id,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                           if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                            if(event = 'buy', 1, 0) as step_0,
                            if(step_0 = 1, timestamp, null) as latest_0,
                            if(event = 'sign up', 1, 0) as step_1,
@@ -466,18 +431,11 @@
                            prop_basic as prop,
                            argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
                     FROM events e
-                    INNER JOIN
+                    LEFT OUTER JOIN
                       (SELECT distinct_id,
                               argMax(person_id, version) as person_id
                        FROM person_distinct_id2
                        WHERE team_id = 2
-                         AND distinct_id IN
-                           (SELECT distinct_id
-                            FROM events
-                            WHERE team_id = 2
-                              AND event IN ['buy', 'sign up']
-                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-08 23:59:59', 'UTC') )
                        GROUP BY distinct_id
                        HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                     WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
@@ -52,9 +52,9 @@
                                                                                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                         e.uuid AS uuid,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -120,9 +120,9 @@
                                                                                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                         e.uuid AS uuid,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step two', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -188,9 +188,9 @@
                                                                                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
                         e.uuid AS uuid,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step three', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(step_0 = 1, "uuid", null) as "uuid_0",

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
@@ -52,9 +52,9 @@
                                                                                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                         e.uuid AS uuid,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step one', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -71,18 +71,11 @@
                         if(step_2 = 1, "$session_id", null) as "$session_id_2",
                         if(step_2 = 1, "$window_id", null) as "$window_id_2"
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['step one', 'step three', 'step two']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -127,9 +120,9 @@
                                                                                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                         e.uuid AS uuid,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step two', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -146,18 +139,11 @@
                         if(step_2 = 1, "$session_id", null) as "$session_id_2",
                         if(step_2 = 1, "$window_id", null) as "$window_id_2"
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['step one', 'step three', 'step two']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -202,9 +188,9 @@
                                                                                                                                                                                                                                                                                  ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) "$window_id_2"
               FROM
                 (SELECT e.timestamp as timestamp,
-                        pdi.person_id as aggregation_target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as aggregation_target,
                         e.uuid AS uuid,
-                        pdi.person_id as person_id,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                         if(event = 'step three', 1, 0) as step_0,
                         if(step_0 = 1, timestamp, null) as latest_0,
                         if(step_0 = 1, "uuid", null) as "uuid_0",
@@ -221,18 +207,11 @@
                         if(step_2 = 1, "$session_id", null) as "$session_id_2",
                         if(step_2 = 1, "$window_id", null) as "$window_id_2"
                  FROM events e
-                 INNER JOIN
+                 LEFT OUTER JOIN
                    (SELECT distinct_id,
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
-                      AND distinct_id IN
-                        (SELECT distinct_id
-                         FROM events
-                         WHERE team_id = 2
-                           AND event IN ['step one', 'step three', 'step two']
-                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
-                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2

--- a/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
+++ b/posthog/queries/funnels/test/__snapshots__/test_funnel_unordered_persons.ambr
@@ -76,6 +76,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['step one', 'step three', 'step two']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -144,6 +151,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['step one', 'step three', 'step two']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2
@@ -212,6 +226,13 @@
                            argMax(person_id, version) as person_id
                     FROM person_distinct_id2
                     WHERE team_id = 2
+                      AND distinct_id IN
+                        (SELECT distinct_id
+                         FROM events
+                         WHERE team_id = 2
+                           AND event IN ['step one', 'step three', 'step two']
+                           AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-01 00:00:00', 'UTC')
+                           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-08 23:59:59', 'UTC') )
                     GROUP BY distinct_id
                     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                  WHERE team_id = 2

--- a/posthog/queries/funnels/test/test_funnel.py
+++ b/posthog/queries/funnels/test/test_funnel.py
@@ -3685,6 +3685,35 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             self.assertEqual(result[0]["count"], 1)
             self.assertEqual(result[1]["count"], 1)
 
+        def test_funnel_personless_events_are_supported(self):
+            personless_user = uuid.uuid4()
+            self._signup_event(distinct_id=personless_user, person_id=personless_user)
+            self._add_to_cart_event(distinct_id=personless_user, person_id=personless_user)
+
+            filters = {
+                "events": [
+                    {
+                        "type": "events",
+                        "id": "user signed up",
+                        "order": 0,
+                        "name": "user signed up",
+                        "math": "total",
+                    },
+                    {
+                        "type": "events",
+                        "id": "added to cart",
+                        "order": 1,
+                        "name": "added to cart",
+                        "math": "total",
+                    },
+                ],
+                "funnel_window_days": 14,
+            }
+
+            result = self._basic_funnel(filters=filters).run()
+            self.assertEqual(result[0]["count"], 1)
+            self.assertEqual(result[1]["count"], 1)
+
     return TestGetFunnel
 
 

--- a/posthog/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/posthog/queries/test/__snapshots__/test_lifecycle.ambr
@@ -28,7 +28,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT pdi.person_id as person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -43,7 +43,7 @@
                   period_status_pairs.2 as status,
                   toDateTime(min(person.created_at), 'UTC') AS created_at
            FROM events AS e SAMPLE 0.1
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -61,7 +61,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-12 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'UTC'))) + INTERVAL 1 day
-           GROUP BY pdi.person_id)
+           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'UTC'))
@@ -101,7 +101,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT pdi.person_id as person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -116,7 +116,7 @@
                   period_status_pairs.2 as status,
                   toDateTime(min(person.created_at), 'UTC') AS created_at
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -134,7 +134,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-12 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'UTC'))) + INTERVAL 1 day
-           GROUP BY pdi.person_id)
+           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'UTC'))
@@ -174,7 +174,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT pdi.person_id as person_id,
+          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'US/Pacific'), 'US/Pacific')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'US/Pacific'), 'US/Pacific')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -189,7 +189,7 @@
                   period_status_pairs.2 as status,
                   toDateTime(min(person.created_at), 'US/Pacific') AS created_at
            FROM events AS e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
@@ -207,7 +207,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-12 00:00:00', 'US/Pacific'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'US/Pacific'))) + INTERVAL 1 day
-           GROUP BY pdi.person_id)
+           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'US/Pacific'))

--- a/posthog/queries/test/__snapshots__/test_lifecycle.ambr
+++ b/posthog/queries/test/__snapshots__/test_lifecycle.ambr
@@ -28,7 +28,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -61,7 +61,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-12 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'UTC'))) + INTERVAL 1 day
-           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
+           GROUP BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'UTC'))
@@ -101,7 +101,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'UTC'), 'UTC')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'UTC'), 'UTC')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -134,7 +134,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-12 00:00:00', 'UTC'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'UTC'))) + INTERVAL 1 day
-           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
+           GROUP BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'UTC'))
@@ -174,7 +174,7 @@
                          count(DISTINCT person_id) counts,
                          status
         FROM
-          (SELECT if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+          (SELECT if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                   arraySort(groupUniqArray(dateTrunc('day', toTimeZone(toDateTime(events.timestamp, 'US/Pacific'), 'US/Pacific')))) AS all_activity,
                   arrayPopBack(arrayPushFront(all_activity, dateTrunc('day', toTimeZone(toDateTime(min(person.created_at), 'US/Pacific'), 'US/Pacific')))) as previous_activity,
                   arrayPopFront(arrayPushBack(all_activity, dateTrunc('day', toDateTime('1970-01-01')))) as following_activity,
@@ -207,7 +207,7 @@
              AND event = '$pageview'
              AND timestamp >= toDateTime(dateTrunc('day', toDateTime('2020-01-12 00:00:00', 'US/Pacific'))) - INTERVAL 1 day
              AND timestamp < toDateTime(dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'US/Pacific'))) + INTERVAL 1 day
-           GROUP BY if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id))
+           GROUP BY if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id))
         GROUP BY start_of_period,
                  status)
      WHERE start_of_period <= dateTrunc('day', toDateTime('2020-01-19 23:59:59', 'US/Pacific'))

--- a/posthog/queries/test/__snapshots__/test_retention.ambr
+++ b/posthog/queries/test/__snapshots__/test_retention.ambr
@@ -234,9 +234,9 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               pdi.person_id as target
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -258,7 +258,7 @@
                  event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-                        pdi.person_id as target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
                         [
                           dateDiff(
                               'Day',
@@ -267,7 +267,7 @@
                           )
                       ] as breakdown_values
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -321,9 +321,9 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               pdi.person_id as target
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -338,7 +338,7 @@
                  event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-                        pdi.person_id as target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
                         [
                           dateDiff(
                               'Day',
@@ -347,7 +347,7 @@
                           )
                       ] as breakdown_values
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -393,9 +393,9 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'US/Pacific')) AS event_date,
-               pdi.person_id as target
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -410,7 +410,7 @@
                  event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'US/Pacific')) AS event_date,
-                        pdi.person_id as target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
                         [
                           dateDiff(
                               'Day',
@@ -419,7 +419,7 @@
                           )
                       ] as breakdown_values
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -465,9 +465,9 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
-               pdi.person_id as target
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -482,7 +482,7 @@
                  event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
-                        pdi.person_id as target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
                         [
                           dateDiff(
                               'Week',
@@ -491,7 +491,7 @@
                           )
                       ] as breakdown_values
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -537,9 +537,9 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 3) AS event_date,
-               pdi.person_id as target
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -554,7 +554,7 @@
                  event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 3) AS event_date,
-                        pdi.person_id as target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
                         [
                           dateDiff(
                               'Week',
@@ -563,7 +563,7 @@
                           )
                       ] as breakdown_values
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2

--- a/posthog/queries/test/__snapshots__/test_retention.ambr
+++ b/posthog/queries/test/__snapshots__/test_retention.ambr
@@ -7,9 +7,9 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               pdi.person_id as target
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
         FROM events e SAMPLE 1.0
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -24,7 +24,7 @@
                  event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-                        pdi.person_id as target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
                         [
                           dateDiff(
                               'Day',
@@ -33,7 +33,7 @@
                           )
                       ] as breakdown_values
         FROM events e SAMPLE 1.0
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -162,9 +162,9 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               pdi.person_id as target
+               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
@@ -179,7 +179,7 @@
                  event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-                        pdi.person_id as target,
+                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
                         [
                           dateDiff(
                               'Day',
@@ -188,7 +188,7 @@
                           )
                       ] as breakdown_values
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2

--- a/posthog/queries/test/__snapshots__/test_retention.ambr
+++ b/posthog/queries/test/__snapshots__/test_retention.ambr
@@ -7,7 +7,7 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target
         FROM events e SAMPLE 1.0
         LEFT OUTER JOIN
           (SELECT distinct_id,
@@ -24,7 +24,7 @@
                  event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target,
                         [
                           dateDiff(
                               'Day',
@@ -162,7 +162,7 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target
         FROM events e
         LEFT OUTER JOIN
           (SELECT distinct_id,
@@ -179,7 +179,7 @@
                  event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target,
                         [
                           dateDiff(
                               'Day',

--- a/posthog/queries/test/__snapshots__/test_retention.ambr
+++ b/posthog/queries/test/__snapshots__/test_retention.ambr
@@ -234,7 +234,7 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target
         FROM events e
         LEFT OUTER JOIN
           (SELECT distinct_id,
@@ -258,7 +258,7 @@
                  event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target,
                         [
                           dateDiff(
                               'Day',
@@ -321,7 +321,7 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target
         FROM events e
         LEFT OUTER JOIN
           (SELECT distinct_id,
@@ -338,7 +338,7 @@
                  event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC')) AS event_date,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target,
                         [
                           dateDiff(
                               'Day',
@@ -393,7 +393,7 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'US/Pacific')) AS event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target
         FROM events e
         LEFT OUTER JOIN
           (SELECT distinct_id,
@@ -410,7 +410,7 @@
                  event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfDay(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'US/Pacific')) AS event_date,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target,
                         [
                           dateDiff(
                               'Day',
@@ -465,7 +465,7 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target
         FROM events e
         LEFT OUTER JOIN
           (SELECT distinct_id,
@@ -482,7 +482,7 @@
                  event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 0) AS event_date,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target,
                         [
                           dateDiff(
                               'Week',
@@ -537,7 +537,7 @@
           NULL as selected_interval,
           returning_event_query as
        (SELECT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 3) AS event_date,
-               if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target
+               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target
         FROM events e
         LEFT OUTER JOIN
           (SELECT distinct_id,
@@ -554,7 +554,7 @@
                  event_date),
           target_event_query as
        (SELECT DISTINCT toStartOfWeek(toTimeZone(toDateTime(e.timestamp, 'UTC'), 'UTC'), 3) AS event_date,
-                        if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as target,
+                        if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as target,
                         [
                           dateDiff(
                               'Week',

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -51,6 +51,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event IN ['sign up']
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -1034,6 +1041,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = 'event_name'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-26 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-02 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -1723,6 +1737,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = 'watched movie'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -1768,6 +1789,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = 'watched movie'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -1840,6 +1868,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = 'watched movie'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -1912,6 +1947,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = 'watched movie'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -2216,6 +2258,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = 'sign up'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-22 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -2258,6 +2307,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = 'sign up'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'UTC')
+                        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -2418,6 +2474,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = 'sign up'
+                  AND toTimeZone(timestamp, 'America/Phoenix') >= toDateTime(toStartOfDay(toDateTime('2019-12-22 00:00:00', 'America/Phoenix')), 'America/Phoenix')
+                  AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 23:59:59', 'America/Phoenix'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -2460,6 +2523,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = 'sign up'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'America/Phoenix')
+                        AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 23:59:59', 'America/Phoenix'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -2620,6 +2690,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = 'sign up'
+                  AND toTimeZone(timestamp, 'Asia/Tokyo') >= toDateTime(toStartOfDay(toDateTime('2019-12-22 00:00:00', 'Asia/Tokyo')), 'Asia/Tokyo')
+                  AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 23:59:59', 'Asia/Tokyo'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -2662,6 +2739,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = 'sign up'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'Asia/Tokyo')
+                        AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 23:59:59', 'Asia/Tokyo'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -2796,6 +2880,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = 'sign up'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 10:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -2823,6 +2914,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'sign up'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-05 07:00:00', 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 08:00:00', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -2884,6 +2982,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = 'sign up'
+                  AND toTimeZone(timestamp, 'America/Phoenix') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix')), 'America/Phoenix')
+                  AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 10:59:59', 'America/Phoenix'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -2911,6 +3016,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'sign up'
+               AND toTimeZone(timestamp, 'America/Phoenix') >= toDateTime('2020-01-05 07:00:00', 'America/Phoenix')
+               AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 08:00:00', 'America/Phoenix'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -2972,6 +3084,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = 'sign up'
+                  AND toTimeZone(timestamp, 'Asia/Tokyo') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')), 'Asia/Tokyo')
+                  AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 10:59:59', 'Asia/Tokyo'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -2999,6 +3118,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'sign up'
+               AND toTimeZone(timestamp, 'Asia/Tokyo') >= toDateTime('2020-01-05 07:00:00', 'Asia/Tokyo')
+               AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 08:00:00', 'Asia/Tokyo'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -3216,6 +3342,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = 'sign up'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -3244,6 +3377,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'sign up'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-04 00:00:00', 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -3274,6 +3414,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'sign up'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-04 00:00:00', 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -3304,6 +3451,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'sign up'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-04 00:00:00', 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -3586,6 +3740,13 @@
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
+             AND distinct_id IN
+               (SELECT distinct_id
+                FROM events
+                WHERE team_id = 2
+                  AND event = 'sign up'
+                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), 'UTC')
+                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -4354,6 +4515,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'viewed video'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
@@ -4477,6 +4645,13 @@
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
               WHERE team_id = 2
+                AND distinct_id IN
+                  (SELECT distinct_id
+                   FROM events
+                   WHERE team_id = 2
+                     AND event = 'viewed video'
+                     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
+                     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC'))
               GROUP BY distinct_id
               HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
            INNER JOIN
@@ -5027,6 +5202,13 @@
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
+       AND distinct_id IN
+         (SELECT distinct_id
+          FROM events
+          WHERE team_id = 2
+            AND event = '$pageview'
+            AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-05 23:59:59', 'UTC')
+            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   WHERE team_id = 2
@@ -5045,6 +5227,13 @@
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
+       AND distinct_id IN
+         (SELECT distinct_id
+          FROM events
+          WHERE team_id = 2
+            AND event = '$pageview'
+            AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-11 23:59:59', 'UTC')
+            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-18 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   WHERE team_id = 2
@@ -5063,6 +5252,13 @@
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
+       AND distinct_id IN
+         (SELECT distinct_id
+          FROM events
+          WHERE team_id = 2
+            AND event = '$pageview'
+            AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-11 23:59:59', 'UTC')
+            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-18 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   WHERE team_id = 2
@@ -5102,6 +5298,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = '$pageview'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-19 23:59:59', 'UTC'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5151,6 +5354,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = '$pageview'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'America/Phoenix')
+                        AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-19 23:59:59', 'America/Phoenix'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5200,6 +5410,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = '$pageview'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'Asia/Tokyo')
+                        AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-19 23:59:59', 'Asia/Tokyo'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5249,6 +5466,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = '$pageview'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-25 00:00:00', 'UTC')
+                        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               INNER JOIN
@@ -5310,6 +5534,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = '$pageview'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-25 00:00:00', 'UTC')
+                        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               INNER JOIN
@@ -5371,6 +5602,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = '$pageview'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-02 06:00:00', 'UTC')
+                        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-09 17:00:00', 'UTC'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5420,6 +5658,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = '$pageview'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-24 00:00:00', 'UTC')
+                        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-29 23:59:59', 'UTC'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5469,6 +5714,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = '$pageview'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-24 00:00:00', 'America/Phoenix')
+                        AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-02-29 23:59:59', 'America/Phoenix'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5518,6 +5770,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = '$pageview'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-24 00:00:00', 'Asia/Tokyo')
+                        AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-02-29 23:59:59', 'Asia/Tokyo'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5567,6 +5826,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = '$pageview'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'UTC')
+                        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-18 23:59:59', 'UTC'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5616,6 +5882,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = '$pageview'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'America/Phoenix')
+                        AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-18 23:59:59', 'America/Phoenix'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5665,6 +5938,13 @@
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
+                   AND distinct_id IN
+                     (SELECT distinct_id
+                      FROM events
+                      WHERE team_id = 2
+                        AND event = '$pageview'
+                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'Asia/Tokyo')
+                        AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-18 23:59:59', 'Asia/Tokyo'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -67,7 +67,7 @@
            AND (has(['x'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$bool_prop'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND ((event = 'sign up'
-                AND (if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) IN
+                AND (if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) IN
                        (SELECT DISTINCT person_id
                         FROM cohortpeople
                         WHERE team_id = 2
@@ -2814,7 +2814,7 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
@@ -2902,7 +2902,7 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
@@ -2990,7 +2990,7 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -46,18 +46,11 @@
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event IN ['sign up']
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -74,7 +67,7 @@
            AND (has(['x'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$bool_prop'), '^"|"$', ''))) SETTINGS optimize_aggregation_in_order = 1) person ON person.id = pdi.person_id
         WHERE team_id = 2
           AND ((event = 'sign up'
-                AND (pdi.person_id IN
+                AND (if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) IN
                        (SELECT DISTINCT person_id
                         FROM cohortpeople
                         WHERE team_id = 2
@@ -1036,18 +1029,11 @@
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = 'event_name'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-26 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-02 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -1732,18 +1718,11 @@
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = 'watched movie'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -1784,18 +1763,11 @@
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = 'watched movie'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -1863,18 +1835,11 @@
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = 'watched movie'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -1942,18 +1907,11 @@
         UNION ALL SELECT count(*) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = 'watched movie'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -2253,18 +2211,11 @@
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = 'sign up'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-22 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -2302,18 +2253,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = 'sign up'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'UTC')
-                        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 23:59:59', 'UTC'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -2469,18 +2413,11 @@
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'America/Phoenix')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = 'sign up'
-                  AND toTimeZone(timestamp, 'America/Phoenix') >= toDateTime(toStartOfDay(toDateTime('2019-12-22 00:00:00', 'America/Phoenix')), 'America/Phoenix')
-                  AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 23:59:59', 'America/Phoenix'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -2518,18 +2455,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'America/Phoenix') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = 'sign up'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'America/Phoenix')
-                        AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 23:59:59', 'America/Phoenix'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -2685,18 +2615,11 @@
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'Asia/Tokyo')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = 'sign up'
-                  AND toTimeZone(timestamp, 'Asia/Tokyo') >= toDateTime(toStartOfDay(toDateTime('2019-12-22 00:00:00', 'Asia/Tokyo')), 'Asia/Tokyo')
-                  AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 23:59:59', 'Asia/Tokyo'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -2734,18 +2657,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'Asia/Tokyo') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = 'sign up'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'Asia/Tokyo')
-                        AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 23:59:59', 'Asia/Tokyo'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -2875,18 +2791,11 @@
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
                          toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = 'sign up'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 10:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -2905,22 +2814,15 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'sign up'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-05 07:00:00', 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-05 08:00:00', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -2977,18 +2879,11 @@
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
                          toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'America/Phoenix')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = 'sign up'
-                  AND toTimeZone(timestamp, 'America/Phoenix') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'America/Phoenix')), 'America/Phoenix')
-                  AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 10:59:59', 'America/Phoenix'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -3007,22 +2902,15 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'sign up'
-               AND toTimeZone(timestamp, 'America/Phoenix') >= toDateTime('2020-01-05 07:00:00', 'America/Phoenix')
-               AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-05 08:00:00', 'America/Phoenix'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -3079,18 +2967,11 @@
         UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
                          toStartOfHour(toTimeZone(toDateTime(timestamp, 'UTC'), 'Asia/Tokyo')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = 'sign up'
-                  AND toTimeZone(timestamp, 'Asia/Tokyo') >= toDateTime(toStartOfHour(toDateTime('2020-01-05 00:00:00', 'Asia/Tokyo')), 'Asia/Tokyo')
-                  AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 10:59:59', 'Asia/Tokyo'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -3109,22 +2990,15 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'sign up'
-               AND toTimeZone(timestamp, 'Asia/Tokyo') >= toDateTime('2020-01-05 07:00:00', 'Asia/Tokyo')
-               AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-05 08:00:00', 'Asia/Tokyo'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -3337,18 +3211,11 @@
         UNION ALL SELECT count(DISTINCT e.person_id) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = 'sign up'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         WHERE team_id = 2
@@ -3372,18 +3239,11 @@
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'sign up'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-04 00:00:00', 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -3409,18 +3269,11 @@
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'sign up'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-04 00:00:00', 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -3446,18 +3299,11 @@
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'sign up'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-04 00:00:00', 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2
@@ -3735,18 +3581,11 @@
         UNION ALL SELECT count(DISTINCT e.distinct_id) AS total,
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
-        INNER JOIN
+        LEFT OUTER JOIN
           (SELECT distinct_id,
                   argMax(person_id, version) as person_id
            FROM person_distinct_id2
            WHERE team_id = 2
-             AND distinct_id IN
-               (SELECT distinct_id
-                FROM events
-                WHERE team_id = 2
-                  AND event = 'sign up'
-                  AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-24 00:00:00', 'UTC')), 'UTC')
-                  AND toTimeZone(timestamp, 'UTC') <= toDateTime('2019-12-31 23:59:59', 'UTC'))
            GROUP BY distinct_id
            HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
         INNER JOIN
@@ -4510,18 +4349,11 @@
   FROM
     (SELECT count() AS intermediate_count
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'viewed video'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      INNER JOIN
@@ -4640,18 +4472,11 @@
           (SELECT count() AS intermediate_count,
                   toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
            FROM events e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
               WHERE team_id = 2
-                AND distinct_id IN
-                  (SELECT distinct_id
-                   FROM events
-                   WHERE team_id = 2
-                     AND event = 'viewed video'
-                     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')), 'UTC')
-                     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-07 23:59:59', 'UTC'))
               GROUP BY distinct_id
               HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
            INNER JOIN
@@ -5197,18 +5022,11 @@
   
   SELECT count(DISTINCT pdi.person_id) AS total
   FROM events e
-  INNER JOIN
+  LEFT OUTER JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
-       AND distinct_id IN
-         (SELECT distinct_id
-          FROM events
-          WHERE team_id = 2
-            AND event = '$pageview'
-            AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-05 23:59:59', 'UTC')
-            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   WHERE team_id = 2
@@ -5222,18 +5040,11 @@
   
   SELECT count(DISTINCT pdi.person_id) AS total
   FROM events e
-  INNER JOIN
+  LEFT OUTER JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
-       AND distinct_id IN
-         (SELECT distinct_id
-          FROM events
-          WHERE team_id = 2
-            AND event = '$pageview'
-            AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-11 23:59:59', 'UTC')
-            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-18 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   WHERE team_id = 2
@@ -5247,18 +5058,11 @@
   
   SELECT count(DISTINCT pdi.person_id) AS total
   FROM events e SAMPLE 1.0
-  INNER JOIN
+  LEFT OUTER JOIN
     (SELECT distinct_id,
             argMax(person_id, version) as person_id
      FROM person_distinct_id2
      WHERE team_id = 2
-       AND distinct_id IN
-         (SELECT distinct_id
-          FROM events
-          WHERE team_id = 2
-            AND event = '$pageview'
-            AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-11 23:59:59', 'UTC')
-            AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-18 23:59:59', 'UTC'))
      GROUP BY distinct_id
      HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
   WHERE team_id = 2
@@ -5293,18 +5097,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = '$pageview'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
-                        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-19 23:59:59', 'UTC'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5349,18 +5146,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'America/Phoenix') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = '$pageview'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'America/Phoenix')
-                        AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-19 23:59:59', 'America/Phoenix'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5405,18 +5195,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'Asia/Tokyo') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = '$pageview'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'Asia/Tokyo')
-                        AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-19 23:59:59', 'Asia/Tokyo'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5461,18 +5244,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = '$pageview'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-25 00:00:00', 'UTC')
-                        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               INNER JOIN
@@ -5529,18 +5305,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = '$pageview'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-25 00:00:00', 'UTC')
-                        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-12 23:59:59', 'UTC'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               INNER JOIN
@@ -5597,18 +5366,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = '$pageview'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2020-01-02 06:00:00', 'UTC')
-                        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-09 17:00:00', 'UTC'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5653,18 +5415,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = '$pageview'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-24 00:00:00', 'UTC')
-                        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-02-29 23:59:59', 'UTC'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5709,18 +5464,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'America/Phoenix') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = '$pageview'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-24 00:00:00', 'America/Phoenix')
-                        AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-02-29 23:59:59', 'America/Phoenix'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5765,18 +5513,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'Asia/Tokyo') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = '$pageview'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-11-24 00:00:00', 'Asia/Tokyo')
-                        AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-02-29 23:59:59', 'Asia/Tokyo'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5821,18 +5562,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = '$pageview'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'UTC')
-                        AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-18 23:59:59', 'UTC'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5877,18 +5611,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'America/Phoenix') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = '$pageview'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'America/Phoenix')
-                        AND toTimeZone(timestamp, 'America/Phoenix') <= toDateTime('2020-01-18 23:59:59', 'America/Phoenix'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2
@@ -5933,18 +5660,11 @@
              (SELECT toTimeZone(toDateTime(timestamp, 'UTC'), 'Asia/Tokyo') AS timestamp,
                      pdi.person_id AS actor_id
               FROM events e
-              INNER JOIN
+              LEFT OUTER JOIN
                 (SELECT distinct_id,
                         argMax(person_id, version) as person_id
                  FROM person_distinct_id2
                  WHERE team_id = 2
-                   AND distinct_id IN
-                     (SELECT distinct_id
-                      FROM events
-                      WHERE team_id = 2
-                        AND event = '$pageview'
-                        AND toDateTime(timestamp, 'UTC') >= toDateTime('2019-12-22 00:00:00', 'Asia/Tokyo')
-                        AND toTimeZone(timestamp, 'Asia/Tokyo') <= toDateTime('2020-01-18 23:59:59', 'Asia/Tokyo'))
                  GROUP BY distinct_id
                  HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
               WHERE team_id = 2

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -688,18 +688,11 @@
            UNION ALL SELECT count(DISTINCT pdi.person_id) AS total,
                             toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
            FROM events e
-           INNER JOIN
+           LEFT OUTER JOIN
              (SELECT distinct_id,
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
               WHERE team_id = 2
-                AND distinct_id IN
-                  (SELECT distinct_id
-                   FROM events
-                   WHERE team_id = 2
-                     AND event = 'session start'
-                     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
-                     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
               GROUP BY distinct_id
               HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
            WHERE team_id = 2

--- a/posthog/queries/trends/test/__snapshots__/test_formula.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_formula.ambr
@@ -693,6 +693,13 @@
                      argMax(person_id, version) as person_id
               FROM person_distinct_id2
               WHERE team_id = 2
+                AND distinct_id IN
+                  (SELECT distinct_id
+                   FROM events
+                   WHERE team_id = 2
+                     AND event = 'session start'
+                     AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                     AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC'))
               GROUP BY distinct_id
               HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
            WHERE team_id = 2

--- a/posthog/queries/trends/test/__snapshots__/test_person.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_person.ambr
@@ -44,22 +44,15 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            pdi.person_id as person_id,
+            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e
-     INNER JOIN
+     LEFT OUTER JOIN
        (SELECT distinct_id,
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
-          AND distinct_id IN
-            (SELECT distinct_id
-             FROM events
-             WHERE team_id = 2
-               AND event = 'pageview'
-               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-21 00:00:00', 'UTC')
-               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-21 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2

--- a/posthog/queries/trends/test/__snapshots__/test_person.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_person.ambr
@@ -44,7 +44,7 @@
          count() AS actor_value
   FROM
     (SELECT e.timestamp as timestamp,
-            if(not(empty(pdi.distinct_id)), pdi.person_id, e.person_id) as person_id,
+            if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
             e.distinct_id as distinct_id,
             e.team_id as team_id
      FROM events e

--- a/posthog/queries/trends/test/__snapshots__/test_person.ambr
+++ b/posthog/queries/trends/test/__snapshots__/test_person.ambr
@@ -53,6 +53,13 @@
                argMax(person_id, version) as person_id
         FROM person_distinct_id2
         WHERE team_id = 2
+          AND distinct_id IN
+            (SELECT distinct_id
+             FROM events
+             WHERE team_id = 2
+               AND event = 'pageview'
+               AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-01-21 00:00:00', 'UTC')
+               AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-01-21 23:59:59', 'UTC'))
         GROUP BY distinct_id
         HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
      WHERE team_id = 2


### PR DESCRIPTION
## Problem

Personless events don't create person profiles. Legacy funnels were joining those profiles using the inner join, so users were filtered out because they didn't have a profile.

## Changes

- Refactored the join type to the left outer join.
- Pick a correct aggregation_target and person_id. If a person's profile exists, pick that ID. Otherwise, pick the distinct_id of the event.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing + added more tests.
