### PR TITLE
chore(data-warehouse): turn off source config

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -227,6 +227,7 @@ export const FEATURE_FLAGS = {
     BILLING_TRIAL_FLOW: 'billing-trial-flow', // owner: @zach
     DEAD_CLICKS_AUTOCAPTURE: 'dead-clicks-autocapture', // owner: @pauldambra #team-replay
     ONBOARDING_PRODUCT_MULTISELECT: 'onboarding-product-multiselect', // owner: @danielbachhuber #team-experiments
+    EDIT_DWH_SOURCE_CONFIG: 'edit_dwh_source_config', // owner: @Gilbert09 #team-data-warehouse
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/pipeline/PipelineNode.tsx
+++ b/frontend/src/scenes/pipeline/PipelineNode.tsx
@@ -2,7 +2,9 @@ import { useValues } from 'kea'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { NotFound } from 'lib/components/NotFound'
 import { PageHeader } from 'lib/components/PageHeader'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs/LemonTabs'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { Schemas } from 'scenes/data-warehouse/settings/source/Schemas'
 import { SourceConfiguration } from 'scenes/data-warehouse/settings/source/SourceConfiguration'
@@ -53,6 +55,7 @@ export const scene: SceneExport = {
 export function PipelineNode(params: { stage?: string; id?: string } = {}): JSX.Element {
     const { stage, id } = paramsToProps({ params })
     const { currentTab, node } = useValues(pipelineNodeLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     if (!stage) {
         return <NotFound object="pipeline stage" />
@@ -62,7 +65,9 @@ export function PipelineNode(params: { stage?: string; id?: string } = {}): JSX.
             ? {
                   [PipelineNodeTab.Schemas]: <Schemas id={node.id} />,
                   [PipelineNodeTab.Syncs]: <Syncs id={node.id} />,
-                  [PipelineNodeTab.SourceConfiguration]: <SourceConfiguration id={node.id} />,
+                  ...(featureFlags[FEATURE_FLAGS.EDIT_DWH_SOURCE_CONFIG]
+                      ? { [PipelineNodeTab.SourceConfiguration]: <SourceConfiguration id={node.id} /> }
+                      : {}),
               }
             : {
                   [PipelineNodeTab.Configuration]: <PipelineNodeConfiguration />,


### PR DESCRIPTION
## Problem
- [context](https://posthog.slack.com/archives/C019RAX2XBN/p1730384585742459?thread_ts=1730377865.448039&cid=C019RAX2XBN)

## Changes
- Put source config behind a flag while we fix the `dbname` field 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
👀 