### PR TITLE
fix: Rework plugin server redis configs

### DIFF
--- a/plugin-server/src/cdp/redis.ts
+++ b/plugin-server/src/cdp/redis.ts
@@ -5,9 +5,9 @@ import { createPool } from 'generic-pool'
 import { Pipeline, Redis } from 'ioredis'
 
 import { PluginsServerConfig } from '../types'
+import { createRedisClient } from '../utils/db/redis'
 import { timeoutGuard } from '../utils/db/utils'
 import { status } from '../utils/status'
-import { createRedisClient } from '../utils/utils'
 
 type WithCheckRateLimit<T> = {
     checkRateLimit: (key: string, now: number, cost: number, poolMax: number, fillRate: number, expiry: number) => T

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -209,19 +209,6 @@ export function getDefaultConfig(): PluginsServerConfig {
     }
 }
 
-export const sessionRecordingConsumerConfig = (config: PluginsServerConfig): PluginsServerConfig => {
-    // When running the blob consumer we override a bunch of settings to use the session recording ones if available
-    return {
-        ...config,
-        KAFKA_HOSTS: config.SESSION_RECORDING_KAFKA_HOSTS || config.KAFKA_HOSTS,
-        KAFKA_SECURITY_PROTOCOL: config.SESSION_RECORDING_KAFKA_SECURITY_PROTOCOL || config.KAFKA_SECURITY_PROTOCOL,
-        POSTHOG_REDIS_HOST:
-            config.POSTHOG_SESSION_RECORDING_REDIS_HOST || config.INGESTION_REDIS_HOST || config.POSTHOG_REDIS_HOST,
-        POSTHOG_REDIS_PORT:
-            config.POSTHOG_SESSION_RECORDING_REDIS_PORT || config.INGESTION_REDIS_PORT || config.POSTHOG_REDIS_PORT,
-    }
-}
-
 export function overrideWithEnv(
     config: PluginsServerConfig,
     env: Record<string, string | undefined> = process.env

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/realtime-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/realtime-manager.ts
@@ -4,9 +4,9 @@ import { Redis } from 'ioredis'
 import { EventEmitter } from 'node:events'
 
 import { PluginsServerConfig, RedisPool } from '../../../../types'
+import { createRedisSessionRecording } from '../../../../utils/db/redis'
 import { timeoutGuard } from '../../../../utils/db/utils'
 import { status } from '../../../../utils/status'
-import { createRedis } from '../../../../utils/utils'
 
 const Keys = {
     snapshots(prefix: string, teamId: number, suffix: string): string {
@@ -45,7 +45,7 @@ export class RealtimeManager extends EventEmitter {
     }
 
     public async subscribe(): Promise<void> {
-        this.pubsubRedis = await createRedis(this.serverConfig)
+        this.pubsubRedis = await createRedisSessionRecording(this.serverConfig)
         await this.pubsubRedis.subscribe(Keys.realtimeSubscriptions(this.serverConfig.SESSION_RECORDING_REDIS_PREFIX))
 
         this.pubsubRedis.on('message', (channel, message) => {

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/realtime-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/realtime-manager.ts
@@ -2,9 +2,9 @@ import { captureException } from '@sentry/node'
 import { randomUUID } from 'crypto'
 import { Redis } from 'ioredis'
 import { EventEmitter } from 'node:events'
+import { createRedis } from 'utils/db/redis'
 
 import { PluginsServerConfig, RedisPool } from '../../../../types'
-import { createRedisSessionRecording } from '../../../../utils/db/redis'
 import { timeoutGuard } from '../../../../utils/db/utils'
 import { status } from '../../../../utils/status'
 
@@ -45,7 +45,7 @@ export class RealtimeManager extends EventEmitter {
     }
 
     public async subscribe(): Promise<void> {
-        this.pubsubRedis = await createRedisSessionRecording(this.serverConfig)
+        this.pubsubRedis = await createRedis(this.serverConfig, 'session-recording')
         await this.pubsubRedis.subscribe(Keys.realtimeSubscriptions(this.serverConfig.SESSION_RECORDING_REDIS_PREFIX))
 
         this.pubsubRedis.on('message', (channel, message) => {

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/realtime-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/realtime-manager.ts
@@ -2,9 +2,9 @@ import { captureException } from '@sentry/node'
 import { randomUUID } from 'crypto'
 import { Redis } from 'ioredis'
 import { EventEmitter } from 'node:events'
-import { createRedis } from 'utils/db/redis'
 
 import { PluginsServerConfig, RedisPool } from '../../../../types'
+import { createRedis } from '../../../../utils/db/redis'
 import { timeoutGuard } from '../../../../utils/db/utils'
 import { status } from '../../../../utils/status'
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -157,7 +157,7 @@ export class SessionRecordingIngester {
     private isDebugLoggingEnabled: ValueMatcher<number>
 
     private sessionRecordingKafkaConfig = (): PluginsServerConfig => {
-        // When running the blob consumer we override a bunch of settings to use the session recording ones if available
+        // TRICKY: We re-use the kafka helpers which assume KAFKA_HOSTS hence we overwrite it if set
         return {
             ...this.config,
             KAFKA_HOSTS: this.config.SESSION_RECORDING_KAFKA_HOSTS || this.config.KAFKA_HOSTS,

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -17,7 +17,7 @@ import { PluginServerService, PluginsServerConfig, RedisPool, TeamId, ValueMatch
 import { BackgroundRefresher } from '../../../utils/background-refresher'
 import { KafkaProducerWrapper } from '../../../utils/db/kafka-producer-wrapper'
 import { PostgresRouter } from '../../../utils/db/postgres'
-import { createRedisPool, createRedisSessionRecording } from '../../../utils/db/redis'
+import { createRedisPool } from '../../../utils/db/redis'
 import { status } from '../../../utils/status'
 import { fetchTeamTokensWithRecordings } from '../../../worker/ingestion/team-manager'
 import { ObjectStorage } from '../../services/object_storage'
@@ -182,7 +182,7 @@ export class SessionRecordingIngester {
 
         // NOTE: globalServerConfig contains the default pluginServer values, typically not pointing at dedicated resources like kafka or redis
         // We still connect to some of the non-dedicated resources such as postgres or the Replay events kafka.
-        this.redisPool = createRedisPool(this.config, () => createRedisSessionRecording(this.config))
+        this.redisPool = createRedisPool(this.config, 'session-recording')
 
         this.realtimeManager = new RealtimeManager(this.redisPool, this.config)
 

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -180,10 +180,7 @@ export class SessionRecordingIngester {
             : KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS
         this.consumerGroupId = this.consumeOverflow ? KAFKA_CONSUMER_GROUP_ID_OVERFLOW : KAFKA_CONSUMER_GROUP_ID
 
-        // NOTE: globalServerConfig contains the default pluginServer values, typically not pointing at dedicated resources like kafka or redis
-        // We still connect to some of the non-dedicated resources such as postgres or the Replay events kafka.
         this.redisPool = createRedisPool(this.config, 'session-recording')
-
         this.realtimeManager = new RealtimeManager(this.redisPool, this.config)
 
         if (config.SESSION_RECORDING_OVERFLOW_ENABLED && captureRedis && !consumeOverflow) {

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -16,15 +16,16 @@ import {
     CdpFunctionCallbackConsumer,
     CdpProcessedEventsConsumer,
 } from '../cdp/cdp-consumers'
-import { defaultConfig, sessionRecordingConsumerConfig } from '../config/config'
+import { defaultConfig } from '../config/config'
 import { Hub, PluginServerCapabilities, PluginServerService, PluginsServerConfig } from '../types'
 import { closeHub, createHub, createKafkaClient, createKafkaProducerWrapper } from '../utils/db/hub'
 import { PostgresRouter } from '../utils/db/postgres'
+import { createRedisClient } from '../utils/db/redis'
 import { cancelAllScheduledJobs } from '../utils/node-schedule'
 import { posthog } from '../utils/posthog'
 import { PubSub } from '../utils/pubsub'
 import { status } from '../utils/status'
-import { createRedisClient, delay } from '../utils/utils'
+import { delay } from '../utils/utils'
 import { ActionManager } from '../worker/ingestion/action-manager'
 import { ActionMatcher } from '../worker/ingestion/action-matcher'
 import { AppMetrics } from '../worker/ingestion/app-metrics'
@@ -408,9 +409,8 @@ export async function startPluginsServer(
 
         if (capabilities.sessionRecordingBlobIngestion) {
             const hub = serverInstance.hub
-            const recordingConsumerConfig = sessionRecordingConsumerConfig(serverConfig)
             const postgres = hub?.postgres ?? new PostgresRouter(serverConfig)
-            const s3 = hub?.objectStorage ?? getObjectStorage(recordingConsumerConfig)
+            const s3 = hub?.objectStorage ?? getObjectStorage(serverConfig)
 
             if (!s3) {
                 throw new Error("Can't start session recording blob ingestion without object storage")
@@ -429,9 +429,8 @@ export async function startPluginsServer(
 
         if (capabilities.sessionRecordingBlobOverflowIngestion) {
             const hub = serverInstance.hub
-            const recordingConsumerConfig = sessionRecordingConsumerConfig(serverConfig)
             const postgres = hub?.postgres ?? new PostgresRouter(serverConfig)
-            const s3 = hub?.objectStorage ?? getObjectStorage(recordingConsumerConfig)
+            const s3 = hub?.objectStorage ?? getObjectStorage(serverConfig)
 
             if (!s3) {
                 throw new Error("Can't start session recording blob ingestion without object storage")

--- a/plugin-server/src/utils/db/celery.ts
+++ b/plugin-server/src/utils/db/celery.ts
@@ -3,7 +3,7 @@ import { CacheOptions } from '@posthog/plugin-scaffold'
 import { PluginsServerConfig, RedisPool } from '../../types'
 import { instrumentQuery } from '../metrics'
 import { UUIDT } from '../utils'
-import { createRedisPool, createRedisPostHog } from './redis'
+import { createRedisPool } from './redis'
 import { timeoutGuard } from './utils'
 
 const CELERY_DEFAULT_QUEUE = 'celery'
@@ -17,7 +17,7 @@ export class Celery {
     private redisPool: RedisPool
 
     constructor(config: PluginsServerConfig) {
-        this.redisPool = createRedisPool(config, () => createRedisPostHog(config))
+        this.redisPool = createRedisPool(config, 'posthog')
     }
 
     private redisLPush(key: string, value: unknown, options: CacheOptions = {}): Promise<number> {

--- a/plugin-server/src/utils/db/celery.ts
+++ b/plugin-server/src/utils/db/celery.ts
@@ -1,10 +1,9 @@
 import { CacheOptions } from '@posthog/plugin-scaffold'
-import { createPool, Pool as GenericPool } from 'generic-pool'
-import Redis from 'ioredis'
 
-import { PluginsServerConfig } from '../../types'
+import { PluginsServerConfig, RedisPool } from '../../types'
 import { instrumentQuery } from '../metrics'
-import { createRedisClient, UUIDT } from '../utils'
+import { UUIDT } from '../utils'
+import { createRedisPool, createRedisPostHog } from './redis'
 import { timeoutGuard } from './utils'
 
 const CELERY_DEFAULT_QUEUE = 'celery'
@@ -15,29 +14,10 @@ const CELERY_DEFAULT_QUEUE = 'celery'
  * such as a shared message bus or an internal HTTP API.
  */
 export class Celery {
-    private redisPool: GenericPool<Redis.Redis>
+    private redisPool: RedisPool
 
     constructor(config: PluginsServerConfig) {
-        // NOTE: We define a redis pool explicitly using the POSTHOG_REDIS_HOST as celery
-        // only works if it is talking to the same redis instance as the django "posthog" app
-        this.redisPool = createPool<Redis.Redis>(
-            {
-                create: async () => {
-                    return await createRedisClient(config.POSTHOG_REDIS_HOST, {
-                        port: config.POSTHOG_REDIS_PORT,
-                        password: config.POSTHOG_REDIS_PASSWORD,
-                    })
-                },
-                destroy: async (client) => {
-                    await client.quit()
-                },
-            },
-            {
-                min: config.REDIS_POOL_MIN_SIZE,
-                max: config.REDIS_POOL_MAX_SIZE,
-                autostart: true,
-            }
-        )
+        this.redisPool = createRedisPool(config, () => createRedisPostHog(config))
     }
 
     private redisLPush(key: string, value: unknown, options: CacheOptions = {}): Promise<number> {

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -32,13 +32,14 @@ import { TeamManager } from '../../worker/ingestion/team-manager'
 import { RustyHook } from '../../worker/rusty-hook'
 import { isTestEnv } from '../env-utils'
 import { status } from '../status'
-import { createRedisPool, UUIDT } from '../utils'
+import { UUIDT } from '../utils'
 import { PluginsApiKeyManager } from './../../worker/vm/extensions/helpers/api-key-manager'
 import { RootAccessManager } from './../../worker/vm/extensions/helpers/root-acess-manager'
 import { Celery } from './celery'
 import { DB } from './db'
 import { KafkaProducerWrapper } from './kafka-producer-wrapper'
 import { PostgresRouter } from './postgres'
+import { createRedisIngestion, createRedisPool } from './redis'
 
 // `node-postgres` would return dates as plain JS Date objects, which would use the local timezone.
 // This converts all date fields to a proper luxon UTC DateTime and then casts them to a string
@@ -120,7 +121,7 @@ export async function createHub(
     status.info('👍', `Postgres Router ready`)
 
     status.info('🤔', `Connecting to Redis...`)
-    const redisPool = createRedisPool(serverConfig)
+    const redisPool = createRedisPool(serverConfig, () => createRedisIngestion(serverConfig))
     status.info('👍', `Redis ready`)
 
     status.info('🤔', `Connecting to object storage...`)

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -39,7 +39,7 @@ import { Celery } from './celery'
 import { DB } from './db'
 import { KafkaProducerWrapper } from './kafka-producer-wrapper'
 import { PostgresRouter } from './postgres'
-import { createRedisIngestion, createRedisPool } from './redis'
+import { createRedisPool } from './redis'
 
 // `node-postgres` would return dates as plain JS Date objects, which would use the local timezone.
 // This converts all date fields to a proper luxon UTC DateTime and then casts them to a string
@@ -121,7 +121,7 @@ export async function createHub(
     status.info('👍', `Postgres Router ready`)
 
     status.info('🤔', `Connecting to Redis...`)
-    const redisPool = createRedisPool(serverConfig, () => createRedisIngestion(serverConfig))
+    const redisPool = createRedisPool(serverConfig, 'ingestion')
     status.info('👍', `Redis ready`)
 
     status.info('🤔', `Connecting to object storage...`)

--- a/plugin-server/src/utils/db/redis.ts
+++ b/plugin-server/src/utils/db/redis.ts
@@ -1,0 +1,99 @@
+import * as Sentry from '@sentry/node'
+import { createPool } from 'generic-pool'
+import Redis, { RedisOptions } from 'ioredis'
+
+import { PluginsServerConfig, RedisPool } from '../../types'
+import { status } from '../../utils/status'
+import { killGracefully } from '../../utils/utils'
+
+/** Number of Redis error events until the server is killed gracefully. */
+const REDIS_ERROR_COUNTER_LIMIT = 10
+
+export async function createRedisPostHog(serverConfig: PluginsServerConfig): Promise<Redis.Redis> {
+    const params = serverConfig.POSTHOG_REDIS_HOST
+        ? {
+              host: serverConfig.POSTHOG_REDIS_HOST,
+              port: serverConfig.POSTHOG_REDIS_PORT,
+              password: serverConfig.POSTHOG_REDIS_PASSWORD,
+          }
+        : undefined
+
+    return createRedisClient(params ? params.host : serverConfig.REDIS_URL, params)
+}
+
+export async function createRedisIngestion(serverConfig: PluginsServerConfig): Promise<Redis.Redis> {
+    // TRICKY: We added the INGESTION_REDIS_HOST later to free up POSTHOG_REDIS_HOST to be clear that it is
+    // the shared django redis, hence we fallback to it if not set.
+
+    const params = serverConfig.INGESTION_REDIS_HOST
+        ? {
+              host: serverConfig.INGESTION_REDIS_HOST,
+              port: serverConfig.INGESTION_REDIS_PORT,
+              password: serverConfig.INGESTION_REDIS_PASSWORD,
+          }
+        : serverConfig.POSTHOG_REDIS_HOST
+        ? {
+              host: serverConfig.POSTHOG_REDIS_HOST,
+              port: serverConfig.POSTHOG_REDIS_PORT,
+              password: serverConfig.POSTHOG_REDIS_PASSWORD,
+          }
+        : undefined
+
+    return createRedisClient(params ? params.host : serverConfig.REDIS_URL, params)
+}
+
+export async function createRedisSessionRecording(serverConfig: PluginsServerConfig): Promise<Redis.Redis> {
+    const params = serverConfig.POSTHOG_SESSION_RECORDING_REDIS_HOST
+        ? {
+              host: serverConfig.POSTHOG_SESSION_RECORDING_REDIS_HOST,
+              port: serverConfig.POSTHOG_SESSION_RECORDING_REDIS_PORT,
+          }
+        : undefined
+
+    return createRedisClient(params ? params.host : serverConfig.REDIS_URL, params)
+}
+
+export async function createRedisClient(url: string, options?: RedisOptions): Promise<Redis.Redis> {
+    const redis = new Redis(url, {
+        ...options,
+        maxRetriesPerRequest: -1,
+    })
+    let errorCounter = 0
+    redis
+        .on('error', (error) => {
+            errorCounter++
+            Sentry.captureException(error)
+            if (errorCounter > REDIS_ERROR_COUNTER_LIMIT) {
+                status.error('😡', 'Redis error encountered! Enough of this, I quit!\n', error)
+                killGracefully()
+            } else {
+                status.error('🔴', 'Redis error encountered! Trying to reconnect...\n', error)
+            }
+        })
+        .on('ready', () => {
+            if (process.env.NODE_ENV !== 'test') {
+                status.info('✅', 'Connected to Redis!')
+            }
+        })
+    await redis.info()
+    return redis
+}
+
+export function createRedisPool(
+    options: Pick<PluginsServerConfig, 'REDIS_POOL_MIN_SIZE' | 'REDIS_POOL_MAX_SIZE'>,
+    create: () => Promise<Redis.Redis>
+): RedisPool {
+    return createPool<Redis.Redis>(
+        {
+            create,
+            destroy: async (client) => {
+                await client.quit()
+            },
+        },
+        {
+            min: options.REDIS_POOL_MIN_SIZE,
+            max: options.REDIS_POOL_MAX_SIZE,
+            autostart: true,
+        }
+    )
+}

--- a/plugin-server/src/utils/db/redis.ts
+++ b/plugin-server/src/utils/db/redis.ts
@@ -15,6 +15,7 @@ export async function createRedis(serverConfig: PluginsServerConfig, kind: REDIS
     let params: { host: string; port: number; password?: string } | undefined
     switch (kind) {
         case 'posthog':
+            // The shared redis instance used by django, celery etc.
             params = serverConfig.POSTHOG_REDIS_HOST
                 ? {
                       host: serverConfig.POSTHOG_REDIS_HOST,
@@ -23,6 +24,8 @@ export async function createRedis(serverConfig: PluginsServerConfig, kind: REDIS
                   }
                 : undefined
         case 'ingestion':
+            // The dedicated ingestion redis instance.
+
             // TRICKY: We added the INGESTION_REDIS_HOST later to free up POSTHOG_REDIS_HOST to be clear that it is
             // the shared django redis, hence we fallback to it if not set.
             params = serverConfig.INGESTION_REDIS_HOST
@@ -39,6 +42,7 @@ export async function createRedis(serverConfig: PluginsServerConfig, kind: REDIS
                   }
                 : undefined
         case 'session-recording':
+            // The dedicated session recording redis instance
             params = serverConfig.POSTHOG_SESSION_RECORDING_REDIS_HOST
                 ? {
                       host: serverConfig.POSTHOG_SESSION_RECORDING_REDIS_HOST,
@@ -47,6 +51,7 @@ export async function createRedis(serverConfig: PluginsServerConfig, kind: REDIS
                 : undefined
     }
 
+    // Fallback to REDIS_URL if not set (primarily for docker compose)
     return createRedisClient(params ? params.host : serverConfig.REDIS_URL, params)
 }
 

--- a/plugin-server/src/utils/pubsub.ts
+++ b/plugin-server/src/utils/pubsub.ts
@@ -3,7 +3,7 @@ import { Redis } from 'ioredis'
 
 import { PluginsServerConfig } from '../types'
 import { status } from './status'
-import { createRedis } from './utils'
+import { createRedisIngestion } from './utils'
 
 export type PubSubTask = ((message: string) => void) | ((message: string) => Promise<void>)
 
@@ -26,7 +26,7 @@ export class PubSub {
         if (this.redisSubscriber) {
             throw new Error('Started PubSub cannot be started again!')
         }
-        this.redisSubscriber = await createRedis(this.serverConfig)
+        this.redisSubscriber = await createRedisIngestion(this.serverConfig)
         const channels = Object.keys(this.taskMap)
         await this.redisSubscriber.subscribe(channels)
         this.redisSubscriber.on('message', (channel: string, message: string) => {
@@ -65,7 +65,7 @@ export class PubSub {
 
     public async publish(channel: string, message: string): Promise<void> {
         if (!this.redisPublisher) {
-            this.redisPublisher = createRedis(this.serverConfig)
+            this.redisPublisher = createRedisIngestion(this.serverConfig)
         }
 
         const redisPublisher = await this.redisPublisher

--- a/plugin-server/src/utils/utils.ts
+++ b/plugin-server/src/utils/utils.ts
@@ -1,8 +1,6 @@
 import { Properties } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
 import { randomBytes } from 'crypto'
-import { createPool } from 'generic-pool'
-import Redis, { RedisOptions } from 'ioredis'
 import { DateTime } from 'luxon'
 import { Pool } from 'pg'
 import { Readable } from 'stream'
@@ -14,15 +12,12 @@ import {
     Plugin,
     PluginConfigId,
     PluginsServerConfig,
-    RedisPool,
     TimestampFormat,
 } from '../types'
 import { status } from './status'
 
 /** Time until autoexit (due to error) gives up on graceful exit and kills the process right away. */
 const GRACEFUL_EXIT_PERIOD_SECONDS = 5
-/** Number of Redis error events until the server is killed gracefully. */
-const REDIS_ERROR_COUNTER_LIMIT = 10
 
 export class NoRowsUpdatedError extends Error {}
 
@@ -329,69 +324,6 @@ export async function tryTwice<T>(callback: () => Promise<T>, errorMessage: stri
         // try one more time
         return await callback()
     }
-}
-
-export async function createRedis(serverConfig: PluginsServerConfig): Promise<Redis.Redis> {
-    // TRICKY: We added dedicated Redis's for different scenarios. The POSTHOG_REDIS_HOST refers to the shared
-    // instance for the core django app but was previously used for the INGESTION_REDIS_HOST. We need both, hence we check
-    // for the INGESTION_REDIS_HOST first and then fall back to POSTHOG_REDIS_HOST and finally REDIS_URL (used by docker compose).
-    const params = serverConfig.INGESTION_REDIS_HOST
-        ? {
-              host: serverConfig.INGESTION_REDIS_HOST,
-              port: serverConfig.INGESTION_REDIS_PORT,
-              password: serverConfig.INGESTION_REDIS_PASSWORD,
-          }
-        : serverConfig.POSTHOG_REDIS_HOST
-        ? {
-              host: serverConfig.POSTHOG_REDIS_HOST,
-              port: serverConfig.POSTHOG_REDIS_PORT,
-              password: serverConfig.POSTHOG_REDIS_PASSWORD,
-          }
-        : undefined
-
-    return createRedisClient(params ? params.host : serverConfig.REDIS_URL, params)
-}
-
-export async function createRedisClient(url: string, options?: RedisOptions): Promise<Redis.Redis> {
-    const redis = new Redis(url, {
-        ...options,
-        maxRetriesPerRequest: -1,
-    })
-    let errorCounter = 0
-    redis
-        .on('error', (error) => {
-            errorCounter++
-            Sentry.captureException(error)
-            if (errorCounter > REDIS_ERROR_COUNTER_LIMIT) {
-                status.error('😡', 'Redis error encountered! Enough of this, I quit!\n', error)
-                killGracefully()
-            } else {
-                status.error('🔴', 'Redis error encountered! Trying to reconnect...\n', error)
-            }
-        })
-        .on('ready', () => {
-            if (process.env.NODE_ENV !== 'test') {
-                status.info('✅', 'Connected to Redis!')
-            }
-        })
-    await redis.info()
-    return redis
-}
-
-export function createRedisPool(serverConfig: PluginsServerConfig): RedisPool {
-    return createPool<Redis.Redis>(
-        {
-            create: () => createRedis(serverConfig),
-            destroy: async (client) => {
-                await client.quit()
-            },
-        },
-        {
-            min: serverConfig.REDIS_POOL_MIN_SIZE,
-            max: serverConfig.REDIS_POOL_MAX_SIZE,
-            autostart: true,
-        }
-    )
 }
 
 export function pluginDigest(plugin: Plugin | Plugin['id'], teamId?: number): string {


### PR DESCRIPTION
## Problem

The change to the redis hosts had some unintended consequences for session recording. This was easy to miss as we aren't explicit when setting up redis configs.

## Changes

* Moved redis stuff to its own utils
* Changed way we set up recording config (the overwriting of config values was more confusing than it was helpful)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

This is really hard to test without setting up multiple redises everywhere locally :(