### PR TITLE
fix: Persons on events for cohorts

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -1056,18 +1056,26 @@
                        AND timestamp < now()
                        AND ((event = 'insight viewed'
                              AND (has(['RETENTION'], replaceRegexpAll(JSONExtractRaw(properties, 'insight'), '^"|"$', ''))
-                                  AND person_id IN
-                                    (SELECT id
-                                     FROM person
-                                     WHERE team_id = 2
-                                       AND id IN
+                                  AND distinct_id IN
+                                    (SELECT distinct_id
+                                     FROM
+                                       (SELECT distinct_id, argMax(person_id, version) as person_id
+                                        FROM person_distinct_id2
+                                        WHERE team_id = 2
+                                        GROUP BY distinct_id
+                                        HAVING argMax(is_deleted, version) = 0)
+                                     WHERE person_id IN
                                          (SELECT id
                                           FROM person
                                           WHERE team_id = 2
-                                            AND ((has(['http://example.com'], replaceRegexpAll(JSONExtractRaw(properties, '$pageview'), '^"|"$', '')))) )
-                                     GROUP BY id
-                                     HAVING max(is_deleted) = 0
-                                     AND ((has(['http://example.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$pageview'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1)))
+                                            AND id IN
+                                              (SELECT id
+                                               FROM person
+                                               WHERE team_id = 2
+                                                 AND ((has(['http://example.com'], replaceRegexpAll(JSONExtractRaw(properties, '$pageview'), '^"|"$', '')))) )
+                                          GROUP BY id
+                                          HAVING max(is_deleted) = 0
+                                          AND ((has(['http://example.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$pageview'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1) )))
                             OR (event = 'insight viewed'
                                 AND (toFloat64OrNull(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, 'filters_count'), '^"|"$', ''), ' ', ''), '^"|"$', '')) > '1'))
                             OR (match(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/123')

--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -1056,26 +1056,18 @@
                        AND timestamp < now()
                        AND ((event = 'insight viewed'
                              AND (has(['RETENTION'], replaceRegexpAll(JSONExtractRaw(properties, 'insight'), '^"|"$', ''))
-                                  AND distinct_id IN
-                                    (SELECT distinct_id
-                                     FROM
-                                       (SELECT distinct_id, argMax(person_id, version) as person_id
-                                        FROM person_distinct_id2
-                                        WHERE team_id = 2
-                                        GROUP BY distinct_id
-                                        HAVING argMax(is_deleted, version) = 0)
-                                     WHERE person_id IN
+                                  AND person_id IN
+                                    (SELECT id
+                                     FROM person
+                                     WHERE team_id = 2
+                                       AND id IN
                                          (SELECT id
                                           FROM person
                                           WHERE team_id = 2
-                                            AND id IN
-                                              (SELECT id
-                                               FROM person
-                                               WHERE team_id = 2
-                                                 AND ((has(['http://example.com'], replaceRegexpAll(JSONExtractRaw(properties, '$pageview'), '^"|"$', '')))) )
-                                          GROUP BY id
-                                          HAVING max(is_deleted) = 0
-                                          AND ((has(['http://example.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$pageview'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1) )))
+                                            AND ((has(['http://example.com'], replaceRegexpAll(JSONExtractRaw(properties, '$pageview'), '^"|"$', '')))) )
+                                     GROUP BY id
+                                     HAVING max(is_deleted) = 0
+                                     AND ((has(['http://example.com'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$pageview'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1)))
                             OR (event = 'insight viewed'
                                 AND (toFloat64OrNull(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(JSONExtractRaw(properties, 'filters_count'), '^"|"$', ''), ' ', ''), '^"|"$', '')) > '1'))
                             OR (match(replaceRegexpAll(JSONExtractRaw(properties, '$current_url'), '^"|"$', ''), '/123')

--- a/posthog/api/test/__snapshots__/test_cohort.ambr
+++ b/posthog/api/test/__snapshots__/test_cohort.ambr
@@ -81,7 +81,7 @@
                   cohort_id
   FROM cohortpeople
   WHERE (team_id = 2
-         AND cohort_id = '1'
+         AND cohort_id = '2'
          AND version < '2')
   '''
 # ---
@@ -177,7 +177,7 @@
                   cohort_id
   FROM cohortpeople
   WHERE (team_id = 2
-         AND cohort_id = '1'
+         AND cohort_id = '2'
          AND version < '2')
   '''
 # ---
@@ -187,7 +187,7 @@
   DELETE
   FROM cohortpeople
   WHERE (team_id = 2
-         AND cohort_id = '1'
+         AND cohort_id = '2'
          AND version < '2')
   '''
 # ---

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -163,7 +163,9 @@ def get_entity_query(
             action=action,
             prepend="_{}_action".format(group_idx),
             hogql_context=hogql_context,
-            person_properties_mode=person_properties_mode,
+            person_properties_mode=person_properties_mode
+            if person_properties_mode
+            else PersonPropertiesMode.USING_SUBQUERY,
         )
         return action_filter_query, action_params
     else:

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -7,7 +7,7 @@ from dateutil import parser
 from django.conf import settings
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
-
+from posthog.queries.util import PersonPropertiesMode
 from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.client import sync_execute
@@ -65,6 +65,7 @@ def format_person_query(cohort: Cohort, index: int, hogql_context: HogQLContext)
         ),
         cohort.team,
         cohort_pk=cohort.pk,
+        persons_on_events_mode=cohort.team.person_on_events_mode,
     )
 
     query, params = query_builder.get_query()
@@ -151,6 +152,7 @@ def get_entity_query(
     team_id: int,
     group_idx: Union[int, str],
     hogql_context: HogQLContext,
+    person_properties_mode: Optional[PersonPropertiesMode] = None,
 ) -> tuple[str, dict[str, str]]:
     if event_id:
         return f"event = %({f'event_{group_idx}'})s", {f"event_{group_idx}": event_id}
@@ -161,6 +163,7 @@ def get_entity_query(
             action=action,
             prepend="_{}_action".format(group_idx),
             hogql_context=hogql_context,
+            person_properties_mode=person_properties_mode,
         )
         return action_filter_query, action_params
     else:

--- a/posthog/queries/foss_cohort_query.py
+++ b/posthog/queries/foss_cohort_query.py
@@ -613,6 +613,9 @@ class FOSSCohortQuery(EventQuery):
                 self._team_id,
                 f"{prepend}_entity_{idx}",
                 self._filter.hogql_context,
+                person_properties_mode=PersonPropertiesMode.DIRECT_ON_EVENTS
+                if self._person_on_events_mode != PersonsOnEventsMode.DISABLED
+                else None,
             )
         elif event[0] == "events":
             self._add_event(str(event[1]))


### PR DESCRIPTION
## Problem

couple of cohorts failing for performance reasons, plus there would be inconsistent results in theory if you compared results with an insight
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

When using an action (with person filter) in a cohort, uses persons on events to do the query.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
