### PR TITLE
fix(frontend): Consistent naming in earliest backfills

### DIFF
--- a/frontend/src/scenes/pipeline/BatchExportBackfillModal.tsx
+++ b/frontend/src/scenes/pipeline/BatchExportBackfillModal.tsx
@@ -108,7 +108,7 @@ export function BatchExportBackfillModal({ id }: BatchExportRunsLogicProps): JSX
                                 }
                             />
                         ) : (
-                            <LemonInput value="Earliest available" disabled />
+                            <LemonInput value="Beginning of time" disabled />
                         )
                     }
                 </LemonField>
@@ -120,8 +120,8 @@ export function BatchExportBackfillModal({ id }: BatchExportRunsLogicProps): JSX
                                 bordered
                                 label={
                                     <span className="flex items-center gap-2">
-                                        Backfill since earliest available
-                                        <Tooltip title="If selected, we will backfill data since the earliest available date until the provided end date. There is no need to set a start date.">
+                                        Backfill since beginning of time
+                                        <Tooltip title="If selected, we will backfill all data since the beginning of time until the end date set below. There is no need to set a start date for the backfill.">
                                             <IconInfo className=" text-lg text-muted-alt" />
                                         </Tooltip>
                                     </span>


### PR DESCRIPTION
## Problem

Small PR to be consistent when talking about person backfills covering since earliest available data. We now use "Since beginning of time" in all user-facing places.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
