### PR TITLE
fix(hogql): toString boolean values when transforming them

### DIFF
--- a/posthog/hogql/database/schema/util/test/test_person_where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/test/test_person_where_clause_extractor.py
@@ -179,6 +179,6 @@ class TestPersonWhereClauseExtractor(ClickhouseTestMixin, APIBaseTest):
         )
         actual = self.print_query("SELECT * FROM events WHERE person.properties.person_boolean = false")
         assert (
-            f"FROM person WHERE and(equals(person.team_id, {self.team.id}), ifNull(equals(transform(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties"
+            f"FROM person WHERE and(equals(person.team_id, {self.team.id}), ifNull(equals(transform(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties"
             in actual
         )

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -1470,9 +1470,9 @@ class TestPrinter(BaseTest):
         )
         assert generated_sql_statements1 == (
             f"SELECT "
-            "ifNull(equals(transform(nullIf(nullIf(events.mat_is_boolean, ''), 'null'), %(hogql_val_0)s, %(hogql_val_1)s, NULL), 1), 0), "
-            "ifNull(equals(transform(nullIf(nullIf(events.mat_is_boolean, ''), 'null'), %(hogql_val_2)s, %(hogql_val_3)s, NULL), 0), 0), "
-            "isNull(transform(nullIf(nullIf(events.mat_is_boolean, ''), 'null'), %(hogql_val_4)s, %(hogql_val_5)s, NULL)) "
+            "ifNull(equals(transform(toString(nullIf(nullIf(events.mat_is_boolean, ''), 'null')), %(hogql_val_0)s, %(hogql_val_1)s, NULL), 1), 0), "
+            "ifNull(equals(transform(toString(nullIf(nullIf(events.mat_is_boolean, ''), 'null')), %(hogql_val_2)s, %(hogql_val_3)s, NULL), 0), 0), "
+            "isNull(transform(toString(nullIf(nullIf(events.mat_is_boolean, ''), 'null')), %(hogql_val_4)s, %(hogql_val_5)s, NULL)) "
             f"FROM events WHERE equals(events.team_id, {self.team.pk}) LIMIT {MAX_SELECT_RETURNED_ROWS}"
         )
         assert context.values == {

--- a/posthog/hogql/transforms/property_types.py
+++ b/posthog/hogql/transforms/property_types.py
@@ -222,7 +222,7 @@ class PropertySwapper(CloningVisitor):
             return ast.Call(
                 name="transform",
                 args=[
-                    node,
+                    ast.Call(name="toString", args=[node]),
                     ast.Constant(value=["true", "false"]),
                     ast.Constant(value=[True, False]),
                     ast.Constant(value=None),

--- a/posthog/hogql/transforms/test/__snapshots__/test_property_types.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_property_types.ambr
@@ -2,7 +2,7 @@
 # name: TestPropertyTypes.test_data_warehouse_person_property_types
   '''
   
-  SELECT persons__extended_properties.string_prop AS string_prop, persons__extended_properties.int_prop AS int_prop, transform(persons__extended_properties.bool_prop, %(hogql_val_8)s, %(hogql_val_9)s, NULL) AS bool_prop 
+  SELECT persons__extended_properties.string_prop AS string_prop, persons__extended_properties.int_prop AS int_prop, transform(toString(persons__extended_properties.bool_prop), %(hogql_val_8)s, %(hogql_val_9)s, NULL) AS bool_prop 
   FROM (
   SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), person.version) AS persons___properties___email, person.id AS id 
   FROM person 
@@ -66,7 +66,7 @@
 # name: TestPropertyTypes.test_resolve_property_types_event
   '''
   
-  SELECT multiply(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), %(hogql_val_1)s), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_2)s), ''), 'null'), '^"|"$', ''), %(hogql_val_3)s)), transform(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_4)s), ''), 'null'), '^"|"$', ''), %(hogql_val_5)s, %(hogql_val_6)s, NULL) AS bool 
+  SELECT multiply(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), %(hogql_val_1)s), accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_2)s), ''), 'null'), '^"|"$', ''), %(hogql_val_3)s)), transform(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_4)s), ''), 'null'), '^"|"$', '')), %(hogql_val_5)s, %(hogql_val_6)s, NULL) AS bool 
   FROM events 
   WHERE equals(events.team_id, 420) 
   LIMIT 50000

--- a/posthog/hogql/transforms/test/__snapshots__/test_property_types.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_property_types.ambr
@@ -19,7 +19,7 @@
 # name: TestPropertyTypes.test_group_boolean_property_types
   '''
   
-  SELECT ifNull(equals(transform(events__group_0.properties___group_boolean, %(hogql_val_2)s, %(hogql_val_3)s, NULL), 1), 0), ifNull(equals(transform(events__group_0.properties___group_boolean, %(hogql_val_4)s, %(hogql_val_5)s, NULL), 0), 0), isNull(transform(events__group_0.properties___group_boolean, %(hogql_val_6)s, %(hogql_val_7)s, NULL)) 
+  SELECT ifNull(equals(transform(toString(events__group_0.properties___group_boolean), %(hogql_val_2)s, %(hogql_val_3)s, NULL), 1), 0), ifNull(equals(transform(toString(events__group_0.properties___group_boolean), %(hogql_val_4)s, %(hogql_val_5)s, NULL), 0), 0), isNull(transform(toString(events__group_0.properties___group_boolean), %(hogql_val_6)s, %(hogql_val_7)s, NULL)) 
   FROM events LEFT JOIN (
   SELECT argMax(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(groups.group_properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), toTimeZone(groups._timestamp, %(hogql_val_1)s)) AS properties___group_boolean, groups.group_type_index AS index, groups.group_key AS key 
   FROM groups 

--- a/posthog/hogql/transforms/test/test_property_types.py
+++ b/posthog/hogql/transforms/test/test_property_types.py
@@ -134,7 +134,7 @@ class TestPropertyTypes(BaseTest):
         )
         assert printed == self.snapshot
         assert (
-            "SELECT ifNull(equals(transform(events__group_0.properties___group_boolean, hogvar, hogvar, NULL), 1), 0), ifNull(equals(transform(events__group_0.properties___group_boolean, hogvar, hogvar, NULL), 0), 0), isNull(transform(events__group_0.properties___group_boolean, hogvar, hogvar, NULL))"
+            "SELECT ifNull(equals(transform(toString(events__group_0.properties___group_boolean), hogvar, hogvar, NULL), 1), 0), ifNull(equals(transform(toString(events__group_0.properties___group_boolean), hogvar, hogvar, NULL), 0), 0), isNull(transform(toString(events__group_0.properties___group_boolean), hogvar, hogvar, NULL))"
             in re.sub(r"%\(hogql_val_\d+\)s", "hogvar", printed)
         )
 


### PR DESCRIPTION
## Problem
- From [here](https://posthog.slack.com/archives/C07P0E4R3MW/p1728641343521739?thread_ts=1728635101.249749&cid=C07P0E4R3MW)
- It looks like we try to transform `boolean` fields from the string version to the actual boolean type, but this also happens when the underlying data is in the correct format (boolean, and not string). Causing us to get this error: `First argument and elements of array of the second argument of function transform must have compatible types: While processing transform(is_internal_user, ['true', 'false'], [true, false], NULL) AS is_internal_user.`

## Changes
- Transform the field to a string when transforming the boolean value so that the transform always works

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Recreated locally and validated 