### PR TITLE
chore(batch-exports): Add (more) memory limits to persons query

### DIFF
--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -55,9 +55,11 @@ FROM
         interval_end={interval_end}
     ) AS persons
 FORMAT ArrowStream
--- This is half of configured MAX_MEMORY_USAGE for batch exports.
--- TODO: Make the setting available to all queries.
-SETTINGS max_bytes_before_external_group_by=50000000000
+SETTINGS
+    -- This is half of configured MAX_MEMORY_USAGE for batch exports.
+    -- TODO: Make the setting available to all queries.
+    max_bytes_before_external_group_by=50000000000,
+    max_bytes_before_external_sort=50000000000
 """
 
 SELECT_FROM_EVENTS_VIEW = Template(


### PR DESCRIPTION
## Problem

Persons batch export query occasionally exceeds memory limits, for some reason.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Set `max_bytes_before_external_sort` to allow spilling to disk if sorting is the operation causing us to exceed memory.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
