### PR TITLE
feat(experiments HogQL): calculate statistics for Trends

### DIFF
--- a/ee/clickhouse/queries/experiments/__init__.py
+++ b/ee/clickhouse/queries/experiments/__init__.py
@@ -11,3 +11,5 @@ MIN_PROBABILITY_FOR_SIGNIFICANCE = 0.9
 
 # Trends only: If p-value is below this threshold, the results are considered significant
 P_VALUE_SIGNIFICANCE_LEVEL = 0.05
+
+CONTROL_VARIANT_KEY = "control"

--- a/ee/clickhouse/queries/experiments/funnel_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/funnel_experiment_result.py
@@ -6,7 +6,7 @@ from zoneinfo import ZoneInfo
 
 from rest_framework.exceptions import ValidationError
 
-from posthog.constants import ExperimentSignificanceCode, ExperimentNoResultsErrorKeys
+from posthog.constants import ExperimentNoResultsErrorKeys
 from posthog.hogql_queries.experiments import CONTROL_VARIANT_KEY
 from posthog.hogql_queries.experiments.funnel_statistics import (
     are_results_significant,
@@ -17,6 +17,7 @@ from posthog.models.feature_flag import FeatureFlag
 from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
 from posthog.queries.funnels import ClickhouseFunnel
+from posthog.schema import ExperimentSignificanceCode
 
 Probability = float
 

--- a/ee/clickhouse/queries/experiments/test_funnel_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/test_funnel_experiment_result.py
@@ -4,14 +4,13 @@ from math import exp, lgamma, log, ceil
 
 from flaky import flaky
 
-from posthog.constants import ExperimentSignificanceCode
 from posthog.hogql_queries.experiments.funnel_statistics import (
     are_results_significant,
     calculate_expected_loss,
     calculate_probabilities,
     calculate_credible_intervals as calculate_funnel_credible_intervals,
 )
-from posthog.schema import ExperimentVariantFunnelResult
+from posthog.schema import ExperimentSignificanceCode, ExperimentVariantFunnelResult
 
 Probability = float
 

--- a/ee/clickhouse/queries/experiments/test_trend_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/test_trend_experiment_result.py
@@ -4,14 +4,13 @@ from math import exp, lgamma, log, ceil
 
 from flaky import flaky
 
-from posthog.constants import ExperimentSignificanceCode
 from posthog.hogql_queries.experiments.trend_statistics import (
     are_results_significant,
     calculate_credible_intervals,
     calculate_p_value,
     calculate_probabilities,
 )
-from posthog.schema import ExperimentVariantTrendResult
+from posthog.schema import ExperimentSignificanceCode, ExperimentVariantTrendBaseStats
 
 Probability = float
 
@@ -24,7 +23,7 @@ def logbeta(x: float, y: float) -> float:
 # Helper function to calculate probability using a different method than the one used in actual code
 # calculation: https://www.evanmiller.org/bayesian-ab-testing.html#count_ab
 def calculate_probability_of_winning_for_target_count_data(
-    target_variant: ExperimentVariantTrendResult, other_variants: list[ExperimentVariantTrendResult]
+    target_variant: ExperimentVariantTrendBaseStats, other_variants: list[ExperimentVariantTrendBaseStats]
 ) -> Probability:
     """
     Calculates the probability of winning for target variant.
@@ -98,8 +97,8 @@ def probability_C_beats_A_and_B_count_data(
 @flaky(max_runs=10, min_passes=1)
 class TestTrendExperimentCalculator(unittest.TestCase):
     def test_calculate_results(self):
-        variant_control = ExperimentVariantTrendResult(key="A", count=20, exposure=1, absolute_exposure=200)
-        variant_test = ExperimentVariantTrendResult(key="B", count=30, exposure=1, absolute_exposure=200)
+        variant_control = ExperimentVariantTrendBaseStats(key="A", count=20, exposure=1, absolute_exposure=200)
+        variant_test = ExperimentVariantTrendBaseStats(key="B", count=30, exposure=1, absolute_exposure=200)
 
         probabilities = calculate_probabilities(variant_control, [variant_test])
         self.assertAlmostEqual(probabilities[1], 0.92, places=1)
@@ -118,8 +117,8 @@ class TestTrendExperimentCalculator(unittest.TestCase):
         self.assertAlmostEqual(credible_intervals[variant_test.key][1], 0.2141, places=3)
 
     def test_calculate_results_small_numbers(self):
-        variant_control = ExperimentVariantTrendResult(key="A", count=2, exposure=1, absolute_exposure=200)
-        variant_test = ExperimentVariantTrendResult(key="B", count=1, exposure=1, absolute_exposure=200)
+        variant_control = ExperimentVariantTrendBaseStats(key="A", count=2, exposure=1, absolute_exposure=200)
+        variant_test = ExperimentVariantTrendBaseStats(key="B", count=1, exposure=1, absolute_exposure=200)
 
         probabilities = calculate_probabilities(variant_control, [variant_test])
         self.assertAlmostEqual(probabilities[1], 0.31, places=1)
@@ -146,9 +145,9 @@ class TestTrendExperimentCalculator(unittest.TestCase):
         self.assertAlmostEqual(probability, probability2)
 
     def test_calculate_results_with_three_variants(self):
-        variant_control = ExperimentVariantTrendResult(key="A", count=20, exposure=1, absolute_exposure=200)
-        variant_test_1 = ExperimentVariantTrendResult(key="B", count=26, exposure=1, absolute_exposure=200)
-        variant_test_2 = ExperimentVariantTrendResult(key="C", count=19, exposure=1, absolute_exposure=200)
+        variant_control = ExperimentVariantTrendBaseStats(key="A", count=20, exposure=1, absolute_exposure=200)
+        variant_test_1 = ExperimentVariantTrendBaseStats(key="B", count=26, exposure=1, absolute_exposure=200)
+        variant_test_2 = ExperimentVariantTrendBaseStats(key="C", count=19, exposure=1, absolute_exposure=200)
 
         probabilities = calculate_probabilities(variant_control, [variant_test_1, variant_test_2])
         self.assertAlmostEqual(probabilities[0], 0.16, places=1)
@@ -172,9 +171,9 @@ class TestTrendExperimentCalculator(unittest.TestCase):
         self.assertAlmostEqual(credible_intervals[variant_test_2.key][1], 0.1484, places=3)
 
     def test_calculate_significance_when_target_variants_underperform(self):
-        variant_control = ExperimentVariantTrendResult(key="A", count=250, exposure=1, absolute_exposure=200)
-        variant_test_1 = ExperimentVariantTrendResult(key="B", count=180, exposure=1, absolute_exposure=200)
-        variant_test_2 = ExperimentVariantTrendResult(key="C", count=50, exposure=1, absolute_exposure=200)
+        variant_control = ExperimentVariantTrendBaseStats(key="A", count=250, exposure=1, absolute_exposure=200)
+        variant_test_1 = ExperimentVariantTrendBaseStats(key="B", count=180, exposure=1, absolute_exposure=200)
+        variant_test_2 = ExperimentVariantTrendBaseStats(key="C", count=50, exposure=1, absolute_exposure=200)
 
         # in this case, should choose B as best test variant
         p_value = calculate_p_value(variant_control, [variant_test_1, variant_test_2])
@@ -188,7 +187,7 @@ class TestTrendExperimentCalculator(unittest.TestCase):
         self.assertEqual(significant, ExperimentSignificanceCode.LOW_WIN_PROBABILITY)
 
         # new B variant is worse, such that control probability ought to be high enough
-        variant_test_1 = ExperimentVariantTrendResult(key="B", count=100, exposure=1, absolute_exposure=200)
+        variant_test_1 = ExperimentVariantTrendBaseStats(key="B", count=100, exposure=1, absolute_exposure=200)
 
         significant, p_value = are_results_significant(
             variant_control, [variant_test_1, variant_test_2], [0.95, 0.03, 0.02]
@@ -205,9 +204,9 @@ class TestTrendExperimentCalculator(unittest.TestCase):
         self.assertAlmostEqual(credible_intervals[variant_test_2.key][1], 0.3295, places=3)
 
     def test_results_with_different_exposures(self):
-        variant_control = ExperimentVariantTrendResult(key="A", count=50, exposure=1.3, absolute_exposure=260)
-        variant_test_1 = ExperimentVariantTrendResult(key="B", count=30, exposure=1.8, absolute_exposure=360)
-        variant_test_2 = ExperimentVariantTrendResult(key="C", count=20, exposure=0.7, absolute_exposure=140)
+        variant_control = ExperimentVariantTrendBaseStats(key="A", count=50, exposure=1.3, absolute_exposure=260)
+        variant_test_1 = ExperimentVariantTrendBaseStats(key="B", count=30, exposure=1.8, absolute_exposure=360)
+        variant_test_2 = ExperimentVariantTrendBaseStats(key="C", count=20, exposure=0.7, absolute_exposure=140)
 
         probabilities = calculate_probabilities(variant_control, [variant_test_1, variant_test_2])  # a is control
         self.assertAlmostEqual(probabilities[0], 0.86, places=1)

--- a/ee/clickhouse/queries/experiments/trend_experiment_result.py
+++ b/ee/clickhouse/queries/experiments/trend_experiment_result.py
@@ -15,7 +15,6 @@ from posthog.constants import (
     TRENDS_CUMULATIVE,
     TRENDS_LINEAR,
     UNIQUE_USERS,
-    ExperimentSignificanceCode,
     ExperimentNoResultsErrorKeys,
 )
 from posthog.hogql_queries.experiments.trend_statistics import (
@@ -28,6 +27,7 @@ from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
 from posthog.queries.trends.trends import Trends
 from posthog.queries.trends.util import ALL_SUPPORTED_MATH_FUNCTIONS
+from posthog.schema import ExperimentSignificanceCode
 
 Probability = float
 

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -5,11 +5,11 @@ from rest_framework import status
 
 from ee.api.test.base import APILicensedTest
 from dateutil import parser
-from posthog.constants import ExperimentSignificanceCode
 from posthog.models.action.action import Action
 from posthog.models.cohort.cohort import Cohort
 from posthog.models.experiment import Experiment
 from posthog.models.feature_flag import FeatureFlag, get_feature_flags_for_team_in_cache
+from posthog.schema import ExperimentSignificanceCode
 from posthog.test.base import (
     ClickhouseTestMixin,
     _create_event,

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1308,9 +1308,19 @@
                     "description": "What triggered the calculation of the query, leave empty if user/immediate",
                     "type": "string"
                 },
+                "credible_intervals": {
+                    "additionalProperties": {
+                        "items": {
+                            "type": "number"
+                        },
+                        "maxItems": 2,
+                        "minItems": 2,
+                        "type": "array"
+                    },
+                    "type": "object"
+                },
                 "insight": {
-                    "const": "TRENDS",
-                    "type": "string"
+                    "$ref": "#/definitions/TrendsQueryResponse"
                 },
                 "is_cached": {
                     "type": "boolean"
@@ -1323,28 +1333,48 @@
                     "format": "date-time",
                     "type": "string"
                 },
+                "p_value": {
+                    "type": "number"
+                },
+                "probability": {
+                    "additionalProperties": {
+                        "type": "number"
+                    },
+                    "type": "object"
+                },
                 "query_status": {
                     "$ref": "#/definitions/QueryStatus",
                     "description": "Query status indicates whether next to the provided data, a query is still running."
                 },
-                "results": {
-                    "additionalProperties": {
-                        "$ref": "#/definitions/ExperimentVariantTrendResult"
-                    },
-                    "type": "object"
+                "significance_code": {
+                    "$ref": "#/definitions/ExperimentSignificanceCode"
+                },
+                "significant": {
+                    "type": "boolean"
                 },
                 "timezone": {
                     "type": "string"
+                },
+                "variants": {
+                    "items": {
+                        "$ref": "#/definitions/ExperimentVariantTrendBaseStats"
+                    },
+                    "type": "array"
                 }
             },
             "required": [
                 "cache_key",
+                "credible_intervals",
                 "insight",
                 "is_cached",
                 "last_refresh",
                 "next_allowed_client_refresh",
-                "results",
-                "timezone"
+                "p_value",
+                "probability",
+                "significance_code",
+                "significant",
+                "timezone",
+                "variants"
             ],
             "type": "object"
         },
@@ -3628,18 +3658,51 @@
                         {
                             "additionalProperties": false,
                             "properties": {
-                                "insight": {
-                                    "const": "TRENDS",
-                                    "type": "string"
-                                },
-                                "results": {
+                                "credible_intervals": {
                                     "additionalProperties": {
-                                        "$ref": "#/definitions/ExperimentVariantTrendResult"
+                                        "items": {
+                                            "type": "number"
+                                        },
+                                        "maxItems": 2,
+                                        "minItems": 2,
+                                        "type": "array"
                                     },
                                     "type": "object"
+                                },
+                                "insight": {
+                                    "$ref": "#/definitions/TrendsQueryResponse"
+                                },
+                                "p_value": {
+                                    "type": "number"
+                                },
+                                "probability": {
+                                    "additionalProperties": {
+                                        "type": "number"
+                                    },
+                                    "type": "object"
+                                },
+                                "significance_code": {
+                                    "$ref": "#/definitions/ExperimentSignificanceCode"
+                                },
+                                "significant": {
+                                    "type": "boolean"
+                                },
+                                "variants": {
+                                    "items": {
+                                        "$ref": "#/definitions/ExperimentVariantTrendBaseStats"
+                                    },
+                                    "type": "array"
                                 }
                             },
-                            "required": ["insight", "results"],
+                            "required": [
+                                "credible_intervals",
+                                "insight",
+                                "p_value",
+                                "probability",
+                                "significance_code",
+                                "significant",
+                                "variants"
+                            ],
                             "type": "object"
                         }
                     ]
@@ -5033,6 +5096,10 @@
             "required": ["insight", "results"],
             "type": "object"
         },
+        "ExperimentSignificanceCode": {
+            "enum": ["significant", "not_enough_exposure", "low_win_probability", "high_loss", "high_p_value"],
+            "type": "string"
+        },
         "ExperimentTrendQuery": {
             "additionalProperties": false,
             "properties": {
@@ -5063,18 +5130,51 @@
         "ExperimentTrendQueryResponse": {
             "additionalProperties": false,
             "properties": {
-                "insight": {
-                    "const": "TRENDS",
-                    "type": "string"
-                },
-                "results": {
+                "credible_intervals": {
                     "additionalProperties": {
-                        "$ref": "#/definitions/ExperimentVariantTrendResult"
+                        "items": {
+                            "type": "number"
+                        },
+                        "maxItems": 2,
+                        "minItems": 2,
+                        "type": "array"
                     },
                     "type": "object"
+                },
+                "insight": {
+                    "$ref": "#/definitions/TrendsQueryResponse"
+                },
+                "p_value": {
+                    "type": "number"
+                },
+                "probability": {
+                    "additionalProperties": {
+                        "type": "number"
+                    },
+                    "type": "object"
+                },
+                "significance_code": {
+                    "$ref": "#/definitions/ExperimentSignificanceCode"
+                },
+                "significant": {
+                    "type": "boolean"
+                },
+                "variants": {
+                    "items": {
+                        "$ref": "#/definitions/ExperimentVariantTrendBaseStats"
+                    },
+                    "type": "array"
                 }
             },
-            "required": ["insight", "results"],
+            "required": [
+                "insight",
+                "variants",
+                "probability",
+                "significant",
+                "significance_code",
+                "p_value",
+                "credible_intervals"
+            ],
             "type": "object"
         },
         "ExperimentVariantFunnelResult": {
@@ -5093,7 +5193,7 @@
             "required": ["key", "success_count", "failure_count"],
             "type": "object"
         },
-        "ExperimentVariantTrendResult": {
+        "ExperimentVariantTrendBaseStats": {
             "additionalProperties": false,
             "properties": {
                 "absolute_exposure": {
@@ -8679,18 +8779,51 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "insight": {
-                            "const": "TRENDS",
-                            "type": "string"
-                        },
-                        "results": {
+                        "credible_intervals": {
                             "additionalProperties": {
-                                "$ref": "#/definitions/ExperimentVariantTrendResult"
+                                "items": {
+                                    "type": "number"
+                                },
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": "array"
                             },
                             "type": "object"
+                        },
+                        "insight": {
+                            "$ref": "#/definitions/TrendsQueryResponse"
+                        },
+                        "p_value": {
+                            "type": "number"
+                        },
+                        "probability": {
+                            "additionalProperties": {
+                                "type": "number"
+                            },
+                            "type": "object"
+                        },
+                        "significance_code": {
+                            "$ref": "#/definitions/ExperimentSignificanceCode"
+                        },
+                        "significant": {
+                            "type": "boolean"
+                        },
+                        "variants": {
+                            "items": {
+                                "$ref": "#/definitions/ExperimentVariantTrendBaseStats"
+                            },
+                            "type": "array"
                         }
                     },
-                    "required": ["insight", "results"],
+                    "required": [
+                        "insight",
+                        "variants",
+                        "probability",
+                        "significant",
+                        "significance_code",
+                        "p_value",
+                        "credible_intervals"
+                    ],
                     "type": "object"
                 },
                 {
@@ -9258,18 +9391,51 @@
                 {
                     "additionalProperties": false,
                     "properties": {
-                        "insight": {
-                            "const": "TRENDS",
-                            "type": "string"
-                        },
-                        "results": {
+                        "credible_intervals": {
                             "additionalProperties": {
-                                "$ref": "#/definitions/ExperimentVariantTrendResult"
+                                "items": {
+                                    "type": "number"
+                                },
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": "array"
                             },
                             "type": "object"
+                        },
+                        "insight": {
+                            "$ref": "#/definitions/TrendsQueryResponse"
+                        },
+                        "p_value": {
+                            "type": "number"
+                        },
+                        "probability": {
+                            "additionalProperties": {
+                                "type": "number"
+                            },
+                            "type": "object"
+                        },
+                        "significance_code": {
+                            "$ref": "#/definitions/ExperimentSignificanceCode"
+                        },
+                        "significant": {
+                            "type": "boolean"
+                        },
+                        "variants": {
+                            "items": {
+                                "$ref": "#/definitions/ExperimentVariantTrendBaseStats"
+                            },
+                            "type": "array"
                         }
                     },
-                    "required": ["insight", "results"],
+                    "required": [
+                        "credible_intervals",
+                        "insight",
+                        "p_value",
+                        "probability",
+                        "significance_code",
+                        "significant",
+                        "variants"
+                    ],
                     "type": "object"
                 },
                 {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1595,7 +1595,7 @@ export type InsightQueryNode =
     | StickinessQuery
     | LifecycleQuery
 
-export interface ExperimentVariantTrendResult {
+export interface ExperimentVariantTrendBaseStats {
     key: string
     count: number
     exposure: number
@@ -1608,9 +1608,22 @@ export interface ExperimentVariantFunnelResult {
     failure_count: number
 }
 
+export enum ExperimentSignificanceCode {
+    Significant = 'significant',
+    NotEnoughExposure = 'not_enough_exposure',
+    LowWinProbability = 'low_win_probability',
+    HighLoss = 'high_loss',
+    HighPValue = 'high_p_value',
+}
+
 export interface ExperimentTrendQueryResponse {
-    insight: InsightType.TRENDS
-    results: Record<string, ExperimentVariantTrendResult>
+    insight: TrendsQueryResponse
+    variants: ExperimentVariantTrendBaseStats[]
+    probability: Record<string, number>
+    significant: boolean
+    significance_code: ExperimentSignificanceCode
+    p_value: number
+    credible_intervals: Record<string, [number, number]>
 }
 
 export type CachedExperimentTrendQueryResponse = CachedQueryResponse<ExperimentTrendQueryResponse>

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -258,14 +258,6 @@ class RetentionQueryType(StrEnum):
     TARGET_FIRST_TIME = "target_first_time"
 
 
-class ExperimentSignificanceCode(StrEnum):
-    SIGNIFICANT = "significant"
-    NOT_ENOUGH_EXPOSURE = "not_enough_exposure"
-    LOW_WIN_PROBABILITY = "low_win_probability"
-    HIGH_LOSS = "high_loss"
-    HIGH_P_VALUE = "high_p_value"
-
-
 class ExperimentNoResultsErrorKeys(StrEnum):
     NO_EVENTS = "no-events"
     NO_FLAG_INFO = "no-flag-info"

--- a/posthog/hogql_queries/experiments/experiment_trend_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_trend_query_runner.py
@@ -1,10 +1,19 @@
+import json
 from zoneinfo import ZoneInfo
 from django.conf import settings
+from posthog.constants import ExperimentNoResultsErrorKeys
 from posthog.hogql import ast
+from posthog.hogql_queries.experiments import CONTROL_VARIANT_KEY
+from posthog.hogql_queries.experiments.trend_statistics import (
+    are_results_significant,
+    calculate_credible_intervals,
+    calculate_probabilities,
+)
 from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQueryRunner
 from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.models.experiment import Experiment
 from posthog.queries.trends.util import ALL_SUPPORTED_MATH_FUNCTIONS
+from rest_framework.exceptions import ValidationError
 from posthog.schema import (
     BaseMathType,
     BreakdownFilter,
@@ -12,13 +21,15 @@ from posthog.schema import (
     ChartDisplayType,
     EventPropertyFilter,
     EventsNode,
+    ExperimentSignificanceCode,
     ExperimentTrendQuery,
     ExperimentTrendQueryResponse,
-    ExperimentVariantTrendResult,
+    ExperimentVariantTrendBaseStats,
     InsightDateRange,
     PropertyMathType,
     TrendsFilter,
     TrendsQuery,
+    TrendsQueryResponse,
 )
 from typing import Any, Optional
 import threading
@@ -33,6 +44,7 @@ class ExperimentTrendQueryRunner(QueryRunner):
         super().__init__(*args, **kwargs)
         self.experiment = Experiment.objects.get(id=self.query.experiment_id)
         self.feature_flag = self.experiment.feature_flag
+        self.variants = [variant["key"] for variant in self.feature_flag.variants]
         self.breakdown_key = f"$feature/{self.feature_flag.key}"
 
         self.prepared_count_query = self._prepare_count_query()
@@ -196,7 +208,7 @@ class ExperimentTrendQueryRunner(QueryRunner):
         return prepared_exposure_query
 
     def calculate(self) -> ExperimentTrendQueryResponse:
-        shared_results: dict[str, Optional[Any]] = {"count_response": None, "exposure_response": None}
+        shared_results: dict[str, Optional[Any]] = {"count_result": None, "exposure_result": None}
         errors = []
 
         def run(query_runner: TrendsQueryRunner, result_key: str, is_parallel: bool):
@@ -214,12 +226,12 @@ class ExperimentTrendQueryRunner(QueryRunner):
 
         # This exists so that we're not spawning threads during unit tests
         if settings.IN_UNIT_TESTING:
-            run(self.count_query_runner, "count_response", False)
-            run(self.exposure_query_runner, "exposure_response", False)
+            run(self.count_query_runner, "count_result", False)
+            run(self.exposure_query_runner, "exposure_result", False)
         else:
             jobs = [
-                threading.Thread(target=run, args=(self.count_query_runner, "count_response", True)),
-                threading.Thread(target=run, args=(self.exposure_query_runner, "exposure_response", True)),
+                threading.Thread(target=run, args=(self.count_query_runner, "count_result", True)),
+                threading.Thread(target=run, args=(self.exposure_query_runner, "exposure_result", True)),
             ]
             [j.start() for j in jobs]  # type: ignore
             [j.join() for j in jobs]  # type: ignore
@@ -228,35 +240,114 @@ class ExperimentTrendQueryRunner(QueryRunner):
         if errors:
             raise errors[0]
 
-        count_response = shared_results["count_response"]
-        exposure_response = shared_results["exposure_response"]
+        count_result = shared_results["count_result"]
+        exposure_result = shared_results["exposure_result"]
 
-        if count_response is None or exposure_response is None:
+        if count_result is None or exposure_result is None:
             raise ValueError("One or both query runners failed to produce a response")
 
-        results = self._process_results(count_response.results, exposure_response.results)
-        return ExperimentTrendQueryResponse(insight="TRENDS", results=results)
+        self._validate_event_variants(count_result)
 
-    def _process_results(
+        # Statistical analysis
+        control_variant, test_variants = self._get_variants_with_base_stats(
+            count_result.results, exposure_result.results
+        )
+        probabilities = calculate_probabilities(control_variant, test_variants)
+        significance_code, p_value = are_results_significant(control_variant, test_variants, probabilities)
+        credible_intervals = calculate_credible_intervals([control_variant, *test_variants])
+
+        return ExperimentTrendQueryResponse(
+            insight=count_result,
+            variants=[variant.model_dump() for variant in [control_variant, *test_variants]],
+            probability={
+                variant.key: probability
+                for variant, probability in zip([control_variant, *test_variants], probabilities)
+            },
+            significant=significance_code == ExperimentSignificanceCode.SIGNIFICANT,
+            significance_code=significance_code,
+            p_value=p_value,
+            credible_intervals=credible_intervals,
+        )
+
+    def _get_variants_with_base_stats(
         self, count_results: list[dict[str, Any]], exposure_results: list[dict[str, Any]]
-    ) -> dict[str, ExperimentVariantTrendResult]:
-        variants = self.feature_flag.variants
-        processed_results = {
-            variant["key"]: ExperimentVariantTrendResult(key=variant["key"], count=0, exposure=0, absolute_exposure=0)
-            for variant in variants
-        }
-
-        for result in count_results:
-            variant = result.get("breakdown_value")
-            if variant in processed_results:
-                processed_results[variant].count += result.get("count", 0)
+    ) -> tuple[ExperimentVariantTrendBaseStats, list[ExperimentVariantTrendBaseStats]]:
+        control_variant: Optional[ExperimentVariantTrendBaseStats] = None
+        test_variants = []
+        exposure_counts = {}
+        exposure_ratios = {}
 
         for result in exposure_results:
-            variant = result.get("breakdown_value")
-            if variant in processed_results:
-                processed_results[variant].absolute_exposure += result.get("count", 0)
+            count = result.get("count", 0)
+            breakdown_value = result.get("breakdown_value")
+            exposure_counts[breakdown_value] = count
 
-        return processed_results
+        control_exposure = exposure_counts.get(CONTROL_VARIANT_KEY, 0)
+
+        if control_exposure != 0:
+            for key, count in exposure_counts.items():
+                exposure_ratios[key] = count / control_exposure
+
+        for result in count_results:
+            count = result.get("count", 0)
+            breakdown_value = result.get("breakdown_value")
+            if breakdown_value == CONTROL_VARIANT_KEY:
+                control_variant = ExperimentVariantTrendBaseStats(
+                    key=breakdown_value,
+                    count=count,
+                    exposure=1,
+                    # TODO: in the absence of exposure data, we should throw rather than default to 1
+                    absolute_exposure=exposure_counts.get(breakdown_value, 1),
+                )
+            else:
+                test_variants.append(
+                    ExperimentVariantTrendBaseStats(
+                        key=breakdown_value,
+                        count=count,
+                        # TODO: in the absence of exposure data, we should throw rather than default to 1
+                        exposure=exposure_ratios.get(breakdown_value, 1),
+                        absolute_exposure=exposure_counts.get(breakdown_value, 1),
+                    )
+                )
+
+        if control_variant is None:
+            raise ValueError("Control variant not found in count results")
+
+        return control_variant, test_variants
+
+    def _validate_event_variants(self, count_result: TrendsQueryResponse):
+        errors = {
+            ExperimentNoResultsErrorKeys.NO_EVENTS: True,
+            ExperimentNoResultsErrorKeys.NO_FLAG_INFO: True,
+            ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
+            ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: True,
+        }
+
+        if not count_result.results or not count_result.results[0]:
+            raise ValidationError(code="no-results", detail=json.dumps(errors))
+
+        errors[ExperimentNoResultsErrorKeys.NO_EVENTS] = False
+
+        # Check if "control" is present
+        for event in count_result.results:
+            event_variant = event.get("breakdown_value")
+            if event_variant == "control":
+                errors[ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT] = False
+                errors[ExperimentNoResultsErrorKeys.NO_FLAG_INFO] = False
+                break
+        # Check if at least one of the test variants is present
+        test_variants = [variant for variant in self.variants if variant != "control"]
+
+        for event in count_result.results:
+            event_variant = event.get("breakdown_value")
+            if event_variant in test_variants:
+                errors[ExperimentNoResultsErrorKeys.NO_TEST_VARIANT] = False
+                errors[ExperimentNoResultsErrorKeys.NO_FLAG_INFO] = False
+                break
+
+        has_errors = any(errors.values())
+        if has_errors:
+            raise ValidationError(detail=json.dumps(errors))
 
     def to_query(self) -> ast.SelectQuery:
         raise ValueError(f"Cannot convert source query of type {self.query.count_query.kind} to query")

--- a/posthog/hogql_queries/experiments/funnel_statistics.py
+++ b/posthog/hogql_queries/experiments/funnel_statistics.py
@@ -2,13 +2,12 @@ from rest_framework.exceptions import ValidationError
 from numpy.random import default_rng
 from sentry_sdk import capture_exception
 import scipy.stats as stats
-from posthog.constants import ExperimentSignificanceCode
 from posthog.hogql_queries.experiments import (
     EXPECTED_LOSS_SIGNIFICANCE_LEVEL,
     FF_DISTRIBUTION_THRESHOLD,
     MIN_PROBABILITY_FOR_SIGNIFICANCE,
 )
-from posthog.schema import ExperimentVariantFunnelResult
+from posthog.schema import ExperimentSignificanceCode, ExperimentVariantFunnelResult
 
 Probability = float
 

--- a/posthog/hogql_queries/experiments/test/test_experiment_trend_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_trend_query_runner.py
@@ -4,9 +4,11 @@ from posthog.models.experiment import Experiment
 from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.schema import (
     EventsNode,
+    ExperimentSignificanceCode,
     ExperimentTrendQuery,
     ExperimentTrendQueryResponse,
     TrendsQuery,
+    TrendsQueryResponse,
 )
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, flush_persons_and_events
 from freezegun import freeze_time
@@ -14,6 +16,9 @@ from typing import cast
 from django.utils import timezone
 from datetime import timedelta
 from posthog.test.test_journeys import journeys_for
+from rest_framework.exceptions import ValidationError
+from posthog.constants import ExperimentNoResultsErrorKeys
+import json
 
 
 @override_settings(IN_UNIT_TESTING=True)
@@ -100,20 +105,13 @@ class TestExperimentTrendQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
         result = query_runner.calculate()
 
-        self.assertEqual(result.insight, "TRENDS")
-        self.assertEqual(len(result.results), 2)
+        self.assertEqual(len(result.variants), 2)
 
-        trend_result = cast(ExperimentTrendQueryResponse, result)
-
-        self.assertIn("control", trend_result.results)
-        self.assertIn("test", trend_result.results)
-
-        control_result = trend_result.results["control"]
-        test_result = trend_result.results["test"]
+        control_result = next(variant for variant in result.variants if variant.key == "control")
+        test_result = next(variant for variant in result.variants if variant.key == "test")
 
         self.assertEqual(control_result.count, 11)
         self.assertEqual(test_result.count, 15)
-
         self.assertEqual(control_result.absolute_exposure, 7)
         self.assertEqual(test_result.absolute_exposure, 9)
 
@@ -207,11 +205,8 @@ class TestExperimentTrendQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         trend_result = cast(ExperimentTrendQueryResponse, result)
 
-        self.assertIn("control", trend_result.results)
-        self.assertIn("test", trend_result.results)
-
-        control_result = trend_result.results["control"]
-        test_result = trend_result.results["test"]
+        control_result = next(variant for variant in trend_result.variants if variant.key == "control")
+        test_result = next(variant for variant in trend_result.variants if variant.key == "test")
 
         self.assertEqual(control_result.count, 3)
         self.assertEqual(test_result.count, 5)
@@ -302,11 +297,8 @@ class TestExperimentTrendQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         trend_result = cast(ExperimentTrendQueryResponse, result)
 
-        self.assertIn("control", trend_result.results)
-        self.assertIn("test", trend_result.results)
-
-        control_result = trend_result.results["control"]
-        test_result = trend_result.results["test"]
+        control_result = next(variant for variant in trend_result.variants if variant.key == "control")
+        test_result = next(variant for variant in trend_result.variants if variant.key == "test")
 
         self.assertEqual(control_result.count, 3)
         self.assertEqual(test_result.count, 5)
@@ -338,3 +330,248 @@ class TestExperimentTrendQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         prepared_count_query = query_runner.prepared_count_query
         self.assertEqual(prepared_count_query.series[0].math, "sum")
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_query_runner_standard_flow(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+
+        ff_property = f"$feature/{feature_flag.key}"
+        count_query = TrendsQuery(series=[EventsNode(event="$pageview")])
+        exposure_query = TrendsQuery(series=[EventsNode(event="$feature_flag_called")])
+
+        experiment_query = ExperimentTrendQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentTrendQuery",
+            count_query=count_query,
+            exposure_query=exposure_query,
+        )
+
+        experiment.metrics = [{"type": "primary", "query": experiment_query.model_dump()}]
+        experiment.save()
+
+        journeys_for(
+            {
+                "user_control_1": [
+                    {"event": "$pageview", "timestamp": "2020-01-02", "properties": {ff_property: "control"}},
+                    {"event": "$pageview", "timestamp": "2020-01-03", "properties": {ff_property: "control"}},
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2020-01-02",
+                        "properties": {ff_property: "control"},
+                    },
+                ],
+                "user_control_2": [
+                    {"event": "$pageview", "timestamp": "2020-01-02", "properties": {ff_property: "control"}},
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2020-01-02",
+                        "properties": {ff_property: "control"},
+                    },
+                ],
+                "user_test_1": [
+                    {"event": "$pageview", "timestamp": "2020-01-02", "properties": {ff_property: "test"}},
+                    {"event": "$pageview", "timestamp": "2020-01-03", "properties": {ff_property: "test"}},
+                    {"event": "$pageview", "timestamp": "2020-01-04", "properties": {ff_property: "test"}},
+                    {"event": "$feature_flag_called", "timestamp": "2020-01-02", "properties": {ff_property: "test"}},
+                ],
+                "user_test_2": [
+                    {"event": "$pageview", "timestamp": "2020-01-02", "properties": {ff_property: "test"}},
+                    {"event": "$pageview", "timestamp": "2020-01-03", "properties": {ff_property: "test"}},
+                    {"event": "$feature_flag_called", "timestamp": "2020-01-02", "properties": {ff_property: "test"}},
+                ],
+            },
+            self.team,
+        )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentTrendQueryRunner(
+            query=ExperimentTrendQuery(**experiment.metrics[0]["query"]), team=self.team
+        )
+        result = query_runner.calculate()
+
+        self.assertEqual(len(result.variants), 2)
+        for variant in result.variants:
+            self.assertIn(variant.key, ["control", "test"])
+
+        control_variant = next(v for v in result.variants if v.key == "control")
+        test_variant = next(v for v in result.variants if v.key == "test")
+
+        self.assertEqual(control_variant.count, 3)
+        self.assertEqual(test_variant.count, 5)
+        self.assertEqual(control_variant.absolute_exposure, 2)
+        self.assertEqual(test_variant.absolute_exposure, 2)
+
+        self.assertAlmostEqual(result.credible_intervals["control"][0], 0.5449, places=3)
+        self.assertAlmostEqual(result.credible_intervals["control"][1], 4.3836, places=3)
+        self.assertAlmostEqual(result.credible_intervals["test"][0], 1.1009, places=3)
+        self.assertAlmostEqual(result.credible_intervals["test"][1], 5.8342, places=3)
+
+        self.assertAlmostEqual(result.p_value, 1.0, places=3)
+
+        self.assertAlmostEqual(result.probability["control"], 0.2549, places=2)
+        self.assertAlmostEqual(result.probability["test"], 0.7453, places=2)
+
+        self.assertEqual(result.significance_code, ExperimentSignificanceCode.NOT_ENOUGH_EXPOSURE)
+
+        self.assertFalse(result.significant)
+
+        self.assertEqual(len(result.variants), 2)
+
+        self.assertEqual(control_variant.absolute_exposure, 2.0)
+        self.assertEqual(control_variant.count, 3.0)
+        self.assertEqual(control_variant.exposure, 1.0)
+
+        self.assertEqual(test_variant.absolute_exposure, 2.0)
+        self.assertEqual(test_variant.count, 5.0)
+        self.assertEqual(test_variant.exposure, 1.0)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_validate_event_variants_no_events(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+
+        count_query = TrendsQuery(series=[EventsNode(event="$pageview")])
+        experiment_query = ExperimentTrendQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentTrendQuery",
+            count_query=count_query,
+        )
+
+        query_runner = ExperimentTrendQueryRunner(query=experiment_query, team=self.team)
+
+        with self.assertRaises(ValidationError) as context:
+            query_runner._validate_event_variants(TrendsQueryResponse(results=[]))
+
+        expected_errors = json.dumps(
+            {
+                ExperimentNoResultsErrorKeys.NO_EVENTS: True,
+                ExperimentNoResultsErrorKeys.NO_FLAG_INFO: True,
+                ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
+                ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: True,
+            }
+        )
+        self.assertEqual(cast(list, context.exception.detail)[0], expected_errors)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_validate_event_variants_no_control(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+
+        ff_property = f"$feature/{feature_flag.key}"
+        journeys_for(
+            {
+                "user_test": [
+                    {"event": "$pageview", "timestamp": "2020-01-02", "properties": {ff_property: "test"}},
+                ],
+            },
+            self.team,
+        )
+
+        flush_persons_and_events()
+
+        count_query = TrendsQuery(series=[EventsNode(event="$pageview")])
+        experiment_query = ExperimentTrendQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentTrendQuery",
+            count_query=count_query,
+        )
+
+        query_runner = ExperimentTrendQueryRunner(query=experiment_query, team=self.team)
+        result = query_runner.count_query_runner.calculate()
+
+        with self.assertRaises(ValidationError) as context:
+            query_runner._validate_event_variants(result)
+
+        expected_errors = json.dumps(
+            {
+                ExperimentNoResultsErrorKeys.NO_EVENTS: False,
+                ExperimentNoResultsErrorKeys.NO_FLAG_INFO: False,
+                ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
+                ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: False,
+            }
+        )
+        self.assertEqual(cast(list, context.exception.detail)[0], expected_errors)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_validate_event_variants_no_test(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+
+        ff_property = f"$feature/{feature_flag.key}"
+        journeys_for(
+            {
+                "user_control": [
+                    {"event": "$pageview", "timestamp": "2020-01-02", "properties": {ff_property: "control"}},
+                ],
+            },
+            self.team,
+        )
+
+        flush_persons_and_events()
+
+        count_query = TrendsQuery(series=[EventsNode(event="$pageview")])
+        experiment_query = ExperimentTrendQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentTrendQuery",
+            count_query=count_query,
+        )
+
+        query_runner = ExperimentTrendQueryRunner(query=experiment_query, team=self.team)
+        result = query_runner.count_query_runner.calculate()
+
+        with self.assertRaises(ValidationError) as context:
+            query_runner._validate_event_variants(result)
+
+        expected_errors = json.dumps(
+            {
+                ExperimentNoResultsErrorKeys.NO_EVENTS: False,
+                ExperimentNoResultsErrorKeys.NO_FLAG_INFO: False,
+                ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: False,
+                ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: True,
+            }
+        )
+        self.assertEqual(cast(list, context.exception.detail)[0], expected_errors)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_validate_event_variants_no_flag_info(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+
+        journeys_for(
+            {
+                "user_no_flag_1": [
+                    {"event": "$pageview", "timestamp": "2020-01-02"},
+                ],
+                "user_no_flag_2": [
+                    {"event": "$pageview", "timestamp": "2020-01-03"},
+                ],
+            },
+            self.team,
+        )
+
+        flush_persons_and_events()
+
+        count_query = TrendsQuery(series=[EventsNode(event="$pageview")])
+        experiment_query = ExperimentTrendQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentTrendQuery",
+            count_query=count_query,
+        )
+
+        query_runner = ExperimentTrendQueryRunner(query=experiment_query, team=self.team)
+        result = query_runner.count_query_runner.calculate()
+
+        with self.assertRaises(ValidationError) as context:
+            query_runner._validate_event_variants(result)
+
+        expected_errors = json.dumps(
+            {
+                ExperimentNoResultsErrorKeys.NO_EVENTS: True,
+                ExperimentNoResultsErrorKeys.NO_FLAG_INFO: True,
+                ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
+                ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: True,
+            }
+        )
+        self.assertEqual(cast(list, context.exception.detail)[0], expected_errors)

--- a/posthog/hogql_queries/experiments/trend_statistics.py
+++ b/posthog/hogql_queries/experiments/trend_statistics.py
@@ -11,14 +11,14 @@ from ee.clickhouse.queries.experiments import (
     MIN_PROBABILITY_FOR_SIGNIFICANCE,
     P_VALUE_SIGNIFICANCE_LEVEL,
 )
-from posthog.constants import ExperimentSignificanceCode
-from posthog.schema import ExperimentVariantTrendResult
+
+from posthog.schema import ExperimentSignificanceCode, ExperimentVariantTrendBaseStats
 
 Probability = float
 
 
 def calculate_probabilities(
-    control_variant: ExperimentVariantTrendResult, test_variants: list[ExperimentVariantTrendResult]
+    control_variant: ExperimentVariantTrendBaseStats, test_variants: list[ExperimentVariantTrendBaseStats]
 ) -> list[Probability]:
     """
     Calculates probability that A is better than B. First variant is control, rest are test variants.
@@ -59,7 +59,7 @@ def calculate_probabilities(
 
 
 def simulate_winning_variant_for_arrival_rates(
-    target_variant: ExperimentVariantTrendResult, variants: list[ExperimentVariantTrendResult]
+    target_variant: ExperimentVariantTrendBaseStats, variants: list[ExperimentVariantTrendBaseStats]
 ) -> float:
     random_sampler = default_rng()
     simulations_count = 100_000
@@ -85,8 +85,8 @@ def simulate_winning_variant_for_arrival_rates(
 
 
 def are_results_significant(
-    control_variant: ExperimentVariantTrendResult,
-    test_variants: list[ExperimentVariantTrendResult],
+    control_variant: ExperimentVariantTrendBaseStats,
+    test_variants: list[ExperimentVariantTrendBaseStats],
     probabilities: list[Probability],
 ) -> tuple[ExperimentSignificanceCode, Probability]:
     # TODO: Experiment with Expected Loss calculations for trend experiments
@@ -152,7 +152,7 @@ def poisson_p_value(control_count, control_exposure, test_count, test_exposure):
 
 
 def calculate_p_value(
-    control_variant: ExperimentVariantTrendResult, test_variants: list[ExperimentVariantTrendResult]
+    control_variant: ExperimentVariantTrendBaseStats, test_variants: list[ExperimentVariantTrendBaseStats]
 ) -> Probability:
     best_test_variant = max(test_variants, key=lambda variant: variant.count)
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -27,14 +27,6 @@ class ActionConversionGoal(BaseModel):
     actionId: int
 
 
-class ActorsPropertyTaxonomyResponse(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    sample_count: int
-    sample_values: list[str]
-
-
 class AggregationAxisFormat(StrEnum):
     NUMERIC = "numeric"
     DURATION = "duration"
@@ -517,6 +509,14 @@ class EventsQueryPersonColumn(BaseModel):
     uuid: str
 
 
+class ExperimentSignificanceCode(StrEnum):
+    SIGNIFICANT = "significant"
+    NOT_ENOUGH_EXPOSURE = "not_enough_exposure"
+    LOW_WIN_PROBABILITY = "low_win_probability"
+    HIGH_LOSS = "high_loss"
+    HIGH_P_VALUE = "high_p_value"
+
+
 class ExperimentVariantFunnelResult(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -526,7 +526,7 @@ class ExperimentVariantFunnelResult(BaseModel):
     success_count: float
 
 
-class ExperimentVariantTrendResult(BaseModel):
+class ExperimentVariantTrendBaseStats(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
@@ -865,10 +865,8 @@ class NodeKind(StrEnum):
     EXPERIMENT_FUNNEL_QUERY = "ExperimentFunnelQuery"
     EXPERIMENT_TREND_QUERY = "ExperimentTrendQuery"
     DATABASE_SCHEMA_QUERY = "DatabaseSchemaQuery"
-    SUGGESTED_QUESTIONS_QUERY = "SuggestedQuestionsQuery"
     TEAM_TAXONOMY_QUERY = "TeamTaxonomyQuery"
     EVENT_TAXONOMY_QUERY = "EventTaxonomyQuery"
-    ACTORS_PROPERTY_TAXONOMY_QUERY = "ActorsPropertyTaxonomyQuery"
 
 
 class PathCleaningFilter(BaseModel):
@@ -1020,37 +1018,6 @@ class QueryResponseAlternative16(BaseModel):
     )
     insight: Literal["FUNNELS"] = "FUNNELS"
     results: dict[str, ExperimentVariantFunnelResult]
-
-
-class QueryResponseAlternative17(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    insight: Literal["TRENDS"] = "TRENDS"
-    results: dict[str, ExperimentVariantTrendResult]
-
-
-class QueryResponseAlternative28(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    insight: Literal["FUNNELS"] = "FUNNELS"
-    results: dict[str, ExperimentVariantFunnelResult]
-
-
-class QueryResponseAlternative29(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    insight: Literal["TRENDS"] = "TRENDS"
-    results: dict[str, ExperimentVariantTrendResult]
-
-
-class QueryResponseAlternative38(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    questions: list[str]
 
 
 class QueryStatus(BaseModel):
@@ -1271,13 +1238,6 @@ class StickinessQueryResponse(BaseModel):
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
-
-
-class SuggestedQuestionsQueryResponse(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    questions: list[str]
 
 
 class TaxonomicFilterGroupType(StrEnum):
@@ -1672,27 +1632,6 @@ class YAxisSettings(BaseModel):
     startAtZero: Optional[bool] = Field(default=None, description="Whether the Y axis should start at zero")
 
 
-class ActorsPropertyTaxonomyQueryResponse(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    error: Optional[str] = Field(
-        default=None,
-        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
-    )
-    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
-    modifiers: Optional[HogQLQueryModifiers] = Field(
-        default=None, description="Modifiers used when performing the query"
-    )
-    query_status: Optional[QueryStatus] = Field(
-        default=None, description="Query status indicates whether next to the provided data, a query is still running."
-    )
-    results: ActorsPropertyTaxonomyResponse
-    timings: Optional[list[QueryTiming]] = Field(
-        default=None, description="Measured timings for different parts of the query generation process"
-    )
-
-
 class ActorsQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1759,36 +1698,6 @@ class CacheMissResponse(BaseModel):
     )
     cache_key: Optional[str] = None
     query_status: Optional[QueryStatus] = None
-
-
-class CachedActorsPropertyTaxonomyQueryResponse(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    cache_key: str
-    cache_target_age: Optional[AwareDatetime] = None
-    calculation_trigger: Optional[str] = Field(
-        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
-    )
-    error: Optional[str] = Field(
-        default=None,
-        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
-    )
-    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
-    is_cached: bool
-    last_refresh: AwareDatetime
-    modifiers: Optional[HogQLQueryModifiers] = Field(
-        default=None, description="Modifiers used when performing the query"
-    )
-    next_allowed_client_refresh: AwareDatetime
-    query_status: Optional[QueryStatus] = Field(
-        default=None, description="Query status indicates whether next to the provided data, a query is still running."
-    )
-    results: ActorsPropertyTaxonomyResponse
-    timezone: str
-    timings: Optional[list[QueryTiming]] = Field(
-        default=None, description="Measured timings for different parts of the query generation process"
-    )
 
 
 class CachedActorsQueryResponse(BaseModel):
@@ -1955,15 +1864,20 @@ class CachedExperimentTrendQueryResponse(BaseModel):
     calculation_trigger: Optional[str] = Field(
         default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
     )
-    insight: Literal["TRENDS"] = "TRENDS"
+    credible_intervals: dict[str, list[float]]
+    insight: TrendsQueryResponse
     is_cached: bool
     last_refresh: AwareDatetime
     next_allowed_client_refresh: AwareDatetime
+    p_value: float
+    probability: dict[str, float]
     query_status: Optional[QueryStatus] = Field(
         default=None, description="Query status indicates whether next to the provided data, a query is still running."
     )
-    results: dict[str, ExperimentVariantTrendResult]
+    significance_code: ExperimentSignificanceCode
+    significant: bool
     timezone: str
+    variants: list[ExperimentVariantTrendBaseStats]
 
 
 class CachedFunnelCorrelationResponse(BaseModel):
@@ -2186,25 +2100,6 @@ class CachedStickinessQueryResponse(BaseModel):
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
-
-
-class CachedSuggestedQuestionsQueryResponse(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    cache_key: str
-    cache_target_age: Optional[AwareDatetime] = None
-    calculation_trigger: Optional[str] = Field(
-        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
-    )
-    is_cached: bool
-    last_refresh: AwareDatetime
-    next_allowed_client_refresh: AwareDatetime
-    query_status: Optional[QueryStatus] = Field(
-        default=None, description="Query status indicates whether next to the provided data, a query is still running."
-    )
-    questions: list[str]
-    timezone: str
 
 
 class CachedTeamTaxonomyQueryResponse(BaseModel):
@@ -2702,8 +2597,13 @@ class Response11(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    insight: Literal["TRENDS"] = "TRENDS"
-    results: dict[str, ExperimentVariantTrendResult]
+    credible_intervals: dict[str, list[float]]
+    insight: TrendsQueryResponse
+    p_value: float
+    probability: dict[str, float]
+    significance_code: ExperimentSignificanceCode
+    significant: bool
+    variants: list[ExperimentVariantTrendBaseStats]
 
 
 class DataWarehousePersonPropertyFilter(BaseModel):
@@ -2868,8 +2768,13 @@ class ExperimentTrendQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    insight: Literal["TRENDS"] = "TRENDS"
-    results: dict[str, ExperimentVariantTrendResult]
+    credible_intervals: dict[str, list[float]]
+    insight: TrendsQueryResponse
+    p_value: float
+    probability: dict[str, float]
+    significance_code: ExperimentSignificanceCode
+    significant: bool
+    variants: list[ExperimentVariantTrendBaseStats]
 
 
 class BreakdownFilter1(BaseModel):
@@ -3461,6 +3366,19 @@ class QueryResponseAlternative15(BaseModel):
     )
 
 
+class QueryResponseAlternative17(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    credible_intervals: dict[str, list[float]]
+    insight: TrendsQueryResponse
+    p_value: float
+    probability: dict[str, float]
+    significance_code: ExperimentSignificanceCode
+    significant: bool
+    variants: list[ExperimentVariantTrendBaseStats]
+
+
 class QueryResponseAlternative18(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -3695,6 +3613,19 @@ class QueryResponseAlternative27(BaseModel):
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
+
+
+class QueryResponseAlternative29(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    credible_intervals: dict[str, list[float]]
+    insight: TrendsQueryResponse
+    p_value: float
+    probability: dict[str, float]
+    significance_code: ExperimentSignificanceCode
+    significant: bool
+    variants: list[ExperimentVariantTrendBaseStats]
 
 
 class QueryResponseAlternative30(BaseModel):
@@ -3961,17 +3892,6 @@ class SessionsTimelineQueryResponse(BaseModel):
     )
 
 
-class SuggestedQuestionsQuery(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    kind: Literal["SuggestedQuestionsQuery"] = "SuggestedQuestionsQuery"
-    modifiers: Optional[HogQLQueryModifiers] = Field(
-        default=None, description="Modifiers used when performing the query"
-    )
-    response: Optional[SuggestedQuestionsQueryResponse] = None
-
-
 class TableSettings(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4094,19 +4014,6 @@ class WebTopClicksQuery(BaseModel):
     response: Optional[WebTopClicksQueryResponse] = None
     sampling: Optional[Sampling] = None
     useSessionsTable: Optional[bool] = None
-
-
-class ActorsPropertyTaxonomyQuery(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    group_type_index: Optional[int] = None
-    kind: Literal["ActorsPropertyTaxonomyQuery"] = "ActorsPropertyTaxonomyQuery"
-    modifiers: Optional[HogQLQueryModifiers] = Field(
-        default=None, description="Modifiers used when performing the query"
-    )
-    property: str
-    response: Optional[ActorsPropertyTaxonomyQueryResponse] = None
 
 
 class AnyResponseType(
@@ -5787,7 +5694,6 @@ class QueryResponseAlternative(
             QueryResponseAlternative25,
             QueryResponseAlternative26,
             QueryResponseAlternative27,
-            QueryResponseAlternative28,
             QueryResponseAlternative29,
             QueryResponseAlternative30,
             QueryResponseAlternative31,
@@ -5795,7 +5701,6 @@ class QueryResponseAlternative(
             QueryResponseAlternative33,
             QueryResponseAlternative36,
             QueryResponseAlternative37,
-            QueryResponseAlternative38,
         ]
     ]
 ):
@@ -5827,7 +5732,6 @@ class QueryResponseAlternative(
         QueryResponseAlternative25,
         QueryResponseAlternative26,
         QueryResponseAlternative27,
-        QueryResponseAlternative28,
         QueryResponseAlternative29,
         QueryResponseAlternative30,
         QueryResponseAlternative31,
@@ -5835,7 +5739,6 @@ class QueryResponseAlternative(
         QueryResponseAlternative33,
         QueryResponseAlternative36,
         QueryResponseAlternative37,
-        QueryResponseAlternative38,
     ]
 
 
@@ -6324,7 +6227,6 @@ class QueryRequest(BaseModel):
         LifecycleQuery,
         FunnelCorrelationQuery,
         DatabaseSchemaQuery,
-        SuggestedQuestionsQuery,
     ] = Field(
         ...,
         description=(
@@ -6388,7 +6290,6 @@ class QuerySchemaRoot(
             LifecycleQuery,
             FunnelCorrelationQuery,
             DatabaseSchemaQuery,
-            SuggestedQuestionsQuery,
         ]
     ]
 ):
@@ -6427,7 +6328,6 @@ class QuerySchemaRoot(
         LifecycleQuery,
         FunnelCorrelationQuery,
         DatabaseSchemaQuery,
-        SuggestedQuestionsQuery,
     ] = Field(..., discriminator="kind")
 
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -27,6 +27,14 @@ class ActionConversionGoal(BaseModel):
     actionId: int
 
 
+class ActorsPropertyTaxonomyResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    sample_count: int
+    sample_values: list[str]
+
+
 class AggregationAxisFormat(StrEnum):
     NUMERIC = "numeric"
     DURATION = "duration"
@@ -865,8 +873,10 @@ class NodeKind(StrEnum):
     EXPERIMENT_FUNNEL_QUERY = "ExperimentFunnelQuery"
     EXPERIMENT_TREND_QUERY = "ExperimentTrendQuery"
     DATABASE_SCHEMA_QUERY = "DatabaseSchemaQuery"
+    SUGGESTED_QUESTIONS_QUERY = "SuggestedQuestionsQuery"
     TEAM_TAXONOMY_QUERY = "TeamTaxonomyQuery"
     EVENT_TAXONOMY_QUERY = "EventTaxonomyQuery"
+    ACTORS_PROPERTY_TAXONOMY_QUERY = "ActorsPropertyTaxonomyQuery"
 
 
 class PathCleaningFilter(BaseModel):
@@ -1018,6 +1028,13 @@ class QueryResponseAlternative16(BaseModel):
     )
     insight: Literal["FUNNELS"] = "FUNNELS"
     results: dict[str, ExperimentVariantFunnelResult]
+
+
+class QueryResponseAlternative38(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    questions: list[str]
 
 
 class QueryStatus(BaseModel):
@@ -1238,6 +1255,13 @@ class StickinessQueryResponse(BaseModel):
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
+
+
+class SuggestedQuestionsQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    questions: list[str]
 
 
 class TaxonomicFilterGroupType(StrEnum):
@@ -1632,6 +1656,27 @@ class YAxisSettings(BaseModel):
     startAtZero: Optional[bool] = Field(default=None, description="Whether the Y axis should start at zero")
 
 
+class ActorsPropertyTaxonomyQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: ActorsPropertyTaxonomyResponse
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
+
+
 class ActorsQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1698,6 +1743,36 @@ class CacheMissResponse(BaseModel):
     )
     cache_key: Optional[str] = None
     query_status: Optional[QueryStatus] = None
+
+
+class CachedActorsPropertyTaxonomyQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: Optional[AwareDatetime] = None
+    calculation_trigger: Optional[str] = Field(
+        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+    )
+    hogql: Optional[str] = Field(default=None, description="Generated HogQL query.")
+    is_cached: bool
+    last_refresh: AwareDatetime
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    next_allowed_client_refresh: AwareDatetime
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    results: ActorsPropertyTaxonomyResponse
+    timezone: str
+    timings: Optional[list[QueryTiming]] = Field(
+        default=None, description="Measured timings for different parts of the query generation process"
+    )
 
 
 class CachedActorsQueryResponse(BaseModel):
@@ -2100,6 +2175,25 @@ class CachedStickinessQueryResponse(BaseModel):
     timings: Optional[list[QueryTiming]] = Field(
         default=None, description="Measured timings for different parts of the query generation process"
     )
+
+
+class CachedSuggestedQuestionsQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: Optional[AwareDatetime] = None
+    calculation_trigger: Optional[str] = Field(
+        default=None, description="What triggered the calculation of the query, leave empty if user/immediate"
+    )
+    is_cached: bool
+    last_refresh: AwareDatetime
+    next_allowed_client_refresh: AwareDatetime
+    query_status: Optional[QueryStatus] = Field(
+        default=None, description="Query status indicates whether next to the provided data, a query is still running."
+    )
+    questions: list[str]
+    timezone: str
 
 
 class CachedTeamTaxonomyQueryResponse(BaseModel):
@@ -3892,6 +3986,17 @@ class SessionsTimelineQueryResponse(BaseModel):
     )
 
 
+class SuggestedQuestionsQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    kind: Literal["SuggestedQuestionsQuery"] = "SuggestedQuestionsQuery"
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    response: Optional[SuggestedQuestionsQueryResponse] = None
+
+
 class TableSettings(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4014,6 +4119,19 @@ class WebTopClicksQuery(BaseModel):
     response: Optional[WebTopClicksQueryResponse] = None
     sampling: Optional[Sampling] = None
     useSessionsTable: Optional[bool] = None
+
+
+class ActorsPropertyTaxonomyQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    group_type_index: Optional[int] = None
+    kind: Literal["ActorsPropertyTaxonomyQuery"] = "ActorsPropertyTaxonomyQuery"
+    modifiers: Optional[HogQLQueryModifiers] = Field(
+        default=None, description="Modifiers used when performing the query"
+    )
+    property: str
+    response: Optional[ActorsPropertyTaxonomyQueryResponse] = None
 
 
 class AnyResponseType(
@@ -5701,6 +5819,7 @@ class QueryResponseAlternative(
             QueryResponseAlternative33,
             QueryResponseAlternative36,
             QueryResponseAlternative37,
+            QueryResponseAlternative38,
         ]
     ]
 ):
@@ -5739,6 +5858,7 @@ class QueryResponseAlternative(
         QueryResponseAlternative33,
         QueryResponseAlternative36,
         QueryResponseAlternative37,
+        QueryResponseAlternative38,
     ]
 
 
@@ -6227,6 +6347,7 @@ class QueryRequest(BaseModel):
         LifecycleQuery,
         FunnelCorrelationQuery,
         DatabaseSchemaQuery,
+        SuggestedQuestionsQuery,
     ] = Field(
         ...,
         description=(
@@ -6290,6 +6411,7 @@ class QuerySchemaRoot(
             LifecycleQuery,
             FunnelCorrelationQuery,
             DatabaseSchemaQuery,
+            SuggestedQuestionsQuery,
         ]
     ]
 ):
@@ -6328,6 +6450,7 @@ class QuerySchemaRoot(
         LifecycleQuery,
         FunnelCorrelationQuery,
         DatabaseSchemaQuery,
+        SuggestedQuestionsQuery,
     ] = Field(..., discriminator="kind")
 
 


### PR DESCRIPTION
## Changes
- Plugged existing statistical methods to `TrendExperimentQueryRunner`, replicating soon-to-be-deprecated `trend_experiment_result.py`
- Some clean ups and name changes

## How did you test this code?
- Added tests
- Existing tests passing