### PR TITLE
fix: Error status handling in hog function

### DIFF
--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -228,9 +228,12 @@ export class HogExecutor {
                 invocation.queue = 'hog'
                 invocation.queueParameters = undefined
 
+                // If we got a response from fetch, we know the response code was in the <300 range,
+                // but if we didn't (indicating a bug in the fetch worker), we use a default of 503
+                let status = response?.status ?? 503
+
                 // If we got a trace, then the last "result" is the final attempt, and we should try to grab a status from it
                 // or any preceding attempts, and produce a log message for each of them
-                let status = null
                 if (trace.length > 0) {
                     logs.push({
                         level: 'error',
@@ -248,10 +251,6 @@ export class HogExecutor {
                         }
                     }
                 }
-
-                // If we got a response from fetch, we know the response code was in the <300 range,
-                // but if we didn't (indicating a bug in the fetch worker), we use a default of 503
-                status = response?.status ?? 503
 
                 if (!invocation.vmState) {
                     throw new Error("VM state wasn't provided for queue parameters")


### PR DESCRIPTION
## Problem

The error status is contained in the trace but we didn't correctly pull it out to pass back to the function.
Additionally our simulated fetch service didn't act in the same way as the rust one making it hard to test. Ideally we should get e2e testing via the rust service working but thats a bigger step.

## Changes

* Fixes the issue with status assignment and updates the local fetch to simulate it correctly.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
