### PR TITLE
chore: do not always refresh

### DIFF
--- a/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
+++ b/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
@@ -58,7 +58,6 @@ export function ErrorTrackingScene(): JSX.Element {
         },
         showOpenEditorButton: false,
         insightProps: insightProps,
-        alwaysRefresh: true,
     }
 
     return (


### PR DESCRIPTION
## Problem

We are always refreshing the error tracking list query, even when navigating between pages

## Changes

Remove the `alwaysRefresh` prop. Can't think of any reason we need it but can call the `loadData` method if necessary in the instances that we do
