### PR TITLE
chore: improve hogfetti position / unsubscribe modal

### DIFF
--- a/frontend/src/lib/components/Hogfetti/Hogfetti.tsx
+++ b/frontend/src/lib/components/Hogfetti/Hogfetti.tsx
@@ -106,7 +106,7 @@ export const useHogfetti = (options: HogfettiOptions = {}): HogfettiHook => {
 
     const trigger = useCallback((): void => {
         const centerX = Math.random() * dimensions.width
-        const centerY = Math.random() * dimensions.height
+        const centerY = Math.random() * dimensions.height * 0.5
 
         const newParticles = Array.from({ length: count }, () => createParticle(centerX, centerY))
         setParticleSets((prev) => [...prev, newParticles])

--- a/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
+++ b/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
@@ -110,7 +110,7 @@ export const UnsubscribeSurveyModal = ({
                 </LemonButton>
                 <LemonButton
                     type="tertiary"
-                    loading={billingLoading}
+                    disabled={billingLoading}
                     onClick={() => {
                         resetUnsubscribeModalStep()
                         reportSurveyDismissed(surveyID)


### PR DESCRIPTION
## Changes

- Shifting hogfetti up so the apex is always in the top 50% of the page. 
- Updating the loading state for unsubscribing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
