### PR TITLE
fix: ci fix

### DIFF
--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -98,7 +98,7 @@ freezegun.configure(extend_ignore_list=["posthog.test.assert_faster_than"])
 
 persons_cache_tests: list[dict[str, Any]] = []
 events_cache_tests: list[dict[str, Any]] = []
-persons_ordering_int: int = 1
+persons_ordering_int: int = 0
 
 
 # Expand string diffs


### PR DESCRIPTION
## Problem

Intermittent CI bug based on test order

Value defaults to 1 but is reset to 0 after tests

![image](https://github.com/user-attachments/assets/fec0145e-a0a0-4086-a650-ddd3391a038b)


## Changes

Change default to 0

## Does this work well for both Cloud and self-hosted?

Yes

