### PR TITLE
chore: set defaults for message payload and remove custom unmarshaller

### DIFF
--- a/livestream/filter.go
+++ b/livestream/filter.go
@@ -63,7 +63,7 @@ func convertToResponseGeoEvent(event PostHogEvent) *ResponseGeoEvent {
 func convertToResponsePostHogEvent(event PostHogEvent, teamId int) *ResponsePostHogEvent {
 	return &ResponsePostHogEvent{
 		Uuid:       event.Uuid,
-		Timestamp:  event.Timestamp.Value,
+		Timestamp:  event.Timestamp,
 		DistinctId: event.DistinctId,
 		PersonId:   uuidFromDistinctId(teamId, event.DistinctId),
 		Event:      event.Event,

--- a/livestream/filter_test.go
+++ b/livestream/filter_test.go
@@ -67,7 +67,7 @@ func TestConvertToResponsePostHogEvent(t *testing.T) {
 	timestamp := "2023-01-01T00:00:00Z"
 	event := PostHogEvent{
 		Uuid:       "123",
-		Timestamp:  Timestamp{Value: timestamp},
+		Timestamp:  timestamp,
 		DistinctId: "user1",
 		Event:      "pageview",
 		Properties: map[string]interface{}{"url": "https://example.com"},
@@ -112,7 +112,7 @@ func TestFilterRun(t *testing.T) {
 	timestamp := "2023-01-01T00:00:00Z"
 	event := PostHogEvent{
 		Uuid:       "123",
-		Timestamp:  Timestamp{Value: timestamp},
+		Timestamp:  timestamp,
 		DistinctId: "user1",
 		Token:      "token1",
 		Event:      "pageview",

--- a/livestream/kafka.go
+++ b/livestream/kafka.go
@@ -16,32 +16,11 @@ type PostHogEventWrapper struct {
 	Data       string `json:"data"`
 }
 
-type Timestamp struct {
-	Value string
-	Raw   string
-}
-
-func (t *Timestamp) UnmarshalJSON(data []byte) error {
-	t.Raw = string(data)
-
-	var s string
-	if err := json.Unmarshal(data, &s); err == nil {
-		t.Value = s
-		return nil
-	}
-
-	log.Printf("Unable to unmarshal timestamp to string. Raw value: %s", t.Raw)
-	// Set Default to empty string
-	t.Value = ""
-
-	return nil
-}
-
 type PostHogEvent struct {
 	Token      string                 `json:"api_key,omitempty"`
 	Event      string                 `json:"event"`
 	Properties map[string]interface{} `json:"properties"`
-	Timestamp  Timestamp              `json:"timestamp,omitempty"`
+	Timestamp  string                 `json:"timestamp,omitempty"`
 
 	Uuid       string
 	DistinctId string
@@ -101,32 +80,35 @@ func (c *PostHogKafkaConsumer) Consume() {
 	for {
 		msg, err := c.consumer.ReadMessage(-1)
 		if err != nil {
-			sentry.CaptureException(err)
 			log.Printf("Error consuming message: %v", err)
-			continue
+			sentry.CaptureException(err)
 		}
 
 		var wrapperMessage PostHogEventWrapper
 		err = json.Unmarshal(msg.Value, &wrapperMessage)
 		if err != nil {
-			sentry.CaptureException(err)
 			log.Printf("Error decoding JSON: %v", err)
-			continue
+			log.Printf("Data: %s", string(msg.Value))
 		}
 
-		var phEvent PostHogEvent
-		err = json.Unmarshal([]byte(wrapperMessage.Data), &phEvent)
+		phEvent := PostHogEvent{
+			Timestamp:  time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
+			Token:      "",
+			Event:      "",
+			Properties: make(map[string]interface{}),
+		}
+
+		data := []byte(wrapperMessage.Data)
+
+		err = json.Unmarshal(data, &phEvent)
 		if err != nil {
 			log.Printf("Error decoding JSON: %v", err)
-			sentry.CaptureException(err)
-			continue
+			log.Printf("Data: %s", string(data))
 		}
 
 		phEvent.Uuid = wrapperMessage.Uuid
 		phEvent.DistinctId = wrapperMessage.DistinctId
-		if phEvent.Timestamp.Value == "" {
-			phEvent.Timestamp.Value = time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
-		}
+
 		if phEvent.Token == "" {
 			if tokenValue, ok := phEvent.Properties["token"].(string); ok {
 				phEvent.Token = tokenValue


### PR DESCRIPTION
## Problem

we may have tokens that are coming in either on the event or in the event properties, this is a bit more sensitive to that

## Changes

This pull request includes several changes to the `livestream` package, focusing on simplifying the handling of timestamps and improving error logging. The most important changes include removing the `Timestamp` struct, updating related test cases, and enhancing error logging in the Kafka consumer.

### Simplification of timestamp handling:

* [`livestream/filter.go`](diffhunk://#diff-c5b3417a40703a0b1571487f33a4c9eaa952856b8213740c9c1bcf7625b4661aL66-R66): Updated the `convertToResponsePostHogEvent` function to use a string directly for the `Timestamp` field instead of the `Timestamp` struct.
* [`livestream/kafka.go`](diffhunk://#diff-93b4990389554be40d529d198cc8d24c3c3c7a2465377bebb170923c2adf02bcL19-R23): Removed the `Timestamp` struct and its `UnmarshalJSON` method, and updated the `PostHogEvent` struct to use a string for the `Timestamp` field.

### Updates to test cases:

* [`livestream/filter_test.go`](diffhunk://#diff-9498bb7c494d4dd77416dc348b8c212eeef90870dbacb004a8ba282224e78fc3L70-R70): Modified the `TestConvertToResponsePostHogEvent` and `TestFilterRun` test functions to align with the changes in the `PostHogEvent` struct's `Timestamp` field. [[1]](diffhunk://#diff-9498bb7c494d4dd77416dc348b8c212eeef90870dbacb004a8ba282224e78fc3L70-R70) [[2]](diffhunk://#diff-9498bb7c494d4dd77416dc348b8c212eeef90870dbacb004a8ba282224e78fc3L115-R115)

### Error logging improvements:

* [`livestream/kafka.go`](diffhunk://#diff-93b4990389554be40d529d198cc8d24c3c3c7a2465377bebb170923c2adf02bcL104-R111): Enhanced the `Consume` method in `PostHogKafkaConsumer` to improve error logging by adding more detailed log messages and reordering the error handling logic.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
