### PR TITLE
fix(batch-exports): Order events by timestamp when backfilling

### DIFF
--- a/posthog/batch_exports/sql.py
+++ b/posthog/batch_exports/sql.py
@@ -130,7 +130,7 @@ CREATE OR REPLACE VIEW events_batch_export_backfill ON CLUSTER {settings.CLICKHO
         event AS event,
         distinct_id AS distinct_id,
         toString(uuid) AS uuid,
-        COALESCE(inserted_at, _timestamp) AS _inserted_at,
+        timestamp AS _inserted_at,
         created_at AS created_at,
         elements_chain AS elements_chain,
         toString(person_id) AS person_id,

--- a/posthog/clickhouse/migrations/0080_recreate_events_backfill.py
+++ b/posthog/clickhouse/migrations/0080_recreate_events_backfill.py
@@ -1,0 +1,11 @@
+from posthog.batch_exports.sql import (
+    CREATE_EVENTS_BATCH_EXPORT_VIEW_BACKFILL,
+)
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+operations = map(
+    run_sql_with_exceptions,
+    [
+        CREATE_EVENTS_BATCH_EXPORT_VIEW_BACKFILL,
+    ],
+)


### PR DESCRIPTION
## Problem

When backfilling, currently we sort events by `inserted_at`. If the worker, for whatever reason, happens to crash, we restart from the latest `inserted_at` exported. However, this `inserted_at` is passed as the `timestamp` field to the backfill query. This is not accurate as `inserted_at` is not the same as `timestamp`. Since we filter events by `timestamp` in backfill, also sort them by `timestamp`.

This mostly affects backfills that fail, so it can be a bit of an edge case.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Sort events by `timestamp` in backfill.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
