### PR TITLE
fix(encryption): remigrate sensitive fields on integration

### DIFF
--- a/latest_migrations.manifest
+++ b/latest_migrations.manifest
@@ -5,7 +5,7 @@ contenttypes: 0002_remove_content_type_name
 ee: 0016_rolemembership_organization_member
 otp_static: 0002_throttling
 otp_totp: 0002_auto_20190420_0723
-posthog: 0478_migrate_encrypted_fields
+posthog: 0479_alter_sensitive_config_2
 sessions: 0001_initial
 social_django: 0010_uid_db_index
 two_factor: 0007_auto_20201201_1019

--- a/posthog/migrations/0479_alter_sensitive_config_2.py
+++ b/posthog/migrations/0479_alter_sensitive_config_2.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+import json
+
+
+def re_encrypt_integrations(apps, schema_editor):
+    for model in ["Integration"]:
+        Model = apps.get_model("posthog", model)
+
+        items = Model.objects.all()
+        for item in items:
+            if isinstance(item.sensitive_config, str):
+                item.sensitive_config = json.loads(item.sensitive_config)
+            item.save()
+
+
+def backwards(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "0478_migrate_encrypted_fields"),
+    ]
+
+    operations = [
+        migrations.RunPython(re_encrypt_integrations, reverse_code=backwards, elidable=True),
+    ]


### PR DESCRIPTION
## Problem

- previous migration, encrypted the fields into a string

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- dict structure should remain
- just encrypt again if it's currently a string

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
