### PR TITLE
fix(batch-exports): Correct display of timestamps in runs view

### DIFF
--- a/frontend/src/scenes/pipeline/batchExportRunsLogic.tsx
+++ b/frontend/src/scenes/pipeline/batchExportRunsLogic.tsx
@@ -4,7 +4,6 @@ import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import api, { PaginatedResponse } from 'lib/api'
 import { Dayjs, dayjs } from 'lib/dayjs'
-import { dayjsUtcToTimezone } from 'lib/dayjs'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { BatchExportRun, GroupedBatchExportRuns, RawBatchExportRun } from '~/types'
@@ -184,12 +183,10 @@ export const batchExportRunsLogic = kea<batchExportRunsLogicType>([
                 return runs.map((run) => {
                     return {
                         ...run,
-                        created_at: dayjsUtcToTimezone(run.created_at, teamLogic.values.timezone),
-                        data_interval_start: dayjsUtcToTimezone(run.data_interval_start, teamLogic.values.timezone),
-                        data_interval_end: dayjsUtcToTimezone(run.data_interval_end, teamLogic.values.timezone),
-                        last_updated_at: run.last_updated_at
-                            ? dayjsUtcToTimezone(run.last_updated_at, teamLogic.values.timezone)
-                            : undefined,
+                        created_at: dayjs(run.created_at),
+                        data_interval_start: dayjs(run.data_interval_start),
+                        data_interval_end: dayjs(run.data_interval_end),
+                        last_updated_at: run.last_updated_at ? dayjs(run.last_updated_at) : undefined,
                     }
                 })
             },
@@ -209,21 +206,19 @@ export const batchExportRunsLogic = kea<batchExportRunsLogicType>([
                     const key = `${run.data_interval_start}-${run.data_interval_end}`
                     if (!groupedRuns[key]) {
                         groupedRuns[key] = {
-                            data_interval_start: dayjsUtcToTimezone(run.data_interval_start, teamLogic.values.timezone),
-                            data_interval_end: dayjsUtcToTimezone(run.data_interval_end, teamLogic.values.timezone),
+                            data_interval_start: dayjs(run.data_interval_start),
+                            data_interval_end: dayjs(run.data_interval_end),
                             runs: [],
-                            last_run_at: dayjsUtcToTimezone(run.created_at, teamLogic.values.timezone),
+                            last_run_at: dayjs(run.created_at),
                         }
                     }
 
                     groupedRuns[key].runs.push({
                         ...run,
-                        created_at: dayjsUtcToTimezone(run.created_at, teamLogic.values.timezone),
-                        data_interval_start: dayjsUtcToTimezone(run.data_interval_start, teamLogic.values.timezone),
-                        data_interval_end: dayjsUtcToTimezone(run.data_interval_end, teamLogic.values.timezone),
-                        last_updated_at: run.last_updated_at
-                            ? dayjsUtcToTimezone(run.last_updated_at, teamLogic.values.timezone)
-                            : undefined,
+                        created_at: dayjs(run.created_at),
+                        data_interval_start: dayjs(run.data_interval_start),
+                        data_interval_end: dayjs(run.data_interval_end),
+                        last_updated_at: run.last_updated_at ? dayjs(run.last_updated_at) : undefined,
                     })
                     groupedRuns[key].runs.sort((a, b) => b.created_at.diff(a.created_at))
                     groupedRuns[key].last_run_at = groupedRuns[key].runs[0].created_at


### PR DESCRIPTION
## Problem

Runs returned by the django API are always in UTC: PostgreSQL converts datetime values to UTC when saved as `timestamp with timezone`, and our API reads these back as timezone-aware datetime objects in UTC timezone that are dumped to JSON by calling `isoformat()`.

By calling `dayjsUtcToTimezone` we were re-converting these dates into the project's timezone, but this is not needed and was causing UI problems. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Do not call `dayjsUtcToTimezone`, instead just parse the datetime string.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yup
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Manually:

Notice that after these changes a workflow that ends at the start of today (October 10th at 00:00) is correctly displayed as Today 00:00:00:

![image](https://github.com/user-attachments/assets/047e80f0-a64f-4a81-9a37-2f221be0ed9e)

And a workflow that covered yesterday up to 05:00, is correctly displayed as Yesterday 05:00:00:

![image](https://github.com/user-attachments/assets/5d2407bf-4c1b-40c2-b557-a7a8d1722769)

Just to show how things look right now, notice that runs that happened today (October 10th) do not show up as "Today":

![image](https://github.com/user-attachments/assets/9c3ff749-5287-4e2f-88b7-f990008d5f80)

Instead, runs that covered yesterdady show up as "Today":

![image](https://github.com/user-attachments/assets/d9f16bf0-d15c-4e4e-b4e6-a8c03f0f08f0)
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
