### PR TITLE
chore: rust linting in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -218,7 +218,7 @@ jobs:
 
             - name: Run clippy
               if: needs.changes.outputs.rust == 'true'
-              run: cargo clippy -- -D warnings
+              run: cargo clippy --all-targets --all-features -- -D warnings
 
             - name: Run cargo check
               if: needs.changes.outputs.rust == 'true'

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -126,7 +126,7 @@ mod test {
             Some("https://app-static.eu.posthog.com/static/chunk-PGUQKT6S.js".to_string())
         );
         assert_eq!(frame.fn_name, "n.loadForeignModule".to_string());
-        assert_eq!(frame.in_app, true);
+        assert!(frame.in_app);
         assert_eq!(frame.line, 64);
         assert_eq!(frame.column, 15003);
 
@@ -142,7 +142,7 @@ mod test {
             "$exception_list": []
         }"#;
 
-        let props: Result<ErrProps, Error> = serde_json::from_str(&raw);
+        let props: Result<ErrProps, Error> = serde_json::from_str(raw);
         assert!(props.is_ok());
         assert_eq!(props.unwrap().exception_list.len(), 0);
 
@@ -152,7 +152,7 @@ mod test {
             }]
         }"#;
 
-        let props: Result<ErrProps, Error> = serde_json::from_str(&raw);
+        let props: Result<ErrProps, Error> = serde_json::from_str(raw);
         assert!(props.is_err());
         assert_eq!(
             props.unwrap_err().to_string(),
@@ -166,7 +166,7 @@ mod test {
             }]
         }"#;
 
-        let props: Result<ErrProps, Error> = serde_json::from_str(&raw);
+        let props: Result<ErrProps, Error> = serde_json::from_str(raw);
         assert!(props.is_err());
         assert_eq!(
             props.unwrap_err().to_string(),

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -116,7 +116,7 @@ mod test {
             Some("https://app-static.eu.posthog.com/static/chunk-PGUQKT6S.js".to_string())
         );
         assert_eq!(frame.fn_name, "?".to_string());
-        assert_eq!(frame.in_app, true);
+        assert!(frame.in_app);
         assert_eq!(frame.line, 64);
         assert_eq!(frame.column, 25112);
 

--- a/rust/feature-flags/src/flag_matching.rs
+++ b/rust/feature-flags/src/flag_matching.rs
@@ -1448,6 +1448,7 @@ mod tests {
         },
     };
 
+    #[allow(clippy::too_many_arguments)]
     fn create_test_flag(
         id: Option<i32>,
         team_id: Option<TeamId>,

--- a/rust/feature-flags/src/request_handler.rs
+++ b/rust/feature-flags/src/request_handler.rs
@@ -213,7 +213,7 @@ fn decode_request(headers: &HeaderMap, body: Bytes) -> Result<FlagRequest, FlagE
 /// Evaluate feature flags for a given distinct_id
 /// - Returns a map of feature flag keys to their values
 /// - If an error occurs while evaluating a flag, we'll set `error_while_computing_flags` to true be logged,
-///  and that flag will be omitted from the result (we will still attempt to evaluate other flags)
+///   and that flag will be omitted from the result (we will still attempt to evaluate other flags)
 // TODO: it could be a cool idea to store the errors as a tuple instead of top-level, so that users can see
 // which flags failed to evaluate
 pub async fn evaluate_feature_flags(context: FeatureFlagEvaluationContext) -> FlagsResponse {


### PR DESCRIPTION
## Problem

We're not throwing any CI errors for `clippy` warnings

## Changes

Fix all existing lint issues, bump CI check to include warnings

## How did you test things
Two previously failing runs before fixing all the warnings
https://github.com/PostHog/posthog/actions/runs/11478829467/job/31943856571?pr=25758
https://github.com/PostHog/posthog/actions/runs/11478666958/job/31943366885?pr=25758