### PR TITLE
fix(plugin-server): trackedFetch lookups

### DIFF
--- a/plugin-server/src/utils/fetch.ts
+++ b/plugin-server/src/utils/fetch.ts
@@ -47,10 +47,13 @@ export async function trackedFetch(url: RequestInfo, init?: RequestInit): Promis
             }
             return await fetch(url, {
                 ...init,
-                agent: ({ protocol }: URL) =>
-                    protocol === 'http:'
-                        ? new http.Agent({ lookup: staticLookup })
-                        : new https.Agent({ lookup: staticLookup }),
+                agent:
+                    isProdEnv() && !process.env.NODE_ENV?.includes('functional-tests')
+                        ? ({ protocol }: URL) =>
+                              protocol === 'http:'
+                                  ? new http.Agent({ lookup: staticLookup })
+                                  : new https.Agent({ lookup: staticLookup })
+                        : undefined,
             })
         }
     )

--- a/plugin-server/src/utils/fetch.ts
+++ b/plugin-server/src/utils/fetch.ts
@@ -42,19 +42,15 @@ export async function trackedFetch(url: RequestInfo, init?: RequestInit): Promis
             description: `${request.method} ${request.url}`,
         },
         async () => {
+            const options = { ...init }
             if (isProdEnv() && !process.env.NODE_ENV?.includes('functional-tests')) {
                 await raiseIfUserProvidedUrlUnsafe(request.url)
+                options.agent = ({ protocol }: URL) =>
+                    protocol === 'http:'
+                        ? new http.Agent({ lookup: staticLookup })
+                        : new https.Agent({ lookup: staticLookup })
             }
-            return await fetch(url, {
-                ...init,
-                agent:
-                    isProdEnv() && !process.env.NODE_ENV?.includes('functional-tests')
-                        ? ({ protocol }: URL) =>
-                              protocol === 'http:'
-                                  ? new http.Agent({ lookup: staticLookup })
-                                  : new https.Agent({ lookup: staticLookup })
-                        : undefined,
-            })
+            return await fetch(url, options)
         }
     )
 }

--- a/plugin-server/src/utils/fetch.ts
+++ b/plugin-server/src/utils/fetch.ts
@@ -42,15 +42,17 @@ export async function trackedFetch(url: RequestInfo, init?: RequestInit): Promis
             description: `${request.method} ${request.url}`,
         },
         async () => {
-            const options = { ...init }
             if (isProdEnv() && !process.env.NODE_ENV?.includes('functional-tests')) {
                 await raiseIfUserProvidedUrlUnsafe(request.url)
-                options.agent = ({ protocol }: URL) =>
-                    protocol === 'http:'
-                        ? new http.Agent({ lookup: staticLookup })
-                        : new https.Agent({ lookup: staticLookup })
+                return await fetch(url, {
+                    ...init,
+                    agent: ({ protocol }: URL) =>
+                        protocol === 'http:'
+                            ? new http.Agent({ lookup: staticLookup })
+                            : new https.Agent({ lookup: staticLookup }),
+                })
             }
-            return await fetch(url, options)
+            return await fetch(url, init)
         }
     )
 }

--- a/plugin-server/src/utils/fetch.ts
+++ b/plugin-server/src/utils/fetch.ts
@@ -2,12 +2,37 @@
 
 import { LookupAddress } from 'dns'
 import dns from 'dns/promises'
+import http from 'http'
+import https from 'https'
 import * as ipaddr from 'ipaddr.js'
+import net from 'node:net'
 import fetch, { type RequestInfo, type RequestInit, type Response, FetchError, Request } from 'node-fetch'
 import { URL } from 'url'
 
 import { runInSpan } from '../sentry'
 import { isProdEnv } from './env-utils'
+
+const staticLookup: net.LookupFunction = async (hostname, options, cb) => {
+    let addrinfo: LookupAddress[]
+    try {
+        addrinfo = await dns.lookup(hostname, { all: true })
+    } catch (err) {
+        cb(new Error('Invalid hostname'), '', 4)
+        return
+    }
+    for (const { address } of addrinfo) {
+        // Prevent addressing internal services
+        if (ipaddr.parse(address).range() !== 'unicast') {
+            cb(new Error('Internal hostname'), '', 4)
+            return
+        }
+    }
+    if (addrinfo.length === 0) {
+        cb(new Error(`Unable to resolve ${hostname}`), '', 4)
+        return
+    }
+    cb(null, addrinfo[0].address, addrinfo[0].family)
+}
 
 export async function trackedFetch(url: RequestInfo, init?: RequestInit): Promise<Response> {
     const request = new Request(url, init)
@@ -20,7 +45,13 @@ export async function trackedFetch(url: RequestInfo, init?: RequestInit): Promis
             if (isProdEnv() && !process.env.NODE_ENV?.includes('functional-tests')) {
                 await raiseIfUserProvidedUrlUnsafe(request.url)
             }
-            return await fetch(url, init)
+            return await fetch(url, {
+                ...init,
+                agent: ({ protocol }: URL) =>
+                    protocol === 'http:'
+                        ? new http.Agent({ lookup: staticLookup })
+                        : new https.Agent({ lookup: staticLookup }),
+            })
         }
     )
 }


### PR DESCRIPTION
## Problem

The node-js fetch function didn't validate DNS records for each hop of a redirect.

Production uses a rust based system instead which does not appear to be affected.

## Changes

Provide a custom DNS lookup function to node-fetch.

## How did you test this code?

I made a fetch request locally to a URL that redirects, and saw the lookup function called twice.