### PR TITLE
fix(cyclotron): fix appmetrics topic names

### DIFF
--- a/rust/common/kafka/src/lib.rs
+++ b/rust/common/kafka/src/lib.rs
@@ -3,5 +3,5 @@ pub mod kafka_messages;
 pub mod kafka_producer;
 pub mod test;
 
-pub const APP_METRICS_TOPIC: &str = "app_metrics";
-pub const APP_METRICS2_TOPIC: &str = "app_metrics2";
+pub const APP_METRICS_TOPIC: &str = "clickhouse_app_metrics";
+pub const APP_METRICS2_TOPIC: &str = "clickhouse_app_metrics2";


### PR DESCRIPTION
Was confused as to why `SELECT * from app_metrics2 where app_source = 'cyclotron' limit 1` returned no results, think this is the reason.

Sure enough, logs during load testing are full of:
```
Failed to produce to app_metrics2 kafka: Message production error: UnknownTopic (Local: Unknown topic)
```