### PR TITLE
fix(propdefs): Handle unresolvable group-type indexes properly

### DIFF
--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -41,12 +41,6 @@ pub struct Config {
     #[envconfig(default = "1000000")]
     pub cache_capacity: usize,
 
-    // We expire cache entries after this many seconds. This is /mostly/ to handle
-    // cases where we don't handle an insert error properly, so that a subsequent
-    // event seen can re-try the insert.
-    #[envconfig(default = "600")] // 10 minutes
-    pub cache_ttl_seconds: u64,
-
     // We impose a slow-start, where each batch update operation is delayed by
     // this many milliseconds, multiplied by the % of the cache currently unused. The idea
     // is that we want to drip-feed updates to the DB during warmup, since


### PR DESCRIPTION
## Problem

Every now and then we get a group-type name we cannot map to an index. I dug into the raw data for this (it happens fairly rarely, and for specific teams), and it mostly looks like those specific teams misusing the groups feature. If we try to insert a property definition for a group property without a group-type index, the insert fails with a constraint violation, and that causes the _whole update batch_ to abort. Instead, we should simply loudly log about these unresolvable group-types, and then drop the update so the rest of the batch is written without issue.