### PR TITLE
fix(cdp): webhook message migration

### DIFF
--- a/posthog/management/commands/migrate_action_webhooks.py
+++ b/posthog/management/commands/migrate_action_webhooks.py
@@ -13,12 +13,14 @@ from posthog.plugins.plugin_server_api import reload_all_hog_functions_on_worker
 
 # Maps to a string or a tuple of name and url
 mappings: dict[str, str | list[str]] = {
-    "[event]": ["{event.name}", "{event.url}"],
+    "[event]": ["{event.event}", "{event.url}"],
     "[event.link]": "{event.url}",
-    "[event.event]": "{event.name}",
+    "[event.event]": "{event.event}",
+    "[event.name]": "{event.event}",
     "[event.uuid]": "{event.uuid}",
     "[person]": ["{person.name}", "{person.url}"],
     "[person.link]": "{person.url}",
+    "[person.uuid]": "{person.id}",
     "[user]": ["{person.name}", "{person.url}"],
     "[user.name]": "{person.name}",
     "[user.pathname]": "{event.properties.$pathname}",
@@ -61,8 +63,8 @@ def convert_slack_message_format_to_hog(action: Action, is_slack: bool) -> tuple
                 # For text we just replace it with the name
                 text = text.replace(match, mappings[match][0])
             else:
-                markdown = markdown.replace(match, mappings[match])
-                text = text.replace(match, mappings[match])
+                markdown = markdown.replace(match, str(mappings[match]))
+                text = text.replace(match, str(mappings[match]))
         elif match.startswith("[action."):
             # Action data is no longer available as it is just a filter hence we need to replace it with static values
             action_property = content.split(".")[1]

--- a/posthog/management/commands/migrate_action_webhooks.py
+++ b/posthog/management/commands/migrate_action_webhooks.py
@@ -19,6 +19,7 @@ mappings: dict[str, str | list[str]] = {
     "[event.uuid]": "{event.uuid}",
     "[person]": ["{person.name}", "{person.url}"],
     "[person.link]": "{person.url}",
+    "[user]": ["{person.name}", "{person.url}"],
     "[user.name]": "{person.name}",
     "[user.pathname]": "{event.properties.$pathname}",
     "[user.email]": "{person.properties.email}",
@@ -46,10 +47,10 @@ def convert_link(text: str, url: str, is_slack: bool) -> str:
 
 def convert_slack_message_format_to_hog(action: Action, is_slack: bool) -> tuple[str, str]:
     message_format = action.slack_message_format or "[action.name] triggered by [person]"
+    message_format = message_format.replace("{", "\\{")
     matches = re.findall(r"(\[[^\]]+\])", message_format)
     markdown = message_format
     text = message_format
-
     # Iterate over each match replacing it with the appropriate hog format
     for match in matches:
         content = match[1:-1]
@@ -60,8 +61,8 @@ def convert_slack_message_format_to_hog(action: Action, is_slack: bool) -> tuple
                 # For text we just replace it with the name
                 text = text.replace(match, mappings[match][0])
             else:
-                markdown = markdown.replace(match, f"{{{content}}}")
-                text = text.replace(match, f"{{{content}}}")
+                markdown = markdown.replace(match, mappings[match])
+                text = text.replace(match, mappings[match])
         elif match.startswith("[action."):
             # Action data is no longer available as it is just a filter hence we need to replace it with static values
             action_property = content.split(".")[1]
@@ -84,15 +85,12 @@ def convert_slack_message_format_to_hog(action: Action, is_slack: bool) -> tuple
                 text = text.replace(match, f"{{{content}}}")
         elif match.startswith("[user."):
             parts = content.split(".")
-            string = ".".join(["person", "properties", "$" + parts[1]])
-            for part in parts[2:]:
-                string += f".{part}"
+            string = ".".join(["person", "properties", "$" + parts[1], *parts[2:]])
             markdown = markdown.replace(match, f"{{{string}}}")
             text = text.replace(match, f"{{{string}}}")
         else:
             markdown = markdown.replace(match, f"{{{content}}}")
             text = text.replace(match, f"{{{content}}}")
-
     print(  # noqa: T201
         f"[Action {action.id}] Converted message format:",
         {
@@ -106,12 +104,9 @@ def convert_slack_message_format_to_hog(action: Action, is_slack: bool) -> tuple
 
 def convert_to_hog_function(action: Action, inert=False) -> Optional[HogFunction]:
     webhook_url = action.team.slack_incoming_webhook
-
     if not webhook_url:
         return None
-
     message_markdown, message_text = convert_slack_message_format_to_hog(action, is_slack="slack" in webhook_url)
-
     if "slack" in webhook_url:
         body = {
             "text": message_text,
@@ -121,12 +116,10 @@ def convert_to_hog_function(action: Action, inert=False) -> Optional[HogFunction
         body = {
             "text": message_markdown,
         }
-
     hog_code = inert_fetch_print if inert else webhook_template.hog
     hog_name = f"Webhook for action {action.id} ({action.name})"
     if inert:
         hog_name = f"[CDP-TEST-HIDDEN] {hog_name}"
-
     hog_function = HogFunction(
         name=hog_name,
         description="Automatically migrated from legacy action webhooks",

--- a/posthog/management/commands/migrate_action_webhooks.py
+++ b/posthog/management/commands/migrate_action_webhooks.py
@@ -88,6 +88,11 @@ def convert_slack_message_format_to_hog(action: Action, is_slack: bool) -> tuple
             string = ".".join(["person", "properties", "$" + parts[1], *parts[2:]])
             markdown = markdown.replace(match, f"{{{string}}}")
             text = text.replace(match, f"{{{string}}}")
+        elif match.startswith("[properties."):
+            parts = content.split(".")
+            string = ".".join(["event", *parts])
+            markdown = markdown.replace(match, f"{{{string}}}")
+            text = text.replace(match, f"{{{string}}}")
         else:
             markdown = markdown.replace(match, f"{{{content}}}")
             text = text.replace(match, f"{{{content}}}")

--- a/posthog/management/commands/test/test_migrate_action_webhooks.py
+++ b/posthog/management/commands/test/test_migrate_action_webhooks.py
@@ -93,11 +93,11 @@ class TestMigrateActionWebhooks(BaseTest):
         assert hog_function.inputs["method"]["value"] == "POST"
         assert hog_function.inputs["body"]["value"] == snapshot(
             {
-                "text": "{event.name} triggered by {person.name}",
+                "text": "{event.event} triggered by {person.name}",
                 "blocks": [
                     {
                         "text": {
-                            "text": "<{event.url}|{event.name}> triggered by <{person.url}|{person.name}>",
+                            "text": "<{event.url}|{event.event}> triggered by <{person.url}|{person.name}>",
                             "type": "mrkdwn",
                         },
                         "type": "section",
@@ -114,7 +114,7 @@ class TestMigrateActionWebhooks(BaseTest):
 
         assert hog_function.inputs["url"]["value"] == "https://webhooks.other.com/123"
         assert hog_function.inputs["body"]["value"] == snapshot(
-            {"text": "[{event.name}]({event.url}) triggered by [{person.name}]({person.url})"}
+            {"text": "[{event.event}]({event.url}) triggered by [{person.name}]({person.url})"}
         )
 
     def test_migrates_advanced_message_format(self):
@@ -125,8 +125,8 @@ class TestMigrateActionWebhooks(BaseTest):
 
         assert (
             hog_function.inputs["body"]["value"]["text"]
-            == """Event: {event.name} {event.event} {event.link} {event.uuid}
-Person: {person.name} {person.link} {person.properties.foo.bar}
+            == """Event: {event.event} {event.event} {event.url} {event.uuid}
+Person: {person.name} {person.url} {person.properties.foo.bar}
 Groups: {groups.organization.url}  {groups.organization.properties.foo.bar}
 Action: Test Action {project.url}/data-management/actions/1""".replace("1", str(self.action.id))
         )
@@ -134,8 +134,8 @@ Action: Test Action {project.url}/data-management/actions/1""".replace("1", str(
         assert hog_function.inputs["body"]["value"]["blocks"] == [
             {
                 "text": {
-                    "text": """Event: <{event.url}|{event.name}> {event.event} {event.link} {event.uuid}
-Person: <{person.url}|{person.name}> {person.link} {person.properties.foo.bar}
+                    "text": """Event: <{event.url}|{event.event}> {event.event} {event.url} {event.uuid}
+Person: <{person.url}|{person.name}> {person.url} {person.properties.foo.bar}
 Groups: {groups.organization.url}  {groups.organization.properties.foo.bar}
 Action: <{project.url}/data-management/actions/1|Test Action> {project.url}/data-management/actions/1""".replace(
                         "1", str(self.action.id)
@@ -156,8 +156,8 @@ Action: <{project.url}/data-management/actions/1|Test Action> {project.url}/data
 
         assert hog_function.inputs["body"]["value"] == {
             "text": """\
-Event: [{event.name}]({event.url}) {event.event} {event.link} {event.uuid}
-Person: [{person.name}]({person.url}) {person.link} {person.properties.foo.bar}
+Event: [{event.event}]({event.url}) {event.event} {event.url} {event.uuid}
+Person: [{person.name}]({person.url}) {person.url} {person.properties.foo.bar}
 Groups: {groups.organization.url}  {groups.organization.properties.foo.bar}
 Action: [Test Action]({project.url}/data-management/actions/1) {project.url}/data-management/actions/1\
 """.replace("1", str(self.action.id))


### PR DESCRIPTION
## Problem

We kept seeing `{user.*}` in converted webhook messages.

## Changes

Fix an overlooked hook migration bug

## How did you test this code?

Created all new migrations with the modified code in a shell. This is essentially just documenting and fixing for the next round.