### PR TITLE
feat: unknown type arg matching

### DIFF
--- a/posthog/hogql/test/test_mapping.py
+++ b/posthog/hogql/test/test_mapping.py
@@ -1,4 +1,8 @@
-from posthog.hogql.ast import FloatType, IntegerType
+from posthog.hogql.ast import FloatType, IntegerType, DateType
+from posthog.hogql.base import UnknownType
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.parser import parse_expr
+from posthog.hogql.printer import print_ast
 from posthog.test.base import BaseTest
 from typing import Optional
 from posthog.hogql.functions.mapping import (
@@ -7,6 +11,7 @@ from posthog.hogql.functions.mapping import (
     find_hogql_aggregation,
     find_hogql_posthog_function,
     HogQLFunctionMeta,
+    HOGQL_CLICKHOUSE_FUNCTIONS,
 )
 
 
@@ -60,3 +65,19 @@ class TestMappings(BaseTest):
     def test_compare_types_mismatch_differing_order(self):
         res = compare_types([IntegerType(), FloatType()], (FloatType(), IntegerType()))
         assert res is False
+
+    def test_unknown_type_mapping(self):
+        HOGQL_CLICKHOUSE_FUNCTIONS["dateEmittingFunction"] = HogQLFunctionMeta(
+            "dateEmittingFunction",
+            1,
+            1,
+            signatures=[
+                ((UnknownType(),), DateType()),
+            ],
+        )
+        ast = print_ast(
+            parse_expr("toDateTime(dateEmittingFunction('123123'))"),
+            HogQLContext(self.team.pk, enable_select_queries=True),
+            "clickhouse",
+        )
+        assert "parseDateTime64BestEffortOrNull" not in ast

--- a/posthog/hogql/test/test_mapping.py
+++ b/posthog/hogql/test/test_mapping.py
@@ -67,6 +67,13 @@ class TestMappings(BaseTest):
         assert res is False
 
     def test_unknown_type_mapping(self):
+        HOGQL_CLICKHOUSE_FUNCTIONS["overloadedFunction"] = HogQLFunctionMeta(
+            "overloadFailure",
+            1,
+            1,
+            overloads=[((DateType,), "overloadSuccess")],
+        )
+
         HOGQL_CLICKHOUSE_FUNCTIONS["dateEmittingFunction"] = HogQLFunctionMeta(
             "dateEmittingFunction",
             1,
@@ -76,8 +83,8 @@ class TestMappings(BaseTest):
             ],
         )
         ast = print_ast(
-            parse_expr("toDateTime(dateEmittingFunction('123123'))"),
+            parse_expr("overloadedFunction(dateEmittingFunction('123123'))"),
             HogQLContext(self.team.pk, enable_select_queries=True),
             "clickhouse",
         )
-        assert "parseDateTime64BestEffortOrNull" not in ast
+        assert "overloadSuccess" in ast

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_udf.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_udf.ambr
@@ -7,7 +7,7 @@
          if(ifNull(greater(reached_from_step_count, 0), 0), round(multiply(divide(reached_to_step_count, reached_from_step_count), 100), 2), 0) AS conversion_rate,
          data.breakdown AS prop
   FROM
-    (SELECT arrayJoin(aggregate_funnel_array_trends(0, 3, 1209600, 'first_touch', 'ordered', [[]], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toTimeZone(toDateTime(toStartOfDay(timestamp), 'UTC'), 'UTC'), [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))))) AS af_tuple,
+    (SELECT arrayJoin(aggregate_funnel_array_trends_v0(0, 3, 1209600, 'first_touch', 'ordered', [[]], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toStartOfDay(timestamp), [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))))) AS af_tuple,
             toTimeZone(af_tuple.1, 'UTC') AS entrance_period_start,
             af_tuple.2 AS success_bool,
             af_tuple.3 AS breakdown
@@ -52,7 +52,7 @@
          if(ifNull(greater(reached_from_step_count, 0), 0), round(multiply(divide(reached_to_step_count, reached_from_step_count), 100), 2), 0) AS conversion_rate,
          data.breakdown AS prop
   FROM
-    (SELECT arrayJoin(aggregate_funnel_array_trends(0, 3, 1209600, 'first_touch', 'ordered', [[]], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toTimeZone(toDateTime(toStartOfDay(timestamp), 'US/Pacific'), 'UTC'), [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))))) AS af_tuple,
+    (SELECT arrayJoin(aggregate_funnel_array_trends_v0(0, 3, 1209600, 'first_touch', 'ordered', [[]], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toStartOfDay(timestamp), [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))))) AS af_tuple,
             toTimeZone(af_tuple.1, 'US/Pacific') AS entrance_period_start,
             af_tuple.2 AS success_bool,
             af_tuple.3 AS breakdown

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_udf.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_udf.ambr
@@ -97,7 +97,7 @@
          if(ifNull(greater(reached_from_step_count, 0), 0), round(multiply(divide(reached_to_step_count, reached_from_step_count), 100), 2), 0) AS conversion_rate,
          data.breakdown AS prop
   FROM
-    (SELECT arrayJoin(aggregate_funnel_array_trends(0, 3, 1209600, 'first_touch', 'ordered', [[]], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toTimeZone(toDateTime(toStartOfWeek(timestamp, 0), 'UTC'), 'UTC'), [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))))) AS af_tuple,
+    (SELECT arrayJoin(aggregate_funnel_array_trends_v0(0, 3, 1209600, 'first_touch', 'ordered', [[]], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toStartOfWeek(timestamp, 0), [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))))) AS af_tuple,
             toTimeZone(af_tuple.1, 'UTC') AS entrance_period_start,
             af_tuple.2 AS success_bool,
             af_tuple.3 AS breakdown

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_udf.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_udf.ambr
@@ -7,7 +7,7 @@
          if(ifNull(greater(reached_from_step_count, 0), 0), round(multiply(divide(reached_to_step_count, reached_from_step_count), 100), 2), 0) AS conversion_rate,
          data.breakdown AS prop
   FROM
-    (SELECT arrayJoin(aggregate_funnel_array_trends_v0(0, 3, 1209600, 'first_touch', 'ordered', [[]], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toStartOfDay(timestamp), [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))))) AS af_tuple,
+    (SELECT arrayJoin(aggregate_funnel_array_trends(0, 3, 1209600, 'first_touch', 'ordered', [[]], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toTimeZone(toDateTime(toStartOfDay(timestamp), 'UTC'), 'UTC'), [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))))) AS af_tuple,
             toTimeZone(af_tuple.1, 'UTC') AS entrance_period_start,
             af_tuple.2 AS success_bool,
             af_tuple.3 AS breakdown
@@ -52,7 +52,7 @@
          if(ifNull(greater(reached_from_step_count, 0), 0), round(multiply(divide(reached_to_step_count, reached_from_step_count), 100), 2), 0) AS conversion_rate,
          data.breakdown AS prop
   FROM
-    (SELECT arrayJoin(aggregate_funnel_array_trends_v0(0, 3, 1209600, 'first_touch', 'ordered', [[]], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toStartOfDay(timestamp), [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))))) AS af_tuple,
+    (SELECT arrayJoin(aggregate_funnel_array_trends(0, 3, 1209600, 'first_touch', 'ordered', [[]], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toTimeZone(toDateTime(toStartOfDay(timestamp), 'US/Pacific'), 'UTC'), [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))))) AS af_tuple,
             toTimeZone(af_tuple.1, 'US/Pacific') AS entrance_period_start,
             af_tuple.2 AS success_bool,
             af_tuple.3 AS breakdown
@@ -97,7 +97,7 @@
          if(ifNull(greater(reached_from_step_count, 0), 0), round(multiply(divide(reached_to_step_count, reached_from_step_count), 100), 2), 0) AS conversion_rate,
          data.breakdown AS prop
   FROM
-    (SELECT arrayJoin(aggregate_funnel_array_trends_v0(0, 3, 1209600, 'first_touch', 'ordered', [[]], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toStartOfWeek(timestamp, 0), [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))))) AS af_tuple,
+    (SELECT arrayJoin(aggregate_funnel_array_trends(0, 3, 1209600, 'first_touch', 'ordered', [[]], arraySort(t -> t.1, groupArray(tuple(accurateCastOrNull(timestamp, 'Float64'), toTimeZone(toDateTime(toStartOfWeek(timestamp, 0), 'UTC'), 'UTC'), [], arrayFilter(x -> ifNull(notEquals(x, 0), 1), [multiply(1, step_0), multiply(2, step_1), multiply(3, step_2)])))))) AS af_tuple,
             toTimeZone(af_tuple.1, 'UTC') AS entrance_period_start,
             af_tuple.2 AS success_bool,
             af_tuple.3 AS breakdown


### PR DESCRIPTION
## Problem

If you have HogQL code that looks like `toDateTime(toStartOfMonth(now())`, HogQL will try to call `parseDateTime64BestEffortOrNull`, which only works on strings, instead of the override, `toDateTime`, because it doesn't know what `toStartOfMonth` should be.

## Changes

A lot of clickhouse functions return only one type, but take multiple input types.

To get the benefits of knowing their types without knowing their input types, allow HogQL to accept "UnknownType" as an input type for method signatures.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unit tests
