### PR TITLE
fix(insights): LineGraph infinite updates

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -2,7 +2,7 @@ import 'chartjs-adapter-dayjs-3'
 
 import { LegendOptions } from 'chart.js'
 import { DeepPartial } from 'chart.js/dist/types/utils'
-import annotationPlugin, { AnnotationPluginOptions } from 'chartjs-plugin-annotation'
+import annotationPlugin, { AnnotationOptions } from 'chartjs-plugin-annotation'
 import ChartDataLabels from 'chartjs-plugin-datalabels'
 import ChartjsPluginStacked100, { ExtendedChartData } from 'chartjs-plugin-stacked100'
 import clsx from 'clsx'
@@ -279,7 +279,7 @@ export function LineGraph_({
     hideYAxis,
     legend = { display: false },
     yAxisScaleType,
-    alertLines = [],
+    alertLines,
 }: LineGraphProps): JSX.Element {
     let datasets = _datasets
 
@@ -397,8 +397,8 @@ export function LineGraph_({
             }
         }
 
-        const annotations = alertLines.reduce((acc, { value }, idx) => {
-            acc[`${idx}`] = {
+        const annotations = (alertLines || []).reduce((acc, { value }, idx) => {
+            acc[idx.toString()] = {
                 type: 'line',
                 yMin: value,
                 yMax: value,
@@ -408,7 +408,7 @@ export function LineGraph_({
             }
 
             return acc
-        }, {} as AnnotationPluginOptions['annotations'])
+        }, {} as Record<string, AnnotationOptions>)
 
         datasets = datasets.map(processDataset)
 

--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -398,7 +398,7 @@ export function LineGraph_({
         }
 
         const annotations = (alertLines || []).reduce((acc, { value }, idx) => {
-            acc[idx.toString()] = {
+            acc[idx] = {
                 type: 'line',
                 yMin: value,
                 yMax: value,


### PR DESCRIPTION
## Problem

Noticed that the LineGraph indefinitely updates, so this PR fixes it.

## Changes

Since useEffect compares values using shallow equality, I removed the default array from the component parameters.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually verified that the fix works.