### PR TITLE
fix(data-warehouse): Fix selecting filter operator on extended person props

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/utils.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.ts
@@ -16,6 +16,7 @@ import {
     AnyPropertyFilter,
     CohortPropertyFilter,
     CohortType,
+    DataWarehousePersonPropertyFilter,
     DataWarehousePropertyFilter,
     ElementPropertyFilter,
     EmptyPropertyFilter,
@@ -220,6 +221,11 @@ export function isGroupPropertyFilter(filter?: AnyFilterLike | null): filter is 
 export function isDataWarehousePropertyFilter(filter?: AnyFilterLike | null): filter is DataWarehousePropertyFilter {
     return filter?.type === PropertyFilterType.DataWarehouse
 }
+export function isDataWarehousePersonPropertyFilter(
+    filter?: AnyFilterLike | null
+): filter is DataWarehousePropertyFilter {
+    return filter?.type === PropertyFilterType.DataWarehousePersonProperty
+}
 export function isFeaturePropertyFilter(filter?: AnyFilterLike | null): filter is FeaturePropertyFilter {
     return filter?.type === PropertyFilterType.Feature
 }
@@ -252,7 +258,8 @@ export function isPropertyFilterWithOperator(
     | LogEntryPropertyFilter
     | FeaturePropertyFilter
     | GroupPropertyFilter
-    | DataWarehousePropertyFilter {
+    | DataWarehousePropertyFilter
+    | DataWarehousePersonPropertyFilter {
     return (
         !isPropertyGroupFilterLike(filter) &&
         (isEventPropertyFilter(filter) ||
@@ -264,7 +271,8 @@ export function isPropertyFilterWithOperator(
             isFeaturePropertyFilter(filter) ||
             isGroupPropertyFilter(filter) ||
             isCohortPropertyFilter(filter) ||
-            isDataWarehousePropertyFilter(filter))
+            isDataWarehousePropertyFilter(filter) ||
+            isDataWarehousePersonPropertyFilter(filter))
     )
 }
 


### PR DESCRIPTION
## Problem
- You can only select "equals" when selecting a filter property operator for extended person properties, see vid below
- [Support ticket](https://posthoghelp.zendesk.com/agent/tickets/19087)

https://github.com/user-attachments/assets/7995b431-609a-4fab-8a84-6534a4d27ac1

## Changes
- Allow selecting other extended person property filter operators - e.g. regex, contains, etc
