### PR TITLE
chore: do not return 404 if no stats are available on /stats endpoint

### DIFF
--- a/livestream/main.go
+++ b/livestream/main.go
@@ -111,6 +111,8 @@ func main() {
 	e.GET("/stats", statsHandler(stats))
 
 	e.GET("/events", func(c echo.Context) error {
+		e.Logger.Printf("SSE client connected, ip: %v", c.RealIP())
+
 		var teamId string
 		eventType := c.QueryParam("eventType")
 		distinctId := c.QueryParam("distinctId")
@@ -168,6 +170,7 @@ func main() {
 		for {
 			select {
 			case <-c.Request().Context().Done():
+				e.Logger.Printf("SSE client disconnected, ip: %v", c.RealIP())
 				filter.unSubChan <- subscription
 				subscription.ShouldClose.Store(true)
 				return nil

--- a/livestream/main.go
+++ b/livestream/main.go
@@ -111,8 +111,6 @@ func main() {
 	e.GET("/stats", statsHandler(stats))
 
 	e.GET("/events", func(c echo.Context) error {
-		e.Logger.Printf("SSE client connected, ip: %v", c.RealIP())
-
 		var teamId string
 		eventType := c.QueryParam("eventType")
 		distinctId := c.QueryParam("distinctId")
@@ -127,13 +125,11 @@ func main() {
 		} else {
 			teamId = ""
 
-			log.Println("~~~~ Looking for auth header")
 			authHeader := c.Request().Header.Get("Authorization")
 			if authHeader == "" {
 				return errors.New("authorization header is required")
 			}
 
-			log.Println("~~~~ decoding auth header")
 			claims, err := decodeAuthToken(authHeader)
 			if err != nil {
 				return err
@@ -141,7 +137,6 @@ func main() {
 			teamId = strconv.Itoa(int(claims["team_id"].(float64)))
 			token = fmt.Sprint(claims["api_token"])
 
-			log.Printf("~~~~ team found %s", teamId)
 			if teamId == "" {
 				return errors.New("teamId is required unless geo=true")
 			}
@@ -173,7 +168,6 @@ func main() {
 		for {
 			select {
 			case <-c.Request().Context().Done():
-				e.Logger.Printf("SSE client disconnected, ip: %v", c.RealIP())
 				filter.unSubChan <- subscription
 				subscription.ShouldClose.Store(true)
 				return nil

--- a/livestream/served.go
+++ b/livestream/served.go
@@ -51,7 +51,7 @@ func statsHandler(stats *Stats) func(c echo.Context) error {
 			resp := resp{
 				Error: "no stats",
 			}
-			return c.JSON(http.StatusNotFound, resp)
+			return c.JSON(http.StatusOK, resp)
 		}
 
 		siteStats := resp{


### PR DESCRIPTION
## Problem

We are seeing issues when we return a 404 when there are no stats to return - let's just return a 200 and say the error in the payload

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
