### PR TITLE
perf: Use cityhash to filter events

### DIFF
--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -115,8 +115,15 @@ class EventsQueryRunner(QueryRunner):
                         ).first()
                         where_exprs.append(
                             parse_expr(
-                                "distinct_id in {list}",
-                                {"list": ast.Constant(value=get_distinct_ids_for_subquery(person, self.team))},
+                                "cityHash64(distinct_id) in {list}",  # Because the events table is partitioned by cityHash64(distinct_ids), using cityhash for the comparison is much quicker,
+                                {
+                                    "list": ast.Constant(
+                                        value=[
+                                            ast.Call(name="cityHash64", args=[ast.Constant(value=id)])
+                                            for id in get_distinct_ids_for_subquery(person, self.team)
+                                        ]
+                                    )
+                                },
                                 timings=self.timings,
                             )
                         )

--- a/posthog/hogql_queries/test/test_events_query_runner.py
+++ b/posthog/hogql_queries/test/test_events_query_runner.py
@@ -131,7 +131,7 @@ class TestEventsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         query_ast = EventsQueryRunner(query=query, team=self.team).to_query()
         where_expr = cast(ast.CompareOperation, cast(ast.And, query_ast.where).exprs[0])
         right_expr = cast(ast.Constant, where_expr.right)
-        self.assertEqual(right_expr.value, ["id1", "id2"])
+        self.assertEqual([x.args[0].value for x in right_expr.value], ["id1", "id2"])
 
         # another team
         another_team = Team.objects.create(organization=Organization.objects.create())


### PR DESCRIPTION
## Problem
Loading events on the person page is slow
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

use cityHash64 when filtering on distinct_ids, which is much faster as we've partitioned on `cityHash64(distinct_id)`. Some quick testing shows a 10x reduction in amount of bytes read
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
