### PR TITLE
fix(batch-exports): Assorted random fixes that make things work

### DIFF
--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -79,7 +79,8 @@ FROM
 FORMAT ArrowStream
 SETTINGS
     -- This is half of configured MAX_MEMORY_USAGE for batch exports.
-    max_bytes_before_external_sort=50000000000
+    max_bytes_before_external_sort=50000000000,
+    max_bytes_before_external_group_by=50000000000
 """
 )
 
@@ -98,7 +99,8 @@ FROM
 FORMAT ArrowStream
 SETTINGS
     -- This is half of configured MAX_MEMORY_USAGE for batch exports.
-    max_bytes_before_external_sort=50000000000
+    max_bytes_before_external_sort=50000000000,
+    max_bytes_before_external_group_by=50000000000
 """
 )
 
@@ -117,7 +119,8 @@ FROM
 FORMAT ArrowStream
 SETTINGS
     -- This is half of configured MAX_MEMORY_USAGE for batch exports.
-    max_bytes_before_external_sort=50000000000
+    max_bytes_before_external_sort=50000000000,
+    max_bytes_before_external_group_by=50000000000
 """
 )
 

--- a/posthog/temporal/common/asyncpa.py
+++ b/posthog/temporal/common/asyncpa.py
@@ -30,7 +30,9 @@ class AsyncMessageReader:
         await self.read_until(4)
 
         if self._buffer[:4] != CONTINUATION_BYTES:
-            raise InvalidMessageFormat("Encapsulated IPC message format must begin with continuation bytes")
+            raise InvalidMessageFormat(
+                f"Encapsulated IPC message format must begin with continuation bytes, instead received: '{self._buffer}'"
+            )
 
         await self.read_until(8)
 


### PR DESCRIPTION
## Problem

A couple:
* We are not seeing what happens when we fail to parse a message. ClickHouse sends the error as bytes in the stream, so let's at least show it in the exception.
* For some reason, `max_bytes_before_external_group_by` makes queries that use up a lot of memory work. Even if the queries themselves have no `GROUP BY` clause.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Append current buffer to exception.
* Use `max_bytes_before_external_group_by` in event queries.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
