### PR TITLE
fix(cdp): remove double indicator

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
@@ -210,8 +210,6 @@ export function HogFunctionConfiguration({ templateId, id }: HogFunctionConfigur
                                         {template && <DestinationTag status={template.status} />}
                                     </div>
 
-                                    <HogFunctionStatusIndicator hogFunction={hogFunction} />
-
                                     {showEnabled && <HogFunctionStatusIndicator hogFunction={hogFunction} />}
                                     {showEnabled && (
                                         <LemonField name="enabled">


### PR DESCRIPTION
## Problem

We were showing the hog function status indicator twice
![2024-10-28 at 15 44 35](https://github.com/user-attachments/assets/fd6d0c46-6912-491a-b74c-8e19dda9b20e)

## Changes

- only show the status indicator when `showEnabled` is true.
