### PR TITLE
chore: no need to set this anymore

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -50,10 +50,6 @@ export function loadPostHogJS(): void {
                 _onCapture: (window as any)._cypress_posthog_captures
                     ? (_, event) => (window as any)._cypress_posthog_captures.push(event)
                     : undefined,
-
-                session_recording: {
-                    compress_events: true,
-                },
             })
         )
 


### PR DESCRIPTION
partial compression in session replay is the default now, so we don't need to set it any more