### PR TITLE
chore: remove all references to ErrorTrackingGroup

### DIFF
--- a/posthog/api/__init__.py
+++ b/posthog/api/__init__.py
@@ -28,7 +28,6 @@ from . import (
     dead_letter_queue,
     debug_ch_queries,
     early_access_feature,
-    error_tracking,
     event_definition,
     exports,
     feature_flag,
@@ -500,12 +499,12 @@ projects_router.register(
     ["project_id"],
 )
 
-projects_router.register(
-    r"error_tracking",
-    error_tracking.ErrorTrackingGroupViewSet,
-    "project_error_tracking",
-    ["team_id"],
-)
+# projects_router.register(
+#     r"error_tracking",
+#     error_tracking.ErrorTrackingGroupViewSet,
+#     "project_error_tracking",
+#     ["team_id"],
+# )
 
 projects_router.register(
     r"comments",

--- a/posthog/api/error_tracking.py
+++ b/posthog/api/error_tracking.py
@@ -1,19 +1,5 @@
-import json
 import structlog
 
-from rest_framework import serializers, viewsets, status
-from rest_framework.response import Response
-from rest_framework.exceptions import ValidationError
-
-from django.db.models import QuerySet
-from django.conf import settings
-from django.utils.http import urlsafe_base64_decode
-
-from posthog.api.forbid_destroy_model import ForbidDestroyModel
-from posthog.models.error_tracking import ErrorTrackingGroup
-from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.api.utils import action
-from posthog.storage import object_storage
 
 FIFTY_MEGABYTES = 50 * 1024 * 1024
 
@@ -24,48 +10,48 @@ class ObjectStorageUnavailable(Exception):
     pass
 
 
-class ErrorTrackingGroupSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = ErrorTrackingGroup
-        fields = ["assignee", "status"]
+# class ErrorTrackingGroupSerializer(serializers.ModelSerializer):
+#     class Meta:
+#         model = ErrorTrackingGroup
+#         fields = ["assignee", "status"]
 
 
-class ErrorTrackingGroupViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):
-    scope_object = "INTERNAL"
-    queryset = ErrorTrackingGroup.objects.all()
-    serializer_class = ErrorTrackingGroupSerializer
+# class ErrorTrackingGroupViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):
+#     scope_object = "INTERNAL"
+#     queryset = ErrorTrackingGroup.objects.all()
+#     serializer_class = ErrorTrackingGroupSerializer
 
-    def safely_get_object(self, queryset) -> QuerySet:
-        stringified_fingerprint = self.kwargs["pk"]
-        fingerprint = json.loads(urlsafe_base64_decode(stringified_fingerprint))
-        group, _ = queryset.get_or_create(fingerprint=fingerprint, team=self.team)
-        return group
+#     def safely_get_object(self, queryset) -> QuerySet:
+#         stringified_fingerprint = self.kwargs["pk"]
+#         fingerprint = json.loads(urlsafe_base64_decode(stringified_fingerprint))
+#         group, _ = queryset.get_or_create(fingerprint=fingerprint, team=self.team)
+#         return group
 
-    @action(methods=["POST"], detail=True)
-    def merge(self, request, **kwargs):
-        group: ErrorTrackingGroup = self.get_object()
-        merging_fingerprints: list[list[str]] = request.data.get("merging_fingerprints", [])
-        group.merge(merging_fingerprints)
-        return Response({"success": True})
+#     @action(methods=["POST"], detail=True)
+#     def merge(self, request, **kwargs):
+#         group: ErrorTrackingGroup = self.get_object()
+#         merging_fingerprints: list[list[str]] = request.data.get("merging_fingerprints", [])
+#         group.merge(merging_fingerprints)
+#         return Response({"success": True})
 
-    @action(methods=["POST"], detail=False)
-    def upload_source_maps(self, request, **kwargs):
-        try:
-            if settings.OBJECT_STORAGE_ENABLED:
-                file = request.FILES["source_map"]
-                if file.size > FIFTY_MEGABYTES:
-                    raise ValidationError(code="file_too_large", detail="Source maps must be less than 50MB")
+#     @action(methods=["POST"], detail=False)
+#     def upload_source_maps(self, request, **kwargs):
+#         try:
+#             if settings.OBJECT_STORAGE_ENABLED:
+#                 file = request.FILES["source_map"]
+#                 if file.size > FIFTY_MEGABYTES:
+#                     raise ValidationError(code="file_too_large", detail="Source maps must be less than 50MB")
 
-                upload_path = (
-                    f"{settings.OBJECT_STORAGE_ERROR_TRACKING_SOURCE_MAPS_FOLDER}/team-{self.team_id}/{file.name}"
-                )
+#                 upload_path = (
+#                     f"{settings.OBJECT_STORAGE_ERROR_TRACKING_SOURCE_MAPS_FOLDER}/team-{self.team_id}/{file.name}"
+#                 )
 
-                object_storage.write(upload_path, file)
-                return Response({"ok": True}, status=status.HTTP_201_CREATED)
-            else:
-                raise ObjectStorageUnavailable()
-        except ObjectStorageUnavailable:
-            raise ValidationError(
-                code="object_storage_required",
-                detail="Object storage must be available to allow source map uploads.",
-            )
+#                 object_storage.write(upload_path, file)
+#                 return Response({"ok": True}, status=status.HTTP_201_CREATED)
+#             else:
+#                 raise ObjectStorageUnavailable()
+#         except ObjectStorageUnavailable:
+#             raise ValidationError(
+#                 code="object_storage_required",
+#                 detail="Object storage must be available to allow source map uploads.",
+#             )

--- a/posthog/api/test/test_error_tracking.py
+++ b/posthog/api/test/test_error_tracking.py
@@ -1,11 +1,8 @@
 import os
 import json
 from boto3 import resource
-from rest_framework import status
 
 from django.utils.http import urlsafe_base64_encode
-from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import override_settings
 
 from posthog.test.base import APIBaseTest
 from botocore.config import Config
@@ -91,41 +88,41 @@ class TestErrorTracking(APIBaseTest):
     #     groups = ErrorTrackingGroup.objects.only("merged_fingerprints")
     #     self.assertEqual(groups[0].merged_fingerprints, merging_fingerprints)
 
-    def test_can_upload_a_source_map(self) -> None:
-        with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_ERROR_TRACKING_SOURCE_MAPS_FOLDER=TEST_BUCKET):
-            with open(get_path_to("source.js.map"), "rb") as image:
-                response = self.client.post(
-                    f"/api/projects/{self.team.id}/error_tracking/upload_source_maps",
-                    {"source_map": image},
-                    format="multipart",
-                )
-                self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+    # def test_can_upload_a_source_map(self) -> None:
+    #     with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_ERROR_TRACKING_SOURCE_MAPS_FOLDER=TEST_BUCKET):
+    #         with open(get_path_to("source.js.map"), "rb") as image:
+    #             response = self.client.post(
+    #                 f"/api/projects/{self.team.id}/error_tracking/upload_source_maps",
+    #                 {"source_map": image},
+    #                 format="multipart",
+    #             )
+    #             self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
 
-    def test_rejects_too_large_file_type(self) -> None:
-        fifty_megabytes_plus_a_little = b"1" * (50 * 1024 * 1024 + 1)
-        fake_big_file = SimpleUploadedFile(
-            name="large_source.js.map",
-            content=fifty_megabytes_plus_a_little,
-            content_type="text/plain",
-        )
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/error_tracking/upload_source_maps",
-            {"source_map": fake_big_file},
-            format="multipart",
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
-        self.assertEqual(response.json()["detail"], "Source maps must be less than 50MB")
+    # def test_rejects_too_large_file_type(self) -> None:
+    #     fifty_megabytes_plus_a_little = b"1" * (50 * 1024 * 1024 + 1)
+    #     fake_big_file = SimpleUploadedFile(
+    #         name="large_source.js.map",
+    #         content=fifty_megabytes_plus_a_little,
+    #         content_type="text/plain",
+    #     )
+    #     response = self.client.post(
+    #         f"/api/projects/{self.team.id}/error_tracking/upload_source_maps",
+    #         {"source_map": fake_big_file},
+    #         format="multipart",
+    #     )
+    #     self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+    #     self.assertEqual(response.json()["detail"], "Source maps must be less than 50MB")
 
-    def test_rejects_upload_when_object_storage_is_unavailable(self) -> None:
-        with override_settings(OBJECT_STORAGE_ENABLED=False):
-            fake_big_file = SimpleUploadedFile(name="large_source.js.map", content=b"", content_type="text/plain")
-            response = self.client.post(
-                f"/api/projects/{self.team.id}/error_tracking/upload_source_maps",
-                {"source_map": fake_big_file},
-                format="multipart",
-            )
-            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
-            self.assertEqual(
-                response.json()["detail"],
-                "Object storage must be available to allow source map uploads.",
-            )
+    # def test_rejects_upload_when_object_storage_is_unavailable(self) -> None:
+    #     with override_settings(OBJECT_STORAGE_ENABLED=False):
+    #         fake_big_file = SimpleUploadedFile(name="large_source.js.map", content=b"", content_type="text/plain")
+    #         response = self.client.post(
+    #             f"/api/projects/{self.team.id}/error_tracking/upload_source_maps",
+    #             {"source_map": fake_big_file},
+    #             format="multipart",
+    #         )
+    #         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+    #         self.assertEqual(
+    #             response.json()["detail"],
+    #             "Object storage must be available to allow source map uploads.",
+    #         )

--- a/posthog/api/test/test_error_tracking.py
+++ b/posthog/api/test/test_error_tracking.py
@@ -8,7 +8,6 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
 
 from posthog.test.base import APIBaseTest
-from posthog.models import Team, ErrorTrackingGroup
 from botocore.config import Config
 from posthog.settings import (
     OBJECT_STORAGE_ENDPOINT,
@@ -46,51 +45,51 @@ class TestErrorTracking(APIBaseTest):
             data=data,
         )
 
-    def test_reuses_existing_group_for_team(self):
-        fingerprint = ["CustomFingerprint"]
-        ErrorTrackingGroup.objects.create(fingerprint=fingerprint, team=self.team)
+    # def test_reuses_existing_group_for_team(self):
+    #     fingerprint = ["CustomFingerprint"]
+    #     ErrorTrackingGroup.objects.create(fingerprint=fingerprint, team=self.team)
 
-        self.assertEqual(ErrorTrackingGroup.objects.count(), 1)
-        self.send_request(fingerprint, {"assignee": self.user.id})
-        self.assertEqual(ErrorTrackingGroup.objects.count(), 1)
+    #     self.assertEqual(ErrorTrackingGroup.objects.count(), 1)
+    #     self.send_request(fingerprint, {"assignee": self.user.id})
+    #     self.assertEqual(ErrorTrackingGroup.objects.count(), 1)
 
-    def test_creates_group_if_not_already_existing_for_team(self):
-        fingerprint = ["CustomFingerprint"]
-        other_team = Team.objects.create(organization=self.organization)
-        ErrorTrackingGroup.objects.create(fingerprint=fingerprint, team=other_team)
+    # def test_creates_group_if_not_already_existing_for_team(self):
+    #     fingerprint = ["CustomFingerprint"]
+    #     other_team = Team.objects.create(organization=self.organization)
+    #     ErrorTrackingGroup.objects.create(fingerprint=fingerprint, team=other_team)
 
-        self.assertEqual(ErrorTrackingGroup.objects.count(), 1)
-        self.send_request(fingerprint, {"assignee": self.user.id})
-        self.assertEqual(ErrorTrackingGroup.objects.count(), 2)
+    #     self.assertEqual(ErrorTrackingGroup.objects.count(), 1)
+    #     self.send_request(fingerprint, {"assignee": self.user.id})
+    #     self.assertEqual(ErrorTrackingGroup.objects.count(), 2)
 
-    def test_can_only_update_allowed_fields(self):
-        fingerprint = ["CustomFingerprint"]
-        other_team = Team.objects.create(organization=self.organization)
-        group = ErrorTrackingGroup.objects.create(fingerprint=fingerprint, team=other_team)
+    # def test_can_only_update_allowed_fields(self):
+    #     fingerprint = ["CustomFingerprint"]
+    #     other_team = Team.objects.create(organization=self.organization)
+    #     group = ErrorTrackingGroup.objects.create(fingerprint=fingerprint, team=other_team)
 
-        self.send_request(fingerprint, {"fingerprint": ["NewFingerprint"], "assignee": self.user.id})
-        group.refresh_from_db()
-        self.assertEqual(group.fingerprint, ["CustomFingerprint"])
+    #     self.send_request(fingerprint, {"fingerprint": ["NewFingerprint"], "assignee": self.user.id})
+    #     group.refresh_from_db()
+    #     self.assertEqual(group.fingerprint, ["CustomFingerprint"])
 
-    def test_merging_of_an_existing_group(self):
-        fingerprint = ["CustomFingerprint"]
-        merging_fingerprints = [["NewFingerprint"]]
-        group = ErrorTrackingGroup.objects.create(fingerprint=fingerprint, team=self.team)
+    # def test_merging_of_an_existing_group(self):
+    #     fingerprint = ["CustomFingerprint"]
+    #     merging_fingerprints = [["NewFingerprint"]]
+    #     group = ErrorTrackingGroup.objects.create(fingerprint=fingerprint, team=self.team)
 
-        self.send_request(fingerprint, {"merging_fingerprints": merging_fingerprints}, endpoint="merge")
+    #     self.send_request(fingerprint, {"merging_fingerprints": merging_fingerprints}, endpoint="merge")
 
-        group.refresh_from_db()
-        self.assertEqual(group.merged_fingerprints, merging_fingerprints)
+    #     group.refresh_from_db()
+    #     self.assertEqual(group.merged_fingerprints, merging_fingerprints)
 
-    def test_merging_when_no_group_exists(self):
-        fingerprint = ["CustomFingerprint"]
-        merging_fingerprints = [["NewFingerprint"]]
+    # def test_merging_when_no_group_exists(self):
+    #     fingerprint = ["CustomFingerprint"]
+    #     merging_fingerprints = [["NewFingerprint"]]
 
-        self.assertEqual(ErrorTrackingGroup.objects.count(), 0)
-        self.send_request(fingerprint, {"merging_fingerprints": merging_fingerprints}, endpoint="merge")
-        self.assertEqual(ErrorTrackingGroup.objects.count(), 1)
-        groups = ErrorTrackingGroup.objects.only("merged_fingerprints")
-        self.assertEqual(groups[0].merged_fingerprints, merging_fingerprints)
+    #     self.assertEqual(ErrorTrackingGroup.objects.count(), 0)
+    #     self.send_request(fingerprint, {"merging_fingerprints": merging_fingerprints}, endpoint="merge")
+    #     self.assertEqual(ErrorTrackingGroup.objects.count(), 1)
+    #     groups = ErrorTrackingGroup.objects.only("merged_fingerprints")
+    #     self.assertEqual(groups[0].merged_fingerprints, merging_fingerprints)
 
     def test_can_upload_a_source_map(self) -> None:
         with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_ERROR_TRACKING_SOURCE_MAPS_FOLDER=TEST_BUCKET):

--- a/posthog/hogql_queries/error_tracking_query_runner.py
+++ b/posthog/hogql_queries/error_tracking_query_runner.py
@@ -10,7 +10,6 @@ from posthog.schema import (
     CachedErrorTrackingQueryResponse,
 )
 from posthog.hogql.parser import parse_expr
-from posthog.models.error_tracking import ErrorTrackingGroup
 from posthog.models.filters.mixins.utils import cached_property
 
 
@@ -240,7 +239,8 @@ class ErrorTrackingQueryRunner(QueryRunner):
                 "fingerprint": fingerprint,
                 "assignee": None,
                 "merged_fingerprints": [],
-                "status": str(ErrorTrackingGroup.Status.ACTIVE),
+                "status": "active",
+                # "status": str(ErrorTrackingGroup.Status.ACTIVE),
             },
         )
 
@@ -269,18 +269,19 @@ class ErrorTrackingQueryRunner(QueryRunner):
 
     @cached_property
     def error_tracking_groups(self):
-        queryset = ErrorTrackingGroup.objects.filter(team=self.team)
-        # :TRICKY: Ideally we'd have no null characters in the fingerprint, but if something made it into the pipeline with null characters
-        # (because rest of the system supports it), try cleaning it up here. Make sure this cleaning is consistent with the rest of the system.
-        cleaned_fingerprint = [part.replace("\x00", "\ufffd") for part in self.query.fingerprint or []]
-        queryset = (
-            queryset.filter(fingerprint=cleaned_fingerprint)
-            if self.query.fingerprint
-            else queryset.filter(status__in=[ErrorTrackingGroup.Status.ACTIVE])
-        )
-        queryset = queryset.filter(assignee=self.query.assignee) if self.query.assignee else queryset
-        groups = queryset.values("fingerprint", "merged_fingerprints", "status", "assignee")
-        return {str(item["fingerprint"]): item for item in groups}
+        return {}
+        # queryset = ErrorTrackingGroup.objects.filter(team=self.team)
+        # # :TRICKY: Ideally we'd have no null characters in the fingerprint, but if something made it into the pipeline with null characters
+        # # (because rest of the system supports it), try cleaning it up here. Make sure this cleaning is consistent with the rest of the system.
+        # cleaned_fingerprint = [part.replace("\x00", "\ufffd") for part in self.query.fingerprint or []]
+        # queryset = (
+        #     queryset.filter(fingerprint=cleaned_fingerprint)
+        #     if self.query.fingerprint
+        #     else queryset.filter(status__in=[ErrorTrackingGroup.Status.ACTIVE])
+        # )
+        # queryset = queryset.filter(assignee=self.query.assignee) if self.query.assignee else queryset
+        # groups = queryset.values("fingerprint", "merged_fingerprints", "status", "assignee")
+        # return {str(item["fingerprint"]): item for item in groups}
 
 
 def search_tokenizer(query: str) -> list[str]:

--- a/posthog/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/posthog/hogql_queries/test/test_error_tracking_query_runner.py
@@ -19,9 +19,6 @@ from posthog.test.base import (
     _create_event,
     flush_persons_and_events,
 )
-from posthog.models import ErrorTrackingGroup
-from datetime import datetime
-from zoneinfo import ZoneInfo
 
 SAMPLE_STACK_TRACE = [
     {
@@ -588,86 +585,86 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, APIBaseTest):
         # two errors exist for person with distinct_id_two
         self.assertEqual(len(results), 2)
 
-    def test_merges_and_defaults_groups(self):
-        ErrorTrackingGroup.objects.create(
-            team=self.team,
-            fingerprint=["SyntaxError"],
-            merged_fingerprints=[["custom_fingerprint"]],
-            assignee=self.user,
-        )
+    # def test_merges_and_defaults_groups(self):
+    #     ErrorTrackingGroup.objects.create(
+    #         team=self.team,
+    #         fingerprint=["SyntaxError"],
+    #         merged_fingerprints=[["custom_fingerprint"]],
+    #         assignee=self.user,
+    #     )
 
-        runner = ErrorTrackingQueryRunner(
-            team=self.team,
-            query=ErrorTrackingQuery(
-                kind="ErrorTrackingQuery", fingerprint=None, dateRange=DateRange(), order="occurrences"
-            ),
-        )
+    #     runner = ErrorTrackingQueryRunner(
+    #         team=self.team,
+    #         query=ErrorTrackingQuery(
+    #             kind="ErrorTrackingQuery", fingerprint=None, dateRange=DateRange(), order="occurrences"
+    #         ),
+    #     )
 
-        results = self._calculate(runner)["results"]
-        self.assertEqual(
-            results,
-            [
-                {
-                    "assignee": self.user.id,
-                    "description": "this is the same error message",
-                    "exception_type": "SyntaxError",
-                    "fingerprint": ["SyntaxError"],
-                    "first_seen": datetime(2020, 1, 10, 12, 11, tzinfo=ZoneInfo("UTC")),
-                    "last_seen": datetime(2020, 1, 10, 12, 11, tzinfo=ZoneInfo("UTC")),
-                    "merged_fingerprints": [["custom_fingerprint"]],
-                    # count is (2 x SyntaxError) + (1 x custom_fingerprint)
-                    "occurrences": 3,
-                    "sessions": 1,
-                    "users": 2,
-                    "volume": None,
-                    "status": ErrorTrackingGroup.Status.ACTIVE,
-                },
-                {
-                    "assignee": None,
-                    "description": None,
-                    "exception_type": "TypeError",
-                    "fingerprint": ["TypeError"],
-                    "first_seen": datetime(2020, 1, 10, 12, 11, tzinfo=ZoneInfo("UTC")),
-                    "last_seen": datetime(2020, 1, 10, 12, 11, tzinfo=ZoneInfo("UTC")),
-                    "merged_fingerprints": [],
-                    "occurrences": 1,
-                    "sessions": 1,
-                    "users": 1,
-                    "volume": None,
-                    "status": ErrorTrackingGroup.Status.ACTIVE,
-                },
-            ],
-        )
+    #     results = self._calculate(runner)["results"]
+    #     self.assertEqual(
+    #         results,
+    #         [
+    #             {
+    #                 "assignee": self.user.id,
+    #                 "description": "this is the same error message",
+    #                 "exception_type": "SyntaxError",
+    #                 "fingerprint": ["SyntaxError"],
+    #                 "first_seen": datetime(2020, 1, 10, 12, 11, tzinfo=ZoneInfo("UTC")),
+    #                 "last_seen": datetime(2020, 1, 10, 12, 11, tzinfo=ZoneInfo("UTC")),
+    #                 "merged_fingerprints": [["custom_fingerprint"]],
+    #                 # count is (2 x SyntaxError) + (1 x custom_fingerprint)
+    #                 "occurrences": 3,
+    #                 "sessions": 1,
+    #                 "users": 2,
+    #                 "volume": None,
+    #                 "status": ErrorTrackingGroup.Status.ACTIVE,
+    #             },
+    #             {
+    #                 "assignee": None,
+    #                 "description": None,
+    #                 "exception_type": "TypeError",
+    #                 "fingerprint": ["TypeError"],
+    #                 "first_seen": datetime(2020, 1, 10, 12, 11, tzinfo=ZoneInfo("UTC")),
+    #                 "last_seen": datetime(2020, 1, 10, 12, 11, tzinfo=ZoneInfo("UTC")),
+    #                 "merged_fingerprints": [],
+    #                 "occurrences": 1,
+    #                 "sessions": 1,
+    #                 "users": 1,
+    #                 "volume": None,
+    #                 "status": ErrorTrackingGroup.Status.ACTIVE,
+    #             },
+    #         ],
+    #     )
 
-    @snapshot_clickhouse_queries
-    def test_assignee_groups(self):
-        ErrorTrackingGroup.objects.create(
-            team=self.team,
-            fingerprint=["SyntaxError"],
-            assignee=self.user,
-        )
-        ErrorTrackingGroup.objects.create(
-            team=self.team,
-            fingerprint=["custom_fingerprint"],
-            assignee=self.user,
-        )
-        ErrorTrackingGroup.objects.create(
-            team=self.team,
-            fingerprint=["TypeError"],
-        )
+    # @snapshot_clickhouse_queries
+    # def test_assignee_groups(self):
+    #     ErrorTrackingGroup.objects.create(
+    #         team=self.team,
+    #         fingerprint=["SyntaxError"],
+    #         assignee=self.user,
+    #     )
+    #     ErrorTrackingGroup.objects.create(
+    #         team=self.team,
+    #         fingerprint=["custom_fingerprint"],
+    #         assignee=self.user,
+    #     )
+    #     ErrorTrackingGroup.objects.create(
+    #         team=self.team,
+    #         fingerprint=["TypeError"],
+    #     )
 
-        runner = ErrorTrackingQueryRunner(
-            team=self.team,
-            query=ErrorTrackingQuery(
-                kind="ErrorTrackingQuery",
-                dateRange=DateRange(),
-                assignee=self.user.pk,
-            ),
-        )
+    #     runner = ErrorTrackingQueryRunner(
+    #         team=self.team,
+    #         query=ErrorTrackingQuery(
+    #             kind="ErrorTrackingQuery",
+    #             dateRange=DateRange(),
+    #             assignee=self.user.pk,
+    #         ),
+    #     )
 
-        results = self._calculate(runner)["results"]
+    #     results = self._calculate(runner)["results"]
 
-        self.assertEqual(sorted([x["fingerprint"] for x in results]), [["SyntaxError"], ["custom_fingerprint"]])
+    #     self.assertEqual(sorted([x["fingerprint"] for x in results]), [["SyntaxError"], ["custom_fingerprint"]])
 
 
 class TestSearchTokenizer(TestCase):

--- a/posthog/models/error_tracking/test/test_error_tracking.py
+++ b/posthog/models/error_tracking/test/test_error_tracking.py
@@ -1,64 +1,60 @@
-from posthog.models.error_tracking import ErrorTrackingGroup
-from posthog.test.base import BaseTest
+# class TestErrorTracking(BaseTest):
+#     def test_defaults(self):
+#         group = ErrorTrackingGroup.objects.create(status="active", team=self.team, fingerprint=["a_fingerprint"])
 
+#         assert group.fingerprint == ["a_fingerprint"]
+#         assert group.merged_fingerprints == []
+#         assert group.assignee is None
 
-class TestErrorTracking(BaseTest):
-    def test_defaults(self):
-        group = ErrorTrackingGroup.objects.create(status="active", team=self.team, fingerprint=["a_fingerprint"])
+#     def test_filtering(self):
+#         ErrorTrackingGroup.objects.bulk_create(
+#             [
+#                 ErrorTrackingGroup(team=self.team, fingerprint=["first_error"]),
+#                 ErrorTrackingGroup(
+#                     team=self.team, fingerprint=["second_error"], merged_fingerprints=[["previously_merged"]]
+#                 ),
+#                 ErrorTrackingGroup(team=self.team, fingerprint=["third_error"]),
+#             ]
+#         )
 
-        assert group.fingerprint == ["a_fingerprint"]
-        assert group.merged_fingerprints == []
-        assert group.assignee is None
+#         matching_groups = ErrorTrackingGroup.objects.filter(fingerprint__in=[["first_error"], ["second_error"]])
+#         assert matching_groups.count() == 2
 
-    def test_filtering(self):
-        ErrorTrackingGroup.objects.bulk_create(
-            [
-                ErrorTrackingGroup(team=self.team, fingerprint=["first_error"]),
-                ErrorTrackingGroup(
-                    team=self.team, fingerprint=["second_error"], merged_fingerprints=[["previously_merged"]]
-                ),
-                ErrorTrackingGroup(team=self.team, fingerprint=["third_error"]),
-            ]
-        )
+#         matching_groups = ErrorTrackingGroup.objects.filter(merged_fingerprints__contains=["previously_merged"])
+#         assert matching_groups.count() == 1
 
-        matching_groups = ErrorTrackingGroup.objects.filter(fingerprint__in=[["first_error"], ["second_error"]])
-        assert matching_groups.count() == 2
+#         matching_groups = ErrorTrackingGroup.filter_fingerprints(
+#             queryset=ErrorTrackingGroup.objects, fingerprints=[["first_error"], ["previously_merged"]]
+#         )
+#         assert matching_groups.count() == 2
 
-        matching_groups = ErrorTrackingGroup.objects.filter(merged_fingerprints__contains=["previously_merged"])
-        assert matching_groups.count() == 1
+#     def test_merge(self):
+#         primary_group = ErrorTrackingGroup.objects.create(
+#             status="active",
+#             team=self.team,
+#             fingerprint=["a_fingerprint"],
+#             merged_fingerprints=[["already_merged_fingerprint"]],
+#         )
+#         merge_group_1 = ErrorTrackingGroup.objects.create(
+#             status="active", team=self.team, fingerprint=["new_fingerprint"]
+#         )
+#         merge_group_2 = ErrorTrackingGroup.objects.create(
+#             status="active",
+#             team=self.team,
+#             fingerprint=["another_fingerprint"],
+#             merged_fingerprints=[["merged_fingerprint"]],
+#         )
 
-        matching_groups = ErrorTrackingGroup.filter_fingerprints(
-            queryset=ErrorTrackingGroup.objects, fingerprints=[["first_error"], ["previously_merged"]]
-        )
-        assert matching_groups.count() == 2
+#         merging_fingerprints = [merge_group_1.fingerprint, merge_group_2.fingerprint, ["no_group_fingerprint"]]
+#         primary_group.merge(merging_fingerprints)
 
-    def test_merge(self):
-        primary_group = ErrorTrackingGroup.objects.create(
-            status="active",
-            team=self.team,
-            fingerprint=["a_fingerprint"],
-            merged_fingerprints=[["already_merged_fingerprint"]],
-        )
-        merge_group_1 = ErrorTrackingGroup.objects.create(
-            status="active", team=self.team, fingerprint=["new_fingerprint"]
-        )
-        merge_group_2 = ErrorTrackingGroup.objects.create(
-            status="active",
-            team=self.team,
-            fingerprint=["another_fingerprint"],
-            merged_fingerprints=[["merged_fingerprint"]],
-        )
+#         assert sorted(primary_group.merged_fingerprints) == [
+#             ["already_merged_fingerprint"],
+#             ["another_fingerprint"],
+#             ["merged_fingerprint"],
+#             ["new_fingerprint"],
+#             ["no_group_fingerprint"],
+#         ]
 
-        merging_fingerprints = [merge_group_1.fingerprint, merge_group_2.fingerprint, ["no_group_fingerprint"]]
-        primary_group.merge(merging_fingerprints)
-
-        assert sorted(primary_group.merged_fingerprints) == [
-            ["already_merged_fingerprint"],
-            ["another_fingerprint"],
-            ["merged_fingerprint"],
-            ["new_fingerprint"],
-            ["no_group_fingerprint"],
-        ]
-
-        # deletes the old groups
-        assert ErrorTrackingGroup.objects.count() == 1
+#         # deletes the old groups
+#         assert ErrorTrackingGroup.objects.count() == 1


### PR DESCRIPTION
## Problem

Prerequisite to https://github.com/PostHog/posthog/pull/25924

## Changes

I would like the migration that deletes the two tables we no longer need to be as clean as possible. Hence removing all usages of them for now. Only commenting because will re-add in the next day or so once we get the new tables spun up.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Everything should pass