### PR TITLE
fix(cdp): test invocation async limits

### DIFF
--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -5,7 +5,7 @@ import { Hub } from '../types'
 import { status } from '../utils/status'
 import { delay } from '../utils/utils'
 import { FetchExecutor } from './fetch-executor'
-import { HogExecutor } from './hog-executor'
+import { HogExecutor, MAX_ASYNC_STEPS } from './hog-executor'
 import { HogFunctionManager } from './hog-function-manager'
 import { HogWatcher, HogWatcherState } from './hog-watcher'
 import { HogFunctionInvocationResult, HogFunctionType, LogEntry } from './types'
@@ -120,7 +120,7 @@ export class CdpApi {
             let count = 0
 
             while (!lastResponse || !lastResponse.finished) {
-                if (count > 5) {
+                if (count > MAX_ASYNC_STEPS * 2) {
                     throw new Error('Too many iterations')
                 }
                 count += 1

--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -18,9 +18,9 @@ import {
 } from './types'
 import { convertToHogFunctionFilterGlobal } from './utils'
 
-const MAX_ASYNC_STEPS = 5
-const MAX_HOG_LOGS = 25
-const MAX_LOG_LENGTH = 10000
+export const MAX_ASYNC_STEPS = 5
+export const MAX_HOG_LOGS = 25
+export const MAX_LOG_LENGTH = 10000
 export const DEFAULT_TIMEOUT_MS = 100
 
 const hogExecutionDuration = new Histogram({


### PR DESCRIPTION
## Problem

You could not test with the same number of async functions that we allow in a function (5)

## Changes

Hooks up the same constant

## How did you test this code?

I could make 5 fetch calls locally. The sixth gave an error.