### PR TITLE
feat(cdp): add option to run a hog function per person per event

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/filters/HogFunctionFilters.tsx
@@ -161,6 +161,10 @@ export function HogFunctionFilters(): JSX.Element {
                                     value: '{person.id}',
                                     label: 'Run once per person per interval',
                                 },
+                                {
+                                    value: '{concat(person.id, event.event)}',
+                                    label: 'Run once per person per interval per event',
+                                },
                             ]}
                             value={value?.hash ?? null}
                             onChange={(val) =>

--- a/frontend/src/scenes/pipeline/hogfunctions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/filters/HogFunctionFilters.tsx
@@ -163,7 +163,7 @@ export function HogFunctionFilters(): JSX.Element {
                                 },
                                 {
                                     value: '{concat(person.id, event.event)}',
-                                    label: 'Run once per person per interval per event',
+                                    label: 'Run once per person per event per interval',
                                 },
                             ]}
                             value={value?.hash ?? null}

--- a/plugin-server/tests/cdp/examples.ts
+++ b/plugin-server/tests/cdp/examples.ts
@@ -708,8 +708,16 @@ export const HOG_MASK_EXAMPLES: Record<string, Pick<HogFunctionType, 'masking'>>
     person: {
         masking: {
             ttl: 30,
-            hash: '{person.uuid}',
-            bytecode: ['_h', 32, 'uuid', 32, 'person', 1, 2],
+            hash: '{person.id}',
+            bytecode: ['_h', 32, 'id', 32, 'person', 1, 2],
+            threshold: null,
+        },
+    },
+    personAndEvent: {
+        masking: {
+            ttl: 30,
+            hash: '{concat(person.id, event.event)}',
+            bytecode: ['_H', 1, 32, 'id', 32, 'person', 1, 2, 32, 'event', 32, 'event', 1, 2, 2, 'concat', 2],
             threshold: null,
         },
     },


### PR DESCRIPTION
## Problem

The only option to get notified per event is to duplicate the hog function multiple times.
https://posthoghelp.zendesk.com/agent/tickets/19696 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/22661)

## Changes

- adds an option to trigger functions `once per person per event per interval`

## How did you test this code?

updated tests	