### PR TITLE
feat(nav): Use emoji in project name as its icon

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
+++ b/frontend/src/lib/lemon-ui/LemonMenu/LemonMenu.tsx
@@ -17,6 +17,8 @@ export interface LemonMenuItemBase
     > {
     label: string | JSX.Element
     key?: React.Key
+    /** @deprecated You're probably doing something wrong if you're setting per-item classes. */
+    className?: string
     /** True if the item is a custom element. */
     custom?: boolean
 }


### PR DESCRIPTION
## Changes

A bit of UI sugar: when the first character of a project name is an emoji, that emoji is used as the project's icon.

<img width="329" alt="Screenshot 2024-10-10 at 14 45 50" src="https://github.com/user-attachments/assets/65c4611f-6504-4b5d-a00b-851c0de98d20">
