### PR TITLE
chore(data-warehouse): Remove button to delete warehouse tables

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
+++ b/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
@@ -81,7 +81,7 @@ export const DatabaseTableTreeWithItems = ({ inline }: DatabaseTableTreeProps): 
             return <></>
         }
 
-        if (table.type === 'view' || table.type === 'data_warehouse' || table.type === 'materialized_view') {
+        if (table.type === 'view' || table.type === 'materialized_view') {
             return (
                 <LemonButton
                     data-attr="schema-list-item-delete"
@@ -95,10 +95,6 @@ export const DatabaseTableTreeWithItems = ({ inline }: DatabaseTableTreeProps): 
                     Delete
                 </LemonButton>
             )
-        }
-
-        if (table.type === 'posthog') {
-            return <></>
         }
 
         return <></>


### PR DESCRIPTION
## Problem
- You can delete sourced warehouse tables from the UI
- This is bad, many unexpected things happen when you delete them - deletion should only happen when the whole source is delete
- see thread https://posthog.slack.com/archives/C019RAX2XBN/p1728048255418039

## Changes


<img width="598" alt="image" src="https://github.com/user-attachments/assets/a52aa2bc-1103-47b0-b9a4-d26163e901c0">

