### PR TITLE
chore(data-warehouse): Set the stripe version when listing objects

### DIFF
--- a/posthog/temporal/data_imports/pipelines/stripe/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/stripe/__init__.py
@@ -337,6 +337,7 @@ def stripe_source(
             },
             "headers": {
                 "Stripe-Account": account_id,
+                "Stripe-Version": "2024-09-30.acacia",
             }
             if account_id is not None and len(account_id) > 0
             else None,


### PR DESCRIPTION
## Problem
- Some stripe endpoints don't support some of our required parameters on older API versions

## Changes
- Explicitly set the API version in our requests instead, this will ensure everyone gets a consistent experience
