### PR TITLE
feat(onboarding): Allow selecting multiple products

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -226,6 +226,7 @@ export const FEATURE_FLAGS = {
     SESSION_REPLAY_URL_BLOCKLIST: 'session-replay-url-blocklist', // owner: @richard-better #team-replay
     BILLING_TRIAL_FLOW: 'billing-trial-flow', // owner: @zach
     DEAD_CLICKS_AUTOCAPTURE: 'dead-clicks-autocapture', // owner: @pauldambra #team-replay
+    ONBOARDING_PRODUCT_MULTISELECT: 'onboarding-product-multiselect', // owner: @danielbachhuber #team-experiments
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -1,5 +1,5 @@
 import * as Icons from '@posthog/icons'
-import { Link, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonLabel, LemonSelect, Link, Tooltip } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
@@ -12,6 +12,8 @@ import { urls } from 'scenes/urls'
 
 import { OnboardingProduct, ProductKey } from '~/types'
 
+import { productsLogic } from './productsLogic'
+
 export const scene: SceneExport = {
     component: Products,
 }
@@ -19,6 +21,57 @@ export const scene: SceneExport = {
 export function getProductIcon(color: string, iconKey?: string | null, className?: string): JSX.Element {
     const Icon = Icons[iconKey || 'IconLogomark']
     return <Icon className={className} color={color} />
+}
+
+export function SelectableProductCard({
+    product,
+    productKey,
+    onClick,
+    orientation = 'vertical',
+    className,
+    selected = false,
+}: {
+    product: OnboardingProduct
+    productKey: string
+    onClick: () => void
+    orientation?: 'horizontal' | 'vertical'
+    className?: string
+    selected?: boolean
+}): JSX.Element {
+    const { currentTeam } = useValues(teamLogic)
+    const onboardingCompleted = currentTeam?.has_completed_onboarding_for?.[productKey]
+    const vertical = orientation === 'vertical'
+    return (
+        <LemonCard
+            data-attr={`${productKey}-onboarding-card`}
+            className={clsx('flex justify-center cursor-pointer', vertical ? 'flex-col' : 'items-center', className)}
+            key={productKey}
+            onClick={onClick}
+            focused={selected}
+        >
+            {onboardingCompleted && (
+                <Tooltip
+                    title="You've already set up this product. Click to return to this product's page."
+                    placement="right"
+                >
+                    <div
+                        className="relative"
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            router.actions.push(getProductUri(productKey as ProductKey))
+                        }}
+                        data-attr={`return-to-${productKey}`}
+                    >
+                        <Icons.IconCheckCircle className="absolute top-0 right-0" color="green" />
+                    </div>
+                </Tooltip>
+            )}
+            <div className="grid grid-rows-[repeat(2,_48px)] justify-items-center">
+                <div className="self-center">{getProductIcon(product.iconColor, product.icon, 'text-2xl')}</div>
+                <div className="font-bold text-center self-start text-md">{product.name}</div>
+            </div>
+        </LemonCard>
+    )
 }
 
 export function ProductCard({
@@ -85,31 +138,97 @@ export function ProductCard({
 export function Products(): JSX.Element {
     const { isFirstProductOnboarding } = useValues(onboardingLogic)
     const { showInviteModal } = useActions(inviteLogic)
+    const { addProductIntent } = useActions(teamLogic)
+    const { setIncludeIntro } = useActions(onboardingLogic)
+
+    const { toggleSelectedProduct, setFirstProductOnboarding } = useActions(productsLogic)
+    const { selectedProducts, firstProductOnboarding } = useValues(productsLogic)
 
     return (
         <div className="flex flex-col flex-1 w-full px-6 items-center justify-center bg-bg-3000 h-[calc(100vh-var(--breadcrumbs-height-full)-2*var(--scene-padding))]">
-            <div className="mb-8">
-                {isFirstProductOnboarding ? (
-                    <h2 className="text-center text-4xl">Where do you want to start?</h2>
-                ) : (
-                    <h2 className="text-center text-4xl">Welcome back. What would you like to set up?</h2>
-                )}
-                {isFirstProductOnboarding && <p className="text-center">You can set up additional products later.</p>}
-            </div>
-            <>
-                <div className="grid gap-4 grid-rows-[160px] grid-cols-[repeat(2,_minmax(min-content,_160px))] md:grid-cols-[repeat(3,_minmax(min-content,_160px))] ">
-                    {Object.keys(availableOnboardingProducts).map((productKey) => (
-                        <ProductCard
-                            product={availableOnboardingProducts[productKey]}
-                            key={productKey}
-                            productKey={productKey}
-                        />
-                    ))}
-                </div>
-                <p className="text-center mt-8">
-                    Need help from a team member? <Link onClick={() => showInviteModal()}>Invite them</Link>
-                </p>
-            </>
+            {true ? (
+                <>
+                    <div className="mb-8">
+                        <h2 className="text-center text-4xl">Which products would you like to use?</h2>
+                    </div>
+                    <div className="grid gap-4 grid-rows-[160px] grid-cols-[repeat(2,_minmax(min-content,_160px))] md:grid-cols-[repeat(3,_minmax(min-content,_160px))] ">
+                        {Object.keys(availableOnboardingProducts).map((productKey) => (
+                            <SelectableProductCard
+                                product={availableOnboardingProducts[productKey]}
+                                key={productKey}
+                                productKey={productKey}
+                                onClick={() => {
+                                    toggleSelectedProduct(productKey)
+                                }}
+                                selected={selectedProducts.includes(productKey)}
+                            />
+                        ))}
+                    </div>
+                    <div className="mt-8 flex gap-2 justify-center items-center">
+                        {selectedProducts.length > 1 ? (
+                            <>
+                                <LemonLabel>Get started with</LemonLabel>
+                                <LemonSelect
+                                    value={firstProductOnboarding}
+                                    options={selectedProducts.map((productKey) => ({
+                                        label: availableOnboardingProducts[productKey].name,
+                                        value: productKey,
+                                    }))}
+                                    onChange={(value) => value && setFirstProductOnboarding(value)}
+                                    placeholder="Select a product"
+                                />
+                                <LemonButton type="primary">Go</LemonButton>
+                            </>
+                        ) : (
+                            <LemonButton
+                                type="primary"
+                                onClick={() => {
+                                    const firstProductKey = selectedProducts[0]
+                                    setIncludeIntro(false)
+                                    router.actions.push(urls.onboarding(firstProductKey))
+                                    addProductIntent({
+                                        product_type: firstProductKey as ProductKey,
+                                        intent_context: 'onboarding product selected',
+                                    })
+                                }}
+                                disabledReason={
+                                    selectedProducts.length === 0 ? 'Select a product to start with' : undefined
+                                }
+                            >
+                                Get started
+                            </LemonButton>
+                        )}
+                    </div>
+                    <p className="text-center mt-8">
+                        Need help from a team member? <Link onClick={() => showInviteModal()}>Invite them</Link>
+                    </p>
+                </>
+            ) : (
+                <>
+                    <div className="mb-8">
+                        {isFirstProductOnboarding ? (
+                            <h2 className="text-center text-4xl">Where do you want to start?</h2>
+                        ) : (
+                            <h2 className="text-center text-4xl">Welcome back. What would you like to set up?</h2>
+                        )}
+                        {isFirstProductOnboarding && (
+                            <p className="text-center">You can set up additional products later.</p>
+                        )}
+                    </div>
+                    <div className="grid gap-4 grid-rows-[160px] grid-cols-[repeat(2,_minmax(min-content,_160px))] md:grid-cols-[repeat(3,_minmax(min-content,_160px))] ">
+                        {Object.keys(availableOnboardingProducts).map((productKey) => (
+                            <ProductCard
+                                product={availableOnboardingProducts[productKey]}
+                                key={productKey}
+                                productKey={productKey}
+                            />
+                        ))}
+                    </div>
+                    <p className="text-center mt-8">
+                        Need help from a team member? <Link onClick={() => showInviteModal()}>Invite them</Link>
+                    </p>
+                </>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -1,5 +1,5 @@
 import * as Icons from '@posthog/icons'
-import { IconArrowRight } from '@posthog/icons'
+import { IconArrowRight, IconCheckCircle } from '@posthog/icons'
 import { LemonButton, LemonLabel, LemonSelect, Link, Tooltip } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
@@ -65,7 +65,7 @@ export function SelectableProductCard({
                         }}
                         data-attr={`return-to-${productKey}`}
                     >
-                        <Icons.IconCheckCircle className="absolute top-0 right-0" color="green" />
+                        <IconCheckCircle className="absolute top-0 right-0" color="green" />
                     </div>
                 </Tooltip>
             )}
@@ -126,7 +126,7 @@ export function ProductCard({
                         }}
                         data-attr={`return-to-${productKey}`}
                     >
-                        <Icons.IconCheckCircle className="absolute top-0 right-0" color="green" />
+                        <IconCheckCircle className="absolute top-0 right-0" color="green" />
                     </div>
                 </Tooltip>
             )}

--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -1,4 +1,5 @@
 import * as Icons from '@posthog/icons'
+import { IconArrowRight } from '@posthog/icons'
 import { LemonButton, LemonLabel, LemonSelect, Link, Tooltip } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
@@ -148,56 +149,63 @@ export function Products(): JSX.Element {
         <div className="flex flex-col flex-1 w-full px-6 items-center justify-center bg-bg-3000 h-[calc(100vh-var(--breadcrumbs-height-full)-2*var(--scene-padding))]">
             {true ? (
                 <>
-                    <div className="mb-8">
-                        <h2 className="text-center text-4xl">Which products would you like to use?</h2>
-                    </div>
-                    <div className="grid gap-4 grid-rows-[160px] grid-cols-[repeat(2,_minmax(min-content,_160px))] md:grid-cols-[repeat(3,_minmax(min-content,_160px))] ">
-                        {Object.keys(availableOnboardingProducts).map((productKey) => (
-                            <SelectableProductCard
-                                product={availableOnboardingProducts[productKey]}
-                                key={productKey}
-                                productKey={productKey}
-                                onClick={() => {
-                                    toggleSelectedProduct(productKey)
-                                }}
-                                selected={selectedProducts.includes(productKey)}
-                            />
-                        ))}
-                    </div>
-                    <div className="mt-8 flex gap-2 justify-center items-center">
-                        {selectedProducts.length > 1 ? (
-                            <>
-                                <LemonLabel>Get started with</LemonLabel>
-                                <LemonSelect
-                                    value={firstProductOnboarding}
-                                    options={selectedProducts.map((productKey) => ({
-                                        label: availableOnboardingProducts[productKey].name,
-                                        value: productKey,
-                                    }))}
-                                    onChange={(value) => value && setFirstProductOnboarding(value)}
-                                    placeholder="Select a product"
+                    <div className="flex flex-col justify-center flex-grow items-center">
+                        <div className="mb-8">
+                            <h2 className="text-center text-4xl">Which products would you like to use?</h2>
+                        </div>
+                        <div className="grid gap-4 grid-rows-[160px] grid-cols-[repeat(2,_minmax(min-content,_160px))] md:grid-cols-[repeat(3,_minmax(min-content,_160px))] ">
+                            {Object.keys(availableOnboardingProducts).map((productKey) => (
+                                <SelectableProductCard
+                                    product={availableOnboardingProducts[productKey]}
+                                    key={productKey}
+                                    productKey={productKey}
+                                    onClick={() => {
+                                        toggleSelectedProduct(productKey)
+                                    }}
+                                    selected={selectedProducts.includes(productKey)}
                                 />
-                                <LemonButton type="primary">Go</LemonButton>
-                            </>
-                        ) : (
-                            <LemonButton
-                                type="primary"
-                                onClick={() => {
-                                    const firstProductKey = selectedProducts[0]
-                                    setIncludeIntro(false)
-                                    router.actions.push(urls.onboarding(firstProductKey))
-                                    addProductIntent({
-                                        product_type: firstProductKey as ProductKey,
-                                        intent_context: 'onboarding product selected',
-                                    })
-                                }}
-                                disabledReason={
-                                    selectedProducts.length === 0 ? 'Select a product to start with' : undefined
-                                }
-                            >
-                                Get started
-                            </LemonButton>
-                        )}
+                            ))}
+                        </div>
+                        <div className="mt-12 flex gap-2 justify-center items-center">
+                            {selectedProducts.length > 1 ? (
+                                <>
+                                    <LemonLabel>Get started with</LemonLabel>
+                                    <LemonSelect
+                                        value={firstProductOnboarding}
+                                        options={selectedProducts.map((productKey) => ({
+                                            label: availableOnboardingProducts[productKey].name,
+                                            value: productKey,
+                                        }))}
+                                        onChange={(value) => value && setFirstProductOnboarding(value)}
+                                        placeholder="Select a product"
+                                        className="bg-bg-light"
+                                    />
+                                    <LemonButton sideIcon={<IconArrowRight />} type="primary" status="alt">
+                                        Go
+                                    </LemonButton>
+                                </>
+                            ) : (
+                                <LemonButton
+                                    type="primary"
+                                    status="alt"
+                                    onClick={() => {
+                                        const firstProductKey = selectedProducts[0]
+                                        setIncludeIntro(false)
+                                        router.actions.push(urls.onboarding(firstProductKey))
+                                        addProductIntent({
+                                            product_type: firstProductKey as ProductKey,
+                                            intent_context: 'onboarding product selected',
+                                        })
+                                    }}
+                                    sideIcon={<IconArrowRight />}
+                                    disabledReason={
+                                        selectedProducts.length === 0 ? 'Select a product to start with' : undefined
+                                    }
+                                >
+                                    Get started
+                                </LemonButton>
+                            )}
+                        </div>
                     </div>
                     <p className="text-center mt-8">
                         Need help from a team member? <Link onClick={() => showInviteModal()}>Invite them</Link>

--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -162,9 +162,9 @@ export function Products(): JSX.Element {
                                     key={productKey}
                                     productKey={productKey}
                                     onClick={() => {
-                                        toggleSelectedProduct(productKey)
+                                        toggleSelectedProduct(productKey as ProductKey)
                                     }}
-                                    selected={selectedProducts.includes(productKey)}
+                                    selected={selectedProducts.includes(productKey as ProductKey)}
                                 />
                             ))}
                         </div>

--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -139,10 +139,8 @@ export function ProductCard({
 export function Products(): JSX.Element {
     const { isFirstProductOnboarding } = useValues(onboardingLogic)
     const { showInviteModal } = useActions(inviteLogic)
-    const { addProductIntent } = useActions(teamLogic)
-    const { setIncludeIntro } = useActions(onboardingLogic)
 
-    const { toggleSelectedProduct, setFirstProductOnboarding } = useActions(productsLogic)
+    const { toggleSelectedProduct, setFirstProductOnboarding, handleStartOnboarding } = useActions(productsLogic)
     const { selectedProducts, firstProductOnboarding } = useValues(productsLogic)
 
     return (
@@ -151,7 +149,7 @@ export function Products(): JSX.Element {
                 <>
                     <div className="flex flex-col justify-center flex-grow items-center">
                         <div className="mb-8">
-                            <h2 className="text-center text-4xl">Which products would you like to use?</h2>
+                            <h2 className="text-center text-4xl">What would you like to set up?</h2>
                         </div>
                         <div className="grid gap-4 grid-rows-[160px] grid-cols-[repeat(2,_minmax(min-content,_160px))] md:grid-cols-[repeat(3,_minmax(min-content,_160px))] ">
                             {Object.keys(availableOnboardingProducts).map((productKey) => (
@@ -180,7 +178,12 @@ export function Products(): JSX.Element {
                                         placeholder="Select a product"
                                         className="bg-bg-light"
                                     />
-                                    <LemonButton sideIcon={<IconArrowRight />} type="primary" status="alt">
+                                    <LemonButton
+                                        sideIcon={<IconArrowRight />}
+                                        onClick={handleStartOnboarding}
+                                        type="primary"
+                                        status="alt"
+                                    >
                                         Go
                                     </LemonButton>
                                 </>
@@ -188,15 +191,7 @@ export function Products(): JSX.Element {
                                 <LemonButton
                                     type="primary"
                                     status="alt"
-                                    onClick={() => {
-                                        const firstProductKey = selectedProducts[0]
-                                        setIncludeIntro(false)
-                                        router.actions.push(urls.onboarding(firstProductKey))
-                                        addProductIntent({
-                                            product_type: firstProductKey as ProductKey,
-                                            intent_context: 'onboarding product selected',
-                                        })
-                                    }}
+                                    onClick={handleStartOnboarding}
                                     sideIcon={<IconArrowRight />}
                                     disabledReason={
                                         selectedProducts.length === 0 ? 'Select a product to start with' : undefined

--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -4,7 +4,9 @@ import { LemonButton, LemonLabel, LemonSelect, Link, Tooltip } from '@posthog/le
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonCard } from 'lib/lemon-ui/LemonCard/LemonCard'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { availableOnboardingProducts, getProductUri, onboardingLogic } from 'scenes/onboarding/onboardingLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { inviteLogic } from 'scenes/settings/organization/inviteLogic'
@@ -139,13 +141,14 @@ export function ProductCard({
 export function Products(): JSX.Element {
     const { isFirstProductOnboarding } = useValues(onboardingLogic)
     const { showInviteModal } = useActions(inviteLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const { toggleSelectedProduct, setFirstProductOnboarding, handleStartOnboarding } = useActions(productsLogic)
     const { selectedProducts, firstProductOnboarding } = useValues(productsLogic)
 
     return (
         <div className="flex flex-col flex-1 w-full px-6 items-center justify-center bg-bg-3000 h-[calc(100vh-var(--breadcrumbs-height-full)-2*var(--scene-padding))]">
-            {true ? (
+            {featureFlags[FEATURE_FLAGS.ONBOARDING_PRODUCT_MULTISELECT] === 'test' ? (
                 <>
                     <div className="flex flex-col justify-center flex-grow items-center">
                         <div className="mb-8">

--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -153,6 +153,7 @@ export function Products(): JSX.Element {
                     <div className="flex flex-col justify-center flex-grow items-center">
                         <div className="mb-8">
                             <h2 className="text-center text-4xl">What would you like to set up?</h2>
+                            <p className="text-center">Don’t worry &mdash; you can pick more than one!</p>
                         </div>
                         <div className="grid gap-4 grid-rows-[160px] grid-cols-[repeat(2,_minmax(min-content,_160px))] md:grid-cols-[repeat(3,_minmax(min-content,_160px))] ">
                             {Object.keys(availableOnboardingProducts).map((productKey) => (

--- a/frontend/src/scenes/products/productsLogic.ts
+++ b/frontend/src/scenes/products/productsLogic.ts
@@ -1,14 +1,22 @@
-import { actions, kea, listeners, path, reducers } from 'kea'
+import { actions, connect, kea, listeners, path, reducers } from 'kea'
+import { router } from 'kea-router'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
 
 import { ProductKey } from '~/types'
 
+import { onboardingLogic } from '../onboarding/onboardingLogic'
 import type { productsLogicType } from './productsLogicType'
 
 export const productsLogic = kea<productsLogicType>([
     path(['scenes', 'products', 'productsLogic']),
+    connect({
+        actions: [onboardingLogic, ['setIncludeIntro'], teamLogic, ['addProductIntent']],
+    }),
     actions(() => ({
         toggleSelectedProduct: (productKey: ProductKey) => ({ productKey }),
         setFirstProductOnboarding: (productKey: ProductKey) => ({ productKey }),
+        handleStartOnboarding: () => true,
     })),
     reducers({
         selectedProducts: [
@@ -26,6 +34,23 @@ export const productsLogic = kea<productsLogicType>([
         ],
     }),
     listeners(({ actions, values }) => ({
+        handleStartOnboarding: () => {
+            if (!values.firstProductOnboarding) {
+                return
+            }
+
+            actions.setIncludeIntro(false)
+            router.actions.push(urls.onboarding(values.firstProductOnboarding))
+            values.selectedProducts.forEach((productKey) => {
+                actions.addProductIntent({
+                    product_type: productKey as ProductKey,
+                    intent_context:
+                        values.firstProductOnboarding === productKey
+                            ? 'onboarding product selected - primary'
+                            : 'onboarding product selected - secondary',
+                })
+            })
+        },
         toggleSelectedProduct: ({ productKey }) => {
             if (values.selectedProducts.includes(productKey) && values.firstProductOnboarding === null) {
                 actions.setFirstProductOnboarding(productKey)

--- a/frontend/src/scenes/products/productsLogic.ts
+++ b/frontend/src/scenes/products/productsLogic.ts
@@ -1,0 +1,37 @@
+import { actions, kea, listeners, path, reducers } from 'kea'
+
+import { ProductKey } from '~/types'
+
+import type { productsLogicType } from './productsLogicType'
+
+export const productsLogic = kea<productsLogicType>([
+    path(['scenes', 'products', 'productsLogic']),
+    actions(() => ({
+        toggleSelectedProduct: (productKey: ProductKey) => ({ productKey }),
+        setFirstProductOnboarding: (productKey: ProductKey) => ({ productKey }),
+    })),
+    reducers({
+        selectedProducts: [
+            [] as ProductKey[],
+            {
+                toggleSelectedProduct: (state, { productKey }) =>
+                    state.includes(productKey) ? state.filter((key) => key !== productKey) : [...state, productKey],
+            },
+        ],
+        firstProductOnboarding: [
+            null as ProductKey | null,
+            {
+                setFirstProductOnboarding: (_, { productKey }) => productKey,
+            },
+        ],
+    }),
+    listeners(({ actions, values }) => ({
+        toggleSelectedProduct: ({ productKey }) => {
+            if (values.selectedProducts.includes(productKey) && values.firstProductOnboarding === null) {
+                actions.setFirstProductOnboarding(productKey)
+            } else if (!values.selectedProducts.includes(productKey) && values.firstProductOnboarding === productKey) {
+                actions.setFirstProductOnboarding(values.selectedProducts[0] || null)
+            }
+        },
+    })),
+])


### PR DESCRIPTION
## Problem

Our current onboarding UI only lets a customer pick one product, even if they want to use more than one product.

## Changes

This PR introduces a new UI behind a `onboarding-product-multiselect` feature flag that lets customers pick multiple products. I decided to work on this because I want an opportunity to test out our product!

Here's what they'll see when they first land on `/products`:

![CleanShot 2024-11-05 at 15 52 29@2x](https://github.com/user-attachments/assets/bc2f9ebc-a029-4a4e-a976-c094dbb62c57)

Once they select a product, the "Get started" button becomes enabled:

![CleanShot 2024-11-05 at 15 52 54@2x](https://github.com/user-attachments/assets/7f2883e9-9f1c-4106-9644-ad7aaf176b81)

If they select multiple products, the "Get started" button transforms into a UI where they can pick the first product they want to start with:

![CleanShot 2024-11-05 at 15 53 46@2x](https://github.com/user-attachments/assets/dce35a28-5e89-46de-a305-e7ab2cf4d0fd)

When "Get started" or "Go" is clicked, we fire `addProductIntent()` for _all_ selected products. However, we're simply logging this data for now — it's not yet incorporated into the rest of the onboarding experience.

## How did you test this code?

I ran `posthog.featureFlags.override({'onboarding-product-multiselect': 'test'})` in my console to enable the new UI. After I refreshed the page, I clicked on a couple of products and verified that I ended up in the expected onboarding flow after clicking "Go".

I then ran `posthog.featureFlags.override({'onboarding-product-multiselect': 'control'})` in my console and verified that clicking on one of the products took me to the expected onboarding flow.