### PR TITLE
fix: improper builds from typo in deploy-hobby

### DIFF
--- a/bin/deploy-hobby
+++ b/bin/deploy-hobby
@@ -12,7 +12,7 @@ export SENTRY_DSN="${SENTRY_DSN:-'https://public@sentry.example.com/1'}"
 POSTHOG_SECRET=$(head -c 28 /dev/urandom | sha224sum -b | head -c 56)
 export POSTHOG_SECRET
 
-ENCRYPTION_KEY=$(openssl rand -hex 16)
+ENCRYPTION_SALT_KEYS=$(openssl rand -hex 16)
 export ENCRYPTION_SALT_KEYS
 
 # Talk to the user


### PR DESCRIPTION
## Problem
ENCRYPTION_KEY was set, then non-existent ENCRYPTION_SALT_KEYS was exported.
This caused the entire build to be improper, seizing the server in many cases.

## Changes
ENCRYPTION_KEY was simply renamed to ENCRYPTION_SALT_KEYS

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Only applies to self-hosted.

## How did you test this code?
Ran the script on a fresh Ubuntu 22.04 Hetzner image.

Follow up to #25526 
