### PR TITLE
feat(clickhouse): Modify inserted_at column to default now64

### DIFF
--- a/posthog/clickhouse/migrations/0082_add_actually_inserted_at_column.py
+++ b/posthog/clickhouse/migrations/0082_add_actually_inserted_at_column.py
@@ -1,7 +1,4 @@
-from infi.clickhouse_orm import migrations
-
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.client import sync_execute
 from posthog.models.event.sql import (
     EVENTS_TABLE_JSON_MV_SQL,
     KAFKA_EVENTS_TABLE_JSON_SQL,
@@ -14,17 +11,19 @@ ON CLUSTER '{cluster}'
 MODIFY COLUMN inserted_at DEFAULT NOW64()
 """
 
-
-def add_columns_to_required_tables(_):
-    sync_execute(ADD_COLUMNS_BASE_SQL.format(table="events", cluster=CLICKHOUSE_CLUSTER))
-    sync_execute(ADD_COLUMNS_BASE_SQL.format(table="writable_events", cluster=CLICKHOUSE_CLUSTER))
-    sync_execute(ADD_COLUMNS_BASE_SQL.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
+DROP_COLUMN_BASE_SQL = """
+ALTER TABLE {table}
+ON CLUSTER '{cluster}'
+DROP COLUMN inserted_at
+"""
 
 
 operations = [
     run_sql_with_exceptions(f"DROP TABLE IF EXISTS events_json_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
     run_sql_with_exceptions(f"DROP TABLE IF EXISTS kafka_events_json ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
-    migrations.RunPython(add_columns_to_required_tables),
+    run_sql_with_exceptions(ADD_COLUMNS_BASE_SQL.format(table="events", cluster=CLICKHOUSE_CLUSTER)),
+    run_sql_with_exceptions(DROP_COLUMN_BASE_SQL.format(table="writeable_events", cluster=CLICKHOUSE_CLUSTER)),
+    run_sql_with_exceptions(ADD_COLUMNS_BASE_SQL.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER)),
     run_sql_with_exceptions(KAFKA_EVENTS_TABLE_JSON_SQL()),
     run_sql_with_exceptions(EVENTS_TABLE_JSON_MV_SQL()),
 ]

--- a/posthog/clickhouse/migrations/0082_add_actually_inserted_at_column.py
+++ b/posthog/clickhouse/migrations/0082_add_actually_inserted_at_column.py
@@ -22,7 +22,7 @@ operations = [
     run_sql_with_exceptions(f"DROP TABLE IF EXISTS events_json_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
     run_sql_with_exceptions(f"DROP TABLE IF EXISTS kafka_events_json ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
     run_sql_with_exceptions(ADD_COLUMNS_BASE_SQL.format(table="events", cluster=CLICKHOUSE_CLUSTER)),
-    run_sql_with_exceptions(DROP_COLUMN_BASE_SQL.format(table="writeable_events", cluster=CLICKHOUSE_CLUSTER)),
+    run_sql_with_exceptions(DROP_COLUMN_BASE_SQL.format(table="writable_events", cluster=CLICKHOUSE_CLUSTER)),
     run_sql_with_exceptions(ADD_COLUMNS_BASE_SQL.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER)),
     run_sql_with_exceptions(KAFKA_EVENTS_TABLE_JSON_SQL()),
     run_sql_with_exceptions(EVENTS_TABLE_JSON_MV_SQL()),

--- a/posthog/clickhouse/migrations/0082_add_actually_inserted_at_column.py
+++ b/posthog/clickhouse/migrations/0082_add_actually_inserted_at_column.py
@@ -1,0 +1,30 @@
+from infi.clickhouse_orm import migrations
+
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.client import sync_execute
+from posthog.models.event.sql import (
+    EVENTS_TABLE_JSON_MV_SQL,
+    KAFKA_EVENTS_TABLE_JSON_SQL,
+)
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+ADD_COLUMNS_BASE_SQL = """
+ALTER TABLE {table}
+ON CLUSTER '{cluster}'
+MODIFY COLUMN inserted_at DEFAULT NOW64()
+"""
+
+
+def add_columns_to_required_tables(_):
+    sync_execute(ADD_COLUMNS_BASE_SQL.format(table="events", cluster=CLICKHOUSE_CLUSTER))
+    sync_execute(ADD_COLUMNS_BASE_SQL.format(table="writable_events", cluster=CLICKHOUSE_CLUSTER))
+    sync_execute(ADD_COLUMNS_BASE_SQL.format(table="sharded_events", cluster=CLICKHOUSE_CLUSTER))
+
+
+operations = [
+    run_sql_with_exceptions(f"DROP TABLE IF EXISTS events_json_mv ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    run_sql_with_exceptions(f"DROP TABLE IF EXISTS kafka_events_json ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    migrations.RunPython(add_columns_to_required_tables),
+    run_sql_with_exceptions(KAFKA_EVENTS_TABLE_JSON_SQL()),
+    run_sql_with_exceptions(EVENTS_TABLE_JSON_MV_SQL()),
+]

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -604,7 +604,7 @@
       
   , _timestamp DateTime
   , _offset UInt64
-  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NULL
+  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64()
       
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_events', sipHash64(distinct_id))
   
@@ -701,7 +701,6 @@
   group3_created_at,
   group4_created_at,
   person_mode,
-  NOW64() AS inserted_at,
   _timestamp,
   _offset
   FROM posthog_test.kafka_events_json
@@ -2218,7 +2217,7 @@
       
   , _timestamp DateTime
   , _offset UInt64
-  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NULL
+  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64()
       
       , INDEX kafka_timestamp_minmax_sharded_events _timestamp TYPE minmax GRANULARITY 3
       
@@ -2631,7 +2630,7 @@
       
   , _timestamp DateTime
   , _offset UInt64
-  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NULL
+  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64()
       
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_events', sipHash64(distinct_id))
   
@@ -3337,7 +3336,7 @@
       
   , _timestamp DateTime
   , _offset UInt64
-  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NULL
+  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64()
       
       , INDEX kafka_timestamp_minmax_sharded_events _timestamp TYPE minmax GRANULARITY 3
       

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -2630,7 +2630,7 @@
       
   , _timestamp DateTime
   , _offset UInt64
-  , inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64()
+  
       
   ) ENGINE = Distributed('posthog', 'posthog_test', 'sharded_events', sipHash64(distinct_id))
   

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -25,7 +25,7 @@ TRUNCATE_EVENTS_TABLE_SQL = (
 DROP_EVENTS_TABLE_SQL = lambda: f"DROP TABLE IF EXISTS {EVENTS_DATA_TABLE()} ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'"
 DROP_DISTRIBUTED_EVENTS_TABLE_SQL = f"DROP TABLE IF EXISTS events ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'"
 
-INSERTED_AT_COLUMN = ", inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NULL"
+INSERTED_AT_COLUMN = ", inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64()"
 
 EVENTS_TABLE_BASE_SQL = """
 CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER '{cluster}'
@@ -175,7 +175,6 @@ group2_created_at,
 group3_created_at,
 group4_created_at,
 person_mode,
-NOW64() AS inserted_at,
 _timestamp,
 _offset
 FROM {database}.kafka_events_json

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -192,7 +192,7 @@ WRITABLE_EVENTS_TABLE_SQL = lambda: EVENTS_TABLE_BASE_SQL.format(
     table_name="writable_events",
     cluster=settings.CLICKHOUSE_CLUSTER,
     engine=Distributed(data_table=EVENTS_DATA_TABLE(), sharding_key="sipHash64(distinct_id)"),
-    extra_fields=KAFKA_COLUMNS + INSERTED_AT_COLUMN,
+    extra_fields=KAFKA_COLUMNS,
     materialized_columns="",
     indexes="",
 )


### PR DESCRIPTION
## Problem

A year ago I messed up: I knew we needed to set `inserted_at` when actually inserting the data but due to a combination of factors[^1], I failed to add this column in the right way. I should have set the default value to `NOW64()` instead of using `NULL` as default and passing it via the materialized view, as the materialized view is subject to lag as it produces the values into a distribution queue.

This error has caused the most long standing issue with batch exports, that I have explained time and time again. Essentially, distribution queue lag leads to events appearing late, which leads to events being missed by batch exports if the lag is big enough, as the batch export has already moved forward.

[^1]: I blame several factors for this oversight: My inexperience with how things work at ClickHouse, the huge complexity present in schema management of our ClickHouse tables[^2], and my reserved attitude when it comes to pushing for changes I believe in.

[^2]: If I may be allowed a place to rant: Why do I need to mentally resolve like 10 Python f-strings to figure out what a query is doing? Who cares about DRY in SQL migrations?? We run them once and we are done, who cares if we repeat some lines of SQL!?

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Modifies `inserted_at` to set it to `DEFAULT NOW64()`.
* More importantly, `inserted_at` column is *removed* from the events Kafka consumer materialized view. The value will be set by ClickHouse when inserting by calling the default (`NOW64()`).
* Updates `events/sql.py`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Maybe.
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

I didn't. I know this is the way. I'm joking, I did run the migration and it appears to work locally.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
