### PR TITLE
fix(surveys): Show notification destinations which have removed survey_response filter

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -412,12 +412,6 @@ export function SurveyView({ id }: { id: string }): JSX.Element {
                                                               order: 0,
                                                               properties: [
                                                                   {
-                                                                      key: '$survey_response',
-                                                                      type: PropertyFilterType.Event,
-                                                                      value: 'is_set',
-                                                                      operator: PropertyOperator.IsSet,
-                                                                  },
-                                                                  {
                                                                       key: '$survey_id',
                                                                       type: PropertyFilterType.Event,
                                                                       value: id,

--- a/frontend/src/scenes/surveys/Surveys.tsx
+++ b/frontend/src/scenes/surveys/Surveys.tsx
@@ -32,7 +32,7 @@ import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
-import { ActivityScope, ProductKey, ProgressStatus, PropertyFilterType, PropertyOperator, Survey } from '~/types'
+import { ActivityScope, ProductKey, ProgressStatus, Survey } from '~/types'
 
 import { SurveyQuestionLabel } from './constants'
 import { openSurveysSettingsDialog } from './SurveySettings'
@@ -127,14 +127,6 @@ export function Surveys(): JSX.Element {
                                     id: 'survey sent',
                                     type: 'events',
                                     order: 0,
-                                    properties: [
-                                        {
-                                            key: '$survey_response',
-                                            type: PropertyFilterType.Event,
-                                            value: 'is_set',
-                                            operator: PropertyOperator.IsSet,
-                                        },
-                                    ],
                                 },
                             ],
                         }}


### PR DESCRIPTION
## Problem

This PR fixes a bug notified by a customer where they removed the `$survey_response is set` filter on their notification settings and that caused the notification to disappear from their view. 

![survey_notifications_bug](https://github.com/user-attachments/assets/0527522a-7da8-4e46-8835-908cfb493e17)


## Changes

Remove the `$survey_response is set` filter condition when showing notification settings in surveys.


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

1. Manual testing.