### PR TITLE
feat(hog): use re2 with like

### DIFF
--- a/hogvm/typescript/package.json
+++ b/hogvm/typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/hogvm",
-    "version": "1.0.52",
+    "version": "1.0.53",
     "description": "PostHog Hog Virtual Machine",
     "types": "dist/index.d.ts",
     "source": "src/index.ts",

--- a/hogvm/typescript/src/execute.ts
+++ b/hogvm/typescript/src/execute.ts
@@ -366,16 +366,16 @@ export function exec(code: any[] | VMState, options?: ExecOptions): ExecResult {
                     pushStack(temp <= temp2)
                     break
                 case Operation.LIKE:
-                    pushStack(like(popStack(), popStack()))
+                    pushStack(like(popStack(), popStack(), false, options?.external?.regex?.match))
                     break
                 case Operation.ILIKE:
-                    pushStack(like(popStack(), popStack(), true))
+                    pushStack(like(popStack(), popStack(), true, options?.external?.regex?.match))
                     break
                 case Operation.NOT_LIKE:
-                    pushStack(!like(popStack(), popStack()))
+                    pushStack(!like(popStack(), popStack(), false, options?.external?.regex?.match))
                     break
                 case Operation.NOT_ILIKE:
-                    pushStack(!like(popStack(), popStack(), true))
+                    pushStack(!like(popStack(), popStack(), true, options?.external?.regex?.match))
                     break
                 case Operation.IN:
                     temp = popStack()

--- a/hogvm/typescript/src/stl/stl.ts
+++ b/hogvm/typescript/src/stl/stl.ts
@@ -49,10 +49,10 @@ export const STL: Record<string, STLFunction> = {
         minArgs: 2,
         maxArgs: 2,
     },
-    like: { fn: ([str, pattern]) => like(str, pattern, false), minArgs: 2, maxArgs: 2 },
-    ilike: { fn: ([str, pattern]) => like(str, pattern, true), minArgs: 2, maxArgs: 2 },
-    notLike: { fn: ([str, pattern]) => !like(str, pattern, false), minArgs: 2, maxArgs: 2 },
-    notILike: { fn: ([str, pattern]) => !like(str, pattern, true), minArgs: 2, maxArgs: 2 },
+    like: { fn: ([str, pattern], _name, options) => like(str, pattern, false, options?.external?.regex?.match), minArgs: 2, maxArgs: 2 },
+    ilike: { fn: ([str, pattern], _name, options) => like(str, pattern, true, options?.external?.regex?.match), minArgs: 2, maxArgs: 2 },
+    notLike: { fn: ([str, pattern], _name, options) => !like(str, pattern, false, options?.external?.regex?.match), minArgs: 2, maxArgs: 2 },
+    notILike: { fn: ([str, pattern], _name, options) => !like(str, pattern, true, options?.external?.regex?.match), minArgs: 2, maxArgs: 2 },
     toString: { fn: STLToString, minArgs: 1, maxArgs: 1 },
     toUUID: {
         fn: (args) => {

--- a/hogvm/typescript/src/utils.ts
+++ b/hogvm/typescript/src/utils.ts
@@ -27,10 +27,18 @@ export class UncaughtHogVMException extends HogVMException {
 /** Fixed cost per object in memory */
 const COST_PER_UNIT = 8
 
-export function like(string: string, pattern: string, caseInsensitive = false): boolean {
+export function like(
+    string: string,
+    pattern: string,
+    caseInsensitive = false,
+    match?: (regex: string, value: string) => boolean
+): boolean {
     pattern = String(pattern)
         .replaceAll(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
         .replaceAll('%', '.*')
+    if (match) {
+        return match((caseInsensitive ? '(?i)' : '') + pattern, string)
+    }
     return new RegExp(pattern, caseInsensitive ? 'i' : undefined).test(string)
 }
 export function getNestedValue(obj: any, chain: any[], nullish = false): any {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "@medv/finder": "^3.1.0",
         "@microlink/react-json-view": "^1.21.3",
         "@monaco-editor/react": "4.6.0",
-        "@posthog/hogvm": "^1.0.52",
+        "@posthog/hogvm": "^1.0.53",
         "@posthog/icons": "0.8.1",
         "@posthog/plugin-scaffold": "^1.4.4",
         "@react-hook/size": "^2.1.2",

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -54,7 +54,7 @@
         "@maxmind/geoip2-node": "^3.4.0",
         "@posthog/clickhouse": "^1.7.0",
         "@posthog/cyclotron": "file:../rust/cyclotron-node",
-        "@posthog/hogvm": "^1.0.52",
+        "@posthog/hogvm": "^1.0.53",
         "@posthog/plugin-scaffold": "1.4.4",
         "@sentry/node": "^7.49.0",
         "@sentry/profiling-node": "^0.3.0",

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -47,8 +47,8 @@ dependencies:
     specifier: file:../rust/cyclotron-node
     version: file:../rust/cyclotron-node
   '@posthog/hogvm':
-    specifier: ^1.0.52
-    version: 1.0.52(luxon@3.4.4)
+    specifier: ^1.0.53
+    version: 1.0.53(luxon@3.4.4)
   '@posthog/plugin-scaffold':
     specifier: 1.4.4
     version: 1.4.4
@@ -3119,8 +3119,8 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /@posthog/hogvm@1.0.52(luxon@3.4.4):
-    resolution: {integrity: sha512-Mn/tLjgZbeKQcp1OTYkCiGD9mNybGeg07baCPJj4EHXFz1EdfSlDzjfYPOcRlpTnAHhF037eYrIocsYbMRdhSg==}
+  /@posthog/hogvm@1.0.53(luxon@3.4.4):
+    resolution: {integrity: sha512-WfZvs+ZWrUmJ8qSmEpDs5EirRL5o2pk6du8FYDlNFkVkEQsdPYBnoTS9VBGEHB1TEVy0BQfHX+dPVQj8U0PTdA==}
     peerDependencies:
       luxon: ^3.4.4
     dependencies:
@@ -10743,5 +10743,5 @@ packages:
   file:../rust/cyclotron-node:
     resolution: {directory: ../rust/cyclotron-node, type: directory}
     name: '@posthog/cyclotron'
-    version: 0.1.4
+    version: 0.1.6
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ dependencies:
     specifier: 4.6.0
     version: 4.6.0(monaco-editor@0.49.0)(react-dom@18.2.0)(react@18.2.0)
   '@posthog/hogvm':
-    specifier: ^1.0.52
-    version: 1.0.52(luxon@3.5.0)
+    specifier: ^1.0.53
+    version: 1.0.53(luxon@3.5.0)
   '@posthog/icons':
     specifier: 0.8.1
     version: 0.8.1(react-dom@18.2.0)(react@18.2.0)
@@ -5394,8 +5394,8 @@ packages:
     resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
     dev: false
 
-  /@posthog/hogvm@1.0.52(luxon@3.5.0):
-    resolution: {integrity: sha512-Mn/tLjgZbeKQcp1OTYkCiGD9mNybGeg07baCPJj4EHXFz1EdfSlDzjfYPOcRlpTnAHhF037eYrIocsYbMRdhSg==}
+  /@posthog/hogvm@1.0.53(luxon@3.5.0):
+    resolution: {integrity: sha512-WfZvs+ZWrUmJ8qSmEpDs5EirRL5o2pk6du8FYDlNFkVkEQsdPYBnoTS9VBGEHB1TEVy0BQfHX+dPVQj8U0PTdA==}
     peerDependencies:
       luxon: ^3.4.4
     dependencies:


### PR DESCRIPTION
## Problem

We were ReDOS'ing ourselves by using the standard Regex library instead of re2 for `like` comparisons.

## Changes

Uses re2 when available.

This resulted in a 170x speedup with my sample event.

## How did you test this code?

- I didn't add a test for slowness.
- All Hog tests kept passing despite a new engine, including case-insensitive parsing