### PR TITLE
fix(product-assistant): use header to disable nginx buffering

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -206,7 +206,9 @@ class QueryViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet)
                     {"prompt": human_message.content, "response": last_message},
                 )
 
-        return StreamingHttpResponse(generate(), content_type=ServerSentEventRenderer.media_type)
+        return StreamingHttpResponse(
+            generate(), content_type=ServerSentEventRenderer.media_type, headers={"X-Accel-Buffering": "no"}
+        )
 
     def handle_column_ch_error(self, error):
         if getattr(error, "message", None):


### PR DESCRIPTION
## Problem

Streaming doesn't work on production because something buffers the response.

## Changes

Set the [header](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#:~:text=Buffering%20can%20also%20be%20enabled,disabled%20using%20the%20proxy_ignore_headers%20directive.&text=Sets%20the%20number%20and%20size,server%2C%20for%20a%20single%20connection.) that should turn off buffering on nginx for the chat endpoint.

## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

Manul testing
