### PR TITLE
chore(batch-exports): Add non-retryable postgres error

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -670,6 +670,8 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
                 # A user added a unique constraint on their table, but batch exports (particularly events)
                 # can cause duplicates.
                 "UniqueViolation",
+                # Something changed in the target table's schema that we were not expecting.
+                "UndefinedColumn",
             ],
             finish_inputs=finish_inputs,
         )


### PR DESCRIPTION
## Problem

An `UndefinedColumn` exception is raised when we try to write a column that doesn't exist. This should never really happen in batch exports unless a user has manually updated their schema.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Do not retry on `UndefinedColumn` errors.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
