### PR TITLE
fix: modal stacking was hard to increment

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
@@ -16,7 +16,7 @@ export type LemonFormDialogProps = LemonDialogFormPropsType &
 
 export type LemonDialogProps = Pick<
     LemonModalProps,
-    'title' | 'description' | 'width' | 'maxWidth' | 'inline' | 'footer'
+    'title' | 'description' | 'width' | 'maxWidth' | 'inline' | 'footer' | 'zIndex'
 > & {
     primaryButton?: LemonButtonProps | null
     secondaryButton?: LemonButtonProps | null

--- a/frontend/src/lib/lemon-ui/LemonModal/LemonModal.scss
+++ b/frontend/src/lib/lemon-ui/LemonModal/LemonModal.scss
@@ -21,6 +21,12 @@
         background-color: transparent;
         backdrop-filter: blur(0);
     }
+
+    @each $i in (1061, 1062, 1066, 1067, 1068, 1069) {
+        &.LemonModal__overlay--z-#{$i} {
+            z-index: #{$i};
+        }
+    }
 }
 
 .LemonModal {

--- a/frontend/src/lib/lemon-ui/LemonModal/LemonModal.tsx
+++ b/frontend/src/lib/lemon-ui/LemonModal/LemonModal.tsx
@@ -46,6 +46,11 @@ export interface LemonModalProps {
     contentRef?: React.RefCallback<HTMLDivElement>
     overlayRef?: React.RefCallback<HTMLDivElement>
     'data-attr'?: string
+    /**
+     * some components need more fine control of the z-index
+     * they can push a specific value to control their position in the stacking order
+     */
+    zIndex?: '1061' | '1062' | '1066' | '1067' | '1068' | '1069'
 }
 
 export const LemonModalHeader = ({ children, className }: LemonModalInnerProps): JSX.Element => {
@@ -84,6 +89,7 @@ export function LemonModal({
     overlayRef,
     hideCloseButton = false,
     'data-attr': dataAttr,
+    zIndex,
 }: LemonModalProps): JSX.Element {
     const nodeRef = useRef(null)
     const [ignoredOverlayClickCount, setIgnoredOverlayClickCount] = useState(0)
@@ -157,7 +163,6 @@ export function LemonModal({
 
     width = !fullScreen ? width : undefined
     maxWidth = !fullScreen ? maxWidth : undefined
-
     const floatingContainer = useFloatingContainer()
 
     return inline ? (
@@ -184,6 +189,7 @@ export function LemonModal({
             className={clsx('LemonModal', fullScreen && 'LemonModal--fullscreen')}
             overlayClassName={clsx(
                 'LemonModal__overlay',
+                zIndex && `LemonModal__overlay--z-${zIndex}`,
                 forceAbovePopovers && 'LemonModal__overlay--force-modal-above-popovers'
             )}
             style={{

--- a/frontend/src/scenes/session-recordings/player/modal/SessionPlayerModal.tsx
+++ b/frontend/src/scenes/session-recordings/player/modal/SessionPlayerModal.tsx
@@ -49,6 +49,7 @@ export function SessionPlayerModal(): JSX.Element | null {
             fullScreen={isFullScreen}
             closable={!isFullScreen}
             zIndex="1061"
+            hideCloseButton={true}
         >
             <header>
                 {activeSessionRecording ? (

--- a/frontend/src/scenes/session-recordings/player/modal/SessionPlayerModal.tsx
+++ b/frontend/src/scenes/session-recordings/player/modal/SessionPlayerModal.tsx
@@ -48,6 +48,7 @@ export function SessionPlayerModal(): JSX.Element | null {
             width={1600}
             fullScreen={isFullScreen}
             closable={!isFullScreen}
+            zIndex="1061"
         >
             <header>
                 {activeSessionRecording ? (

--- a/frontend/src/scenes/session-recordings/player/share/PlayerShare.tsx
+++ b/frontend/src/scenes/session-recordings/player/share/PlayerShare.tsx
@@ -76,5 +76,6 @@ export function openPlayerShareDialog({ seconds, id }: PlayerShareLogicProps): v
             children: 'Close',
             type: 'secondary',
         },
+        zIndex: '1062',
     })
 }

--- a/frontend/src/styles/vars.scss
+++ b/frontend/src/styles/vars.scss
@@ -194,9 +194,13 @@ $_lifecycle_dormant: map.get($colors, 'danger');
     --z-command-palette: 1875;
     --z-force-modal-above-popovers: 1850;
     --z-tooltip: 1070;
-    --z-definition-popover: 1064;
-    --z-popover: 1063;
-    --z-graph-tooltip: 1062;
+
+    // 1066 through 1069 are reserved to be set from code
+    --z-definition-popover: 1065;
+    --z-popover: 1064;
+    --z-graph-tooltip: 1063;
+
+    // 1061 and 1062 are reserved to be set from code
     --z-modal: 1060;
     --z-hedgehog-buddy: 1059;
     --z-annotation-popover: 1049;


### PR DESCRIPTION
closes https://github.com/PostHog/posthog/issues/25486

the lemon modal could be at its default z-index or forced to the top of the stack

this doesn't help when 

* you open the actor modal 
* from there you open the replay modal
* from there you open the sharing modal

(that chain isn't actually possible at the moment because the replay modal would be behind the actor modal - but it should be possible)

We don't _need_ the modal component to know about why it is being given a z-index and there are already gaps in the reserved z-indices in `vars.scss` 

so we can let the LemonModal accept one of a short list of z-index overrides for circumstances where you need a little more control

|before|after|
|-|-|
|![2024-10-09 23 04 39](https://github.com/user-attachments/assets/94dfd1e0-cb77-42a8-a907-067da4f5b107)|![2024-10-09 23 03 46](https://github.com/user-attachments/assets/bbbfbec8-5d64-4d53-9fda-80da2e194785)|



fly-by the close button doesn't display correctly on the replay modal. you can click outside or hit escape to close it, so let's not have one
![2024-10-09 23 12 17](https://github.com/user-attachments/assets/e59bb146-1b19-4947-9084-3282fe2feae6)

