### PR TITLE
labs(hogql): rust parser experiment

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -591,6 +591,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +763,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1036,6 +1058,12 @@ checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1433,6 +1461,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "globset"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.5",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +1634,7 @@ dependencies = [
 name = "hogql-parser"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "serde",
  "serde_json",
  "wasm-bindgen",
@@ -1966,6 +2008,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6593a41c7a73841868772495db7dc1e8ecab43bb5c0b6da2059246c4b506ab60"
+dependencies = [
+ "console",
+ "globset",
+ "lazy_static",
+ "linked-hash-map",
+ "serde",
+ "similar",
+ "walkdir",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2196,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1590,6 +1590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hogql-parser"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4490,6 +4499,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ members = [
   "cyclotron-core",
   "cyclotron-node",
   "cyclotron-janitor",
-  "cyclotron-fetch",
+  "cyclotron-fetch", "hogql-parser",
 ]
 
 [workspace.lints.rust]

--- a/rust/hogql-parser/Cargo.toml
+++ b/rust/hogql-parser/Cargo.toml
@@ -8,6 +8,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 
+[dev-dependencies]
+insta = { version = "1.40.0", features = ["glob", "json"] }
+
 [lints]
 workspace = true
 

--- a/rust/hogql-parser/Cargo.toml
+++ b/rust/hogql-parser/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "hogql-parser"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "hogql_parser"
+path = "src/bin/main.rs"

--- a/rust/hogql-parser/index.html
+++ b/rust/hogql-parser/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>HogQL Parser</title>
+</head>
+<body>
+    <h1>HogQL Parser</h1>
+    <pre id="output"></pre>
+    <script type="module">
+        import init, { parse_query } from './pkg/hogql_parser.js';
+
+        async function run() {
+            await init();
+
+            const query = 'SELECT name, age FROM users WHERE age > 30 AND status = \'active\';';
+            const ast = parse_query(query);
+            document.getElementById('output').textContent = JSON.stringify(ast, null, 2);
+        }
+
+        run();
+    </script>
+</body>
+</html>

--- a/rust/hogql-parser/src/bin/main.rs
+++ b/rust/hogql-parser/src/bin/main.rs
@@ -1,0 +1,16 @@
+// src/bin/main.rs
+use hogql_parser::parse_query;
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        eprintln!("Usage: hogql_parser \"SQL QUERY\"");
+        std::process::exit(1);
+    }
+
+    let query = &args[1];
+    let ast = parse_query(query);
+    println!("{}", serde_json::to_string_pretty(&ast).unwrap());
+}

--- a/rust/hogql-parser/src/lexer.rs
+++ b/rust/hogql-parser/src/lexer.rs
@@ -4,110 +4,471 @@ use std::str::Chars;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub enum Token {
-    Select,
-    From,
-    Where,
+    // Keywords
+    All,
     And,
+    Anti,
+    Any,
+    Array,
+    As,
+    Ascending,
+    Asc,
+    Asof,
+    Between,
+    Both,
+    By,
+    Case,
+    Cast,
+    Catch,
+    Cohort,
+    Collate,
+    Cross,
+    Cube,
+    Current,
+    Date,
+    Day,
+    Desc,
+    Descending,
+    Distinct,
+    Else,
+    End,
+    Extract,
+    Final,
+    Finally,
+    First,
+    Fn,
+    Following,
+    For,
+    From,
+    Full,
+    Fun,
+    Group,
+    Having,
+    Hour,
+//     Id,
+    If,
+    Ilike,
+    In,
+    Inf,
+    Inner,
+    Interval,
+    Is,
+    Join,
+    Key,
+    Last,
+    Leading,
+    Left,
+    Let,
+    Like,
+    Limit,
+    Minute,
+    Month,
+    NanSql,
+    Not,
+    NullSql,
+    Nulls,
+    Offset,
+    On,
     Or,
+    Order,
+    Outer,
+    Over,
+    Partition,
+    Preceding,
+    Prewhere,
+    Quarter,
+    Range,
+    Return,
+    Right,
+    Rollup,
+    Row,
+    Rows,
+    Sample,
+    Second,
+    Select,
+    Semi,
+    Settings,
+    Substring,
+    Then,
+    Throw,
+    Ties,
+    Timestamp,
+    To,
+    Top,
+    Totals,
+    Trailing,
+    Trim,
+    Truncate,
+    Try,
+    Unbounded,
+    Union,
+    Using,
+    Week,
+    When,
+    Where,
+    While,
+    Window,
+    With,
+    Year,
+
+    // Identifiers and Literals
     Identifier(String),
+    StringLiteral(String),
+    NumberLiteral(String),
+
+    // Operators
     Operator(String),
-    Literal(String),
+
+    // Symbols
     Comma,
     Semicolon,
     Asterisk,
-    LeftParen,
-    RightParen,
+    LParen,
+    RParen,
+    LBracket,
+    RBracket,
+    LBrace,
+    RBrace,
+    Dot,
+    Plus,
+    Dash,
+    Slash,
+    Percent,
+    Colon,
+    Query,
+    EqSingle,
+    EqDouble,
+    NotEq,
+    Lt,
+    LtEq,
+    Gt,
+    GtEq,
+    AndOp,
+    OrOp,
+    NotOp,
+    Concat,
+    Arrow,
+    // ... Add other symbols as needed
+
     EOF,
 }
 
 pub struct Lexer<'a> {
     input: Peekable<Chars<'a>>,
+    current_char: Option<char>,
 }
 
 impl<'a> Lexer<'a> {
     pub fn new(input: &'a str) -> Self {
-        Lexer {
+        let mut lexer = Lexer {
             input: input.chars().peekable(),
-        }
+            current_char: None,
+        };
+        lexer.advance();
+        lexer
     }
 
-    fn next_char(&mut self) -> Option<char> {
-        self.input.next()
+    fn advance(&mut self) {
+        self.current_char = self.input.next();
     }
 
-    fn peek_char(&mut self) -> Option<&char> {
+    fn peek(&mut self) -> Option<&char> {
         self.input.peek()
     }
 
     fn skip_whitespace(&mut self) {
-        while matches!(self.peek_char(), Some(c) if c.is_whitespace()) {
-            self.next_char();
+        while matches!(self.current_char, Some(c) if c.is_whitespace()) {
+            self.advance();
         }
     }
 
-    fn lex_identifier(&mut self, first_char: char) -> String {
-        let mut ident = first_char.to_string();
-        while matches!(self.peek_char(), Some(c) if c.is_alphanumeric() || *c == '_') {
-            ident.push(self.next_char().unwrap());
+    fn lex_identifier_or_keyword(&mut self) -> Token {
+        let mut ident = String::new();
+        while matches!(self.current_char, Some(c) if c.is_alphanumeric() || c == '_' || c == '$') {
+            ident.push(self.current_char.unwrap());
+            self.advance();
         }
-        ident
+        match ident.to_uppercase().as_str() {
+            "ALL" => Token::All,
+            "AND" => Token::And,
+            "ANTI" => Token::Anti,
+            "ANY" => Token::Any,
+            "ARRAY" => Token::Array,
+            "AS" => Token::As,
+            "ASC" => Token::Asc,
+            "ASCENDING" => Token::Ascending,
+            "ASOF" => Token::Asof,
+            "BETWEEN" => Token::Between,
+            "BOTH" => Token::Both,
+            "BY" => Token::By,
+            "CASE" => Token::Case,
+            "CAST" => Token::Cast,
+            "CATCH" => Token::Catch,
+            "COHORT" => Token::Cohort,
+            "COLLATE" => Token::Collate,
+            "CROSS" => Token::Cross,
+            "CUBE" => Token::Cube,
+            "CURRENT" => Token::Current,
+            "DATE" => Token::Date,
+            "DAY" => Token::Day,
+            "DESC" => Token::Desc,
+            "DESCENDING" => Token::Descending,
+            "DISTINCT" => Token::Distinct,
+            "ELSE" => Token::Else,
+            "END" => Token::End,
+            "EXTRACT" => Token::Extract,
+            "FINAL" => Token::Final,
+            "FINALLY" => Token::Finally,
+            "FIRST" => Token::First,
+            "FN" => Token::Fn,
+            "FOLLOWING" => Token::Following,
+            "FOR" => Token::For,
+            "FROM" => Token::From,
+            "FULL" => Token::Full,
+            "FUN" => Token::Fun,
+            "GROUP" => Token::Group,
+            "HAVING" => Token::Having,
+            "HOUR" => Token::Hour,
+//             "ID" => Token::Id,
+            "IF" => Token::If,
+            "ILIKE" => Token::Ilike,
+            "IN" => Token::In,
+            "INF" => Token::Inf,
+            "INNER" => Token::Inner,
+            "INTERVAL" => Token::Interval,
+            "IS" => Token::Is,
+            "JOIN" => Token::Join,
+            "KEY" => Token::Key,
+            "LAST" => Token::Last,
+            "LEADING" => Token::Leading,
+            "LEFT" => Token::Left,
+            "LET" => Token::Let,
+            "LIKE" => Token::Like,
+            "LIMIT" => Token::Limit,
+            "MINUTE" => Token::Minute,
+            "MONTH" => Token::Month,
+            "NAN" | "NAN_SQL" => Token::NanSql,
+            "NOT" => Token::Not,
+            "NULL" | "NULL_SQL" => Token::NullSql,
+            "NULLS" => Token::Nulls,
+            "OFFSET" => Token::Offset,
+            "ON" => Token::On,
+            "OR" => Token::Or,
+            "ORDER" => Token::Order,
+            "OUTER" => Token::Outer,
+            "OVER" => Token::Over,
+            "PARTITION" => Token::Partition,
+            "PRECEDING" => Token::Preceding,
+            "PREWHERE" => Token::Prewhere,
+            "QUARTER" => Token::Quarter,
+            "RANGE" => Token::Range,
+            "RETURN" => Token::Return,
+            "RIGHT" => Token::Right,
+            "ROLLUP" => Token::Rollup,
+            "ROW" => Token::Row,
+            "ROWS" => Token::Rows,
+            "SAMPLE" => Token::Sample,
+            "SECOND" => Token::Second,
+            "SELECT" => Token::Select,
+            "SEMI" => Token::Semi,
+            "SETTINGS" => Token::Settings,
+            "SUBSTRING" => Token::Substring,
+            "THEN" => Token::Then,
+            "THROW" => Token::Throw,
+            "TIES" => Token::Ties,
+            "TIMESTAMP" => Token::Timestamp,
+            "TO" => Token::To,
+            "TOP" => Token::Top,
+            "TOTALS" => Token::Totals,
+            "TRAILING" => Token::Trailing,
+            "TRIM" => Token::Trim,
+            "TRUNCATE" => Token::Truncate,
+            "TRY" => Token::Try,
+            "UNBOUNDED" => Token::Unbounded,
+            "UNION" => Token::Union,
+            "USING" => Token::Using,
+            "WEEK" => Token::Week,
+            "WHEN" => Token::When,
+            "WHERE" => Token::Where,
+            "WHILE" => Token::While,
+            "WINDOW" => Token::Window,
+            "WITH" => Token::With,
+            "YEAR" => Token::Year,
+            // Add more keywords as needed
+            _ => Token::Identifier(ident),
+        }
     }
 
-    fn lex_number(&mut self, first_char: char) -> String {
-        let mut number = first_char.to_string();
-        while matches!(self.peek_char(), Some(c) if c.is_numeric() || *c == '.') {
-            number.push(self.next_char().unwrap());
+    fn lex_number(&mut self) -> Token {
+        let mut number = String::new();
+        while matches!(self.current_char, Some(c) if c.is_numeric() || c == '.') {
+            number.push(self.current_char.unwrap());
+            self.advance();
         }
-        number
+        Token::NumberLiteral(number)
     }
 
-    fn lex_string(&mut self) -> String {
+    fn lex_string(&mut self) -> Token {
+        let quote_char = self.current_char.unwrap();
+        self.advance(); // Skip opening quote
         let mut string = String::new();
-        // Do not skip the opening quote here
-        while let Some(c) = self.next_char() {
-            if c == '\'' {
+        while let Some(c) = self.current_char {
+            if c == quote_char {
+                self.advance(); // Skip closing quote
                 break;
             }
-            string.push(c);
+            if c == '\\' {
+                self.advance();
+                if let Some(escaped_char) = self.current_char {
+                    match escaped_char {
+                        'n' => string.push('\n'),
+                        't' => string.push('\t'),
+                        '\\' => string.push('\\'),
+                        '\'' => string.push('\''),
+                        '"' => string.push('"'),
+                        _ => string.push(escaped_char),
+                    }
+                    self.advance();
+                }
+            } else {
+                string.push(c);
+                self.advance();
+            }
         }
-        string
+        Token::StringLiteral(string)
     }
 
     pub fn get_next_token(&mut self) -> Token {
         self.skip_whitespace();
-        if let Some(c) = self.next_char() {
+        if let Some(c) = self.current_char {
             match c {
-                ',' => Token::Comma,
-                ';' => Token::Semicolon,
-                '*' => Token::Asterisk,
-                '(' => Token::LeftParen,
-                ')' => Token::RightParen,
-                '=' | '>' | '<' | '!' => {
-                    let mut op = c.to_string();
-                    if let Some(next_c) = self.peek_char() {
-                        if *next_c == '=' || (c == '<' && *next_c == '>') || (c == '!' && *next_c == '=') {
-                            op.push(*next_c);
-                            self.next_char();
-                        }
-                    }
-                    Token::Operator(op)
+                ',' => {
+                    self.advance();
+                    Token::Comma
                 }
-                '\'' => {
-                    Token::Literal(self.lex_string())
-                },
-                c if c.is_alphabetic() || c == '_' => {
-                    let ident = self.lex_identifier(c);
-                    match ident.to_uppercase().as_str() {
-                        "SELECT" => Token::Select,
-                        "FROM" => Token::From,
-                        "WHERE" => Token::Where,
-                        "AND" => Token::And,
-                        "OR" => Token::Or,
-                        _ => Token::Identifier(ident),
+                ';' => {
+                    self.advance();
+                    Token::Semicolon
+                }
+                '*' => {
+                    self.advance();
+                    Token::Asterisk
+                }
+                '(' => {
+                    self.advance();
+                    Token::LParen
+                }
+                ')' => {
+                    self.advance();
+                    Token::RParen
+                }
+                '[' => {
+                    self.advance();
+                    Token::LBracket
+                }
+                ']' => {
+                    self.advance();
+                    Token::RBracket
+                }
+                '{' => {
+                    self.advance();
+                    Token::LBrace
+                }
+                '}' => {
+                    self.advance();
+                    Token::RBrace
+                }
+                '.' => {
+                    self.advance();
+                    Token::Dot
+                }
+                '+' => {
+                    self.advance();
+                    Token::Plus
+                }
+                '-' => {
+                    self.advance();
+                    if self.current_char == Some('>') {
+                        self.advance();
+                        Token::Arrow
+                    } else {
+                        Token::Dash
                     }
                 }
-                c if c.is_numeric() => Token::Literal(self.lex_number(c)),
-                _ => panic!("Unknown character: {}", c),
+                '/' => {
+                    self.advance();
+                    Token::Slash
+                }
+                '%' => {
+                    self.advance();
+                    Token::Percent
+                }
+                ':' => {
+                    self.advance();
+                    Token::Colon
+                }
+                '?' => {
+                    self.advance();
+                    Token::Query
+                }
+                '=' => {
+                    self.advance();
+                    if self.current_char == Some('=') {
+                        self.advance();
+                        Token::EqDouble
+                    } else {
+                        Token::EqSingle
+                    }
+                }
+                '!' => {
+                    self.advance();
+                    if self.current_char == Some('=') {
+                        self.advance();
+                        Token::NotEq
+                    } else {
+                        Token::NotOp
+                    }
+                }
+                '<' => {
+                    self.advance();
+                    if self.current_char == Some('=') {
+                        self.advance();
+                        Token::LtEq
+                    } else if self.current_char == Some('>') {
+                        self.advance();
+                        Token::NotEq
+                    } else {
+                        Token::Lt
+                    }
+                }
+                '>' => {
+                    self.advance();
+                    if self.current_char == Some('=') {
+                        self.advance();
+                        Token::GtEq
+                    } else {
+                        Token::Gt
+                    }
+                }
+                '&' => {
+                    self.advance();
+                    Token::AndOp
+                }
+                '|' => {
+                    self.advance();
+                    if self.current_char == Some('|') {
+                        self.advance();
+                        Token::Concat
+                    } else {
+                        Token::OrOp
+                    }
+                }
+                '\'' | '"' => self.lex_string(),
+                c if c.is_alphabetic() || c == '_' || c == '$' => self.lex_identifier_or_keyword(),
+                c if c.is_numeric() => self.lex_number(),
+                _ => {
+                    panic!("Unknown character: {}", c);
+                }
             }
         } else {
             Token::EOF

--- a/rust/hogql-parser/src/lexer.rs
+++ b/rust/hogql-parser/src/lexer.rs
@@ -1,0 +1,116 @@
+// src/lexer.rs
+use std::iter::Peekable;
+use std::str::Chars;
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub enum Token {
+    Select,
+    From,
+    Where,
+    And,
+    Or,
+    Identifier(String),
+    Operator(String),
+    Literal(String),
+    Comma,
+    Semicolon,
+    Asterisk,
+    LeftParen,
+    RightParen,
+    EOF,
+}
+
+pub struct Lexer<'a> {
+    input: Peekable<Chars<'a>>,
+}
+
+impl<'a> Lexer<'a> {
+    pub fn new(input: &'a str) -> Self {
+        Lexer {
+            input: input.chars().peekable(),
+        }
+    }
+
+    fn next_char(&mut self) -> Option<char> {
+        self.input.next()
+    }
+
+    fn peek_char(&mut self) -> Option<&char> {
+        self.input.peek()
+    }
+
+    fn skip_whitespace(&mut self) {
+        while matches!(self.peek_char(), Some(c) if c.is_whitespace()) {
+            self.next_char();
+        }
+    }
+
+    fn lex_identifier(&mut self, first_char: char) -> String {
+        let mut ident = first_char.to_string();
+        while matches!(self.peek_char(), Some(c) if c.is_alphanumeric() || *c == '_') {
+            ident.push(self.next_char().unwrap());
+        }
+        ident
+    }
+
+    fn lex_number(&mut self, first_char: char) -> String {
+        let mut number = first_char.to_string();
+        while matches!(self.peek_char(), Some(c) if c.is_numeric() || *c == '.') {
+            number.push(self.next_char().unwrap());
+        }
+        number
+    }
+
+    fn lex_string(&mut self) -> String {
+        let mut string = String::new();
+        // Do not skip the opening quote here
+        while let Some(c) = self.next_char() {
+            if c == '\'' {
+                break;
+            }
+            string.push(c);
+        }
+        string
+    }
+
+    pub fn get_next_token(&mut self) -> Token {
+        self.skip_whitespace();
+        if let Some(c) = self.next_char() {
+            match c {
+                ',' => Token::Comma,
+                ';' => Token::Semicolon,
+                '*' => Token::Asterisk,
+                '(' => Token::LeftParen,
+                ')' => Token::RightParen,
+                '=' | '>' | '<' | '!' => {
+                    let mut op = c.to_string();
+                    if let Some(next_c) = self.peek_char() {
+                        if *next_c == '=' || (c == '<' && *next_c == '>') || (c == '!' && *next_c == '=') {
+                            op.push(*next_c);
+                            self.next_char();
+                        }
+                    }
+                    Token::Operator(op)
+                }
+                '\'' => {
+                    Token::Literal(self.lex_string())
+                },
+                c if c.is_alphabetic() || c == '_' => {
+                    let ident = self.lex_identifier(c);
+                    match ident.to_uppercase().as_str() {
+                        "SELECT" => Token::Select,
+                        "FROM" => Token::From,
+                        "WHERE" => Token::Where,
+                        "AND" => Token::And,
+                        "OR" => Token::Or,
+                        _ => Token::Identifier(ident),
+                    }
+                }
+                c if c.is_numeric() => Token::Literal(self.lex_number(c)),
+                _ => panic!("Unknown character: {}", c),
+            }
+        } else {
+            Token::EOF
+        }
+    }
+}

--- a/rust/hogql-parser/src/lib.rs
+++ b/rust/hogql-parser/src/lib.rs
@@ -1,0 +1,18 @@
+// src/lib.rs
+mod lexer;
+mod parser;
+
+use lexer::Lexer;
+use parser::Parser;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+pub fn parse_query(input: &str) -> serde_json::Value {
+    let lexer = Lexer::new(input);
+    let mut parser = Parser::new(lexer);
+
+    let ast = parser.parse();
+    serde_json::to_value(&ast).unwrap()
+}

--- a/rust/hogql-parser/src/main.rs
+++ b/rust/hogql-parser/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/rust/hogql-parser/src/parser.rs
+++ b/rust/hogql-parser/src/parser.rs
@@ -1,0 +1,210 @@
+// src/parser.rs
+use crate::lexer::{Lexer, Token};
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub enum ASTNode {
+    Select {
+        columns: Vec<ASTNode>,
+        from: Box<ASTNode>,
+        where_clause: Option<Box<ASTNode>>,
+    },
+    Identifier(String),
+    Literal(String),
+    BinaryOp {
+        left: Box<ASTNode>,
+        op: String,
+        right: Box<ASTNode>,
+    },
+}
+
+pub struct Parser<'a> {
+    lexer: Lexer<'a>,
+    current_token: Token,
+}
+
+impl<'a> Parser<'a> {
+    pub fn new(mut lexer: Lexer<'a>) -> Self {
+        let current_token = lexer.get_next_token();
+        Parser { lexer, current_token }
+    }
+
+    fn eat(&mut self, expected: Token) {
+        if self.current_token == expected {
+            self.current_token = self.lexer.get_next_token();
+        } else {
+            panic!(
+                "Unexpected token {:?}, expected {:?}",
+                self.current_token, expected
+            );
+        }
+    }
+
+    fn factor(&mut self) -> ASTNode {
+        match &self.current_token {
+            Token::Identifier(name) => {
+                let node = ASTNode::Identifier(name.clone());
+                self.current_token = self.lexer.get_next_token();
+                node
+            }
+            Token::Literal(value) => {
+                let node = ASTNode::Literal(value.clone());
+                self.current_token = self.lexer.get_next_token();
+                node
+            }
+            Token::LeftParen => {
+                self.eat(Token::LeftParen);
+                let node = self.expr();
+                self.eat(Token::RightParen);
+                node
+            }
+            _ => panic!("Unexpected token in factor: {:?}", self.current_token),
+        }
+    }
+
+    fn expr(&mut self) -> ASTNode {
+        let mut node = self.term();
+
+        while matches!(&self.current_token, Token::Operator(op) if op == "+" || op == "-") {
+            if let Token::Operator(op) = &self.current_token {
+                let op_clone = op.clone();
+                self.current_token = self.lexer.get_next_token();
+                node = ASTNode::BinaryOp {
+                    left: Box::new(node),
+                    op: op_clone,
+                    right: Box::new(self.term()),
+                };
+            }
+        }
+
+        node
+    }
+
+    fn parse_select(&mut self) -> ASTNode {
+        self.eat(Token::Select);
+
+        let mut columns = Vec::new();
+
+        if self.current_token == Token::Asterisk {
+            columns.push(ASTNode::Identifier("*".to_string()));
+            self.eat(Token::Asterisk);
+        } else {
+            columns.push(self.expr());
+            while self.current_token == Token::Comma {
+                self.eat(Token::Comma);
+                columns.push(self.expr());
+            }
+        }
+
+        self.eat(Token::From);
+        let from = Box::new(self.parse_from());
+
+        let where_clause = if self.current_token == Token::Where {
+            self.eat(Token::Where);
+            Some(Box::new(self.parse_condition()))
+        } else {
+            None
+        };
+
+        ASTNode::Select {
+            columns,
+            from,
+            where_clause,
+        }
+    }
+
+
+    fn parse_from(&mut self) -> ASTNode {
+        match &self.current_token {
+            Token::Identifier(_) => self.factor(),
+            _ => panic!("Expected table name after FROM"),
+        }
+    }
+
+    fn parse_condition(&mut self) -> ASTNode {
+        self.logical_expr()
+    }
+
+    fn logical_expr(&mut self) -> ASTNode {
+        let mut node = self.comparison_expr();
+
+        while matches!(&self.current_token, Token::And | Token::Or) {
+            let op = match &self.current_token {
+                Token::And => "AND".to_string(),
+                Token::Or => "OR".to_string(),
+                _ => unreachable!(),
+            };
+            self.current_token = self.lexer.get_next_token();
+            let right = self.comparison_expr();
+            node = ASTNode::BinaryOp {
+                left: Box::new(node),
+                op,
+                right: Box::new(right),
+            };
+        }
+
+        node
+    }
+
+    fn comparison_expr(&mut self) -> ASTNode {
+        let mut node = self.arith_expr();
+
+        while matches!(&self.current_token, Token::Operator(op) if op == "=" || op == ">" || op == "<" || op == ">=" || op == "<=" || op == "!=" || op == "<>") {
+            if let Token::Operator(op) = &self.current_token {
+                let op_clone = op.clone();
+                self.current_token = self.lexer.get_next_token();
+                let right = self.arith_expr();
+                node = ASTNode::BinaryOp {
+                    left: Box::new(node),
+                    op: op_clone,
+                    right: Box::new(right),
+                };
+            }
+        }
+
+        node
+    }
+
+    fn arith_expr(&mut self) -> ASTNode {
+        let mut node = self.term();
+
+        while matches!(&self.current_token, Token::Operator(op) if op == "+" || op == "-") {
+            if let Token::Operator(op) = &self.current_token {
+                let op_clone = op.clone();
+                self.current_token = self.lexer.get_next_token();
+                node = ASTNode::BinaryOp {
+                    left: Box::new(node),
+                    op: op_clone,
+                    right: Box::new(self.term()),
+                };
+            }
+        }
+
+        node
+    }
+
+    fn term(&mut self) -> ASTNode {
+        let mut node = self.factor();
+
+        while matches!(&self.current_token, Token::Operator(op) if op == "*" || op == "/") {
+            if let Token::Operator(op) = &self.current_token {
+                let op_clone = op.clone();
+                self.current_token = self.lexer.get_next_token();
+                node = ASTNode::BinaryOp {
+                    left: Box::new(node),
+                    op: op_clone,
+                    right: Box::new(self.factor()),
+                };
+            }
+        }
+
+        node
+    }
+
+    pub fn parse(&mut self) -> ASTNode {
+        match self.current_token {
+            Token::Select => self.parse_select(),
+            _ => panic!("Unexpected token at start: {:?}", self.current_token),
+        }
+    }
+}

--- a/rust/hogql-parser/src/parser.rs
+++ b/rust/hogql-parser/src/parser.rs
@@ -4,207 +4,487 @@ use serde::Serialize;
 
 #[derive(Debug, Serialize)]
 pub enum ASTNode {
-    Select {
-        columns: Vec<ASTNode>,
-        from: Box<ASTNode>,
-        where_clause: Option<Box<ASTNode>>,
+    Program {
+        declarations: Vec<ASTNode>,
     },
-    Identifier(String),
-    Literal(String),
-    BinaryOp {
+    Declaration(Box<ASTNode>),
+    VarDecl {
+        name: String,
+        expr: Option<Box<ASTNode>>,
+    },
+    SelectStmt {
+        distinct: bool,
+        columns: Vec<ASTNode>,
+        from: Option<Box<ASTNode>>,
+        where_clause: Option<Box<ASTNode>>,
+        group_by: Option<Vec<ASTNode>>,
+        having: Option<Box<ASTNode>>,
+        order_by: Option<Vec<ASTNode>>,
+        limit: Option<Box<ASTNode>>,
+        // Add other clauses as needed
+    },
+    ColumnExprAlias {
+        expr: Box<ASTNode>,
+        alias: String,
+    },
+    ColumnExprFunction {
+        name: String,
+        args: Vec<ASTNode>,
+    },
+    ColumnExprIdentifier(String),
+    ColumnExprLiteral(Box<ASTNode>),
+    ColumnExprBinaryOp {
         left: Box<ASTNode>,
         op: String,
         right: Box<ASTNode>,
     },
+    ColumnExprUnaryOp {
+        op: String,
+        expr: Box<ASTNode>,
+    },
+    NumberLiteral(String),
+    StringLiteral(String),
+    OrderExpr {
+        expr: Box<ASTNode>,
+        order: Option<String>, // "ASC" or "DESC"
+    },
+    // Add other AST nodes as needed
 }
 
 pub struct Parser<'a> {
     lexer: Lexer<'a>,
     current_token: Token,
+    peek_token: Token,
 }
 
 impl<'a> Parser<'a> {
     pub fn new(mut lexer: Lexer<'a>) -> Self {
         let current_token = lexer.get_next_token();
-        Parser { lexer, current_token }
+        let peek_token = lexer.get_next_token();
+        Parser {
+            lexer,
+            current_token,
+            peek_token,
+        }
     }
 
-    fn eat(&mut self, expected: Token) {
-        if self.current_token == expected {
-            self.current_token = self.lexer.get_next_token();
+    fn advance(&mut self) {
+        self.current_token = std::mem::replace(&mut self.peek_token, self.lexer.get_next_token());
+    }
+
+    fn expect(&mut self, expected: &Token) {
+        if &self.current_token == expected {
+            self.advance();
         } else {
             panic!(
-                "Unexpected token {:?}, expected {:?}",
-                self.current_token, expected
+                "Expected token {:?}, but found {:?}",
+                expected, self.current_token
             );
         }
     }
 
-    fn factor(&mut self) -> ASTNode {
+    pub fn parse(&mut self) -> ASTNode {
+        self.parse_program()
+    }
+
+    fn parse_program(&mut self) -> ASTNode {
+        let mut declarations = Vec::new();
+        while self.current_token != Token::EOF {
+            declarations.push(self.parse_declaration());
+        }
+        ASTNode::Program { declarations }
+    }
+
+    fn parse_declaration(&mut self) -> ASTNode {
         match &self.current_token {
-            Token::Identifier(name) => {
-                let node = ASTNode::Identifier(name.clone());
-                self.current_token = self.lexer.get_next_token();
-                node
-            }
-            Token::Literal(value) => {
-                let node = ASTNode::Literal(value.clone());
-                self.current_token = self.lexer.get_next_token();
-                node
-            }
-            Token::LeftParen => {
-                self.eat(Token::LeftParen);
-                let node = self.expr();
-                self.eat(Token::RightParen);
-                node
-            }
-            _ => panic!("Unexpected token in factor: {:?}", self.current_token),
+            Token::Let => self.parse_var_decl(),
+            Token::Select => self.parse_select_stmt(),
+            // Add other declarations
+            _ => panic!("Unexpected token: {:?}", self.current_token),
         }
     }
 
-    fn expr(&mut self) -> ASTNode {
-        let mut node = self.term();
-
-        while matches!(&self.current_token, Token::Operator(op) if op == "+" || op == "-") {
-            if let Token::Operator(op) = &self.current_token {
-                let op_clone = op.clone();
-                self.current_token = self.lexer.get_next_token();
-                node = ASTNode::BinaryOp {
-                    left: Box::new(node),
-                    op: op_clone,
-                    right: Box::new(self.term()),
-                };
+    fn parse_var_decl(&mut self) -> ASTNode {
+        self.expect(&Token::Let);
+        if let Token::Identifier(name) = &self.current_token {
+            let var_name = name.clone();
+            self.advance();
+            let expr = if self.current_token == Token::Colon {
+                self.advance();
+                self.expect(&Token::EqSingle);
+                Some(Box::new(self.parse_expression()))
+            } else {
+                None
+            };
+            ASTNode::VarDecl {
+                name: var_name,
+                expr,
             }
-        }
-
-        node
-    }
-
-    fn parse_select(&mut self) -> ASTNode {
-        self.eat(Token::Select);
-
-        let mut columns = Vec::new();
-
-        if self.current_token == Token::Asterisk {
-            columns.push(ASTNode::Identifier("*".to_string()));
-            self.eat(Token::Asterisk);
         } else {
-            columns.push(self.expr());
-            while self.current_token == Token::Comma {
-                self.eat(Token::Comma);
-                columns.push(self.expr());
-            }
+            panic!("Expected identifier after 'let'");
         }
+    }
 
-        self.eat(Token::From);
-        let from = Box::new(self.parse_from());
+    fn parse_select_stmt(&mut self) -> ASTNode {
+        self.expect(&Token::Select);
+        let distinct = if self.current_token == Token::Distinct {
+            self.advance();
+            true
+        } else {
+            false
+        };
+        let columns = self.parse_column_expr_list();
 
-        let where_clause = if self.current_token == Token::Where {
-            self.eat(Token::Where);
-            Some(Box::new(self.parse_condition()))
+        let from = if self.current_token == Token::From {
+            self.advance();
+            Some(Box::new(self.parse_table_expr()))
         } else {
             None
         };
 
-        ASTNode::Select {
+        let where_clause = if self.current_token == Token::Where {
+            self.advance();
+            Some(Box::new(self.parse_expression()))
+        } else {
+            None
+        };
+
+        let group_by = if self.current_token == Token::Group {
+            self.advance();
+            self.expect(&Token::By);
+            Some(self.parse_column_expr_list())
+        } else {
+            None
+        };
+
+        let having = if self.current_token == Token::Having {
+            self.advance();
+            Some(Box::new(self.parse_expression()))
+        } else {
+            None
+        };
+
+        let order_by = if self.current_token == Token::Order {
+            self.advance();
+            self.expect(&Token::By);
+            Some(self.parse_order_expr_list())
+        } else {
+            None
+        };
+
+        let limit = if self.current_token == Token::Limit {
+            self.advance();
+            Some(Box::new(self.parse_expression()))
+        } else {
+            None
+        };
+
+        ASTNode::SelectStmt {
+            distinct,
             columns,
             from,
             where_clause,
+            group_by,
+            having,
+            order_by,
+            limit,
         }
     }
 
+    fn parse_order_expr_list(&mut self) -> Vec<ASTNode> {
+        let mut expressions = Vec::new();
+        expressions.push(self.parse_order_expr());
+        while self.current_token == Token::Comma {
+            self.advance();
+            expressions.push(self.parse_order_expr());
+        }
+        expressions
+    }
 
-    fn parse_from(&mut self) -> ASTNode {
-        match &self.current_token {
-            Token::Identifier(_) => self.factor(),
-            _ => panic!("Expected table name after FROM"),
+    fn parse_order_expr(&mut self) -> ASTNode {
+        let expr = self.parse_column_expr();
+        let order = if self.current_token == Token::Asc || self.current_token == Token::Ascending {
+            self.advance();
+            Some("ASC".to_string())
+        } else if self.current_token == Token::Desc || self.current_token == Token::Descending {
+            self.advance();
+            Some("DESC".to_string())
+        } else {
+            None
+        };
+        ASTNode::OrderExpr {
+            expr: Box::new(expr),
+            order,
         }
     }
 
-    fn parse_condition(&mut self) -> ASTNode {
-        self.logical_expr()
+    fn parse_column_expr_list(&mut self) -> Vec<ASTNode> {
+        let mut columns = Vec::new();
+        columns.push(self.parse_column_expr());
+        while self.current_token == Token::Comma {
+            self.advance();
+            columns.push(self.parse_column_expr());
+        }
+        columns
     }
 
-    fn logical_expr(&mut self) -> ASTNode {
-        let mut node = self.comparison_expr();
+    fn parse_column_expr(&mut self) -> ASTNode {
+        let mut expr = self.parse_column_expr_base();
 
-        while matches!(&self.current_token, Token::And | Token::Or) {
-            let op = match &self.current_token {
-                Token::And => "AND".to_string(),
-                Token::Or => "OR".to_string(),
-                _ => unreachable!(),
+        // Handle aliases
+        if self.current_token == Token::As {
+            self.advance();
+            if let Token::Identifier(alias) = &self.current_token {
+                let alias_name = alias.clone();
+                self.advance();
+                expr = ASTNode::ColumnExprAlias {
+                    expr: Box::new(expr),
+                    alias: alias_name,
+                };
+            } else {
+                panic!("Expected identifier after AS");
+            }
+        } else if let Token::Identifier(alias) = &self.current_token {
+            // Implicit alias
+            let alias_name = alias.clone();
+            self.advance();
+            expr = ASTNode::ColumnExprAlias {
+                expr: Box::new(expr),
+                alias: alias_name,
             };
-            self.current_token = self.lexer.get_next_token();
-            let right = self.comparison_expr();
-            node = ASTNode::BinaryOp {
+        }
+
+        expr
+    }
+
+    fn parse_column_expr_base(&mut self) -> ASTNode {
+        match &self.current_token {
+            Token::Identifier(name) => {
+                let func_name = name.clone();
+                self.advance();
+                if self.current_token == Token::LParen {
+                    self.advance();
+                    let args = if self.current_token != Token::RParen {
+                        self.parse_column_expr_list()
+                    } else {
+                        Vec::new()
+                    };
+                    self.expect(&Token::RParen);
+                    ASTNode::ColumnExprFunction {
+                        name: func_name,
+                        args,
+                    }
+                } else {
+                    ASTNode::ColumnExprIdentifier(func_name)
+                }
+            }
+            Token::StringLiteral(value) => {
+                let string_value = value.clone();
+                self.advance();
+                ASTNode::ColumnExprLiteral(Box::new(ASTNode::StringLiteral(string_value)))
+            }
+            Token::NumberLiteral(value) => {
+                let number_value = value.clone();
+                self.advance();
+                ASTNode::ColumnExprLiteral(Box::new(ASTNode::NumberLiteral(number_value)))
+            }
+            Token::LParen => {
+                self.advance();
+                let expr = self.parse_expression();
+                self.expect(&Token::RParen);
+                expr
+            }
+            _ => panic!("Unexpected token in column expression: {:?}", self.current_token),
+        }
+    }
+
+    fn parse_table_expr(&mut self) -> ASTNode {
+        match &self.current_token {
+            Token::Identifier(name) => {
+                let table_name = name.clone();
+                self.advance();
+                ASTNode::ColumnExprIdentifier(table_name)
+            }
+            Token::LParen => {
+                self.advance();
+                let subquery = self.parse_select_stmt();
+                self.expect(&Token::RParen);
+                subquery
+            }
+            _ => panic!("Unexpected token in table expression: {:?}", self.current_token),
+        }
+    }
+
+    fn parse_expression(&mut self) -> ASTNode {
+        self.parse_logical_or()
+    }
+
+    fn parse_logical_or(&mut self) -> ASTNode {
+        let mut node = self.parse_logical_and();
+        while self.current_token == Token::Or {
+            self.advance();
+            let right = self.parse_logical_and();
+            node = ASTNode::ColumnExprBinaryOp {
+                left: Box::new(node),
+                op: "OR".to_string(),
+                right: Box::new(right),
+            };
+        }
+        node
+    }
+
+    fn parse_logical_and(&mut self) -> ASTNode {
+        let mut node = self.parse_equality();
+        while self.current_token == Token::And {
+            self.advance();
+            let right = self.parse_equality();
+            node = ASTNode::ColumnExprBinaryOp {
+                left: Box::new(node),
+                op: "AND".to_string(),
+                right: Box::new(right),
+            };
+        }
+        node
+    }
+
+    fn parse_equality(&mut self) -> ASTNode {
+        let mut node = self.parse_comparison();
+        while matches!(self.current_token, Token::EqSingle | Token::EqDouble | Token::NotEq) {
+            let op = match &self.current_token {
+                Token::EqSingle => "=",
+                Token::EqDouble => "==",
+                Token::NotEq => "!=",
+                _ => unreachable!(),
+            }
+            .to_string();
+            self.advance();
+            let right = self.parse_comparison();
+            node = ASTNode::ColumnExprBinaryOp {
                 left: Box::new(node),
                 op,
                 right: Box::new(right),
             };
         }
-
         node
     }
 
-    fn comparison_expr(&mut self) -> ASTNode {
-        let mut node = self.arith_expr();
-
-        while matches!(&self.current_token, Token::Operator(op) if op == "=" || op == ">" || op == "<" || op == ">=" || op == "<=" || op == "!=" || op == "<>") {
-            if let Token::Operator(op) = &self.current_token {
-                let op_clone = op.clone();
-                self.current_token = self.lexer.get_next_token();
-                let right = self.arith_expr();
-                node = ASTNode::BinaryOp {
-                    left: Box::new(node),
-                    op: op_clone,
-                    right: Box::new(right),
-                };
+    fn parse_comparison(&mut self) -> ASTNode {
+        let mut node = self.parse_term();
+        while matches!(
+            self.current_token,
+            Token::Lt | Token::LtEq | Token::Gt | Token::GtEq
+        ) {
+            let op = match &self.current_token {
+                Token::Lt => "<",
+                Token::LtEq => "<=",
+                Token::Gt => ">",
+                Token::GtEq => ">=",
+                _ => unreachable!(),
             }
+            .to_string();
+            self.advance();
+            let right = self.parse_term();
+            node = ASTNode::ColumnExprBinaryOp {
+                left: Box::new(node),
+                op,
+                right: Box::new(right),
+            };
         }
-
         node
     }
 
-    fn arith_expr(&mut self) -> ASTNode {
-        let mut node = self.term();
-
-        while matches!(&self.current_token, Token::Operator(op) if op == "+" || op == "-") {
-            if let Token::Operator(op) = &self.current_token {
-                let op_clone = op.clone();
-                self.current_token = self.lexer.get_next_token();
-                node = ASTNode::BinaryOp {
-                    left: Box::new(node),
-                    op: op_clone,
-                    right: Box::new(self.term()),
-                };
+    fn parse_term(&mut self) -> ASTNode {
+        let mut node = self.parse_factor();
+        while matches!(self.current_token, Token::Plus | Token::Dash) {
+            let op = match &self.current_token {
+                Token::Plus => "+",
+                Token::Dash => "-",
+                _ => unreachable!(),
             }
+            .to_string();
+            self.advance();
+            let right = self.parse_factor();
+            node = ASTNode::ColumnExprBinaryOp {
+                left: Box::new(node),
+                op,
+                right: Box::new(right),
+            };
         }
-
         node
     }
 
-    fn term(&mut self) -> ASTNode {
-        let mut node = self.factor();
-
-        while matches!(&self.current_token, Token::Operator(op) if op == "*" || op == "/") {
-            if let Token::Operator(op) = &self.current_token {
-                let op_clone = op.clone();
-                self.current_token = self.lexer.get_next_token();
-                node = ASTNode::BinaryOp {
-                    left: Box::new(node),
-                    op: op_clone,
-                    right: Box::new(self.factor()),
-                };
+    fn parse_factor(&mut self) -> ASTNode {
+        let mut node = self.parse_unary();
+        while matches!(
+            self.current_token,
+            Token::Asterisk | Token::Slash | Token::Percent
+        ) {
+            let op = match &self.current_token {
+                Token::Asterisk => "*",
+                Token::Slash => "/",
+                Token::Percent => "%",
+                _ => unreachable!(),
             }
+            .to_string();
+            self.advance();
+            let right = self.parse_unary();
+            node = ASTNode::ColumnExprBinaryOp {
+                left: Box::new(node),
+                op,
+                right: Box::new(right),
+            };
         }
-
         node
     }
 
-    pub fn parse(&mut self) -> ASTNode {
-        match self.current_token {
-            Token::Select => self.parse_select(),
-            _ => panic!("Unexpected token at start: {:?}", self.current_token),
+    fn parse_unary(&mut self) -> ASTNode {
+        if matches!(self.current_token, Token::Not | Token::Dash | Token::Plus) {
+            let op = match &self.current_token {
+                Token::Not => "NOT",
+                Token::Dash => "-",
+                Token::Plus => "+",
+                _ => unreachable!(),
+            }
+            .to_string();
+            self.advance();
+            let expr = self.parse_unary();
+            ASTNode::ColumnExprUnaryOp {
+                op,
+                expr: Box::new(expr),
+            }
+        } else {
+            self.parse_primary()
+        }
+    }
+
+    fn parse_primary(&mut self) -> ASTNode {
+        match &self.current_token {
+            Token::Identifier(_) => self.parse_column_expr(),
+            Token::NumberLiteral(_) | Token::StringLiteral(_) => self.parse_literal(),
+            Token::LParen => {
+                self.advance();
+                let expr = self.parse_expression();
+                self.expect(&Token::RParen);
+                expr
+            }
+            _ => panic!("Unexpected token in primary expression: {:?}", self.current_token),
+        }
+    }
+
+    fn parse_literal(&mut self) -> ASTNode {
+        match &self.current_token {
+            Token::NumberLiteral(value) => {
+                let num = value.clone();
+                self.advance();
+                ASTNode::NumberLiteral(num)
+            }
+            Token::StringLiteral(value) => {
+                let str_val = value.clone();
+                self.advance();
+                ASTNode::StringLiteral(str_val)
+            }
+            _ => panic!("Unexpected token in literal: {:?}", self.current_token),
         }
     }
 }
+

--- a/rust/hogql-parser/tests/parser_tests.rs
+++ b/rust/hogql-parser/tests/parser_tests.rs
@@ -21,21 +21,21 @@ fn test_queries() {
 
 #[test]
 fn test_select_with_and() {
-    let query = "SELECT * FROM users WHERE active = true AND role = 'admin';";
+    let query = "SELECT aa FROM users WHERE active = true AND role = 'admin'";
     let ast = parse_query(query);
     assert_json_snapshot!(ast);
 }
 
 #[test]
 fn test_select_with_or() {
-    let query = "SELECT id FROM orders WHERE status = 'pending' OR status = 'processing';";
+    let query = "SELECT id FROM orders WHERE status = 'pending' OR status = 'processing'";
     let ast = parse_query(query);
     assert_json_snapshot!(ast);
 }
 
 #[test]
 fn test_invalid_query() {
-    let query = "SELECT FROM WHERE;";
+    let query = "SELECT FROM WHERE";
     let result = std::panic::catch_unwind(|| parse_query(query));
     assert!(result.is_err(), "Parser should panic on invalid query");
 }

--- a/rust/hogql-parser/tests/parser_tests.rs
+++ b/rust/hogql-parser/tests/parser_tests.rs
@@ -1,0 +1,41 @@
+// tests/parser_tests.rs
+use hogql_parser::parse_query;
+use insta::assert_json_snapshot;
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn test_queries() {
+    let queries_dir = Path::new("tests/queries");
+    for entry in fs::read_dir(queries_dir).expect("Failed to read queries directory") {
+        let entry = entry.expect("Failed to read directory entry");
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("sql") {
+            let query_name = path.file_stem().and_then(|s| s.to_str()).unwrap();
+            let query = fs::read_to_string(&path).expect("Failed to read query file");
+            let ast = parse_query(&query);
+            assert_json_snapshot!(query_name, ast);
+        }
+    }
+}
+
+#[test]
+fn test_select_with_and() {
+    let query = "SELECT * FROM users WHERE active = true AND role = 'admin';";
+    let ast = parse_query(query);
+    assert_json_snapshot!(ast);
+}
+
+#[test]
+fn test_select_with_or() {
+    let query = "SELECT id FROM orders WHERE status = 'pending' OR status = 'processing';";
+    let ast = parse_query(query);
+    assert_json_snapshot!(ast);
+}
+
+#[test]
+fn test_invalid_query() {
+    let query = "SELECT FROM WHERE;";
+    let result = std::panic::catch_unwind(|| parse_query(query));
+    assert!(result.is_err(), "Parser should panic on invalid query");
+}

--- a/rust/hogql-parser/tests/queries/simple_select.sql
+++ b/rust/hogql-parser/tests/queries/simple_select.sql
@@ -1,1 +1,1 @@
-SELECT * FROM users WHERE active = true AND role = 'admin';
+SELECT a FROM users WHERE active = true AND role = 'admin'

--- a/rust/hogql-parser/tests/queries/simple_select.sql
+++ b/rust/hogql-parser/tests/queries/simple_select.sql
@@ -1,0 +1,1 @@
+SELECT * FROM users WHERE active = true AND role = 'admin';

--- a/rust/hogql-parser/tests/snapshots/parser_tests__select_with_and.snap
+++ b/rust/hogql-parser/tests/snapshots/parser_tests__select_with_and.snap
@@ -1,0 +1,43 @@
+---
+source: hogql-parser/tests/parser_tests.rs
+expression: ast
+---
+{
+  "Select": {
+    "columns": [
+      {
+        "Identifier": "*"
+      }
+    ],
+    "from": {
+      "Identifier": "users"
+    },
+    "where_clause": {
+      "BinaryOp": {
+        "left": {
+          "BinaryOp": {
+            "left": {
+              "Identifier": "active"
+            },
+            "op": "=",
+            "right": {
+              "Identifier": "true"
+            }
+          }
+        },
+        "op": "AND",
+        "right": {
+          "BinaryOp": {
+            "left": {
+              "Identifier": "role"
+            },
+            "op": "=",
+            "right": {
+              "Literal": "admin"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/rust/hogql-parser/tests/snapshots/parser_tests__select_with_and.snap
+++ b/rust/hogql-parser/tests/snapshots/parser_tests__select_with_and.snap
@@ -3,41 +3,52 @@ source: hogql-parser/tests/parser_tests.rs
 expression: ast
 ---
 {
-  "Select": {
-    "columns": [
+  "Program": {
+    "declarations": [
       {
-        "Identifier": "*"
-      }
-    ],
-    "from": {
-      "Identifier": "users"
-    },
-    "where_clause": {
-      "BinaryOp": {
-        "left": {
-          "BinaryOp": {
-            "left": {
-              "Identifier": "active"
-            },
-            "op": "=",
-            "right": {
-              "Identifier": "true"
+        "SelectStmt": {
+          "columns": [
+            {
+              "ColumnExprIdentifier": "aa"
             }
-          }
-        },
-        "op": "AND",
-        "right": {
-          "BinaryOp": {
-            "left": {
-              "Identifier": "role"
-            },
-            "op": "=",
-            "right": {
-              "Literal": "admin"
+          ],
+          "distinct": false,
+          "from": {
+            "ColumnExprIdentifier": "users"
+          },
+          "group_by": null,
+          "having": null,
+          "limit": null,
+          "order_by": null,
+          "where_clause": {
+            "ColumnExprBinaryOp": {
+              "left": {
+                "ColumnExprBinaryOp": {
+                  "left": {
+                    "ColumnExprIdentifier": "active"
+                  },
+                  "op": "=",
+                  "right": {
+                    "ColumnExprIdentifier": "true"
+                  }
+                }
+              },
+              "op": "AND",
+              "right": {
+                "ColumnExprBinaryOp": {
+                  "left": {
+                    "ColumnExprIdentifier": "role"
+                  },
+                  "op": "=",
+                  "right": {
+                    "StringLiteral": "admin"
+                  }
+                }
+              }
             }
           }
         }
       }
-    }
+    ]
   }
 }

--- a/rust/hogql-parser/tests/snapshots/parser_tests__select_with_or.snap
+++ b/rust/hogql-parser/tests/snapshots/parser_tests__select_with_or.snap
@@ -3,41 +3,52 @@ source: hogql-parser/tests/parser_tests.rs
 expression: ast
 ---
 {
-  "Select": {
-    "columns": [
+  "Program": {
+    "declarations": [
       {
-        "Identifier": "id"
-      }
-    ],
-    "from": {
-      "Identifier": "orders"
-    },
-    "where_clause": {
-      "BinaryOp": {
-        "left": {
-          "BinaryOp": {
-            "left": {
-              "Identifier": "status"
-            },
-            "op": "=",
-            "right": {
-              "Literal": "pending"
+        "SelectStmt": {
+          "columns": [
+            {
+              "ColumnExprIdentifier": "id"
             }
-          }
-        },
-        "op": "OR",
-        "right": {
-          "BinaryOp": {
-            "left": {
-              "Identifier": "status"
-            },
-            "op": "=",
-            "right": {
-              "Literal": "processing"
+          ],
+          "distinct": false,
+          "from": {
+            "ColumnExprIdentifier": "orders"
+          },
+          "group_by": null,
+          "having": null,
+          "limit": null,
+          "order_by": null,
+          "where_clause": {
+            "ColumnExprBinaryOp": {
+              "left": {
+                "ColumnExprBinaryOp": {
+                  "left": {
+                    "ColumnExprIdentifier": "status"
+                  },
+                  "op": "=",
+                  "right": {
+                    "StringLiteral": "pending"
+                  }
+                }
+              },
+              "op": "OR",
+              "right": {
+                "ColumnExprBinaryOp": {
+                  "left": {
+                    "ColumnExprIdentifier": "status"
+                  },
+                  "op": "=",
+                  "right": {
+                    "StringLiteral": "processing"
+                  }
+                }
+              }
             }
           }
         }
       }
-    }
+    ]
   }
 }

--- a/rust/hogql-parser/tests/snapshots/parser_tests__select_with_or.snap
+++ b/rust/hogql-parser/tests/snapshots/parser_tests__select_with_or.snap
@@ -1,0 +1,43 @@
+---
+source: hogql-parser/tests/parser_tests.rs
+expression: ast
+---
+{
+  "Select": {
+    "columns": [
+      {
+        "Identifier": "id"
+      }
+    ],
+    "from": {
+      "Identifier": "orders"
+    },
+    "where_clause": {
+      "BinaryOp": {
+        "left": {
+          "BinaryOp": {
+            "left": {
+              "Identifier": "status"
+            },
+            "op": "=",
+            "right": {
+              "Literal": "pending"
+            }
+          }
+        },
+        "op": "OR",
+        "right": {
+          "BinaryOp": {
+            "left": {
+              "Identifier": "status"
+            },
+            "op": "=",
+            "right": {
+              "Literal": "processing"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/rust/hogql-parser/tests/snapshots/parser_tests__simple_select.snap
+++ b/rust/hogql-parser/tests/snapshots/parser_tests__simple_select.snap
@@ -1,0 +1,43 @@
+---
+source: hogql-parser/tests/parser_tests.rs
+expression: ast
+---
+{
+  "Select": {
+    "columns": [
+      {
+        "Identifier": "*"
+      }
+    ],
+    "from": {
+      "Identifier": "users"
+    },
+    "where_clause": {
+      "BinaryOp": {
+        "left": {
+          "BinaryOp": {
+            "left": {
+              "Identifier": "active"
+            },
+            "op": "=",
+            "right": {
+              "Identifier": "true"
+            }
+          }
+        },
+        "op": "AND",
+        "right": {
+          "BinaryOp": {
+            "left": {
+              "Identifier": "role"
+            },
+            "op": "=",
+            "right": {
+              "Literal": "admin"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/rust/hogql-parser/tests/snapshots/parser_tests__simple_select.snap
+++ b/rust/hogql-parser/tests/snapshots/parser_tests__simple_select.snap
@@ -3,41 +3,52 @@ source: hogql-parser/tests/parser_tests.rs
 expression: ast
 ---
 {
-  "Select": {
-    "columns": [
+  "Program": {
+    "declarations": [
       {
-        "Identifier": "*"
-      }
-    ],
-    "from": {
-      "Identifier": "users"
-    },
-    "where_clause": {
-      "BinaryOp": {
-        "left": {
-          "BinaryOp": {
-            "left": {
-              "Identifier": "active"
-            },
-            "op": "=",
-            "right": {
-              "Identifier": "true"
+        "SelectStmt": {
+          "columns": [
+            {
+              "ColumnExprIdentifier": "a"
             }
-          }
-        },
-        "op": "AND",
-        "right": {
-          "BinaryOp": {
-            "left": {
-              "Identifier": "role"
-            },
-            "op": "=",
-            "right": {
-              "Literal": "admin"
+          ],
+          "distinct": false,
+          "from": {
+            "ColumnExprIdentifier": "users"
+          },
+          "group_by": null,
+          "having": null,
+          "limit": null,
+          "order_by": null,
+          "where_clause": {
+            "ColumnExprBinaryOp": {
+              "left": {
+                "ColumnExprBinaryOp": {
+                  "left": {
+                    "ColumnExprIdentifier": "active"
+                  },
+                  "op": "=",
+                  "right": {
+                    "ColumnExprIdentifier": "true"
+                  }
+                }
+              },
+              "op": "AND",
+              "right": {
+                "ColumnExprBinaryOp": {
+                  "left": {
+                    "ColumnExprIdentifier": "role"
+                  },
+                  "op": "=",
+                  "right": {
+                    "StringLiteral": "admin"
+                  }
+                }
+              }
             }
           }
         }
       }
-    }
+    ]
   }
 }


### PR DESCRIPTION
## Problem

The goal is to build a Rust/WASM HogQL parser using the "recursive descent" algorithm. The benefits of this would be:

- We can show better errors in autocomplete (avoids the endless red line on a syntax error)
- We can run in the browser directly (no request to the hog compiler API)
- It should be another 10x faster due to the 

The drawbacks are:
- Harder to add new grammar once built
- Might not be possible to build without breaking changes to SQL (where there's a will...)
- Either one parser to rule them all, or we now have a 3rd target to maintain

## Changes

```json5
// cargo run --bin hogql_parser -- "select a, b, c from users where foo='bar' group by foo"

{
  "Program": {
    "declarations": [
      {
        "SelectStmt": {
          "columns": [
            {
              "ColumnExprIdentifier": "a"
            },
            {
              "ColumnExprIdentifier": "b"
            },
            {
              "ColumnExprIdentifier": "c"
            }
          ],
          "distinct": false,
          "from": {
            "ColumnExprIdentifier": "users"
          },
          "group_by": [
            {
              "ColumnExprIdentifier": "foo"
            }
          ],
          "having": null,
          "limit": null,
          "order_by": null,
          "where_clause": {
            "ColumnExprBinaryOp": {
              "left": {
                "ColumnExprIdentifier": "foo"
              },
              "op": "=",
              "right": {
                "StringLiteral": "bar"
              }
            }
          }
        }
      }
    ]
  }
}
```

## Notes

There's no rush with this, I'm just curious to see how hard it would be to build an even faster parser. The parser in any case is just one part of the puzzle. The Hog bytecode compiler will remain in Python for the foreseeable future. 

Most likely this PR will be abandoned and if we ever actually need to run Hog in the browser, we'll modify the C++ parser to output JSON, and compile that to WASM. I'm not sure how big that executable would be though. This is what the current mini parser is after compilation to webassembly:

```
> ls -l pkg/
total 160
-rw-r--r--  1 marius  staff   1148 Sep 23 23:56 hogql_parser.d.ts
-rw-r--r--  1 marius  staff   5590 Sep 23 23:56 hogql_parser.js
-rw-r--r--  1 marius  staff  60227 Sep 23 23:56 hogql_parser_bg.wasm
-rw-r--r--  1 marius  staff    295 Sep 23 23:56 hogql_parser_bg.wasm.d.ts
-rw-r--r--  1 marius  staff    267 Sep 23 23:56 package.json
```


## How did you test this code?

Snapshot tests

## Misc

Yes, obviously Chat wrote all of the code.