### PR TITLE
chore: count data ingested by source

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
@@ -23,6 +23,12 @@ const replayEventsCounter = new Counter({
     help: 'Number of Replay events successfully ingested',
 })
 
+const dataIngestedCounter = new Counter({
+    name: 'replay_data_ingested',
+    help: 'Amount of data being ingested',
+    labelNames: ['snapshot_source'],
+})
+
 export class ReplayEventsIngester {
     constructor(
         private readonly producer: RdKafkaProducer,
@@ -178,6 +184,7 @@ export class ReplayEventsIngester {
             }
 
             replayEventsCounter.inc()
+            dataIngestedCounter.inc({ snapshot_source: replayRecord.snapshot_source ?? undefined }, replayRecord.size)
 
             return [
                 produce({

--- a/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/services/replay-events-ingester.ts
@@ -21,6 +21,7 @@ const HIGH_WATERMARK_KEY = 'session_replay_events_ingester'
 const replayEventsCounter = new Counter({
     name: 'replay_events_ingested',
     help: 'Number of Replay events successfully ingested',
+    labelNames: ['snapshot_source'],
 })
 
 const dataIngestedCounter = new Counter({
@@ -183,7 +184,7 @@ export class ReplayEventsIngester {
                 return drop('session_replay_summarizer_error')
             }
 
-            replayEventsCounter.inc()
+            replayEventsCounter.inc({ snapshot_source: replayRecord.snapshot_source ?? undefined })
             dataIngestedCounter.inc({ snapshot_source: replayRecord.snapshot_source ?? undefined }, replayRecord.size)
 
             return [


### PR DESCRIPTION
we want to get a feeling for relative data ingestion mobile vs web

so, let's add a counter to ingestion

drawback here is if we ingest something more than once, deduplication elsewhere will kick in but the counter will still count up

but since it's only to give guidance it can afford to be a little wobbly