### PR TITLE
fix(cdp): add gclid fallback and warning

### DIFF
--- a/posthog/cdp/templates/google_ads/template_google_ads.py
+++ b/posthog/cdp/templates/google_ads/template_google_ads.py
@@ -8,6 +8,11 @@ template: HogFunctionTemplate = HogFunctionTemplate(
     icon_url="/static/services/google-ads.png",
     category=["Advertisement"],
     hog="""
+if (empty(inputs.gclid)) {
+    print('Empty `gclid`. Skipping...')
+    return
+}
+
 let res := fetch(f'https://googleads.googleapis.com/v17/customers/{replaceAll(inputs.customerId, '-', '')}:uploadClickConversions', {
     'method': 'POST',
     'headers': {
@@ -71,7 +76,7 @@ if (res.status >= 400) {
             "type": "string",
             "label": "Google Click ID (gclid)",
             "description": "The Google click ID (gclid) associated with this conversion.",
-            "default": "{person.gclid}",
+            "default": "{person.properties.gclid ?? person.properties.$initial_gclid}",
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/google_ads/test_template_google_ads.py
+++ b/posthog/cdp/templates/google_ads/test_template_google_ads.py
@@ -49,3 +49,9 @@ class TestTemplateGoogleAds(BaseHogFunctionTemplateTest):
                 },
             )
         )
+
+    def test_function_requires_identifier(self):
+        self.run_function(self._inputs(gclid=""))
+
+        assert not self.get_mock_fetch_calls()
+        assert self.get_mock_print_calls() == snapshot([("Empty `gclid`. Skipping...",)])


### PR DESCRIPTION
## Problem

in some cases the latest gclid is empty
![2024-10-24 at 17 19 27](https://github.com/user-attachments/assets/146bb31c-25d1-43fe-8191-761aa44e19ff)

## Changes

- changes the default for the gclid selector to use `$initial_gclid` as a fallback
- adds a warning if the gclid is empty

## How did you test this code?

added tests
