### PR TITLE
chore(data-warehouse): Added logs to heartbeats

### DIFF
--- a/posthog/temporal/common/heartbeat_sync.py
+++ b/posthog/temporal/common/heartbeat_sync.py
@@ -1,17 +1,28 @@
 import threading
-from typing import Any
+from typing import Any, Optional
 from temporalio import activity
 from contextvars import copy_context
 
+from posthog.temporal.common.logger import FilteringBoundLogger
+
 
 class HeartbeaterSync:
-    def __init__(self, details: tuple[Any, ...] = (), factor: int = 12):
+    def __init__(self, details: tuple[Any, ...] = (), factor: int = 12, logger: Optional[FilteringBoundLogger] = None):
         self.details: tuple[Any, ...] = details
         self.factor = factor
+        self.logger = logger
+
+    def log_debug(self, message: str) -> None:
+        if self.logger:
+            self.logger.debug(message)
 
     def heartbeat_regularly(self, stop_event: threading.Event, interval: int, details: tuple[Any, ...]):
         while not stop_event.is_set():
-            activity.heartbeat(*details)
+            try:
+                activity.heartbeat(*details)
+                self.log_debug("Heartbeat")
+            except Exception as e:
+                self.log_debug(f"Heartbeat failed with {e}")
             stop_event.wait(interval)
 
     def __enter__(self):
@@ -24,14 +35,20 @@ class HeartbeaterSync:
 
         interval = heartbeat_timeout.total_seconds() / self.factor
 
+        self.log_debug(f"Heartbeat interval: {interval}s")
+
         self.heartbeat_thread = threading.Thread(
             target=context.run, args=(self.heartbeat_regularly, self.stop_event, interval, self.details), daemon=True
         )
+
+        self.log_debug("Starting heartbeat thread...")
         self.heartbeat_thread.start()
 
     def __exit__(self, *args, **kwargs):
         if self.stop_event is not None:
             self.stop_event.set()
+            self.log_debug("Heartbeat stop event set")
 
         if self.heartbeat_thread is not None:
             self.heartbeat_thread.join()
+            self.log_debug("Heartbeat thread joined")

--- a/posthog/temporal/data_imports/workflow_activities/import_data.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data.py
@@ -42,7 +42,7 @@ async def import_data_activity(inputs: ImportDataActivityInputs):
 
         logger = await bind_temporal_worker_logger(team_id=inputs.team_id)
 
-        logger.info("Running *ASYNC* import_data")
+        logger.debug("Running *ASYNC* import_data")
 
         job_inputs = PipelineInputs(
             source_id=inputs.source_id,

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -24,14 +24,14 @@ from posthog.warehouse.models.ssh_tunnel import SSHTunnel
 
 @activity.defn
 def import_data_activity_sync(inputs: ImportDataActivityInputs):
-    with HeartbeaterSync(factor=30):
+    logger = bind_temporal_worker_logger_sync(team_id=inputs.team_id)
+
+    with HeartbeaterSync(factor=30, logger=logger):
         model = ExternalDataJob.objects.prefetch_related(
             "pipeline", Prefetch("schema", queryset=ExternalDataSchema.objects.prefetch_related("source"))
         ).get(id=inputs.run_id)
 
-        logger = bind_temporal_worker_logger_sync(team_id=inputs.team_id)
-
-        logger.info("Running *SYNC* import_data")
+        logger.debug("Running *SYNC* import_data")
 
         job_inputs = PipelineInputs(
             source_id=inputs.source_id,


### PR DESCRIPTION
## Problem
- We sometimes are seeing a heartbeat timeout on the sync workflows

## Changes
- Added debug logging for the heartbeater
  - this works cross threads, but do shout if there's something I should do to make this more thread safe
- Updated the schema logs to only show INFO logs and above, unless if you're staff, then you can see DEBUG logs
