### PR TITLE
fix(data-warehouse): Fix edit view definition button

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
+++ b/frontend/src/scenes/data-warehouse/external/DataWarehouseTables.tsx
@@ -131,18 +131,17 @@ export const DatabaseTableTreeWithItems = ({ inline }: DatabaseTableTreeProps): 
             >
                 Add join
             </LemonButton>
-            {table.type == 'view' ||
-                (table.type == 'materialized_view' && (
-                    <LemonButton
-                        onClick={() => {
-                            router.actions.push(urls.dataWarehouseView(table.id))
-                        }}
-                        data-attr="schema-list-item-edit"
-                        fullWidth
-                    >
-                        Edit view definition
-                    </LemonButton>
-                ))}
+            {(table.type == 'view' || table.type == 'materialized_view') && (
+                <LemonButton
+                    onClick={() => {
+                        router.actions.push(urls.dataWarehouseView(table.id))
+                    }}
+                    data-attr="schema-list-item-edit"
+                    fullWidth
+                >
+                    Edit view definition
+                </LemonButton>
+            )}
             {featureFlags[FEATURE_FLAGS.DATA_MODELING] && table.type === 'view' && (
                 <LemonButton
                     onClick={() => {


### PR DESCRIPTION
## Problem
- The edit view definition button has gone missing 😱 

## Changes
- Correct some pesky parentheses' when rendering the button 

**Prod**
<img width="364" alt="image" src="https://github.com/user-attachments/assets/270c9daf-5c68-423e-9fd0-5d154a9b7da6">

**Changes:**
<img width="532" alt="image" src="https://github.com/user-attachments/assets/46a20f93-340c-40fe-9fbe-b26797083408">

