### PR TITLE
fix: autocapture activity description is flipped

### DIFF
--- a/frontend/src/scenes/teamActivityDescriber.tsx
+++ b/frontend/src/scenes/teamActivityDescriber.tsx
@@ -164,7 +164,7 @@ const teamActionsMapping: Record<
         return { description: [<>set allowed web vitals autocapture metrics to {metricsList}</>] }
     },
     autocapture_opt_out(change: ActivityChange | undefined): ChangeMapping | null {
-        return { description: [<>{change?.after ? 'opted in to' : 'opted out of'} autocapture</>] }
+        return { description: [<>{change?.after ? 'opted out of' : 'opted in to'} autocapture</>] }
     },
     heatmaps_opt_in(change: ActivityChange | undefined): ChangeMapping | null {
         return { description: [<>{change?.after ? 'enabled' : 'disabled'} heatmaps</>] }


### PR DESCRIPTION
server side autocapture opt in is presented as an opt in but really it's an opt out, so the activity log description was back to forwards