### PR TITLE
fix(cohorts): set unique task names for cohorts

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -203,7 +203,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     sender.add_periodic_task(
         get_crontab(settings.CALCULATE_COHORTS_DAY_SCHEDULE),
         calculate_cohort.s(),
-        name="recalculate cohorts",
+        name="recalculate cohorts day",
         expires=120 * 1.5,
         args=(settings.CALCULATE_X_PARALLEL_COHORTS_DURING_DAY,),
     )
@@ -211,7 +211,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     sender.add_periodic_task(
         get_crontab(settings.CALCULATE_COHORTS_NIGHT_SCHEDULE),
         calculate_cohort.s(),
-        name="recalculate cohorts",
+        name="recalculate cohorts night",
         expires=60 * 1.5,
         args=(settings.CALCULATE_X_PARALLEL_COHORTS_DURING_NIGHT,),
     )


### PR DESCRIPTION
## Problem

Celery requires unique names for tasks.

## Changes

Set unique names for day and night schedules.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing.