### PR TITLE
fix(hedgehog-mode): Make Max crisp again

### DIFF
--- a/frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.tsx
+++ b/frontend/src/lib/components/HedgehogBuddy/HedgehogBuddy.tsx
@@ -803,7 +803,7 @@ export class HedgehogActor {
                     >
                         {this.mainAnimation ? (
                             <div
-                                className="image-rendering-pixelated"
+                                className="rendering-pixelated"
                                 // eslint-disable-next-line react/forbid-dom-props
                                 style={{
                                     width: SPRITE_SIZE,
@@ -824,7 +824,7 @@ export class HedgehogActor {
 
                         {this.accessories().map((accessory, index) => (
                             <div
-                                className={`absolute top-0 left-0 w-[${SPRITE_SIZE}px] h-[${SPRITE_SIZE}px] image-rendering-pixelated`}
+                                className={`absolute top-0 left-0 w-[${SPRITE_SIZE}px] h-[${SPRITE_SIZE}px] rendering-pixelated`}
                                 key={index}
                                 // eslint-disable-next-line react/forbid-dom-props
                                 style={{
@@ -838,7 +838,7 @@ export class HedgehogActor {
                         ))}
                         {this.overlayAnimation ? (
                             <div
-                                className={`absolute top-0 left-0 w-[${SPRITE_SIZE}px] h-[${SPRITE_SIZE}px] image-rendering-pixelated`}
+                                className={`absolute top-0 left-0 w-[${SPRITE_SIZE}px] h-[${SPRITE_SIZE}px] rendering-pixelated`}
                                 // eslint-disable-next-line react/forbid-dom-props
                                 style={{
                                     backgroundImage: `url(${spriteOverlayUrl(this.overlayAnimation.spriteInfo.img)})`,

--- a/frontend/src/styles/utilities.scss
+++ b/frontend/src/styles/utilities.scss
@@ -59,7 +59,7 @@
 
 // Extra utilties that Tailwind doesn't have built in
 @layer utilities {
-    .image-pixelated {
+    .rendering-pixelated {
         image-rendering: pixelated;
     }
 }


### PR DESCRIPTION
## Problem

Noticed that https://github.com/PostHog/posthog/pull/25035 made Max blurry, because we use a custom utility class for `image-rendering: pixelated`, ending in a naming mismatch here.

## Changes

Fixes usage of the utility class.