### PR TITLE
feat(flags): Add holdout groups

### DIFF
--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -88,6 +88,11 @@ class FeatureFlag(models.Model):
         return self.get_filters().get("super_groups", []) or []
 
     @property
+    def holdout_conditions(self):
+        "Each feature flag can have multiple holdout conditions to match, they are OR-ed together."
+        return self.get_filters().get("holdout_groups", []) or []
+
+    @property
     def _payloads(self):
         return self.get_filters().get("payloads", {}) or {}
 

--- a/posthog/test/test_feature_flag.py
+++ b/posthog/test/test_feature_flag.py
@@ -855,6 +855,125 @@ class TestFeatureFlagMatcher(BaseTest, QueryMatchingTest):
                 FeatureFlagMatch(False, None, FeatureFlagMatchReason.NO_CONDITION_MATCH, 0),
             )
 
+    def test_feature_flag_with_holdout_filter(self):
+        # example_id is outside 70% holdout
+        Person.objects.create(
+            team=self.team,
+            distinct_ids=["example_id"],
+            properties={"$some_prop": 5},
+        )
+        # example_id2 is within 70% holdout
+        Person.objects.create(
+            team=self.team,
+            distinct_ids=["example_id2"],
+            properties={"$some_prop": 5},
+        )
+
+        multivariate_json = {
+            "variants": [
+                {
+                    "key": "first-variant",
+                    "name": "First Variant",
+                    "rollout_percentage": 50,
+                },
+                {
+                    "key": "second-variant",
+                    "name": "Second Variant",
+                    "rollout_percentage": 25,
+                },
+                {
+                    "key": "third-variant",
+                    "name": "Third Variant",
+                    "rollout_percentage": 25,
+                },
+                {
+                    "key": "holdout",
+                    "name": "Hold out variant",
+                    "rollout_percentage": 0,
+                },
+            ]
+        }
+        feature_flag = self.create_feature_flag(
+            key="flag-with-gt-filter",
+            filters={
+                "groups": [{"properties": [{"key": "$some_prop", "value": 4, "type": "person", "operator": "gt"}]}],
+                "holdout_groups": [
+                    {
+                        "properties": [],
+                        "rollout_percentage": 70,
+                        "variant": "holdout",
+                    }
+                ],
+                "multivariate": multivariate_json,
+            },
+        )
+
+        other_feature_flag = self.create_feature_flag(
+            key="other-flag-with-gt-filter",
+            filters={
+                "groups": [{"properties": [{"key": "$some_prop", "value": 4, "type": "person", "operator": "gt"}]}],
+                "holdout_groups": [
+                    {
+                        "properties": [],
+                        "rollout_percentage": 70,
+                        "variant": "holdout",
+                    }
+                ],
+                "multivariate": multivariate_json,
+            },
+        )
+
+        other_flag_without_holdout = self.create_feature_flag(
+            key="other-flag-without-holdout-with-gt-filter",
+            filters={
+                "groups": [{"properties": [{"key": "$some_prop", "value": 4, "type": "person", "operator": "gt"}]}],
+                "holdout_groups": [
+                    {
+                        "properties": [],
+                        "rollout_percentage": 0,
+                        "variant": "holdout",
+                    }
+                ],
+                "multivariate": multivariate_json,
+            },
+        )
+
+        # regular flag evaluation when outside holdout
+        with self.assertNumQueries(4):
+            self.assertEqual(
+                self.match_flag(feature_flag, "example_id"),
+                FeatureFlagMatch(True, "second-variant", FeatureFlagMatchReason.CONDITION_MATCH, 0),
+            )
+
+        # inside holdout, get holdout variant override.
+        # also, should have no db queries here.
+        with self.assertNumQueries(0):
+            self.assertEqual(
+                self.match_flag(feature_flag, "example_id2"),
+                FeatureFlagMatch(True, "holdout", FeatureFlagMatchReason.HOLDOUT_CONDITION_VALUE, 0),
+            )
+
+        # same should hold true for a different feature flag when within holdout
+        self.assertEqual(
+            self.match_flag(other_feature_flag, "example_id2"),
+            FeatureFlagMatch(True, "holdout", FeatureFlagMatchReason.HOLDOUT_CONDITION_VALUE, 0),
+        )
+        # but the variants may change outside holdout since different flag
+        self.assertEqual(
+            self.match_flag(other_feature_flag, "example_id"),
+            FeatureFlagMatch(True, "third-variant", FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+
+        # when holdout exists but is zero, should default to regular flag evaluation
+        self.assertEqual(
+            self.match_flag(other_flag_without_holdout, "example_id"),
+            FeatureFlagMatch(True, "second-variant", FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+        self.assertEqual(
+            self.match_flag(other_flag_without_holdout, "example_id2"),
+            FeatureFlagMatch(True, "second-variant", FeatureFlagMatchReason.CONDITION_MATCH, 0),
+        )
+
     def test_coercion_of_strings_and_numbers(self):
         Person.objects.create(
             team=self.team,


### PR DESCRIPTION
## Problem

^^ Add support for holdout groups to flags. These will be used by experiments.


Still need to add: 
Validation to API for when incorrect holdout groups are added
test for API

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
