### PR TITLE
fix(cdp): Choose the correct value when saving inputs

### DIFF
--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -340,6 +340,42 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         assert obj.encrypted_inputs["secret1"]["value"] == "I AM SECRET"
         assert obj.encrypted_inputs["secret2"]["value"] == "I AM ALSO SECRET"
 
+    def test_secret_inputs_updated_if_changed(self, *args):
+        payload = {
+            "name": "Fetch URL",
+            "hog": "fetch(inputs.url);",
+            "inputs_schema": [
+                {"key": "secret1", "type": "string", "label": "Secret 1", "secret": True, "required": True},
+                {"key": "secret2", "type": "string", "label": "Secret 2", "secret": True, "required": False},
+            ],
+            "inputs": {
+                "secret1": {
+                    "value": "I AM SECRET",
+                },
+            },
+        }
+        res = self.client.post(f"/api/projects/{self.team.id}/hog_functions/", data={**payload})
+        assert res.json()["inputs"] == {"secret1": {"secret": True}}, res.json()
+        res = self.client.patch(
+            f"/api/projects/{self.team.id}/hog_functions/{res.json()['id']}",
+            data={
+                "inputs": {
+                    "secret1": {
+                        "value": "I AM CHANGED",
+                    },
+                    "secret2": {
+                        "value": "I AM ALSO SECRET",
+                    },
+                },
+            },
+        )
+        assert res.json()["inputs"] == {"secret1": {"secret": True}, "secret2": {"secret": True}}, res.json()
+
+        # Finally check the DB has the real value
+        obj = HogFunction.objects.get(id=res.json()["id"])
+        assert obj.encrypted_inputs["secret1"]["value"] == "I AM CHANGED"
+        assert obj.encrypted_inputs["secret2"]["value"] == "I AM ALSO SECRET"
+
     def test_generates_hog_bytecode(self, *args):
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_functions/",

--- a/posthog/models/hog_functions/hog_function.py
+++ b/posthog/models/hog_functions/hog_function.py
@@ -116,7 +116,7 @@ class HogFunction(UUIDModel):
                 final_inputs[schema["key"]] = value
             else:
                 # We either store the incoming value if given or the encrypted value
-                final_encrypted_inputs[schema["key"]] = encrypted_value or value
+                final_encrypted_inputs[schema["key"]] = value or encrypted_value
 
         self.inputs = final_inputs
         self.encrypted_inputs = final_encrypted_inputs


### PR DESCRIPTION
## Problem

There is a bug that means we always use the old encrypted value when we should use the new one. 

## Changes

* Fixed the order
* Added a test to catch it

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
