### PR TITLE
fix: encryption salt keys take 2

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -100,6 +100,7 @@ services:
             OBJECT_STORAGE_SECRET_ACCESS_KEY: 'object_storage_root_password'
             OBJECT_STORAGE_ENDPOINT: http://objectstorage:19000
             OBJECT_STORAGE_ENABLED: true
+            ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
         depends_on:
             - db
             - redis
@@ -122,6 +123,7 @@ services:
             OBJECT_STORAGE_ENABLED: true
             CDP_REDIS_HOST: redis7
             CDP_REDIS_PORT: 6379
+            ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
         depends_on:
             - db
             - redis

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -83,6 +83,7 @@ services:
             OBJECT_STORAGE_SECRET_ACCESS_KEY: 'object_storage_root_password'
             OBJECT_STORAGE_ENDPOINT: http://objectstorage:19000
             OBJECT_STORAGE_ENABLED: true
+            ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
         image: $REGISTRY_URL:$POSTHOG_APP_TAG
     web:
         extends:


### PR DESCRIPTION
follow-up to #25454 

it doesn't matter that we have the environment variable if we don't pass it to the right docker services 🙈 