### PR TITLE
fix(batch-exports): Raise non-retryable error on empty S3 endpoint

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -132,7 +132,7 @@ class IntermittentUploadPartTimeoutError(Exception):
 
 
 class EmptyS3EndpointURLError(Exception):
-    """Exception raised when an S3 endpoint URL is not `None` but empty string."""
+    """Exception raised when an S3 endpoint URL is empty string."""
 
     def __init__(self):
         super().__init__("Endpoint URL cannot be empty.")

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -131,6 +131,13 @@ class IntermittentUploadPartTimeoutError(Exception):
         super().__init__(f"An intermittent `RequestTimeout` was raised while attempting to upload part {part_number}")
 
 
+class EmptyS3EndpointURLError(Exception):
+    """Exception raised when an S3 endpoint URL is not `None` but empty string."""
+
+    def __init__(self):
+        super().__init__("Endpoint URL cannot be empty.")
+
+
 Part = dict[str, str | int]
 
 
@@ -177,6 +184,9 @@ class S3MultiPartUpload:
         self.kms_key_id = kms_key_id
         self.upload_id: str | None = None
         self.parts: list[Part] = []
+
+        if self.endpoint_url == "":
+            raise EmptyS3EndpointURLError()
 
     def to_state(self) -> S3MultiPartUploadState:
         """Produce state tuple that can be used to resume this S3MultiPartUpload."""
@@ -727,6 +737,8 @@ class S3BatchExportWorkflow(PostHogWorkflow):
                 "NoSuchBucket",
                 # Couldn't connect to custom S3 endpoint
                 "EndpointConnectionError",
+                # Input contained an empty S3 endpoint URL
+                "EmptyS3EndpointURLError",
             ],
             finish_inputs=finish_inputs,
         )

--- a/posthog/temporal/batch_exports/temporary_file.py
+++ b/posthog/temporal/batch_exports/temporary_file.py
@@ -14,6 +14,9 @@ import brotli
 import orjson
 import pyarrow as pa
 import pyarrow.parquet as pq
+import structlog
+
+logger = structlog.get_logger()
 
 
 def replace_broken_unicode(obj):
@@ -33,6 +36,7 @@ def json_dumps_bytes(d) -> bytes:
     except orjson.JSONEncodeError:
         # orjson is very strict about invalid unicode. This slow path protects us against
         # things we've observed in practice, like single surrogate codes, e.g. "\ud83d"
+        logger.exception("Failed to encode with orjson: %s", d)
         cleaned_d = replace_broken_unicode(d)
         return orjson.dumps(cleaned_d, default=str)
 


### PR DESCRIPTION
## Problem

Our underlying S3 library raises a `ValueError` on an empty endpoint URL. This exception is retryable, and we may want to keep it like that as it's quite generic. So, let's raise our own exception in case of an empty endpoint (`""`), and make that non-retryable.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
* New non-retryable exception `EmptyS3EndpointURLError` is raised if an empty `endpoint_url` is provided.
* Also includes logging changes when encoding an invalid value using orjson.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
