### PR TITLE
fix(replay-templates): show event selector button, diff mobile filter

### DIFF
--- a/frontend/src/scenes/session-recordings/templates/SessionRecordingTemplates.tsx
+++ b/frontend/src/scenes/session-recordings/templates/SessionRecordingTemplates.tsx
@@ -56,11 +56,11 @@ const NestedFilterGroup = ({
                         />
                     )
                 })}
-                {selectOne && filterGroup.values.length === 0 && (
+                {!selectOne || (selectOne && filterGroup.values.length === 0) ? (
                     <div>
                         <UniversalFilters.AddFilterButton title={buttonTitle} type="secondary" size="xsmall" />
                     </div>
-                )}
+                ) : null}
             </div>
         </div>
     )

--- a/frontend/src/scenes/session-recordings/templates/availableTemplates.tsx
+++ b/frontend/src/scenes/session-recordings/templates/availableTemplates.tsx
@@ -197,7 +197,7 @@ export const replayTemplates: ReplayTemplateType[] = [
     {
         key: 'mobile-devices',
         name: 'Mobile devices',
-        description: 'Watch all replays from mobile devices to look for problems with your responsive design.',
+        description: 'Watch replays from mobile device web browsers to look for problems with your responsive design.',
         variables: [
             {
                 type: 'snapshot_source',
@@ -206,10 +206,17 @@ export const replayTemplates: ReplayTemplateType[] = [
                 description: 'Users who used your website on a mobile device.',
                 noTouch: true,
                 filterGroup: {
-                    key: 'snapshot_source',
-                    value: ['mobile'],
-                    operator: PropertyOperator.Exact,
-                    type: PropertyFilterType.Recording,
+                    id: '$pageview',
+                    name: '$pageview',
+                    type: 'events',
+                    properties: [
+                        {
+                            key: '$screen_width',
+                            value: '600',
+                            operator: PropertyOperator.LessThan,
+                            type: PropertyFilterType.Event,
+                        },
+                    ],
                 },
             },
         ],


### PR DESCRIPTION
## Problem

In making sure people can only select one flag, I broke the event selector button 😅 

![Arc 2024-10-22 12 01 16](https://github.com/user-attachments/assets/65f1291c-0654-4480-b8bf-5e50292d5fe0)

This is why I love shipping things behind feature flags 😄 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Fixes the bug - button shows now for events and person props template again.

![image](https://github.com/user-attachments/assets/e367a026-8acb-44c4-8fa4-d7419d4ce39e)

Also updates the filter we are using for mobile device browser replays.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

🐭 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
