### PR TITLE
fix(LemonInputSelect): remove all escaped commas

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -115,7 +115,7 @@ export function LemonInputSelect({
         // Show the input value if custom values are allowed and it's not in the list
         if (inputValue && !values.includes(inputValue)) {
             if (allowCustomValues) {
-                const unescapedInputValue = inputValue.replace('\\,', ',') // Transform escaped commas to plain commas
+                const unescapedInputValue = inputValue.replaceAll('\\,', ',') // Transform escaped commas to plain commas
                 ret.push({ key: unescapedInputValue, label: unescapedInputValue, __isInput: true })
             }
         } else if (mode === 'single' && values.length > 0) {
@@ -164,7 +164,7 @@ export function LemonInputSelect({
 
             // We split on commas EXCEPT if they're escaped (to allow for commas in values)
             newValue.split(NON_ESCAPED_COMMA_REGEX).forEach((value) => {
-                const trimmedValue = value.replace('\\,', ',').trim() // Transform escaped commas to plain commas
+                const trimmedValue = value.replaceAll('\\,', ',').trim() // Transform escaped commas to plain commas
                 if (trimmedValue && !values.includes(trimmedValue)) {
                     newValues.push(trimmedValue)
                 }


### PR DESCRIPTION
## Problem

LemonInputSelect only removes the first occurrence of an escaped comma. It makes filtering practically impossible for values containing multiple commas because the following commas are still escaped. For example, pasting the `one\,two\,three` value would produce the `one,two\,three` value in a SQL query.

**Before**

<img width="524" alt="Screenshot 2024-10-17 at 13 35 58" src="https://github.com/user-attachments/assets/4f0d66ef-a05e-4537-87e4-d44098ec7571">

## Changes

Replace the `replace` method with `replaceAll`, which is supported by 93.5% browsers.

**After**

<img width="507" alt="Screenshot 2024-10-17 at 13 33 11" src="https://github.com/user-attachments/assets/da9503b6-70f5-416c-8bf5-621f6ea29d8e">

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
