### PR TITLE
fix(batch-exports): Set queries to cancel after disconnect

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -438,6 +438,7 @@ async def get_client(
                 max_execution_time=settings.CLICKHOUSE_MAX_EXECUTION_TIME,
                 max_memory_usage=settings.CLICKHOUSE_MAX_MEMORY_USAGE,
                 max_block_size=max_block_size,
+                cancel_http_readonly_queries_on_client_close=1,
                 output_format_arrow_string_as_string="true",
                 **kwargs,
             ) as client:


### PR DESCRIPTION
## Problem

Batch exports can be cancelled or fail for whatever reason, even reasons beyond query execution. In those cases, we should make sure we at least attempt to cancel queries on ClickHouse's side to avoid overloading the cluster if we continuously fail and retry the same heavy queries.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Enable setting `cancel_http_readonly_queries_on_client_close`. Since all batch export queries are just a `SELECT` this should take care of cancelling them once we disconnect the client.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
