### PR TITLE
fix(onboarding): Styleguide fixes for product multiselect

### DIFF
--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -153,7 +153,7 @@ export function Products(): JSX.Element {
                     <div className="flex flex-col justify-center flex-grow items-center">
                         <div className="mb-8">
                             <h2 className="text-center text-4xl">What would you like to set up?</h2>
-                            <p className="text-center">Don’t worry &mdash; you can pick more than one!</p>
+                            <p className="text-center">Don't worry &ndash; you can pick more than one!</p>
                         </div>
                         <div className="grid gap-4 grid-rows-[160px] grid-cols-[repeat(2,_minmax(min-content,_160px))] md:grid-cols-[repeat(3,_minmax(min-content,_160px))] ">
                             {Object.keys(availableOnboardingProducts).map((productKey) => (


### PR DESCRIPTION
## Changes

Uses straight apostrophe and en dash, per [style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide), instead of curled apostrophe and em dash.

TIL! Quite extraordinary to have this documented already too.

**Before**

![CleanShot 2024-11-06 at 07 32 49@2x](https://github.com/user-attachments/assets/20c2887a-eeeb-45b6-844c-6be8bcc4474b)

**After**

![CleanShot 2024-11-06 at 07 32 30@2x](https://github.com/user-attachments/assets/67f2b400-6305-4ba7-8fc1-28a2e9255b52)

## How did you test this code?

Took a peak at the display.