### PR TITLE
perf: Improve `toDateTime` nullability checks to increase index utilization

### DIFF
--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1523,6 +1523,8 @@ class _Printer(Visitor):
             return node.type.is_nullable(self.context)
         elif isinstance(node, ast.Alias):
             return self._is_nullable(node.expr)
+        elif isinstance(node, ast.Call) and node.name == "toDateTime":
+            return any(self._is_nullable(arg) for arg in node.args)
 
         # we don't know if it's nullable, so we assume it can be
         return True


### PR DESCRIPTION
## Problem

`ifNull` wrapping prevents the ClickHouse analyzer from utilizing the `timestamp` part of the primary key index when the other operand in the comparison is the result of a `toDateTime` call. This causes us to read much more data than is necessary for some queries.

## Changes

Only consider the output of `toDateTime` as nullable in cases where `toDateTime` is either conclusively `NULL` or ambiguous/unknowable. Don't consider the return type of `toDateTime` as nullable when it shouldn't be (e.g. all arguments are non-`NULL` constants.)

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
