### PR TITLE
fix(ingest): stop doing person processing on group identify

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -193,6 +193,12 @@ export class EventPipelineRunner {
             }
         }
 
+        // if the event is a groupidentify event, we should always skip person processing entirely. We
+        // don't allow use of $set and friends on groupidentify events
+        if (event.event === '$groupidentify') {
+            processPerson = false
+        }
+
         if (event.event === '$$client_ingestion_warning') {
             await captureIngestionWarning(
                 this.hub.db.kafkaProducer,

--- a/plugin-server/src/worker/ingestion/process-event.ts
+++ b/plugin-server/src/worker/ingestion/process-event.ts
@@ -169,10 +169,10 @@ export class EventsProcessor {
         if (processPerson) {
             // Adds group_0 etc values to properties
             properties = await addGroupProperties(team.id, properties, this.groupTypeManager)
-
-            if (event === '$groupidentify') {
-                await this.upsertGroup(team.id, properties, timestamp)
-            }
+        } else if (event === '$groupidentify') {
+            // This is mutually exclusive with the above - we don't want to do person processing if
+            // group identify is used
+            await this.upsertGroup(team.id, properties, timestamp)
         }
 
         return {


### PR DESCRIPTION
We already disallow `$set` et al, so we should simply entirely disable person processing if we're processing a group identify event, since we know it can only be used to set group-level properties.