### PR TITLE
feat: rejig session summary

### DIFF
--- a/ee/session_recordings/ai/embeddings_runner.py
+++ b/ee/session_recordings/ai/embeddings_runner.py
@@ -16,7 +16,6 @@ from posthog.clickhouse.client import sync_execute
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 from ee.session_recordings.ai.utils import (
     SessionSummaryPromptData,
-    reduce_elements_chain,
     simplify_window_id,
     format_dates,
     collapse_sequence_of_events,
@@ -263,11 +262,7 @@ class SessionEventsEmbeddingsPreparation(EmbeddingPreparation):
         processed_sessions = collapse_sequence_of_events(
             only_pageview_urls(
                 format_dates(
-                    reduce_elements_chain(
-                        simplify_window_id(
-                            SessionSummaryPromptData(columns=session_events[0], results=session_events[1])
-                        )
-                    ),
+                    simplify_window_id(SessionSummaryPromptData(columns=session_events[0], results=session_events[1])),
                     start=datetime.datetime(1970, 1, 1, tzinfo=pytz.UTC),  # epoch timestamp
                 )
             )

--- a/ee/session_recordings/session_summary/summarize_session.py
+++ b/ee/session_recordings/session_summary/summarize_session.py
@@ -126,7 +126,9 @@ def summarize_recording(recording: SessionRecording, user: User, team: Team):
                     "role": "user",
                     "content": """
             generate a two or three sentence summary of the session.
-            use as concise and simple language as is possible. Dont' refer to the session length unless it is notable for some reason.
+            only summarize, don't offer advice.
+            use as concise and simple language as is possible.
+            Dont' refer to the session length unless it is notable for some reason.
             assume a reading age of around 12 years old.
             generate no text other than the summary.""",
                 },

--- a/ee/session_recordings/session_summary/summarize_session.py
+++ b/ee/session_recordings/session_summary/summarize_session.py
@@ -12,7 +12,6 @@ from posthog.utils import get_instance_region
 
 from ee.session_recordings.ai.utils import (
     SessionSummaryPromptData,
-    reduce_elements_chain,
     simplify_window_id,
     deduplicate_urls,
     format_dates,
@@ -81,11 +80,7 @@ def summarize_recording(recording: SessionRecording, user: User, team: Team):
         prompt_data = deduplicate_urls(
             collapse_sequence_of_events(
                 format_dates(
-                    reduce_elements_chain(
-                        simplify_window_id(
-                            SessionSummaryPromptData(columns=session_events[0], results=session_events[1])
-                        )
-                    ),
+                    simplify_window_id(SessionSummaryPromptData(columns=session_events[0], results=session_events[1])),
                     start=start_time,
                 )
             )
@@ -95,9 +90,7 @@ def summarize_recording(recording: SessionRecording, user: User, team: Team):
 
     with timer("openai_completion"):
         result = openai.chat.completions.create(
-            # model="gpt-4-1106-preview",  # allows 128k tokens
-            # model="gpt-4",  # allows 8k tokens
-            model="gpt-4o",  # allows 128k tokens
+            model="gpt-4o-mini",  # allows 128k tokens
             temperature=0.7,
             messages=[
                 {
@@ -107,6 +100,7 @@ def summarize_recording(recording: SessionRecording, user: User, team: Team):
             We also gather events that occur like mouse clicks and key presses.
             You write two or three sentence concise and simple summaries of those sessions based on a prompt.
             You are more likely to mention errors or things that look like business success such as checkout events.
+            You always try to make the summary actionable. E.g. mentioning what someone clicked on, or summarizing errors they experienced.
             You don't help with other knowledge.""",
                 },
                 {
@@ -117,7 +111,7 @@ def summarize_recording(recording: SessionRecording, user: User, team: Team):
                 {
                     "role": "user",
                     "content": f"""
-            URLs associated with the events can be found in this mapping {prompt_data.url_mapping}.
+            URLs associated with the events can be found in this mapping {prompt_data.url_mapping}. You never refer to URLs by their placeholder. Always refer to the URL with the simplest version e.g. posthog.com or posthog.com/replay
             """,
                 },
                 {
@@ -125,14 +119,14 @@ def summarize_recording(recording: SessionRecording, user: User, team: Team):
                     "content": f"""the session events I have are {prompt_data.results}.
             with columns {prompt_data.columns}.
             they give an idea of what happened and when,
-            if present the elements_chain extracted from the html can aid in understanding
+            if present the elements_chain_texts, elements_chain_elements, and elements_chain_href extracted from the html can aid in understanding what a user interacted with
             but should not be directly used in your response""",
                 },
                 {
                     "role": "user",
                     "content": """
             generate a two or three sentence summary of the session.
-            use as concise and simple language as is possible.
+            use as concise and simple language as is possible. Dont' refer to the session length unless it is notable for some reason.
             assume a reading age of around 12 years old.
             generate no text other than the summary.""",
                 },

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarOverviewTab.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarOverviewTab.tsx
@@ -2,6 +2,7 @@ import { PersonDisplay } from '@posthog/apps-common'
 import { useValues } from 'kea'
 import { PropertiesTable } from 'lib/components/PropertiesTable'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { PlayerSidebarSessionSummary } from 'scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary'
 
 import { PropertyDefinitionType } from '~/types'
 
@@ -16,6 +17,7 @@ export function PlayerSidebarOverviewTab(): JSX.Element {
     return (
         <div className="flex flex-col overflow-auto bg-bg-3000">
             <PlayerSidebarOverviewGrid />
+            <PlayerSidebarSessionSummary />
             <div className="font-bold bg-bg-light px-2 border-b py-3">
                 <PersonDisplay person={sessionPerson} withIcon noPopover />
             </div>

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
@@ -78,7 +78,7 @@ export function PlayerSidebarSessionSummary(): JSX.Element | null {
                             Thinking... <Spinner />{' '}
                         </>
                     ) : sessionSummary ? (
-                        <SessionSummary summary={sessionSummary} />
+                        <SessionSummary />
                     ) : (
                         <LoadSessionSummaryButton />
                     )}

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarSessionSummary.tsx
@@ -1,0 +1,89 @@
+import { IconMagicWand, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
+import { useActions, useValues } from 'kea'
+import { FlaggedFeature } from 'lib/components/FlaggedFeature'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
+import { Spinner } from 'lib/lemon-ui/Spinner'
+import { playerMetaLogic } from 'scenes/session-recordings/player/playerMetaLogic'
+import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
+
+function SessionSummary(): JSX.Element {
+    const { logicProps } = useValues(sessionRecordingPlayerLogic)
+    const { sessionSummary, summaryHasHadFeedback } = useValues(playerMetaLogic(logicProps))
+    const { sessionSummaryFeedback } = useActions(playerMetaLogic(logicProps))
+
+    return (
+        <div>
+            {sessionSummary.content}
+            <LemonDivider dashed={true} />
+            <div className="text-right">
+                <p>Is this a good summary?</p>
+                <div className="flex flex-row gap-2 justify-end">
+                    <LemonButton
+                        size="xsmall"
+                        type="primary"
+                        icon={<IconThumbsUp />}
+                        disabledReason={summaryHasHadFeedback ? 'Thanks for your feedback!' : undefined}
+                        onClick={() => {
+                            sessionSummaryFeedback('good')
+                        }}
+                    />
+                    <LemonButton
+                        size="xsmall"
+                        type="primary"
+                        icon={<IconThumbsDown />}
+                        disabledReason={summaryHasHadFeedback ? 'Thanks for your feedback!' : undefined}
+                        onClick={() => {
+                            sessionSummaryFeedback('bad')
+                        }}
+                    />
+                </div>
+            </div>
+        </div>
+    )
+}
+
+function LoadSessionSummaryButton(): JSX.Element {
+    const { logicProps } = useValues(sessionRecordingPlayerLogic)
+    const { sessionSummaryLoading } = useValues(playerMetaLogic(logicProps))
+    const { summarizeSession } = useActions(playerMetaLogic(logicProps))
+
+    return (
+        <LemonButton
+            size="small"
+            type="primary"
+            icon={<IconMagicWand />}
+            fullWidth={true}
+            data-attr="load-session-summary"
+            disabledReason={sessionSummaryLoading ? 'Loading...' : undefined}
+            onClick={summarizeSession}
+        >
+            Use AI to summarise this session
+        </LemonButton>
+    )
+}
+
+export function PlayerSidebarSessionSummary(): JSX.Element | null {
+    const { logicProps } = useValues(sessionRecordingPlayerLogic)
+    const { sessionSummary, sessionSummaryLoading } = useValues(playerMetaLogic(logicProps))
+
+    return (
+        <>
+            <FlaggedFeature flag={FEATURE_FLAGS.AI_SESSION_SUMMARY} match={true}>
+                <div className="rounded border bg-bg-light m-2 px-2 py-1">
+                    <h2>AI Session Summary</h2>
+                    {sessionSummaryLoading ? (
+                        <>
+                            Thinking... <Spinner />{' '}
+                        </>
+                    ) : sessionSummary ? (
+                        <SessionSummary summary={sessionSummary} />
+                    ) : (
+                        <LoadSessionSummaryButton />
+                    )}
+                </div>
+            </FlaggedFeature>
+        </>
+    )
+}

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
@@ -1,18 +1,13 @@
-import { IconBug, IconCursorClick, IconKeyboard, IconLive, IconMagicWand, IconPinFilled } from '@posthog/icons'
+import { IconBug, IconCursorClick, IconKeyboard, IconLive, IconPinFilled } from '@posthog/icons'
 import clsx from 'clsx'
 import { useValues } from 'kea'
-import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { PropertyIcon } from 'lib/components/PropertyIcon'
 import { TZLabel } from 'lib/components/TZLabel'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
-import { Popover } from 'lib/lemon-ui/Popover'
-import { Spinner } from 'lib/lemon-ui/Spinner'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { colonDelimitedDuration } from 'lib/utils'
-import { useState } from 'react'
 import { countryCodeToName } from 'scenes/insights/views/WorldMap'
 import { DraggableToNotebook } from 'scenes/notebooks/AddToNotebook/DraggableToNotebook'
 import { asDisplay } from 'scenes/persons/person-utils'
@@ -29,8 +24,6 @@ export interface SessionRecordingPreviewProps {
     isActive?: boolean
     onClick?: () => void
     pinned?: boolean
-    summariseFn?: (recording: SessionRecordingType) => void
-    sessionSummaryLoading?: boolean
 }
 
 function RecordingDuration({ recordingDuration }: { recordingDuration: number | undefined }): JSX.Element {
@@ -182,8 +175,6 @@ export function SessionRecordingPreview({
     isActive,
     onClick,
     pinned,
-    summariseFn,
-    sessionSummaryLoading,
 }: SessionRecordingPreviewProps): JSX.Element {
     const { orderBy } = useValues(sessionRecordingsPlaylistLogic)
 
@@ -194,10 +185,6 @@ export function SessionRecordingPreview({
 
     const iconClassNames = 'text-muted-alt shrink-0'
 
-    const [summaryPopoverIsVisible, setSummaryPopoverIsVisible] = useState<boolean>(false)
-
-    const [summaryButtonIsVisible, setSummaryButtonIsVisible] = useState<boolean>(false)
-
     return (
         <DraggableToNotebook href={urls.replaySingle(recording.id)}>
             <div
@@ -207,44 +194,7 @@ export function SessionRecordingPreview({
                     isActive && 'SessionRecordingPreview--active'
                 )}
                 onClick={() => onClick?.()}
-                onMouseEnter={() => setSummaryButtonIsVisible(true)}
-                onMouseLeave={() => setSummaryButtonIsVisible(false)}
             >
-                <FlaggedFeature flag={FEATURE_FLAGS.AI_SESSION_SUMMARY} match={true}>
-                    {summariseFn && (
-                        <Popover
-                            showArrow={true}
-                            visible={summaryPopoverIsVisible && summaryButtonIsVisible}
-                            placement="right"
-                            onClickOutside={() => setSummaryPopoverIsVisible(false)}
-                            overlay={
-                                sessionSummaryLoading ? (
-                                    <Spinner />
-                                ) : (
-                                    <div className="text-xl max-w-auto lg:max-w-3/5">{recording.summary}</div>
-                                )
-                            }
-                        >
-                            <LemonButton
-                                size="small"
-                                type="primary"
-                                className={clsx(
-                                    summaryButtonIsVisible ? 'block' : 'hidden',
-                                    'absolute right-px top-px'
-                                )}
-                                icon={<IconMagicWand />}
-                                onClick={(e) => {
-                                    e.preventDefault()
-                                    e.stopPropagation()
-                                    setSummaryPopoverIsVisible(!summaryPopoverIsVisible)
-                                    if (!recording.summary) {
-                                        summariseFn(recording)
-                                    }
-                                }}
-                            />
-                        </Popover>
-                    )}
-                </FlaggedFeature>
                 <div className="grow overflow-hidden space-y-1">
                     <div className="flex items-center justify-between gap-2">
                         <div className="flex overflow-hidden font-medium text-link ph-no-capture">
@@ -258,7 +208,7 @@ export function SessionRecordingPreview({
                         />
                     </div>
 
-                    <div className="flex items-center justify-between items-center gap-2">
+                    <div className="flex justify-between items-center gap-2">
                         <div className="flex space-x-2 text-muted text-xs">
                             <PropertyIcons
                                 recordingProperties={iconProperties}

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -35,12 +35,10 @@ export function SessionRecordingsPlaylist(props: SessionRecordingPlaylistLogicPr
         matchingEventsMatchType,
         sessionRecordingsResponseLoading,
         otherRecordings,
-        sessionSummaryLoading,
         activeSessionRecordingId,
         hasNext,
     } = useValues(logic)
-    const { maybeLoadSessionRecordings, summarizeSession, setSelectedRecordingId, setFilters, setShowOtherRecordings } =
-        useActions(logic)
+    const { maybeLoadSessionRecordings, setSelectedRecordingId, setFilters, setShowOtherRecordings } = useActions(logic)
 
     const { featureFlags } = useValues(featureFlagLogic)
     const isTestingSaved = featureFlags[FEATURE_FLAGS.SAVED_NOT_PINNED] === 'test'
@@ -50,10 +48,6 @@ export function SessionRecordingsPlaylist(props: SessionRecordingPlaylistLogicPr
     const notebookNode = useNotebookNode()
 
     const sections: PlaylistSection<SessionRecordingType>[] = []
-
-    const onSummarizeClick = (recording: SessionRecordingType): void => {
-        summarizeSession(recording.id)
-    }
 
     if (pinnedRecordings.length) {
         sections.push({
@@ -71,15 +65,7 @@ export function SessionRecordingsPlaylist(props: SessionRecordingPlaylistLogicPr
         key: 'other',
         title: 'Other recordings',
         items: otherRecordings,
-        render: ({ item, isActive }) => (
-            <SessionRecordingPreview
-                recording={item}
-                isActive={isActive}
-                pinned={false}
-                summariseFn={onSummarizeClick}
-                sessionSummaryLoading={sessionSummaryLoading}
-            />
-        ),
+        render: ({ item, isActive }) => <SessionRecordingPreview recording={item} isActive={isActive} pinned={false} />,
         footer: (
             <div className="p-4">
                 <div className="h-10 flex items-center justify-center gap-2 text-muted-alt">

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -265,11 +265,6 @@ export interface SessionRecordingPlaylistLogicProps {
     onPinnedChange?: (recording: SessionRecordingType, pinned: boolean) => void
 }
 
-export interface SessionSummaryResponse {
-    id: SessionRecordingType['id']
-    content: string
-}
-
 export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogicType>([
     path((key) => ['scenes', 'session-recordings', 'playlist', 'sessionRecordingsPlaylistLogic', key]),
     props({} as SessionRecordingPlaylistLogicProps),
@@ -306,7 +301,6 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
         loadPinnedRecordings: true,
         loadSessionRecordings: (direction?: 'newer' | 'older') => ({ direction }),
         maybeLoadSessionRecordings: (direction?: 'newer' | 'older') => ({ direction }),
-        summarizeSession: (id: SessionRecordingType['id']) => ({ id }),
         loadNext: true,
         loadPrev: true,
         setShowOtherRecordings: (show: boolean) => ({ show }),
@@ -322,15 +316,6 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
     }),
 
     loaders(({ props, values, actions }) => ({
-        sessionSummary: {
-            summarizeSession: async ({ id }): Promise<SessionSummaryResponse | null> => {
-                if (!id) {
-                    return null
-                }
-                const response = await api.recordings.summarize(id)
-                return { content: response.content, id: id }
-            },
-        },
         eventsHaveSessionId: [
             {} as Record<string, boolean>,
             {
@@ -432,13 +417,6 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                 setOrderBy: (_, { orderBy }) => orderBy,
             },
         ],
-        sessionBeingSummarized: [
-            null as null | SessionRecordingType['id'],
-            {
-                summarizeSession: (_, { id }) => id,
-                sessionSummarySuccess: () => null,
-            },
-        ],
         // If we initialise with pinned recordings then we don't show others by default
         // but if we go down to 0 pinned recordings then we show others
         showOtherRecordings: [
@@ -521,20 +499,6 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                         }
                         return { ...s }
                     }),
-
-                summarizeSessionSuccess: (state, { sessionSummary }) => {
-                    return sessionSummary
-                        ? state.map((s) => {
-                              if (s.id === sessionSummary.id) {
-                                  return {
-                                      ...s,
-                                      summary: sessionSummary.content,
-                                  }
-                              }
-                              return s
-                          })
-                        : state
-                },
             },
         ],
         selectedRecordingId: [

--- a/posthog/session_recordings/queries/session_replay_events.py
+++ b/posthog/session_recordings/queries/session_replay_events.py
@@ -136,7 +136,7 @@ class SessionReplayEvents:
         from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
 
         q = """
-            select event, timestamp, elements_chain, properties.$window_id, properties.$current_url, properties.$event_type
+            select event, timestamp, elements_chain_href, elements_chain_texts, elements_chain_elements, properties.$window_id, properties.$current_url, properties.$event_type
             from events
             where timestamp >= {start_time} and timestamp <= {end_time}
             and $session_id = {session_id}


### PR DESCRIPTION
Now we have an overview tab we've got a much nicer place to put the AI session summary

* moves session summary into the overview tab
* grabs elements info from the new elements columns on the events table
* adds a mini feedback button to the summary
* it is still really slow 🙈 

## offering a summary

<img width="436" alt="Screenshot 2024-09-30 at 19 33 44" src="https://github.com/user-attachments/assets/b27cd893-964d-4183-8646-ac1ba729d13d">

## showing a summary

<img width="414" alt="Screenshot 2024-09-30 at 19 34 07" src="https://github.com/user-attachments/assets/5c05976e-5229-42c1-ab00-4300a58cb849">

## only feedback once

<img width="327" alt="Screenshot 2024-09-30 at 19 37 37" src="https://github.com/user-attachments/assets/758cf8a8-c891-421b-a341-9930f5c26405">
