### PR TITLE
fix(sidepanel): REVERT parse the stringified JSON from the `getFeatureFlagPayload` response"

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
@@ -200,20 +200,11 @@ export const sidePanelActivityLogic = kea<sidePanelActivityLogicType>([
 
                     let changelogNotification: ChangelogFlagPayload | null = null
                     const flagPayload = posthog.getFeatureFlagPayload('changelog-notification')
-                    // `getFeatureFlagPayload` ostensibly returns a JsonType, but in practice it's a stringified JSON object,
-                    // so we need to parse it before checking for the presence of the required fields.
-                    if (typeof flagPayload === 'string') {
-                        try {
-                            const parsedPayload = JSON.parse(flagPayload)
-                            if (parsedPayload.markdown && parsedPayload.notificationDate) {
-                                changelogNotification = {
-                                    markdown: parsedPayload.markdown,
-                                    notificationDate: dayjs(parsedPayload.notificationDate),
-                                } as ChangelogFlagPayload
-                            }
-                        } catch (e) {
-                            console.error('Failed to parse changelog notification payload', e)
-                        }
+                    if (flagPayload) {
+                        changelogNotification = {
+                            markdown: flagPayload['markdown'],
+                            notificationDate: dayjs(flagPayload['notificationDate']),
+                        } as ChangelogFlagPayload
                     }
 
                     if (changelogNotification) {
@@ -237,8 +228,9 @@ export const sidePanelActivityLogic = kea<sidePanelActivityLogicType>([
                                 return 1
                             } else if (a.created_at.isAfter(b.created_at)) {
                                 return -1
+                            } else {
+                                return 0
                             }
-                            return 0
                         })
                         return notifications
                     }


### PR DESCRIPTION
Reverts PostHog/posthog#25180

Turns it out it was a red herring; see the thread [from here](https://posthog.slack.com/archives/C034XD440RK/p1727203492825819?thread_ts=1727184377.090709&cid=C034XD440RK) for context