### PR TITLE
fix(sessions): Limit the teams for which we ingest sessions v1 events

### DIFF
--- a/posthog/clickhouse/migrations/0083_recreate_sessions_v1_after_limiting_teams.py
+++ b/posthog/clickhouse/migrations/0083_recreate_sessions_v1_after_limiting_teams.py
@@ -1,0 +1,8 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.sessions.sql import DROP_SESSION_MATERIALIZED_VIEW_SQL, SESSIONS_TABLE_MV_SQL
+
+operations = [
+    # drop the mv, and recreate it with the new part of the WHERE clause
+    run_sql_with_exceptions(DROP_SESSION_MATERIALIZED_VIEW_SQL()),
+    run_sql_with_exceptions(SESSIONS_TABLE_MV_SQL()),
+]

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -2086,7 +2086,7 @@
   sumIf(1, event='$autocapture') as autocapture_count
   
   FROM posthog_test.sharded_events
-  WHERE `$session_id` IS NOT NULL AND `$session_id` != ''
+  WHERE `$session_id` IS NOT NULL AND `$session_id` != '' AND team_id IN (1, 2, 13610, 19279, 21173, 29929, 32050, 9910, 11775, 21129, 31490)
   GROUP BY `$session_id`, team_id
   
   

--- a/posthog/clickhouse/test/test_sessions_model.py
+++ b/posthog/clickhouse/test/test_sessions_model.py
@@ -23,8 +23,8 @@ def create_session_id():
     return f"s{session_id_counter}"
 
 
-# only certain team ids can insert events into this legacy sessions table
-TEAM_ID = 1
+# only certain team ids can insert events into this legacy sessions table, see sessions/sql.py for more info
+TEAM_ID = 2
 TEAM = Team(id=TEAM_ID)
 
 

--- a/posthog/clickhouse/test/test_sessions_model.py
+++ b/posthog/clickhouse/test/test_sessions_model.py
@@ -1,8 +1,10 @@
 from posthog.clickhouse.client import sync_execute, query_with_columns
+from posthog.models import Team
 from posthog.test.base import (
     _create_event,
     ClickhouseTestMixin,
     BaseTest,
+    ClickhouseDestroyTablesMixin,
 )
 
 distinct_id_counter = 0
@@ -21,7 +23,12 @@ def create_session_id():
     return f"s{session_id_counter}"
 
 
-class TestSessionsModel(ClickhouseTestMixin, BaseTest):
+# only certain team ids can insert events into this legacy sessions table
+TEAM_ID = 1
+TEAM = Team(id=TEAM_ID)
+
+
+class TestSessionsModel(ClickhouseDestroyTablesMixin, ClickhouseTestMixin, BaseTest):
     def select_by_session_id(self, session_id):
         return query_with_columns(
             """
@@ -34,7 +41,7 @@ class TestSessionsModel(ClickhouseTestMixin, BaseTest):
                 """,
             {
                 "session_id": session_id,
-                "team_id": self.team.id,
+                "team_id": TEAM_ID,
             },
         )
 
@@ -42,7 +49,7 @@ class TestSessionsModel(ClickhouseTestMixin, BaseTest):
         distinct_id = create_distinct_id()
         session_id = create_session_id()
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageview",
             distinct_id=distinct_id,
             properties={"$current_url": "/", "$session_id": session_id},
@@ -60,7 +67,7 @@ class TestSessionsModel(ClickhouseTestMixin, BaseTest):
                 """,
             {
                 "distinct_id": distinct_id,
-                "team_id": self.team.id,
+                "team_id": TEAM_ID,
             },
         )
 
@@ -72,14 +79,14 @@ class TestSessionsModel(ClickhouseTestMixin, BaseTest):
         session_id = create_session_id()
 
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageview",
             distinct_id=distinct_id1,
             properties={"$session_id": session_id},
             timestamp="2024-03-08",
         )
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageview",
             distinct_id=distinct_id2,
             properties={"$session_id": session_id},
@@ -96,28 +103,28 @@ class TestSessionsModel(ClickhouseTestMixin, BaseTest):
         session_id = create_session_id()
 
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageview",
             distinct_id=distinct_id,
             properties={"$current_url": "/entry", "$session_id": session_id},
             timestamp="2024-03-08:01",
         )
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageview",
             distinct_id=distinct_id,
             properties={"$current_url": "/middle", "$session_id": session_id},
             timestamp="2024-03-08:02",
         )
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageview",
             distinct_id=distinct_id,
             properties={"$current_url": "/middle", "$session_id": session_id},
             timestamp="2024-03-08:03",
         )
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageview",
             distinct_id=distinct_id,
             properties={"$current_url": "/exit", "$session_id": session_id},
@@ -136,14 +143,14 @@ class TestSessionsModel(ClickhouseTestMixin, BaseTest):
         session_id = create_session_id()
 
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageview",
             distinct_id=distinct_id,
             properties={"$session_id": session_id, "utm_source": "source"},
             timestamp="2024-03-08",
         )
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageview",
             distinct_id=distinct_id,
             properties={"$session_id": session_id, "utm_source": "other_source"},
@@ -159,35 +166,35 @@ class TestSessionsModel(ClickhouseTestMixin, BaseTest):
         session_id = create_session_id()
 
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageview",
             distinct_id=distinct_id,
             properties={"$session_id": session_id},
             timestamp="2024-03-08",
         )
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$autocapture",
             distinct_id=distinct_id,
             properties={"$session_id": session_id},
             timestamp="2024-03-08",
         )
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$autocapture",
             distinct_id=distinct_id,
             properties={"$session_id": session_id},
             timestamp="2024-03-08",
         )
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="other event",
             distinct_id=distinct_id,
             properties={"$session_id": session_id},
             timestamp="2024-03-08",
         )
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageleave",
             distinct_id=distinct_id,
             properties={"$session_id": session_id},
@@ -209,14 +216,14 @@ class TestSessionsModel(ClickhouseTestMixin, BaseTest):
         session_id3 = create_session_id()
 
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageview",
             distinct_id=distinct_id,
             properties={"$session_id": session_id1},
             timestamp="2024-03-08",
         )
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageview",
             distinct_id=distinct_id,
             properties={"$session_id": session_id2},
@@ -235,7 +242,7 @@ class TestSessionsModel(ClickhouseTestMixin, BaseTest):
         distinct_id = create_distinct_id()
         session_id = create_session_id()
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageview",
             distinct_id=distinct_id,
             properties={"$session_id": session_id},
@@ -260,7 +267,7 @@ class TestSessionsModel(ClickhouseTestMixin, BaseTest):
         """,
             {
                 "session_id": session_id,
-                "team_id": self.team.id,
+                "team_id": TEAM_ID,
             },
         )
         self.assertEqual(len(responses), 1)
@@ -270,7 +277,7 @@ class TestSessionsModel(ClickhouseTestMixin, BaseTest):
         distinct_id = create_distinct_id()
         session_id = create_session_id()
         _create_event(
-            team=self.team,
+            team=TEAM,
             event="$pageview",
             distinct_id=distinct_id,
             properties={"$session_id": session_id},
@@ -295,7 +302,7 @@ class TestSessionsModel(ClickhouseTestMixin, BaseTest):
         """,
             {
                 "session_id": session_id,
-                "team_id": self.team.id,
+                "team_id": TEAM_ID,
             },
         )
         self.assertEqual(len(responses), 1)

--- a/posthog/hogql/database/schema/test/test_sessions_v1.py
+++ b/posthog/hogql/database/schema/test/test_sessions_v1.py
@@ -19,7 +19,7 @@ from posthog.test.base import (
     ClickhouseDestroyTablesMixin,
 )
 
-# only some teams can use this table
+# only certain team ids can insert events into this legacy sessions table, see sessions/sql.py for more info
 ALLOWED_TEAM_ID = 2
 
 

--- a/posthog/hogql/database/schema/test/test_sessions_v1.py
+++ b/posthog/hogql/database/schema/test/test_sessions_v1.py
@@ -16,10 +16,19 @@ from posthog.test.base import (
     ClickhouseTestMixin,
     _create_event,
     _create_person,
+    ClickhouseDestroyTablesMixin,
 )
 
+# only some teams can use this table
+ALLOWED_TEAM_ID = 2
 
-class TestSessionsV1(ClickhouseTestMixin, APIBaseTest):
+
+class TestSessionsV1(ClickhouseDestroyTablesMixin, ClickhouseTestMixin, APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.team.id = ALLOWED_TEAM_ID
+        self.team.pk = ALLOWED_TEAM_ID
+
     def __execute(self, query):
         modifiers = HogQLQueryModifiers(sessionTableVersion=SessionTableVersion.V1)
         return execute_hogql_query(

--- a/posthog/hogql_queries/web_analytics/test/test_session_attribution_explorer_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/test/test_session_attribution_explorer_query_runner.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-from parameterized import parameterized
 
 from posthog.hogql.constants import LimitContext
 from posthog.hogql_queries.web_analytics.session_attribution_explorer_query_runner import (
@@ -80,7 +79,7 @@ class TestSessionAttributionQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self,
         date_from: Optional[str] = None,
         date_to: Optional[str] = None,
-        session_table_version: SessionTableVersion = SessionTableVersion.V1,
+        session_table_version: SessionTableVersion = SessionTableVersion.V2,
         group_by: Optional[list[SessionAttributionGroupBy]] = None,
         limit_context: Optional[LimitContext] = None,
         properties: Optional[list[SessionPropertyFilter]] = None,
@@ -94,20 +93,14 @@ class TestSessionAttributionQueryRunner(ClickhouseTestMixin, APIBaseTest):
         runner = SessionAttributionExplorerQueryRunner(team=self.team, query=query, limit_context=limit_context)
         return runner.calculate()
 
-    @parameterized.expand([[SessionTableVersion.V1], [SessionTableVersion.V2]])
-    def test_no_crash_when_no_data(self, session_table_version: SessionTableVersion):
-        results = self._run_session_attribution_query(
-            session_table_version=session_table_version,
-        ).results
+    def test_no_crash_when_no_data(self):
+        results = self._run_session_attribution_query().results
         assert results == [(0, [], [], [], [], [], [], [])]
 
-    @parameterized.expand([[SessionTableVersion.V1], [SessionTableVersion.V2]])
-    def test_group_by_nothing(self, session_table_version: SessionTableVersion):
+    def test_group_by_nothing(self):
         self._create_data()
 
-        results = self._run_session_attribution_query(
-            session_table_version=session_table_version,
-        ).results
+        results = self._run_session_attribution_query().results
 
         assert results == [
             (
@@ -122,12 +115,10 @@ class TestSessionAttributionQueryRunner(ClickhouseTestMixin, APIBaseTest):
             )
         ]
 
-    @parameterized.expand([[SessionTableVersion.V1], [SessionTableVersion.V2]])
-    def test_group_by_initial_url(self, session_table_version: SessionTableVersion):
+    def test_group_by_initial_url(self):
         self._create_data()
 
         results = self._run_session_attribution_query(
-            session_table_version=session_table_version,
             group_by=[SessionAttributionGroupBy.INITIAL_URL],
         ).results
 
@@ -164,12 +155,10 @@ class TestSessionAttributionQueryRunner(ClickhouseTestMixin, APIBaseTest):
             ),
         ]
 
-    @parameterized.expand([[SessionTableVersion.V1], [SessionTableVersion.V2]])
-    def test_group_channel_medium_source(self, session_table_version: SessionTableVersion):
+    def test_group_channel_medium_source(self):
         self._create_data()
 
         results = self._run_session_attribution_query(
-            session_table_version=session_table_version,
             group_by=[
                 SessionAttributionGroupBy.CHANNEL_TYPE,
                 SessionAttributionGroupBy.MEDIUM,
@@ -191,12 +180,10 @@ class TestSessionAttributionQueryRunner(ClickhouseTestMixin, APIBaseTest):
             (1, "Referral", ["referring_domain2"], "source2", "medium2", ["campaign2"], [], ["http://example.com/2"]),
         ]
 
-    @parameterized.expand([[SessionTableVersion.V1], [SessionTableVersion.V2]])
-    def test_filters(self, session_table_version: SessionTableVersion):
+    def test_filters(self):
         self._create_data()
 
         results = self._run_session_attribution_query(
-            session_table_version=session_table_version,
             group_by=[
                 SessionAttributionGroupBy.CHANNEL_TYPE,
                 SessionAttributionGroupBy.MEDIUM,


### PR DESCRIPTION
## Problem

We're currently pulling all events into both the sessions v1 and v2 tables, but only a few times are using v1. 

## Changes

This PR changes this so that only the teams that are actually using v1 will get their events pulled into it.

I also deleted a bunch of tests for the v1 sessions table, as it was hard to get them working with the new restrictions and the effort v reward was not there for keeping them! The core data model tests are still there.


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Updated the tests :) a similar change has already been made on prod anyway, this is just codifying it.
