### PR TITLE
feat(feature flags): info banner when a flag can't be scheduled

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -222,7 +222,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
             label: 'Permissions',
             key: FeatureFlagsTab.PERMISSIONS,
             content: (
-                <PayGateMini feature={AvailableFeature.ROLE_BASED_ACCESS}>
+                <PayGateMini feature={true}>
                     <ResourcePermission
                         resourceType={Resource.FEATURE_FLAGS}
                         onChange={(roleIds) => setRolesToAdd(roleIds)}

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -222,7 +222,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
             label: 'Permissions',
             key: FeatureFlagsTab.PERMISSIONS,
             content: (
-                <PayGateMini feature={true}>
+                <PayGateMini feature={AvailableFeature.ROLE_BASED_ACCESS}>
                     <ResourcePermission
                         resourceType={Resource.FEATURE_FLAGS}
                         onChange={(roleIds) => setRolesToAdd(roleIds)}

--- a/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSchedule.tsx
@@ -1,4 +1,5 @@
 import {
+    LemonBanner,
     LemonButton,
     LemonCalendarSelectInput,
     LemonCheckbox,
@@ -121,7 +122,8 @@ export default function FeatureFlagSchedule(): JSX.Element {
             width: 0,
             render: function Render(_, scheduledChange: ScheduledChangeType) {
                 return (
-                    !scheduledChange.executed_at && (
+                    !scheduledChange.executed_at &&
+                    featureFlag.can_edit && (
                         <More
                             overlay={
                                 <LemonButton
@@ -141,77 +143,89 @@ export default function FeatureFlagSchedule(): JSX.Element {
 
     return (
         <div>
-            <h3 className="l3">Add a scheduled change</h3>
-            <div className="mb-6">Automatically change flag properties at a future point in time.</div>
-            <div className="inline-flex gap-10 mb-8">
+            {featureFlag.can_edit ? (
                 <div>
-                    <div className="font-semibold leading-6 h-6 mb-1">Change type</div>
-                    <LemonSelect<ScheduledChangeOperationType>
-                        className="w-50"
-                        placeholder="Select variant"
-                        value={scheduledChangeOperation}
-                        onChange={(value) => value && setScheduledChangeOperation(value)}
-                        options={[
-                            { label: 'Change status', value: ScheduledChangeOperationType.UpdateStatus },
-                            { label: 'Add a condition', value: ScheduledChangeOperationType.AddReleaseCondition },
-                        ]}
-                    />
-                </div>
-                <div className="w-50">
-                    <div className="font-semibold leading-6 h-6 mb-1">Date and time</div>
-                    <LemonCalendarSelectInput
-                        value={scheduleDateMarker}
-                        onChange={(value) => setScheduleDateMarker(value)}
-                        placeholder="Select date"
-                        selectionPeriod="upcoming"
-                        granularity="minute"
-                    />
-                </div>
-            </div>
-
-            <div className="space-y-4">
-                {scheduledChangeOperation === ScheduledChangeOperationType.UpdateStatus && (
-                    <>
-                        <div className="border rounded p-4">
-                            <LemonCheckbox
-                                id="flag-enabled-checkbox"
-                                label="Enable feature flag"
-                                onChange={(value) => {
-                                    setSchedulePayload(null, value)
-                                }}
-                                checked={schedulePayload.active}
+                    <h3 className="l3">Add a scheduled change</h3>
+                    <div className="mb-6">Automatically change flag properties at a future point in time.</div>
+                    <div className="inline-flex gap-10 mb-8">
+                        <div>
+                            <div className="font-semibold leading-6 h-6 mb-1">Change type</div>
+                            <LemonSelect<ScheduledChangeOperationType>
+                                className="w-50"
+                                placeholder="Select variant"
+                                value={scheduledChangeOperation}
+                                onChange={(value) => value && setScheduledChangeOperation(value)}
+                                options={[
+                                    { label: 'Change status', value: ScheduledChangeOperationType.UpdateStatus },
+                                    {
+                                        label: 'Add a condition',
+                                        value: ScheduledChangeOperationType.AddReleaseCondition,
+                                    },
+                                ]}
                             />
                         </div>
-                    </>
-                )}
-                {scheduledChangeOperation === ScheduledChangeOperationType.AddReleaseCondition && (
-                    <FeatureFlagReleaseConditions
-                        id={`schedule-release-conditions-${featureFlag.id}`}
-                        filters={scheduleFilters}
-                        onChange={(value, errors) => setSchedulePayload(value, null, errors)}
-                        hideMatchOptions
-                    />
-                )}
-                <div className="flex items-center justify-end">
-                    <LemonButton
-                        type="primary"
-                        onClick={createScheduledChange}
-                        disabledReason={
-                            !scheduleDateMarker
-                                ? 'Select the scheduled date and time'
-                                : hasFormErrors(schedulePayloadErrors)
-                                ? 'Fix release condition errors'
-                                : undefined
-                        }
-                    >
-                        Schedule
-                    </LemonButton>
+                        <div className="w-50">
+                            <div className="font-semibold leading-6 h-6 mb-1">Date and time</div>
+                            <LemonCalendarSelectInput
+                                value={scheduleDateMarker}
+                                onChange={(value) => setScheduleDateMarker(value)}
+                                placeholder="Select date"
+                                selectionPeriod="upcoming"
+                                granularity="minute"
+                            />
+                        </div>
+                    </div>
+
+                    <div className="space-y-4">
+                        {scheduledChangeOperation === ScheduledChangeOperationType.UpdateStatus && (
+                            <>
+                                <div className="border rounded p-4">
+                                    <LemonCheckbox
+                                        id="flag-enabled-checkbox"
+                                        label="Enable feature flag"
+                                        onChange={(value) => {
+                                            setSchedulePayload(null, value)
+                                        }}
+                                        checked={schedulePayload.active}
+                                    />
+                                </div>
+                            </>
+                        )}
+                        {scheduledChangeOperation === ScheduledChangeOperationType.AddReleaseCondition && (
+                            <FeatureFlagReleaseConditions
+                                id={`schedule-release-conditions-${featureFlag.id}`}
+                                filters={scheduleFilters}
+                                onChange={(value, errors) => setSchedulePayload(value, null, errors)}
+                                hideMatchOptions
+                            />
+                        )}
+                        <div className="flex items-center justify-end">
+                            <LemonButton
+                                type="primary"
+                                onClick={createScheduledChange}
+                                disabledReason={
+                                    !scheduleDateMarker
+                                        ? 'Select the scheduled date and time'
+                                        : hasFormErrors(schedulePayloadErrors)
+                                        ? 'Fix release condition errors'
+                                        : undefined
+                                }
+                            >
+                                Schedule
+                            </LemonButton>
+                        </div>
+                        <LemonDivider className="" />
+                    </div>
                 </div>
-                <LemonDivider className="" />
-            </div>
+            ) : (
+                <LemonBanner type="info" className="mb-2">
+                    You don't have the necessary permissions to schedule changes to this flag. Contact your
+                    administrator to request editing rights.
+                </LemonBanner>
+            )}
             <LemonTable
                 rowClassName={(record) => (record.executed_at ? 'opacity-75' : '')}
-                className="mt-8"
+                className="mt-4"
                 loading={false}
                 dataSource={scheduledChanges}
                 columns={columns}


### PR DESCRIPTION
## Problem
Raised by @leonposthog
> Hey team - I have a question regarding role based access for Feature Flags, it looks like a user who only has "Feature Flags View" permissions, can still use the Scheduling feature of feature flags, is that expected?

## Changes
Permissioning is handled at the API level, so any update attempt by a user without the edit permissions would already fail when trying to execute a scheduled flag change.

Now adding a banner to inform non-permissioned users that they need to request edit permissions before scheduling.

<img width="1245" alt="image" src="https://github.com/user-attachments/assets/31b5c96d-97f9-4c19-8a17-e45d865e9888">

## How did you test this code?
👀 