### PR TITLE
feat: copy UDFs when user_scripts folder is updated

### DIFF
--- a/.github/workflows/copy-clickhouse-udfs.yml
+++ b/.github/workflows/copy-clickhouse-udfs.yml
@@ -1,9 +1,11 @@
 name: Trigger UDFs Workflow
 
 on:
-  pull_request:
-    # paths:
-    #   - 'posthog/user_scripts/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'posthog/user_scripts/**'
 
 jobs:
   trigger_udfs_workflow:

--- a/.github/workflows/copy-clickhouse-udfs.yml
+++ b/.github/workflows/copy-clickhouse-udfs.yml
@@ -13,7 +13,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: .github/workflows/clickhouse-udfs.yml
-          repo: posthog/cloud-infra
+          repo: posthog/posthog-cloud-infra
           token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
           ref: refs/heads/main
 

--- a/.github/workflows/copy-clickhouse-udfs.yml
+++ b/.github/workflows/copy-clickhouse-udfs.yml
@@ -14,6 +14,6 @@ jobs:
         with:
           workflow: .github/workflows/clickhouse-udfs.yml
           repo: posthog/cloud-infra
-          # token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
           ref: refs/heads/main
 

--- a/.github/workflows/copy-clickhouse-udfs.yml
+++ b/.github/workflows/copy-clickhouse-udfs.yml
@@ -14,6 +14,6 @@ jobs:
         with:
           workflow: .github/workflows/clickhouse-udfs.yml
           repo: posthog/cloud-infra
-          token: ${{ secrets.PAT_TOKEN }}
+          # token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }}
           ref: refs/heads/main
 

--- a/.github/workflows/copy-clickhouse-udfs.yml
+++ b/.github/workflows/copy-clickhouse-udfs.yml
@@ -1,0 +1,19 @@
+name: Trigger UDFs Workflow
+
+on:
+  pull_request:
+    # paths:
+    #   - 'posthog/user_scripts/**'
+
+jobs:
+  trigger_udfs_workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger UDFs Workflow
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: .github/workflows/clickhouse-udfs.yml
+          repo: posthog/cloud-infra
+          token: ${{ secrets.PAT_TOKEN }}
+          ref: refs/heads/main
+


### PR DESCRIPTION
## Problem

Every time a UDFs code changes, we need to trigger the workflow manually.

## Changes

When the `user_scripts` folder is updated, automatically trigger the workflow..

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
