### PR TITLE
chore(bi): Remove popover overlay when showing list variables on dashboards

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/Variables.tsx
@@ -248,6 +248,17 @@ const VariableComponent = ({
 }: VariableComponentProps): JSX.Element => {
     const [isPopoverOpen, setPopoverOpen] = useState(false)
 
+    // Dont show the popover overlay for list variables not in edit mode
+    if (!showEditingUI && variable.type === 'List') {
+        return (
+            <LemonSelect
+                value={variable.value ?? variable.default_value}
+                onChange={(value) => onChange(variable.id, value)}
+                options={variable.values.map((n) => ({ label: n, value: n }))}
+            />
+        )
+    }
+
     return (
         <Popover
             key={variable.id}


### PR DESCRIPTION
## Problem
- When you have a list variable on a dashboard, it requires 4 mouse clicks to change the value

## Changes
- Render the Lemon Select directly on the dashboard instead of the popover

**Old:**
<img width="332" alt="image" src="https://github.com/user-attachments/assets/990dfa8b-1db9-4104-bb5a-c6113e6427d4">


**New:**
<img width="575" alt="image" src="https://github.com/user-attachments/assets/5ce19239-3936-449b-bbb2-f92a7649f027">

