### PR TITLE
test: Warn if $session_id is non-UUIDv7

### DIFF
--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -865,7 +865,7 @@ def _create_event(**kwargs):
 def _warn_if_session_id_malformed(session_id: str):
     try:
         session_id_parsed = uuid.UUID(session_id)
-    except ValueError:
+    except:
         print(  # noqa: T201
             f"WARNING: $session_id SHOULD be a UUIDv7 and {repr(session_id)} doesn't resemble a UUID. "
             "Events with a non-UUIDv7 session ID don't count as part of any session in HogQL-based querying. Use uuid7()!"

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -867,7 +867,7 @@ def _warn_if_session_id_malformed(session_id: str):
         session_id_parsed = uuid.UUID(session_id)
     except ValueError:
         print(  # noqa: T201
-            f"WARNING: $session_id should be a UUIDv7 and {repr(session_id)} doesn't resemble a UUID. "
+            f"WARNING: $session_id SHOULD be a UUIDv7 and {repr(session_id)} doesn't resemble a UUID. "
             "Events with a non-UUIDv7 session ID don't count as part of any session in HogQL-based querying. Use uuid7()!"
         )
     else:
@@ -877,12 +877,12 @@ def _warn_if_session_id_malformed(session_id: str):
         session_id_unix_time_ms = session_id_parsed.int >> 80
         if session_id_unix_time_ms < min_accepted_unix_time_ms:
             print(  # noqa: T201
-                f"WARNING: $session_id should be a UUIDv7 and {session_id_parsed}'s value appears too small to be a UUIDv7. "
+                f"WARNING: $session_id SHOULD be a UUIDv7 and {session_id_parsed}'s value appears too small to be a UUIDv7. "
                 "Events with a non-UUIDv7 session ID don't count as part of any session in HogQL-based querying. Use uuid7()!"
             )
         elif session_id_unix_time_ms > max_accepted_unix_time_ms:
             print(  # noqa: T201
-                f"WARNING: $session_id should be a UUIDv7 and {session_id_parsed}'s value appears too large to be a UUIDv7. "
+                f"WARNING: $session_id SHOULD be a UUIDv7 and {session_id_parsed}'s value appears too large to be a UUIDv7. "
                 "Events with a non-UUIDv7 session ID don't count as part of any session in HogQL-based querying. Use uuid7()!"
             )
 


### PR DESCRIPTION
## Problem

I wasted some time debugging `$session_duration`-related test failures in https://github.com/PostHog/posthog/pull/25757, because it's completely unobvious that `$session_id` must be a UUIDv7 for the event to count towards a session these days – especially since so many older tests use random strings as session IDs.

## Changes

This will now show up in test results on failure:

<img width="1038" alt="Screenshot 2024-10-23 at 13 45 01" src="https://github.com/user-attachments/assets/36bceeff-9ee2-4bb7-8a1c-40b3df74925d">
