### PR TITLE
feat: support HLS media playback

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/index.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/index.ts
@@ -154,7 +154,7 @@ export const HLSPlayerPlugin: ReplayPlugin = {
                 }
                 // HLS not supported natively but can play in Safari
                 else if (videoEl.canPlayType('application/vnd.apple.mpegurl')) {
-                    videoEl.src = 'https://devunstuck.com/videos/earthlings2/earthlings.m3u8'
+                    videoEl.src = hlsSrc
                 }
             }
         }

--- a/frontend/src/scenes/session-recordings/player/rrweb/index.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/index.ts
@@ -1,3 +1,4 @@
+import Hls from 'hls.js'
 import { EventType, eventWithTime, IncrementalSource } from 'rrweb'
 import { playerConfig, ReplayPlugin } from 'rrweb/typings/types'
 
@@ -120,6 +121,44 @@ export const WindowTitlePlugin = (cb: (windowId: string, title: string) => void)
             }
         },
     }
+}
+
+export const HLSPlayerPlugin: ReplayPlugin = {
+    onBuild: (node) => {
+        if (node && node.nodeName === 'VIDEO' && node.nodeType === 1) {
+            const videoEl = node as HTMLVideoElement
+            const hlsSrc = videoEl.getAttribute('hls-src')
+
+            if (videoEl && hlsSrc) {
+                if (Hls.isSupported()) {
+                    const hls = new Hls()
+                    hls.loadSource(hlsSrc)
+                    hls.attachMedia(videoEl)
+
+                    hls.on(Hls.Events.ERROR, (_, data) => {
+                        if (data.fatal) {
+                            switch (data.type) {
+                                case Hls.ErrorTypes.NETWORK_ERROR:
+                                    hls.startLoad()
+                                    break
+                                case Hls.ErrorTypes.MEDIA_ERROR:
+                                    hls.recoverMediaError()
+                                    break
+                                // Unrecoverable error
+                                default:
+                                    hls.destroy()
+                                    break
+                            }
+                        }
+                    })
+                }
+                // HLS not supported natively but can play in Safari
+                else if (videoEl.canPlayType('application/vnd.apple.mpegurl')) {
+                    videoEl.src = 'https://devunstuck.com/videos/earthlings2/earthlings.m3u8'
+                }
+            }
+        }
+    },
 }
 
 const defaultStyleRules = `.ph-no-capture { background-image: ${PLACEHOLDER_SVG_DATA_IMAGE_URL} }`

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -41,7 +41,7 @@ import { AvailableFeature, RecordingSegment, SessionPlayerData, SessionPlayerSta
 
 import type { sessionRecordingsPlaylistLogicType } from '../playlist/sessionRecordingsPlaylistLogicType'
 import { playerSettingsLogic } from './playerSettingsLogic'
-import { COMMON_REPLAYER_CONFIG, CorsPlugin } from './rrweb'
+import { COMMON_REPLAYER_CONFIG, CorsPlugin, HLSPlayerPlugin } from './rrweb'
 import { CanvasReplayerPlugin } from './rrweb/canvas/canvas-plugin'
 import type { sessionRecordingPlayerLogicType } from './sessionRecordingPlayerLogicType'
 import { deleteRecording } from './utils/playerUtils'
@@ -596,7 +596,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 return
             }
 
-            const plugins: ReplayPlugin[] = []
+            const plugins: ReplayPlugin[] = [HLSPlayerPlugin]
 
             // We don't want non-cloud products to talk to our proxy as it likely won't work, but we _do_ want local testing to work
             if (values.preflight?.cloud || window.location.hostname === 'localhost') {

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
         "kea-test-utils": "^0.2.4",
         "kea-waitfor": "^0.2.1",
         "kea-window-values": "^3.0.0",
+        "hls.js": "^1.5.15",
         "lodash.merge": "^4.6.2",
         "maplibre-gl": "^3.5.1",
         "md5": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ dependencies:
   heatmap.js:
     specifier: ^2.0.5
     version: 2.0.5(patch_hash=gydrxrztd4ruyhouu6tu7zh43e)
+  hls.js:
+    specifier: ^1.5.15
+    version: 1.5.15
   husky:
     specifier: ^7.0.4
     version: 7.0.4
@@ -374,7 +377,7 @@ dependencies:
 optionalDependencies:
   fsevents:
     specifier: ^2.3.2
-    version: 2.3.2
+    version: 2.3.3
 
 devDependencies:
   '@babel/core':
@@ -13070,6 +13073,7 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /fsevents@2.3.3:
@@ -13536,6 +13540,10 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.0
     dev: true
+
+  /hls.js@1.5.15:
+    resolution: {integrity: sha512-6cD7xN6bycBHaXz2WyPIaHn/iXFizE5au2yvY5q9aC4wfihxAr16C9fUy4nxh2a3wOw0fEgLRa9dN6wsYjlpNg==}
+    dev: false
 
   /hogan.js@3.0.2:
     resolution: {integrity: sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==}
@@ -18314,7 +18322,7 @@ packages:
       react: '>=15'
     dependencies:
       react: 18.2.0
-      unlayer-types: 1.95.0
+      unlayer-types: 1.103.0
     dev: false
 
   /react-error-boundary@3.1.4(react@18.2.0):
@@ -20861,8 +20869,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  /unlayer-types@1.95.0:
-    resolution: {integrity: sha512-WsvQp85+Xl8Gggkt+dSSePawoVAnGqjJzJJcDhIQswlPejARBRzAhl5dOF1Q+LjQckhWhKNDaJ5tcOeT+PV4ew==}
+  /unlayer-types@1.103.0:
+    resolution: {integrity: sha512-aVZS7g5F6dWEoxc0dhSDqYYncu+LIMB/SerJi6u5FKVSfTWnzA2MTpjFCbGkOOi8rUiIOabeuEOfyO/WDnarJg==}
     dev: false
 
   /unpipe@1.0.0:


### PR DESCRIPTION
## Problem

HLS media playback is not supported in Replay right now because the `src` is not added to the DOM and thus not captured by rrweb

## Changes

Implementation as described in https://github.com/PostHog/posthog/issues/25087#issuecomment-2370915690

Key thing to note is that the media source must be added as a `hls-src` attribute on the video element (needs to be added to the docs once this is testred)

## How did you test this code?

Tested video plays back locally

|Before|After|
|----|----|
| ![before](https://github.com/user-attachments/assets/cab6b93f-78f2-42e6-912c-18f597c0eaef) | ![after](https://github.com/user-attachments/assets/8692f2e7-24e9-4eec-9cc8-e88746c4ad3e) |