### PR TITLE
fix(product-assistant): adjust limits for taxonomy queries

### DIFF
--- a/posthog/hogql_queries/ai/event_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/event_taxonomy_query_runner.py
@@ -62,6 +62,7 @@ class EventTaxonomyQueryRunner(TaxonomyCacheMixin, QueryRunner):
                 WHERE {filter}
                 GROUP BY key
                 ORDER BY total_count DESC
+                LIMIT 500
             """,
             placeholders={"from_query": self._get_subquery(), "filter": self._get_omit_filter()},
         )

--- a/posthog/hogql_queries/ai/team_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/team_taxonomy_query_runner.py
@@ -56,6 +56,7 @@ class TeamTaxonomyQueryRunner(TaxonomyCacheMixin, QueryRunner):
                     event
                 ORDER BY
                     count DESC
+                LIMIT 500
             """
         )
 

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_event_taxonomy_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_event_taxonomy_query_runner.ambr
@@ -16,7 +16,7 @@
   WHERE not(match(key, '(\\$set|\\$time|\\$set_once|\\$sent_at|\\$ip|__|phjs|survey_dismissed|survey_responded|partial_filter_chosen|changed_action|window-id|changed_event|partial_filter)'))
   GROUP BY key
   ORDER BY total_count DESC
-  LIMIT 100 SETTINGS readonly=2,
+  LIMIT 500 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_suggested_questions_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_suggested_questions_query_runner.ambr
@@ -7,7 +7,7 @@
   WHERE and(equals(events.team_id, 2), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), minus(now64(6, 'UTC'), toIntervalDay(30))))
   GROUP BY events.event
   ORDER BY count DESC
-  LIMIT 100 SETTINGS readonly=2,
+  LIMIT 500 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_team_taxonomy_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_team_taxonomy_query_runner.ambr
@@ -7,7 +7,7 @@
   WHERE and(equals(events.team_id, 2), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), minus(now64(6, 'UTC'), toIntervalDay(30))))
   GROUP BY events.event
   ORDER BY count DESC
-  LIMIT 100 SETTINGS readonly=2,
+  LIMIT 500 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,
                      format_csv_allow_double_quotes=0,

--- a/posthog/hogql_queries/ai/test/test_event_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_event_taxonomy_query_runner.py
@@ -226,3 +226,28 @@ class TestEventTaxonomyQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
             assert isinstance(response, CachedEventTaxonomyQueryResponse)
             self.assertEqual(len(response.results), 1)
+
+    def test_limit(self):
+        _create_person(
+            distinct_ids=["person1"],
+            properties={"email": "person1@example.com"},
+            team=self.team,
+        )
+
+        for i in range(100):
+            _create_event(
+                event="event1",
+                distinct_id="person1",
+                properties={
+                    f"prop_{i + 10}": "value",
+                    f"prop_{i + 100}": "value",
+                    f"prop_{i + 1000}": "value",
+                    f"prop_{i + 10000}": "value",
+                    f"prop_{i + 100000}": "value",
+                    f"prop_{i + 1000000}": "value",
+                },
+                team=self.team,
+            )
+
+        response = EventTaxonomyQueryRunner(team=self.team, query=EventTaxonomyQuery(event="event1")).calculate()
+        self.assertEqual(len(response.results), 500)


### PR DESCRIPTION
## Problem

The default limit of 100 rows for taxonomy queries is too low.

## Changes

Adjust the limit to 500. It won't affect the performance of queries, so we could adjust the included records directly in the assistant rather than in the query.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unit tests.