### PR TITLE
fix(settings): Fix edge case crashing org logo selection

### DIFF
--- a/frontend/src/lib/hooks/useUploadFiles.ts
+++ b/frontend/src/lib/hooks/useUploadFiles.ts
@@ -68,7 +68,7 @@ export function useUploadFiles({
             }
         }
         uploadFiles().catch(console.error)
-    }, [filesToUpload])
+    }, [filesToUpload, onUpload, onError])
 
     return { setFilesToUpload, filesToUpload, uploading }
 }

--- a/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
@@ -61,9 +61,11 @@ export const LemonFileInput = ({
 
         const eventFiles = e.target.files
         const filesArr = Array.prototype.slice.call(eventFiles)
-        const localFiles = multiple ? [...files, ...filesArr] : [filesArr[0]]
-        setFiles(localFiles)
-        onChange?.(localFiles)
+        const localFiles = multiple ? [...files, ...filesArr] : filesArr.slice(0, 1)
+        if (filesArr.length > 0) {
+            setFiles(localFiles)
+            onChange?.(localFiles)
+        }
     }
 
     const handleDrag = (e: DragEvent): void => {
@@ -141,7 +143,7 @@ export const LemonFileInput = ({
                     !alternativeDropTargetRef?.current && drag && 'FileDropTarget--active'
                 )}
             >
-                <label className="text-muted inline-flex flex flow-row items-center gap-1 cursor-pointer">
+                <label className="text-muted inline-flex flow-row items-center gap-1 cursor-pointer">
                     <input
                         className="hidden"
                         type="file"

--- a/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonFileInput/LemonFileInput.tsx
@@ -61,8 +61,8 @@ export const LemonFileInput = ({
 
         const eventFiles = e.target.files
         const filesArr = Array.prototype.slice.call(eventFiles)
-        const localFiles = multiple ? [...files, ...filesArr] : filesArr.slice(0, 1)
         if (filesArr.length > 0) {
+            const localFiles = multiple ? [...files, ...filesArr] : filesArr.slice(0, 1)
             setFiles(localFiles)
             onChange?.(localFiles)
         }


### PR DESCRIPTION
## Problem

Things crashed when you took the following steps:
- upload new logo
- save it
- click on the photo to upload a new one
- escape the file select

Reported in ZEN-18681.

## Changes

Turns out file input `onInputChange` runs even if nothing was selected. This adjusts our logic for that.