### PR TITLE
fix(batch-exports): Set default function when JSON dumping

### DIFF
--- a/posthog/temporal/batch_exports/temporary_file.py
+++ b/posthog/temporal/batch_exports/temporary_file.py
@@ -482,7 +482,7 @@ class JSONLBatchExportWriter(BatchExportWriter):
                         # We tried, fallback to the slower but more permissive stdlib
                         # json.
                         logger.exception("PostHog $web_vitals event didn't match expected structure")
-                        dumped = json.dumps(d).encode("utf-8")
+                        dumped = json.dumps(d, default=str).encode("utf-8")
                         n = self.batch_export_file.write(dumped + b"\n")
                     else:
                         dumped = orjson.dumps(d, default=str)
@@ -492,7 +492,7 @@ class JSONLBatchExportWriter(BatchExportWriter):
                     # In this case, we fallback to the slower but more permissive stdlib
                     # json.
                     logger.exception("Orjson detected a deeply nested dict: %s", d)
-                    dumped = json.dumps(d).encode("utf-8")
+                    dumped = json.dumps(d, default=str).encode("utf-8")
                     n = self.batch_export_file.write(dumped + b"\n")
             else:
                 # Orjson is very strict about invalid unicode. This slow path protects us


### PR DESCRIPTION
## Problem

We do this when dumping with `orjson` but not with the stdlib `json` fallback. So, in very rare circumstances (a user has a deeply nested dict, that also contains non-serializable JSON data) this can fail.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Similar to `orsjon`, set default function for `json.dumps` to `str`. This helps with, mostly, `datetime` values.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
