### PR TITLE
fix: Fix missing type on action migration

### DIFF
--- a/posthog/management/commands/migrate_action_webhooks.py
+++ b/posthog/management/commands/migrate_action_webhooks.py
@@ -129,6 +129,7 @@ def convert_to_hog_function(action: Action, inert=False) -> Optional[HogFunction
         hog_name = f"[CDP-TEST-HIDDEN] {hog_name}"
     hog_function = HogFunction(
         name=hog_name,
+        type="destination",
         description="Automatically migrated from legacy action webhooks",
         team_id=action.team_id,
         inputs=validate_inputs(


### PR DESCRIPTION
## Problem

We added a type field but didn't set it when migrating an action which isn't good.

## Changes

* This fixes the missing type, hopefully in turn fixing the issue overall

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
