### PR TITLE
fix(plugins): include transpiler source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 # Compile and install Node.js dependencies.
 COPY ./plugin-server/package.json ./plugin-server/pnpm-lock.yaml ./plugin-server/tsconfig.json ./
 COPY ./plugin-server/patches/ ./patches/
+COPY ./plugin-transpiler/ ./plugin-transpiler/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     "make" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,13 +44,13 @@ RUN pnpm build
 FROM ghcr.io/posthog/rust-node-container:bullseye_rust_1.80.1-node_18.19.1 AS plugin-server-build
 WORKDIR /code
 COPY ./rust ./rust
+COPY ./plugin-transpiler/ ./plugin-transpiler/
 WORKDIR /code/plugin-server
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 
 # Compile and install Node.js dependencies.
 COPY ./plugin-server/package.json ./plugin-server/pnpm-lock.yaml ./plugin-server/tsconfig.json ./
 COPY ./plugin-server/patches/ ./patches/
-COPY ./plugin-transpiler/ ./plugin-transpiler/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     "make" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,9 @@ RUN apt-get update && \
     corepack enable && \
     mkdir /tmp/pnpm-store && \
     pnpm install --frozen-lockfile --store-dir /tmp/pnpm-store && \
+    cd ../plugin-transpiler && \
+    pnpm install --frozen-lockfile --store-dir /tmp/pnpm-store && \
+    pnpm build && \
     rm -rf /tmp/pnpm-store
 
 # Build the plugin server.
@@ -186,10 +189,10 @@ ARG COMMIT_HASH
 RUN echo $COMMIT_HASH > /code/commit.txt
 
 # Add in the compiled plugin-server & its runtime dependencies from the plugin-server-build stage.
+COPY --from=plugin-server-build --chown=posthog:posthog /code/plugin-transpiler/dist /code/plugin-transpiler/dist
 COPY --from=plugin-server-build --chown=posthog:posthog /code/plugin-server/dist /code/plugin-server/dist
 COPY --from=plugin-server-build --chown=posthog:posthog /code/plugin-server/node_modules /code/plugin-server/node_modules
 COPY --from=plugin-server-build --chown=posthog:posthog /code/plugin-server/package.json /code/plugin-server/package.json
-
 
 # Copy the Python dependencies and Django staticfiles from the posthog-build stage.
 COPY --from=posthog-build --chown=posthog:posthog /code/staticfiles /code/staticfiles


### PR DESCRIPTION
## Problem

We can't transpile site apps on cloud because of this error:

```
node:internal/modules/cjs/loader:1143 throw err; ^ Error: Cannot find module '/code/plugin-transpiler/dist/index.js' at Module._resolveFilename
```

## Changes

Makes sure the plugin-transpiler is also built inside the dockerfile. I'm not sure how this got taken out, it used to be there.

## How did you test this code?

Testing in CI. If Docker builds and the `plugin-transpiler/dist/indes.js` file is there, we should be good to go, and it seems to be:

```bash
(env) marius@Mariuss-MBP-2 ~/P/P/posthog (plugin-transpiler) [0|1]> docker run --rm -it --entrypoint bash sha256:2505cd4a65485ebe771e091754e8439dfcc1fd408b18d4cac37c7425273f317f
root@fc4c150494b9:/code# ls
bin  commit.txt  ee  frontend  gunicorn.config.py  hogvm  manage.py  plugin-server  plugin-transpiler  posthog  share  staticfiles
root@fc4c150494b9:/code# cd plugin-transpiler/
root@fc4c150494b9:/code/plugin-transpiler# ls
dist
root@fc4c150494b9:/code/plugin-transpiler# cd dist/
root@fc4c150494b9:/code/plugin-transpiler/dist# ls -l
total 5368
-rw-r--r-- 1 posthog posthog 5489571 Oct  4 08:00 index.js
-rw-r--r-- 1 posthog posthog     928 Oct  4 08:00 presets.js
root@fc4c150494b9:/code/plugin-transpiler/dist# 
```
