### PR TITLE
chore: use the wrapper token if it exists

### DIFF
--- a/livestream/kafka.go
+++ b/livestream/kafka.go
@@ -14,6 +14,7 @@ type PostHogEventWrapper struct {
 	DistinctId string `json:"distinct_id"`
 	Ip         string `json:"ip"`
 	Data       string `json:"data"`
+	Token      string `json:"token"`
 }
 
 type PostHogEvent struct {
@@ -109,9 +110,13 @@ func (c *PostHogKafkaConsumer) Consume() {
 		phEvent.Uuid = wrapperMessage.Uuid
 		phEvent.DistinctId = wrapperMessage.DistinctId
 
-		if phEvent.Token == "" {
+		if wrapperMessage.Token != "" {
+			phEvent.Token = wrapperMessage.Token
+		} else if phEvent.Token == "" {
 			if tokenValue, ok := phEvent.Properties["token"].(string); ok {
 				phEvent.Token = tokenValue
+			} else {
+				log.Printf("No valid token found in event %s", string(msg.Value))
 			}
 		}
 


### PR DESCRIPTION
## Problem

There appears to be a token in the event wrapper, will use that if it exists

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
