### PR TITLE
fix(cohorts): correct crontab schedules

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -201,7 +201,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     sender.add_periodic_task(
-        crontab(settings.CALCULATE_COHORTS_DAY_SCHEDULE),
+        get_crontab(settings.CALCULATE_COHORTS_DAY_SCHEDULE),
         calculate_cohort.s(),
         name="recalculate cohorts",
         expires=120 * 1.5,
@@ -209,7 +209,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     sender.add_periodic_task(
-        crontab(settings.CALCULATE_COHORTS_NIGHT_SCHEDULE),
+        get_crontab(settings.CALCULATE_COHORTS_NIGHT_SCHEDULE),
         calculate_cohort.s(),
         name="recalculate cohorts",
         expires=60 * 1.5,


### PR DESCRIPTION
## Problem

`crontab` only supports kwargs while I was passing it using a single string. Correct the schedules to use `get_crontab` function.

## Changes

Use `get_crontab`.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing.