### PR TITLE
feat(cdp): remove "show hidden" test actions

### DIFF
--- a/frontend/src/scenes/pipeline/destinations/DestinationsFilters.tsx
+++ b/frontend/src/scenes/pipeline/destinations/DestinationsFilters.tsx
@@ -15,7 +15,7 @@ export function DestinationsFilters({
     hideShowPaused,
     hideKind,
 }: DestinationsFiltersProps): JSX.Element | null {
-    const { user, filters } = useValues(destinationsFiltersLogic)
+    const { filters } = useValues(destinationsFiltersLogic)
     const { setFilters, openFeedbackDialog } = useActions(destinationsFiltersLogic)
 
     return (
@@ -42,16 +42,6 @@ export function DestinationsFilters({
                         onChange={(e) => setFilters({ showPaused: e ?? undefined })}
                     />
                 )}
-                {(user?.is_staff || user?.is_impersonated) && (
-                    <LemonCheckbox
-                        label="Show hidden"
-                        bordered
-                        size="small"
-                        checked={filters.showHidden}
-                        onChange={(e) => setFilters({ showHidden: e ?? undefined })}
-                    />
-                )}
-
                 {!hideKind && (
                     <LemonSelect
                         type="secondary"

--- a/frontend/src/scenes/pipeline/destinations/destinationsFiltersLogic.tsx
+++ b/frontend/src/scenes/pipeline/destinations/destinationsFiltersLogic.tsx
@@ -15,7 +15,6 @@ export type DestinationsFilters = {
     kind?: PipelineBackend | null
     sub_template?: string
     showPaused?: boolean
-    showHidden?: boolean
 }
 
 export const destinationsFiltersLogic = kea<destinationsFiltersLogicType>([

--- a/frontend/src/scenes/pipeline/destinations/destinationsLogic.tsx
+++ b/frontend/src/scenes/pipeline/destinations/destinationsLogic.tsx
@@ -161,7 +161,7 @@ export const pipelineDestinationsLogic = kea<pipelineDestinationsLogicType>([
             },
         ],
 
-        _hogFunctions: [
+        hogFunctions: [
             [] as HogFunctionType[],
             {
                 loadHogFunctions: async () => {
@@ -205,11 +205,6 @@ export const pipelineDestinationsLogic = kea<pipelineDestinationsLogicType>([
         ],
     })),
     selectors({
-        hogFunctions: [
-            (s) => [s._hogFunctions, s.filters],
-            (hogFunctions, filters) =>
-                filters.showHidden ? hogFunctions : hogFunctions.filter((hf) => !hf.name.includes('[CDP-TEST-HIDDEN]')),
-        ],
         paidHogFunctions: [
             (s) => [s.hogFunctions],
             (hogFunctions) => {
@@ -220,7 +215,7 @@ export const pipelineDestinationsLogic = kea<pipelineDestinationsLogicType>([
             },
         ],
         loading: [
-            (s) => [s.pluginsLoading, s.pluginConfigsLoading, s.batchExportConfigsLoading, s._hogFunctionsLoading],
+            (s) => [s.pluginsLoading, s.pluginConfigsLoading, s.batchExportConfigsLoading, s.hogFunctionsLoading],
             (pluginsLoading, pluginConfigsLoading, batchExportConfigsLoading, hogFunctionsLoading) =>
                 pluginsLoading || pluginConfigsLoading || batchExportConfigsLoading || hogFunctionsLoading,
         ],

--- a/frontend/src/scenes/pipeline/hogfunctions/list/HogFunctionsList.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/list/HogFunctionsList.tsx
@@ -17,7 +17,7 @@ export function HogFunctionList({
     extraControls,
     ...props
 }: HogFunctionListLogicProps & { extraControls?: JSX.Element }): JSX.Element {
-    const { user, loading, filteredHogFunctions, filters, hogFunctions, canEnableHogFunction } = useValues(
+    const { loading, filteredHogFunctions, filters, hogFunctions, canEnableHogFunction } = useValues(
         hogFunctionListLogic(props)
     )
     const { loadHogFunctions, setFilters, resetFilters, toggleEnabled, deleteHogFunction } = useActions(
@@ -45,15 +45,6 @@ export function HogFunctionList({
                         size="small"
                         checked={filters.showPaused}
                         onChange={(e) => setFilters({ showPaused: e ?? undefined })}
-                    />
-                )}
-                {(user?.is_staff || user?.is_impersonated) && typeof props.forceFilters?.showHidden !== 'boolean' && (
-                    <LemonCheckbox
-                        label="Show hidden"
-                        bordered
-                        size="small"
-                        checked={filters.showHidden}
-                        onChange={(e) => setFilters({ showHidden: e ?? undefined })}
                     />
                 )}
                 {extraControls}

--- a/frontend/src/scenes/pipeline/hogfunctions/list/hogFunctionListLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/list/hogFunctionListLogic.tsx
@@ -21,7 +21,6 @@ export interface Fuse extends FuseClass<HogFunctionType> {}
 export type HogFunctionListFilters = {
     search?: string
     showPaused?: boolean
-    showHidden?: boolean
     filters?: Record<string, any>
 }
 
@@ -70,7 +69,7 @@ export const hogFunctionListLogic = kea<hogFunctionListLogicType>([
         ],
     })),
     loaders(({ values, actions }) => ({
-        _hogFunctions: [
+        hogFunctions: [
             [] as HogFunctionType[],
             {
                 loadHogFunctions: async () => {
@@ -114,18 +113,13 @@ export const hogFunctionListLogic = kea<hogFunctionListLogicType>([
                     ]
                 },
                 addHogFunction: ({ hogFunction }) => {
-                    return [hogFunction, ...values._hogFunctions]
+                    return [hogFunction, ...values.hogFunctions]
                 },
             },
         ],
     })),
     selectors({
-        loading: [(s) => [s._hogFunctionsLoading], (hogFunctionsLoading) => hogFunctionsLoading],
-        hogFunctions: [
-            (s) => [s._hogFunctions, s.filters],
-            (hogFunctions, filters) =>
-                filters.showHidden ? hogFunctions : hogFunctions.filter((hf) => !hf.name.includes('[CDP-TEST-HIDDEN]')),
-        ],
+        loading: [(s) => [s.hogFunctionsLoading], (hogFunctionsLoading) => hogFunctionsLoading],
         sortedHogFunctions: [
             (s) => [s.hogFunctions],
             (hogFunctions): HogFunctionType[] => {


### PR DESCRIPTION
## Problem

This "show hidden" option should be removed now that the first testing period is over

![image](https://github.com/user-attachments/assets/ec1dcccd-b962-4449-9794-6c7efc9b908c)

## Changes

Removes the filter.

![Screenshot 2024-10-09 at 17 16 56](https://github.com/user-attachments/assets/804a4c73-0fb1-449e-b702-3042f056f560)

All TEST actions like above have been removed on cloud for all users.

## How did you test this code?

Clicked in the interface