### PR TITLE
feat: add decide field based on env var for rollout of identified_only as default

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -10,15 +10,20 @@ from rest_framework import status
 from sentry_sdk import capture_exception
 from statshog.defaults.django import statsd
 
-from posthog.geoip import get_geoip_properties
 from posthog.api.survey import SURVEY_TARGETING_FLAG_PREFIX
-from posthog.api.utils import get_project_id, get_token, hostname_in_allowed_url_list, parse_domain
+from posthog.api.utils import (
+    get_project_id,
+    get_token,
+    hostname_in_allowed_url_list,
+    parse_domain,
+)
 from posthog.database_healthcheck import DATABASE_FOR_FLAG_MATCHING
 from posthog.exceptions import (
-    UnspecifiedCompressionFallbackParsingError,
     RequestParsingError,
+    UnspecifiedCompressionFallbackParsingError,
     generate_exception_response,
 )
+from posthog.geoip import get_geoip_properties
 from posthog.logging.timing import timed
 from posthog.metrics import LABEL_TEAM_ID
 from posthog.models import Team, User
@@ -265,7 +270,11 @@ def get_decide(request: HttpRequest):
             response["sessionRecording"] = _session_recording_config_response(request, team, token)
 
             if settings.DECIDE_SESSION_REPLAY_QUOTA_CHECK:
-                from ee.billing.quota_limiting import QuotaLimitingCaches, QuotaResource, list_limited_team_attributes
+                from ee.billing.quota_limiting import (
+                    QuotaLimitingCaches,
+                    QuotaResource,
+                    list_limited_team_attributes,
+                )
 
                 limited_tokens_recordings = list_limited_team_attributes(
                     QuotaResource.RECORDINGS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
@@ -277,6 +286,8 @@ def get_decide(request: HttpRequest):
 
             response["surveys"] = True if team.surveys_opt_in else False
             response["heatmaps"] = True if team.heatmaps_opt_in else False
+            default_identified_only = team.pk >= settings.DEFAULT_IDENTIFIED_ONLY_TEAM_ID_MIN
+            response["defaultIdentifiedOnly"] = bool(default_identified_only)
 
             site_apps = []
             # errors mean the database is unavailable, bail in this case

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -2,8 +2,8 @@
 import os
 from datetime import timedelta
 
-from corsheaders.defaults import default_headers
 import structlog
+from corsheaders.defaults import default_headers
 
 from posthog.settings.base_variables import BASE_DIR, DEBUG, TEST
 from posthog.settings.utils import get_from_env, get_list, str_to_bool
@@ -40,6 +40,9 @@ DECIDE_SKIP_POSTGRES_FLAGS = get_from_env("DECIDE_SKIP_POSTGRES_FLAGS", False, t
 
 DECIDE_BILLING_SAMPLING_RATE = get_from_env("DECIDE_BILLING_SAMPLING_RATE", 0.1, type_cast=float)
 DECIDE_BILLING_ANALYTICS_TOKEN = get_from_env("DECIDE_BILLING_ANALYTICS_TOKEN", None, type_cast=str, optional=True)
+
+# temporary, used for safe rollout of defaulting people into anonymous events / process_persons: identified_only
+DEFAULT_IDENTIFIED_ONLY_TEAM_ID_MIN: int = get_from_env("DEFAULT_IDENTIFIED_ONLY_TEAM_ID_MIN", 1000000, type_cast=int)
 
 # Decide regular request analytics
 # Takes 3 possible formats, all separated by commas:


### PR DESCRIPTION
## Problem

We want to roll out identified_only as the default person_processing mode for our stateful SDKs. See: https://github.com/PostHog/product-internal/pull/637

posthog-js changes that consume this field here: https://github.com/PostHog/posthog-js/pull/1468

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Uses an env var to add a boolean to the decide response. If a team ID is greater than the var (I think this is safer to do by using newer team IDs / higher numbers first, since many of them will be using identified_only already), set `defaultIdentifiedOnly: true` in the response.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Shouldn't impact self-hosted.

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Will update tests shortly

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
