### PR TITLE
fix: update trials ui logic

### DIFF
--- a/frontend/src/scenes/billing/BillingProductAddon.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddon.tsx
@@ -1,12 +1,10 @@
-import { IconCheckCircle, IconPlus } from '@posthog/icons'
+import { IconCheckCircle } from '@posthog/icons'
 import { LemonButton, LemonModal, LemonSelectOptions, LemonTag, Link, Tooltip } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { supportLogic } from 'lib/components/Support/supportLogic'
-import { FEATURE_FLAGS, UNSUBSCRIBE_SURVEY_ID } from 'lib/constants'
-import { dayjs } from 'lib/dayjs'
-import { More } from 'lib/lemon-ui/LemonButton/More'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { humanFriendlyCurrency, toSentenceCase } from 'lib/utils'
+import { humanFriendlyCurrency } from 'lib/utils'
 import { ReactNode, useMemo, useRef } from 'react'
 import { getProductIcon } from 'scenes/products/Products'
 
@@ -14,11 +12,12 @@ import { BillingProductV2AddonType } from '~/types'
 
 import { getProration } from './billing-utils'
 import { billingLogic } from './billingLogic'
+import { BillingProductAddonActions } from './BillingProductAddonActions'
 import { billingProductLogic } from './billingProductLogic'
 import { ProductPricingModal } from './ProductPricingModal'
 import { UnsubscribeSurveyModal } from './UnsubscribeSurveyModal'
 
-const formatFlatRate = (flatRate: number, unit: string | null): string | ReactNode => {
+export const formatFlatRate = (flatRate: number, unit: string | null): string | ReactNode => {
     if (!unit) {
         return `$${flatRate}`
     }
@@ -109,6 +108,7 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
             data-attr={`billing-product-addon-${addon.type}`}
         >
             <div className="sm:flex justify-between gap-x-4">
+                {/* Header */}
                 <div className="flex gap-x-4">
                     <div className="w-8">{getProductIcon(addon.name, addon.icon_key, 'text-2xl')}</div>
                     <div>
@@ -152,149 +152,29 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
                         )}
                     </div>
                 </div>
-                <div className="min-w-64">
-                    <div className="ml-4 mt-2 self-center flex items-center justify-end gap-x-3 whitespace-nowrap">
-                        {addon.subscribed && !addon.inclusion_only ? (
-                            !addon.contact_support && (
-                                <More
-                                    overlay={
-                                        <>
-                                            <LemonButton
-                                                fullWidth
-                                                onClick={() => {
-                                                    setSurveyResponse('$survey_response_1', addon.type)
-                                                    reportSurveyShown(UNSUBSCRIBE_SURVEY_ID, addon.type)
-                                                }}
-                                            >
-                                                Remove add-on
-                                            </LemonButton>
-                                        </>
-                                    }
-                                />
-                            )
-                        ) : billing?.trial?.target === addon.type ? (
-                            <div className="flex flex-col items-end justify-end">
-                                <Tooltip
-                                    title={
-                                        <p>
-                                            You are currently on a free trial for{' '}
-                                            <b>{toSentenceCase(billing.trial.target)}</b> until{' '}
-                                            <b>{dayjs(billing.trial.expires_at).format('LL')}</b>. At the end of the
-                                            trial{' '}
-                                            {billing.trial.type === 'autosubscribe'
-                                                ? 'you will be automatically subscribed to the plan.'
-                                                : 'you will be asked to subscribe. If you choose not to, you will lose access to the features.'}
-                                        </p>
-                                    }
-                                >
-                                    <LemonTag type="completion" icon={<IconCheckCircle />}>
-                                        You're on a trial for this add-on
-                                    </LemonTag>
-                                </Tooltip>
-                                <LemonButton
-                                    type="primary"
-                                    size="small"
-                                    onClick={cancelTrial}
-                                    loading={trialLoading}
-                                    className="mt-1"
-                                >
-                                    Cancel trial
-                                </LemonButton>
-                            </div>
-                        ) : addon.included_with_main_product ? (
-                            <LemonTag type="completion" icon={<IconCheckCircle />}>
-                                Included with plan
-                            </LemonTag>
-                        ) : addon.contact_support ? (
-                            <LemonButton type="secondary" to="https://posthog.com/talk-to-a-human">
-                                Contact support
-                            </LemonButton>
-                        ) : (
-                            <>
-                                {currentAndUpgradePlans?.upgradePlan?.flat_rate ? (
-                                    <h4 className="leading-5 font-bold mb-0 space-x-0.5">
-                                        {addon.trial && !!trialExperiment ? (
-                                            <span>{addon.trial.length} day free trial</span>
-                                        ) : (
-                                            <span>
-                                                {formatFlatRate(
-                                                    Number(upgradePlan?.unit_amount_usd),
-                                                    upgradePlan?.unit
-                                                )}
-                                            </span>
-                                        )}
-                                    </h4>
-                                ) : (
-                                    <LemonButton
-                                        type="secondary"
-                                        onClick={() => {
-                                            toggleIsPricingModalOpen()
-                                        }}
-                                    >
-                                        View pricing
-                                    </LemonButton>
-                                )}
-                                {!addon.inclusion_only &&
-                                    (addon.trial && !!trialExperiment ? (
-                                        <LemonButton
-                                            type="primary"
-                                            icon={<IconPlus />}
-                                            size="small"
-                                            disableClientSideRouting
-                                            disabledReason={
-                                                (billingError && billingError.message) ||
-                                                (billing?.subscription_level === 'free' && 'Upgrade to add add-ons')
-                                            }
-                                            loading={billingProductLoading === addon.type}
-                                            onClick={handleTrialActivation}
-                                        >
-                                            Start trial
-                                        </LemonButton>
-                                    ) : (
-                                        <LemonButton
-                                            type="primary"
-                                            icon={<IconPlus />}
-                                            size="small"
-                                            disableClientSideRouting
-                                            disabledReason={
-                                                (billingError && billingError.message) ||
-                                                (billing?.subscription_level === 'free' && 'Upgrade to add add-ons')
-                                            }
-                                            loading={billingProductLoading === addon.type}
-                                            onClick={() =>
-                                                initiateProductUpgrade(
-                                                    addon,
-                                                    currentAndUpgradePlans?.upgradePlan,
-                                                    redirectPath
-                                                )
-                                            }
-                                        >
-                                            Add
-                                        </LemonButton>
-                                    ))}
-                            </>
-                        )}
-                    </div>
-                    {!addon.inclusion_only &&
-                        !addon.trial &&
-                        isProrated &&
-                        !addon.contact_support &&
-                        !billing?.trial && (
-                            <p className="mt-2 text-xs text-muted text-right">
-                                Pay ~${prorationAmount} today (prorated) and
-                                <br />
-                                {formatFlatRate(Number(upgradePlan?.unit_amount_usd), upgradePlan?.unit)} every month
-                                thereafter.
-                            </p>
-                        )}
-                    {!!addon.trial && !!trialExperiment && !billing?.trial && (
-                        <p className="mt-2 text-xs text-muted text-right">
-                            You'll have {addon.trial.length} days to try it out. Then you'll be charged{' '}
-                            {formatFlatRate(Number(upgradePlan?.unit_amount_usd), upgradePlan?.unit)}.
-                        </p>
-                    )}
-                </div>
+
+                {/* Actions */}
+                <BillingProductAddonActions
+                    addon={addon}
+                    billing={billing}
+                    billingProductLoading={billingProductLoading}
+                    billingError={billingError}
+                    upgradePlan={upgradePlan}
+                    currentAndUpgradePlans={currentAndUpgradePlans}
+                    trialExperiment={trialExperiment as string}
+                    trialLoading={trialLoading}
+                    isProrated={isProrated}
+                    prorationAmount={prorationAmount}
+                    setSurveyResponse={setSurveyResponse}
+                    reportSurveyShown={reportSurveyShown}
+                    toggleIsPricingModalOpen={toggleIsPricingModalOpen}
+                    handleTrialActivation={handleTrialActivation}
+                    initiateProductUpgrade={initiateProductUpgrade}
+                    cancelTrial={cancelTrial}
+                />
             </div>
+
+            {/* Features */}
             <div className="mt-3 ml-11">
                 {addonFeatures?.length > 2 && (
                     <div>
@@ -320,6 +200,8 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
                     </div>
                 )}
             </div>
+
+            {/* Pricing modal */}
             <ProductPricingModal
                 modalOpen={isPricingModalOpen}
                 onClose={toggleIsPricingModalOpen}
@@ -330,7 +212,11 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
                         : currentAndUpgradePlans?.upgradePlan?.plan_key
                 }
             />
+
+            {/* Unsubscribe survey modal */}
             {surveyID && <UnsubscribeSurveyModal product={addon} />}
+
+            {/* Trial modal */}
             <LemonModal
                 isOpen={trialModalOpen}
                 onClose={() => setTrialModalOpen(false)}

--- a/frontend/src/scenes/billing/BillingProductAddonActions.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddonActions.tsx
@@ -201,7 +201,7 @@ export const BillingProductAddonActions = ({ addon, productRef }: BillingProduct
         )
     } else if (!billing?.trial) {
         // Customer is not subscribed to any trial
-        // TODO: add support for when subscription to paid here
+        // TODO: add support for when a customer has a Paid Plan trial
         content = renderPurchaseActions()
     }
 

--- a/frontend/src/scenes/billing/BillingProductAddonActions.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddonActions.tsx
@@ -5,17 +5,18 @@ import { dayjs } from 'lib/dayjs'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { toSentenceCase } from 'lib/utils'
 
-import { BillingProductV2AddonType } from '~/types'
+import { BillingPlanType, BillingProductV2AddonType, BillingType } from '~/types'
 
+import { BillingError } from './billingLogic'
 import { formatFlatRate } from './BillingProductAddon'
 
 interface BillingProductAddonActionsProps {
     addon: BillingProductV2AddonType
-    billing: any // Replace with proper type
+    billing: BillingType | null
     billingProductLoading: string | null
-    billingError: any // Replace with proper type
-    upgradePlan: any // Replace with proper type
-    currentAndUpgradePlans: any // Replace with proper type
+    billingError: BillingError | null
+    upgradePlan: BillingPlanType
+    currentAndUpgradePlans: any
     trialExperiment: string
     trialLoading: boolean
     isProrated: boolean
@@ -74,9 +75,9 @@ export const BillingProductAddonActions = ({
             <Tooltip
                 title={
                     <p>
-                        You are currently on a free trial for <b>{toSentenceCase(billing.trial.target)}</b> until{' '}
-                        <b>{dayjs(billing.trial.expires_at).format('LL')}</b>. At the end of the trial{' '}
-                        {billing.trial.type === 'autosubscribe'
+                        You are currently on a free trial for <b>{toSentenceCase(billing?.trial?.target || '')}</b>{' '}
+                        until <b>{dayjs(billing?.trial?.expires_at).format('LL')}</b>. At the end of the trial{' '}
+                        {billing?.trial?.type === 'autosubscribe'
                             ? 'you will be automatically subscribed to the plan.'
                             : 'you will be asked to subscribe. If you choose not to, you will lose access to the features.'}
                     </p>
@@ -174,7 +175,7 @@ export const BillingProductAddonActions = ({
                 Included with plan
             </LemonTag>
         )
-    } else if (billing?.trial?.target === addon.type) {
+    } else if (billing?.trial && billing?.trial?.target === addon.type) {
         // Current trial on this addon
         content = renderTrialActions()
     } else if (addon.contact_support) {

--- a/frontend/src/scenes/billing/BillingProductAddonActions.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddonActions.tsx
@@ -1,0 +1,200 @@
+import { IconCheckCircle, IconPlus } from '@posthog/icons'
+import { LemonButton, LemonTag, Tooltip } from '@posthog/lemon-ui'
+import { UNSUBSCRIBE_SURVEY_ID } from 'lib/constants'
+import { dayjs } from 'lib/dayjs'
+import { More } from 'lib/lemon-ui/LemonButton/More'
+import { toSentenceCase } from 'lib/utils'
+
+import { BillingProductV2AddonType } from '~/types'
+
+import { formatFlatRate } from './BillingProductAddon'
+
+interface BillingProductAddonActionsProps {
+    addon: BillingProductV2AddonType
+    billing: any // Replace with proper type
+    billingProductLoading: string | null
+    billingError: any // Replace with proper type
+    upgradePlan: any // Replace with proper type
+    currentAndUpgradePlans: any // Replace with proper type
+    trialExperiment: string
+    trialLoading: boolean
+    isProrated: boolean
+    prorationAmount: string
+    // Actions
+    setSurveyResponse: (key: string, value: string) => void
+    reportSurveyShown: (surveyId: string, type: string) => void
+    toggleIsPricingModalOpen: () => void
+    handleTrialActivation: () => void
+    initiateProductUpgrade: (addon: BillingProductV2AddonType, plan: any, redirectPath: string) => void
+    cancelTrial: () => void
+}
+
+export const BillingProductAddonActions = ({
+    addon,
+    billing,
+    billingProductLoading,
+    billingError,
+    upgradePlan,
+    currentAndUpgradePlans,
+    trialExperiment,
+    trialLoading,
+    isProrated,
+    prorationAmount,
+    // Actions
+    setSurveyResponse,
+    reportSurveyShown,
+    toggleIsPricingModalOpen,
+    handleTrialActivation,
+    initiateProductUpgrade,
+    cancelTrial,
+}: BillingProductAddonActionsProps): JSX.Element => {
+    const renderSubscribedActions = (): JSX.Element | null => {
+        if (addon.contact_support) {
+            return null
+        }
+        return (
+            <More
+                overlay={
+                    <LemonButton
+                        fullWidth
+                        onClick={() => {
+                            setSurveyResponse('$survey_response_1', addon.type)
+                            reportSurveyShown(UNSUBSCRIBE_SURVEY_ID, addon.type)
+                        }}
+                    >
+                        Remove add-on
+                    </LemonButton>
+                }
+            />
+        )
+    }
+
+    const renderTrialActions = (): JSX.Element => (
+        <div className="flex flex-col items-end justify-end">
+            <Tooltip
+                title={
+                    <p>
+                        You are currently on a free trial for <b>{toSentenceCase(billing.trial.target)}</b> until{' '}
+                        <b>{dayjs(billing.trial.expires_at).format('LL')}</b>. At the end of the trial{' '}
+                        {billing.trial.type === 'autosubscribe'
+                            ? 'you will be automatically subscribed to the plan.'
+                            : 'you will be asked to subscribe. If you choose not to, you will lose access to the features.'}
+                    </p>
+                }
+            >
+                <LemonTag type="completion" icon={<IconCheckCircle />}>
+                    You're on a trial for this add-on
+                </LemonTag>
+            </Tooltip>
+            {addon.type !== 'enterprise' && (
+                <LemonButton type="primary" size="small" onClick={cancelTrial} loading={trialLoading} className="mt-1">
+                    Cancel trial
+                </LemonButton>
+            )}
+        </div>
+    )
+
+    const renderPurchaseActions = (): JSX.Element => {
+        const showPricing = currentAndUpgradePlans?.upgradePlan?.flat_rate
+        const isTrialEligible = addon.trial && !!trialExperiment
+
+        return (
+            <>
+                {showPricing ? (
+                    <h4 className="leading-5 font-bold mb-0 space-x-0.5">
+                        {isTrialEligible ? (
+                            <span>{addon.trial?.length} day free trial</span>
+                        ) : (
+                            <span>{formatFlatRate(Number(upgradePlan?.unit_amount_usd), upgradePlan?.unit)}</span>
+                        )}
+                    </h4>
+                ) : (
+                    <LemonButton type="secondary" onClick={toggleIsPricingModalOpen}>
+                        View pricing
+                    </LemonButton>
+                )}
+
+                {!addon.inclusion_only && (
+                    <LemonButton
+                        type="primary"
+                        icon={<IconPlus />}
+                        size="small"
+                        disableClientSideRouting
+                        disabledReason={
+                            (billingError && billingError.message) ||
+                            (billing?.subscription_level === 'free' && 'Upgrade to add add-ons')
+                        }
+                        loading={billingProductLoading === addon.type}
+                        onClick={
+                            isTrialEligible
+                                ? handleTrialActivation
+                                : () => initiateProductUpgrade(addon, currentAndUpgradePlans?.upgradePlan, '')
+                        }
+                    >
+                        {isTrialEligible ? 'Start trial' : 'Add'}
+                    </LemonButton>
+                )}
+            </>
+        )
+    }
+
+    const renderPricingInfo = (): JSX.Element | null => {
+        if (addon.inclusion_only || addon.contact_support || billing?.trial || addon.subscribed) {
+            return null
+        }
+
+        if (addon.trial && trialExperiment) {
+            return (
+                <p className="mt-2 text-xs text-muted text-right">
+                    You'll have {addon.trial.length} days to try it out. Then you'll be charged{' '}
+                    {formatFlatRate(Number(upgradePlan?.unit_amount_usd), upgradePlan?.unit)}.
+                </p>
+            )
+        }
+
+        if (isProrated) {
+            return (
+                <p className="mt-2 text-xs text-muted text-right">
+                    Pay ~${prorationAmount} today (prorated) and
+                    <br />
+                    {formatFlatRate(Number(upgradePlan?.unit_amount_usd), upgradePlan?.unit)} every month thereafter.
+                </p>
+            )
+        }
+
+        return null
+    }
+
+    let content
+    if (addon.subscribed && !addon.inclusion_only) {
+        content = renderSubscribedActions()
+    } else if (addon.included_with_main_product) {
+        content = (
+            <LemonTag type="completion" icon={<IconCheckCircle />}>
+                Included with plan
+            </LemonTag>
+        )
+    } else if (billing?.trial?.target === addon.type) {
+        // Current trial on this addon
+        content = renderTrialActions()
+    } else if (addon.contact_support) {
+        content = (
+            <LemonButton type="secondary" to="https://posthog.com/talk-to-a-human">
+                Contact support
+            </LemonButton>
+        )
+    } else if (!billing?.trial) {
+        // Customer is not subscribed to any trial
+        // TODO: add support for when subscription to paid here
+        content = renderPurchaseActions()
+    }
+
+    return (
+        <div className="min-w-64">
+            <div className="ml-4 mt-2 self-center flex items-center justify-end gap-x-3 whitespace-nowrap">
+                {content}
+            </div>
+            {renderPricingInfo()}
+        </div>
+    )
+}


### PR DESCRIPTION
## Changes

We've got quite a few issues with the UI for trials, so many cases. This cleans those up and fixes them.

- can't cancel enterprise trial
- teams show properly if enterprise trial is on
- cases for when trial is on 
- cases for when trial is not on

I've moved all the addon actions into a new function to make this cleaner. 

Normally sub'd to teams
<img width="600" alt="Screenshot 2024-11-05 at 10 54 35 AM" src="https://github.com/user-attachments/assets/2c33e31e-cc82-422f-b4c8-c38e8e6207f7">

Paid plan w/ no trials
<img width="600" alt="Screenshot 2024-11-05 at 10 52 05 AM" src="https://github.com/user-attachments/assets/63033ea1-c21f-4f2e-9568-7b7c0dfd9b19">

Teams trial
<img width="600" alt="Screenshot 2024-11-05 at 10 51 02 AM" src="https://github.com/user-attachments/assets/948f4b3d-34bf-4ae7-8f72-bdfca97c1e2b">

Enterprise trial
<img width="600" alt="Screenshot 2024-11-05 at 10 50 42 AM" src="https://github.com/user-attachments/assets/98ce01f1-2a56-45e1-8a0a-5bd1ee7012f4">

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
