### PR TITLE
feat(data-warehouse): BI breakdowns

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -32,13 +32,13 @@ import { ChartSettings, YAxisSettings } from '~/queries/schema'
 import { ChartDisplayType, GraphType } from '~/types'
 
 import {
-    AxisBreakdownSeries,
     AxisSeries,
     AxisSeriesSettings,
     dataVisualizationLogic,
     formatDataWithSettings,
 } from '../../dataVisualizationLogic'
 import { displayLogic } from '../../displayLogic'
+import { AxisBreakdownSeries, seriesBreakdownLogic } from '../seriesBreakdownLogic'
 
 Chart.register(annotationPlugin)
 Chart.register(ChartjsPluginStacked100)
@@ -100,13 +100,16 @@ export const LineGraph = (): JSX.Element => {
 
     // TODO: Extract this logic out of this component and inject values in
     // via props. Make this a purely presentational component
-    const { xData, yData, seriesBreakdownData, presetChartHeight, visualizationType, showEditingUI, chartSettings } =
+
+    // LineGraph displays a graph using either x and y data or series breakdown data
+    const { xData, yData, presetChartHeight, visualizationType, showEditingUI, chartSettings } =
         useValues(dataVisualizationLogic)
     const isBarChart =
         visualizationType === ChartDisplayType.ActionsBar || visualizationType === ChartDisplayType.ActionsStackedBar
     const isStackedBarChart = visualizationType === ChartDisplayType.ActionsStackedBar
     const isAreaChart = visualizationType === ChartDisplayType.ActionsAreaGraph
 
+    const { seriesBreakdownData } = useValues(seriesBreakdownLogic)
     const { goalLines } = useValues(displayLogic)
 
     useEffect(() => {

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -32,7 +32,7 @@ import { ChartSettings, YAxisSettings } from '~/queries/schema'
 import { ChartDisplayType, GraphType } from '~/types'
 
 import {
-    AxisBreakoutSeries,
+    AxisBreakdownSeries,
     AxisSeries,
     AxisSeriesSettings,
     dataVisualizationLogic,
@@ -100,7 +100,7 @@ export const LineGraph = (): JSX.Element => {
 
     // TODO: Extract this logic out of this component and inject values in
     // via props. Make this a purely presentational component
-    const { xData, yData, seriesBreakoutData, presetChartHeight, visualizationType, showEditingUI, chartSettings } =
+    const { xData, yData, seriesBreakdownData, presetChartHeight, visualizationType, showEditingUI, chartSettings } =
         useValues(dataVisualizationLogic)
     const isBarChart =
         visualizationType === ChartDisplayType.ActionsBar || visualizationType === ChartDisplayType.ActionsStackedBar
@@ -110,14 +110,14 @@ export const LineGraph = (): JSX.Element => {
     const { goalLines } = useValues(displayLogic)
 
     useEffect(() => {
-        // we expect either x and y data or series breakout data
-        let ySeriesData: AxisSeries<number>[] | AxisBreakoutSeries<number>[]
+        // we expect either x and y data or series breakdown data
+        let ySeriesData: AxisSeries<number>[] | AxisBreakdownSeries<number>[]
         let xSeriesData: AxisSeries<string>
         let hasRightYAxis = false
         let hasLeftYAxis = false
-        if (seriesBreakoutData.xData.data.length && seriesBreakoutData.seriesData.length) {
-            ySeriesData = seriesBreakoutData.seriesData
-            xSeriesData = seriesBreakoutData.xData
+        if (seriesBreakdownData.xData.data.length && seriesBreakdownData.seriesData.length) {
+            ySeriesData = seriesBreakdownData.seriesData
+            xSeriesData = seriesBreakdownData.xData
             hasRightYAxis = !!ySeriesData.find((n) => n.settings?.display?.yAxisPosition === 'right')
             hasLeftYAxis = !hasRightYAxis || !!ySeriesData.find((n) => n.settings?.display?.yAxisPosition === 'left')
         } else if (xData && yData) {
@@ -421,7 +421,7 @@ export const LineGraph = (): JSX.Element => {
             plugins: [dataLabelsPlugin],
         })
         return () => newChart.destroy()
-    }, [xData, yData, seriesBreakoutData, visualizationType, goalLines, chartSettings])
+    }, [xData, yData, seriesBreakdownData, visualizationType, goalLines, chartSettings])
 
     return (
         <div

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -45,7 +45,7 @@ Chart.register(ChartjsPluginStacked100)
 Chart.register(chartTrendline)
 
 const getGraphType = (chartType: ChartDisplayType, settings: AxisSeriesSettings | undefined): GraphType => {
-    if (!settings || !settings.display || settings.display?.displayType === 'auto') {
+    if (!settings || !settings.display || !settings.display.displayType || settings.display?.displayType === 'auto') {
         return chartType === ChartDisplayType.ActionsBar || chartType === ChartDisplayType.ActionsStackedBar
             ? GraphType.Bar
             : GraphType.Line

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -93,6 +93,7 @@ const getYAxisSettings = (
     }
 }
 
+// LineGraph displays a graph using either x and y data or series breakdown data
 export const LineGraph = (): JSX.Element => {
     const canvasRef = useRef<HTMLCanvasElement | null>(null)
     const { isDarkModeOn } = useValues(themeLogic)
@@ -100,16 +101,14 @@ export const LineGraph = (): JSX.Element => {
 
     // TODO: Extract this logic out of this component and inject values in
     // via props. Make this a purely presentational component
-
-    // LineGraph displays a graph using either x and y data or series breakdown data
-    const { xData, yData, presetChartHeight, visualizationType, showEditingUI, chartSettings } =
+    const { xData, yData, presetChartHeight, visualizationType, showEditingUI, chartSettings, dataVisualizationProps } =
         useValues(dataVisualizationLogic)
     const isBarChart =
         visualizationType === ChartDisplayType.ActionsBar || visualizationType === ChartDisplayType.ActionsStackedBar
     const isStackedBarChart = visualizationType === ChartDisplayType.ActionsStackedBar
     const isAreaChart = visualizationType === ChartDisplayType.ActionsAreaGraph
 
-    const { seriesBreakdownData } = useValues(seriesBreakdownLogic)
+    const { seriesBreakdownData } = useValues(seriesBreakdownLogic({ key: dataVisualizationProps.key }))
     const { goalLines } = useValues(displayLogic)
 
     useEffect(() => {

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -107,7 +107,7 @@ export const LineGraph = (): JSX.Element => {
         // we expect either x and y data or series breakout data
         let ySeriesData
         let xSeriesData
-        if (seriesBreakoutData) {
+        if (seriesBreakoutData.xData.data.length && seriesBreakoutData.seriesData.length) {
             ySeriesData = seriesBreakoutData.seriesData
             xSeriesData = seriesBreakoutData.xData
         } else if (xData && yData) {

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -31,7 +31,13 @@ import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { ChartSettings, YAxisSettings } from '~/queries/schema'
 import { ChartDisplayType, GraphType } from '~/types'
 
-import { AxisSeriesSettings, dataVisualizationLogic, formatDataWithSettings } from '../../dataVisualizationLogic'
+import {
+    AxisBreakoutSeries,
+    AxisSeries,
+    AxisSeriesSettings,
+    dataVisualizationLogic,
+    formatDataWithSettings,
+} from '../../dataVisualizationLogic'
 import { displayLogic } from '../../displayLogic'
 
 Chart.register(annotationPlugin)
@@ -105,20 +111,23 @@ export const LineGraph = (): JSX.Element => {
 
     useEffect(() => {
         // we expect either x and y data or series breakout data
-        let ySeriesData
-        let xSeriesData
+        let ySeriesData: AxisSeries<number>[] | AxisBreakoutSeries<number>[]
+        let xSeriesData: AxisSeries<string>
+        let hasRightYAxis = false
+        let hasLeftYAxis = false
         if (seriesBreakoutData.xData.data.length && seriesBreakoutData.seriesData.length) {
             ySeriesData = seriesBreakoutData.seriesData
             xSeriesData = seriesBreakoutData.xData
+            hasRightYAxis = !!ySeriesData.find((n) => n.settings?.display?.yAxisPosition === 'right')
+            hasLeftYAxis = !hasRightYAxis || !!ySeriesData.find((n) => n.settings?.display?.yAxisPosition === 'left')
         } else if (xData && yData) {
             ySeriesData = yData
             xSeriesData = xData
+            hasRightYAxis = !!ySeriesData.find((n) => n.settings?.display?.yAxisPosition === 'right')
+            hasLeftYAxis = !hasRightYAxis || !!ySeriesData.find((n) => n.settings?.display?.yAxisPosition === 'left')
         } else {
             return
         }
-
-        const hasRightYAxis = !!ySeriesData.find((n) => n.settings?.display?.yAxisPosition === 'right')
-        const hasLeftYAxis = !hasRightYAxis || !!ySeriesData.find((n) => n.settings?.display?.yAxisPosition === 'left')
 
         const data: ChartData = {
             labels: xSeriesData.data,

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -19,8 +19,9 @@ import { hexToRGBA, lightenDarkenColor, RGBToRGBA } from 'lib/utils'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
-import { AxisBreakdownSeries, AxisSeries, dataVisualizationLogic } from '../dataVisualizationLogic'
+import { AxisSeries, dataVisualizationLogic } from '../dataVisualizationLogic'
 import { ColorPickerButton } from './ColorPickerButton'
+import { AxisBreakdownSeries, seriesBreakdownLogic } from './seriesBreakdownLogic'
 import { ySeriesLogic, YSeriesLogicProps, YSeriesSettingsTab } from './ySeriesLogic'
 
 export const SeriesTab = (): JSX.Element => {
@@ -33,9 +34,10 @@ export const SeriesTab = (): JSX.Element => {
         showTableSettings,
         tabularColumns,
         selectedXAxis,
-        showSeriesBreakdown,
     } = useValues(dataVisualizationLogic)
-    const { updateXSeries, addYSeries, addSeriesBreakdown } = useActions(dataVisualizationLogic)
+    const { updateXSeries, addYSeries } = useActions(dataVisualizationLogic)
+    const { showSeriesBreakdown } = useValues(seriesBreakdownLogic)
+    const { addSeriesBreakdown } = useActions(seriesBreakdownLogic)
 
     const hideAddYSeries = yData.length >= numericalColumns.length
     const hideAddSeriesBreakdown = !(!showSeriesBreakdown && selectedXAxis && columns.length > yData.length)
@@ -111,15 +113,10 @@ export const SeriesTab = (): JSX.Element => {
 }
 
 const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number }): JSX.Element => {
-    const {
-        columns,
-        numericalColumns,
-        responseLoading,
-        dataVisualizationProps,
-        showTableSettings,
-        selectedSeriesBreakdownColumn,
-    } = useValues(dataVisualizationLogic)
+    const { columns, numericalColumns, responseLoading, dataVisualizationProps, showTableSettings } =
+        useValues(dataVisualizationLogic)
     const { updateSeriesIndex, deleteYSeries } = useActions(dataVisualizationLogic)
+    const { selectedSeriesBreakdownColumn } = useValues(seriesBreakdownLogic)
 
     const seriesLogicProps: YSeriesLogicProps = { series, seriesIndex: index, dataVisualizationProps }
     const seriesLogic = ySeriesLogic(seriesLogicProps)
@@ -332,9 +329,9 @@ const Y_SERIES_SETTINGS_TABS = {
 }
 
 export const SeriesBreakdownSelector = (): JSX.Element => {
-    const { columns, responseLoading, selectedXAxis, selectedSeriesBreakdownColumn, seriesBreakdownData } =
-        useValues(dataVisualizationLogic)
-    const { addSeriesBreakdown, deleteSeriesBreakdown } = useActions(dataVisualizationLogic)
+    const { columns, responseLoading, selectedXAxis } = useValues(dataVisualizationLogic)
+    const { selectedSeriesBreakdownColumn, seriesBreakdownData } = useValues(seriesBreakdownLogic)
+    const { addSeriesBreakdown, deleteSeriesBreakdown } = useActions(seriesBreakdownLogic)
 
     const seriesBreakdownOptions = columns
         .map(({ name, type }) => ({

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -19,7 +19,7 @@ import { hexToRGBA, lightenDarkenColor, RGBToRGBA } from 'lib/utils'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
-import { AxisBreakoutSeries, AxisSeries, dataVisualizationLogic } from '../dataVisualizationLogic'
+import { AxisBreakdownSeries, AxisSeries, dataVisualizationLogic } from '../dataVisualizationLogic'
 import { ColorPickerButton } from './ColorPickerButton'
 import { ySeriesLogic, YSeriesLogicProps, YSeriesSettingsTab } from './ySeriesLogic'
 
@@ -33,12 +33,12 @@ export const SeriesTab = (): JSX.Element => {
         showTableSettings,
         tabularColumns,
         selectedXAxis,
-        showSeriesBreakout,
+        showSeriesBreakdown,
     } = useValues(dataVisualizationLogic)
-    const { updateXSeries, addYSeries, addSeriesBreakout } = useActions(dataVisualizationLogic)
+    const { updateXSeries, addYSeries, addSeriesBreakdown } = useActions(dataVisualizationLogic)
 
     const hideAddYSeries = yData.length >= numericalColumns.length
-    const hideAddSeriesBreakout = !(!showSeriesBreakout && selectedXAxis && columns.length > yData.length)
+    const hideAddSeriesBreakdown = !(!showSeriesBreakdown && selectedXAxis && columns.length > yData.length)
 
     if (showTableSettings) {
         return (
@@ -78,18 +78,18 @@ export const SeriesTab = (): JSX.Element => {
                     }
                 }}
             />
-            {!hideAddSeriesBreakout && (
+            {!hideAddSeriesBreakdown && (
                 <LemonButton
                     className="mt-1"
                     type="tertiary"
-                    onClick={() => addSeriesBreakout(null)}
+                    onClick={() => addSeriesBreakdown(null)}
                     icon={<IconPlusSmall />}
                     fullWidth
                 >
-                    Add series breakout
+                    Add series breakdown
                 </LemonButton>
             )}
-            {showSeriesBreakout && <SeriesBreakoutSelector />}
+            {showSeriesBreakdown && <SeriesBreakdownSelector />}
 
             <LemonLabel className="mt-4 mb-1">Y-axis</LemonLabel>
             {yData.map((series, index) => (
@@ -117,7 +117,7 @@ const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number 
         responseLoading,
         dataVisualizationProps,
         showTableSettings,
-        selectedSeriesBreakoutColumn,
+        selectedSeriesBreakdownColumn,
     } = useValues(dataVisualizationLogic)
     const { updateSeriesIndex, deleteYSeries } = useActions(dataVisualizationLogic)
 
@@ -135,7 +135,7 @@ const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number 
         value: name,
         label: (
             <div className="items-center flex flex-1">
-                {!showTableSettings && !selectedSeriesBreakoutColumn && (
+                {!showTableSettings && !selectedSeriesBreakdownColumn && (
                     <SeriesGlyph
                         style={{
                             borderColor: seriesColor,
@@ -331,12 +331,12 @@ const Y_SERIES_SETTINGS_TABS = {
     },
 }
 
-export const SeriesBreakoutSelector = (): JSX.Element => {
-    const { columns, responseLoading, selectedXAxis, selectedSeriesBreakoutColumn, seriesBreakoutData } =
+export const SeriesBreakdownSelector = (): JSX.Element => {
+    const { columns, responseLoading, selectedXAxis, selectedSeriesBreakdownColumn, seriesBreakdownData } =
         useValues(dataVisualizationLogic)
-    const { addSeriesBreakout, deleteSeriesBreakout } = useActions(dataVisualizationLogic)
+    const { addSeriesBreakdown, deleteSeriesBreakdown } = useActions(dataVisualizationLogic)
 
-    const seriesBreakoutOptions = columns
+    const seriesBreakdownOptions = columns
         .map(({ name, type }) => ({
             value: name,
             label: (
@@ -355,13 +355,13 @@ export const SeriesBreakoutSelector = (): JSX.Element => {
             <div className="flex gap-1 my-1">
                 <LemonSelect
                     className="grow"
-                    value={selectedSeriesBreakoutColumn !== null ? selectedSeriesBreakoutColumn : 'None'}
-                    options={seriesBreakoutOptions}
+                    value={selectedSeriesBreakdownColumn !== null ? selectedSeriesBreakdownColumn : 'None'}
+                    options={seriesBreakdownOptions}
                     disabledReason={responseLoading ? 'Query loading...' : undefined}
                     onChange={(value) => {
                         const column = columns.find((n) => n.name === value)
                         if (column) {
-                            addSeriesBreakout(column.name)
+                            addSeriesBreakdown(column.name)
                         }
                     }}
                 />
@@ -369,17 +369,17 @@ export const SeriesBreakoutSelector = (): JSX.Element => {
                     key="delete"
                     icon={<IconTrash />}
                     status="danger"
-                    title="Delete series breakout"
+                    title="Delete series breakdown"
                     noPadding
-                    onClick={() => deleteSeriesBreakout()}
+                    onClick={() => deleteSeriesBreakdown()}
                 />
             </div>
             <div className="ml-4 mt-2">
-                {seriesBreakoutData.error ? (
-                    <div className="text-danger font-bold mt-1">{seriesBreakoutData.error}</div>
+                {seriesBreakdownData.error ? (
+                    <div className="text-danger font-bold mt-1">{seriesBreakdownData.error}</div>
                 ) : (
-                    seriesBreakoutData.seriesData.map((series, index) => (
-                        <BreakoutSeries series={series} index={index} key={`${series.name}-${index}`} />
+                    seriesBreakdownData.seriesData.map((series, index) => (
+                        <BreakdownSeries series={series} index={index} key={`${series.name}-${index}`} />
                     ))
                 )}
             </div>
@@ -387,7 +387,7 @@ export const SeriesBreakoutSelector = (): JSX.Element => {
     )
 }
 
-const BreakoutSeries = ({ series, index }: { series: AxisBreakoutSeries<number>; index: number }): JSX.Element => {
+const BreakdownSeries = ({ series, index }: { series: AxisBreakdownSeries<number>; index: number }): JSX.Element => {
     const { isDarkModeOn } = useValues(themeLogic)
     const seriesColor = series.settings?.display?.color ?? getSeriesColor(index)
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -128,13 +128,14 @@ const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number 
 
     const { isDarkModeOn } = useValues(themeLogic)
     const seriesColor = series.settings?.display?.color ?? getSeriesColor(index)
+    const showSeriesColor = !showTableSettings && !selectedSeriesBreakdownColumn
 
     const columnsInOptions = showTableSettings ? columns : numericalColumns
     const options = columnsInOptions.map(({ name, type }) => ({
         value: name,
         label: (
             <div className="items-center flex flex-1">
-                {!showTableSettings && !selectedSeriesBreakdownColumn && (
+                {showSeriesColor && (
                     <SeriesGlyph
                         style={{
                             borderColor: seriesColor,
@@ -244,33 +245,43 @@ const YSeriesFormattingTab = ({ ySeriesLogicProps }: { ySeriesLogicProps: YSerie
 }
 
 const YSeriesDisplayTab = ({ ySeriesLogicProps }: { ySeriesLogicProps: YSeriesLogicProps }): JSX.Element => {
-    const { showTableSettings } = useValues(dataVisualizationLogic)
+    const { showTableSettings, dataVisualizationProps } = useValues(dataVisualizationLogic)
+    const { selectedSeriesBreakdownColumn } = useValues(seriesBreakdownLogic({ key: dataVisualizationProps.key }))
+
+    const showColorPicker = !showTableSettings && !selectedSeriesBreakdownColumn
+    const showLabelInput = showTableSettings || !selectedSeriesBreakdownColumn
 
     return (
         <Form logic={ySeriesLogic} props={ySeriesLogicProps} formKey="display" className="space-y-4">
-            <div className="flex gap-3">
-                {!showTableSettings && (
-                    <LemonField name="color" label="Color">
-                        {({ value, onChange }) => (
-                            <ColorPickerButton
-                                color={value}
-                                onColorSelect={onChange}
-                                colorChoices={getSeriesColorPalette()}
-                            />
-                        )}
-                    </LemonField>
-                )}
-                <LemonField name="label" label="Label">
-                    <LemonInput />
-                </LemonField>
-            </div>
+            {(showColorPicker || showLabelInput) && (
+                <div className="flex gap-3">
+                    {showColorPicker && (
+                        <LemonField name="color" label="Color">
+                            {({ value, onChange }) => (
+                                <ColorPickerButton
+                                    color={value}
+                                    onColorSelect={onChange}
+                                    colorChoices={getSeriesColorPalette()}
+                                />
+                            )}
+                        </LemonField>
+                    )}
+                    {showLabelInput && (
+                        <LemonField name="label" label="Label">
+                            <LemonInput />
+                        </LemonField>
+                    )}
+                </div>
+            )}
             {!showTableSettings && (
                 <>
-                    <LemonField name="trendLine" label="Trend line">
-                        {({ value, onChange }) => (
-                            <LemonSwitch checked={value} onChange={(newValue) => onChange(newValue)} />
-                        )}
-                    </LemonField>
+                    {!selectedSeriesBreakdownColumn && (
+                        <LemonField name="trendLine" label="Trend line">
+                            {({ value, onChange }) => (
+                                <LemonSwitch checked={value} onChange={(newValue) => onChange(newValue)} />
+                            )}
+                        </LemonField>
+                    )}
                     <LemonField name="yAxisPosition" label="Y-axis position">
                         {({ value, onChange }) => (
                             <LemonSegmentedButton

--- a/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SeriesTab.tsx
@@ -34,10 +34,12 @@ export const SeriesTab = (): JSX.Element => {
         showTableSettings,
         tabularColumns,
         selectedXAxis,
+        dataVisualizationProps,
     } = useValues(dataVisualizationLogic)
     const { updateXSeries, addYSeries } = useActions(dataVisualizationLogic)
-    const { showSeriesBreakdown } = useValues(seriesBreakdownLogic)
-    const { addSeriesBreakdown } = useActions(seriesBreakdownLogic)
+    const breakdownLogic = seriesBreakdownLogic({ key: dataVisualizationProps.key })
+    const { showSeriesBreakdown } = useValues(breakdownLogic)
+    const { addSeriesBreakdown } = useActions(breakdownLogic)
 
     const hideAddYSeries = yData.length >= numericalColumns.length
     const hideAddSeriesBreakdown = !(!showSeriesBreakdown && selectedXAxis && columns.length > yData.length)
@@ -116,7 +118,7 @@ const YSeries = ({ series, index }: { series: AxisSeries<number>; index: number 
     const { columns, numericalColumns, responseLoading, dataVisualizationProps, showTableSettings } =
         useValues(dataVisualizationLogic)
     const { updateSeriesIndex, deleteYSeries } = useActions(dataVisualizationLogic)
-    const { selectedSeriesBreakdownColumn } = useValues(seriesBreakdownLogic)
+    const { selectedSeriesBreakdownColumn } = useValues(seriesBreakdownLogic({ key: dataVisualizationProps.key }))
 
     const seriesLogicProps: YSeriesLogicProps = { series, seriesIndex: index, dataVisualizationProps }
     const seriesLogic = ySeriesLogic(seriesLogicProps)
@@ -329,9 +331,10 @@ const Y_SERIES_SETTINGS_TABS = {
 }
 
 export const SeriesBreakdownSelector = (): JSX.Element => {
-    const { columns, responseLoading, selectedXAxis } = useValues(dataVisualizationLogic)
-    const { selectedSeriesBreakdownColumn, seriesBreakdownData } = useValues(seriesBreakdownLogic)
-    const { addSeriesBreakdown, deleteSeriesBreakdown } = useActions(seriesBreakdownLogic)
+    const { columns, responseLoading, selectedXAxis, dataVisualizationProps } = useValues(dataVisualizationLogic)
+    const breakdownLogic = seriesBreakdownLogic({ key: dataVisualizationProps.key })
+    const { selectedSeriesBreakdownColumn, seriesBreakdownData } = useValues(breakdownLogic)
+    const { addSeriesBreakdown, deleteSeriesBreakdown } = useActions(breakdownLogic)
 
     const seriesBreakdownOptions = columns
         .map(({ name, type }) => ({

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
@@ -205,6 +205,16 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                     return {
                         name: value || '[No value]',
                         data: dataset,
+                        // we copy supported settings over from the selected
+                        // y-axis since we don't support setting these on the
+                        // breakdown series at the moment
+                        settings: {
+                            formatting: selectedYAxis.settings.formatting,
+                            display: {
+                                yAxisPosition: selectedYAxis.settings?.display?.yAxisPosition,
+                                displayType: selectedYAxis.settings?.display?.displayType,
+                            },
+                        },
                     }
                 })
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
@@ -1,0 +1,222 @@
+import { actions, connect, kea, key, path, props, reducers, selectors } from 'kea'
+
+import { AxisSeries, AxisSeriesSettings, dataVisualizationLogic } from '../dataVisualizationLogic'
+import type { seriesBreakdownLogicType } from './seriesBreakdownLogicType'
+
+export interface AxisBreakdownSeries<T> {
+    name: string
+    data: T[]
+    settings?: AxisSeriesSettings
+}
+
+export interface BreakdownSeriesData<T> {
+    xData: AxisSeries<string>
+    seriesData: AxisBreakdownSeries<T>[]
+    isUnaggregated?: boolean
+    error?: string
+}
+
+export const EmptyBreakdownSeries: BreakdownSeriesData<number> = {
+    xData: {
+        column: {
+            name: 'None',
+            type: {
+                name: 'INTEGER',
+                isNumerical: false,
+            },
+            label: 'None',
+            dataIndex: -1,
+        },
+        data: [],
+    },
+    seriesData: [],
+}
+
+const createEmptyBreakdownSeriesWithError = (error: string): BreakdownSeriesData<number> => {
+    return {
+        ...EmptyBreakdownSeries,
+        error,
+    }
+}
+
+export interface SeriesBreakdownLogicProps {
+    key: string
+}
+
+export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
+    path(['queries', 'nodes', 'DataVisualization', 'Components', 'seriesBreakdownLogic']),
+    key((props) => props.key),
+    props({ key: '' } as SeriesBreakdownLogicProps),
+    connect({
+        actions: [dataVisualizationLogic, ['clearAxis']],
+        values: [dataVisualizationLogic, ['response', 'columns', 'selectedXAxis', 'selectedYAxis']],
+    }),
+    actions(({ values }) => ({
+        addSeriesBreakdown: (columnName: string | null) => ({ columnName, response: values.response }),
+        deleteSeriesBreakdown: () => ({}),
+    })),
+    reducers({
+        showSeriesBreakdown: [
+            false as boolean,
+            {
+                clearAxis: () => false,
+                addSeriesBreakdown: () => true,
+                deleteSeriesBreakdown: () => false,
+            },
+        ],
+        selectedSeriesBreakdownColumn: [
+            null as string | null,
+            {
+                clearAxis: () => null,
+                addSeriesBreakdown: (_, { columnName }) => columnName,
+                deleteSeriesBreakdown: () => null,
+            },
+        ],
+    }),
+    selectors({
+        breakdownColumnValues: [
+            (state) => [state.selectedSeriesBreakdownColumn, state.response, state.columns],
+            (breakdownColumn, response, columns): string[] => {
+                if (!response || breakdownColumn === null) {
+                    return []
+                }
+
+                const data: any[] = response?.['results'] ?? response?.['result'] ?? []
+
+                const column = columns.find((n) => n.name === breakdownColumn)
+                if (!column) {
+                    return []
+                }
+
+                // return list of unique column values
+                return Array.from(new Set(data.map((n) => n[column.dataIndex])))
+            },
+        ],
+        seriesBreakdownData: [
+            (state) => [
+                state.selectedSeriesBreakdownColumn,
+                state.breakdownColumnValues,
+                state.selectedYAxis,
+                state.selectedXAxis,
+                state.response,
+                state.columns,
+            ],
+            (
+                selectedBreakdownColumn,
+                breakdownColumnValues,
+                ySeries,
+                xSeries,
+                response,
+                columns
+            ): BreakdownSeriesData<number> => {
+                if (
+                    !response ||
+                    !selectedBreakdownColumn ||
+                    ySeries === null ||
+                    ySeries.length === 0 ||
+                    xSeries === null ||
+                    columns === null ||
+                    columns.length === 0
+                ) {
+                    return EmptyBreakdownSeries
+                }
+
+                // shouldn't be possible to have more than 1 ySeries with a breakdown
+                if (ySeries.length > 1) {
+                    return EmptyBreakdownSeries
+                }
+
+                const selectedYAxis = ySeries[0]
+                if (!selectedYAxis) {
+                    return EmptyBreakdownSeries
+                }
+                const yColumn = columns.find((n) => n.name === selectedYAxis.name)
+                if (!yColumn) {
+                    return EmptyBreakdownSeries
+                }
+                const xColumn = columns.find((n) => n.name === xSeries)
+                if (!xColumn) {
+                    return EmptyBreakdownSeries
+                }
+
+                const breakdownColumn = columns.find((n) => n.name === selectedBreakdownColumn)
+                if (!breakdownColumn) {
+                    return EmptyBreakdownSeries
+                }
+
+                if (breakdownColumnValues.length > 50) {
+                    return createEmptyBreakdownSeriesWithError('Too many breakdown values (max 50)')
+                }
+
+                const data: any[] = response?.['results'] ?? response?.['result'] ?? []
+
+                // xData is unique x values
+                const xData = Array.from(new Set(data.map((n) => n[xColumn.dataIndex])))
+
+                let isUnaggregated = false
+
+                const seriesData: AxisBreakdownSeries<number>[] = breakdownColumnValues.map((value) => {
+                    // first filter data by breakdown column value
+                    const filteredData = data.filter((n) => n[breakdownColumn.dataIndex] === value)
+                    if (filteredData.length === 0) {
+                        return {
+                            name: value,
+                            data: [],
+                        }
+                    }
+
+                    // check if there are any duplicates of xColumn values
+                    // (if we know there is unaggregated data, we don't need to check again)
+                    if (!isUnaggregated) {
+                        const xColumnValues = filteredData.map((n) => n[xColumn.dataIndex])
+                        const xColumnValuesSet = new Set(xColumnValues)
+                        if (xColumnValues.length !== xColumnValuesSet.size) {
+                            isUnaggregated = true
+                        }
+                    }
+
+                    // sum y values for each x value, setting to 0 if no corresponding y value
+                    const dataset = xData.map((xValue) => {
+                        const yValue = filteredData
+                            .filter((n) => n[xColumn.dataIndex] === xValue)
+                            .map((n) => {
+                                try {
+                                    const value = n[yColumn.dataIndex]
+                                    const multiplier = selectedYAxis.settings.formatting?.style === 'percent' ? 100 : 1
+
+                                    if (selectedYAxis.settings.formatting?.decimalPlaces) {
+                                        return parseFloat(
+                                            (parseFloat(value) * multiplier).toFixed(
+                                                selectedYAxis.settings.formatting.decimalPlaces
+                                            )
+                                        )
+                                    }
+
+                                    const isInt = Number.isInteger(value)
+                                    return isInt ? parseInt(value) * multiplier : parseFloat(value) * multiplier
+                                } catch {
+                                    return 0
+                                }
+                            })
+                            .reduce((a, b) => a + b, 0)
+                        return yValue
+                    })
+
+                    return {
+                        name: value || '[No value]',
+                        data: dataset,
+                    }
+                })
+
+                return {
+                    xData: {
+                        column: xColumn,
+                        data: xData,
+                    },
+                    seriesData,
+                    isUnaggregated,
+                }
+            },
+        ],
+    }),
+])

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -98,42 +98,6 @@ const DefaultAxisSettings = (): AxisSeriesSettings => ({
     },
 })
 
-export interface AxisBreakdownSeries<T> {
-    name: string
-    data: T[]
-    settings?: AxisSeriesSettings
-}
-
-export interface BreakdownSeriesData<T> {
-    xData: AxisSeries<string>
-    seriesData: AxisBreakdownSeries<T>[]
-    isUnaggregated?: boolean
-    error?: string
-}
-
-export const EmptyBreakdownSeries: BreakdownSeriesData<number> = {
-    xData: {
-        column: {
-            name: 'None',
-            type: {
-                name: 'INTEGER',
-                isNumerical: false,
-            },
-            label: 'None',
-            dataIndex: -1,
-        },
-        data: [],
-    },
-    seriesData: [],
-}
-
-const createEmptyBreakdownSeriesWithError = (error: string): BreakdownSeriesData<number> => {
-    return {
-        ...EmptyBreakdownSeries,
-        error,
-    }
-}
-
 export const formatDataWithSettings = (
     data: number | string | null | object,
     settings?: AxisSeriesSettings
@@ -302,8 +266,6 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             allColumns: values.columns,
         }),
         deleteYSeries: (seriesIndex: number) => ({ seriesIndex }),
-        addSeriesBreakdown: (columnName: string | null) => ({ columnName, response: values.response }),
-        deleteSeriesBreakdown: () => ({}),
         clearAxis: true,
         setQuery: (node: DataVisualizationNode) => ({ node }),
         updateChartSettings: (settings: ChartSettings) => ({ settings }),
@@ -475,22 +437,6 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
 
                     return ySeries
                 },
-            },
-        ],
-        showSeriesBreakdown: [
-            false as boolean,
-            {
-                clearAxis: () => false,
-                addSeriesBreakdown: () => true,
-                deleteSeriesBreakdown: () => false,
-            },
-        ],
-        selectedSeriesBreakdownColumn: [
-            null as string | null,
-            {
-                clearAxis: () => null,
-                addSeriesBreakdown: (_, { columnName }) => columnName,
-                deleteSeriesBreakdown: () => null,
             },
         ],
         activeSideBarTab: [
@@ -716,150 +662,6 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 return {
                     column,
                     data: data.map((n) => n[column.dataIndex]),
-                }
-            },
-        ],
-        breakdownColumnValues: [
-            (state) => [state.selectedSeriesBreakdownColumn, state.response, state.columns],
-            (breakdownColumn, response, columns): string[] => {
-                if (!response || breakdownColumn === null) {
-                    return []
-                }
-
-                const data: any[] = response?.['results'] ?? response?.['result'] ?? []
-
-                const column = columns.find((n) => n.name === breakdownColumn)
-                if (!column) {
-                    return []
-                }
-
-                // return list of unique column values
-                return Array.from(new Set(data.map((n) => n[column.dataIndex])))
-            },
-        ],
-        seriesBreakdownData: [
-            (state) => [
-                state.selectedSeriesBreakdownColumn,
-                state.breakdownColumnValues,
-                state.selectedYAxis,
-                state.selectedXAxis,
-                state.response,
-                state.columns,
-            ],
-            (
-                selectedBreakdownColumn,
-                breakdownColumnValues,
-                ySeries,
-                xSeries,
-                response,
-                columns
-            ): BreakdownSeriesData<number> => {
-                if (
-                    !response ||
-                    !selectedBreakdownColumn ||
-                    ySeries === null ||
-                    ySeries.length === 0 ||
-                    xSeries === null ||
-                    columns === null ||
-                    columns.length === 0
-                ) {
-                    return EmptyBreakdownSeries
-                }
-
-                // shouldn't be possible to have more than 1 ySeries with a breakdown
-                if (ySeries.length > 1) {
-                    return EmptyBreakdownSeries
-                }
-
-                const selectedYAxis = ySeries[0]
-                if (!selectedYAxis) {
-                    return EmptyBreakdownSeries
-                }
-                const yColumn = columns.find((n) => n.name === selectedYAxis.name)
-                if (!yColumn) {
-                    return EmptyBreakdownSeries
-                }
-                const xColumn = columns.find((n) => n.name === xSeries)
-                if (!xColumn) {
-                    return EmptyBreakdownSeries
-                }
-
-                const breakdownColumn = columns.find((n) => n.name === selectedBreakdownColumn)
-                if (!breakdownColumn) {
-                    return EmptyBreakdownSeries
-                }
-
-                if (breakdownColumnValues.length > 50) {
-                    return createEmptyBreakdownSeriesWithError('Too many breakdown values (max 50)')
-                }
-
-                const data: any[] = response?.['results'] ?? response?.['result'] ?? []
-
-                // xData is unique x values
-                const xData = Array.from(new Set(data.map((n) => n[xColumn.dataIndex])))
-
-                let isUnaggregated = false
-
-                const seriesData: AxisBreakdownSeries<number>[] = breakdownColumnValues.map((value) => {
-                    // first filter data by breakdown column value
-                    const filteredData = data.filter((n) => n[breakdownColumn.dataIndex] === value)
-                    if (filteredData.length === 0) {
-                        return {
-                            name: value,
-                            data: [],
-                        }
-                    }
-
-                    // check if there are any duplicates of xColumn values
-                    // (if we know there is unaggregated data, we don't need to check again)
-                    if (!isUnaggregated) {
-                        const xColumnValues = filteredData.map((n) => n[xColumn.dataIndex])
-                        const xColumnValuesSet = new Set(xColumnValues)
-                        if (xColumnValues.length !== xColumnValuesSet.size) {
-                            isUnaggregated = true
-                        }
-                    }
-
-                    // sum y values for each x value, setting to 0 if no corresponding y value
-                    const dataset = xData.map((xValue) => {
-                        const yValue = filteredData
-                            .filter((n) => n[xColumn.dataIndex] === xValue)
-                            .map((n) => {
-                                try {
-                                    const value = n[yColumn.dataIndex]
-                                    const multiplier = selectedYAxis.settings.formatting?.style === 'percent' ? 100 : 1
-
-                                    if (selectedYAxis.settings.formatting?.decimalPlaces) {
-                                        return parseFloat(
-                                            (parseFloat(value) * multiplier).toFixed(
-                                                selectedYAxis.settings.formatting.decimalPlaces
-                                            )
-                                        )
-                                    }
-
-                                    const isInt = Number.isInteger(value)
-                                    return isInt ? parseInt(value) * multiplier : parseFloat(value) * multiplier
-                                } catch {
-                                    return 0
-                                }
-                            })
-                            .reduce((a, b) => a + b, 0)
-                        return yValue
-                    })
-
-                    return {
-                        name: value || '[No value]',
-                        data: dataset,
-                    }
-                })
-
-                return {
-                    xData: {
-                        column: xColumn,
-                        data: xData,
-                    },
-                    seriesData,
-                    isUnaggregated,
                 }
             },
         ],

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -266,6 +266,8 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             allColumns: values.columns,
         }),
         deleteYSeries: (seriesIndex: number) => ({ seriesIndex }),
+        addSeriesBreakout: (columnName: string | null) => ({ columnName }),
+        deleteSeriesBreakout: () => ({}),
         clearAxis: true,
         setQuery: (node: DataVisualizationNode) => ({ node }),
         updateChartSettings: (settings: ChartSettings) => ({ settings }),
@@ -437,6 +439,22 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
 
                     return ySeries
                 },
+            },
+        ],
+        showSeriesBreakout: [
+            false as boolean,
+            {
+                clearAxis: () => false,
+                addSeriesBreakout: () => true,
+                deleteSeriesBreakout: () => false,
+            },
+        ],
+        selectedSeriesBreakout: [
+            null as string | null,
+            {
+                clearAxis: () => null,
+                addSeriesBreakout: (_, { columnName }) => columnName,
+                deleteSeriesBreakout: () => null,
             },
         ],
         activeSideBarTab: [

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -98,20 +98,20 @@ const DefaultAxisSettings = (): AxisSeriesSettings => ({
     },
 })
 
-export interface AxisBreakoutSeries<T> {
+export interface AxisBreakdownSeries<T> {
     name: string
     data: T[]
     settings?: AxisSeriesSettings
 }
 
-export interface BreakoutSeriesData<T> {
+export interface BreakdownSeriesData<T> {
     xData: AxisSeries<string>
-    seriesData: AxisBreakoutSeries<T>[]
+    seriesData: AxisBreakdownSeries<T>[]
     isUnaggregated?: boolean
     error?: string
 }
 
-export const EmptyBreakoutSeries: BreakoutSeriesData<number> = {
+export const EmptyBreakdownSeries: BreakdownSeriesData<number> = {
     xData: {
         column: {
             name: 'None',
@@ -127,9 +127,9 @@ export const EmptyBreakoutSeries: BreakoutSeriesData<number> = {
     seriesData: [],
 }
 
-const createEmptyBreakoutSeriesWithError = (error: string): BreakoutSeriesData<number> => {
+const createEmptyBreakdownSeriesWithError = (error: string): BreakdownSeriesData<number> => {
     return {
-        ...EmptyBreakoutSeries,
+        ...EmptyBreakdownSeries,
         error,
     }
 }
@@ -302,8 +302,8 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
             allColumns: values.columns,
         }),
         deleteYSeries: (seriesIndex: number) => ({ seriesIndex }),
-        addSeriesBreakout: (columnName: string | null) => ({ columnName, response: values.response }),
-        deleteSeriesBreakout: () => ({}),
+        addSeriesBreakdown: (columnName: string | null) => ({ columnName, response: values.response }),
+        deleteSeriesBreakdown: () => ({}),
         clearAxis: true,
         setQuery: (node: DataVisualizationNode) => ({ node }),
         updateChartSettings: (settings: ChartSettings) => ({ settings }),
@@ -477,20 +477,20 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 },
             },
         ],
-        showSeriesBreakout: [
+        showSeriesBreakdown: [
             false as boolean,
             {
                 clearAxis: () => false,
-                addSeriesBreakout: () => true,
-                deleteSeriesBreakout: () => false,
+                addSeriesBreakdown: () => true,
+                deleteSeriesBreakdown: () => false,
             },
         ],
-        selectedSeriesBreakoutColumn: [
+        selectedSeriesBreakdownColumn: [
             null as string | null,
             {
                 clearAxis: () => null,
-                addSeriesBreakout: (_, { columnName }) => columnName,
-                deleteSeriesBreakout: () => null,
+                addSeriesBreakdown: (_, { columnName }) => columnName,
+                deleteSeriesBreakdown: () => null,
             },
         ],
         activeSideBarTab: [
@@ -719,16 +719,16 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 }
             },
         ],
-        breakoutColumnValues: [
-            (state) => [state.selectedSeriesBreakoutColumn, state.response, state.columns],
-            (breakoutColumn, response, columns): string[] => {
-                if (!response || breakoutColumn === null) {
+        breakdownColumnValues: [
+            (state) => [state.selectedSeriesBreakdownColumn, state.response, state.columns],
+            (breakdownColumn, response, columns): string[] => {
+                if (!response || breakdownColumn === null) {
                     return []
                 }
 
                 const data: any[] = response?.['results'] ?? response?.['result'] ?? []
 
-                const column = columns.find((n) => n.name === breakoutColumn)
+                const column = columns.find((n) => n.name === breakdownColumn)
                 if (!column) {
                     return []
                 }
@@ -737,60 +737,60 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 return Array.from(new Set(data.map((n) => n[column.dataIndex])))
             },
         ],
-        seriesBreakoutData: [
+        seriesBreakdownData: [
             (state) => [
-                state.selectedSeriesBreakoutColumn,
-                state.breakoutColumnValues,
+                state.selectedSeriesBreakdownColumn,
+                state.breakdownColumnValues,
                 state.selectedYAxis,
                 state.selectedXAxis,
                 state.response,
                 state.columns,
             ],
             (
-                selectedBreakoutColumn,
-                breakoutColumnValues,
+                selectedBreakdownColumn,
+                breakdownColumnValues,
                 ySeries,
                 xSeries,
                 response,
                 columns
-            ): BreakoutSeriesData<number> => {
+            ): BreakdownSeriesData<number> => {
                 if (
                     !response ||
-                    !selectedBreakoutColumn ||
+                    !selectedBreakdownColumn ||
                     ySeries === null ||
                     ySeries.length === 0 ||
                     xSeries === null ||
                     columns === null ||
                     columns.length === 0
                 ) {
-                    return EmptyBreakoutSeries
+                    return EmptyBreakdownSeries
                 }
 
-                // shouldn't be possible to have more than 1 ySeries with a breakout
+                // shouldn't be possible to have more than 1 ySeries with a breakdown
                 if (ySeries.length > 1) {
-                    return EmptyBreakoutSeries
+                    return EmptyBreakdownSeries
                 }
 
                 const selectedYAxis = ySeries[0]
                 if (!selectedYAxis) {
-                    return EmptyBreakoutSeries
+                    return EmptyBreakdownSeries
                 }
                 const yColumn = columns.find((n) => n.name === selectedYAxis.name)
                 if (!yColumn) {
-                    return EmptyBreakoutSeries
+                    return EmptyBreakdownSeries
                 }
                 const xColumn = columns.find((n) => n.name === xSeries)
                 if (!xColumn) {
-                    return EmptyBreakoutSeries
+                    return EmptyBreakdownSeries
                 }
 
-                const breakoutColumn = columns.find((n) => n.name === selectedBreakoutColumn)
-                if (!breakoutColumn) {
-                    return EmptyBreakoutSeries
+                const breakdownColumn = columns.find((n) => n.name === selectedBreakdownColumn)
+                if (!breakdownColumn) {
+                    return EmptyBreakdownSeries
                 }
 
-                if (breakoutColumnValues.length > 50) {
-                    return createEmptyBreakoutSeriesWithError('Too many breakout values (max 50)')
+                if (breakdownColumnValues.length > 50) {
+                    return createEmptyBreakdownSeriesWithError('Too many breakdown values (max 50)')
                 }
 
                 const data: any[] = response?.['results'] ?? response?.['result'] ?? []
@@ -800,9 +800,9 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
 
                 let isUnaggregated = false
 
-                const seriesData: AxisBreakoutSeries<number>[] = breakoutColumnValues.map((value) => {
-                    // first filter data by breakout column value
-                    const filteredData = data.filter((n) => n[breakoutColumn.dataIndex] === value)
+                const seriesData: AxisBreakdownSeries<number>[] = breakdownColumnValues.map((value) => {
+                    // first filter data by breakdown column value
+                    const filteredData = data.filter((n) => n[breakdownColumn.dataIndex] === value)
                     if (filteredData.length === 0) {
                         return {
                             name: value,


### PR DESCRIPTION
## Problem

At the moment it is not possible to breakdown data using an additional column in the query. Here we add basic support for this.

See screencast for an example of how this works:

https://github.com/user-attachments/assets/189ab618-25c4-412c-82ff-215ef0ae3ec7

## Questions

- ~What terminology should be used here: _breakdown_ or _breakout_? The ticket used the former but Metabase uses the latter. Not sure which is the most common?~ **After disussion have gone for _breakdown_ as this is a term we already use**

## Scope for improvement:
- Show a warning if trying to plot an unaggregated field, like is done in Metabase
![image](https://github.com/user-attachments/assets/2eea3b89-f155-48de-bf3b-1b90f18dc52c)

- Add ability to show/hide individual breakdown values
- Change color of individual breakdown values


## Changes

- Add option to add series breakdown if there is an additional column to use for aggregations

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Should do

## How did you test this code?

Local testing (not sure if we have any unit tests for this stuff?)
