### PR TITLE
fix: allow dashboard refresh on min next allowed client refresh

### DIFF
--- a/frontend/src/lib/dayjs.ts
+++ b/frontend/src/lib/dayjs.ts
@@ -4,6 +4,7 @@ import duration from 'dayjs/plugin/duration'
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
 import LocalizedFormat from 'dayjs/plugin/localizedFormat'
+import minMax from 'dayjs/plugin/minMax'
 import quarterOfYear from 'dayjs/plugin/quarterOfYear'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import timezone from 'dayjs/plugin/timezone'
@@ -18,6 +19,7 @@ dayjs.extend(utc)
 dayjs.extend(timezone)
 dayjs.extend(duration)
 dayjs.extend(quarterOfYear)
+dayjs.extend(minMax)
 
 const now = (): Dayjs => dayjs()
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -888,10 +888,12 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     return []
                 }
 
-                const validDates = insightTiles
+                const validDates: Dayjs[] = insightTiles
                     .filter((i) => !!i.insight?.cache_target_age || !!i.insight?.next_allowed_client_refresh)
-                    .map((i) => dayjs(i.insight?.cache_target_age ?? i.insight?.next_allowed_client_refresh))
-                    .filter((date) => date.isValid())
+                    .map((i) =>
+                        dayjs.min(dayjs(i.insight?.cache_target_age), dayjs(i.insight?.next_allowed_client_refresh))
+                    )
+                    .filter((date) => date?.isValid()) as Dayjs[]
                 return sortDayJsDates(validDates)
             },
         ],


### PR DESCRIPTION
## Problem

Manual dashboard refresh is disabled for too long. Often for hours on short insights.

https://posthog.slack.com/archives/C06QZ97A6KH/p1730380591333989?thread_ts=1730292553.434939&cid=C06QZ97A6KH

## Changes

Change the code to allow manual refresh based on the min of `cache_target_age` and `next_allowed_client_refresh`, instead of just taking cache_target_age before next_allowed_client_refresh.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Checked out local dashboard, saw that it had the same issue.
