### PR TITLE
feat(cdp): Throw on customerio api errors

### DIFF
--- a/posthog/cdp/templates/customerio/template_customerio.py
+++ b/posthog/cdp/templates/customerio/template_customerio.py
@@ -71,7 +71,7 @@ let res := fetch(f'https://{inputs.host}/api/v2/entity', {
 })
 
 if (res.status >= 400) {
-    print('Error from customer.io api:', res.status, res.body)
+    throw Error(f'Error from customer.io api: {res.status}: {res.body}');
 }
 
 """.strip(),

--- a/posthog/cdp/templates/customerio/test_template_customerio.py
+++ b/posthog/cdp/templates/customerio/test_template_customerio.py
@@ -120,7 +120,7 @@ class TestTemplateCustomerio(BaseHogFunctionTemplateTest):
         )
 
     def test_function_errors_on_bad_status(self):
-        self.mock_fetch_response = lambda *args: {"status": 400, "body": {"error": "error"}}  # noqa
+        self.mock_fetch_response = lambda *args: {"status": 400, "body": {"error": "error"}}  # type: ignore
         with pytest.raises(UncaughtHogVMException) as e:
             self.run_function(inputs=create_inputs())
         assert e.value.message == "Error from customer.io api: 400: {'error': 'error'}"

--- a/posthog/cdp/templates/customerio/test_template_customerio.py
+++ b/posthog/cdp/templates/customerio/test_template_customerio.py
@@ -1,4 +1,6 @@
 from inline_snapshot import snapshot
+import pytest
+from hogvm.python.utils import UncaughtHogVMException
 from posthog.cdp.templates.helpers import BaseHogFunctionTemplateTest
 from posthog.cdp.templates.customerio.template_customerio import (
     TemplateCustomerioMigrator,
@@ -116,6 +118,12 @@ class TestTemplateCustomerio(BaseHogFunctionTemplateTest):
         assert self.get_mock_print_calls() == snapshot(
             [("No identifier set. Skipping as at least 1 identifier is needed.",)]
         )
+
+    def test_function_errors_on_bad_status(self):
+        self.mock_fetch_response = lambda *args: {"status": 400, "body": {"error": "error"}}  # noqa
+        with pytest.raises(UncaughtHogVMException) as e:
+            self.run_function(inputs=create_inputs())
+        assert e.value.message == "Error from customer.io api: 400: {'error': 'error'}"
 
 
 class TestTemplateMigration(BaseTest):


### PR DESCRIPTION
## Problem

Currently we only warn which does not trigger the failure metrics. Swap to throwing instead

## Changes

* As on the tin

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
