### PR TITLE
fix(err): cluster frames before resolution

### DIFF
--- a/rust/common/metrics/src/lib.rs
+++ b/rust/common/metrics/src/lib.rs
@@ -46,7 +46,8 @@ pub fn setup_metrics_routes(router: Router) -> Router {
 
 pub fn setup_metrics_recorder() -> PrometheusHandle {
     const BUCKETS: &[f64] = &[
-        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 50.0, 100.0, 250.0,
+        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 50.0, 100.0, 250.0, 500.0,
+        1000.0, 2000.0, 5000.0, 10000.0,
     ];
 
     PrometheusBuilder::new()

--- a/rust/cymbal/src/langs/js.rs
+++ b/rust/cymbal/src/langs/js.rs
@@ -62,7 +62,7 @@ impl RawJSFrame {
         (self, e).into()
     }
 
-    fn source_url(&self) -> Result<Url, JsResolveErr> {
+    pub fn source_url(&self) -> Result<Url, JsResolveErr> {
         // We can't resolve a frame without a source ref, and are forced
         // to assume this frame is not minified
         let Some(source_url) = &self.source_url else {

--- a/rust/cymbal/src/main.rs
+++ b/rust/cymbal/src/main.rs
@@ -135,6 +135,7 @@ async fn main() -> Result<(), Error> {
         let team_id = event.team_id;
         let mut results = Vec::with_capacity(stack_trace.len());
         for (_, frames) in groups.into_iter() {
+            context.worker_liveness.report_healthy().await; // TODO - we shouldn't need to do this, but we do for now.
             let mut any_success = false;
             let per_frame_group = common_metrics::timing_guard(PER_FRAME_GROUP_TIME, &[]);
             for frame in frames {

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -15,3 +15,4 @@ pub const STORE_CACHE_EVICTIONS: &str = "cymbal_store_cache_evictions";
 pub const MAIN_LOOP_TIME: &str = "cymbal_main_loop_time";
 pub const PER_FRAME_TIME: &str = "cymbal_per_frame_time";
 pub const PER_STACK_TIME: &str = "cymbal_per_stack_time";
+pub const PER_FRAME_GROUP_TIME: &str = "cymbal_per_frame_group_time";

--- a/rust/cymbal/src/types/frames.rs
+++ b/rust/cymbal/src/types/frames.rs
@@ -27,6 +27,11 @@ impl RawFrame {
 
         res
     }
+
+    pub fn symbol_set_group_key(&self) -> String {
+        let RawFrame::JavaScript(raw) = self;
+        raw.source_url().map(String::from).unwrap_or_default()
+    }
 }
 
 // We emit a single, unified representation of a frame, which is what we pass on to users.


### PR DESCRIPTION
Idea is to only fetch a symbol set at most once per event, at least. 