### PR TITLE
chore: even more taxonomy fangling

### DIFF
--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -1212,6 +1212,10 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
             description: 'posthog-js adds these to the page leave event, they are used in web analytics calculations',
             label: 'Previous pageview duration',
         },
+        $surveys_activated: {
+            label: 'Surveys Activated',
+            description: 'The surveys that were activated for this event.',
+        },
     },
     numerical_event_properties: {}, // Same as event properties, see assignment below
     person_properties: {}, // Currently person properties are the same as event properties, see assignment below
@@ -1432,7 +1436,13 @@ export const NON_DOLLAR_POSTHOG_PROPERTY_KEYS = [
     'current_usage.session_replay',
     'current_usage.surveys',
     'customer_deactivated',
-    'custom_limits_usd.data_warehouse',
+    'custom_limits.data_warehouse',
+    'custom_limits.feature_flags',
+    'custom_limits.integrations',
+    'custom_limits.platform_and_support',
+    'custom_limits.product_analytics',
+    'custom_limits.session_replay',
+    'custom_limits.surveys',
     'free_allocation.data_warehouse',
     'free_allocation.feature_flags',
     'free_allocation.integrations',

--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -1484,8 +1484,6 @@ export const NON_DOLLAR_POSTHOG_PROPERTY_KEYS = [
     'email_service_available',
     'slack_service_available',
     'commit_sha',
-    'token',
-    'distinct_id',
 ]
 
 /** Return whether a given filter key is part of PostHog's core (marked by the PostHog logo). */


### PR DESCRIPTION
* adds some missed billing properties
* moves a few non dollar properties out since some events are pretty bare without anything shown
* adds another surveys event to the taxonomy so it has nice display in the table