### PR TITLE
fix: Public templates api

### DIFF
--- a/posthog/api/test/test_hog_function_templates.py
+++ b/posthog/api/test/test_hog_function_templates.py
@@ -1,0 +1,37 @@
+from rest_framework import status
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, QueryMatchingTest
+from posthog.cdp.templates.slack.template_slack import template
+
+# NOTE: We check this as a sanity check given that this is a public API so we want to explicitly define what is exposed
+EXPECTED_FIRST_RESULT = {
+    "sub_templates": template.sub_templates,
+    "status": template.status,
+    "id": template.id,
+    "name": template.name,
+    "description": template.description,
+    "hog": template.hog,
+    "inputs_schema": template.inputs_schema,
+    "category": template.category,
+    "filters": template.filters,
+    "masking": template.masking,
+    "icon_url": template.icon_url,
+}
+
+
+class TestHogFunctionTemplates(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
+    def test_list_function_templates(self):
+        response = self.client.get("/api/projects/@current/hog_function_templates/")
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert len(response.json()["results"]) > 5
+        print(response.json()["results"][0])
+        assert response.json()["results"][0] == EXPECTED_FIRST_RESULT
+
+    def test_public_list_function_templates(self):
+        self.client.logout()
+        response = self.client.get("/api/public_hog_function_templates/")
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert len(response.json()["results"]) > 5
+        assert response.json()["results"][0] == EXPECTED_FIRST_RESULT

--- a/posthog/api/test/test_hog_function_templates.py
+++ b/posthog/api/test/test_hog_function_templates.py
@@ -1,3 +1,4 @@
+from unittest.mock import ANY
 from rest_framework import status
 
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, QueryMatchingTest
@@ -5,7 +6,7 @@ from posthog.cdp.templates.slack.template_slack import template
 
 # NOTE: We check this as a sanity check given that this is a public API so we want to explicitly define what is exposed
 EXPECTED_FIRST_RESULT = {
-    "sub_templates": template.sub_templates,
+    "sub_templates": ANY,
     "status": template.status,
     "id": template.id,
     "name": template.name,
@@ -25,7 +26,6 @@ class TestHogFunctionTemplates(ClickhouseTestMixin, APIBaseTest, QueryMatchingTe
 
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert len(response.json()["results"]) > 5
-        print(response.json()["results"][0])
         assert response.json()["results"][0] == EXPECTED_FIRST_RESULT
 
     def test_public_list_function_templates(self):

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -186,6 +186,10 @@ urlpatterns = [
         "api/reset/<str:user_uuid>/",
         authentication.PasswordResetCompleteViewSet.as_view({"get": "retrieve", "post": "create"}),
     ),
+    opt_slash_path(
+        "api/public_hog_function_templates",
+        hog_function_template.PublicHogFunctionTemplateViewSet.as_view({"get": "list"}),
+    ),
     re_path(r"^api.+", api_not_found),
     path("authorize_and_redirect/", login_required(authorize_and_redirect)),
     path(
@@ -229,10 +233,6 @@ urlpatterns = [
     path("year_in_posthog/2022/<str:user_uuid>/", year_in_posthog.render_2022),
     path("year_in_posthog/2023/<str:user_uuid>", year_in_posthog.render_2023),
     path("year_in_posthog/2023/<str:user_uuid>/", year_in_posthog.render_2023),
-    opt_slash_path(
-        "api/public_hog_function_templates",
-        hog_function_template.PublicHogFunctionTemplateViewSet.as_view({"get": "list"}),
-    ),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
## Problem

I think in a merge the url ended up in the wrong place

## Changes

* Fixes it and adds tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
