### PR TITLE
feat: batch export run activity log [WIP]

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3831,6 +3831,7 @@ export enum ActivityScope {
     EXPERIMENT = 'Experiment',
     SURVEY = 'Survey',
     EARLY_ACCESS_FEATURE = 'EarlyAccessFeature',
+    BATCH_EXPORT_RUN = 'BatchExportRun',
     COMMENT = 'Comment',
     COHORT = 'Cohort',
     TEAM = 'Team',

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -37,6 +37,7 @@ ActivityScope = Literal[
     "Replay",
     "Experiment",
     "Survey",
+    "BatchExportRun",
     "EarlyAccessFeature",
     "SessionRecordingPlaylist",
     "Comment",


### PR DESCRIPTION
## Problem

We don't track any kind of batch export run activity. We had to rely on a session recording to see what was going on during a recent incident

## Changes

Add activity items for batch export runs
