### PR TITLE
fix: template type

### DIFF
--- a/posthog/cdp/templates/june/template_june.py
+++ b/posthog/cdp/templates/june/template_june.py
@@ -2,6 +2,7 @@ from posthog.cdp.templates.hog_function_template import HogFunctionTemplate
 
 template: HogFunctionTemplate = HogFunctionTemplate(
     status="beta",
+    type="destination",
     id="template-june",
     name="June.so",
     description="Send events to June.so ",


### PR DESCRIPTION
## Problem

Fix a bug that landed in master due to merging out of order:
- PR that adds `type` field to function templates
- PR that adds a new template without filling in the field

## Changes

Adds the type

## How did you test this code?

Same bug locally, this fixed it.