### PR TITLE
chore(batch-exports): Add non-retryable error for PostgreSQL

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -674,6 +674,8 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
                 "UndefinedColumn",
                 # A VARCHAR column is too small.
                 "StringDataRightTruncation",
+                # Raised by PostgreSQL client. Self explanatory.
+                "DiskFull",
             ],
             finish_inputs=finish_inputs,
         )


### PR DESCRIPTION
## Problem

Another exception that we can't do nothing about about: If our user's db doesn't have disk space we should not retry.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Make `DiskFull` error non-retryable.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yup

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
