### PR TITLE
chore(batch-exports): Make PostgreSQL connection errors non-retryable

### DIFF
--- a/posthog/batch_exports/sql.py
+++ b/posthog/batch_exports/sql.py
@@ -139,8 +139,8 @@ CREATE OR REPLACE VIEW events_batch_export ON CLUSTER {settings.CLICKHOUSE_CLUST
     FROM
         events
     PREWHERE
-        events.inserted_at >= {{interval_start:DateTime64}}
-        AND events.inserted_at < {{interval_end:DateTime64}}
+        COALESCE(events.inserted_at, events._timestamp) >= {{interval_start:DateTime64}}
+        AND COALESCE(events.inserted_at, events._timestamp) < {{interval_end:DateTime64}}
     WHERE
         team_id = {{team_id:Int64}}
         AND events.timestamp >= {{interval_start:DateTime64}} - INTERVAL {{lookback_days:Int32}} DAY
@@ -172,8 +172,8 @@ CREATE OR REPLACE VIEW events_batch_export_unbounded ON CLUSTER {settings.CLICKH
     FROM
         events
     PREWHERE
-        events.inserted_at >= {{interval_start:DateTime64}}
-        AND events.inserted_at < {{interval_end:DateTime64}}
+        COALESCE(events.inserted_at, events._timestamp) >= {{interval_start:DateTime64}}
+        AND COALESCE(events.inserted_at, events._timestamp) < {{interval_end:DateTime64}}
     WHERE
         team_id = {{team_id:Int64}}
         AND (length({{include_events:Array(String)}}) = 0 OR event IN {{include_events:Array(String)}})

--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -136,7 +136,7 @@ class PostgreSQLClient:
         max_attempts = 5
         connect = make_retryable_with_exponential_backoff(
             psycopg.AsyncConnection.connect,
-            max_attempts=5,
+            max_attempts=max_attempts,
             retryable_exceptions=(psycopg.OperationalError, psycopg.errors.ConnectionTimeout),
         )
 

--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -133,21 +133,34 @@ class PostgreSQLClient:
             # Disable certificate verification for self-signed certificates.
             kwargs["sslrootcert"] = None
 
+        max_attempts = 5
         connect = make_retryable_with_exponential_backoff(
             psycopg.AsyncConnection.connect,
-            retryable_exceptions=(psycopg.OperationalError,),
+            max_attempts=5,
+            retryable_exceptions=(psycopg.OperationalError, psycopg.errors.ConnectionTimeout),
         )
 
-        connection: psycopg.AsyncConnection = await connect(
-            user=self.user,
-            password=self.password,
-            dbname=self.database,
-            host=self.host,
-            port=self.port,
-            connect_timeout=self.connection_timeout,
-            sslmode="prefer" if settings.TEST else "require",
-            **kwargs,
-        )
+        try:
+            connection: psycopg.AsyncConnection = await connect(
+                user=self.user,
+                password=self.password,
+                dbname=self.database,
+                host=self.host,
+                port=self.port,
+                connect_timeout=self.connection_timeout,
+                sslmode="prefer" if settings.TEST else "require",
+                **kwargs,
+            )
+        except psycopg.errors.ConnectionTimeout as err:
+            raise PostgreSQLConnectionError(
+                f"Timed-out while trying to connect for {max_attempts} attempts. Is the "
+                f"server running at '{self.host}', port '{self.port}' and accepting "
+                "TCP/IP connections?"
+            ) from err
+        except psycopg.OperationalError as err:
+            raise PostgreSQLConnectionError(
+                f"Failed to connect after {max_attempts} attempts. Please review connection configuration."
+            ) from err
 
         async with connection as connection:
             self._connection = connection
@@ -689,6 +702,8 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
                 "StringDataRightTruncation",
                 # Raised by PostgreSQL client. Self explanatory.
                 "DiskFull",
+                # Raised by our PostgreSQL client when failing to connect after several attempts.
+                "PostgreSQLConnectionError",
             ],
             finish_inputs=finish_inputs,
         )

--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -603,6 +603,8 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
                 # A column, usually properties, exceeds the limit for a VARCHAR field,
                 # usually the max of 65535 bytes
                 "StringDataRightTruncation",
+                # Raised by our PostgreSQL client when failing to connect after several attempts.
+                "PostgreSQLConnectionError",
             ],
             finish_inputs=finish_inputs,
         )


### PR DESCRIPTION
## Problem

Redshift and PostgreSQL batch exports are raising retryable errors when timing out. This is usually pointless as a 30 sec timeout in connecting probably means the database is unreachable.

Moreover, I'm updating our CREATE VIEW statements for batch exports to match latest changes. These are already deployed, so no migration is necessary.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Ensure we are retrying at least 5 times when trying to connect to give the database a fair shot of being up.
* After those 5 attempts, raise a non-retryable error.
* Update batch export CREATE statements to match database.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
