### PR TITLE
refactor(batch-exports): Switch backfill workflow to use Heartbeater

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -81,13 +81,23 @@ class PostgresInsertInputs:
 class PostgreSQLClient:
     """PostgreSQL connection client used in batch exports."""
 
-    def __init__(self, user: str, password: str, host: str, port: int, database: str, has_self_signed_cert: bool):
+    def __init__(
+        self,
+        user: str,
+        password: str,
+        host: str,
+        port: int,
+        database: str,
+        has_self_signed_cert: bool,
+        connection_timeout: int = 30,
+    ):
         self.user = user
         self.password = password
         self.database = database
         self.host = host
         self.port = port
         self.has_self_signed_cert = has_self_signed_cert
+        self.connection_timeout = connection_timeout
 
         self._connection: None | psycopg.AsyncConnection = None
 
@@ -134,6 +144,7 @@ class PostgreSQLClient:
             dbname=self.database,
             host=self.host,
             port=self.port,
+            connect_timeout=self.connection_timeout,
             sslmode="prefer" if settings.TEST else "require",
             **kwargs,
         )

--- a/posthog/temporal/tests/batch_exports/test_batch_exports.py
+++ b/posthog/temporal/tests/batch_exports/test_batch_exports.py
@@ -832,5 +832,4 @@ async def test_raise_on_produce_task_failure_does_not_raise():
     task = asyncio.create_task(fake_produce_task())
     await asyncio.wait([task])
 
-    result = await raise_on_produce_task_failure(task)
-    assert result is None
+    await raise_on_produce_task_failure(task)


### PR DESCRIPTION
## Problem

Batch export backfills were manually calling `hearbeat`. Critically, this means we were not heartbeating during `sleep` intervals. 

Moreover, PostgreSQL batch exports didn't have a connection timeout, so we would wait forever on a broken connection.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Switch batch export backfills to use `Heartbeater` which is just better and covers everything in the activity.
* Add connection timeout to PostgreSQL batch exports.
* Add some missing tests.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
