### PR TITLE
fix(data-warehouse): Ensure the temporal context is copied into the heartbeat thread

### DIFF
--- a/posthog/temporal/common/heartbeat_sync.py
+++ b/posthog/temporal/common/heartbeat_sync.py
@@ -1,6 +1,7 @@
 import threading
 from typing import Any
 from temporalio import activity
+from contextvars import copy_context
 
 
 class HeartbeaterSync:
@@ -18,12 +19,13 @@ class HeartbeaterSync:
         if not heartbeat_timeout:
             return
 
+        context = copy_context()
         self.stop_event = threading.Event()
 
         interval = heartbeat_timeout.total_seconds() / self.factor
 
         self.heartbeat_thread = threading.Thread(
-            target=self.heartbeat_regularly, args=(self.stop_event, interval, self.details), daemon=True
+            target=context.run, args=(self.heartbeat_regularly, self.stop_event, interval, self.details), daemon=True
         )
         self.heartbeat_thread.start()
 


### PR DESCRIPTION
## Problem
- When spawning the heartbeat thread, we don't copy the temporal context and thus the heartbeat call fails 

## Changes
- Use `contextvars` ([as suggested by temporal](https://github.com/temporalio/sdk-python#synchronous-activities)) to copy the context into the newly spawned thread

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Debugged and tested locally 