### PR TITLE
fix(cdp): update authentication to use the basic header

### DIFF
--- a/posthog/cdp/templates/mailjet/template_mailjet.py
+++ b/posthog/cdp/templates/mailjet/template_mailjet.py
@@ -10,6 +10,13 @@ input_api_key = {
     "secret": True,
     "required": True,
 }
+input_secret_key = {
+    "key": "secret_key",
+    "type": "string",
+    "label": "Mailjet Secret Key",
+    "secret": True,
+    "required": True,
+}
 input_email = {
     "key": "email",
     "type": "string",
@@ -43,7 +50,7 @@ if (empty(inputs.email)) {
 fetch(f'https://api.mailjet.com/v3/REST/contact/', {
     'method': 'POST',
     'headers': {
-        'Authorization': f'Bearer {inputs.api_key}',
+        'Authorization': f'Basic {base64Encode(f'{inputs.api_key}:{inputs.secret_key}')}',
         'Content-Type': 'application/json'
     },
     'body': {
@@ -55,6 +62,7 @@ fetch(f'https://api.mailjet.com/v3/REST/contact/', {
 """.strip(),
     inputs_schema=[
         input_api_key,
+        input_secret_key,
         input_email,
         {
             "key": "name",
@@ -95,7 +103,7 @@ if (empty(inputs.email)) {
 fetch(f'https://api.mailjet.com/v3/REST/contact/{inputs.email}/managecontactlists', {
     'method': 'POST',
     'headers': {
-        'Authorization': f'Bearer {inputs.api_key}',
+        'Authorization': f'Basic {base64Encode(f'{inputs.api_key}:{inputs.secret_key}')}',
         'Content-Type': 'application/json'
     },
     'body': {
@@ -110,6 +118,7 @@ fetch(f'https://api.mailjet.com/v3/REST/contact/{inputs.email}/managecontactlist
 """.strip(),
     inputs_schema=[
         input_api_key,
+        input_secret_key,
         input_email,
         {
             "key": "contact_list_id",
@@ -163,7 +172,7 @@ fun sendEmail(email) {
     fetch(f'https://api.mailjet.com/v3.1/send', {
         'method': 'POST',
         'headers': {
-            'Authorization': f'Bearer {inputs.api_key}',
+            'Authorization': f'Basic {base64Encode(f'{inputs.api_key}:{inputs.secret_key}')}',
             'Content-Type': 'application/json'
         },
         'body': {
@@ -191,6 +200,7 @@ return {'sendEmail': sendEmail}
 """.strip(),
     inputs_schema=[
         input_api_key,
+        input_secret_key,
         {
             "key": "from_email",
             "type": "string",

--- a/posthog/cdp/templates/mailjet/test_template_mailjet.py
+++ b/posthog/cdp/templates/mailjet/test_template_mailjet.py
@@ -4,7 +4,7 @@ from posthog.cdp.templates.mailjet.template_mailjet import template_create_conta
 
 
 def create_inputs(**kwargs):
-    inputs = {"api_key": "API_KEY", "email": "example@posthog.com"}
+    inputs = {"api_key": "API_KEY", "secret_key": "SECRET_KEY", "email": "example@posthog.com"}
     inputs.update(kwargs)
     return inputs
 
@@ -20,7 +20,7 @@ class TestTemplateMailjetCreateContact(BaseHogFunctionTemplateTest):
                 "https://api.mailjet.com/v3/REST/contact/",
                 {
                     "method": "POST",
-                    "headers": {"Authorization": "Bearer API_KEY", "Content-Type": "application/json"},
+                    "headers": {"Authorization": "Basic QVBJX0tFWTpTRUNSRVRfS0VZ", "Content-Type": "application/json"},
                     "body": {"Email": "example@posthog.com", "Name": "Example", "IsExcludedFromCampaigns": False},
                 },
             )
@@ -43,7 +43,7 @@ class TestTemplateMailjetUpdateContactList(BaseHogFunctionTemplateTest):
                 "https://api.mailjet.com/v3/REST/contact/example@posthog.com/managecontactlists",
                 {
                     "method": "POST",
-                    "headers": {"Authorization": "Bearer API_KEY", "Content-Type": "application/json"},
+                    "headers": {"Authorization": "Basic QVBJX0tFWTpTRUNSRVRfS0VZ", "Content-Type": "application/json"},
                     "body": {"ContactsLists": [{"Action": "addnoforce", "ListID": 123}]},
                 },
             )


### PR DESCRIPTION
## Problem

Seems like the Mailjet destination never worked. https://posthoghelp.zendesk.com/agent/tickets/20146 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/22383)
They only supporting Basic headers for authentication https://dev.mailjet.com/email/reference/overview/authentication/

## Changes

- use basic headers instead

## How did you test this code?

updated tests
