### PR TITLE
fix(cdp): wrap text by default in teams destination

### DIFF
--- a/posthog/cdp/templates/microsoft_teams/template_microsoft_teams.py
+++ b/posthog/cdp/templates/microsoft_teams/template_microsoft_teams.py
@@ -27,7 +27,8 @@ let res := fetch(inputs.webhookUrl, {
                     'body': [
                         {
                             'type': 'TextBlock',
-                            'text': inputs.text
+                            'text': inputs.text,
+                            'wrap': true
                         }
                     ]
                 }

--- a/posthog/cdp/templates/microsoft_teams/test_template_microsoft_teams.py
+++ b/posthog/cdp/templates/microsoft_teams/test_template_microsoft_teams.py
@@ -40,6 +40,7 @@ class TestTemplateMicrosoftTeams(BaseHogFunctionTemplateTest):
                                         {
                                             "type": "TextBlock",
                                             "text": "**max@posthog.com** triggered event: '$pageview'",
+                                            "wrap": True,
                                         }
                                     ],
                                 },


### PR DESCRIPTION
## Changes

- defaults to `wrap: true`

## How did you test this code?

updated test
