### PR TITLE
fix: Improve render pricing info logic

### DIFF
--- a/frontend/src/scenes/billing/BillingProductAddonActions.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddonActions.tsx
@@ -155,7 +155,19 @@ export const BillingProductAddonActions = ({ addon, productRef }: BillingProduct
     }
 
     const renderPricingInfo = (): JSX.Element | null => {
-        if (addon.inclusion_only || addon.contact_support || billing?.trial || addon.subscribed) {
+        // Don't render if
+        // - the product is inclusion only (it's automatically included and can't be subscribed to)
+        // - the plan requires contacting support
+        // - the customer is on a trial
+        // - the customer is already subscribed to the product
+        // - the product is included with the main product
+        if (
+            addon.inclusion_only ||
+            addon.contact_support ||
+            billing?.trial ||
+            addon.subscribed ||
+            addon.included_with_main_product
+        ) {
             return null
         }
 


### PR DESCRIPTION
## Changes

Resolving an edgecase that the posthog account is seeing: 

<img width="476" alt="Screenshot 2024-11-05 at 1 42 59 PM" src="https://github.com/user-attachments/assets/630349e0-d92c-4249-af8e-c1a4985ebba2">

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
