### PR TITLE
fix(plugin-server): use UTC now instead of invalid years for timestamp

### DIFF
--- a/plugin-server/tests/worker/ingestion/timestamps.test.ts
+++ b/plugin-server/tests/worker/ingestion/timestamps.test.ts
@@ -145,6 +145,34 @@ describe('parseEventTimestamp()', () => {
         expect(timestamp.toUTC().toISO()).toEqual('2021-10-29T01:43:54.000Z')
     })
 
+    it('timestamps adjusted way out of bounds are ignored', () => {
+        const event = {
+            offset: 600000000000000,
+            timestamp: '2021-10-28T01:00:00.000Z',
+            sent_at: '2021-10-28T01:05:00.000Z',
+            now: '2021-10-28T01:10:00.000Z',
+            uuid: new UUIDT(),
+        } as any as PluginEvent
+
+        const callbackMock = jest.fn()
+        const timestamp = parseEventTimestamp(event, callbackMock)
+        expect(callbackMock.mock.calls).toEqual([
+            [
+                'ignored_invalid_timestamp',
+                {
+                    field: 'timestamp',
+                    eventUuid: event.uuid,
+                    offset: 600000000000000,
+                    parsed_year: -16992,
+                    reason: 'out of bounds',
+                    value: '2021-10-28T01:00:00.000Z',
+                },
+            ],
+        ])
+
+        expect(timestamp.toUTC().toISO()).toEqual('2020-08-12T01:02:00.000Z')
+    })
+
     it('reports timestamp parsing error and fallbacks to DateTime.utc', () => {
         const event = {
             team_id: 123,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Because of weird timestamp mutations in plugin-server, we can emit *very* negative or far future dates into the CH JSON topic. This trips up things that parse by `YYYY-MM-DD`, and can't possibly be what the user is expecting.

## Changes

Consider `< 0, > 9999` years as invalid, so that we fallback to [DateTime.utc()](https://github.com/PostHog/posthog/blob/084eb2941e7aceacbd95f84d1e1063a2b9e94b51/plugin-server/src/worker/ingestion/timestamps.ts#L55) like we do for other invalid dates.

We could be more restrictive here (`1900-2100`?) but as usual, ingestion changes make me nervous and I want to at least fix the specific issue at hand.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes.

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
New unit test.