### PR TITLE
chore(batch-exports): Allow external sort on all models

### DIFF
--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -76,6 +76,9 @@ FROM
         exclude_events={exclude_events}::Array(String)
     ) AS events
 FORMAT ArrowStream
+SETTINGS
+    -- This is half of configured MAX_MEMORY_USAGE for batch exports.
+    max_bytes_before_external_sort=50000000000
 """
 )
 
@@ -92,6 +95,9 @@ FROM
         exclude_events={exclude_events}::Array(String)
     ) AS events
 FORMAT ArrowStream
+SETTINGS
+    -- This is half of configured MAX_MEMORY_USAGE for batch exports.
+    max_bytes_before_external_sort=50000000000
 """
 )
 
@@ -108,6 +114,9 @@ FROM
         exclude_events={exclude_events}::Array(String)
     ) AS events
 FORMAT ArrowStream
+SETTINGS
+    -- This is half of configured MAX_MEMORY_USAGE for batch exports.
+    max_bytes_before_external_sort=50000000000
 """
 )
 


### PR DESCRIPTION
## Problem

From time to time, batch exports may use too much memory. We do not allow the ClickHouse queries to spill to disk, so they just fail.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Enable external sorting to allow spilling to disk when memory is running to tight.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yup.
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

We have been running this setting in persons export to great success, this just enables it for the other queries too.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
