### PR TITLE
fix(data-warehouse): add naming convention to url pattern

### DIFF
--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -41,6 +41,7 @@ from posthog.warehouse.models.datawarehouse_saved_query import DataWarehouseSave
 from posthog.warehouse.models.table import DataWarehouseTable
 from posthog.warehouse.models.modeling import DataWarehouseModelPath
 from posthog.warehouse.util import database_sync_to_async
+from dlt.common.normalizers.naming.snake_case import NamingConvention
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
 
@@ -131,6 +132,7 @@ async def test_create_table_activity(activity_environment, ateam):
 
     table = await DataWarehouseTable.objects.aget(name=saved_query.name)
     assert table.name == saved_query.name
+    assert NamingConvention().normalize_identifier(saved_query.name) in table.url_pattern
 
 
 @pytest.mark.parametrize(

--- a/posthog/warehouse/models/datawarehouse_saved_query.py
+++ b/posthog/warehouse/models/datawarehouse_saved_query.py
@@ -19,6 +19,7 @@ from posthog.warehouse.models.util import (
 )
 from posthog.hogql.database.s3_table import S3Table
 from posthog.warehouse.util import database_sync_to_async
+from dlt.common.normalizers.naming.snake_case import NamingConvention
 
 
 def validate_saved_query_name(value):
@@ -137,9 +138,8 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDModel, DeletedMetaFields):
 
     @property
     def url_pattern(self):
-        return (
-            f"https://{settings.AIRBYTE_BUCKET_DOMAIN}/dlt/team_{self.team.pk}_model_{self.id.hex}/modeling/{self.name}"
-        )
+        normalized_name = NamingConvention().normalize_identifier(self.name)
+        return f"https://{settings.AIRBYTE_BUCKET_DOMAIN}/dlt/team_{self.team.pk}_model_{self.id.hex}/modeling/{normalized_name}"
 
     def hogql_definition(self, modifiers: Optional[HogQLQueryModifiers] = None) -> Union[SavedQuery, S3Table]:
         from posthog.warehouse.models.table import CLICKHOUSE_HOGQL_MAPPING


### PR DESCRIPTION
## Problem

- naming convention isn't applied to saved query name

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- apply it

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
