### PR TITLE
chore: warn on switch with fall through

### DIFF
--- a/plugin-server/.eslintrc.js
+++ b/plugin-server/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
         '@typescript-eslint/no-floating-promises': 'error',
         '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: false }],
         curly: 'error',
+        'no-fallthrough': 'warn',
     },
     overrides: [
         {


### PR DESCRIPTION
see #25342 

humans are bad at reading diffs... or at least badderer than eslint

let's warn when someone uses switch without break statements because it is rarely what they want

<img width="645" alt="Screenshot 2024-10-03 at 09 12 27" src="https://github.com/user-attachments/assets/cc3d828a-850f-4606-b011-6164a0433c5a">
