### PR TITLE
chore(data-warehouse): Upgraded temporal UI image

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -285,7 +285,8 @@ services:
         environment:
             - TEMPORAL_ADDRESS=temporal:7233
             - TEMPORAL_CORS_ORIGINS=http://localhost:3000
-        image: temporalio/ui:2.10.3
+            - TEMPORAL_CSRF_COOKIE_INSECURE=true
+        image: temporalio/ui:2.31.2
         ports:
             - 8081:8080
     temporal-django-worker:


### PR DESCRIPTION
## Problem
- When using the Temporal UI locally, we can't perform any admin tasks - every network request gets returned with an error. This is cause the csrf token cookie is a HTTPS cookie and the UI is served over HTTP

## Changes
- Newer versions of `temporalio/ui` takes an env var to serve the csrf cookie over HTTP, allowing us to be. able to cancel/delete workflows etc from the UI directly 🥳 
  - Updates the UI image the latest build
  - Adds the insecure csrf env var
