### PR TITLE
chore(batch-exports): Add StringDataRightTruncation error as non-retryable

### DIFF
--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -586,6 +586,9 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
                 "InvalidSchemaName",
                 # Missing permissions to, e.g., insert into table.
                 "InsufficientPrivilege",
+                # A column, usually properties, exceeds the limit for a VARCHAR field,
+                # usually the max of 65535 bytes
+                "StringDataRightTruncation",
             ],
             finish_inputs=finish_inputs,
         )


### PR DESCRIPTION
## Problem

When properties exceed the 65535 byte limit for `VARCHAR(65535)` there is nothing we can do (for now, we may give the user to opt in to truncation or dropping the row later).

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Do not retry on `VARCHAR(65535)` limit exceeded.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
