### PR TITLE
fix(replay): reload recordings when orderBy changes

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -820,6 +820,9 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                 actions.loadSessionRecordings()
             }
         },
+        orderBy: () => {
+            actions.loadSessionRecordings()
+        },
     })),
 
     // NOTE: It is important this comes after urlToAction, as it will override the default behavior


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

When testing  #25102, noticed that while the recordings are shown in the correct order, the initial network call made still uses `start_time`, regardless of the orderBy value.




## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Listening on when orderBy changes should solve this, by always loading recordings when that value changes.


https://github.com/user-attachments/assets/a68b8338-d550-4cf9-82d3-54bfa106433c





👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
