### PR TITLE
fix(data-warehouse): Increase timeout for creating external data model activity

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -156,7 +156,7 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
         job_id, incremental = await workflow.execute_activity(
             create_external_data_job_model_activity,
             create_external_data_job_inputs,
-            start_to_close_timeout=dt.timedelta(minutes=1),
+            start_to_close_timeout=dt.timedelta(minutes=5),
             retry_policy=RetryPolicy(
                 initial_interval=dt.timedelta(seconds=10),
                 maximum_interval=dt.timedelta(seconds=60),


### PR DESCRIPTION
## Problem
- [Context](https://posthog.slack.com/archives/C019RAX2XBN/p1729244978063459)
- Jobs were failing due to an activity timeout

## Changes
Increase the timeout