### PR TITLE
fix: belt and braces check for symbolic link

### DIFF
--- a/docker/clickhouse/docker-entrypoint-initdb.d/init-db.sh
+++ b/docker/clickhouse/docker-entrypoint-initdb.d/init-db.sh
@@ -3,5 +3,10 @@ set -e
 
 apt-get update
 apt-get -y install python3.9
-ln -s /usr/bin/python3.9 /usr/bin/python3
+
+# Check if /usr/bin/python3 already exists and if it points to python3.9
+if [[ $(readlink /usr/bin/python3) != "/usr/bin/python3.9" ]]; then
+    ln -sf /usr/bin/python3.9 /usr/bin/python3
+fi
+
 cp -r /idl/* /var/lib/clickhouse/format_schemas/


### PR DESCRIPTION
clickhouse is not starting on my selfhosted instance because it's trying to create a symbolic link that already exists