### PR TITLE
fix: replay will send nonsense strings that should be captured

### DIFF
--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -163,8 +163,8 @@ pub fn router<
         .layer(axum::middleware::from_fn(track_metrics))
         .with_state(state);
 
-    // Don't install metrics unless asked to
-    // Installing a global recorder when capture is used as a library (during tests etc)
+    // Don't install metrics unless asked.
+    // Installing a global recorder when capture is used as a library (during tests etc.)
     // does not work well.
     if metrics {
         let recorder_handle = setup_metrics_recorder();

--- a/rust/capture/src/utils.rs
+++ b/rust/capture/src/utils.rs
@@ -36,3 +36,148 @@ pub fn uuid_v7() -> Uuid {
 
     encode_unix_timestamp_millis(now_millis, &bytes)
 }
+
+pub fn replace_invalid_hex_escape_strings(
+    json_str: String,
+) -> Result<String, std::string::FromUtf8Error> {
+    // Consume the String and get its bytes
+    let mut bytes = json_str.into_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        if bytes[i] == b'\\' && i + 1 < len && bytes[i + 1] == b'u' {
+            // Check if there are enough bytes for a Unicode escape sequence
+            if i + 6 <= len {
+                // Extract the four escape sequence bytes
+                let mut code_point_bytes: [u8; 4] =
+                    [bytes[i + 2], bytes[i + 3], bytes[i + 4], bytes[i + 5]];
+
+                // Convert the bytes to a string, then parse it into a u16 to check if it's a valid escape sequence
+                if let Ok(Ok(num)) =
+                    std::str::from_utf8(&code_point_bytes).map(|s| u16::from_str_radix(s, 16))
+                {
+                    if (0xD800..=0xDBFF).contains(&num) {
+                        // High surrogate without a following low surrogate
+                        if !is_next_low_surrogate(&bytes, i + 6) {
+                            // Replace with 'FFFD' (Unicode replacement character)
+                            code_point_bytes.copy_from_slice(b"FFFD");
+                        } else {
+                            // This is a high surrogate, and the next is a low one, so we should skip over both
+                            // without modification
+                            i += 12;
+                            continue;
+                        }
+                    } else if (0xDC00..=0xDFFF).contains(&num) {
+                        // Unpaired low surrogate - we know this, because if it had a preceding high surrogate,
+                        // we would have skipped over it in the previous iteration (above) - replace it
+                        code_point_bytes.copy_from_slice(b"FFFD");
+                    }
+                    // The unhandled else case is that this isn't part of a surrogate pair, so we don't need to do anything
+                } else {
+                    // if we couldn't parse those 4 bytes as a hex escape code, or couldn't go from that hex escape code to a u16, replace with 'FFFD'
+                    code_point_bytes.copy_from_slice(b"FFFD");
+                }
+                bytes[i + 2] = code_point_bytes[0];
+                bytes[i + 3] = code_point_bytes[1];
+                bytes[i + 4] = code_point_bytes[2];
+                bytes[i + 5] = code_point_bytes[3];
+                i += 6; // Move past the Unicode escape sequence
+                continue;
+            } else {
+                // Not enough bytes for a Unicode escape sequence, truncate the buffer to before the slash, then append the replacement characters
+                bytes.truncate(i);
+                bytes.extend_from_slice("\\uFFFD".as_bytes());
+                break; // We're done, we just replaced the last 4 bytes
+            }
+        }
+        i += 1;
+    }
+
+    // Convert bytes back to String
+    String::from_utf8(bytes)
+}
+
+fn is_next_low_surrogate(bytes: &[u8], start: usize) -> bool {
+    let len = bytes.len();
+    if start + 6 <= len && bytes[start] == b'\\' && bytes[start + 1] == b'u' {
+        let code_point_bytes = &bytes[start + 2..start + 6];
+        if let Ok(code_point_str) = std::str::from_utf8(code_point_bytes) {
+            if let Ok(num) = u16::from_str_radix(code_point_str, 16) {
+                return (0xDC00..=0xDFFF).contains(&num);
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    pub fn treplace_unpaired_high_surrogate() {
+        let json_str = r#"{"key":"\uD800"}"#.to_string();
+        let expected = r#"{"key":"\uFFFD"}"#.to_string();
+        assert_eq!(
+            super::replace_invalid_hex_escape_strings(json_str).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    pub fn replace_unpaired_low_surrogate() {
+        let json_str = r#"{"key":"\uDC00"}"#.to_string();
+        let expected = r#"{"key":"\uFFFD"}"#.to_string();
+        assert_eq!(
+            super::replace_invalid_hex_escape_strings(json_str).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    pub fn replace_two_unpaired_low_surrogates() {
+        let json_str = r#"{"key":"\uDC00\uDC00"}"#.to_string();
+        let expected = r#"{"key":"\uFFFD\uFFFD"}"#.to_string();
+        assert_eq!(
+            super::replace_invalid_hex_escape_strings(json_str).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    pub fn replace_two_unpaired_high_surrogates() {
+        let json_str = r#"{"key":"\uD800\uD800"}"#.to_string();
+        let expected = r#"{"key":"\uFFFD\uFFFD"}"#.to_string();
+        assert_eq!(
+            super::replace_invalid_hex_escape_strings(json_str).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    pub fn replace_out_of_order_low_high_surrogates() {
+        let json_str = r#"{"key":"\uDC00\uD800"}"#.to_string();
+        let expected = r#"{"key":"\uFFFD\uFFFD"}"#.to_string();
+        assert_eq!(
+            super::replace_invalid_hex_escape_strings(json_str).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    pub fn replace_unfinished_surrogate() {
+        let json_str = r#"{"key":"\uD800\uDC0"#.to_string();
+        let expected = r#"{"key":"\uFFFD\uFFFD"#.to_string();
+        assert_eq!(
+            super::replace_invalid_hex_escape_strings(json_str).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    pub fn test_from_bad_data() {
+        let string = include_str!("../tests/session_recording_utf_surrogate_console.json");
+        let replaced = super::replace_invalid_hex_escape_strings(string.to_string()).unwrap();
+        let _result: serde_json::Value = serde_json::from_str(&replaced).unwrap();
+    }
+}

--- a/rust/capture/src/utils.rs
+++ b/rust/capture/src/utils.rs
@@ -58,7 +58,9 @@ pub fn replace_invalid_hex_escape_strings(
         // First, figure out if this byte is the start of an escape sequence,
         // and if it is, set the flag and move forward
         if bytes[i] == b'\\' {
+            println!("found possible escape sequence at {}", i);
             escaped = !escaped; // Handle e.g. "\\u1234" as not an escape sequence
+            println!("escaped: {}", escaped);
             i += 1;
             continue;
         }
@@ -218,7 +220,8 @@ mod test {
     #[test]
     pub fn test_escaped_escaped_escaped_sequences() {
         let json_str = r#"{"key":"\\\uDC00"}"#.to_string();
-        let expected = r#"{"key":"\\\uDC00"}"#.to_string();
+        // Ordering is enter escape, find escaped \, enter escape, find invalid hex escape, replace with FFFD
+        let expected = r#"{"key":"\\\uFFFD"}"#.to_string();
         assert_eq!(
             super::replace_invalid_hex_escape_strings(json_str).unwrap(),
             expected

--- a/rust/capture/src/utils.rs
+++ b/rust/capture/src/utils.rs
@@ -207,8 +207,8 @@ mod test {
 
     #[test]
     pub fn test_escaped_escape_sequences() {
-        let json_str = r#"{"key":"\\u1234"}"#.to_string();
-        let expected = r#"{"key":"\\u1234"}"#.to_string();
+        let json_str = r#"{"key":"\\uDC00"}"#.to_string();
+        let expected = r#"{"key":"\\uDC00"}"#.to_string();
         assert_eq!(
             super::replace_invalid_hex_escape_strings(json_str).unwrap(),
             expected
@@ -217,8 +217,8 @@ mod test {
 
     #[test]
     pub fn test_escaped_escaped_escaped_sequences() {
-        let json_str = r#"{"key":"\\\u1234"}"#.to_string();
-        let expected = r#"{"key":"\\\u1234"}"#.to_string();
+        let json_str = r#"{"key":"\\\uDC00"}"#.to_string();
+        let expected = r#"{"key":"\\\uDC00"}"#.to_string();
         assert_eq!(
             super::replace_invalid_hex_escape_strings(json_str).unwrap(),
             expected

--- a/rust/capture/src/utils.rs
+++ b/rust/capture/src/utils.rs
@@ -58,9 +58,7 @@ pub fn replace_invalid_hex_escape_strings(
         // First, figure out if this byte is the start of an escape sequence,
         // and if it is, set the flag and move forward
         if bytes[i] == b'\\' {
-            println!("found possible escape sequence at {}", i);
             escaped = !escaped; // Handle e.g. "\\u1234" as not an escape sequence
-            println!("escaped: {}", escaped);
             i += 1;
             continue;
         }

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 /// Flexible endpoint that targets wide compatibility with the wide range of requests
-/// processed by posthog-events. 
+/// processed by posthog-events.
 ///
 /// TODO Because it must accommodate several shapes, it is inefficient in places. A v1 endpoint should be created, that only accepts the BatchedRequest payload shape.
 async fn handle_common(

--- a/rust/capture/src/v0_endpoint.rs
+++ b/rust/capture/src/v0_endpoint.rs
@@ -26,11 +26,9 @@ use crate::{
 };
 
 /// Flexible endpoint that targets wide compatibility with the wide range of requests
-/// currently processed by posthog-events (analytics events capture). Replay is out
-/// of scope and should be processed on a separate endpoint.
+/// processed by posthog-events. 
 ///
-/// Because it must accommodate several shapes, it is inefficient in places. A v1
-/// endpoint should be created, that only accepts the BatchedRequest payload shape.
+/// TODO Because it must accommodate several shapes, it is inefficient in places. A v1 endpoint should be created, that only accepts the BatchedRequest payload shape.
 async fn handle_common(
     state: &State<router::State>,
     InsecureClientIp(ip): &InsecureClientIp,

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -173,6 +173,7 @@ impl RawRequest {
                 report_dropped_events("event_too_big", 1);
                 return Err(CaptureError::EventTooBig);
             }
+            println!("{}", s);
             s
         };
 
@@ -541,5 +542,16 @@ mod tests {
         let json = serde_json::json!({"uuid": invalid_uuid});
         let result = test_deserialize(json);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_bad_utf() {
+        let the_bytes = include_bytes!("../tests/session_recording_utf_surrogate_console.json");
+        let the_payload = RawRequest::from_bytes(Bytes::from_static(the_bytes), 25*1024*1024);
+
+        if let Err(e) = &the_payload {
+            println!("{:?}", e);
+        }
+        assert!(the_payload.is_ok());
     }
 }

--- a/rust/capture/tests/recordings.rs
+++ b/rust/capture/tests/recordings.rs
@@ -9,6 +9,39 @@ use time::Duration;
 
 mod common;
 
+fn make_console_plugin_event(level: Option<&str>,
+                             message: Option<&str>,
+                             text: Option<&str>) -> Value {
+    let level = level.unwrap_or("warn");
+    let message = message.unwrap_or("Default message");
+    let text = text.unwrap_or("#text");
+
+    json!({
+        "windowId": "01924ccf-34f9-764e-b7f9-73c74eb7ed55",
+        "data": {
+          "payload": {
+            "level": level,
+            "payload": [
+                           format!("\"{}\"", message),
+              format!("\"{}\"", text)
+            ],
+            "trace": [
+              "q/< (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:19808)",
+              "q (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:20042)",
+              "z (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:21009)",
+              "a (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:34064)",
+              "e/this.emit (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:35299)",
+              "e/this.processMutations (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:33691)"
+            ]
+          },
+          "plugin": "rrweb/console@1"
+        },
+        "timestamp": 1727865503680_u64,
+        "type": 6,
+        "seen": 1185537021728171_u64
+      })
+}
+
 #[tokio::test]
 async fn it_captures_one_recording() -> Result<()> {
     setup_tracing();
@@ -28,7 +61,9 @@ async fn it_captures_one_recording() -> Result<()> {
         "properties": {
             "$session_id": session_id,
             "$window_id": window_id,
-            "$snapshot_data": [],
+            "$snapshot_data": [
+                make_console_plugin_event(Some("log"), Some("info"), Some("Hello, \0world! \u{1F600} \u{1F4A9} \\\\\\\",\"emoji_flag\":\"\u{d83c}...[truncated]")),
+            ],
         }
     });
     let res = server.capture_recording(event.to_string()).await;

--- a/rust/capture/tests/recordings.rs
+++ b/rust/capture/tests/recordings.rs
@@ -14,15 +14,25 @@ async fn it_captures_one_recording() -> Result<()> {
     setup_tracing();
     let token = random_string("token", 16);
     let distinct_id = random_string("id", 16);
-    // let session_id = random_string("id", 16);
-    // let window_id = random_string("id", 16);
+    let session_id = random_string("id", 16);
+    let window_id = random_string("id", 16);
 
     let main_topic = EphemeralTopic::new().await;
     let server = ServerHandle::for_recordings(&main_topic).await;
 
-    let file_contents = include_str!("../tests/session_recording_utf_surrogate_console.json");
-    let res = server.capture_recording(file_contents.to_string()).await;
-    assert_eq!(StatusCode::OK, res.status(), "{}", res.text().await?);
+    let event = json!({
+        "token": token,
+        "event": "testing",
+        "distinct_id": distinct_id,
+        "$session_id": session_id,
+        "properties": {
+            "$session_id": session_id,
+            "$window_id": window_id,
+            "$snapshot_data": [],
+        }
+    });
+    let res = server.capture_recording(event.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
 
     let event = main_topic.next_event()?;
     assert_json_include!(

--- a/rust/capture/tests/session_recording_utf_surrogate_console.json
+++ b/rust/capture/tests/session_recording_utf_surrogate_console.json
@@ -1,25 +1,28 @@
 {
-    "$snapshot_data": [
-        {
-            "windowId": "01924ccf-34f9-764e-b7f9-73c74eb7ed55",
-            "data": {
-                "payload": {
-                    "level": "warn",
-                    "payload": ["\\\\\\\",\\\\\\\"emoji_flag\\\\\\\":\\\\\\\"\ud83c...[truncated]", "\"test\""],
-                    "trace": [
-                        "q/< (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:19808)",
-                        "q (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:20042)",
-                        "z (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:21009)",
-                        "a (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:34064)",
-                        "e/this.emit (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:35299)",
-                        "e/this.processMutations (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:33691)"
-                    ]
+    "event": "$snapshot",
+    "properties": {
+        "$snapshot_data": [
+            {
+                "windowId": "01924ccf-34f9-764e-b7f9-73c74eb7ed55",
+                "data": {
+                    "payload": {
+                        "level": "warn",
+                        "payload": ["\\\\\\\",\\\\\\\"emoji_flag\\\\\\\":\\\\\\\"\ud83c...[truncated]", "\"test\""],
+                        "trace": [
+                            "q/< (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:19808)",
+                            "q (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:20042)",
+                            "z (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:21009)",
+                            "a (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:34064)",
+                            "e/this.emit (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:35299)",
+                            "e/this.processMutations (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:33691)"
+                        ]
+                    },
+                    "plugin": "rrweb/console@1"
                 },
-                "plugin": "rrweb/console@1"
-            },
-            "timestamp": 1727865503680,
-            "type": 6,
-            "seen": 1185537021728171
-        }
-    ]
+                "timestamp": 1727865503680,
+                "type": 6,
+                "seen": 1185537021728171
+            }
+        ]
+    }
 }

--- a/rust/capture/tests/session_recording_utf_surrogate_console.json
+++ b/rust/capture/tests/session_recording_utf_surrogate_console.json
@@ -1,0 +1,25 @@
+{
+    "$snapshot_data": [
+        {
+            "windowId": "01924ccf-34f9-764e-b7f9-73c74eb7ed55",
+            "data": {
+                "payload": {
+                    "level": "warn",
+                    "payload": ["\\\\\\\",\\\\\\\"emoji_flag\\\\\\\":\\\\\\\"\ud83c...[truncated]", "\"test\""],
+                    "trace": [
+                        "q/< (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:19808)",
+                        "q (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:20042)",
+                        "z (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:21009)",
+                        "a (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:34064)",
+                        "e/this.emit (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:35299)",
+                        "e/this.processMutations (https://internal-t.posthog.com/static/recorder.js?v=1.166.0:1:33691)"
+                    ]
+                },
+                "plugin": "rrweb/console@1"
+            },
+            "timestamp": 1727865503680,
+            "type": 6,
+            "seen": 1185537021728171
+        }
+    ]
+}


### PR DESCRIPTION
We know from experience that replay will send technically unrepresentable strings and that we still want to capture them

An example from prod is truncating strings from the console and getting only one half a surrogate pair

We need to be super tolerant of _some_ nonsense because replay is very sensitive to missing events

Rust is not super tolerant of nonsense so we have to de-fuckulate what we receive