### PR TITLE
fix(batch-exports): Create async session in async function

### DIFF
--- a/posthog/temporal/tests/conftest.py
+++ b/posthog/temporal/tests/conftest.py
@@ -1,14 +1,14 @@
 import asyncio
 import random
 
+import psycopg
 import pytest
 import pytest_asyncio
 import temporalio.worker
 from asgiref.sync import sync_to_async
 from django.conf import settings
-from temporalio.testing import ActivityEnvironment
-import psycopg
 from psycopg import sql
+from temporalio.testing import ActivityEnvironment
 
 from posthog.models import Organization, Team
 from posthog.temporal.common.clickhouse import ClickHouseClient
@@ -65,10 +65,10 @@ def activity_environment():
     return ActivityEnvironment()
 
 
-@pytest.fixture(scope="module")
-def clickhouse_client():
+@pytest_asyncio.fixture(scope="module")
+async def clickhouse_client():
     """Provide a ClickHouseClient to use in tests."""
-    client = ClickHouseClient(
+    async with ClickHouseClient(
         url=settings.CLICKHOUSE_HTTP_URL,
         user=settings.CLICKHOUSE_USER,
         password=settings.CLICKHOUSE_PASSWORD,
@@ -78,9 +78,8 @@ def clickhouse_client():
         # Durting testing, it's useful to enable it to wait for mutations.
         # Otherwise, tests that rely on running a mutation may become flaky.
         mutations_sync=2,
-    )
-
-    yield client
+    ) as client:
+        yield client
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
## Problem

Creating a client session outside async function could have problems (see [here](https://docs.aiohttp.org/en/stable/faq.html#why-is-creating-a-clientsession-outside-of-an-event-loop-dangerous)). Let's maintain a connection in the context manager, otherwise error.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Create connection on async context manager `__aenter__`.
Close connection on `__aexit__`.
Raise error if attempting to run query outside context manager.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
