### PR TITLE
fix: shared insight fails to load

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -647,7 +647,7 @@ class InsightSerializer(InsightBasicSerializer, UserPermissionsSerializerMixin):
                     insight,
                     dashboard=dashboard,
                     execution_mode=execution_mode,
-                    user=self.context["request"].user,
+                    user=None if self.request.user.is_anonymous else self.context["request"].user,
                     filters_override=filters_override,
                 )
             except ExposedHogQLError as e:

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -647,7 +647,7 @@ class InsightSerializer(InsightBasicSerializer, UserPermissionsSerializerMixin):
                     insight,
                     dashboard=dashboard,
                     execution_mode=execution_mode,
-                    user=None if self.request.user.is_anonymous else self.context["request"].user,
+                    user=None if self.context["request"].user.is_anonymous else self.context["request"].user,
                     filters_override=filters_override,
                 )
             except ExposedHogQLError as e:


### PR DESCRIPTION
## Problem

Shared insight fails to load because an anonymous user object has no distinct id

https://grafana.prod-eu.posthog.dev/explore?schemaVersion=1&panes=%7B%22ndl%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Blevel%3D%5C%22error%5C%22%7D%20%7C%3D%20%60QSzWBtIR5WlN3766df0VawKsHVS7rg%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22builder%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1

## Changes

Don't pass in a user if they're anonymous

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

:shrug: 
