### PR TITLE
fix(plugin-server): missing break statement

### DIFF
--- a/plugin-server/src/main/services/http-server.ts
+++ b/plugin-server/src/main/services/http-server.ts
@@ -121,11 +121,13 @@ async function getProfileByType(req: Request, res: Response) {
                 v8Profiler.setSamplingInterval(interval ?? 1000) // in microseconds
                 v8Profiler.startProfiling('cpu', true, mode)
                 finishProfile = () => v8Profiler.stopProfiling('cpu')
+                break
             case 'heap':
                 // See https://v8docs.nodesource.com/node-18.16/d7/d76/classv8_1_1_heap_profiler.html
                 const depth = typeof req.query.depth === 'string' ? parseInt(req.query.depth) : 16
                 v8Profiler.startSamplingHeapProfiling(interval ?? 512 * 1024, depth)
                 finishProfile = () => v8Profiler.stopSamplingHeapProfiling()
+                break
         }
 
         if (finishProfile) {


### PR DESCRIPTION
## Problem

I saw this:

![image](https://github.com/user-attachments/assets/0b20d390-be28-4535-8bd4-585e14749801)

## Changes

It does look like a bug if the case falls through, so did the quickest change and added two break statements

## How did you test this code?

CI.