### PR TITLE
fix(insights): replace `breakdown_value` by label in exported insights

### DIFF
--- a/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/insightTooltipUtils.tsx
@@ -111,10 +111,8 @@ export function invertDataSource(
     seriesData.forEach((s) => {
         let datumTitle
         const pillValues = []
-        if (s.breakdown_value !== undefined) {
-            pillValues.push(
-                formatBreakdownLabel(s.breakdown_value, breakdownFilter, cohorts, formatPropertyValueForDisplay)
-            )
+        if (s.label !== undefined) {
+            pillValues.push(formatBreakdownLabel(s.label, breakdownFilter, cohorts, formatPropertyValueForDisplay))
         }
         if (s.compare_label) {
             pillValues.push(capitalizeFirstLetter(String(s.compare_label)))

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -144,7 +144,7 @@ export function InsightsTable({
 
     if (breakdownFilter?.breakdown) {
         const formatItemBreakdownLabel = (item: IndexedTrendResult): string =>
-            formatBreakdownLabel(item.breakdown_value, breakdownFilter, cohorts, formatPropertyValueForDisplay)
+            formatBreakdownLabel(item.label, breakdownFilter, cohorts, formatPropertyValueForDisplay)
 
         columns.push({
             title: <BreakdownColumnTitle breakdownFilter={breakdownFilter} />,

--- a/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsHorizontalBar.tsx
@@ -48,12 +48,7 @@ export function ActionsHorizontalBar({ showPersonsModal = true }: ChartParams): 
                 personsValues: _data.map((item) => item.persons),
                 breakdownValues: _data.map((item) => item.breakdown_value),
                 breakdownLabels: _data.map((item) => {
-                    return formatBreakdownLabel(
-                        item.breakdown_value,
-                        breakdownFilter,
-                        cohorts,
-                        formatPropertyValueForDisplay
-                    )
+                    return formatBreakdownLabel(item.label, breakdownFilter, cohorts, formatPropertyValueForDisplay)
                 }),
                 compareLabels: _data.map((item) => item.compare_label),
                 backgroundColor: colorList,

--- a/frontend/src/scenes/trends/viz/ActionsPie.tsx
+++ b/frontend/src/scenes/trends/viz/ActionsPie.tsx
@@ -56,12 +56,7 @@ export function ActionsPie({ inSharedMode, showPersonsModal = true, context }: C
                 actions: indexedResults.map((item) => item.action),
                 breakdownValues: indexedResults.map((item) => item.breakdown_value),
                 breakdownLabels: indexedResults.map((item) => {
-                    return formatBreakdownLabel(
-                        item.breakdown_value,
-                        breakdownFilter,
-                        cohorts,
-                        formatPropertyValueForDisplay
-                    )
+                    return formatBreakdownLabel(item.label, breakdownFilter, cohorts, formatPropertyValueForDisplay)
                 }),
                 compareLabels: indexedResults.map((item) => item.compare_label),
                 personsValues: indexedResults.map((item) => item.persons),


### PR DESCRIPTION
Fixes #25223

Problem statement:
Exported insights with cohort breakdown used to display the `breakdown_value` in the tooltips/y-axis labels. Now, the exported insights show the exact same view as the ones in the dashboard.


https://github.com/user-attachments/assets/4845fd41-28ef-46a7-b7a0-178e84ba8589

