### PR TITLE
feat(comms): Open customer success zendesk ticket instead email

### DIFF
--- a/frontend/src/scenes/billing/UnsubscribeCard.tsx
+++ b/frontend/src/scenes/billing/UnsubscribeCard.tsx
@@ -1,5 +1,6 @@
 import { LemonButton, Link } from '@posthog/lemon-ui'
 import { useActions } from 'kea'
+import { supportLogic } from 'lib/components/Support/supportLogic'
 import { UNSUBSCRIBE_SURVEY_ID } from 'lib/constants'
 
 import { BillingProductV2Type } from '~/types'
@@ -8,6 +9,7 @@ import { billingProductLogic } from './billingProductLogic'
 
 export const UnsubscribeCard = ({ product }: { product: BillingProductV2Type }): JSX.Element => {
     const { reportSurveyShown, setSurveyResponse } = useActions(billingProductLogic({ product }))
+    const { openSupportForm } = useActions(supportLogic)
 
     return (
         <div className="p-5 gap-4 flex">
@@ -26,7 +28,7 @@ export const UnsubscribeCard = ({ product }: { product: BillingProductV2Type }):
                         reduce your bill
                     </Link>{' '}
                     or{' '}
-                    <Link to="mailto:sales@posthog.com?subject=Help%20reducing%20PostHog%20bill" target="_blank">
+                    <Link to="" onClick={() => openSupportForm({ target_area: 'billing', isEmailFormOpen: true })}>
                         chat with support.
                     </Link>{' '}
                     Check out more about our pricing on our{' '}

--- a/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
+++ b/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
@@ -2,6 +2,7 @@ import './UnsubscribeSurveyModal.scss'
 
 import { LemonBanner, LemonButton, LemonCheckbox, LemonLabel, LemonModal, LemonTextArea, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
+import { supportLogic } from 'lib/components/Support/supportLogic'
 
 import { BillingProductV2AddonType, BillingProductV2Type } from '~/types'
 
@@ -32,6 +33,7 @@ export const UnsubscribeSurveyModal = ({
     const { deactivateProduct, resetUnsubscribeError } = useActions(billingLogic)
     const { unsubscribeError, billingLoading, billing } = useValues(billingLogic)
     const { unsubscribeDisabledReason, itemsToDisable } = useValues(exportsUnsubscribeTableLogic)
+    const { openSupportForm } = useActions(supportLogic)
 
     const textAreaNotEmpty = surveyResponse['$survey_response']?.length > 0
     const includesPipelinesAddon =
@@ -150,10 +152,11 @@ export const UnsubscribeSurveyModal = ({
                         </Link>
                         {`${product.type !== 'session_replay' ? ' or ' : ', '}`}
                         <Link
-                            to="mailto:sales@posthog.com?subject=Help%20reducing%20PostHog%20bill"
+                            to=""
                             target="_blank"
                             onClick={() => {
                                 reportSurveyDismissed(surveyID)
+                                openSupportForm({ target_area: 'billing', isEmailFormOpen: true })
                             }}
                         >
                             chat with support


### PR DESCRIPTION
## Changes

Open the support panel instead of linking to mailto:sales@posthog.com

![2024-10-11 at 11 43 02](https://github.com/user-attachments/assets/5943fcf0-3c2b-4d92-9285-9714bd77e933)