### PR TITLE
fix(batch-exports): Do not hardcode properties data type value

### DIFF
--- a/frontend/src/scenes/pipeline/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/pipeline/batch-exports/BatchExportEditForm.tsx
@@ -411,7 +411,6 @@ export function BatchExportsEditFields({
                                     { value: 'varchar', label: 'VARCHAR(65535)' },
                                     { value: 'super', label: 'SUPER' },
                                 ]}
-                                value="varchar"
                             />
                         </LemonField>
 


### PR DESCRIPTION
## Problem

This was hardcoded in the frontend, let's not do that.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Allow users to set "Properties data type" to "SUPER"
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
