### PR TITLE
fix(batch-exports): Iterate over clickhouse chunks not any

### DIFF
--- a/posthog/temporal/common/asyncpa.py
+++ b/posthog/temporal/common/asyncpa.py
@@ -12,7 +12,7 @@ class InvalidMessageFormat(Exception):
 class AsyncMessageReader:
     """Asynchronously read PyArrow messages from bytes iterator."""
 
-    def __init__(self, bytes_iter: typing.AsyncIterator[bytes]):
+    def __init__(self, bytes_iter: typing.AsyncIterator[tuple[bytes, bool]]):
         self._bytes = bytes_iter
         self._buffer = bytearray()
 
@@ -58,7 +58,8 @@ class AsyncMessageReader:
     async def read_until(self, n: int) -> None:
         """Read from self._bytes until there are at least n bytes in self._buffer."""
         while len(self._buffer) < n:
-            self._buffer.extend(await anext(self._bytes))
+            bytes, _ = await anext(self._bytes)
+            self._buffer.extend(bytes)
 
     def parse_body_size(self, metadata_flatbuffer: bytearray) -> int:
         """Parse body size from metadata flatbuffer.
@@ -98,7 +99,7 @@ class AsyncMessageReader:
 class AsyncRecordBatchReader:
     """Asynchronously read PyArrow RecordBatches from an iterator of bytes."""
 
-    def __init__(self, bytes_iter: typing.AsyncIterator[bytes]) -> None:
+    def __init__(self, bytes_iter: typing.AsyncIterator[tuple[bytes, bool]]) -> None:
         self._reader = AsyncMessageReader(bytes_iter)
         self._schema: None | pa.Schema = None
 

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -386,7 +386,7 @@ class ClickHouseClient:
         As pyarrow doesn't support async/await buffers, this method is sync and utilizes requests instead of aiohttp.
         """
         async with self.apost_query(query, *data, query_parameters=query_parameters, query_id=query_id) as response:
-            reader = AsyncRecordBatchReader(response.content.iter_any())
+            reader = AsyncRecordBatchReader(response.content.iter_chunks())
             async for batch in reader:
                 yield batch
 


### PR DESCRIPTION
## Problem

Connection issues with ClickHouse:
* From the server side (ClickHouse) it looks like the client disconnects and closes the socket without warning.
* From the client side, it looks like we are done reading the response (no error).

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

`iter_any` and `iter_chunks` are semantically different. The latter will only stop iteration when receiving empty bytes and not at the end of a chunk, whereas the former will stop iteration when receiving empty bytes. I am wondering if perhaps clickhouse is sending some empty data in the middle that cause the former to stop without raising an error.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
