### PR TITLE
feat(batch-exports): Add cloudflare regions

### DIFF
--- a/frontend/src/scenes/pipeline/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/pipeline/batch-exports/BatchExportEditForm.tsx
@@ -165,6 +165,12 @@ export function BatchExportsEditFields({
                                         { value: 'eu-north-1', label: 'Europe (Stockholm)' },
                                         { value: 'me-south-1', label: 'Middle East (Bahrain)' },
                                         { value: 'sa-east-1', label: 'South America (São Paulo)' },
+                                        { value: 'auto', label: 'Automatic (AUTO)' },
+                                        { value: 'apac', label: 'Asia Pacific (APAC)' },
+                                        { value: 'eeur', label: 'Eastern Europe (EEUR)' },
+                                        { value: 'enam', label: 'Eastern North America (ENAM)' },
+                                        { value: 'weur', label: 'Western Europe (WEUR)' },
+                                        { value: 'wnam', label: 'Western North America (WNAM)' },
                                     ]}
                                 />
                             </LemonField>


### PR DESCRIPTION
## Problem

Users trying to use Cloudflare R2 as an S3-compatible destination for batch exports. We are almost all the way there, as users are able to set the `endpoint_url` for Cloudflare. We are just missing support for the regions that Cloudflare needs, that are not exactly like the ones used by S3.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add Cloudflare R2 regions to the list of regions in S3 batch export.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
