### PR TITLE
fix(batch-exports): Deal with deeply nested events

### DIFF
--- a/posthog/temporal/batch_exports/temporary_file.py
+++ b/posthog/temporal/batch_exports/temporary_file.py
@@ -7,6 +7,7 @@ import contextlib
 import csv
 import datetime as dt
 import gzip
+import json
 import tempfile
 import typing
 
@@ -457,16 +458,43 @@ class JSONLBatchExportWriter(BatchExportWriter):
         """Write a single row of JSONL."""
         try:
             n = self.batch_export_file.write(orjson.dumps(d, default=str) + b"\n")
-        except orjson.JSONEncodeError:
-            logger.exception("Failed to encode with orjson: %s", d)
-            # orjson is very strict about invalid unicode. This slow path protects us against
-            # things we've observed in practice, like single surrogate codes, e.g. "\ud83d"
-            cleaned_content = replace_broken_unicode(d)
-            n = self.batch_export_file.write(orjson.dumps(cleaned_content, default=str) + b"\n")
-        except TypeError:
-            logger.exception("Orjson detected a deeply nested dict: %s", d)
-            raise
+        except orjson.JSONEncodeError as err:
+            # NOTE: `orjson.JSONEncodeError` is actually just an alias for `TypeError`.
+            # This handler will catch everything coming from orjson, so we have to
+            # awkwardly check error messages.
+            if str(err) == "Recursion limit reached":
+                # Orjson enforces an unmodifiable recursion limit (256), so we can't
+                # dump very nested dicts.
+                if d.get("event", None) == "$web_vitals":
+                    # These are PostHog events that for a while included a bunch of
+                    # nested DOM structures. Eventually, this was removed, but these
+                    # events could still be present in database.
+                    # Let's try to clear the key with nested elements first.
+                    try:
+                        del d["properties"]["$web_vitals_INP_event"]["attribution"]["interactionTargetElement"]
+                    except KeyError:
+                        # We tried, fallback to the slower but more permissive stdlib
+                        # json.
+                        logger.exception("PostHog $web_vitals event didn't match expected structure")
+                        dumped = json.dumps(d).encode("utf-8")
+                        n = self.batch_export_file.write(dumped + b"\n")
+                    else:
+                        dumped = orjson.dumps(d, default=str)
+                        n = self.batch_export_file.write(dumped + b"\n")
 
+                else:
+                    # In this case, we fallback to the slower but more permissive stdlib
+                    # json.
+                    logger.exception("Orjson detected a deeply nested dict: %s", d)
+                    dumped = json.dumps(d).encode("utf-8")
+                    n = self.batch_export_file.write(dumped + b"\n")
+            else:
+                # Orjson is very strict about invalid unicode. This slow path protects us
+                # against things we've observed in practice, like single surrogate codes, e.g.
+                # "\ud83d"
+                logger.exception("Failed to encode with orjson: %s", d)
+                cleaned_content = replace_broken_unicode(d)
+                n = self.batch_export_file.write(orjson.dumps(cleaned_content, default=str) + b"\n")
         return n
 
     def _write_record_batch(self, record_batch: pa.RecordBatch) -> None:

--- a/posthog/temporal/tests/batch_exports/test_temporary_file.py
+++ b/posthog/temporal/tests/batch_exports/test_temporary_file.py
@@ -246,6 +246,7 @@ async def test_jsonl_writer_writes_record_batches(record_batch):
 
     assert writer.records_total == record_batch.num_rows
 
+    in_memory_file_obj.seek(0)
     lines = in_memory_file_obj.readlines()
     for index, line in enumerate(lines):
         written_jsonl = json.loads(line)
@@ -254,7 +255,7 @@ async def test_jsonl_writer_writes_record_batches(record_batch):
         expected_jsonl = single_record_batch.to_pylist()[0]
 
         assert "_inserted_at" not in written_jsonl
-        assert written_jsonl == expected_jsonl
+        assert written_jsonl == {k: v for k, v in expected_jsonl.items() if k != "_inserted_at"}
 
     assert inserted_ats_seen == [record_batch.column("_inserted_at")[-1].as_py()]
 
@@ -288,6 +289,7 @@ async def test_csv_writer_writes_record_batches(record_batch):
     async with writer.open_temporary_file():
         await writer.write_record_batch(record_batch)
 
+    in_memory_file_obj.seek(0)
     reader = csv.reader(
         in_memory_file_obj,
         delimiter=",",
@@ -297,10 +299,10 @@ async def test_csv_writer_writes_record_batches(record_batch):
     )
     for index, written_csv_row in enumerate(reader):
         single_record_batch = record_batch.slice(offset=index, length=1)
-        expected_csv = single_record_batch.to_pylist()[0]
+        expected_dict = single_record_batch.to_pylist()[0]
 
         assert "_inserted_at" not in written_csv_row
-        assert written_csv_row == expected_csv
+        assert written_csv_row == list({k: v for k, v in expected_dict.items() if k != "_inserted_at"}.values())
 
     assert inserted_ats_seen == [record_batch.column("_inserted_at")[-1].as_py()]
 
@@ -339,6 +341,7 @@ async def test_parquet_writer_writes_record_batches(record_batch):
     async with writer.open_temporary_file():
         await writer.write_record_batch(record_batch)
 
+    in_memory_file_obj.seek(0)
     written_parquet = pq.read_table(in_memory_file_obj)
 
     for index, written_row_as_dict in enumerate(written_parquet.to_pylist()):
@@ -418,3 +421,108 @@ async def test_flushing_parquet_writer_resets_underlying_file(record_batch):
         assert writer.records_since_last_flush == 0
 
     assert flush_counter == 2
+
+
+@pytest.mark.asyncio
+async def test_jsonl_writer_deals_with_web_vitals():
+    """Test old $web_vitals record batches are written as valid JSONL."""
+    in_memory_file_obj = io.BytesIO()
+    inserted_ats_seen: list[LastInsertedAt] = []
+
+    record_batch = pa.RecordBatch.from_pydict(
+        {
+            "event": pa.array(["$web_vitals"]),
+            "properties": pa.array(
+                [
+                    {
+                        "$web_vitals_INP_event": {
+                            "attribution": {"interactionTargetElement": json.loads("[" * 256 + "]" * 256)},
+                            "somethingElse": 1,
+                        }
+                    }
+                ]
+            ),
+            "_inserted_at": pa.array([0]),
+        }
+    )
+
+    async def store_in_memory_on_flush(
+        batch_export_file,
+        records_since_last_flush,
+        bytes_since_last_flush,
+        flush_counter,
+        last_inserted_at,
+        is_last,
+        error,
+    ):
+        assert writer.records_since_last_flush == record_batch.num_rows
+        in_memory_file_obj.write(batch_export_file.read())
+        inserted_ats_seen.append(last_inserted_at)
+
+    writer = JSONLBatchExportWriter(max_bytes=1, flush_callable=store_in_memory_on_flush)
+
+    async with writer.open_temporary_file():
+        await writer.write_record_batch(record_batch)
+
+    assert writer.records_total == record_batch.num_rows == 1
+
+    in_memory_file_obj.seek(0)
+    lines = in_memory_file_obj.readlines()
+    line = lines[0]
+    written_jsonl = json.loads(line)
+    expected_jsonl = record_batch.to_pylist()[0]
+
+    assert "_inserted_at" not in written_jsonl
+    assert "interactionTargetElement" not in written_jsonl["properties"]["$web_vitals_INP_event"]["attribution"]
+    assert "interactionTargetElement" in expected_jsonl["properties"]["$web_vitals_INP_event"]["attribution"]
+
+    del expected_jsonl["properties"]["$web_vitals_INP_event"]["attribution"]["interactionTargetElement"]
+
+    assert written_jsonl == {k: v for k, v in expected_jsonl.items() if k != "_inserted_at"}
+    assert inserted_ats_seen == [record_batch.column("_inserted_at")[-1].as_py()]
+
+
+@pytest.mark.asyncio
+async def test_jsonl_writer_deals_with_nested_user_events():
+    """Test very nested user event record batches are written as valid JSONL."""
+    in_memory_file_obj = io.BytesIO()
+    inserted_ats_seen: list[LastInsertedAt] = []
+
+    record_batch = pa.RecordBatch.from_pydict(
+        {
+            "event": pa.array(["my_event"]),
+            "properties": pa.array([{"we_have_to_go_deeper": json.loads("[" * 256 + "]" * 256)}]),
+            "_inserted_at": pa.array([0]),
+        }
+    )
+
+    async def store_in_memory_on_flush(
+        batch_export_file,
+        records_since_last_flush,
+        bytes_since_last_flush,
+        flush_counter,
+        last_inserted_at,
+        is_last,
+        error,
+    ):
+        assert writer.records_since_last_flush == record_batch.num_rows
+        in_memory_file_obj.write(batch_export_file.read())
+        inserted_ats_seen.append(last_inserted_at)
+
+    writer = JSONLBatchExportWriter(max_bytes=1, flush_callable=store_in_memory_on_flush)
+
+    record_batch = record_batch.sort_by("_inserted_at")
+    async with writer.open_temporary_file():
+        await writer.write_record_batch(record_batch)
+
+    assert writer.records_total == record_batch.num_rows
+
+    in_memory_file_obj.seek(0)
+    lines = in_memory_file_obj.readlines()
+    line = lines[0]
+    written_jsonl = json.loads(line)
+    expected_jsonl = record_batch.to_pylist()[0]
+
+    assert "_inserted_at" not in written_jsonl
+    assert written_jsonl == {k: v for k, v in expected_jsonl.items() if k != "_inserted_at"}
+    assert inserted_ats_seen == [record_batch.column("_inserted_at")[-1].as_py()]


### PR DESCRIPTION
## Problem

Some events can have deeply nested properties that `orjson` can't deal with. One of these events is actually generated by us, the `$web_vitals` event. Even though, we removed the deeply nested key, historical events in the db may still contain it, so we should deal with that.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* If event is `$web_vitals` attempt to remove deeply nested key when exporting.
* Else, use stdlib json that is slower but more flexible than orjson.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added two new tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
