### PR TITLE
fix(cdp): Default text value for slack

### DIFF
--- a/posthog/cdp/templates/slack/template_slack.py
+++ b/posthog/cdp/templates/slack/template_slack.py
@@ -99,6 +99,7 @@ if (res.status != 200 or not res.body.ok) {
             "type": "string",
             "label": "Plain text message",
             "description": "Optional fallback message if blocks are not provided or supported",
+            "default": "*{person.name}* triggered event: '{event.event}'",
             "secret": False,
             "required": False,
         },


### PR DESCRIPTION
## Problem

Noticed it was missing when swapping between presets

## Changes

* Fixes it

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
