### PR TITLE
refactor(insights): Filter actions by project rather than team

### DIFF
--- a/posthog/hogql_queries/insights/funnels/base.py
+++ b/posthog/hogql_queries/insights/funnels/base.py
@@ -304,7 +304,7 @@ class FunnelBase(ABC):
                 "Data warehouse tables are not supported in funnels just yet. For now, please try this funnel without the data warehouse-based step."
             )
         else:
-            action = Action.objects.get(pk=step.id)
+            action = Action.objects.get(pk=step.id, team__project_id=self.context.team.project_id)
             name = action.name
             action_id = step.id
             type = "actions"
@@ -676,7 +676,7 @@ class FunnelBase(ABC):
 
         if isinstance(entity, ActionsNode) or isinstance(entity, FunnelExclusionActionsNode):
             # action
-            action = Action.objects.get(pk=int(entity.id), team=self.context.team)
+            action = Action.objects.get(pk=int(entity.id), team__project_id=self.context.team.project_id)
             event_expr = action_to_expr(action)
         elif isinstance(entity, DataWarehouseNode):
             raise ValidationError(

--- a/posthog/hogql_queries/insights/funnels/base.py
+++ b/posthog/hogql_queries/insights/funnels/base.py
@@ -304,7 +304,7 @@ class FunnelBase(ABC):
                 "Data warehouse tables are not supported in funnels just yet. For now, please try this funnel without the data warehouse-based step."
             )
         else:
-            assert self.team.project_id is not None
+            assert self.context.team.project_id is not None
             action = Action.objects.get(pk=step.id, team__project_id=self.context.team.project_id)
             name = action.name
             action_id = step.id
@@ -677,7 +677,7 @@ class FunnelBase(ABC):
 
         if isinstance(entity, ActionsNode) or isinstance(entity, FunnelExclusionActionsNode):
             # action
-            assert self.team.project_id is not None
+            assert self.context.team.project_id is not None
             action = Action.objects.get(pk=int(entity.id), team__project_id=self.context.team.project_id)
             event_expr = action_to_expr(action)
         elif isinstance(entity, DataWarehouseNode):

--- a/posthog/hogql_queries/insights/funnels/base.py
+++ b/posthog/hogql_queries/insights/funnels/base.py
@@ -304,6 +304,7 @@ class FunnelBase(ABC):
                 "Data warehouse tables are not supported in funnels just yet. For now, please try this funnel without the data warehouse-based step."
             )
         else:
+            assert self.team.project_id is not None
             action = Action.objects.get(pk=step.id, team__project_id=self.context.team.project_id)
             name = action.name
             action_id = step.id
@@ -676,6 +677,7 @@ class FunnelBase(ABC):
 
         if isinstance(entity, ActionsNode) or isinstance(entity, FunnelExclusionActionsNode):
             # action
+            assert self.team.project_id is not None
             action = Action.objects.get(pk=int(entity.id), team__project_id=self.context.team.project_id)
             event_expr = action_to_expr(action)
         elif isinstance(entity, DataWarehouseNode):

--- a/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
@@ -830,6 +830,7 @@ class FunnelCorrelationQueryRunner(QueryRunner):
         events: set[str] = set()
         for entity in self.funnels_query.series:
             if isinstance(entity, ActionsNode):
+                assert self.team.project_id is not None
                 action = Action.objects.get(pk=int(entity.id), team__project_id=self.context.team.project_id)
                 events.update([x for x in action.get_step_events() if x])
             elif isinstance(entity, EventsNode):

--- a/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
@@ -830,7 +830,7 @@ class FunnelCorrelationQueryRunner(QueryRunner):
         events: set[str] = set()
         for entity in self.funnels_query.series:
             if isinstance(entity, ActionsNode):
-                assert self.team.project_id is not None
+                assert self.context.team.project_id is not None
                 action = Action.objects.get(pk=int(entity.id), team__project_id=self.context.team.project_id)
                 events.update([x for x in action.get_step_events() if x])
             elif isinstance(entity, EventsNode):

--- a/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_correlation_query_runner.py
@@ -830,7 +830,7 @@ class FunnelCorrelationQueryRunner(QueryRunner):
         events: set[str] = set()
         for entity in self.funnels_query.series:
             if isinstance(entity, ActionsNode):
-                action = Action.objects.get(pk=int(entity.id), team=self.context.team)
+                action = Action.objects.get(pk=int(entity.id), team__project_id=self.context.team.project_id)
                 events.update([x for x in action.get_step_events() if x])
             elif isinstance(entity, EventsNode):
                 if entity.event is not None:

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -132,7 +132,7 @@ class FunnelEventQuery:
         )
 
     def _entity_expr(self, skip_entity_filter: bool) -> ast.Expr | None:
-        team, query, funnelsFilter = self.context.team, self.context.query, self.context.funnelsFilter
+        query, funnelsFilter = self.context.query, self.context.funnelsFilter
         exclusions = funnelsFilter.exclusions or []
 
         if skip_entity_filter is True:
@@ -145,7 +145,7 @@ class FunnelEventQuery:
                 events.add(node.event)
             elif isinstance(node, ActionsNode) or isinstance(node, FunnelExclusionActionsNode):
                 try:
-                    action = Action.objects.get(pk=int(node.id), team=team)
+                    action = Action.objects.get(pk=int(node.id), team__project_id=self.context.team.project_id)
                     events.update(action.get_step_events())
                 except Action.DoesNotExist:
                     raise ValidationError(f"Action ID {node.id} does not exist!")

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -144,7 +144,7 @@ class FunnelEventQuery:
             if isinstance(node, EventsNode) or isinstance(node, FunnelExclusionEventsNode):
                 events.add(node.event)
             elif isinstance(node, ActionsNode) or isinstance(node, FunnelExclusionActionsNode):
-                assert self.team.project_id is not None
+                assert self.context.team.project_id is not None
                 try:
                     action = Action.objects.get(pk=int(node.id), team__project_id=self.context.team.project_id)
                     events.update(action.get_step_events())

--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -144,6 +144,7 @@ class FunnelEventQuery:
             if isinstance(node, EventsNode) or isinstance(node, FunnelExclusionEventsNode):
                 events.add(node.event)
             elif isinstance(node, ActionsNode) or isinstance(node, FunnelExclusionActionsNode):
+                assert self.team.project_id is not None
                 try:
                     action = Action.objects.get(pk=int(node.id), team__project_id=self.context.team.project_id)
                     events.update(action.get_step_events())

--- a/posthog/hogql_queries/insights/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle_query_runner.py
@@ -181,7 +181,7 @@ class LifecycleQueryRunner(QueryRunner):
             action_object = {}
             label = "{} - {}".format("", val[2])
             if isinstance(self.query.series[0], ActionsNode):
-                action = Action.objects.get(pk=int(self.query.series[0].id), team=self.team)
+                action = Action.objects.get(pk=int(self.query.series[0].id), team__project_id=self.team.project_id)
                 label = "{} - {}".format(action.name, val[2])
                 action_object = {
                     "id": str(action.pk),
@@ -248,7 +248,7 @@ class LifecycleQueryRunner(QueryRunner):
         with self.timings.measure("series_filters"):
             for serie in self.query.series or []:
                 if isinstance(serie, ActionsNode):
-                    action = Action.objects.get(pk=int(serie.id), team=self.team)
+                    action = Action.objects.get(pk=int(serie.id), team__project_id=self.team.project_id)
                     event_filters.append(action_to_expr(action))
                 elif isinstance(serie, EventsNode):
                     if serie.event is not None:

--- a/posthog/hogql_queries/insights/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle_query_runner.py
@@ -181,6 +181,7 @@ class LifecycleQueryRunner(QueryRunner):
             action_object = {}
             label = "{} - {}".format("", val[2])
             if isinstance(self.query.series[0], ActionsNode):
+                assert self.team.project_id is not None
                 action = Action.objects.get(pk=int(self.query.series[0].id), team__project_id=self.team.project_id)
                 label = "{} - {}".format(action.name, val[2])
                 action_object = {
@@ -248,6 +249,7 @@ class LifecycleQueryRunner(QueryRunner):
         with self.timings.measure("series_filters"):
             for serie in self.query.series or []:
                 if isinstance(serie, ActionsNode):
+                    assert self.team.project_id is not None
                     action = Action.objects.get(pk=int(serie.id), team__project_id=self.team.project_id)
                     event_filters.append(action_to_expr(action))
                 elif isinstance(serie, EventsNode):

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -87,7 +87,7 @@ class RetentionQueryRunner(QueryRunner):
 
     def _get_events_for_entity(self, entity: RetentionEntity) -> list[str | None]:
         if entity.type == EntityType.ACTIONS and entity.id:
-            action = Action.objects.get(pk=int(entity.id))
+            action = Action.objects.get(pk=int(entity.id), team__project_id=self.team.project_id)
             return action.get_step_events()
         return [entity.id] if isinstance(entity.id, str) else [None]
 

--- a/posthog/hogql_queries/insights/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention_query_runner.py
@@ -87,6 +87,7 @@ class RetentionQueryRunner(QueryRunner):
 
     def _get_events_for_entity(self, entity: RetentionEntity) -> list[str | None]:
         if entity.type == EntityType.ACTIONS and entity.id:
+            assert self.team.project_id is not None
             action = Action.objects.get(pk=int(entity.id), team__project_id=self.team.project_id)
             return action.get_step_events()
         return [entity.id] if isinstance(entity.id, str) else [None]

--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -276,7 +276,7 @@ class StickinessQueryRunner(QueryRunner):
             )
         elif isinstance(series, ActionsNode):
             try:
-                action = Action.objects.get(pk=int(series.id), team=self.team)
+                action = Action.objects.get(pk=int(series.id), team__project_id=self.team.project_id)
                 filters.append(action_to_expr(action))
             except Action.DoesNotExist:
                 # If an action doesn't exist, we want to return no events
@@ -331,7 +331,7 @@ class StickinessQueryRunner(QueryRunner):
 
         if isinstance(series, ActionsNode):
             # TODO: Can we load the Action in more efficiently?
-            action = Action.objects.get(pk=int(series.id), team=self.team)
+            action = Action.objects.get(pk=int(series.id), team__project_id=self.team.project_id)
             return action.name
 
     def intervals_num(self):

--- a/posthog/hogql_queries/insights/stickiness_query_runner.py
+++ b/posthog/hogql_queries/insights/stickiness_query_runner.py
@@ -275,6 +275,7 @@ class StickinessQueryRunner(QueryRunner):
                 )
             )
         elif isinstance(series, ActionsNode):
+            assert self.team.project_id is not None
             try:
                 action = Action.objects.get(pk=int(series.id), team__project_id=self.team.project_id)
                 filters.append(action_to_expr(action))
@@ -330,6 +331,7 @@ class StickinessQueryRunner(QueryRunner):
             return series.table_name
 
         if isinstance(series, ActionsNode):
+            assert self.team.project_id is not None
             # TODO: Can we load the Action in more efficiently?
             action = Action.objects.get(pk=int(series.id), team__project_id=self.team.project_id)
             return action.name

--- a/posthog/hogql_queries/insights/trends/test/test_trends.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends.py
@@ -3850,6 +3850,21 @@ class TestTrends(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEntityResponseEqual(action_response, event_response)
 
+    def test_action_filtering_for_action_in_different_env_of_project(self):
+        sign_up_action, person = self._create_events()
+        other_team_in_project = Team.objects.create(organization=self.organization, project=self.project)
+        sign_up_action.team = other_team_in_project
+        sign_up_action.save()
+
+        action_response = self._run(
+            Filter(team=self.team, data={"actions": [{"id": sign_up_action.id}]}),
+            self.team,
+        )
+        event_response = self._run(Filter(team=self.team, data={"events": [{"id": "sign up"}]}), self.team)
+        self.assertEqual(len(action_response), 1)
+
+        self.assertEntityResponseEqual(action_response, event_response)
+
     @also_test_with_person_on_events_v2
     @snapshot_clickhouse_queries
     def test_action_filtering_with_cohort(self):

--- a/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
@@ -293,7 +293,7 @@ class TrendsActorsQueryBuilder:
         if isinstance(self.entity, ActionsNode):
             # Actions
             try:
-                action = Action.objects.get(pk=int(self.entity.id), team=self.team)
+                action = Action.objects.get(pk=int(self.entity.id), team__project_id=self.team.project_id)
                 return action_to_expr(action)
             except Action.DoesNotExist:
                 # If an action doesn't exist, we want to return no events

--- a/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_actors_query_builder.py
@@ -292,6 +292,7 @@ class TrendsActorsQueryBuilder:
     def _event_or_action_where_expr(self) -> ast.Expr | None:
         if isinstance(self.entity, ActionsNode):
             # Actions
+            assert self.team.project_id is not None
             try:
                 action = Action.objects.get(pk=int(self.entity.id), team__project_id=self.team.project_id)
                 return action_to_expr(action)

--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -737,7 +737,7 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
         # Actions
         if isinstance(self.series, ActionsNode):
             try:
-                action = Action.objects.get(pk=int(self.series.id), team=self.team)
+                action = Action.objects.get(pk=int(self.series.id), team__project_id=self.team.project_id)
                 return action_to_expr(action)
             except Action.DoesNotExist:
                 # If an action doesn't exist, we want to return no events

--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -736,6 +736,7 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
 
         # Actions
         if isinstance(self.series, ActionsNode):
+            assert self.team.project_id is not None
             try:
                 action = Action.objects.get(pk=int(self.series.id), team__project_id=self.team.project_id)
                 return action_to_expr(action)

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -641,7 +641,7 @@ class TrendsQueryRunner(QueryRunner):
             return series.event
         if isinstance(series, ActionsNode):
             # TODO: Can we load the Action in more efficiently?
-            action = Action.objects.get(pk=int(series.id), team=self.team)
+            action = Action.objects.get(pk=int(series.id), team__project_id=self.team.project_id)
             return action.name
 
         if isinstance(series, DataWarehouseNode):

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -640,6 +640,7 @@ class TrendsQueryRunner(QueryRunner):
         if isinstance(series, EventsNode):
             return series.event
         if isinstance(series, ActionsNode):
+            assert self.team.project_id is not None
             # TODO: Can we load the Action in more efficiently?
             action = Action.objects.get(pk=int(series.id), team__project_id=self.team.project_id)
             return action.name

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -100,7 +100,7 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner):
     @cached_property
     def conversion_goal_expr(self) -> ast.Expr:
         if isinstance(self.query.conversionGoal, ActionConversionGoal):
-            action = Action.objects.get(pk=self.query.conversionGoal.actionId)
+            action = Action.objects.get(pk=self.query.conversionGoal.actionId, team__project_id=self.team.project_id)
             return action_to_expr(action)
         elif isinstance(self.query.conversionGoal, CustomEventConversionGoal):
             return ast.CompareOperation(

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -100,6 +100,7 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner):
     @cached_property
     def conversion_goal_expr(self) -> ast.Expr:
         if isinstance(self.query.conversionGoal, ActionConversionGoal):
+            assert self.team.project_id is not None
             action = Action.objects.get(pk=self.query.conversionGoal.actionId, team__project_id=self.team.project_id)
             return action_to_expr(action)
         elif isinstance(self.query.conversionGoal, CustomEventConversionGoal):


### PR DESCRIPTION
## Changes

Allowing actions from other environments to be used, as long as it's the same project.

## How did you test this code?

Added a test to trends. Didn't add for _each_ insight type.