### PR TITLE
fix(actions): fix crash with actionsEditLogic

### DIFF
--- a/frontend/src/scenes/actions/actionEditLogic.tsx
+++ b/frontend/src/scenes/actions/actionEditLogic.tsx
@@ -226,11 +226,11 @@ export const actionEditLogic = kea<actionEditLogicType>([
         },
     })),
 
-    beforeUnload(({ actions, values }) => ({
-        enabled: () => values.actionChanged,
+    beforeUnload((logic) => ({
+        enabled: () => (logic.isMounted() ? logic.values.actionChanged : false),
         message: 'Leave action?\nChanges you made will be discarded.',
         onConfirm: () => {
-            actions.resetAction()
+            logic.actions.resetAction()
         },
     })),
 ])


### PR DESCRIPTION
## Problem

https://posthog.slack.com/archives/C0351B1DMUY/p1728404912256569

## Changes

Fixes the unmounted logic from crashing the page

## How did you test this code?

Managed to get it to crash reliably by clicking 1) action edit, 2) other page, 3) any other page . It always crashed on step 3.

After the fix it didn't.