### PR TITLE
fix(errors): Key logic so display is overridden correctly

### DIFF
--- a/frontend/src/scenes/error-tracking/errorTrackingGroupSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingGroupSceneLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 import api from 'lib/api'
@@ -37,6 +37,7 @@ export enum ErrorGroupTab {
 export const errorTrackingGroupSceneLogic = kea<errorTrackingGroupSceneLogicType>([
     path((key) => ['scenes', 'error-tracking', 'errorTrackingGroupSceneLogic', key]),
     props({} as ErrorTrackingGroupSceneLogicProps),
+    key((props) => JSON.stringify(props.fingerprint)),
 
     connect({
         values: [errorTrackingLogic, ['dateRange', 'filterTestAccounts', 'filterGroup', 'hasGroupActions']],


### PR DESCRIPTION
## Problem

Starting to annoy me a bit more - right now you need to refresh aafter you click on an error to get the error group events list 😅 - it doesn't correctly update because the logic isn't keyed on the fingerprint

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
