### PR TITLE
chore: Change the definition of counter to directly check if there'd be a difference with the new normalisation approach

### DIFF
--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -50,26 +50,10 @@ export function timeoutGuard(
         }
     }, timeout)
 }
-
-// when changing this set, be sure to update the frontend as well (taxonomy.tsx (eventToPersonProperties))
-export const eventToPersonProperties = new Set([
-    // mobile params
-    '$app_build',
-    '$app_name',
-    '$app_namespace',
-    '$app_version',
-    // web params
-    '$browser',
-    '$browser_version',
-    '$device_type',
-    '$current_url',
-    '$pathname',
-    '$os',
-    '$os_name', // $os_name is a special case, it's treated as an alias of $os!
-    '$os_version',
-    '$referring_domain',
-    '$referrer',
-    // campaign params - automatically added by posthog-js here https://github.com/PostHog/posthog-js/blob/master/src/utils/event-utils.ts
+// When changing this set, make sure you also make the same changes in:
+// - taxonomy.tsx (CAMPAIGN_PROPERTIES)
+// - posthog-js event-utils.ts (CAMPAIGN_PARAMS)
+export const campaignParams = new Set([
     'utm_source',
     'utm_medium',
     'utm_campaign',
@@ -90,6 +74,31 @@ export const eventToPersonProperties = new Set([
     'igshid', // instagram
     'ttclid', // tiktok
     'rdt_cid', // reddit
+])
+
+export const initialCampaignParams = new Set(Array.from(campaignParams, (key) => `$initial_${key.replace('$', '')}`))
+
+// When changing this set, make sure you also make the same changes in:
+// - taxonomy.tsx (PERSON_PROPERTIES_ADAPTED_FROM_EVENT)
+export const eventToPersonProperties = new Set([
+    // mobile params
+    '$app_build',
+    '$app_name',
+    '$app_namespace',
+    '$app_version',
+    // web params
+    '$browser',
+    '$browser_version',
+    '$device_type',
+    '$current_url',
+    '$pathname',
+    '$os',
+    '$os_name', // $os_name is a special case, it's treated as an alias of $os!
+    '$os_version',
+    '$referring_domain',
+    '$referrer',
+
+    ...campaignParams,
 ])
 export const initialEventToPersonProperties = new Set(
     Array.from(eventToPersonProperties, (key) => `$initial_${key.replace('$', '')}`)

--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -146,6 +146,13 @@ export function hasDifferenceWithProposedNewNormalisationMode(properties: Proper
     // this functions checks if there would be a difference in the properties if we strip the initial campaign params
     // when any $set_once initial eventToPersonProperties are present. This will often return true for events from
     // posthog-js, but it is unknown if this will be the case for other SDKs.
+    if (
+        !properties.$set_once ||
+        !Object.keys(properties.$set_once).some((key) => initialEventToPersonProperties.has(key))
+    ) {
+        return false
+    }
+
     const propertiesForPerson: [string, any][] = Object.entries(properties).filter(([key]) =>
         eventToPersonProperties.has(key)
     )
@@ -161,8 +168,10 @@ export function hasDifferenceWithProposedNewNormalisationMode(properties: Proper
 
     const filteredMayBeSetOnce = maybeSetOnce.filter(([key]) => !initialCampaignParams.has(key))
 
-    const setOnce = new Map({ ...Object.fromEntries(maybeSetOnce), ...(properties.$set_once || {}) })
-    const filteredSetOnce = new Map({ ...Object.fromEntries(filteredMayBeSetOnce), ...(properties.$set_once || {}) })
+    const setOnce = new Map(Object.entries({ ...Object.fromEntries(maybeSetOnce), ...(properties.$set_once || {}) }))
+    const filteredSetOnce = new Map(
+        Object.entries({ ...Object.fromEntries(filteredMayBeSetOnce), ...(properties.$set_once || {}) })
+    )
 
     return !areMapsEqual(setOnce, filteredSetOnce)
 }

--- a/plugin-server/src/utils/utils.ts
+++ b/plugin-server/src/utils/utils.ts
@@ -675,3 +675,16 @@ export const getKnownLibValueOrSentinel = (lib: string): string => {
     }
     return '$other'
 }
+
+// Check if 2 maps with primitive values are equal
+export const areMapsEqual = <K, V>(map1: Map<K, V>, map2: Map<K, V>): boolean => {
+    if (map1.size !== map2.size) {
+        return false
+    }
+    for (const [key, value] of map1) {
+        if (!map2.has(key) || map2.get(key) !== value) {
+            return false
+        }
+    }
+    return true
+}


### PR DESCRIPTION
## Problem

In https://github.com/PostHog/posthog/pull/25148 I didn't exactly check for what I needed to. If the test was negative that would have been a true negative, but the positive might be a false positive. The test was positive so I want to make the test more accurate.

See https://grafana.prod-eu.posthog.dev/explore?schemaVersion=1&panes=%7B%22wn7%22:%7B%22datasource%22:%22victoriametrics%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22sum%20by%28library%29%20%28raw_set_once_initial_event_to_person_property%29%22,%22range%22:false,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22victoriametrics%22%7D,%22editorMode%22:%22builder%22,%22legendFormat%22:%22__auto%22,%22useBackend%22:false,%22disableTextWrap%22:false,%22fullMetaSearch%22:false,%22includeNullMetadata%22:true,%22exemplar%22:false,%22format%22:%22table%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1

## Changes
Changes the Counter to be triggered only when there'd be an actual difference

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Existing tests still pass, ran some tests in the debugger with a breakpoint on the counter to make sure it was / wasn't hit where expected
