### PR TITLE
chore(hogql): Allow exposing of parsing UUID clickhouse error

### DIFF
--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -390,7 +390,7 @@ CLICKHOUSE_ERROR_CODE_LOOKUP: dict[int, ErrorCodeMeta] = {
     373: ErrorCodeMeta("SESSION_IS_LOCKED"),
     374: ErrorCodeMeta("INVALID_SESSION_TIMEOUT"),
     375: ErrorCodeMeta("CANNOT_DLOPEN"),
-    376: ErrorCodeMeta("CANNOT_PARSE_UUID"),
+    376: ErrorCodeMeta("CANNOT_PARSE_UUID", user_safe=True),
     377: ErrorCodeMeta("ILLEGAL_SYNTAX_FOR_DATA_TYPE"),
     378: ErrorCodeMeta("DATA_TYPE_CANNOT_HAVE_ARGUMENTS"),
     380: ErrorCodeMeta("CANNOT_KILL"),


### PR DESCRIPTION
## Problem
- Sometimes people try to compare `person_id` in HogQL to a non-uuid value, causing Clickhouse to fail with no error message due to not being able to parse the UUID provided
- Example: [zendesk ticket](https://posthoghelp.zendesk.com/agent/tickets/18838), and [sentry error](https://posthog.sentry.io/issues/5621745341/?environment=prod-eu&project=1899813&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20user.email%3Ajoe%40sunsave.energy&referrer=issue-stream&statsPeriod=14d&stream_index=0)

## Changes
- Allow this error message to be exposed to users
