### PR TITLE
perf: Don't fetch UUID in person modal

### DIFF
--- a/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
@@ -180,7 +180,6 @@ class TrendsActorsQueryBuilder:
 
     def _get_events_query(self) -> ast.SelectQuery:
         columns: list[ast.Expr] = [
-            ast.Alias(alias="uuid", expr=ast.Field(chain=["e", "uuid"])),
             *(
                 [ast.Alias(alias="$session_id", expr=ast.Field(chain=["e", "$session_id"]))]
                 if self.include_recordings


### PR DESCRIPTION
## Problem

In funnel person modals we read the UUID and then don't actually use it anywhere. This is somewhat expensive.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Don't read UUID
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
