### PR TITLE
fix(cdp): Change StreamName -> StreamARN in Kinesis template

### DIFF
--- a/posthog/cdp/templates/aws_kinesis/template_aws_kinesis.py
+++ b/posthog/cdp/templates/aws_kinesis/template_aws_kinesis.py
@@ -16,7 +16,7 @@ fun getPayload() {
   let date := formatDateTime(now(), '%Y%m%d')
 
   let payload := jsonStringify({
-    'StreamName': inputs.aws_kinesis_stream_arn,
+    'StreamARN': inputs.aws_kinesis_stream_arn,
     'PartitionKey': inputs.aws_kinesis_partition_key ?? generateUUIDv4(),
     'Data': base64Encode(jsonStringify(inputs.payload)),
   })


### PR DESCRIPTION
## Problem

https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecord.html#API_PutRecord_RequestSyntax

The inputs ask for an ARN but the code populates the API's Name parameter. Best I can tell, this was mislabeled even in the first iteration of this template, and right now it fails in an obvious way in the function test logs.

You could use the StreamName, but Kinesis recommends the ARN. I think it's also nice to see the account in which the stream was created.

```
When invoking this API, you must use either the StreamARN or the StreamName parameter, or both. It is recommended that you use the StreamARN input parameter when you invoke this API.
```

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

I believe this would not change the behavior across those environments.

## How did you test this code?

When trying to set up my first instance of the Kinesis template, I noticed it fails in an obvious way, in that the ARN does not succeed the API's regex for StreamName. Changing the input to just the stream name does allow the function to at least pass that step.

I haven't explicitly tested this change, but it's at least in line with the API documentation.
