### PR TITLE
chore: make the timestamp field optional (looks like it's coming in with a variety of types)

### DIFF
--- a/livestream/filter.go
+++ b/livestream/filter.go
@@ -63,7 +63,7 @@ func convertToResponseGeoEvent(event PostHogEvent) *ResponseGeoEvent {
 func convertToResponsePostHogEvent(event PostHogEvent, teamId int) *ResponsePostHogEvent {
 	return &ResponsePostHogEvent{
 		Uuid:       event.Uuid,
-		Timestamp:  *event.Timestamp,
+		Timestamp:  event.Timestamp.Value,
 		DistinctId: event.DistinctId,
 		PersonId:   uuidFromDistinctId(teamId, event.DistinctId),
 		Event:      event.Event,

--- a/livestream/filter.go
+++ b/livestream/filter.go
@@ -63,7 +63,7 @@ func convertToResponseGeoEvent(event PostHogEvent) *ResponseGeoEvent {
 func convertToResponsePostHogEvent(event PostHogEvent, teamId int) *ResponsePostHogEvent {
 	return &ResponsePostHogEvent{
 		Uuid:       event.Uuid,
-		Timestamp:  event.Timestamp,
+		Timestamp:  *event.Timestamp,
 		DistinctId: event.DistinctId,
 		PersonId:   uuidFromDistinctId(teamId, event.DistinctId),
 		Event:      event.Event,

--- a/livestream/filter_test.go
+++ b/livestream/filter_test.go
@@ -67,7 +67,7 @@ func TestConvertToResponsePostHogEvent(t *testing.T) {
 	timestamp := "2023-01-01T00:00:00Z"
 	event := PostHogEvent{
 		Uuid:       "123",
-		Timestamp:  &timestamp,
+		Timestamp:  Timestamp{Value: timestamp},
 		DistinctId: "user1",
 		Event:      "pageview",
 		Properties: map[string]interface{}{"url": "https://example.com"},
@@ -112,7 +112,7 @@ func TestFilterRun(t *testing.T) {
 	timestamp := "2023-01-01T00:00:00Z"
 	event := PostHogEvent{
 		Uuid:       "123",
-		Timestamp:  &timestamp,
+		Timestamp:  Timestamp{Value: timestamp},
 		DistinctId: "user1",
 		Token:      "token1",
 		Event:      "pageview",

--- a/livestream/filter_test.go
+++ b/livestream/filter_test.go
@@ -64,9 +64,10 @@ func TestConvertToResponseGeoEvent(t *testing.T) {
 }
 
 func TestConvertToResponsePostHogEvent(t *testing.T) {
+	timestamp := "2023-01-01T00:00:00Z"
 	event := PostHogEvent{
 		Uuid:       "123",
-		Timestamp:  "2023-01-01T00:00:00Z",
+		Timestamp:  &timestamp,
 		DistinctId: "user1",
 		Event:      "pageview",
 		Properties: map[string]interface{}{"url": "https://example.com"},
@@ -108,9 +109,10 @@ func TestFilterRun(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Test event filtering
+	timestamp := "2023-01-01T00:00:00Z"
 	event := PostHogEvent{
 		Uuid:       "123",
-		Timestamp:  "2023-01-01T00:00:00Z",
+		Timestamp:  &timestamp,
 		DistinctId: "user1",
 		Token:      "token1",
 		Event:      "pageview",

--- a/livestream/kafka.go
+++ b/livestream/kafka.go
@@ -22,23 +22,18 @@ type Timestamp struct {
 }
 
 func (t *Timestamp) UnmarshalJSON(data []byte) error {
-	// Store the raw JSON string
 	t.Raw = string(data)
 
-	// Try to unmarshal into a string
 	var s string
 	if err := json.Unmarshal(data, &s); err == nil {
 		t.Value = s
 		return nil
 	}
 
-	// If unmarshalling to string fails, log the raw value
 	log.Printf("Unable to unmarshal timestamp to string. Raw value: %s", t.Raw)
-
-	// Set Value to empty string
+	// Set Default to empty string
 	t.Value = ""
 
-	// Return nil to continue unmarshalling the rest of the struct
 	return nil
 }
 


### PR DESCRIPTION
- **chore: make the timestamp field optional (looks like it's coming in with a variety of types)**
- **update to log what these bad timestamps look like**

## Problem

We are having a hard time deserializing timestamps on events which fails the entire event unmarshalling....so let's not let that blow up the entire thing and also let's log what the timestamp looks like if we can't deserialize them.
https://posthog.sentry.io/issues/5713951333/?project=4507460997283840&referrer=project-issue-stream

## Changes

This pull request introduces a new `Timestamp` type to handle timestamp values more robustly across the codebase. The changes include modifications to the `PostHogEvent` struct and updates to related functions and tests to accommodate the new `Timestamp` type.

### Introduction of `Timestamp` Type:
* [`livestream/kafka.go`](diffhunk://#diff-93b4990389554be40d529d198cc8d24c3c3c7a2465377bebb170923c2adf02bcR19-R49): Added a new `Timestamp` struct with `Value` and `Raw` fields, along with an `UnmarshalJSON` method to handle JSON unmarshalling. Updated the `PostHogEvent` struct to use the new `Timestamp` type for the `Timestamp` field.

### Code Adjustments for `Timestamp` Type:
* [`livestream/filter.go`](diffhunk://#diff-c5b3417a40703a0b1571487f33a4c9eaa952856b8213740c9c1bcf7625b4661aL66-R66): Updated the `convertToResponsePostHogEvent` function to use `event.Timestamp.Value` instead of `event.Timestamp`.
* [`livestream/kafka.go`](diffhunk://#diff-93b4990389554be40d529d198cc8d24c3c3c7a2465377bebb170923c2adf02bcL99-R133): Modified the `Consume` method to check `phEvent.Timestamp.Value` instead of `phEvent.Timestamp` for empty values and set the current time if empty.

### Test Updates:
* [`livestream/filter_test.go`](diffhunk://#diff-9498bb7c494d4dd77416dc348b8c212eeef90870dbacb004a8ba282224e78fc3R67-R70): Updated the `TestConvertToResponsePostHogEvent` and `TestFilterRun` tests to use the new `Timestamp` type for the `Timestamp` field in `PostHogEvent` instances. [[1]](diffhunk://#diff-9498bb7c494d4dd77416dc348b8c212eeef90870dbacb004a8ba282224e78fc3R67-R70) [[2]](diffhunk://#diff-9498bb7c494d4dd77416dc348b8c212eeef90870dbacb004a8ba282224e78fc3R112-R115)
👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
