### PR TITLE
fix(data-warehouse): Use destination tables for bigquery syncs

### DIFF
--- a/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 import contextlib
 from google.oauth2 import service_account
 from google.cloud import bigquery
-
 from posthog.warehouse.types import IncrementalFieldType
 
 # Actual data ingestion happens via the `sql_database` source. This is more for BigQuery utils
@@ -30,6 +29,13 @@ def bigquery_client(project_id: str, private_key: str, private_key_id: str, clie
         yield client
     finally:
         client.close()
+
+
+def delete_table(
+    table_id: str, project_id: str, private_key: str, private_key_id: str, client_email: str, token_uri: str
+) -> None:
+    with bigquery_client(project_id, private_key, private_key_id, client_email, token_uri) as bq:
+        bq.delete_table(table_id, not_found_ok=True)
 
 
 def get_schemas(

--- a/posthog/temporal/data_imports/pipelines/sql_database/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/sql_database/__init__.py
@@ -143,6 +143,7 @@ def bigquery_source(
     client_email: str,
     token_uri: str,
     table_name: str,
+    bq_destination_table_id: str,
     incremental_field: Optional[str] = None,
     incremental_field_type: Optional[IncrementalFieldType] = None,
 ) -> DltSource:
@@ -162,7 +163,10 @@ def bigquery_source(
         "token_uri": token_uri,
     }
 
-    engine = create_engine(f"bigquery://{project_id}/{dataset_id}", credentials_info=credentials_info)
+    engine = create_engine(
+        f"bigquery://{project_id}/{dataset_id}?create_disposition=CREATE_IF_NEEDED&allowLargeResults=true&destination={bq_destination_table_id}",
+        credentials_info=credentials_info,
+    )
 
     return sql_database(engine, schema=None, table_names=[table_name], incremental=incremental)
 


### PR DESCRIPTION
## Problem
Bigquery have query limits of 10GB when using temp destination tables, meaning we can't sync anything over 10GB right now

## Changes
- Explicitly set a destination table and delete that table after we're done with the sync

## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
Tested locally with BQ tables