### PR TITLE
fix(data-warehouse): Dont hard delete joins

### DIFF
--- a/posthog/warehouse/data_load/source_templates.py
+++ b/posthog/warehouse/data_load/source_templates.py
@@ -7,23 +7,31 @@ from posthog.warehouse.util import database_sync_to_async
 
 @database_sync_to_async
 def database_operations(team_id: int, table_prefix: str) -> None:
-    customer_join_exists = DataWarehouseJoin.objects.filter(
-        team_id=team_id,
-        source_table_name="persons",
-        source_table_key="properties.email",
-        joining_table_name=f"{table_prefix}stripe_customer",
-        joining_table_key="email",
-        field_name=f"{table_prefix}stripe_customer",
-    ).exists()
+    customer_join_exists = (
+        DataWarehouseJoin.objects.filter(
+            team_id=team_id,
+            source_table_name="persons",
+            source_table_key="properties.email",
+            joining_table_name=f"{table_prefix}stripe_customer",
+            joining_table_key="email",
+            field_name=f"{table_prefix}stripe_customer",
+        )
+        .exclude(deleted=True)
+        .exists()
+    )
 
-    invoice_join_exists = DataWarehouseJoin.objects.filter(
-        team_id=team_id,
-        source_table_name="persons",
-        source_table_key="properties.email",
-        joining_table_name=f"{table_prefix}stripe_invoice",
-        joining_table_key="customer_email",
-        field_name=f"{table_prefix}stripe_invoice",
-    ).exists()
+    invoice_join_exists = (
+        DataWarehouseJoin.objects.filter(
+            team_id=team_id,
+            source_table_name="persons",
+            source_table_key="properties.email",
+            joining_table_name=f"{table_prefix}stripe_invoice",
+            joining_table_key="customer_email",
+            field_name=f"{table_prefix}stripe_invoice",
+        )
+        .exclude(deleted=True)
+        .exists()
+    )
 
     if not customer_join_exists:
         DataWarehouseJoin.objects.create(

--- a/posthog/warehouse/models/join.py
+++ b/posthog/warehouse/models/join.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from warnings import warn
-
+from datetime import datetime
 from django.db import models
 
 from posthog.hogql.ast import SelectQuery
@@ -40,6 +40,11 @@ class DataWarehouseJoin(CreatedMetaFields, UUIDModel, DeletedMetaFields):
     joining_table_name = models.CharField(max_length=400)
     joining_table_key = models.CharField(max_length=400)
     field_name = models.CharField(max_length=400)
+
+    def soft_delete(self):
+        self.deleted = True
+        self.deleted_at = datetime.now()
+        self.save()
 
     def join_function(
         self, override_source_table_key: Optional[str] = None, override_joining_table_key: Optional[str] = None


### PR DESCRIPTION
## Problem
- Deleting a table also deletes all joins with the tables name... but for _all_ teams 🫨 😱 😨 

## Changes
- Limit deletes to only joins in my team
- Also only soft delete joins
