### PR TITLE
fix: stored heatmap URL in toolbar

### DIFF
--- a/frontend/src/toolbar/stats/currentPageLogic.ts
+++ b/frontend/src/toolbar/stats/currentPageLogic.ts
@@ -81,6 +81,14 @@ export const currentPageLogic = kea<currentPageLogicType>([
     })),
 
     afterMount(({ actions, values, cache }) => {
+        // an earlier bug means that some folk have a bad URL saved
+        // this auto-fixes things for those folks
+        // to save us having to explain the fix individually
+        // can be removed by end of Nov 2024
+        if (values.href && values.href.includes('#__posthog=')) {
+            actions.setHref(withoutPostHogInit(values.href))
+        }
+
         cache.interval = window.setInterval(() => {
             if (window.location.href !== values.href) {
                 actions.setHref(window.location.href)


### PR DESCRIPTION
follow-up to https://github.com/PostHog/posthog/pull/25743

that PR stops people getting in the bad state but doesn't fix things for folk who are already in that bad state

so autofix ftw