### PR TITLE
fix(ai): Bring back SQL AI

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -457,10 +457,6 @@ posthog/hogql/test/_test_parser.py:0: error: Item "None" of "JoinExpr | None" ha
 posthog/hogql/test/_test_parser.py:0: error: Item "None" of "JoinExpr | None" has no attribute "alias"  [union-attr]
 posthog/hogql/test/_test_parser.py:0: error: Item "None" of "JoinExpr | None" has no attribute "table"  [union-attr]
 posthog/hogql/database/schema/event_sessions.py:0: error: Statement is unreachable  [unreachable]
-posthog/hogql/ai.py:0: error: No overload variant of "__getitem__" of "tuple" matches argument type "str"  [call-overload]
-posthog/hogql/ai.py:0: note: Possible overload variants:
-posthog/hogql/ai.py:0: note: def __getitem__(self, SupportsIndex, /) -> str | Any
-posthog/hogql/ai.py:0: note: def __getitem__(self, slice, /) -> tuple[str | Any, ...]
 posthog/heatmaps/test/test_heatmaps_api.py:0: error: "HttpResponse" has no attribute "json"  [attr-defined]
 posthog/heatmaps/test/test_heatmaps_api.py:0: error: "HttpResponse" has no attribute "json"  [attr-defined]
 posthog/heatmaps/test/test_heatmaps_api.py:0: error: "HttpResponse" has no attribute "json"  [attr-defined]

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -1101,3 +1101,12 @@ class TestQueryRetrieve(APIBaseTest):
         response = self.client.delete(f"/api/projects/{self.team.id}/query/{self.valid_query_id}/")
         self.assertEqual(response.status_code, 204)
         self.assertEqual(self.redis_client_mock.delete.call_count, 2)
+
+
+class TestQueryDraftSql(APIBaseTest):
+    @patch("posthog.hogql.ai.hit_openai", return_value=("SELECT 1", 21, 37))
+    def test_draft_sql(self, hit_openai_mock):
+        response = self.client.get(f"/api/projects/{self.team.id}/query/draft_sql/", {"prompt": "I need the number 1"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"sql": "SELECT 1"})
+        hit_openai_mock.assert_called_once()

--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -32,7 +32,7 @@ GROUP BY week_of
 ORDER BY week_of DESC"""
 
 SCHEMA_MESSAGE = (
-    "My schema is:\n{schema_description}\nPerson or event metadata unspecified above (emails, names, etc.) "
+    "This project's schema is:\n\n{schema_description}\nPerson or event metadata unspecified above (emails, names, etc.) "
     'is stored in `properties` fields, accessed like: `properties.foo.bar`. Note: "persons" means "users".\nSpecial events/properties such as pageview or screen start with `$`. Custom ones don\'t.'
 )
 
@@ -63,8 +63,8 @@ def write_sql_from_prompt(prompt: str, *, current_query: Optional[str] = None, t
     schema_description = "\n\n".join(
         (
             f"Table {table_name} with fields:\n"
-            + "\n".join(f'- {field["key"]} ({field["type"]})' for field in table_fields)
-            for table_name, table_fields in serialized_database.items()
+            + "\n".join(f"- {field.name} ({field.type})" for field in table.fields.values())
+            for table_name, table in serialized_database.items()
         )
     )
     instance_region = get_instance_region() or "HOBBY"


### PR DESCRIPTION
## Problem

Our pre-existing SQL drafting feature stopped working some time ago as our database schema types changed – and we had no tests to catch this.

<img width="942" alt="Screenshot 2024-10-14 at 12 28 33" src="https://github.com/user-attachments/assets/ddec3d6e-3547-48de-a140-862232f5535b">

## Changes

Fixed SQL drafting.

## How did you test this code?

Added a test to prevent this issue from reoccurring.