### PR TITLE
fix: cohort negation

### DIFF
--- a/ee/clickhouse/models/test/test_filters.py
+++ b/ee/clickhouse/models/test/test_filters.py
@@ -126,6 +126,7 @@ class TestFilters(PGTestFilters):
                             {
                                 "key": "id",
                                 "value": cohort.pk,
+                                "negation": False,
                                 "type": "precalculated-cohort",
                             }
                         ],
@@ -141,6 +142,7 @@ class TestFilters(PGTestFilters):
                         "values": [
                             {
                                 "key": "id",
+                                "negation": False,
                                 "value": cohort.pk,
                                 "type": "precalculated-cohort",
                             }
@@ -158,7 +160,7 @@ class TestFilters(PGTestFilters):
             {
                 "properties": {
                     "type": "AND",
-                    "values": [{"type": "static-cohort", "key": "id", "value": cohort.pk}],
+                    "values": [{"type": "static-cohort", "negation": False, "key": "id", "value": cohort.pk}],
                 }
             },
         )
@@ -172,7 +174,7 @@ class TestFilters(PGTestFilters):
             {
                 "properties": {
                     "type": "AND",
-                    "values": [{"type": "cohort", "key": "id", "value": cohort.pk}],
+                    "values": [{"type": "cohort", "negation": False, "key": "id", "value": cohort.pk}],
                 }
             },
         )

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -482,7 +482,8 @@ def property_to_expr(
         return ast.CompareOperation(
             left=ast.Field(chain=["id" if scope == "person" else "person_id"]),
             op=ast.CompareOperationOp.NotInCohort
-            if property.operator == PropertyOperator.NOT_IN.value
+            # Kludge: negation is outdated but still used in places
+            if property.negation or property.operator == PropertyOperator.NOT_IN.value
             else ast.CompareOperationOp.InCohort,
             right=ast.Constant(value=cohort.pk),
         )

--- a/posthog/hogql_queries/legacy_compatibility/clean_properties.py
+++ b/posthog/hogql_queries/legacy_compatibility/clean_properties.py
@@ -100,7 +100,8 @@ def clean_property(property: dict):
             cleaned_property["operator"] = (
                 PropertyOperator.NOT_IN.value if cleaned_property.get("negation", False) else PropertyOperator.IN_.value
             )
-        del cleaned_property["negation"]
+        if "negation" in cleaned_property:
+            del cleaned_property["negation"]
 
     # set a default operator for properties that support it, but don't have an operator set
     if is_property_with_operator(cleaned_property) and cleaned_property.get("operator") is None:

--- a/posthog/hogql_queries/legacy_compatibility/test/test_clean_properties.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_clean_properties.py
@@ -40,7 +40,7 @@ class TestCleanGlobalProperties(BaseTest):
                 "values": [
                     {
                         "type": "AND",
-                        "values": [{"key": "id", "type": "cohort", "value": 636}],
+                        "values": [{"key": "id", "type": "cohort", "operator": "in", "value": 636}],
                     }
                 ],
             },
@@ -61,7 +61,33 @@ class TestCleanGlobalProperties(BaseTest):
                 "values": [
                     {
                         "type": "AND",
-                        "values": [{"key": "id", "type": "cohort", "value": 850}],
+                        "values": [{"key": "id", "type": "cohort", "operator": "in", "value": 850}],
+                    }
+                ],
+            },
+        )
+
+    def test_handles_cohort_negation(self):
+        properties = {
+            "type": "AND",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [{"key": "id", "type": "cohort", "value": 850, "operator": None, "negation": True}],
+                }
+            ],
+        }
+
+        result = clean_global_properties(properties)
+
+        self.assertEqual(
+            result,
+            {
+                "type": "AND",
+                "values": [
+                    {
+                        "type": "AND",
+                        "values": [{"key": "id", "type": "cohort", "operator": "not_in", "value": 850}],
                     }
                 ],
             },
@@ -82,7 +108,7 @@ class TestCleanGlobalProperties(BaseTest):
                 "values": [
                     {
                         "type": "AND",
-                        "values": [{"key": "id", "type": "cohort", "value": 850}],
+                        "values": [{"key": "id", "type": "cohort", "operator": "in", "value": 850}],
                     }
                 ],
             },

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 from posthog.constants import PropertyOperatorType
 from posthog.models.property import GroupTypeIndex, PropertyGroup
+from posthog.schema import PropertyOperator
 
 if TYPE_CHECKING:  # Avoid circular import
     from posthog.models import Property, Team
@@ -112,7 +113,9 @@ class SimplifyFilterMixin:
                 # :TODO: Handle non-existing resource in-query instead
                 return PropertyGroup(type=PropertyOperatorType.AND, values=[property])
 
-            return simplified_cohort_filter_properties(cohort, team, property.negation)
+            return simplified_cohort_filter_properties(
+                cohort, team, property.negation or property.operator == PropertyOperator.NOT_IN.value
+            )
 
         # PropertyOperatorType doesn't really matter here, since only one value.
         return PropertyGroup(type=PropertyOperatorType.AND, values=[property])


### PR DESCRIPTION
## Problem

Replay page wasn't respecting "not_in" filters - it turns out that cohort property groups were getting modified into:
![image](https://github.com/user-attachments/assets/0ff88c31-d4ed-4f2e-b570-272f4260e295) by the `SimplifyFilterMixin` 


## Changes

Pass "not in" operator down through old style properties as "negation: True"

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Looked at session replay query after making change, passing and modifying tests.

![image](https://github.com/user-attachments/assets/ecf9e96b-1413-4376-a1e4-b927bee817f0)

