### PR TITLE
fix(cdp): Ask for kinesis stream name, not the ARN

### DIFF
--- a/posthog/cdp/templates/aws_kinesis/template_aws_kinesis.py
+++ b/posthog/cdp/templates/aws_kinesis/template_aws_kinesis.py
@@ -16,7 +16,7 @@ fun getPayload() {
   let date := formatDateTime(now(), '%Y%m%d')
 
   let payload := jsonStringify({
-    'StreamName': inputs.aws_kinesis_stream_arn,
+    'StreamName': inputs.aws_kinesis_stream_name,
     'PartitionKey': inputs.aws_kinesis_partition_key ?? generateUUIDv4(),
     'Data': base64Encode(jsonStringify(inputs.payload)),
   })
@@ -108,9 +108,9 @@ if (res.status >= 200 and res.status < 300) {
             "default": "us-east-1",
         },
         {
-            "key": "aws_kinesis_stream_arn",
+            "key": "aws_kinesis_stream_name",
             "type": "string",
-            "label": "Kinesis Stream ARN",
+            "label": "Kinesis Stream Name",
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/aws_kinesis/test_template_aws_kinesis.py
+++ b/posthog/cdp/templates/aws_kinesis/test_template_aws_kinesis.py
@@ -13,7 +13,7 @@ class TestTemplateAwsKinesis(BaseHogFunctionTemplateTest):
                 "aws_access_key_id": "aws_access_key_id",
                 "aws_secret_access_key": "aws_secret_access_key",
                 "aws_region": "aws_region",
-                "aws_kinesis_stream_arn": "aws_kinesis_stream_arn",
+                "aws_kinesis_stream_name": "aws_kinesis_stream_name",
                 "aws_kinesis_partition_key": "1",
                 "payload": {"hello": "world"},
             }
@@ -30,7 +30,7 @@ class TestTemplateAwsKinesis(BaseHogFunctionTemplateTest):
                     "Host": "kinesis.aws_region.amazonaws.com",
                     "Authorization": "AWS4-HMAC-SHA256 Credential=aws_access_key_id/20240416/aws_region/kinesis/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=65b18913b42d8a7a1d33c0711da192d5a2e99eb79fb08ab3e5eefb6488b903ff",
                 },
-                "body": '{"StreamName": "aws_kinesis_stream_arn", "PartitionKey": "1", "Data": "eyJoZWxsbyI6ICJ3b3JsZCJ9"}',
+                "body": '{"StreamName": "aws_kinesis_stream_name", "PartitionKey": "1", "Data": "eyJoZWxsbyI6ICJ3b3JsZCJ9"}',
                 "method": "POST",
             },
         )

--- a/posthog/cdp/templates/aws_kinesis/test_template_aws_kinesis.py
+++ b/posthog/cdp/templates/aws_kinesis/test_template_aws_kinesis.py
@@ -13,7 +13,7 @@ class TestTemplateAwsKinesis(BaseHogFunctionTemplateTest):
                 "aws_access_key_id": "aws_access_key_id",
                 "aws_secret_access_key": "aws_secret_access_key",
                 "aws_region": "aws_region",
-                "aws_kinesis_stream_name": "aws_kinesis_stream_name",
+                "aws_kinesis_stream_name": "aws_kinesis_stream_arn",
                 "aws_kinesis_partition_key": "1",
                 "payload": {"hello": "world"},
             }
@@ -30,7 +30,7 @@ class TestTemplateAwsKinesis(BaseHogFunctionTemplateTest):
                     "Host": "kinesis.aws_region.amazonaws.com",
                     "Authorization": "AWS4-HMAC-SHA256 Credential=aws_access_key_id/20240416/aws_region/kinesis/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target, Signature=65b18913b42d8a7a1d33c0711da192d5a2e99eb79fb08ab3e5eefb6488b903ff",
                 },
-                "body": '{"StreamName": "aws_kinesis_stream_name", "PartitionKey": "1", "Data": "eyJoZWxsbyI6ICJ3b3JsZCJ9"}',
+                "body": '{"StreamName": "aws_kinesis_stream_arn", "PartitionKey": "1", "Data": "eyJoZWxsbyI6ICJ3b3JsZCJ9"}',
                 "method": "POST",
             },
         )


### PR DESCRIPTION
This misled a user, who then filed a support ticket because our debugging story isn't quite as nice as it should be. Improving the debug story is in progress, but we can make this fix quickly now too.