### PR TITLE
feat(cyclotron): janitor control interface

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
  "eyre",
  "health",
  "rdkafka",
+ "serde",
  "serde_json",
  "sqlx",
  "time",

--- a/rust/common/metrics/src/lib.rs
+++ b/rust/common/metrics/src/lib.rs
@@ -17,7 +17,10 @@ pub async fn serve(router: Router, bind: &str) -> Result<(), std::io::Error> {
 }
 
 /// Add the prometheus endpoint and middleware to a router, should be called last.
-pub fn setup_metrics_routes(router: Router) -> Router {
+pub fn setup_metrics_routes<S>(router: Router<S>) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
     let recorder_handle = setup_metrics_recorder();
 
     router

--- a/rust/cyclotron-core/src/janitor.rs
+++ b/rust/cyclotron-core/src/janitor.rs
@@ -1,4 +1,4 @@
-use crate::{types::DeleteSet, DEAD_LETTER_QUEUE};
+use crate::{ops::janitor::query_jobs, types::DeleteSet, Job, JobQuery, DEAD_LETTER_QUEUE};
 use chrono::Duration;
 use sqlx::PgPool;
 
@@ -58,6 +58,10 @@ impl Janitor {
 
     pub async fn waiting_jobs(&self) -> Result<Vec<(u64, String)>, QueueError> {
         count_total_waiting_jobs(&self.pool).await
+    }
+
+    pub async fn query_jobs(&self, query: JobQuery) -> Result<Vec<Job>, QueueError> {
+        query_jobs(&self.pool, query).await
     }
 
     pub async fn count_dlq_depth(&self) -> Result<u64, QueueError> {

--- a/rust/cyclotron-core/src/janitor.rs
+++ b/rust/cyclotron-core/src/janitor.rs
@@ -1,4 +1,4 @@
-use crate::DEAD_LETTER_QUEUE;
+use crate::{types::DeleteSet, DEAD_LETTER_QUEUE};
 use chrono::Duration;
 use sqlx::PgPool;
 
@@ -7,7 +7,6 @@ use crate::{
         janitor::{delete_completed_and_failed_jobs, detect_poison_pills, reset_stalled_jobs},
         meta::{count_total_waiting_jobs, dead_letter, run_migrations},
     },
-    types::AggregatedDelete,
     PoolConfig, QueueError,
 };
 
@@ -30,9 +29,7 @@ impl Janitor {
         run_migrations(&self.pool).await;
     }
 
-    pub async fn delete_completed_and_failed_jobs(
-        &self,
-    ) -> Result<Vec<AggregatedDelete>, QueueError> {
+    pub async fn delete_completed_and_failed_jobs(&self) -> Result<DeleteSet, QueueError> {
         delete_completed_and_failed_jobs(&self.pool).await
     }
 

--- a/rust/cyclotron-core/src/lib.rs
+++ b/rust/cyclotron-core/src/lib.rs
@@ -9,6 +9,7 @@ pub use types::Bytes;
 pub use types::DeleteSet;
 pub use types::Job;
 pub use types::JobInit;
+pub use types::JobQuery;
 pub use types::JobState;
 pub use types::JobUpdate;
 

--- a/rust/cyclotron-core/src/lib.rs
+++ b/rust/cyclotron-core/src/lib.rs
@@ -6,6 +6,7 @@ mod ops;
 mod types;
 pub use types::AggregatedDelete;
 pub use types::Bytes;
+pub use types::DeleteSet;
 pub use types::Job;
 pub use types::JobInit;
 pub use types::JobState;

--- a/rust/cyclotron-core/src/ops/meta.rs
+++ b/rust/cyclotron-core/src/ops/meta.rs
@@ -1,4 +1,4 @@
-use sqlx::{postgres::PgQueryResult, PgPool};
+use sqlx::{postgres::PgQueryResult, Encode, PgPool, QueryBuilder, Type};
 use uuid::Uuid;
 
 use crate::{
@@ -87,4 +87,22 @@ where
     .await?;
 
     Ok(())
+}
+
+pub fn set_helper<'args, T, DB>(
+    query: &mut QueryBuilder<'args, DB>,
+    column_name: &str,
+    joiner: &str,
+    value: T,
+    needs_joiner: bool,
+) where
+    T: 'args + Encode<'args, DB> + Send + Type<DB>,
+    DB: sqlx::Database,
+{
+    if needs_joiner {
+        query.push(joiner);
+    }
+    query.push(column_name);
+    query.push(" = ");
+    query.push_bind(value);
 }

--- a/rust/cyclotron-janitor/Cargo.toml
+++ b/rust/cyclotron-janitor/Cargo.toml
@@ -22,7 +22,8 @@ health = { path = "../common/health" }
 common-alloc = { path = "../common/alloc" }
 time = { workspace = true }
 rdkafka = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 sqlx = { workspace = true }
-serde_json = { workspace = true }

--- a/rust/cyclotron-janitor/src/app_context.rs
+++ b/rust/cyclotron-janitor/src/app_context.rs
@@ -1,0 +1,155 @@
+use chrono::{DateTime, Duration, Utc};
+use common_kafka::kafka_producer::{create_kafka_producer, KafkaContext};
+use cyclotron_core::{DeleteSet, SHARD_ID_KEY};
+use health::{HealthHandle, HealthRegistry};
+use rdkafka::producer::FutureProducer;
+use serde::Serialize;
+use tokio::sync::Mutex;
+
+use crate::{
+    config::{Config, JanitorSettings},
+    janitor::run_once,
+};
+
+pub struct AppContext {
+    pub janitor: cyclotron_core::Janitor,
+    pub kafka_producer: FutureProducer<KafkaContext>,
+    pub metrics_labels: Vec<(String, String)>,
+    pub health: HealthRegistry,
+    pub janitor_liveness: HealthHandle,
+    pub state: AppState,
+    pub shard_id: String,
+    pub janitor_id: String,
+    pub metrics: bool,
+}
+
+impl AppContext {
+    pub async fn new(config: Config) -> Self {
+        let config = config.get_janitor_config();
+        let janitor = cyclotron_core::Janitor::new(config.pool)
+            .await
+            .expect("Failed to create janitor"); // If he dies, he dies (we'd rather panic than try and handle a hard dependecy failure)
+
+        let health = HealthRegistry::new("liveness");
+
+        let metrics_labels = vec![
+            ("janitor_id".to_string(), config.janitor.id.clone()),
+            (SHARD_ID_KEY.to_string(), config.janitor.shard_id.clone()),
+        ];
+
+        let kafka_liveness = health
+            .register("rdkafka".to_string(), time::Duration::seconds(30))
+            .await;
+
+        let kafka_producer = create_kafka_producer(&config.kafka, kafka_liveness)
+            .await
+            .expect("failed to create kafka producer");
+
+        let janitor_liveness = health
+            .register(
+                "janitor".to_string(),
+                time::Duration::seconds(config.janitor.cleanup_interval.num_seconds() * 4),
+            )
+            .await;
+
+        let state = AppState::new(&config.janitor);
+
+        Self {
+            janitor,
+            kafka_producer,
+            metrics_labels,
+            health,
+            janitor_liveness,
+            state,
+            shard_id: config.janitor.shard_id,
+            janitor_id: config.janitor.id,
+            metrics: config.janitor.metrics,
+        }
+    }
+
+    pub async fn run_migrations(&self) {
+        self.janitor.run_migrations().await;
+    }
+
+    pub async fn cleanup_loop(&self) {
+        // Where we're going, we don't need `break`
+        loop {
+            let next_run = Utc::now() + self.state.get_control().await.cleanup_interval;
+            let mut next_status = run_once(self).await;
+            next_status.next_run = Some(next_run);
+            self.state.set_status(next_status).await;
+            let sleep_time = next_run - Utc::now();
+            tokio::time::sleep(sleep_time.to_std().unwrap_or(Default::default())).await;
+        }
+    }
+}
+
+// Cross-cutting state, shared between the cleanup loop and the control interface.
+#[derive(Debug)]
+pub struct AppState {
+    status: Mutex<JanitorStatus>,
+    control: Mutex<ControlFlags>,
+}
+
+// Transient state, displayed to the user on the control interface. Includes "status" and "control"
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct JanitorStatus {
+    pub last_delete: Option<DeleteSet>,
+    pub last_poisoned: Option<u64>,
+    pub last_stalled: Option<u64>,
+    pub last_available: Option<Vec<(u64, String)>>,
+    pub last_dlq_count: Option<u64>,
+    pub last_error: Option<String>,
+    pub last_error_time: Option<DateTime<Utc>>,
+    pub last_successful_run: Option<DateTime<Utc>>,
+    pub next_run: Option<DateTime<Utc>>,
+}
+
+// Control flags
+#[derive(Debug, Clone, Default)]
+pub struct ControlFlags {
+    // Top-level cleanup loop pause
+    pub paused_until: Option<DateTime<Utc>>,
+    // Top level cleanup loop interval
+    pub cleanup_interval: Duration,
+    // How long a lock can be held by a worker before it's considered stalled
+    pub stall_timeout: Duration,
+    // How many times a job can be touched before it's considered poison
+    pub max_touches: i16,
+}
+
+impl AppState {
+    pub fn new(settings: &JanitorSettings) -> Self {
+        let status = Default::default();
+        let control = ControlFlags {
+            cleanup_interval: settings.cleanup_interval,
+            stall_timeout: settings.stall_timeout,
+            max_touches: settings.max_touches,
+            paused_until: None, // Default to unpaused
+        };
+        Self {
+            status: Mutex::new(status),
+            control: Mutex::new(control),
+        }
+    }
+
+    // The idea with these getters/setters is that the control server
+    // or loop should never block each other, so they get a
+    // "snapshot" of the current state values, and then call
+    // a setter with an updated value, if they're changing anything.
+    pub async fn get_status(&self) -> JanitorStatus {
+        self.status.lock().await.clone()
+    }
+
+    pub async fn get_control(&self) -> ControlFlags {
+        self.control.lock().await.clone()
+    }
+
+    pub async fn set_control(&self, control: ControlFlags) {
+        *self.control.lock().await = control;
+    }
+
+    pub async fn set_status(&self, status: JanitorStatus) {
+        *self.status.lock().await = status;
+    }
+}

--- a/rust/cyclotron-janitor/src/http.rs
+++ b/rust/cyclotron-janitor/src/http.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use crate::app_context::AppContext;
+use axum::{
+    extract::State,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use common_metrics::setup_metrics_routes;
+use eyre::Result;
+
+pub async fn listen(app: Router, bind: String) -> Result<()> {
+    let listener = tokio::net::TcpListener::bind(bind).await?;
+
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+async fn index(State(context): State<Arc<AppContext>>) -> String {
+    format!("cyclotron janitor {}", context.janitor_id)
+}
+
+async fn liveness(State(context): State<Arc<AppContext>>) -> Response {
+    context.health.get_status().into_response()
+}
+
+pub fn app(context: Arc<AppContext>) -> Router {
+    let metrics_enabled = context.metrics;
+    let router = Router::new();
+
+    let router = router
+        .route("/", get(index))
+        .route("/_readiness", get(index))
+        .route("/_liveness", get(liveness));
+
+    // setup_metrics_routes touches global objects, so we need to be able to selectively
+    // disable it e.g. for tests
+    let router = if metrics_enabled {
+        setup_metrics_routes(router)
+    } else {
+        router
+    };
+
+    router.with_state(context)
+}

--- a/rust/cyclotron-janitor/src/http.rs
+++ b/rust/cyclotron-janitor/src/http.rs
@@ -1,14 +1,24 @@
 use std::sync::Arc;
 
-use crate::app_context::AppContext;
-use axum::{
-    extract::State,
-    response::{IntoResponse, Response},
-    routing::get,
-    Router,
+use crate::{
+    app_context::{AppContext, JanitorStatus},
+    janitor::run_once,
 };
+use axum::{
+    debug_handler,
+    extract::{Query, State},
+    http::StatusCode,
+    response::{Html, IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use chrono::{DateTime, Duration, Utc};
 use common_metrics::setup_metrics_routes;
+use cyclotron_core::{Job, JobQuery, JobState};
 use eyre::Result;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+use uuid::Uuid;
 
 pub async fn listen(app: Router, bind: String) -> Result<()> {
     let listener = tokio::net::TcpListener::bind(bind).await?;
@@ -18,14 +28,171 @@ pub async fn listen(app: Router, bind: String) -> Result<()> {
     Ok(())
 }
 
-async fn index(State(context): State<Arc<AppContext>>) -> String {
-    format!("cyclotron janitor {}", context.janitor_id)
+#[debug_handler]
+async fn index(State(context): State<Arc<AppContext>>) -> Html<String> {
+    Html(
+        include_str!("static/index.html")
+            .replace("$SHARD_ID", &context.shard_id)
+            .replace("$JANITOR_ID", &context.janitor_id),
+    )
 }
 
 async fn liveness(State(context): State<Arc<AppContext>>) -> Response {
     context.health.get_status().into_response()
 }
 
+#[debug_handler]
+async fn get_jobs(
+    State(context): State<Arc<AppContext>>,
+    Json(query): Json<JobQuery>,
+) -> Result<Json<Vec<JobResponse>>, (StatusCode, String)> {
+    info!("querying jobs: {:?}", query);
+    let res = context.janitor.query_jobs(query).await;
+    info!("query result: {:?}", res);
+
+    match res {
+        Ok(jobs) => Ok(Json(jobs.into_iter().map(JobResponse::new).collect())),
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+    }
+}
+
+#[derive(Deserialize)]
+struct PauseQuery {
+    until: DateTime<Utc>,
+}
+
+#[debug_handler]
+async fn pause(State(context): State<Arc<AppContext>>, Query(q): Query<PauseQuery>) {
+    info!("pausing janitor until: {}", q.until);
+    let mut control = context.state.get_control().await;
+    control.paused_until = Some(q.until);
+    context.state.set_control(control).await;
+}
+
+#[debug_handler]
+async fn resume(State(context): State<Arc<AppContext>>) {
+    info!("resuming janitor");
+    let mut control = context.state.get_control().await;
+    control.paused_until = None;
+    context.state.set_control(control).await;
+}
+
+#[derive(Deserialize)]
+pub struct SecondsQuery {
+    seconds: u64,
+}
+
+#[debug_handler]
+async fn set_cleanup_interval(
+    State(context): State<Arc<AppContext>>,
+    Query(q): Query<SecondsQuery>,
+) {
+    info!("setting cleanup interval to: {} seconds", q.seconds);
+    let mut control = context.state.get_control().await;
+    control.cleanup_interval = Duration::seconds(q.seconds as i64);
+    context.state.set_control(control).await;
+}
+
+#[debug_handler]
+async fn set_stall_timeout(State(context): State<Arc<AppContext>>, Query(q): Query<SecondsQuery>) {
+    info!("setting stall timeout to: {} seconds", q.seconds);
+    let mut control = context.state.get_control().await;
+    control.stall_timeout = Duration::seconds(q.seconds as i64);
+    context.state.set_control(control).await;
+}
+
+#[derive(Deserialize)]
+pub struct MaxTouchesQuery {
+    touches: i16,
+}
+
+#[debug_handler]
+async fn set_max_touches(State(context): State<Arc<AppContext>>, Query(q): Query<MaxTouchesQuery>) {
+    info!("setting max touches to: {}", q.touches);
+    let mut control = context.state.get_control().await;
+    control.max_touches = q.touches;
+    context.state.set_control(control).await;
+}
+
+#[debug_handler]
+async fn force_cleanup(State(context): State<Arc<AppContext>>) -> Json<JanitorStatus> {
+    info!("forcing cleanup");
+    Json(run_once(&context).await)
+}
+
+#[derive(Serialize)]
+struct StateResponse {
+    state: JanitorStatus,
+    paused_until: Option<DateTime<Utc>>,
+    cleanup_interval_seconds: i64,
+    stall_timeout_seconds: i64,
+    max_touches: i16,
+}
+
+#[derive(Serialize)]
+struct JobResponse {
+    pub id: Uuid,
+    pub team_id: i32,
+    pub function_id: Option<Uuid>,
+    pub created: DateTime<Utc>,
+    pub lock_id: Option<Uuid>,
+    pub last_heartbeat: Option<DateTime<Utc>>,
+    pub janitor_touch_count: i16,
+    pub transition_count: i16,
+    pub last_transition: DateTime<Utc>,
+    pub queue_name: String,
+    pub state: JobState,
+    pub priority: i16,
+    pub scheduled: DateTime<Utc>,
+    pub vm_state: Option<String>,
+    pub metadata: Option<String>,
+    pub parameters: Option<String>,
+    pub blob: Option<String>,
+}
+
+impl JobResponse {
+    pub fn new(job: Job) -> Self {
+        Self {
+            id: job.id,
+            team_id: job.team_id,
+            function_id: job.function_id,
+            created: job.created,
+            lock_id: job.lock_id,
+            last_heartbeat: job.last_heartbeat,
+            janitor_touch_count: job.janitor_touch_count,
+            transition_count: job.transition_count,
+            last_transition: job.last_transition,
+            queue_name: job.queue_name,
+            state: job.state,
+            priority: job.priority,
+            scheduled: job.scheduled,
+            vm_state: job.vm_state.map(unwrap_or_unparseable),
+            metadata: job.metadata.map(unwrap_or_unparseable),
+            parameters: job.parameters.map(unwrap_or_unparseable),
+            blob: job.blob.map(unwrap_or_unparseable),
+        }
+    }
+}
+
+fn unwrap_or_unparseable(b: Vec<u8>) -> String {
+    String::from_utf8(b).unwrap_or("unparseable".to_string())
+}
+
+#[debug_handler]
+async fn get_state(State(context): State<Arc<AppContext>>) -> Json<StateResponse> {
+    let status = context.state.get_status().await;
+    let control_flags = context.state.get_control().await;
+
+    let response = StateResponse {
+        state: status,
+        paused_until: control_flags.paused_until,
+        cleanup_interval_seconds: control_flags.cleanup_interval.num_seconds(),
+        stall_timeout_seconds: control_flags.stall_timeout.num_seconds(),
+        max_touches: control_flags.max_touches,
+    };
+
+    Json(response)
+}
 pub fn app(context: Arc<AppContext>) -> Router {
     let metrics_enabled = context.metrics;
     let router = Router::new();
@@ -34,6 +201,16 @@ pub fn app(context: Arc<AppContext>) -> Router {
         .route("/", get(index))
         .route("/_readiness", get(index))
         .route("/_liveness", get(liveness));
+
+    let router = router
+        .route("/jobs", post(get_jobs))
+        .route("/pause", post(pause))
+        .route("/resume", post(resume))
+        .route("/cleanup_interval", post(set_cleanup_interval))
+        .route("/stall_timeout", post(set_stall_timeout))
+        .route("/max_touches", post(set_max_touches))
+        .route("/force_cleanup", post(force_cleanup))
+        .route("/state", get(get_state));
 
     // setup_metrics_routes touches global objects, so we need to be able to selectively
     // disable it e.g. for tests

--- a/rust/cyclotron-janitor/src/janitor.rs
+++ b/rust/cyclotron-janitor/src/janitor.rs
@@ -12,15 +12,6 @@ use tracing::{error, info, warn};
 use crate::app_context::{AppContext, JanitorStatus};
 use crate::metrics_constants::*;
 
-// The janitor reports it's own metrics, this is mostly for testing purposes
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct CleanupResult {
-    pub completed: u64,
-    pub failed: u64,
-    pub poisoned: u64,
-    pub stalled: u64,
-}
-
 pub async fn run_once(context: &AppContext) -> JanitorStatus {
     match run_once_inner(context).await {
         Ok(status) => status,

--- a/rust/cyclotron-janitor/src/janitor.rs
+++ b/rust/cyclotron-janitor/src/janitor.rs
@@ -1,19 +1,16 @@
+use chrono::Utc;
 use common_kafka::kafka_messages::app_metrics2::{
     AppMetric2, Kind as AppMetric2Kind, Source as AppMetric2Source,
 };
-use common_kafka::kafka_producer::create_kafka_producer;
-use common_kafka::kafka_producer::{send_iter_to_kafka, KafkaContext, KafkaProduceError};
+
+use common_kafka::kafka_producer::{send_iter_to_kafka, KafkaProduceError};
 use common_kafka::APP_METRICS2_TOPIC;
-use cyclotron_core::{AggregatedDelete, QueueError, SHARD_ID_KEY};
-use health::HealthRegistry;
+use cyclotron_core::{AggregatedDelete, QueueError};
+
 use tracing::{error, info, warn};
 
-use rdkafka::producer::FutureProducer;
-
-use crate::{
-    config::{JanitorConfig, JanitorSettings},
-    metrics_constants::*,
-};
+use crate::app_context::{AppContext, JanitorStatus};
+use crate::metrics_constants::*;
 
 // The janitor reports it's own metrics, this is mostly for testing purposes
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -24,140 +21,128 @@ pub struct CleanupResult {
     pub stalled: u64,
 }
 
-pub struct Janitor {
-    pub inner: cyclotron_core::Janitor,
-    pub kafka_producer: FutureProducer<KafkaContext>,
-    pub settings: JanitorSettings,
-    pub metrics_labels: Vec<(String, String)>,
+pub async fn run_once(context: &AppContext) -> JanitorStatus {
+    match run_once_inner(context).await {
+        Ok(status) => status,
+        Err(e) => {
+            error!("Janitor loop failed: {:?}", e);
+            let mut status = context.state.get_status().await;
+            status.last_error = Some(e.to_string());
+            status.last_error_time = Some(Utc::now());
+            status
+        }
+    }
 }
 
-impl Janitor {
-    pub async fn new(
-        config: JanitorConfig,
-        health_registry: &HealthRegistry,
-    ) -> Result<Self, QueueError> {
-        let settings = config.settings;
-        let inner = cyclotron_core::Janitor::new(config.pool).await?;
+async fn run_once_inner(context: &AppContext) -> Result<JanitorStatus, QueueError> {
+    info!("Running janitor loop");
 
-        let metrics_labels = vec![
-            ("janitor_id".to_string(), settings.id.clone()),
-            (SHARD_ID_KEY.to_string(), settings.shard_id.clone()),
-        ];
+    // Grab a snapshot of the control state at the instant we started this
+    // run
+    let control_state = context.state.get_control().await;
 
-        let kafka_liveness = health_registry
-            .register("rdkafka".to_string(), time::Duration::seconds(30))
-            .await;
-
-        let kafka_producer = create_kafka_producer(&config.kafka, kafka_liveness)
-            .await
-            .expect("failed to create kafka producer");
-
-        Ok(Self {
-            inner,
-            kafka_producer,
-            settings,
-            metrics_labels,
-        })
+    if control_state
+        .paused_until
+        .map(|t| t > Utc::now())
+        .unwrap_or(false)
+    {
+        info!("Janitor is paused, skipping cleanup");
+        return Ok(context.state.get_status().await); // No status update, we didn't run.
     }
 
-    pub async fn run_migrations(&self) {
-        self.inner.run_migrations().await;
+    let labels = &context.metrics_labels;
+
+    let _loop_start = common_metrics::timing_guard(RUN_TIME, labels);
+    common_metrics::inc(RUN_STARTS, &context.metrics_labels, 1);
+
+    let delete_set = {
+        let _time = common_metrics::timing_guard(CLEANUP_TIME, labels);
+        context.janitor.delete_completed_and_failed_jobs().await?
+    };
+
+    common_metrics::inc(COMPLETED_COUNT, labels, delete_set.total_completed() as u64);
+    common_metrics::inc(FAILED_COUNT, labels, delete_set.total_failed() as u64);
+
+    match send_iter_to_kafka(
+        &context.kafka_producer,
+        APP_METRICS2_TOPIC,
+        delete_set
+            .deletes
+            .clone()
+            .into_iter()
+            .map(aggregated_delete_to_app_metric2),
+    )
+    .await
+    {
+        Ok(()) => {}
+        Err(KafkaProduceError::SerializationError { error }) => {
+            error!("Failed to serialize app_metrics2: {error}");
+        }
+        Err(KafkaProduceError::KafkaProduceError { error }) => {
+            error!("Failed to produce to app_metrics2 kafka: {error}");
+        }
+        Err(KafkaProduceError::KafkaProduceCanceled) => {
+            error!("Failed to produce to app_metrics2 kafka (timeout)");
+        }
     }
 
-    pub async fn run_once(&self) -> Result<CleanupResult, QueueError> {
-        info!("Running janitor loop");
-        let _loop_start = common_metrics::timing_guard(RUN_TIME, &self.metrics_labels);
-        common_metrics::inc(RUN_STARTS, &self.metrics_labels, 1);
+    let poisoned = {
+        let _time = common_metrics::timing_guard(POISONED_TIME, labels);
+        context
+            .janitor
+            .delete_poison_pills(control_state.stall_timeout, control_state.max_touches)
+            .await?
+    };
+    common_metrics::inc(POISONED_COUNT, labels, poisoned);
 
-        let aggregated_deletes = {
-            let _time = common_metrics::timing_guard(CLEANUP_TIME, &self.metrics_labels);
-            self.inner.delete_completed_and_failed_jobs().await?
-        };
-
-        let mut completed_count = 0u64;
-        let mut failed_count = 0u64;
-        for delete in &aggregated_deletes {
-            if delete.state == "completed" {
-                completed_count += delete.count as u64;
-            } else if delete.state == "failed" {
-                failed_count += delete.count as u64;
-            }
-        }
-        common_metrics::inc(COMPLETED_COUNT, &self.metrics_labels, completed_count);
-        common_metrics::inc(FAILED_COUNT, &self.metrics_labels, failed_count);
-
-        match send_iter_to_kafka(
-            &self.kafka_producer,
-            APP_METRICS2_TOPIC,
-            aggregated_deletes
-                .into_iter()
-                .map(aggregated_delete_to_app_metric2),
-        )
-        .await
-        {
-            Ok(()) => {}
-            Err(KafkaProduceError::SerializationError { error }) => {
-                error!("Failed to serialize app_metrics2: {error}");
-            }
-            Err(KafkaProduceError::KafkaProduceError { error }) => {
-                error!("Failed to produce to app_metrics2 kafka: {error}");
-            }
-            Err(KafkaProduceError::KafkaProduceCanceled) => {
-                error!("Failed to produce to app_metrics2 kafka (timeout)");
-            }
-        }
-
-        let poisoned = {
-            let _time = common_metrics::timing_guard(POISONED_TIME, &self.metrics_labels);
-            self.inner
-                .delete_poison_pills(self.settings.stall_timeout, self.settings.max_touches)
-                .await?
-        };
-        common_metrics::inc(POISONED_COUNT, &self.metrics_labels, poisoned);
-
-        if poisoned > 0 {
-            warn!("Deleted {} poison pills", poisoned);
-        }
-
-        let stalled = {
-            let _time = common_metrics::timing_guard(STALLED_TIME, &self.metrics_labels);
-            self.inner
-                .reset_stalled_jobs(self.settings.stall_timeout)
-                .await?
-        };
-        common_metrics::inc(STALLED_COUNT, &self.metrics_labels, stalled);
-
-        if stalled > 0 {
-            warn!("Reset {} stalled jobs", stalled);
-        }
-
-        let available = {
-            let _time = common_metrics::timing_guard(AVAILABLE_DEPTH_TIME, &self.metrics_labels);
-            self.inner.waiting_jobs().await?
-        };
-
-        let mut available_labels = self.metrics_labels.clone();
-        for (count, queue_name) in available {
-            available_labels.push(("queue_name".to_string(), queue_name));
-            common_metrics::gauge(AVAILABLE_DEPTH, &available_labels, count as f64);
-            available_labels.pop();
-        }
-
-        let dlq_depth = {
-            let _time = common_metrics::timing_guard(DLQ_DEPTH_TIME, &self.metrics_labels);
-            self.inner.count_dlq_depth().await?
-        };
-        common_metrics::gauge(DLQ_DEPTH, &self.metrics_labels, dlq_depth as f64);
-
-        common_metrics::inc(RUN_ENDS, &self.metrics_labels, 1);
-        info!("Janitor loop complete");
-        Ok(CleanupResult {
-            completed: completed_count,
-            failed: failed_count,
-            poisoned,
-            stalled,
-        })
+    if poisoned > 0 {
+        warn!("Deleted {} poison pills", poisoned);
     }
+
+    let stalled = {
+        let _time = common_metrics::timing_guard(STALLED_TIME, labels);
+        context
+            .janitor
+            .reset_stalled_jobs(control_state.stall_timeout)
+            .await?
+    };
+    common_metrics::inc(STALLED_COUNT, labels, stalled);
+
+    if stalled > 0 {
+        warn!("Reset {} stalled jobs", stalled);
+    }
+
+    let available = {
+        let _time = common_metrics::timing_guard(AVAILABLE_DEPTH_TIME, labels);
+        context.janitor.waiting_jobs().await?
+    };
+
+    let mut available_labels = labels.clone();
+    for (count, queue_name) in available.clone() {
+        available_labels.push(("queue_name".to_string(), queue_name));
+        common_metrics::gauge(AVAILABLE_DEPTH, &available_labels, count as f64);
+        available_labels.pop();
+    }
+
+    let dlq_depth = {
+        let _time = common_metrics::timing_guard(DLQ_DEPTH_TIME, labels);
+        context.janitor.count_dlq_depth().await?
+    };
+    common_metrics::gauge(DLQ_DEPTH, labels, dlq_depth as f64);
+
+    common_metrics::inc(RUN_ENDS, labels, 1);
+    info!("Janitor loop complete");
+
+    let mut status = context.state.get_status().await;
+
+    status.last_delete = Some(delete_set);
+    status.last_poisoned = Some(poisoned);
+    status.last_stalled = Some(stalled);
+    status.last_available = Some(available);
+    status.last_dlq_count = Some(dlq_depth);
+    status.last_successful_run = Some(Utc::now());
+
+    Ok(status)
 }
 
 fn aggregated_delete_to_app_metric2(delete: AggregatedDelete) -> AppMetric2 {

--- a/rust/cyclotron-janitor/src/lib.rs
+++ b/rust/cyclotron-janitor/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod app_context;
 pub mod config;
+pub mod http;
 pub mod janitor;
 pub mod metrics_constants;

--- a/rust/cyclotron-janitor/src/main.rs
+++ b/rust/cyclotron-janitor/src/main.rs
@@ -1,104 +1,40 @@
-use axum::{extract::State, routing::get, Router};
-use common_metrics::setup_metrics_routes;
-use cyclotron_janitor::{config::Config, janitor::Janitor};
+use std::sync::Arc;
+
+use cyclotron_janitor::{
+    app_context::AppContext,
+    config::Config,
+    http::{app, listen},
+};
 use envconfig::Envconfig;
-use eyre::Result;
-use health::{HealthHandle, HealthRegistry};
-use std::{future::ready, time::Duration};
 use tracing::{error, info};
 
 common_alloc::used!();
 
-async fn cleanup_loop(janitor: Janitor, livenes: HealthHandle, interval_secs: u64) -> Result<()> {
-    let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
-
-    loop {
-        interval.tick().await;
-
-        if let Err(e) = janitor.run_once().await {
-            // don't bother reporting unhealthy - a few times around this loop will put us in a stalled state
-            error!("janitor failed cleanup with: {}", e);
-        } else {
-            livenes.report_healthy().await;
-        }
-    }
-}
-
-async fn listen(app: Router, bind: String) -> Result<()> {
-    let listener = tokio::net::TcpListener::bind(bind).await?;
-
-    axum::serve(listener, app).await?;
-
-    Ok(())
-}
-
-// For axums state stuff
-#[derive(Clone)]
-struct JanitorId(pub String);
-
-pub fn app(liveness: HealthRegistry, janitor_id: String) -> Router {
-    Router::new()
-        .route("/", get(index))
-        .route("/_readiness", get(index))
-        .route("/_liveness", get(move || ready(liveness.get_status())))
-        .with_state(JanitorId(janitor_id))
-}
-
-async fn index(State(janitor_id): State<JanitorId>) -> String {
-    format!("cyclotron janitor {}", janitor_id.0)
-}
-
 #[tokio::main]
 async fn main() {
     let config = Config::init_from_env().expect("failed to load configuration from env");
-    tracing_subscriber::fmt::init();
-
-    let liveness = HealthRegistry::new("liveness");
-
-    let janitor_config = config.get_janitor_config();
-
-    let janitor_id = janitor_config.settings.id.clone();
     let bind = format!("{}:{}", config.host, config.port);
+    tracing_subscriber::fmt::init();
+    info!("starting janitor, bound to {}", bind);
 
-    info!(
-        "Starting janitor with ID {:?}, listening at {}",
-        janitor_id, bind
-    );
+    let context = Arc::new(AppContext::new(config).await);
 
-    let janitor = Janitor::new(janitor_config, &liveness)
-        .await
-        .expect("failed to create janitor");
+    let m_context = context.clone();
+    let janitor_loop = async move { m_context.cleanup_loop().await };
 
-    janitor.run_migrations().await;
+    let app = app(context.clone());
 
-    let janitor_liveness = liveness
-        .register(
-            "janitor".to_string(),
-            Duration::from_secs(config.cleanup_interval_secs * 4),
-        )
-        .await;
+    let http_server = listen(app, bind);
 
-    let janitor_loop = tokio::spawn(cleanup_loop(
-        janitor,
-        janitor_liveness,
-        config.cleanup_interval_secs,
-    ));
-
-    let app = setup_metrics_routes(app(liveness, janitor_id));
-    let http_server = tokio::spawn(listen(app, bind));
+    let loop_handle = tokio::spawn(janitor_loop);
+    let server_handle = tokio::spawn(http_server);
 
     tokio::select! {
-        res = janitor_loop => {
+        _ = loop_handle => {
             error!("janitor loop exited");
-            if let Err(e) = res {
-                error!("janitor failed with: {}", e)
-            }
         }
-        res = http_server => {
+        _ = server_handle => {
             error!("http server exited");
-            if let Err(e) = res {
-                error!("server failed with: {}", e)
-            }
         }
     }
 

--- a/rust/cyclotron-janitor/src/static/index.html
+++ b/rust/cyclotron-janitor/src/static/index.html
@@ -129,6 +129,8 @@
     <div id="stateSection">
         <pre id="stateOutput">Loading system state...</pre>
         <p id="refreshTime"></p>
+        <!-- New button to force state retrieval -->
+        <button onclick="getState()">Force Retrieve State</button>
     </div>
 
     <script>
@@ -243,13 +245,13 @@
 
         setInterval(() => {
             getState();
-        }, 10000);
+        }, 10000); // Auto-refresh every 10 seconds
 
         setInterval(() => {
             updateTimeSinceRefresh();
-        }, 1000);
+        }, 1000); // Update time since last refresh every second
 
-        getState();
+        getState(); // Initial state load
     </script>
 
 </body>

--- a/rust/cyclotron-janitor/src/static/index.html
+++ b/rust/cyclotron-janitor/src/static/index.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Janitor $SHARD_ID:$JANITOR_ID control</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+        }
+        h1 {
+            color: #333;
+        }
+        button {
+            margin: 10px 0;
+            padding: 10px 15px;
+        }
+        input, select {
+            padding: 5px;
+            margin: 5px 0;
+        }
+        .form-group {
+            margin-bottom: 10px;
+        }
+        #stateSection {
+            margin-top: 20px;
+        }
+        pre {
+            background-color: #f4f4f4;
+            padding: 10px;
+            border: 1px solid #ddd;
+            max-height: 400px;
+            overflow-y: auto;
+        }
+        .notice {
+            display: none;
+            font-size: 0.9em;
+            color: green;
+            margin-left: 10px;
+            animation: pulse 3s ease-in-out;
+        }
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
+    </style>
+</head>
+<body>
+
+    <h1>Janitor $SHARD_ID:$JANITOR_ID control</h1>
+
+    <h2>Control Commands</h2>
+
+    <div>
+        <button onclick="pauseSystem()">Pause System</button>
+        <input type="datetime-local" id="pauseUntil" placeholder="Pause until (UTC)">
+        <span id="pauseNotice" class="notice">System paused successfully</span>
+    </div>
+
+    <div>
+        <button onclick="resumeSystem()">Resume System</button>
+        <span id="resumeNotice" class="notice">System resumed successfully</span>
+    </div>
+
+    <div>
+        <button onclick="setCleanupInterval()">Set Cleanup Interval</button>
+        <input type="number" id="cleanupInterval" placeholder="Interval (seconds)">
+        <span id="cleanupNotice" class="notice">Cleanup interval set successfully</span>
+    </div>
+
+    <div>
+        <button onclick="setStallTimeout()">Set Stall Timeout</button>
+        <input type="number" id="stallTimeout" placeholder="Timeout (seconds)">
+        <span id="stallNotice" class="notice">Stall timeout set successfully</span>
+    </div>
+
+    <div>
+        <button onclick="setMaxTouches()">Set Max Touches</button>
+        <input type="number" id="maxTouches" placeholder="Max Touches">
+        <span id="touchesNotice" class="notice">Max touches set successfully</span>
+    </div>
+
+    <div>
+        <button onclick="forceCleanup()">Force Cleanup</button>
+        <span id="cleanupForceNotice" class="notice">Cleanup forced successfully</span>
+    </div>
+
+    <h2>Query Jobs</h2>
+    <form id="jobQueryForm">
+        <div class="form-group">
+            <label for="teamId">Team ID (Optional):</label>
+            <input type="number" id="teamId" name="team_id">
+        </div>
+        <div class="form-group">
+            <label for="functionId">Function ID (Optional, UUID):</label>
+            <input type="text" id="functionId" name="function_id" placeholder="Enter a valid UUID">
+        </div>
+        <div class="form-group">
+            <label for="jobState">Job State (Optional):</label>
+            <select id="jobState" name="state">
+                <option value="">Select Job State</option>
+                <option value="available">Available</option>
+                <option value="running">Running</option>
+                <option value="completed">Completed</option>
+                <option value="failed">Failed</option>
+                <option value="paused">Paused</option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="queueName">Queue Name (Optional):</label>
+            <input type="text" id="queueName" name="queue_name" placeholder="Queue name">
+        </div>
+        <div class="form-group">
+            <label for="scheduledBy">Scheduled By (Optional, UTC DateTime):</label>
+            <input type="datetime-local" id="scheduledBy" name="scheduled_by">
+        </div>
+        <div class="form-group">
+            <label for="limit">Limit (Optional):</label>
+            <input type="number" id="limit" name="limit" placeholder="Max number of jobs to return">
+        </div>
+        <button type="button" onclick="queryJobs()">Query Jobs</button>
+    </form>
+
+    <h2>Job Results</h2>
+    <pre id="jobResults">No job query performed yet.</pre>
+
+    <h2>System State</h2>
+    <div id="stateSection">
+        <pre id="stateOutput">Loading system state...</pre>
+        <p id="refreshTime"></p>
+    </div>
+
+    <script>
+        const apiUrl = window.location.origin;
+
+        let lastRefreshTime = 0;
+
+        function showNotice(noticeId) {
+            const notice = document.getElementById(noticeId);
+            notice.style.display = "inline"; // Show the notice
+            setTimeout(() => {
+                notice.style.display = "none"; // Hide after 3 seconds
+            }, 3000);
+        }
+
+        async function pauseSystem() {
+            const until = document.getElementById("pauseUntil").value;
+            if (until) {
+                const timestamp = new Date(until).toISOString();
+                await fetch(`${apiUrl}/pause?until=${timestamp}`, { method: "POST" });
+                showNotice("pauseNotice");
+            }
+        }
+
+        async function resumeSystem() {
+            await fetch(`${apiUrl}/resume`, { method: "POST" });
+            showNotice("resumeNotice");
+        }
+
+        async function setCleanupInterval() {
+            const interval = document.getElementById("cleanupInterval").value;
+            if (interval) {
+                await fetch(`${apiUrl}/cleanup_interval?seconds=${interval}`, { method: "POST" });
+                showNotice("cleanupNotice");
+            }
+        }
+
+        async function setStallTimeout() {
+            const timeout = document.getElementById("stallTimeout").value;
+            if (timeout) {
+                await fetch(`${apiUrl}/stall_timeout?seconds=${timeout}`, { method: "POST" });
+                showNotice("stallNotice");
+            }
+        }
+
+        async function setMaxTouches() {
+            const touches = document.getElementById("maxTouches").value;
+            if (touches) {
+                await fetch(`${apiUrl}/max_touches?touches=${touches}`, { method: "POST" });
+                showNotice("touchesNotice");
+            }
+        }
+
+        async function forceCleanup() {
+            await fetch(`${apiUrl}/force_cleanup`, { method: "POST" });
+            showNotice("cleanupForceNotice");
+        }
+
+        async function getState() {
+            const response = await fetch(`${apiUrl}/state`);
+            const data = await response.json();
+            document.getElementById("stateOutput").textContent = JSON.stringify(data, null, 2);
+            lastRefreshTime = 0;
+        }
+
+        async function queryJobs() {
+            const teamId = document.getElementById("teamId").value;
+            const functionId = document.getElementById("functionId").value;
+            const jobState = document.getElementById("jobState").value;
+            const queueName = document.getElementById("queueName").value;
+            const scheduledBy = document.getElementById("scheduledBy").value;
+            const limit = document.getElementById("limit").value;
+
+            const queryParams = {
+                team_id: teamId ? Number(teamId) : null,
+                function_id: functionId || null,
+                state: jobState || null,
+                queue_name: queueName || null,
+                scheduled_by: scheduledBy ? new Date(scheduledBy).toISOString() : null,
+                limit: limit ? Number(limit) : null
+            };
+
+            const filteredParams = Object.fromEntries(Object.entries(queryParams).filter(([_, v]) => v != null));
+
+            const response = await fetch(`${apiUrl}/jobs`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify(filteredParams)
+            });
+
+            const jobs = await response.json();
+            updateJobResults(jobs);
+        }
+
+        function updateJobResults(jobs) {
+            const resultsElement = document.getElementById("jobResults");
+            if (jobs.length === 0) {
+                resultsElement.textContent = "No jobs found.";
+                return;
+            }
+
+            const formattedJobs = jobs.map(job => JSON.stringify(job)).join("\n");
+            resultsElement.textContent = formattedJobs;
+        }
+
+        function updateTimeSinceRefresh() {
+            lastRefreshTime += 1;
+            document.getElementById("refreshTime").textContent = `Time since last refresh: ${lastRefreshTime} seconds.`;
+        }
+
+        setInterval(() => {
+            getState();
+        }, 10000);
+
+        setInterval(() => {
+            updateTimeSinceRefresh();
+        }, 1000);
+
+        getState();
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
As cyclotron starts handling heavy traffic, we want to make the debugging story a bit better than just "make some DB queries", particularly if/when we add inline blob/state compression, or even out-of-line blob storage. This PR is the first steps of this:
- [x] Be able to temporarily pause the janitor cleanup loop
- [x] Be able to retrieve a sample of jobs by state, function id, team, and queue (or any combination thereof), and have their data displayed in a human readable format (if possible - if the byte arrays are not parseable to strings, we'll just put some placeholder in)
- [x] Be able to control the frequency of janitor loop runs, and how aggressively it resets stalled jobs and DLQ's poison pills

I need to talk to someone from infra about how to get this API exposed on tailscale, because port forwarding doesn't seem to play very nicely, and I don't know the ins and outs of our networking setup 🤷.

-------
An aside: I've wondered to what degree these settings should be persisted - it'd be fairly trivial to put them into a simple key:value PG table, and make them persist across janitor restarts. I _think_ it's better to have these all reset (except _perhaps_ the paused_until setting) - it's nicer to be able to look at an env file and know if you restart the pod, those are the settings it's running with, but then, if the janitor exposes it's settings in it's interface, does that really matter?. I expect _eventually_ persistent settings will be the way to go, but maybe a problem for much later.