### PR TITLE
fix: Add to `visit_interval_type` to `TraversingVisitor`

### DIFF
--- a/posthog/hogql/test/test_visitor.py
+++ b/posthog/hogql/test/test_visitor.py
@@ -154,3 +154,7 @@ class TestVisitor(BaseTest):
         assert NamingCheck().visit(UUIDType()) == "visit_uuid_type"
         assert NamingCheck().visit(HogQLXAttribute(name="a", value="a")) == "visit_hogqlx_attribute"
         assert NamingCheck().visit(HogQLXTag(kind="", attributes=[])) == "visit_hogqlx_tag"
+
+    def test_visit_interval_type(self):
+        # Just ensure ``IntervalType`` can be visited without throwing ``NotImplementedError``
+        TraversingVisitor().visit(ast.IntervalType())

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -236,6 +236,9 @@ class TraversingVisitor(Visitor[None]):
     def visit_date_time_type(self, node: ast.DateTimeType):
         pass
 
+    def visit_interval_type(self, node: ast.DateTimeType):
+        pass
+
     def visit_uuid_type(self, node: ast.UUIDType):
         pass
 

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -236,7 +236,7 @@ class TraversingVisitor(Visitor[None]):
     def visit_date_time_type(self, node: ast.DateTimeType):
         pass
 
-    def visit_interval_type(self, node: ast.DateTimeType):
+    def visit_interval_type(self, node: ast.IntervalType):
         pass
 
     def visit_uuid_type(self, node: ast.UUIDType):


### PR DESCRIPTION
## Problem

I did in fact overlook something in #25640.

## Changes

Adds `visit_interval_type` function to `TraversingVisitor`.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

- Added test.
- Checked subtype hierarchy of `TraversingVisitor` to ensure no additional changes were necessary.

Fixes [POSTHOG-1SY1](https://posthog.sentry.io/issues/6015075176/), [POSTHOG-1SY3](https://posthog.sentry.io/issues/6015108510/), [POSTHOG-1SY4](https://posthog.sentry.io/issues/6015108531/)