### PR TITLE
fix: switch to the project after creation

### DIFF
--- a/frontend/src/scenes/projectLogic.ts
+++ b/frontend/src/scenes/projectLogic.ts
@@ -19,7 +19,7 @@ export const projectLogic = kea<projectLogicType>([
         deleteProjectFailure: true,
     }),
     connect(() => ({
-        actions: [userLogic, ['loadUser']],
+        actions: [userLogic, ['loadUser', 'switchTeam']],
     })),
     reducers({
         projectBeingDeleted: [
@@ -100,6 +100,11 @@ export const projectLogic = kea<projectLogicType>([
         },
         deleteProjectSuccess: () => {
             lemonToast.success('Project has been deleted')
+        },
+        createProjectSuccess: ({ currentProject }) => {
+            if (currentProject) {
+                actions.switchTeam(currentProject.id)
+            }
         },
     })),
     afterMount(({ actions }) => {


### PR DESCRIPTION
## Problem

The environments switch left something behind - switching to a new project after it was created! When a user created a new project, it was made "behind the scenes" but the page required a refresh to get the new project data showing up, and wasn't taken to the new project.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

After creation just calls `switchTeam` with the _project_ ID, which seems to work fine? 🤷‍♀️ @Twixes is this expected that it just works?

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
