### PR TITLE
feat(cdp): Added event to debug log

### DIFF
--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -422,7 +422,7 @@ export class HogExecutor {
                     messages.push(`Sync: ${execRes.state.syncDuration}ms.`)
                     messages.push(`Mem: ${execRes.state.maxMemUsed} bytes.`)
                     messages.push(`Ops: ${execRes.state.ops}.`)
-                    messages.push(`Event: '${globals.event.uuid}'`)
+                    messages.push(`Event: '${globals.event.url}'`)
 
                     hogFunctionStateMemory.observe(execRes.state.maxMemUsed / 1024)
 
@@ -432,7 +432,7 @@ export class HogExecutor {
                             hogFunctionId: invocation.hogFunction.id,
                             hogFunctionName: invocation.hogFunction.name,
                             teamId: invocation.teamId,
-                            eventId: invocation.globals.event.uuid,
+                            eventId: invocation.globals.event.url,
                             memoryUsedKb: execRes.state.maxMemUsed / 1024,
                         })
                     }
@@ -448,7 +448,7 @@ export class HogExecutor {
             result.finished = true // Explicitly set to true to prevent infinite loops
             status.error(
                 '🦔',
-                `[HogExecutor] Error executing function ${invocation.hogFunction.id} - ${invocation.hogFunction.name}. Event: '${invocation.globals.event.uuid}'`,
+                `[HogExecutor] Error executing function ${invocation.hogFunction.id} - ${invocation.hogFunction.name}. Event: '${invocation.globals.event.url}'`,
                 err
             )
         }

--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -448,7 +448,7 @@ export class HogExecutor {
             result.finished = true // Explicitly set to true to prevent infinite loops
             status.error(
                 '🦔',
-                `[HogExecutor] Error executing function ${invocation.hogFunction.id} - ${invocation.hogFunction.name}`,
+                `[HogExecutor] Error executing function ${invocation.hogFunction.id} - ${invocation.hogFunction.name}. Event: '${invocation.globals.event.uuid}'`,
                 err
             )
         }

--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -422,6 +422,7 @@ export class HogExecutor {
                     messages.push(`Sync: ${execRes.state.syncDuration}ms.`)
                     messages.push(`Mem: ${execRes.state.maxMemUsed} bytes.`)
                     messages.push(`Ops: ${execRes.state.ops}.`)
+                    messages.push(`Event: '${globals.event.uuid}'`)
 
                     hogFunctionStateMemory.observe(execRes.state.maxMemUsed / 1024)
 

--- a/plugin-server/tests/cdp/hog-executor.test.ts
+++ b/plugin-server/tests/cdp/hog-executor.test.ts
@@ -127,7 +127,7 @@ describe('Hog Executor', () => {
                   "{\\"foo\\":\\"***REDACTED***\\",\\"null\\":null,\\"bool\\":false}",
                   "substring: ***REDACTED***",
                   "{\\"input_1\\":\\"test\\",\\"secret_input_2\\":{\\"foo\\":\\"***REDACTED***\\",\\"null\\":null,\\"bool\\":false},\\"secret_input_3\\":\\"***REDACTED***\\"}",
-                  "Function completed in 0ms. Sync: 0ms. Mem: 169 bytes. Ops: 28.",
+                  "Function completed in 0ms. Sync: 0ms. Mem: 169 bytes. Ops: 28. Event: 'uuid'",
                 ]
             `)
         })
@@ -190,7 +190,7 @@ describe('Hog Executor', () => {
                   "Suspending function due to async function call 'fetch'. Payload: 1872 bytes",
                   "Resuming function",
                   "Fetch response:, {\\"status\\":200,\\"body\\":\\"success\\"}",
-                  "Function completed in 100ms. Sync: 0ms. Mem: 779 bytes. Ops: 22.",
+                  "Function completed in 100ms. Sync: 0ms. Mem: 779 bytes. Ops: 22. Event: 'uuid'",
                 ]
             `)
         })
@@ -209,7 +209,7 @@ describe('Hog Executor', () => {
                   "Suspending function due to async function call 'fetch'. Payload: 1872 bytes",
                   "Resuming function",
                   "Fetch response:, {\\"status\\":200,\\"body\\":{\\"foo\\":\\"bar\\"}}",
-                  "Function completed in 100ms. Sync: 0ms. Mem: 779 bytes. Ops: 22.",
+                  "Function completed in 100ms. Sync: 0ms. Mem: 779 bytes. Ops: 22. Event: 'uuid'",
                 ]
             `)
         })

--- a/plugin-server/tests/cdp/hog-executor.test.ts
+++ b/plugin-server/tests/cdp/hog-executor.test.ts
@@ -127,7 +127,7 @@ describe('Hog Executor', () => {
                   "{\\"foo\\":\\"***REDACTED***\\",\\"null\\":null,\\"bool\\":false}",
                   "substring: ***REDACTED***",
                   "{\\"input_1\\":\\"test\\",\\"secret_input_2\\":{\\"foo\\":\\"***REDACTED***\\",\\"null\\":null,\\"bool\\":false},\\"secret_input_3\\":\\"***REDACTED***\\"}",
-                  "Function completed in 0ms. Sync: 0ms. Mem: 169 bytes. Ops: 28. Event: 'uuid'",
+                  "Function completed in 0ms. Sync: 0ms. Mem: 169 bytes. Ops: 28. Event: 'http://localhost:8000/events/1'",
                 ]
             `)
         })
@@ -190,7 +190,7 @@ describe('Hog Executor', () => {
                   "Suspending function due to async function call 'fetch'. Payload: 1872 bytes",
                   "Resuming function",
                   "Fetch response:, {\\"status\\":200,\\"body\\":\\"success\\"}",
-                  "Function completed in 100ms. Sync: 0ms. Mem: 779 bytes. Ops: 22. Event: 'uuid'",
+                  "Function completed in 100ms. Sync: 0ms. Mem: 779 bytes. Ops: 22. Event: 'http://localhost:8000/events/1'",
                 ]
             `)
         })
@@ -209,7 +209,7 @@ describe('Hog Executor', () => {
                   "Suspending function due to async function call 'fetch'. Payload: 1872 bytes",
                   "Resuming function",
                   "Fetch response:, {\\"status\\":200,\\"body\\":{\\"foo\\":\\"bar\\"}}",
-                  "Function completed in 100ms. Sync: 0ms. Mem: 779 bytes. Ops: 22. Event: 'uuid'",
+                  "Function completed in 100ms. Sync: 0ms. Mem: 779 bytes. Ops: 22. Event: 'http://localhost:8000/events/1'",
                 ]
             `)
         })


### PR DESCRIPTION
## Problem

Whenever debugging after the fact we are often interested to know what event caused an invocation or error. This adds the ID to the debug log

## Changes

* As described

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
