### PR TITLE
fix: Added missing clickhouse string sanitization

### DIFF
--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -26,6 +26,7 @@ import {
 } from '../types'
 import { createKafkaProducerWrapper } from '../utils/db/hub'
 import { KafkaProducerWrapper } from '../utils/db/kafka-producer-wrapper'
+import { safeClickhouseString } from '../utils/db/utils'
 import { status } from '../utils/status'
 import { castTimestampOrNow } from '../utils/utils'
 import { RustyHook } from '../worker/rusty-hook'
@@ -158,7 +159,7 @@ abstract class CdpConsumerBase {
             messages.map((x) =>
                 this.kafkaProducer!.produce({
                     topic: x.topic,
-                    value: Buffer.from(JSON.stringify(x.value)),
+                    value: Buffer.from(safeClickhouseString(JSON.stringify(x.value))),
                     key: x.key,
                     waitForAck: true,
                 }).catch((reason) => {


### PR DESCRIPTION
## Problem

We need to sanitize the log entry before writing it and we missed one place for this

## Changes

* Fixes it 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
