### PR TITLE
fix(err): FrameBag, for across-event frame resolution batching

### DIFF
--- a/rust/common/metrics/src/lib.rs
+++ b/rust/common/metrics/src/lib.rs
@@ -46,7 +46,8 @@ pub fn setup_metrics_routes(router: Router) -> Router {
 
 pub fn setup_metrics_recorder() -> PrometheusHandle {
     const BUCKETS: &[f64] = &[
-        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 50.0, 100.0, 250.0,
+        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 50.0, 100.0, 250.0, 500.0,
+        1000.0, 2000.0, 5000.0, 10000.0,
     ];
 
     PrometheusBuilder::new()

--- a/rust/cymbal/src/langs/js.rs
+++ b/rust/cymbal/src/langs/js.rs
@@ -62,7 +62,7 @@ impl RawJSFrame {
         (self, e).into()
     }
 
-    fn source_url(&self) -> Result<Url, JsResolveErr> {
+    pub fn source_url(&self) -> Result<Url, JsResolveErr> {
         // We can't resolve a frame without a source ref, and are forced
         // to assume this frame is not minified
         let Some(source_url) = &self.source_url else {

--- a/rust/cymbal/src/metric_consts.rs
+++ b/rust/cymbal/src/metric_consts.rs
@@ -15,3 +15,4 @@ pub const STORE_CACHE_EVICTIONS: &str = "cymbal_store_cache_evictions";
 pub const MAIN_LOOP_TIME: &str = "cymbal_main_loop_time";
 pub const PER_FRAME_TIME: &str = "cymbal_per_frame_time";
 pub const PER_STACK_TIME: &str = "cymbal_per_stack_time";
+pub const PER_FRAME_GROUP_TIME: &str = "cymbal_per_frame_group_time";

--- a/rust/cymbal/src/types/frames.rs
+++ b/rust/cymbal/src/types/frames.rs
@@ -27,6 +27,11 @@ impl RawFrame {
 
         res
     }
+
+    pub fn symbol_set_group_key(&self) -> String {
+        let RawFrame::JavaScript(raw) = self;
+        raw.source_url().map(String::from).unwrap_or_default()
+    }
 }
 
 // We emit a single, unified representation of a frame, which is what we pass on to users.

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 pub mod frames;
+pub mod stack;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Mechanism {

--- a/rust/cymbal/src/types/stack.rs
+++ b/rust/cymbal/src/types/stack.rs
@@ -1,0 +1,81 @@
+use tokio::sync::oneshot;
+
+use crate::error::Error;
+
+use super::frames::{Frame, RawFrame};
+
+pub struct Stack<S>(S);
+
+// The basic idea is that we want to be able to get a bunch of stacks, explode them into
+// their individual frames, and then cluster and resolve those frames however we want, and
+// once we've kicked off all those tasks or whatever, we just can use the stack object itself
+// to wait for the results to come back. This is /kind of/ a future, but with more flexibility.
+// The win here is that we're able to process a batch of events all at once, but we pay some
+// complexity cost.
+pub struct FrameResolveWaiter {
+    handle: oneshot::Receiver<Result<Frame, Error>>,
+}
+
+pub struct FrameResolveHandle {
+    frame: RawFrame,
+    handle: oneshot::Sender<Result<Frame, Error>>,
+}
+
+// The state transitions a stack can go through, from a stack of unprocessed frames, to an intermediate
+// state where the stack has been "exploded" and is waiting on the results of each frame, to a stack of
+// resolved frames.
+pub struct Unprocessed(Vec<RawFrame>);
+pub struct Resolving(Vec<FrameResolveWaiter>);
+pub struct Resolved(Vec<Frame>);
+
+pub struct FrameBag(Vec<FrameResolveHandle>);
+
+pub type UnprocessedStack = Stack<Unprocessed>;
+pub type ResolvingStack = Stack<Resolving>;
+pub type ResolvedStack = Stack<Resolved>;
+
+impl From<Vec<RawFrame>> for Stack<Unprocessed> {
+    fn from(frames: Vec<RawFrame>) -> Self {
+        Self(Unprocessed(frames))
+    }
+}
+
+impl Stack<Unprocessed> {
+    pub fn explode(self) -> (Stack<Resolving>, FrameBag) {
+        let mut waiters = Vec::with_capacity(self.0 .0.len());
+        let mut handles = Vec::with_capacity(self.0 .0.len());
+        for frame in self.0 .0.into_iter() {
+            let (tx, rx) = oneshot::channel();
+            waiters.push(FrameResolveWaiter { handle: rx });
+            handles.push(FrameResolveHandle { frame, handle: tx });
+        }
+
+        (Stack(Resolving(waiters)), FrameBag(handles))
+    }
+}
+
+impl FrameBag {
+    pub fn merge(self, other: Self) -> Self {
+        let mut handles = self.0;
+        handles.extend(other.0);
+        FrameBag(handles)
+    }
+
+    pub async fn resolve(self) {
+        // Things get a little tricky with indexes here...
+        let mut frames = Vec::with_capacity(self.0.len());
+        let mut handles = Vec::with_capacity(self.0.len());
+        for (i, handle) in self.0.into_iter().enumerate() {
+            frames.push(handle.frame);
+            handles.push(handle.handle);
+        }
+
+        Ok(Stack(Resolved(frames)))
+    }
+}
+
+struct FrameGroup<Ref, Frame> {
+    source_ref: Option<Ref>,
+    frames: Vec<Frame>,
+    indices: Vec<usize>,
+}


### PR DESCRIPTION
We want to be able to cluster frames by symbol source, even across multiple events. This gets pretty tricky pretty fast (symbol sets are unique per reference and team, you have to keep track of where in the original stack trace the frames appeared even through you're grouping and clustering them)

I have vague ideas sketched out here I want to return to, but I'm leaving this as a draft for now.