### PR TITLE
fix(data-warehouse): Use SSL CA for mysql connections

### DIFF
--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -4,6 +4,7 @@ from typing import Optional
 from django.db import models
 from django_deprecate_fields import deprecate_field
 import snowflake.connector
+from django.conf import settings
 from posthog.models.team import Team
 from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UUIDModel, UpdatedMetaFields, sane_repr
 import uuid
@@ -314,6 +315,7 @@ def get_mysql_schemas(
             user=user,
             password=password,
             connect_timeout=5,
+            ssl_ca="/etc/ssl/cert.pem" if settings.DEBUG else "/etc/ssl/certs/ca-certificates.crt",
         )
 
         with connection.cursor() as cursor:


### PR DESCRIPTION
## Problem
- Planetscale mysql databases require using the severs CA SSL cert

## Changes
Use the correct CA cert when on Mac vs Linux pods

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested a planetscale DB locally (was borked before I added my changes)
