### PR TITLE
fix: encryption salt key is not any random string

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -12,7 +12,7 @@ export SENTRY_DSN="${SENTRY_DSN:-'https://public@sentry.example.com/1'}"
 POSTHOG_SECRET=$(head -c 28 /dev/urandom | sha224sum -b | head -c 56)
 export POSTHOG_SECRET
 
-ENCRYPTION_SALT_KEYS=$(head -c 28 /dev/urandom | sha224sum -b | head -c 56)
+ENCRYPTION_KEY=$(head -c 32 /dev/urandom | base64 | tr +/ -_ | tr -d =)
 export ENCRYPTION_SALT_KEYS
 
 # Talk to the user

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -56,12 +56,25 @@ else
 fi
 
 [[ -f ".env" ]] && export $(cat .env | xargs) || ( echo "No .env file found. Please create it with POSTHOG_SECRET and DOMAIN set." && exit 1)
+
 # we introduced ENCRYPTION_SALT_KEYS and so if there isn't one, need to add it
 # check for it in the .env file
-if ! grep -q "ENCRYPTION_SALT_KEYS" .env
-then
-    ENCRYPTION_SALT_KEYS=$(head -c 28 /dev/urandom | sha224sum -b | head -c 56)
-    echo "ENCRYPTION_SALT_KEYS=$ENCRYPTION_SALT_KEYS" >> .env
+if ! grep -q "ENCRYPTION_SALT_KEYS" .env; then
+    NEW_KEY=$(generate_fernet_key)
+    echo "ENCRYPTION_SALT_KEYS=$NEW_KEY" >> .env
+    echo "Added missing ENCRYPTION_SALT_KEYS to .env file"
+else
+    # Read the existing key
+    EXISTING_KEY=$(grep "ENCRYPTION_SALT_KEYS" .env | cut -d '=' -f2)
+    
+    # Check if the existing key is in the correct format (32 bytes base64url)
+    if [[ ! $EXISTING_KEY =~ ^[A-Za-z0-9_-]{43}$ ]]; then
+        NEW_KEY=$(generate_fernet_key)
+        sed -i "s/ENCRYPTION_SALT_KEYS=.*/ENCRYPTION_SALT_KEYS=$NEW_KEY/" .env
+        echo "Replaced ENCRYPTION_SALT_KEYS in .env file with a new, correctly formatted key"
+    else
+        echo "Existing ENCRYPTION_SALT_KEYS is correctly formatted"
+    fi
 fi
 
 

--- a/bin/upgrade-hobby
+++ b/bin/upgrade-hobby
@@ -60,8 +60,8 @@ fi
 # we introduced ENCRYPTION_SALT_KEYS and so if there isn't one, need to add it
 # check for it in the .env file
 if ! grep -q "ENCRYPTION_SALT_KEYS" .env; then
-    NEW_KEY=$(generate_fernet_key)
-    echo "ENCRYPTION_SALT_KEYS=$NEW_KEY" >> .env
+    ENCRYPTION_KEY=$(head -c 32 /dev/urandom | base64 | tr +/ -_ | tr -d =)
+    echo "ENCRYPTION_SALT_KEYS=$ENCRYPTION_KEY" >> .env
     echo "Added missing ENCRYPTION_SALT_KEYS to .env file"
 else
     # Read the existing key
@@ -69,11 +69,10 @@ else
     
     # Check if the existing key is in the correct format (32 bytes base64url)
     if [[ ! $EXISTING_KEY =~ ^[A-Za-z0-9_-]{43}$ ]]; then
-        NEW_KEY=$(generate_fernet_key)
-        sed -i "s/ENCRYPTION_SALT_KEYS=.*/ENCRYPTION_SALT_KEYS=$NEW_KEY/" .env
-        echo "Replaced ENCRYPTION_SALT_KEYS in .env file with a new, correctly formatted key"
-    else
-        echo "Existing ENCRYPTION_SALT_KEYS is correctly formatted"
+        echo "ENCRYPTION_SALT_KEYS is not in the correct fernet format and will not work"
+        echo "🛑 Stop this script and do not proceed"
+        echo "remove ENCRYPTION_SALT_KEYS from .env and try again"
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
follow-up to https://github.com/PostHog/posthog/pull/25479

this continues to be the gift that gives

now plugin server does not start because 

{"level":"error","time":1728490554991,"pid":36,"hostname":"f01ec11b8962","error":"Error: Key must be 32-byte long base64url encoded string.\n    at Fernet.checkKey (/code/plugin-server/node_modules/.pnpm/fernet-nodejs@1.0.6/node_modules/fernet-nodejs/dist/Fernet.js:28:19)\n 

so

* generate a 32 byte long base64 url encoded string
* add that if it isn't present when upgrading
* replace an incorrect key if present when upgrading (because someone may have a broken key from #25479 