### PR TITLE
fix(batch-exports): Create backfills with IDs in UTC

### DIFF
--- a/posthog/api/test/batch_exports/test_backfill.py
+++ b/posthog/api/test/batch_exports/test_backfill.py
@@ -362,5 +362,6 @@ def test_batch_export_backfill_created_in_timezone(client: HttpClient):
         )
 
         data = response.json()
+
         assert response.status_code == status.HTTP_200_OK, data
-        assert data["backfill_id"] == f"{batch_export_id}-Backfill-2021-01-01 05:00:00+00:00-2021-10-01 04:00:00+00:00"
+        assert data["backfill_id"] == f"{batch_export_id}-Backfill-2021-01-01T05:00:00+00:00-2021-10-01T04:00:00+00:00"

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -449,14 +449,20 @@ def backfill_export(
         start_at=start_at.isoformat(),
         end_at=end_at.isoformat() if end_at else None,
     )
-    workflow_id = start_backfill_batch_export_workflow(temporal, inputs=inputs)
+    start_at_utc = start_at.astimezone(tz=dt.UTC)
+    end_at_utc = end_at.astimezone(tz=dt.UTC) if end_at else None
+
+    workflow_id = f"{inputs.batch_export_id}-Backfill-{start_at_utc}-{end_at_utc}"
+
+    workflow_id = start_backfill_batch_export_workflow(temporal, workflow_id, inputs=inputs)
     return workflow_id
 
 
 @async_to_sync
-async def start_backfill_batch_export_workflow(temporal: Client, inputs: BackfillBatchExportInputs) -> str:
+async def start_backfill_batch_export_workflow(
+    temporal: Client, workflow_id: str, inputs: BackfillBatchExportInputs
+) -> str:
     """Async call to start a BackfillBatchExportWorkflow."""
-    workflow_id = f"{inputs.batch_export_id}-Backfill-{inputs.start_at}-{inputs.end_at}"
     await temporal.start_workflow(
         "backfill-batch-export",
         inputs,

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -357,7 +357,14 @@ def disable_and_delete_export(instance: BatchExport):
     instance.deleted = True
 
     for backfill in running_backfills_for_batch_export(instance.id):
-        async_to_sync(cancel_running_batch_export_backfill)(temporal, backfill)
+        try:
+            async_to_sync(cancel_running_batch_export_backfill)(temporal, backfill)
+        except Exception:
+            logger.exception(
+                "Failed to delete backfill %s for batch export %s, but will continue on with delete",
+                backfill.id,
+                instance.id,
+            )
 
     try:
         batch_export_delete_schedule(temporal, str(instance.pk))
@@ -449,10 +456,12 @@ def backfill_export(
         start_at=start_at.isoformat(),
         end_at=end_at.isoformat() if end_at else None,
     )
-    start_at_utc = start_at.astimezone(tz=dt.UTC)
-    end_at_utc = end_at.astimezone(tz=dt.UTC) if end_at else None
+    start_at_utc_str = start_at.astimezone(tz=dt.UTC).isoformat()
+    # TODO: Should we use another signal besides "None"? i.e. "Inf" or "END".
+    # Keeping it like this for now for backwards compatibility.
+    end_at_utc_str = end_at.astimezone(tz=dt.UTC).isoformat() if end_at else "None"
 
-    workflow_id = f"{inputs.batch_export_id}-Backfill-{start_at_utc}-{end_at_utc}"
+    workflow_id = f"{inputs.batch_export_id}-Backfill-{start_at_utc_str}-{end_at_utc_str}"
 
     workflow_id = start_backfill_batch_export_workflow(temporal, workflow_id, inputs=inputs)
     return workflow_id


### PR DESCRIPTION
## Problem

PostgreSQL stores timestamps with timezone by first converting them to UTC (see [docs](https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME-INPUT-TIME-STAMPS)). This introduces a problem:
* When we create a backfill, we assign its Workflow ID to contain the start date and end date in the batch export/team timezone. 
* When storing the start at and end at in PostgreSQL we lose the timezone component, as they get converted to UTC (notice the timestamp is equivalent, just the timezone representation is lost).
* When we try to locate the backfill again to, for example, delete it, we can't find it as the timestamps appear to be in UTC so we cannot figure out what its ID is.
* We fail to delete the backfill.

The solution is to make all backfill IDs be in UTC, that way they will match the value stored in PostgreSQL. Moving forward, I will also explore just using the backfill UUID as the Workflow ID, as that would make things easier. In the meantime, this solution keeps backwards compatbility and was a smaller effort to implement.
  
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Ensure the backfill bounds are in UTC timezone before we set them in the backfill's workflow ID. 
* Make it so failing to cancel a backfill will not fail to (soft)delete the parent batch export. Worst case, backfills have logic to detect they have become orphaned and will cancel themselves.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added a unit test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
