### PR TITLE
fix: Rework plugin server redis configs

### DIFF
--- a/plugin-server/src/cdp/redis.ts
+++ b/plugin-server/src/cdp/redis.ts
@@ -5,9 +5,9 @@ import { createPool } from 'generic-pool'
 import { Pipeline, Redis } from 'ioredis'
 
 import { PluginsServerConfig } from '../types'
+import { createRedisClient } from '../utils/db/redis'
 import { timeoutGuard } from '../utils/db/utils'
 import { status } from '../utils/status'
-import { createRedisClient } from '../utils/utils'
 
 type WithCheckRateLimit<T> = {
     checkRateLimit: (key: string, now: number, cost: number, poolMax: number, fillRate: number, expiry: number) => T

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -209,19 +209,6 @@ export function getDefaultConfig(): PluginsServerConfig {
     }
 }
 
-export const sessionRecordingConsumerConfig = (config: PluginsServerConfig): PluginsServerConfig => {
-    // When running the blob consumer we override a bunch of settings to use the session recording ones if available
-    return {
-        ...config,
-        KAFKA_HOSTS: config.SESSION_RECORDING_KAFKA_HOSTS || config.KAFKA_HOSTS,
-        KAFKA_SECURITY_PROTOCOL: config.SESSION_RECORDING_KAFKA_SECURITY_PROTOCOL || config.KAFKA_SECURITY_PROTOCOL,
-        POSTHOG_REDIS_HOST:
-            config.POSTHOG_SESSION_RECORDING_REDIS_HOST || config.INGESTION_REDIS_HOST || config.POSTHOG_REDIS_HOST,
-        POSTHOG_REDIS_PORT:
-            config.POSTHOG_SESSION_RECORDING_REDIS_PORT || config.INGESTION_REDIS_PORT || config.POSTHOG_REDIS_PORT,
-    }
-}
-
 export function overrideWithEnv(
     config: PluginsServerConfig,
     env: Record<string, string | undefined> = process.env

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -67,7 +67,6 @@ export function getDefaultConfig(): PluginsServerConfig {
         KAFKA_PRODUCER_BATCH_SIZE: 8 * 1024 * 1024, // rdkafka default is 1MiB
         KAFKA_PRODUCER_QUEUE_BUFFERING_MAX_MESSAGES: 100_000, // rdkafka default is 100_000
         REDIS_URL: 'redis://127.0.0.1',
-        INGESTION_REDIS_PASSWORD: '',
         INGESTION_REDIS_HOST: '',
         INGESTION_REDIS_PORT: 6379,
         POSTHOG_REDIS_PASSWORD: '',

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/realtime-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/realtime-manager.ts
@@ -4,9 +4,9 @@ import { Redis } from 'ioredis'
 import { EventEmitter } from 'node:events'
 
 import { PluginsServerConfig, RedisPool } from '../../../../types'
+import { createRedis } from '../../../../utils/db/redis'
 import { timeoutGuard } from '../../../../utils/db/utils'
 import { status } from '../../../../utils/status'
-import { createRedis } from '../../../../utils/utils'
 
 const Keys = {
     snapshots(prefix: string, teamId: number, suffix: string): string {
@@ -45,7 +45,7 @@ export class RealtimeManager extends EventEmitter {
     }
 
     public async subscribe(): Promise<void> {
-        this.pubsubRedis = await createRedis(this.serverConfig)
+        this.pubsubRedis = await createRedis(this.serverConfig, 'session-recording')
         await this.pubsubRedis.subscribe(Keys.realtimeSubscriptions(this.serverConfig.SESSION_RECORDING_REDIS_PREFIX))
 
         this.pubsubRedis.on('message', (channel, message) => {

--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -5,7 +5,7 @@ import { mkdirSync, rmSync } from 'node:fs'
 import { CODES, features, KafkaConsumer, librdkafkaVersion, Message, TopicPartition } from 'node-rdkafka'
 import { Counter, Gauge, Histogram, Summary } from 'prom-client'
 
-import { buildIntegerMatcher, sessionRecordingConsumerConfig } from '../../../config/config'
+import { buildIntegerMatcher } from '../../../config/config'
 import {
     KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS,
     KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_OVERFLOW,
@@ -17,8 +17,8 @@ import { PluginServerService, PluginsServerConfig, RedisPool, TeamId, ValueMatch
 import { BackgroundRefresher } from '../../../utils/background-refresher'
 import { KafkaProducerWrapper } from '../../../utils/db/kafka-producer-wrapper'
 import { PostgresRouter } from '../../../utils/db/postgres'
+import { createRedisPool } from '../../../utils/db/redis'
 import { status } from '../../../utils/status'
-import { createRedisPool } from '../../../utils/utils'
 import { fetchTeamTokensWithRecordings } from '../../../worker/ingestion/team-manager'
 import { ObjectStorage } from '../../services/object_storage'
 import { runInstrumentedFunction } from '../../utils'
@@ -143,7 +143,6 @@ export class SessionRecordingIngester {
     partitionMetrics: Record<number, PartitionMetrics> = {}
     teamsRefresher: BackgroundRefresher<Record<string, TeamIDWithConfig>>
     latestOffsetsRefresher: BackgroundRefresher<Record<number, number | undefined>>
-    config: PluginsServerConfig
     topic: string
     consumerGroupId: string
     totalNumPartitions = 0
@@ -157,32 +156,38 @@ export class SessionRecordingIngester {
     private sharedClusterProducerWrapper: KafkaProducerWrapper | undefined = undefined
     private isDebugLoggingEnabled: ValueMatcher<number>
 
+    private sessionRecordingKafkaConfig = (): PluginsServerConfig => {
+        // TRICKY: We re-use the kafka helpers which assume KAFKA_HOSTS hence we overwrite it if set
+        return {
+            ...this.config,
+            KAFKA_HOSTS: this.config.SESSION_RECORDING_KAFKA_HOSTS || this.config.KAFKA_HOSTS,
+            KAFKA_SECURITY_PROTOCOL:
+                this.config.SESSION_RECORDING_KAFKA_SECURITY_PROTOCOL || this.config.KAFKA_SECURITY_PROTOCOL,
+        }
+    }
+
     constructor(
-        private globalServerConfig: PluginsServerConfig,
+        private config: PluginsServerConfig,
         private postgres: PostgresRouter,
         private objectStorage: ObjectStorage,
         private consumeOverflow: boolean,
         captureRedis: Redis | undefined
     ) {
-        this.isDebugLoggingEnabled = buildIntegerMatcher(globalServerConfig.SESSION_RECORDING_DEBUG_PARTITION, true)
+        this.isDebugLoggingEnabled = buildIntegerMatcher(config.SESSION_RECORDING_DEBUG_PARTITION, true)
 
         this.topic = consumeOverflow
             ? KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_OVERFLOW
             : KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS
         this.consumerGroupId = this.consumeOverflow ? KAFKA_CONSUMER_GROUP_ID_OVERFLOW : KAFKA_CONSUMER_GROUP_ID
 
-        // NOTE: globalServerConfig contains the default pluginServer values, typically not pointing at dedicated resources like kafka or redis
-        // We still connect to some of the non-dedicated resources such as postgres or the Replay events kafka.
-        this.config = sessionRecordingConsumerConfig(globalServerConfig)
-        this.redisPool = createRedisPool(this.config)
-
+        this.redisPool = createRedisPool(this.config, 'session-recording')
         this.realtimeManager = new RealtimeManager(this.redisPool, this.config)
 
-        if (globalServerConfig.SESSION_RECORDING_OVERFLOW_ENABLED && captureRedis && !consumeOverflow) {
+        if (config.SESSION_RECORDING_OVERFLOW_ENABLED && captureRedis && !consumeOverflow) {
             this.overflowDetection = new OverflowManager(
-                globalServerConfig.SESSION_RECORDING_OVERFLOW_BUCKET_CAPACITY,
-                globalServerConfig.SESSION_RECORDING_OVERFLOW_BUCKET_REPLENISH_RATE,
-                globalServerConfig.SESSION_RECORDING_OVERFLOW_MIN_PER_BATCH,
+                config.SESSION_RECORDING_OVERFLOW_BUCKET_CAPACITY,
+                config.SESSION_RECORDING_OVERFLOW_BUCKET_REPLENISH_RATE,
+                config.SESSION_RECORDING_OVERFLOW_MIN_PER_BATCH,
                 24 * 3600, // One day,
                 CAPTURE_OVERFLOW_REDIS_KEY,
                 captureRedis
@@ -191,7 +196,10 @@ export class SessionRecordingIngester {
 
         // We create a hash of the cluster to use as a unique identifier for the high-water marks
         // This enables us to swap clusters without having to worry about resetting the high-water marks
-        const kafkaClusterIdentifier = crypto.createHash('md5').update(this.config.KAFKA_HOSTS).digest('hex')
+        const kafkaClusterIdentifier = crypto
+            .createHash('md5')
+            .update(this.sessionRecordingKafkaConfig().KAFKA_HOSTS)
+            .digest('hex')
 
         this.sessionHighWaterMarker = new OffsetHighWaterMarker(
             this.redisPool,
@@ -463,9 +471,9 @@ export class SessionRecordingIngester {
         // Load teams into memory
         await this.teamsRefresher.refresh()
 
-        // NOTE: This is the only place where we need to use the shared server config
-        const globalConnectionConfig = createRdConnectionConfigFromEnvVars(this.globalServerConfig)
-        const globalProducerConfig = createRdProducerConfigFromEnvVars(this.globalServerConfig)
+        // NOTE: We use the standard config as we connect to the analytics kafka for producing
+        const globalConnectionConfig = createRdConnectionConfigFromEnvVars(this.config)
+        const globalProducerConfig = createRdProducerConfigFromEnvVars(this.config)
 
         this.sharedClusterProducerWrapper = new KafkaProducerWrapper(
             await createKafkaProducer(globalConnectionConfig, globalProducerConfig)
@@ -489,7 +497,7 @@ export class SessionRecordingIngester {
         // Create a node-rdkafka consumer that fetches batches of messages, runs
         // eachBatchWithContext, then commits offsets for the batch.
         // the batch consumer reads from the session replay kafka cluster
-        const replayClusterConnectionConfig = createRdConnectionConfigFromEnvVars(this.config)
+        const replayClusterConnectionConfig = createRdConnectionConfigFromEnvVars(this.sessionRecordingKafkaConfig())
 
         this.batchConsumer = await startBatchConsumer({
             connectionConfig: replayClusterConnectionConfig,

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -16,15 +16,16 @@ import {
     CdpFunctionCallbackConsumer,
     CdpProcessedEventsConsumer,
 } from '../cdp/cdp-consumers'
-import { defaultConfig, sessionRecordingConsumerConfig } from '../config/config'
+import { defaultConfig } from '../config/config'
 import { Hub, PluginServerCapabilities, PluginServerService, PluginsServerConfig } from '../types'
 import { closeHub, createHub, createKafkaClient, createKafkaProducerWrapper } from '../utils/db/hub'
 import { PostgresRouter } from '../utils/db/postgres'
+import { createRedisClient } from '../utils/db/redis'
 import { cancelAllScheduledJobs } from '../utils/node-schedule'
 import { posthog } from '../utils/posthog'
 import { PubSub } from '../utils/pubsub'
 import { status } from '../utils/status'
-import { createRedisClient, delay } from '../utils/utils'
+import { delay } from '../utils/utils'
 import { ActionManager } from '../worker/ingestion/action-manager'
 import { ActionMatcher } from '../worker/ingestion/action-matcher'
 import { AppMetrics } from '../worker/ingestion/app-metrics'
@@ -408,9 +409,8 @@ export async function startPluginsServer(
 
         if (capabilities.sessionRecordingBlobIngestion) {
             const hub = serverInstance.hub
-            const recordingConsumerConfig = sessionRecordingConsumerConfig(serverConfig)
             const postgres = hub?.postgres ?? new PostgresRouter(serverConfig)
-            const s3 = hub?.objectStorage ?? getObjectStorage(recordingConsumerConfig)
+            const s3 = hub?.objectStorage ?? getObjectStorage(serverConfig)
 
             if (!s3) {
                 throw new Error("Can't start session recording blob ingestion without object storage")
@@ -429,9 +429,8 @@ export async function startPluginsServer(
 
         if (capabilities.sessionRecordingBlobOverflowIngestion) {
             const hub = serverInstance.hub
-            const recordingConsumerConfig = sessionRecordingConsumerConfig(serverConfig)
             const postgres = hub?.postgres ?? new PostgresRouter(serverConfig)
-            const s3 = hub?.objectStorage ?? getObjectStorage(recordingConsumerConfig)
+            const s3 = hub?.objectStorage ?? getObjectStorage(serverConfig)
 
             if (!s3) {
                 throw new Error("Can't start session recording blob ingestion without object storage")

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -156,7 +156,6 @@ export interface PluginsServerConfig extends CdpConfig {
     // Redis url pretty much only used locally / self hosted
     REDIS_URL: string
     // Redis params for the ingestion services
-    INGESTION_REDIS_PASSWORD: string
     INGESTION_REDIS_HOST: string
     INGESTION_REDIS_PORT: number
     // Redis params for the core posthog (django+celery) services

--- a/plugin-server/src/utils/db/celery.ts
+++ b/plugin-server/src/utils/db/celery.ts
@@ -1,10 +1,9 @@
 import { CacheOptions } from '@posthog/plugin-scaffold'
-import { createPool, Pool as GenericPool } from 'generic-pool'
-import Redis from 'ioredis'
 
-import { PluginsServerConfig } from '../../types'
+import { PluginsServerConfig, RedisPool } from '../../types'
 import { instrumentQuery } from '../metrics'
-import { createRedisClient, UUIDT } from '../utils'
+import { UUIDT } from '../utils'
+import { createRedisPool } from './redis'
 import { timeoutGuard } from './utils'
 
 const CELERY_DEFAULT_QUEUE = 'celery'
@@ -15,29 +14,10 @@ const CELERY_DEFAULT_QUEUE = 'celery'
  * such as a shared message bus or an internal HTTP API.
  */
 export class Celery {
-    private redisPool: GenericPool<Redis.Redis>
+    private redisPool: RedisPool
 
     constructor(config: PluginsServerConfig) {
-        // NOTE: We define a redis pool explicitly using the POSTHOG_REDIS_HOST as celery
-        // only works if it is talking to the same redis instance as the django "posthog" app
-        this.redisPool = createPool<Redis.Redis>(
-            {
-                create: async () => {
-                    return await createRedisClient(config.POSTHOG_REDIS_HOST, {
-                        port: config.POSTHOG_REDIS_PORT,
-                        password: config.POSTHOG_REDIS_PASSWORD,
-                    })
-                },
-                destroy: async (client) => {
-                    await client.quit()
-                },
-            },
-            {
-                min: config.REDIS_POOL_MIN_SIZE,
-                max: config.REDIS_POOL_MAX_SIZE,
-                autostart: true,
-            }
-        )
+        this.redisPool = createRedisPool(config, 'posthog')
     }
 
     private redisLPush(key: string, value: unknown, options: CacheOptions = {}): Promise<number> {

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -32,13 +32,14 @@ import { TeamManager } from '../../worker/ingestion/team-manager'
 import { RustyHook } from '../../worker/rusty-hook'
 import { isTestEnv } from '../env-utils'
 import { status } from '../status'
-import { createRedisPool, UUIDT } from '../utils'
+import { UUIDT } from '../utils'
 import { PluginsApiKeyManager } from './../../worker/vm/extensions/helpers/api-key-manager'
 import { RootAccessManager } from './../../worker/vm/extensions/helpers/root-acess-manager'
 import { Celery } from './celery'
 import { DB } from './db'
 import { KafkaProducerWrapper } from './kafka-producer-wrapper'
 import { PostgresRouter } from './postgres'
+import { createRedisPool } from './redis'
 
 // `node-postgres` would return dates as plain JS Date objects, which would use the local timezone.
 // This converts all date fields to a proper luxon UTC DateTime and then casts them to a string
@@ -120,7 +121,7 @@ export async function createHub(
     status.info('👍', `Postgres Router ready`)
 
     status.info('🤔', `Connecting to Redis...`)
-    const redisPool = createRedisPool(serverConfig)
+    const redisPool = createRedisPool(serverConfig, 'ingestion')
     status.info('👍', `Redis ready`)
 
     status.info('🤔', `Connecting to object storage...`)

--- a/plugin-server/src/utils/db/redis.ts
+++ b/plugin-server/src/utils/db/redis.ts
@@ -1,0 +1,98 @@
+import * as Sentry from '@sentry/node'
+import { createPool } from 'generic-pool'
+import Redis, { RedisOptions } from 'ioredis'
+
+import { PluginsServerConfig, RedisPool } from '../../types'
+import { status } from '../../utils/status'
+import { killGracefully } from '../../utils/utils'
+
+/** Number of Redis error events until the server is killed gracefully. */
+const REDIS_ERROR_COUNTER_LIMIT = 10
+
+export type REDIS_SERVER_KIND = 'posthog' | 'ingestion' | 'session-recording'
+
+export async function createRedis(serverConfig: PluginsServerConfig, kind: REDIS_SERVER_KIND): Promise<Redis.Redis> {
+    let params: { host: string; port: number; password?: string } | undefined
+    switch (kind) {
+        case 'posthog':
+            // The shared redis instance used by django, celery etc.
+            params = serverConfig.POSTHOG_REDIS_HOST
+                ? {
+                      host: serverConfig.POSTHOG_REDIS_HOST,
+                      port: serverConfig.POSTHOG_REDIS_PORT,
+                      password: serverConfig.POSTHOG_REDIS_PASSWORD,
+                  }
+                : undefined
+        case 'ingestion':
+            // The dedicated ingestion redis instance.
+
+            // TRICKY: We added the INGESTION_REDIS_HOST later to free up POSTHOG_REDIS_HOST to be clear that it is
+            // the shared django redis, hence we fallback to it if not set.
+            params = serverConfig.INGESTION_REDIS_HOST
+                ? {
+                      host: serverConfig.INGESTION_REDIS_HOST,
+                      port: serverConfig.INGESTION_REDIS_PORT,
+                      password: serverConfig.INGESTION_REDIS_PASSWORD,
+                  }
+                : serverConfig.POSTHOG_REDIS_HOST
+                ? {
+                      host: serverConfig.POSTHOG_REDIS_HOST,
+                      port: serverConfig.POSTHOG_REDIS_PORT,
+                      password: serverConfig.POSTHOG_REDIS_PASSWORD,
+                  }
+                : undefined
+        case 'session-recording':
+            // The dedicated session recording redis instance
+            params = serverConfig.POSTHOG_SESSION_RECORDING_REDIS_HOST
+                ? {
+                      host: serverConfig.POSTHOG_SESSION_RECORDING_REDIS_HOST,
+                      port: serverConfig.POSTHOG_SESSION_RECORDING_REDIS_PORT ?? 6379,
+                  }
+                : undefined
+    }
+
+    // Fallback to REDIS_URL if not set (primarily for docker compose)
+    return createRedisClient(params ? params.host : serverConfig.REDIS_URL, params)
+}
+
+export async function createRedisClient(url: string, options?: RedisOptions): Promise<Redis.Redis> {
+    const redis = new Redis(url, {
+        ...options,
+        maxRetriesPerRequest: -1,
+    })
+    let errorCounter = 0
+    redis
+        .on('error', (error) => {
+            errorCounter++
+            Sentry.captureException(error)
+            if (errorCounter > REDIS_ERROR_COUNTER_LIMIT) {
+                status.error('😡', 'Redis error encountered! Enough of this, I quit!\n', error)
+                killGracefully()
+            } else {
+                status.error('🔴', 'Redis error encountered! Trying to reconnect...\n', error)
+            }
+        })
+        .on('ready', () => {
+            if (process.env.NODE_ENV !== 'test') {
+                status.info('✅', 'Connected to Redis!')
+            }
+        })
+    await redis.info()
+    return redis
+}
+
+export function createRedisPool(options: PluginsServerConfig, kind: REDIS_SERVER_KIND): RedisPool {
+    return createPool<Redis.Redis>(
+        {
+            create: () => createRedis(options, kind),
+            destroy: async (client) => {
+                await client.quit()
+            },
+        },
+        {
+            min: options.REDIS_POOL_MIN_SIZE,
+            max: options.REDIS_POOL_MAX_SIZE,
+            autostart: true,
+        }
+    )
+}

--- a/plugin-server/src/utils/pubsub.ts
+++ b/plugin-server/src/utils/pubsub.ts
@@ -2,8 +2,8 @@ import { captureException } from '@sentry/node'
 import { Redis } from 'ioredis'
 
 import { PluginsServerConfig } from '../types'
+import { createRedis } from './db/redis'
 import { status } from './status'
-import { createRedis } from './utils'
 
 export type PubSubTask = ((message: string) => void) | ((message: string) => Promise<void>)
 
@@ -26,7 +26,7 @@ export class PubSub {
         if (this.redisSubscriber) {
             throw new Error('Started PubSub cannot be started again!')
         }
-        this.redisSubscriber = await createRedis(this.serverConfig)
+        this.redisSubscriber = await createRedis(this.serverConfig, 'ingestion')
         const channels = Object.keys(this.taskMap)
         await this.redisSubscriber.subscribe(channels)
         this.redisSubscriber.on('message', (channel: string, message: string) => {
@@ -65,7 +65,7 @@ export class PubSub {
 
     public async publish(channel: string, message: string): Promise<void> {
         if (!this.redisPublisher) {
-            this.redisPublisher = createRedis(this.serverConfig)
+            this.redisPublisher = createRedis(this.serverConfig, 'ingestion')
         }
 
         const redisPublisher = await this.redisPublisher

--- a/plugin-server/src/utils/utils.ts
+++ b/plugin-server/src/utils/utils.ts
@@ -1,8 +1,6 @@
 import { Properties } from '@posthog/plugin-scaffold'
 import * as Sentry from '@sentry/node'
 import { randomBytes } from 'crypto'
-import { createPool } from 'generic-pool'
-import Redis, { RedisOptions } from 'ioredis'
 import { DateTime } from 'luxon'
 import { Pool } from 'pg'
 import { Readable } from 'stream'
@@ -14,15 +12,12 @@ import {
     Plugin,
     PluginConfigId,
     PluginsServerConfig,
-    RedisPool,
     TimestampFormat,
 } from '../types'
 import { status } from './status'
 
 /** Time until autoexit (due to error) gives up on graceful exit and kills the process right away. */
 const GRACEFUL_EXIT_PERIOD_SECONDS = 5
-/** Number of Redis error events until the server is killed gracefully. */
-const REDIS_ERROR_COUNTER_LIMIT = 10
 
 export class NoRowsUpdatedError extends Error {}
 
@@ -329,69 +324,6 @@ export async function tryTwice<T>(callback: () => Promise<T>, errorMessage: stri
         // try one more time
         return await callback()
     }
-}
-
-export async function createRedis(serverConfig: PluginsServerConfig): Promise<Redis.Redis> {
-    // TRICKY: We added dedicated Redis's for different scenarios. The POSTHOG_REDIS_HOST refers to the shared
-    // instance for the core django app but was previously used for the INGESTION_REDIS_HOST. We need both, hence we check
-    // for the INGESTION_REDIS_HOST first and then fall back to POSTHOG_REDIS_HOST and finally REDIS_URL (used by docker compose).
-    const params = serverConfig.INGESTION_REDIS_HOST
-        ? {
-              host: serverConfig.INGESTION_REDIS_HOST,
-              port: serverConfig.INGESTION_REDIS_PORT,
-              password: serverConfig.INGESTION_REDIS_PASSWORD,
-          }
-        : serverConfig.POSTHOG_REDIS_HOST
-        ? {
-              host: serverConfig.POSTHOG_REDIS_HOST,
-              port: serverConfig.POSTHOG_REDIS_PORT,
-              password: serverConfig.POSTHOG_REDIS_PASSWORD,
-          }
-        : undefined
-
-    return createRedisClient(params ? params.host : serverConfig.REDIS_URL, params)
-}
-
-export async function createRedisClient(url: string, options?: RedisOptions): Promise<Redis.Redis> {
-    const redis = new Redis(url, {
-        ...options,
-        maxRetriesPerRequest: -1,
-    })
-    let errorCounter = 0
-    redis
-        .on('error', (error) => {
-            errorCounter++
-            Sentry.captureException(error)
-            if (errorCounter > REDIS_ERROR_COUNTER_LIMIT) {
-                status.error('😡', 'Redis error encountered! Enough of this, I quit!\n', error)
-                killGracefully()
-            } else {
-                status.error('🔴', 'Redis error encountered! Trying to reconnect...\n', error)
-            }
-        })
-        .on('ready', () => {
-            if (process.env.NODE_ENV !== 'test') {
-                status.info('✅', 'Connected to Redis!')
-            }
-        })
-    await redis.info()
-    return redis
-}
-
-export function createRedisPool(serverConfig: PluginsServerConfig): RedisPool {
-    return createPool<Redis.Redis>(
-        {
-            create: () => createRedis(serverConfig),
-            destroy: async (client) => {
-                await client.quit()
-            },
-        },
-        {
-            min: serverConfig.REDIS_POOL_MIN_SIZE,
-            max: serverConfig.REDIS_POOL_MAX_SIZE,
-            autostart: true,
-        }
-    )
 }
 
 export function pluginDigest(plugin: Plugin | Plugin['id'], teamId?: number): string {

--- a/plugin-server/tests/utils/db/redis.test.ts
+++ b/plugin-server/tests/utils/db/redis.test.ts
@@ -1,0 +1,83 @@
+import { defaultConfig } from '../../../src/config/config'
+import { getRedisConnectionOptions } from '../../../src/utils/db/redis'
+
+describe('Redis', () => {
+    describe('getRedisConnectionOptions', () => {
+        const config = { ...defaultConfig }
+
+        beforeEach(() => {
+            config.REDIS_URL = 'redis://localhost:6379'
+            config.POSTHOG_REDIS_HOST = 'posthog-redis'
+            config.POSTHOG_REDIS_PORT = 6379
+            config.POSTHOG_REDIS_PASSWORD = 'posthog-password'
+            config.INGESTION_REDIS_HOST = 'ingestion-redis'
+            config.INGESTION_REDIS_PORT = 6479
+            config.POSTHOG_SESSION_RECORDING_REDIS_HOST = 'session-recording-redis'
+            config.POSTHOG_SESSION_RECORDING_REDIS_PORT = 6579
+        })
+
+        it('should respond with unique options if all values set', () => {
+            expect(getRedisConnectionOptions(config, 'posthog')).toMatchInlineSnapshot(`
+                Object {
+                  "options": Object {
+                    "password": "posthog-password",
+                    "port": 6379,
+                  },
+                  "url": "posthog-redis",
+                }
+            `)
+            expect(getRedisConnectionOptions(config, 'ingestion')).toMatchInlineSnapshot(`
+                Object {
+                  "options": Object {
+                    "port": 6479,
+                  },
+                  "url": "ingestion-redis",
+                }
+            `)
+            expect(getRedisConnectionOptions(config, 'session-recording')).toMatchInlineSnapshot(`
+                Object {
+                  "options": Object {
+                    "port": 6579,
+                  },
+                  "url": "session-recording-redis",
+                }
+            `)
+        })
+
+        it('should respond with REDIS_HOST if no options set', () => {
+            config.POSTHOG_REDIS_HOST = ''
+            config.INGESTION_REDIS_HOST = ''
+            config.POSTHOG_SESSION_RECORDING_REDIS_HOST = ''
+
+            expect(getRedisConnectionOptions(config, 'posthog')).toMatchInlineSnapshot(`
+                Object {
+                  "url": "redis://localhost:6379",
+                }
+            `)
+            expect(getRedisConnectionOptions(config, 'ingestion')).toMatchInlineSnapshot(`
+                Object {
+                  "url": "redis://localhost:6379",
+                }
+            `)
+            expect(getRedisConnectionOptions(config, 'session-recording')).toMatchInlineSnapshot(`
+                Object {
+                  "url": "redis://localhost:6379",
+                }
+            `)
+        })
+
+        it('should use the POSTHOG_REDIS_HOST for ingestion if INGESTION_REDIS_HOST is not set', () => {
+            config.INGESTION_REDIS_HOST = ''
+
+            expect(getRedisConnectionOptions(config, 'ingestion')).toMatchInlineSnapshot(`
+                Object {
+                  "options": Object {
+                    "password": "posthog-password",
+                    "port": 6379,
+                  },
+                  "url": "posthog-redis",
+                }
+            `)
+        })
+    })
+})


### PR DESCRIPTION
## Problem

Second attempt at https://github.com/PostHog/posthog/pull/25328

## Changes

- [x] The issue before was in the cdp that it failed to start up due to pubsub issues. It looks like missing env vars meant it fell back to the REDIS_URL but thats for sure not what we want. Need to debug to figure out why before merging
  - fixed it - the redis picker was missing breaks in the switch statement. Reworked it and added tests.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
