### PR TITLE
fix(notebooks): disable HogQL controls in blocks

### DIFF
--- a/cypress/e2e/notebooks-insights.ts
+++ b/cypress/e2e/notebooks-insights.ts
@@ -5,7 +5,18 @@ describe('Notebooks', () => {
         cy.clickNavMenu('notebooks')
         cy.location('pathname').should('include', '/notebooks')
     })
-    ;['SQL', 'TRENDS', 'FUNNELS', 'RETENTION', 'PATHS', 'STICKINESS', 'LIFECYCLE'].forEach((insightType) => {
+
+    it(`Can add a HogQL insight`, () => {
+        savedInsights.createNewInsightOfType('SQL')
+        insight.editName('SQL Insight')
+        insight.save()
+        cy.get('[data-attr="notebooks-add-button"]').click()
+        cy.get('[data-attr="notebooks-select-button-create"]').click()
+        cy.get('.ErrorBoundary').should('not.exist')
+        // Detect if table settings are present. They shouldn't appear in the block, but rather on side.
+        cy.get('[data-attr="notebook-node-query"]').get('[data-attr="export-button"]').should('not.exist')
+    })
+    ;['TRENDS', 'FUNNELS', 'RETENTION', 'PATHS', 'STICKINESS', 'LIFECYCLE'].forEach((insightType) => {
         it(`Can add a ${insightType} insight`, () => {
             savedInsights.createNewInsightOfType(insightType)
             insight.editName(`${insightType} Insight`)

--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -118,7 +118,7 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
             />
         )
     } else if (isSavedInsightNode(query)) {
-        component = <SavedInsight query={query} context={queryContext} />
+        component = <SavedInsight query={query} context={queryContext} readOnly={readOnly} embedded={embedded} />
     } else if (isInsightVizNode(query)) {
         component = (
             <InsightViz

--- a/frontend/src/queries/nodes/SavedInsight/SavedInsight.tsx
+++ b/frontend/src/queries/nodes/SavedInsight/SavedInsight.tsx
@@ -12,9 +12,11 @@ import { InsightLogicProps } from '~/types'
 interface InsightProps {
     query: SavedInsightNode
     context?: QueryContext
+    embedded?: boolean
+    readOnly?: boolean
 }
 
-export function SavedInsight({ query: propsQuery, context }: InsightProps): JSX.Element {
+export function SavedInsight({ query: propsQuery, context, embedded, readOnly }: InsightProps): JSX.Element {
     const insightProps: InsightLogicProps = { dashboardItemId: propsQuery.shortId }
     const { insight, insightLoading } = useValues(insightLogic(insightProps))
     const { query: dataQuery } = useValues(insightDataLogic(insightProps))
@@ -29,5 +31,13 @@ export function SavedInsight({ query: propsQuery, context }: InsightProps): JSX.
 
     const query = { ...propsQuery, ...dataQuery, full: propsQuery.full }
 
-    return <Query query={query} cachedResults={insight} context={{ ...context, insightProps }} />
+    return (
+        <Query
+            query={query}
+            cachedResults={insight}
+            context={{ ...context, insightProps }}
+            embedded={embedded}
+            readOnly={readOnly}
+        />
+    )
 }

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeQuery.tsx
@@ -97,7 +97,7 @@ const Component = ({
     }
 
     return (
-        <div className="flex flex-1 flex-col h-full">
+        <div className="flex flex-1 flex-col h-full" data-attr="notebook-node-query">
             <BindLogic logic={insightLogic} props={insightLogicProps}>
                 <Query
                     // use separate keys for the settings and visualization to avoid conflicts with insightProps
@@ -111,6 +111,8 @@ const Component = ({
                             } as QuerySchema,
                         })
                     }}
+                    embedded
+                    readOnly
                 />
             </BindLogic>
         </div>


### PR DESCRIPTION
## Problem

This is a follow-up fix for https://github.com/PostHog/posthog/pull/25623. I fixed the visualization but didn't notice the controls. They should appear on the left of the block rather than in the block itself.

**Before**

<img width="1078" alt="Screenshot 2024-10-22 at 16 07 43" src="https://github.com/user-attachments/assets/5664725b-4556-4965-b8c8-c7d2f974c9bf">

## Changes

Passed readOnly and embedded props to SavedQuery.

**After**

<img width="1022" alt="Screenshot 2024-10-22 at 16 04 30" src="https://github.com/user-attachments/assets/2ead9e66-fb50-4c46-b7da-04bf0f2de31c">

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added a regression test.
