### PR TITLE
feat: remove show ticks setting

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerSettings.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSettings.tsx
@@ -6,9 +6,8 @@ import { useActions, useValues } from 'kea'
 import { playerSettingsLogic } from './playerSettingsLogic'
 
 export const PlayerSettings = (): JSX.Element => {
-    const { autoplayDirection, skipInactivitySetting, showMouseTail, showSeekbarTicks } = useValues(playerSettingsLogic)
-    const { setAutoplayDirection, setSkipInactivitySetting, setShowMouseTail, setShowSeekbarTicks } =
-        useActions(playerSettingsLogic)
+    const { autoplayDirection, skipInactivitySetting, showMouseTail } = useValues(playerSettingsLogic)
+    const { setAutoplayDirection, setSkipInactivitySetting, setShowMouseTail } = useActions(playerSettingsLogic)
 
     return (
         <LemonMenu
@@ -50,19 +49,6 @@ export const PlayerSettings = (): JSX.Element => {
                             checked={showMouseTail}
                             onChange={setShowMouseTail}
                             label="Show mouse tail"
-                            fullWidth
-                        />
-                    ),
-                },
-                {
-                    custom: true,
-                    label: () => (
-                        <LemonSwitch
-                            className="px-2 py-1"
-                            checked={showSeekbarTicks}
-                            onChange={setShowSeekbarTicks}
-                            label="Seekbar ticks"
-                            tooltip="Show $pageview and $screen events on the seekbar"
                             fullWidth
                         />
                     ),

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.ts
@@ -200,7 +200,7 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
         ],
         values: [
             playerSettingsLogic,
-            ['showOnlyMatching', 'showSeekbarTicks', 'tab', 'miniFiltersByKey', 'searchQuery'],
+            ['showOnlyMatching', 'tab', 'miniFiltersByKey', 'searchQuery'],
             sessionRecordingDataLogic(props),
             [
                 'sessionPlayerData',
@@ -652,20 +652,15 @@ export const playerInspectorLogic = kea<playerInspectorLogicType>([
         ],
 
         seekbarItems: [
-            (s) => [s.filteredItems, s.showOnlyMatching, s.showSeekbarTicks, s.showMatchingEventsFilter],
+            (s) => [s.filteredItems, s.showOnlyMatching, s.showMatchingEventsFilter],
             (
                 filteredItems,
                 showOnlyMatching,
-                showSeekbarTicks,
                 showMatchingEventsFilter
             ): (InspectorListItemEvent | InspectorListItemComment)[] => {
                 let items: (InspectorListItemEvent | InspectorListItemComment)[] = filteredItems.filter(
                     (item): item is InspectorListItemEvent | InspectorListItemComment => {
                         if (item.type === SessionRecordingPlayerTab.EVENTS) {
-                            if (!showSeekbarTicks && ['$pageview', '$screen'].includes(item.data.event)) {
-                                return false
-                            }
-
                             return !(showMatchingEventsFilter && showOnlyMatching && item.highlightColor !== 'primary')
                         }
 

--- a/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/playerSettingsLogic.ts
@@ -198,7 +198,6 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
         setPlaybackMode: (mode: PlaybackMode) => ({ mode }),
         setSidebarOpen: (open: boolean) => ({ open }),
         setShowMouseTail: (showMouseTail: boolean) => ({ showMouseTail }),
-        setShowSeekbarTicks: (show: boolean) => ({ show }),
     }),
     connect({
         values: [teamLogic, ['currentTeam']],
@@ -276,13 +275,6 @@ export const playerSettingsLogic = kea<playerSettingsLogicType>([
             { persist: true },
             {
                 setShowMouseTail: (_, { showMouseTail }) => showMouseTail,
-            },
-        ],
-        showSeekbarTicks: [
-            true,
-            { persist: true },
-            {
-                setShowSeekbarTicks: (_, { show }) => show,
             },
         ],
 


### PR DESCRIPTION
the show ticks setting that filters down to only pageview or screen events has only been clicked 7 times and not at all in the last 30 days

and since we now obey the inspector filters for ticks then folk have more control so we don't need it