### PR TITLE
fix(temporal): Handle SIGTERM correctly on worker cleanup

### DIFF
--- a/bin/temporal-django-worker
+++ b/bin/temporal-django-worker
@@ -2,8 +2,21 @@
 
 set -e
 
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+cleanup() {
+    echo "Stopping worker..."
+    if kill -0 "$worker_pid" >/dev/null 2>&1; then
+        kill "$worker_pid"
+    else
+        echo "Worker process is not running."
+    fi
+}
 
-python3 manage.py start_temporal_worker "$@"
+trap cleanup SIGINT SIGTERM EXIT
 
-wait
+python3 manage.py start_temporal_worker "$@" &
+
+worker_pid=$!
+
+wait $worker_pid
+
+cleanup

--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -1,5 +1,5 @@
+import asyncio
 import signal
-import sys
 from datetime import timedelta
 
 from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
@@ -43,10 +43,10 @@ async def start_worker(
 
     # catch the TERM signal, and stop the worker gracefully
     # https://github.com/temporalio/sdk-python#worker-shutdown
-    async def signal_handler(sig, frame):
+    async def shutdown_worker():
         await worker.shutdown()
-        sys.exit(0)
 
-    signal.signal(signal.SIGTERM, signal_handler)
+    loop = asyncio.get_event_loop()
+    loop.add_signal_handler(signal.SIGTERM, lambda: asyncio.create_task(shutdown_worker()))
 
     await worker.run()


### PR DESCRIPTION
## Problem

Local devs may have realized that on stopping `./bin/start` the underlying `temporal-worker-django` process wasn't stopping. This was because we were not properly handling `SIGTERM` as a coroutine was not awaited.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Cleanup `./bin/temporal-django-worker`
* Properly handle SIGTERM in async python.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Manually:
1. run `./bin/start/`
2. CTRL+C
3. ps | grep 'temporal', nothing pops up. Without code change, the process is still there.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
