### PR TITLE
chore: continue on timeout for CH lightweight deletes

### DIFF
--- a/posthog/models/async_deletion/delete_events.py
+++ b/posthog/models/async_deletion/delete_events.py
@@ -76,16 +76,12 @@ class AsyncEventDeletion(AsyncDeletionProcess):
                         args,
                         settings={},
                     )
-                except Exception as e:
+                except SocketTimeoutError:
                     # This is unfortunately needed because currently all lightweight deletes are executed sync
-                    if isinstance(e, SocketTimeoutError):
-                        logger.warning(
-                            "ClickHouse query timed out during async deletion. This is expected. Continuing with next batch.",
-                            exc_info=True,
-                        )
-                    else:
-                        # Re-raise other exceptions
-                        raise
+                    logger.warning(
+                        "ClickHouse query timed out during async deletion. This is expected. Continuing with next batch.",
+                        exc_info=True,
+                    )
 
                 conditions, args = [], {}
 

--- a/posthog/models/async_deletion/delete_events.py
+++ b/posthog/models/async_deletion/delete_events.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from clickhouse_driver.errors import SocketTimeoutError
 from prometheus_client import Counter
 
 from posthog.client import sync_execute
@@ -69,11 +70,22 @@ class AsyncEventDeletion(AsyncDeletionProcess):
             # If the query size is greater than the max predicate size, execute the query and reset the query predicate
             if query_size > MAX_QUERY_SIZE:
                 logger.debug(f"Executing query with args: {args}")
-                sync_execute(
-                    query,
-                    args,
-                    settings={},
-                )
+                try:
+                    sync_execute(
+                        query,
+                        args,
+                        settings={},
+                    )
+                except Exception as e:
+                    # This is unfortunately needed because currently all lightweight deletes are executed sync
+                    if isinstance(e, SocketTimeoutError):
+                        logger.warning(
+                            "ClickHouse query timed out during async deletion. This is expected. Continuing with next batch.",
+                            exc_info=True,
+                        )
+                    else:
+                        # Re-raise other exceptions
+                        raise
 
                 conditions, args = [], {}
 


### PR DESCRIPTION
## Problem

The first batch of deletes is the only one successfully enqueued just because the client times out and gives up on future batches. This is an issue with CH until 24.4.

https://grafana.prod-us.posthog.dev/explore?schemaVersion=1&panes=%7B%22c32%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bcontainer%3D%5C%22posthog-workers%5C%22%7D%20%7C%3D%20%60SocketTimeoutError%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22builder%22%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1

## Changes

Catch the `SocketTimeoutError` and continue as usual

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
