### PR TITLE
feat(cdp): add hubspot event template

### DIFF
--- a/posthog/cdp/templates/__init__.py
+++ b/posthog/cdp/templates/__init__.py
@@ -1,6 +1,6 @@
 from .webhook.template_webhook import template as webhook
 from .slack.template_slack import template as slack
-from .hubspot.template_hubspot import template as hubspot, TemplateHubspotMigrator
+from .hubspot.template_hubspot import template_event as hubspot_event, template as hubspot, TemplateHubspotMigrator
 from .braze.template_braze import template as braze
 from .customerio.template_customerio import template as customerio, TemplateCustomerioMigrator
 from .intercom.template_intercom import template as intercom, TemplateIntercomMigrator
@@ -59,6 +59,7 @@ HOG_FUNCTION_TEMPLATES = [
     google_cloud_storage,
     google_pubsub,
     hubspot,
+    hubspot_event,
     intercom,
     june,
     klaviyo_event,

--- a/posthog/cdp/templates/helpers.py
+++ b/posthog/cdp/templates/helpers.py
@@ -12,7 +12,7 @@ class BaseHogFunctionTemplateTest(BaseTest):
     mock_fetch = MagicMock()
     mock_print = MagicMock()
     mock_posthog_capture = MagicMock()
-    fetch_responses = {}
+    fetch_responses: dict[str, dict[Any, Any]] = {}
 
     def setUp(self):
         super().setUp()

--- a/posthog/cdp/templates/helpers.py
+++ b/posthog/cdp/templates/helpers.py
@@ -12,6 +12,7 @@ class BaseHogFunctionTemplateTest(BaseTest):
     mock_fetch = MagicMock()
     mock_print = MagicMock()
     mock_posthog_capture = MagicMock()
+    fetch_responses = {}
 
     def setUp(self):
         super().setUp()
@@ -26,7 +27,8 @@ class BaseHogFunctionTemplateTest(BaseTest):
             side_effect=lambda *args: print("[DEBUG HogFunctionPostHogCapture]", *args)  # noqa: T201
         )
 
-    mock_fetch_response = lambda *args: {"status": 200, "body": {}}
+    def mock_fetch_response(self, url, *args):
+        return self.fetch_responses.get(url, {"status": 200, "body": {}})
 
     def get_mock_fetch_calls(self):
         # Return a simple array which is easier to debug

--- a/posthog/cdp/templates/hubspot/template_hubspot.py
+++ b/posthog/cdp/templates/hubspot/template_hubspot.py
@@ -114,14 +114,22 @@ let properties := {}
 
 for (let key, value in inputs.properties) {
     if (not empty(value)) {
-        properties[key] := value
+        if (typeof(value) in ('object', 'array', 'tuple')) {
+            properties[key] := jsonStringify(value)
+        } else {
+            properties[key] := value
+        }
     }
 }
 
 if (inputs.include_all_properties) {
     for (let key, value in event.properties) {
         if (not empty(value) and not key like '$%') {
-            properties[key] := value
+            if (typeof(value) in ('object', 'array', 'tuple')) {
+                properties[key] := jsonStringify(value)
+            } else {
+                properties[key] := value
+            }
         }
     }
 }

--- a/posthog/cdp/templates/hubspot/template_hubspot.py
+++ b/posthog/cdp/templates/hubspot/template_hubspot.py
@@ -153,7 +153,7 @@ fun getPropValueType(propValue) {
 
 fun getPropValueTypeDefinition(name, propValue) {
     let propType := typeof(propValue)
-    if (propType == 'string' or propType == 'object') {
+    if (propType == 'string' or propType == 'object' or propType == 'array' or propType == 'tuple') {
         return {
             'name': name,
             'label': name,

--- a/posthog/cdp/templates/hubspot/template_hubspot.py
+++ b/posthog/cdp/templates/hubspot/template_hubspot.py
@@ -110,6 +110,11 @@ if (empty(inputs.email)) {
     return
 }
 
+if (not match(event.event, '^([a-z])([a-z0-9_-])+$')) {
+    throw Error(f'Event name must start with a letter and can only contain lowercase letters, numbers, underscores, and hyphens. Not sending event: {event.event}')
+    return
+}
+
 let properties := {}
 
 for (let key, value in inputs.properties) {

--- a/posthog/cdp/templates/hubspot/template_hubspot.py
+++ b/posthog/cdp/templates/hubspot/template_hubspot.py
@@ -96,6 +96,210 @@ if (res.status == 200) {
     },
 )
 
+template_event: HogFunctionTemplate = HogFunctionTemplate(
+    status="beta",
+    id="template-hubspot-event",
+    name="Hubspot",
+    description="Send events to Hubspot.",
+    icon_url="/static/services/hubspot.png",
+    category=["CRM", "Customer Success"],
+    hog="""
+if (empty(inputs.email)) {
+    print('`email` input is empty. Not sending event.')
+    return
+}
+
+let properties := {}
+
+for (let key, value in inputs.properties) {
+    if (not empty(value)) {
+        properties[key] := value
+    }
+}
+
+if (inputs.include_all_properties) {
+    for (let key, value in event.properties) {
+        if (not empty(value) and not key like '$%') {
+            properties[key] := value
+        }
+    }
+}
+
+let eventSchema := fetch(f'https://api.hubapi.com/events/v3/event-definitions/{event.event}/?includeProperties=true', {
+    'method': 'GET',
+    'headers': {
+        'Authorization': f'Bearer {inputs.oauth.access_token}',
+        'Content-Type': 'application/json'
+    },
+})
+
+fun getPropValueType(propValue) {
+    let propType := typeof(propValue)
+    if (propType == 'string') {
+        return 'string'
+    } else if (propType == 'integer') {
+        return 'number'
+    } else if (propType == 'float') {
+        return 'number'
+    } else if (propType == 'boolean') {
+        return 'enumeration'
+    } else if (propType == 'object') {
+        return 'string'
+    } else {
+        return null
+    }
+}
+
+fun getPropValueTypeDefinition(name, propValue) {
+    let propType := typeof(propValue)
+    if (propType == 'string' or propType == 'object') {
+        return {
+            'name': name,
+            'label': name,
+            'type': 'string',
+            'description': f'{name} - (created by PostHog)'
+        }
+    } else if (propType == 'integer' or propType == 'float') {
+        return {
+            'name': name,
+            'label': name,
+            'type': 'number',
+            'description': f'{name} - (created by PostHog)'
+        }
+    } else if (propType == 'boolean') {
+        return {
+            'name': name,
+            'label': name,
+            'type': 'number',
+            'description': f'{name} - (created by PostHog)',
+            'options': [
+                {
+                    'label': 'true',
+                    'value': true,
+                    'hidden': false,
+                    'description': 'True',
+                    'displayOrder': 1
+                },
+                {
+                    'label': 'false',
+                    'value': false,
+                    'hidden': false,
+                    'description': 'False',
+                    'displayOrder': 2
+                }
+            ]
+        }
+    } else {
+        print('unsupported type for key', name)
+        return null
+    }
+}
+
+let fullyQualifiedName := ''
+
+if (eventSchema.status >= 400) {
+    let body := {
+        'label': event.event,
+        'name': event.event,
+        'description': f'{event.event} - (created by PostHog)',
+        'primaryObject': 'CONTACT',
+        'propertyDefinitions': []
+    }
+
+    for (let key, value in properties) {
+        body.propertyDefinitions := arrayPushBack(body.propertyDefinitions, getPropValueTypeDefinition(key, value))
+    }
+
+    let res := fetch('https://api.hubapi.com/events/v3/event-definitions', {
+        'method': 'POST',
+        'headers': {
+            'Authorization': f'Bearer {inputs.oauth.access_token}',
+            'Content-Type': 'application/json'
+        },
+        'body': body
+    })
+
+    if (res.status >= 400) {
+        throw Error(f'Error from api.hubapi.com api: {res.status}: {res.body}');
+    } else {
+        fullyQualifiedName := res.body.fullyQualifiedName
+    }
+} else {
+    fullyQualifiedName := eventSchema.body.fullyQualifiedName
+    for (let key, value in properties) {
+        if (not arrayExists(property -> property.name == key and property.type == getPropValueType(value), eventSchema.body.properties)) {
+            print('at least one property is missing or has an incorrect type')
+            // TODO: update event properties
+            return
+        }
+    }
+}
+
+let res := fetch('https://api.hubapi.com/events/v3/send', {
+    'method': 'POST',
+    'headers': {
+        'Authorization': f'Bearer {inputs.oauth.access_token}',
+        'Content-Type': 'application/json'
+    },
+    'body': {
+        'eventName': fullyQualifiedName,
+        'email': inputs.email,
+        'occurredAt': event.timestamp,
+        'properties': properties
+    }
+})
+
+if (res.status >= 400) {
+    throw Error(f'Error from api.hubapi.com api: {res.status}: {res.body}');
+}
+""".strip(),
+    inputs_schema=[
+        {
+            "key": "oauth",
+            "type": "integration",
+            "integration": "hubspot",
+            "label": "Hubspot connection",
+            "secret": False,
+            "required": True,
+        },
+        {
+            "key": "email",
+            "type": "string",
+            "label": "Email of the user",
+            "description": "Where to find the email for the contact to be created. You can use the filters section to filter out unwanted emails or internal users.",
+            "default": "{person.properties.email}",
+            "secret": False,
+            "required": True,
+        },
+        {
+            "key": "include_all_properties",
+            "type": "boolean",
+            "label": "Include all event properties",
+            "description": "If set, all event properties will be included. Individual properties can be overridden below.",
+            "default": False,
+            "secret": False,
+            "required": True,
+        },
+        {
+            "key": "properties",
+            "type": "dictionary",
+            "label": "Property mapping",
+            "description": "Map any event properties to Hubspot properties.",
+            "default": {
+                "price": "{event.properties.price}",
+                "currency": "USD",
+            },
+            "secret": False,
+            "required": True,
+        },
+    ],
+    filters={
+        "events": [{"id": "checkout", "name": "checkout", "type": "events", "order": 0}],
+        "actions": [],
+        "filter_test_accounts": True,
+    },
+)
+
 
 class TemplateHubspotMigrator(HogFunctionTemplateMigrator):
     plugin_url = "https://github.com/PostHog/hubspot-plugin"

--- a/posthog/cdp/templates/hubspot/template_hubspot.py
+++ b/posthog/cdp/templates/hubspot/template_hubspot.py
@@ -241,7 +241,7 @@ if (eventSchema.status >= 400) {
         if (not arrayExists(property -> property.name == key, eventSchema.body.properties)) {
             missingProperties := arrayPushBack(missingProperties, { 'key': key, 'value': value })
         } else if (not arrayExists(property -> property.name == key and property.type == getPropValueType(value), eventSchema.body.properties)) {
-            missingProperties := arrayPushBack(wrongTypeProperties, { 'key': key, 'value': value })
+            wrongTypeProperties := arrayPushBack(wrongTypeProperties, { 'key': key, 'value': value })
         }
     }
 
@@ -263,7 +263,7 @@ if (eventSchema.status >= 400) {
     }
 
     if (not empty(wrongTypeProperties)) {
-        throw Error('Property type mismatch for the following properties: {wrongTypeProperties}. Not sending event.')
+        throw Error(f'Property type mismatch for the following properties: {wrongTypeProperties}. Not sending event.')
     }
 }
 

--- a/posthog/cdp/templates/hubspot/test_template_hubspot.py
+++ b/posthog/cdp/templates/hubspot/test_template_hubspot.py
@@ -344,7 +344,7 @@ class TestTemplateHubspotEvent(BaseHogFunctionTemplateTest):
 
         assert len(self.get_mock_fetch_calls()) == snapshot(1)
         assert (
-            e.value.message  # type: ignore[attr-defined]
+            e.value.message
             == "Property type mismatch for the following properties: [{'key': 'price', 'value': '50 coins'}]. Not sending event."
         )
 

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -166,7 +166,7 @@ class OauthIntegration:
                 token_info_config_fields=["hub_id", "hub_domain", "user", "user_id"],
                 client_id=settings.HUBSPOT_APP_CLIENT_ID,
                 client_secret=settings.HUBSPOT_APP_CLIENT_SECRET,
-                scope="tickets crm.objects.contacts.write sales-email-read crm.objects.companies.read crm.objects.deals.read crm.objects.contacts.read crm.objects.quotes.read",
+                scope="tickets crm.objects.contacts.write sales-email-read crm.objects.companies.read crm.objects.deals.read crm.objects.contacts.read crm.objects.quotes.read analytics.behavioral_events.send behavioral_events.event_definitions.read_write",
                 id_path="hub_id",
                 name_path="hub_domain",
             )


### PR DESCRIPTION
## Problem

It's not possible to send individual events to Hubspot

## Changes

- adds Hubspot event template
- adds the ability to mock individual endpoints ([example](https://github.com/PostHog/posthog/pull/25920/files#diff-ab2f17b4c2775b61106dbf94ea40621bef43f8f448e34739cd3ad3282f7df241R147-R156))

TODO:
- [x] Add tests
- [x] create new event definitions
- [x] adjust hubspot property definitions
- [x] update hubspot scopes (add `analytics.behavioral_events.send behavioral_events.event_definitions.read_write`)
