### PR TITLE
fix(data-warehouse): Upgrade temporalio

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -91,7 +91,7 @@ sshtunnel==0.4.0
 statshog==1.0.6
 structlog==23.2.0
 sqlparse==0.4.4
-temporalio==1.7.0
+temporalio==1.7.1
 token-bucket==0.3.0
 toronado==0.1.0
 webdriver_manager==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -680,7 +680,7 @@ structlog==23.2.0
     # via
     #   -r requirements.in
     #   django-structlog
-temporalio==1.7.0
+temporalio==1.7.1
     # via -r requirements.in
 tenacity==8.2.3
     # via


### PR DESCRIPTION
## Problem
In long-running temporal activities, we're occasionally seeing:
```
2024-09-24T09:28:37.104794Z  WARN temporal_sdk_core::worker::activities::activity_heartbeat_manager: Error when recording heartbeat: Status { code: Cancelled, message: "operation was canceled", source: Some(tonic::transport::Error(Transport, hyper::Error(Canceled, "connection closed"))) }
```
causing the heartbeat to sometimes fail and thus causing some long-running activities to constantly fail.

This is a known bug of `temporalio==1.7.0` but fixed in `1.7.1`

## Changes
Upgrade the `temporalio` package to 1.7.1

## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
Goo unit test coverage
