### PR TITLE
chore(batch-exports): Set sock connect timeout to 30s

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -461,7 +461,7 @@ async def get_client(
     #        ssl_context.load_verify_locations(settings.CLICKHOUSE_CA)
     #    elif ssl_context.verify_mode is ssl.CERT_REQUIRED:
     #        ssl_context.load_default_certs(ssl.Purpose.SERVER_AUTH)
-    timeout = aiohttp.ClientTimeout(total=None, connect=None, sock_connect=None, sock_read=None)
+    timeout = aiohttp.ClientTimeout(total=None, connect=None, sock_connect=30, sock_read=None)
 
     if team_id is None:
         max_block_size = settings.CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT


### PR DESCRIPTION
## Problem

Now that we know the reason for disconnects was that we were to slow reading from the connection, we can start re-adding back timeouts. This will allow us to retry when clickhouse is being unresponsive.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Set `sock_timeout` to 30s. This timeout fires off if it takes longer than 30 seconds to setup a connection to ClickHouse. If we take longer than 30s, something has happened and it's better to retry.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
