### PR TITLE
perf: Fully separate the modifiers used for materialized columns and materialized property groups

### DIFF
--- a/posthog/hogql/modifiers.py
+++ b/posthog/hogql/modifiers.py
@@ -79,19 +79,18 @@ def set_default_modifier_values(modifiers: HogQLQueryModifiers, team: "Team"):
     if modifiers.sessionTableVersion is None:
         modifiers.sessionTableVersion = SessionTableVersion.AUTO
 
-    if (
-        modifiers.propertyGroupsMode is None
-        and is_cloud()
-        and posthoganalytics.feature_enabled(
+    if modifiers.propertyGroupsMode is None:
+        if is_cloud() and posthoganalytics.feature_enabled(
             "hogql-optimized-property-groups-mode-enabled",
             str(team.uuid),
             groups={"project": str(team.id)},
             group_properties={"project": {"id": str(team.id), "created_at": team.created_at, "uuid": team.uuid}},
             only_evaluate_locally=True,
             send_feature_flag_events=False,
-        )
-    ):
-        modifiers.propertyGroupsMode = PropertyGroupsMode.OPTIMIZED
+        ):
+            modifiers.propertyGroupsMode = PropertyGroupsMode.OPTIMIZED
+        else:
+            modifiers.propertyGroupsMode = PropertyGroupsMode.DISABLED
 
 
 def set_default_in_cohort_via(modifiers: HogQLQueryModifiers) -> HogQLQueryModifiers:

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1315,7 +1315,10 @@ class _Printer(Visitor):
                         self._print_identifier(materialized_column),
                     )
 
-            if self.context.modifiers.propertyGroupsMode != PropertyGroupsMode.DISABLED:
+            if self.context.modifiers.propertyGroupsMode in (
+                PropertyGroupsMode.ENABLED,
+                PropertyGroupsMode.OPTIMIZED,
+            ):
                 # For now, we're assuming that properties are in either no groups or one group, so just using the
                 # first group returned is fine. If we start putting properties in multiple groups, this should be
                 # revisited to find the optimal set (i.e. smallest set) of groups to read from.

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -1315,10 +1315,7 @@ class _Printer(Visitor):
                         self._print_identifier(materialized_column),
                     )
 
-            if self.context.modifiers.propertyGroupsMode in (
-                PropertyGroupsMode.ENABLED,
-                PropertyGroupsMode.OPTIMIZED,
-            ):
+            if self.context.modifiers.propertyGroupsMode != PropertyGroupsMode.DISABLED:
                 # For now, we're assuming that properties are in either no groups or one group, so just using the
                 # first group returned is fine. If we start putting properties in multiple groups, this should be
                 # revisited to find the optimal set (i.e. smallest set) of groups to read from.

--- a/posthog/hogql/test/test_printer.py
+++ b/posthog/hogql/test/test_printer.py
@@ -19,7 +19,6 @@ from posthog.models import PropertyDefinition
 from posthog.models.team.team import WeekStartDay
 from posthog.schema import (
     HogQLQueryModifiers,
-    MaterializationMode,
     PersonsArgMaxVersion,
     PersonsOnEventsMode,
     PropertyGroupsMode,
@@ -352,7 +351,6 @@ class TestPrinter(BaseTest):
         context = HogQLContext(
             team_id=self.team.pk,
             modifiers=HogQLQueryModifiers(
-                materializationMode=MaterializationMode.AUTO,
                 propertyGroupsMode=PropertyGroupsMode.ENABLED,
             ),
         )
@@ -382,7 +380,6 @@ class TestPrinter(BaseTest):
             return HogQLContext(
                 team_id=self.team.pk,
                 modifiers=HogQLQueryModifiers(
-                    materializationMode=MaterializationMode.AUTO,
                     propertyGroupsMode=property_groups_mode,
                 ),
             )
@@ -639,7 +636,6 @@ class TestPrinter(BaseTest):
                 team_id=self.team.pk,
                 enable_select_queries=True,
                 modifiers=HogQLQueryModifiers(
-                    materializationMode=MaterializationMode.AUTO,
                     propertyGroupsMode=property_groups_mode,
                 ),
             )

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -117,7 +117,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_93427f8f06e6cc8643a394ae002de2c1")
+        self.assertEqual(cache_key, "cache_0da1bc2ef4cc1cc2953a237e3ff3a573")
 
     def test_cache_key_runner_subclass(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -131,7 +131,7 @@ class TestQueryRunner(BaseTest):
         runner = TestSubclassQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_bb6398a99867dfbdc45a2fc4fccb8f27")
+        self.assertEqual(cache_key, "cache_76eed63814c314fdebcb14056ae63815")
 
     def test_cache_key_different_timezone(self):
         TestQueryRunner = self.setup_test_query_runner_class()
@@ -142,7 +142,7 @@ class TestQueryRunner(BaseTest):
         runner = TestQueryRunner(query={"some_attr": "bla"}, team=team)
 
         cache_key = runner.get_cache_key()
-        self.assertEqual(cache_key, "cache_e0c2bb1ad091102533399ebdddbfb24d")
+        self.assertEqual(cache_key, "cache_cb44eae669c816e30ed188410fe5a717")
 
     @mock.patch("django.db.transaction.on_commit")
     def test_cache_response(self, mock_on_commit):

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -14,6 +14,7 @@ from posthog.schema import (
     HogQLQueryModifiers,
     MaterializationMode,
     PersonsOnEventsMode,
+    PropertyGroupsMode,
     TestBasicQueryResponse,
     TestCachedBasicQueryResponse,
 )
@@ -95,6 +96,7 @@ class TestQueryRunner(BaseTest):
                     "personsArgMaxVersion": "auto",
                     "optimizeJoinedFilters": False,
                     "personsOnEventsMode": PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED,
+                    "propertyGroupsMode": PropertyGroupsMode.DISABLED,
                     "bounceRatePageViewMode": "count_pageviews",
                     "sessionTableVersion": "auto",
                 },


### PR DESCRIPTION
## Problem

Currently, materialized property groups can only be used if materialized columns are also enabled. These modifiers don't necessarily _need_ to be coupled, and this coupling also prevents us from being able to use the modifiers to benchmark the difference between materialized column performance and property group performance without resorting to manually rewriting queries.

## Changes

Separates the property group modifier paths from the materialized column path so that they can be used independently of each other.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Updated property groups tests to remove references to unrelated setting.