### PR TITLE
fix(batch-exports): Re-raise on producer task error

### DIFF
--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -445,7 +445,7 @@ async def raise_on_produce_task_failure(produce_task: asyncio.Task) -> None:
     should only be called after producer is done to check its exception.
     """
     if not produce_task.done():
-        raise TaskNotDoneError("producer_task")
+        raise TaskNotDoneError("produce")
 
     if produce_task.exception() is None:
         return

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -8,6 +8,7 @@ import uuid
 from string import Template
 
 import pyarrow as pa
+import structlog
 from django.conf import settings
 from temporalio import activity, exceptions, workflow
 from temporalio.common import RetryPolicy
@@ -34,6 +35,8 @@ from posthog.temporal.common.clickhouse import ClickHouseClient
 from posthog.temporal.common.client import connect
 from posthog.temporal.common.logger import bind_temporal_worker_logger
 from posthog.warehouse.util import database_sync_to_async
+
+logger = structlog.get_logger()
 
 BytesGenerator = collections.abc.Generator[bytes, None, None]
 RecordsGenerator = collections.abc.Generator[pa.RecordBatch, None, None]
@@ -337,6 +340,20 @@ class RecordBatchQueue(asyncio.Queue):
         return self._bytes_size
 
 
+class RecordBatchProducerError(Exception):
+    """Raised when an error occurs during production of record batches."""
+
+    def __init__(self):
+        super().__init__("The record batch producer encountered an error during execution")
+
+
+class TaskNotDoneError(Exception):
+    """Raised when a task that should be done, isn't."""
+
+    def __init__(self, task: str):
+        super().__init__(f"Expected task '{task}' to be done by now")
+
+
 def start_produce_batch_export_record_batches(
     client: ClickHouseClient,
     model_name: str,
@@ -412,14 +429,30 @@ def start_produce_batch_export_record_batches(
 
     queue = RecordBatchQueue(max_size_bytes=settings.BATCH_EXPORT_BUFFER_QUEUE_MAX_SIZE_BYTES)
     query_id = uuid.uuid4()
-    done_event = asyncio.Event()
     produce_task = asyncio.create_task(
         client.aproduce_query_as_arrow_record_batches(
-            view, queue=queue, done_event=done_event, query_parameters=parameters, query_id=str(query_id)
+            view, queue=queue, query_parameters=parameters, query_id=str(query_id)
         )
     )
 
-    return queue, done_event, produce_task
+    return queue, produce_task
+
+
+async def raise_on_produce_task_failure(produce_task: asyncio.Task) -> None:
+    """Raise `RecordBatchProducerError` if a produce task failed.
+
+    We will also raise a `TaskNotDone` if the producer is not done, as this
+    should only be called after producer is done to check its exception.
+    """
+    if not produce_task.done():
+        raise TaskNotDoneError("producer_task")
+
+    if produce_task.exception() is None:
+        return
+
+    exc = produce_task.exception()
+    await logger.aexception("Produce task failed", exc_info=exc)
+    raise RecordBatchProducerError() from exc
 
 
 def iter_records(

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -30,6 +30,7 @@ from posthog.temporal.batch_exports.batch_exports import (
     default_fields,
     execute_batch_export_insert_activity,
     get_data_interval,
+    raise_on_produce_task_failure,
     start_batch_export_run,
     start_produce_batch_export_record_batches,
 )
@@ -391,7 +392,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
             extra_query_parameters = model["values"] if model is not None else {}
             fields = model["fields"] if model is not None else None
 
-        queue, done_event, produce_task = start_produce_batch_export_record_batches(
+        queue, produce_task = start_produce_batch_export_record_batches(
             client=client,
             model_name=model_name,
             is_backfill=inputs.is_backfill,
@@ -406,23 +407,26 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
         )
 
         get_schema_task = asyncio.create_task(queue.get_schema())
-        wait_for_producer_done_task = asyncio.create_task(done_event.wait())
 
-        await asyncio.wait([get_schema_task, wait_for_producer_done_task], return_when=asyncio.FIRST_COMPLETED)
+        await asyncio.wait(
+            [get_schema_task, produce_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
 
         # Finishing producing happens sequentially after putting to queue and setting the schema.
-        # So, either we finished both tasks, or we finished without putting anything in the queue.
+        # So, either we finished producing and setting the schema tasks, or we finished without
+        # putting anything in the queue.
         if get_schema_task.done():
             # In the first case, we'll land here.
             # The schema is available, and the queue is not empty, so we can start the batch export.
             record_batch_schema = get_schema_task.result()
-        elif wait_for_producer_done_task.done():
-            # In the second case, we'll land here.
-            # The schema is not available as the queue is empty.
-            # Since we finished producing with an empty queue, there is nothing to batch export.
-            return 0
         else:
-            raise Exception("Unreachable")
+            # In the second case, we'll land here: We finished producing without putting anything.
+            # Since we finished producing with an empty queue, there is nothing to batch export.
+            # We could have also failed, so we need to re-raise that exception to allow a retry if
+            # that's the case.
+            await raise_on_produce_task_failure(produce_task)
+            return 0
 
         if inputs.use_json_type is True:
             json_type = "JSON"
@@ -507,13 +511,13 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                     heartbeater.details = (str(last_inserted_at),)
 
                 flush_tasks = []
-                while not queue.empty() or not done_event.is_set():
+                while not queue.empty() or not produce_task.done():
                     await logger.adebug("Starting record batch writer")
                     flush_start_event = asyncio.Event()
                     task = asyncio.create_task(
                         consume_batch_export_record_batches(
                             queue,
-                            done_event,
+                            produce_task,
                             flush_start_event,
                             flush_to_bigquery,
                             json_columns,
@@ -525,10 +529,11 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
 
                     flush_tasks.append(task)
 
-                await logger.adebug(
-                    "Finished producing and consuming all record batches, now waiting on any pending flush tasks"
-                )
+                await logger.adebug("Finished producing, now waiting on any pending flush tasks")
                 await asyncio.wait(flush_tasks)
+
+                await raise_on_produce_task_failure(produce_task)
+                await logger.adebug("Successfully consumed all record batches")
 
                 records_total = functools.reduce(operator.add, (task.result() for task in flush_tasks))
 
@@ -549,7 +554,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
 
 async def consume_batch_export_record_batches(
     queue: asyncio.Queue,
-    done_event: asyncio.Event,
+    produce_task: asyncio.Task,
     flush_start_event: asyncio.Event,
     flush_to_bigquery: FlushCallable,
     json_columns: list[str],
@@ -572,7 +577,9 @@ async def consume_batch_export_record_batches(
 
     Arguments:
         queue: The queue we will be listening on for record batches.
-        done_event: Event set by producer when done.
+        produce_task: Producer task we check to be done if queue is empty, as
+            that would indicate we have finished reading record batches before
+            hitting the flush limit, so we have to break early.
         flush_to_start_event: Event set by us when flushing is to about to
             start.
         json_columns: Used to cast columns of the record batch to JSON.
@@ -592,7 +599,7 @@ async def consume_batch_export_record_batches(
             try:
                 record_batch = queue.get_nowait()
             except asyncio.QueueEmpty:
-                if done_event.is_set():
+                if produce_task.done():
                     await logger.adebug("Empty queue with no more events being produced, closing writer loop")
                     flush_start_event.set()
                     # Exit context manager to trigger flush

--- a/posthog/temporal/common/asyncpa.py
+++ b/posthog/temporal/common/asyncpa.py
@@ -34,7 +34,9 @@ class AsyncMessageReader:
         await self.read_until(4)
 
         if self._buffer[:4] != CONTINUATION_BYTES:
-            raise InvalidMessageFormat("Encapsulated IPC message format must begin with continuation bytes")
+            raise InvalidMessageFormat(
+                f"Encapsulated IPC message format must begin with continuation bytes, received: '{self._buffer}'"
+            )
 
         await self.read_until(8)
 

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -460,7 +460,7 @@ async def get_client(
     #        ssl_context.load_verify_locations(settings.CLICKHOUSE_CA)
     #    elif ssl_context.verify_mode is ssl.CERT_REQUIRED:
     #        ssl_context.load_default_certs(ssl.Purpose.SERVER_AUTH)
-    timeout = aiohttp.ClientTimeout(total=None, connect=None, sock_connect=30, sock_read=60)
+    timeout = aiohttp.ClientTimeout(total=None, connect=None, sock_connect=30, sock_read=None)
 
     if team_id is None:
         max_block_size = settings.CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -395,7 +395,6 @@ class ClickHouseClient:
         query,
         *data,
         queue: asyncio.Queue,
-        done_event: asyncio.Event,
         query_parameters=None,
         query_id: str | None = None,
     ) -> None:
@@ -407,7 +406,7 @@ class ClickHouseClient:
         """
         async with self.apost_query(query, *data, query_parameters=query_parameters, query_id=query_id) as response:
             reader = asyncpa.AsyncRecordBatchProducer(response.content.iter_chunks())
-            await reader.produce(queue=queue, done_event=done_event)
+            await reader.produce(queue=queue)
 
     async def __aenter__(self):
         """Enter method part of the AsyncContextManager protocol."""

--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -461,7 +461,7 @@ async def get_client(
     #        ssl_context.load_verify_locations(settings.CLICKHOUSE_CA)
     #    elif ssl_context.verify_mode is ssl.CERT_REQUIRED:
     #        ssl_context.load_default_certs(ssl.Purpose.SERVER_AUTH)
-    timeout = aiohttp.ClientTimeout(total=None, connect=None, sock_connect=30, sock_read=None)
+    timeout = aiohttp.ClientTimeout(total=None, connect=None, sock_connect=30, sock_read=60)
 
     if team_id is None:
         max_block_size = settings.CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT

--- a/posthog/temporal/tests/batch_exports/test_batch_exports.py
+++ b/posthog/temporal/tests/batch_exports/test_batch_exports.py
@@ -1,20 +1,20 @@
+import asyncio
 import datetime as dt
 import json
 import operator
 from random import randint
-import asyncio
 
+import pyarrow as pa
 import pytest
 from django.test import override_settings
-import pyarrow as pa
 
 from posthog.batch_exports.service import BatchExportModel
 from posthog.temporal.batch_exports.batch_exports import (
+    RecordBatchQueue,
     get_data_interval,
     iter_model_records,
     iter_records,
     start_produce_batch_export_record_batches,
-    RecordBatchQueue,
 )
 from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse
 
@@ -410,12 +410,12 @@ def test_get_data_interval(interval, data_interval_end, expected):
     assert result == expected
 
 
-async def get_record_batch_from_queue(queue, done_event):
-    while not queue.empty() or not done_event.is_set():
+async def get_record_batch_from_queue(queue, produce_task):
+    while not queue.empty() or not produce_task.done():
         try:
             record_batch = queue.get_nowait()
         except asyncio.QueueEmpty:
-            if done_event.is_set():
+            if produce_task.done:
                 break
             else:
                 await asyncio.sleep(0.1)
@@ -423,6 +423,18 @@ async def get_record_batch_from_queue(queue, done_event):
 
         return record_batch
     return None
+
+
+async def get_all_record_batches_from_queue(queue, produce_task):
+    records = []
+    while not queue.empty() or not produce_task.done():
+        record_batch = await get_record_batch_from_queue(queue, produce_task)
+        if record_batch is None:
+            break
+
+        for record in record_batch.to_pylist():
+            records.append(record)
+    return records
 
 
 async def test_start_produce_batch_export_record_batches_uses_extra_query_parameters(clickhouse_client):
@@ -443,7 +455,7 @@ async def test_start_produce_batch_export_record_batches_uses_extra_query_parame
         properties={"$browser": "Chrome", "$os": "Mac OS X", "custom": 3},
     )
 
-    queue, done_event, _ = start_produce_batch_export_record_batches(
+    queue, produce_task = start_produce_batch_export_record_batches(
         client=clickhouse_client,
         team_id=team_id,
         is_backfill=False,
@@ -456,14 +468,7 @@ async def test_start_produce_batch_export_record_batches_uses_extra_query_parame
         extra_query_parameters={"hogql_val_0": "custom"},
     )
 
-    records = []
-    while not queue.empty() or not done_event.is_set():
-        record_batch = await get_record_batch_from_queue(queue, done_event)
-        if record_batch is None:
-            break
-
-        for record in record_batch.to_pylist():
-            records.append(record)
+    records = await get_all_record_batches_from_queue(queue, produce_task)
 
     for expected, record in zip(events, records):
         if expected["properties"] is None:
@@ -490,7 +495,7 @@ async def test_start_produce_batch_export_record_batches_can_flatten_properties(
         properties={"$browser": "Chrome", "$os": "Mac OS X", "custom-property": 3},
     )
 
-    queue, done_event, _ = start_produce_batch_export_record_batches(
+    queue, produce_task = start_produce_batch_export_record_batches(
         client=clickhouse_client,
         team_id=team_id,
         is_backfill=False,
@@ -506,14 +511,7 @@ async def test_start_produce_batch_export_record_batches_can_flatten_properties(
         extra_query_parameters={"hogql_val_0": "custom"},
     )
 
-    records = []
-    while not queue.empty() or not done_event.is_set():
-        record_batch = await get_record_batch_from_queue(queue, done_event)
-        if record_batch is None:
-            break
-
-        for record in record_batch.to_pylist():
-            records.append(record)
+    records = await get_all_record_batches_from_queue(queue, produce_task)
 
     all_expected = sorted(events, key=operator.itemgetter("event"))
     all_record = sorted(records, key=operator.itemgetter("event"))
@@ -554,7 +552,7 @@ async def test_start_produce_batch_export_record_batches_with_single_field_and_a
         properties={"$browser": "Chrome", "$os": "Mac OS X"},
     )
 
-    queue, done_event, _ = start_produce_batch_export_record_batches(
+    queue, produce_task = start_produce_batch_export_record_batches(
         client=clickhouse_client,
         team_id=team_id,
         is_backfill=False,
@@ -565,14 +563,7 @@ async def test_start_produce_batch_export_record_batches_with_single_field_and_a
         extra_query_parameters={},
     )
 
-    records = []
-    while not queue.empty() or not done_event.is_set():
-        record_batch = await get_record_batch_from_queue(queue, done_event)
-        if record_batch is None:
-            break
-
-        for record in record_batch.to_pylist():
-            records.append(record)
+    records = await get_all_record_batches_from_queue(queue, produce_task)
 
     all_expected = sorted(events, key=operator.itemgetter(field["expression"]))
     all_record = sorted(records, key=operator.itemgetter(field["alias"]))
@@ -616,7 +607,7 @@ async def test_start_produce_batch_export_record_batches_ignores_timestamp_predi
         inserted_at=inserted_at,
     )
 
-    queue, done_event, _ = start_produce_batch_export_record_batches(
+    queue, produce_task = start_produce_batch_export_record_batches(
         client=clickhouse_client,
         team_id=team_id,
         is_backfill=False,
@@ -625,19 +616,12 @@ async def test_start_produce_batch_export_record_batches_ignores_timestamp_predi
         interval_end=data_interval_end.isoformat(),
     )
 
-    records = []
-    while not queue.empty() or not done_event.is_set():
-        record_batch = await get_record_batch_from_queue(queue, done_event)
-        if record_batch is None:
-            break
-
-        for record in record_batch.to_pylist():
-            records.append(record)
+    records = await get_all_record_batches_from_queue(queue, produce_task)
 
     assert len(records) == 0
 
     with override_settings(UNCONSTRAINED_TIMESTAMP_TEAM_IDS=[str(team_id)]):
-        queue, done_event, _ = start_produce_batch_export_record_batches(
+        queue, produce_task = start_produce_batch_export_record_batches(
             client=clickhouse_client,
             team_id=team_id,
             is_backfill=False,
@@ -647,8 +631,8 @@ async def test_start_produce_batch_export_record_batches_ignores_timestamp_predi
         )
 
         records = []
-        while not queue.empty() or not done_event.is_set():
-            record_batch = await get_record_batch_from_queue(queue, done_event)
+        while not queue.empty() or not produce_task.done():
+            record_batch = await get_record_batch_from_queue(queue, produce_task)
             if record_batch is None:
                 break
 
@@ -679,7 +663,7 @@ async def test_start_produce_batch_export_record_batches_can_include_events(clic
     # Include the latter half of events.
     include_events = (event["event"] for event in events[5000:])
 
-    queue, done_event, _ = start_produce_batch_export_record_batches(
+    queue, produce_task = start_produce_batch_export_record_batches(
         client=clickhouse_client,
         team_id=team_id,
         is_backfill=False,
@@ -689,14 +673,7 @@ async def test_start_produce_batch_export_record_batches_can_include_events(clic
         include_events=include_events,
     )
 
-    records = []
-    while not queue.empty() or not done_event.is_set():
-        record_batch = await get_record_batch_from_queue(queue, done_event)
-        if record_batch is None:
-            break
-
-        for record in record_batch.to_pylist():
-            records.append(record)
+    records = await get_all_record_batches_from_queue(queue, produce_task)
 
     assert_records_match_events(records, events[5000:])
 
@@ -722,7 +699,7 @@ async def test_start_produce_batch_export_record_batches_can_exclude_events(clic
     # Exclude the latter half of events.
     exclude_events = (event["event"] for event in events[5000:])
 
-    queue, done_event, _ = start_produce_batch_export_record_batches(
+    queue, produce_task = start_produce_batch_export_record_batches(
         client=clickhouse_client,
         team_id=team_id,
         is_backfill=False,
@@ -732,14 +709,7 @@ async def test_start_produce_batch_export_record_batches_can_exclude_events(clic
         exclude_events=exclude_events,
     )
 
-    records = []
-    while not queue.empty() or not done_event.is_set():
-        record_batch = await get_record_batch_from_queue(queue, done_event)
-        if record_batch is None:
-            break
-
-        for record in record_batch.to_pylist():
-            records.append(record)
+    records = await get_all_record_batches_from_queue(queue, produce_task)
 
     assert_records_match_events(records, events[:5000])
 
@@ -762,7 +732,7 @@ async def test_start_produce_batch_export_record_batches_handles_duplicates(clic
         person_properties={"$browser": "Chrome", "$os": "Mac OS X"},
     )
 
-    queue, done_event, _ = start_produce_batch_export_record_batches(
+    queue, produce_task = start_produce_batch_export_record_batches(
         client=clickhouse_client,
         team_id=team_id,
         is_backfill=False,
@@ -771,14 +741,7 @@ async def test_start_produce_batch_export_record_batches_handles_duplicates(clic
         interval_end=data_interval_end.isoformat(),
     )
 
-    records = []
-    while not queue.empty() or not done_event.is_set():
-        record_batch = await get_record_batch_from_queue(queue, done_event)
-        if record_batch is None:
-            break
-
-        for record in record_batch.to_pylist():
-            records.append(record)
+    records = await get_all_record_batches_from_queue(queue, produce_task)
 
     assert_records_match_events(records, events)
 

--- a/posthog/temporal/tests/batch_exports/test_batch_exports.py
+++ b/posthog/temporal/tests/batch_exports/test_batch_exports.py
@@ -415,7 +415,7 @@ async def get_record_batch_from_queue(queue, produce_task):
         try:
             record_batch = queue.get_nowait()
         except asyncio.QueueEmpty:
-            if produce_task.done:
+            if produce_task.done():
                 break
             else:
                 await asyncio.sleep(0.1)
@@ -630,14 +630,7 @@ async def test_start_produce_batch_export_record_batches_ignores_timestamp_predi
             interval_end=data_interval_end.isoformat(),
         )
 
-        records = []
-        while not queue.empty() or not produce_task.done():
-            record_batch = await get_record_batch_from_queue(queue, produce_task)
-            if record_batch is None:
-                break
-
-            for record in record_batch.to_pylist():
-                records.append(record)
+        records = await get_all_record_batches_from_queue(queue, produce_task)
 
     assert_records_match_events(records, events)
 


### PR DESCRIPTION
## Problem

We are not checking if the producer task finished successfully. This means that if ClickHouse returns an error, we are not propagating it to the main thread. This is not a big deal as it just means the batch export will stop forever and the temporal retry mechanisms will kick in. But it does mean we are waiting until the timeout fires-off, which is a waste of time for no reason.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Check if producer task failed before starting writer loop.
* Check if producer task failed after finishing writer loop.
* In both cases, raise a retryable exception.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
