### PR TITLE
fix(batch-exports): Enable aggregation in order optimization

### DIFF
--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -59,7 +59,8 @@ SETTINGS
     -- This is half of configured MAX_MEMORY_USAGE for batch exports.
     -- TODO: Make the setting available to all queries.
     max_bytes_before_external_group_by=50000000000,
-    max_bytes_before_external_sort=50000000000
+    max_bytes_before_external_sort=50000000000,
+    optimize_aggregation_in_order=1
 """
 
 SELECT_FROM_EVENTS_VIEW = Template(


### PR DESCRIPTION
## Problem

So, the problem is that ClickHouse allows us to control memory usage during grouping and sorting, but not during the final results merge. Such a feature is currently in development. Until then, this means we can run out of memory _after_ we are done grouping and sorting.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

To address this, we can enable `optimize_aggregation_in_order=1` as this makes our group by more efficient, and for some reason uses up less memory. To be completely honest, I am not sure why this helps, but I tested it, and it does. We have this setting in the events query where it has already proven itself useful.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
