### PR TITLE
feat: Use the CDP Api endpoint for proper scheduling

### DIFF
--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -237,10 +237,10 @@ export class CdpApi {
                             url: `${this.hub.SITE_URL ?? 'http://localhost:8000'}/project/${team.id}`,
                         },
                     },
-                    hogFunction
+                    hogFunction,
                     // The "email" hog functions export a "sendEmail" function that we must explicitly call
                     // BW - This feels super tricky. We have specific functions for specific things? Why don't we just invoke the function as it is with the required globals like any other function?
-                    // hogFunction.type === 'email' ? ['sendEmail', [x.email]] : undefined
+                    hogFunction.type === 'email' ? ['sendEmail', [x.email]] : undefined
                 )
             )
 


### PR DESCRIPTION
## Problem

Followed up from Marius' work to look at having a more standard way of queueing work that isn't kafka. Took me a bit to get my head around what was going on so there is still a lot to do here.

## Changes

* Starts modifying the invoke endpoint so that we can really queue the message and get the returned invocation IDs (for testing / displaying metrics about success rates)
* The alternative would be a kafka topic but for now this gets us the same outcome with less infra changes

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
