### PR TITLE
chore: improve observability when bootstrapping scheduled tasks

### DIFF
--- a/posthog/celery.py
+++ b/posthog/celery.py
@@ -1,6 +1,7 @@
 import os
 import time
 
+import structlog
 from celery import Celery
 from celery.signals import (
     setup_logging,
@@ -15,6 +16,11 @@ from django.dispatch import receiver
 from django_structlog.celery import signals
 from django_structlog.celery.steps import DjangoStructLogInitStep
 from prometheus_client import Counter, Histogram
+
+from posthog.cloud_utils import is_cloud
+
+logger = structlog.get_logger(__name__)
+
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
@@ -160,8 +166,11 @@ def setup_periodic_tasks(sender: Celery, **kwargs):
         setup_periodic_tasks(sender)
     except Exception as exc:
         # Setup fails silently. Alert the team if a configuration error is detected in periodic tasks.
-        create_incident(
-            f"Periodic tasks setup failed: {exc}",
-            "posthog.celery.setup_periodic_tasks",
-            "critical",
-        )
+        if is_cloud():
+            create_incident(
+                f"Periodic tasks setup failed: {exc}",
+                "posthog.celery.setup_periodic_tasks",
+                "critical",
+            )
+        else:
+            logger.exception("Periodic tasks setup failed", exception=exc)

--- a/posthog/tasks/test/test_scheduled.py
+++ b/posthog/tasks/test/test_scheduled.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+
+from posthog.celery import app
+from posthog.tasks.scheduled import setup_periodic_tasks
+
+
+class TestScheduledTasks(TestCase):
+    def test_scheduled_tasks(self) -> None:
+        """
+        `setup_periodic_tasks` may fail silently. This test ensures that it doesn't.
+        """
+        try:
+            setup_periodic_tasks(app)
+        except Exception as exc:
+            assert exc is None, exc


### PR DESCRIPTION
## Problem

#25129 introduced an uncaught exception in the `setup_scheduled_tasks` function, which prevented tasks from starting. This was uncaught on tests/CI level as well as alerting wasn't in place. This PR adds measures to ensure that it won't happen again.

## Changes

- Add a test to catch uncaught exceptions in `setup_celery_tasks` locally and on CI.
- Add alerting in case it is a configuration mistake.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

N/A