### PR TITLE
chore(batch-exports): Make StringDataRightTruncation non-retryable

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -672,6 +672,8 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
                 "UniqueViolation",
                 # Something changed in the target table's schema that we were not expecting.
                 "UndefinedColumn",
+                # A VARCHAR column is too small.
+                "StringDataRightTruncation",
             ],
             finish_inputs=finish_inputs,
         )


### PR DESCRIPTION
## Problem

This error can happen when a VARCHAR column is too small to hold some String value. This should never happen unless the schema is edited from the default values.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Make `StringDataRightTruncation` non-retryable.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
