### PR TITLE
fix(cdp): improve ux around test globals

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
@@ -94,8 +94,9 @@ export function HogFunctionTest(props: HogFunctionTestLogicProps): JSX.Element {
                                         type="secondary"
                                         onClick={loadSampleGlobals}
                                         loading={sampleGlobalsLoading}
+                                        tooltip="Find the last event matching filteres, and use it to populate the globals below."
                                     >
-                                        Reload context
+                                        Refresh globals
                                     </LemonButton>
                                     <LemonField name="mock_async_functions">
                                         {({ value, onChange }) => (
@@ -178,20 +179,15 @@ export function HogFunctionTest(props: HogFunctionTestLogicProps): JSX.Element {
                             </div>
                         ) : (
                             <div className="space-y-2">
-                                <LemonField name="globals" label="Test invocation context">
+                                <LemonField name="globals">
                                     {({ value, onChange }) => (
                                         <>
-                                            <div>
-                                                <p className="flex-1">
-                                                    The globals object is the context in which your function will be
-                                                    tested. It should contain all the data that your function will need
-                                                    to run
-                                                </p>
+                                            <div className="space-y-2">
+                                                <div>Here are all the global variables you can use in your code:</div>
                                                 {sampleGlobalsError ? (
-                                                    <p className="text-warning">{sampleGlobalsError}</p>
+                                                    <div className="text-warning">{sampleGlobalsError}</div>
                                                 ) : null}
                                             </div>
-
                                             <HogFunctionTestEditor value={value} onChange={onChange} />
                                         </>
                                     )}

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
@@ -94,7 +94,7 @@ export function HogFunctionTest(props: HogFunctionTestLogicProps): JSX.Element {
                                         type="secondary"
                                         onClick={loadSampleGlobals}
                                         loading={sampleGlobalsLoading}
-                                        tooltip="Find the last event matching filteres, and use it to populate the globals below."
+                                        tooltip="Find the last event matching filters, and use it to populate the globals below."
                                     >
                                         Refresh globals
                                     </LemonButton>


### PR DESCRIPTION
## Problem

The concept "test invocation context" means nothing to normal people. We've seen people get confused on recordings.

<img width="974" alt="image" src="https://github.com/user-attachments/assets/4dbdb59d-4847-4f2f-b843-57775c05db00">


## Changes

<img width="777" alt="Screenshot 2024-10-08 at 10 04 17" src="https://github.com/user-attachments/assets/d7b10c8f-dc21-4a30-8e56-fc7a3db06952">

## How did you test this code?

👀 ☝️ 