### PR TITLE
feat(repl): tables and tags

### DIFF
--- a/frontend/src/scenes/debug/hog/HogRepl.tsx
+++ b/frontend/src/scenes/debug/hog/HogRepl.tsx
@@ -1,14 +1,68 @@
-import { LemonButton } from '@posthog/lemon-ui'
+import { printHogStringOutput } from '@posthog/hogvm'
+import { LemonButton, LemonTable, LemonTabs } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
+import { JSONViewer } from 'lib/components/JSONViewer'
 import { CodeEditorInline } from 'lib/monaco/CodeEditorInline'
+import React, { useState } from 'react'
 import { SceneExport } from 'scenes/sceneTypes'
 
+import { renderHogQLX } from '~/queries/nodes/HogQLX/render'
+
 import { hogReplLogic, ReplChunk as ReplChunkType } from './hogReplLogic'
+
+export interface ReplResultsTableProps {
+    response: {
+        results: any[][]
+        columns: string[]
+    }
+}
+
+export function ReplResultsTable({ response }: ReplResultsTableProps): JSX.Element {
+    const [activeTab, setActiveTab] = useState<'table' | 'json'>('table')
+    return (
+        <div>
+            <LemonTabs
+                activeKey={activeTab}
+                onChange={setActiveTab}
+                tabs={[
+                    {
+                        key: 'table',
+                        label: 'Table',
+                        content: (
+                            <LemonTable
+                                columns={response.columns.map((col, index) => ({ dataIndex: index, title: col }))}
+                                dataSource={response.results}
+                            />
+                        ),
+                    },
+                    {
+                        key: 'json',
+                        label: 'JSON',
+                        content: <JSONViewer name={false} src={response} />,
+                    },
+                ]}
+            />
+        </div>
+    )
+}
+
+function printRichHogOutput(arg: any): JSX.Element | string {
+    if (typeof arg === 'object' && arg !== null) {
+        if ('__hx_tag' in arg) {
+            return renderHogQLX(arg)
+        }
+        if ('results' in arg && 'columns' in arg && Array.isArray(arg.results) && Array.isArray(arg.columns)) {
+            return <ReplResultsTable response={arg} />
+        }
+    }
+    return printHogStringOutput(arg)
+}
 
 interface ReplChunkProps {
     chunk: ReplChunkType
     editFromHere: () => void
 }
+
 export function ReplChunk({
     chunk: { code, result, print, error, status },
     editFromHere,
@@ -40,7 +94,7 @@ export function ReplChunk({
                     </svg>
                 </div>
             )}
-            {print ? (
+            {print && Array.isArray(print) ? (
                 <div className="flex items-start mt-2">
                     <span
                         // eslint-disable-next-line react/forbid-dom-props
@@ -48,10 +102,21 @@ export function ReplChunk({
                     >
                         #
                     </span>
-                    <div className="flex-1 whitespace-pre-wrap ml-2">{print}</div>
+                    <div className="flex-1 whitespace-pre-wrap ml-2">
+                        {print.map((line, index) => (
+                            <div key={index}>
+                                {line.map((arg, argIndex) => (
+                                    <React.Fragment key={argIndex}>
+                                        {printRichHogOutput(arg)}
+                                        {argIndex < line.length - 1 ? ' ' : ''}
+                                    </React.Fragment>
+                                ))}
+                            </div>
+                        ))}
+                    </div>
                 </div>
             ) : null}
-            {status === 'success' && (
+            {status === 'success' && result !== undefined && (
                 <div className="flex items-start mt-2">
                     <span
                         // eslint-disable-next-line react/forbid-dom-props
@@ -59,7 +124,7 @@ export function ReplChunk({
                     >
                         {'<'}
                     </span>
-                    <div className="flex-1 whitespace-pre-wrap ml-2">{String(result)}</div>
+                    <div className="flex-1 whitespace-pre-wrap ml-2">{printRichHogOutput(result)}</div>
                 </div>
             )}
             {status === 'error' && (

--- a/frontend/src/scenes/debug/hog/HogRepl.tsx
+++ b/frontend/src/scenes/debug/hog/HogRepl.tsx
@@ -23,7 +23,7 @@ export function ReplResultsTable({ response }: ReplResultsTableProps): JSX.Eleme
         <div>
             <LemonTabs
                 activeKey={activeTab}
-                onChange={setActiveTab}
+                onChange={setActiveTab as any}
                 tabs={[
                     {
                         key: 'table',
@@ -39,6 +39,11 @@ export function ReplResultsTable({ response }: ReplResultsTableProps): JSX.Eleme
                         key: 'json',
                         label: 'JSON',
                         content: <JSONViewer name={false} src={response} />,
+                    },
+                    {
+                        key: 'raw',
+                        label: 'Raw',
+                        content: <div>{printHogStringOutput(response)}</div>,
                     },
                 ]}
             />

--- a/posthog/hogql/test/test_bytecode.py
+++ b/posthog/hogql/test/test_bytecode.py
@@ -263,3 +263,9 @@ class TestBytecode(BaseTest):
             create_bytecode(parse_program("let a:=1"), in_repl=True).bytecode,
             [_H, HOGQL_BYTECODE_VERSION, op.INTEGER, 1],
         )
+
+    def test_bytecode_hogqlx(self):
+        self.assertEqual(
+            execute_hog("<Sparkline data={[1,2,3]} />", team=self.team).result,
+            {"__hx_tag": "Sparkline", "data": [1, 2, 3]},
+        )


### PR DESCRIPTION
## Changes

Adding two quick features to the Hog repl:
- Table view for SQL results
- HogQLX tag passthrough (sparklines, etc)
- Save state in the URL

## How did you test this code?

### Sparklines

![2024-11-07 11 35 46](https://github.com/user-attachments/assets/ae0557f7-4482-42b7-928d-ce640e43e339)

[Local example URL](http://localhost:8000/project/1/debug/hog#repl=%5B%7B%22code%22%3A%22let%20results%20%3A%3D%20run('select%20count()%2C%20event%20from%20events%20group%20by%20event%20order%20by%20count()%20desc%20limit%205')%22%2C%22status%22%3A%22success%22%2C%22bytecode%22%3A%5B32%2C%22select%20count()%2C%20event%20from%20events%20group%20by%20event%20order%20by%20count()%20desc%20limit%205%22%2C2%2C%22run%22%2C1%5D%2C%22locals%22%3A%5B%5B%22results%22%2C1%2Cfalse%5D%5D%2C%22result%22%3A%7B%22results%22%3A%5B%5B1818%2C%22%24feature_flag_called%22%5D%2C%5B1059%2C%22query%20completed%22%5D%2C%5B971%2C%22%24pageview%22%5D%2C%5B411%2C%22%24groupidentify%22%5D%2C%5B172%2C%22update%20user%20properties%22%5D%5D%2C%22columns%22%3A%5B%22count()%22%2C%22event%22%5D%7D%2C%22state%22%3A%7B%22bytecodes%22%3A%7B%22root%22%3A%7B%22bytecode%22%3A%5B%22_H%22%2C1%2C32%2C%22select%20count()%2C%20event%20from%20events%20group%20by%20event%20order%20by%20count()%20desc%20limit%205%22%2C2%2C%22run%22%2C1%5D%7D%7D%2C%22stack%22%3A%5B%7B%22results%22%3A%5B%5B1818%2C%22%24feature_flag_called%22%5D%2C%5B1059%2C%22query%20completed%22%5D%2C%5B971%2C%22%24pageview%22%5D%2C%5B411%2C%22%24groupidentify%22%5D%2C%5B172%2C%22update%20user%20properties%22%5D%5D%2C%22columns%22%3A%5B%22count()%22%2C%22event%22%5D%7D%5D%2C%22upvalues%22%3A%5B%5D%2C%22callStack%22%3A%5B%5D%2C%22throwStack%22%3A%5B%5D%2C%22declaredFunctions%22%3A%7B%7D%2C%22ops%22%3A2%2C%22asyncSteps%22%3A1%2C%22syncDuration%22%3A0%2C%22maxMemUsed%22%3A282%7D%7D%2C%7B%22code%22%3A%22let%20events%20%3A%3D%20arrayMap(a%20-%3E%20a.2%2C%20results.results)%5Cnfor%20(let%20event%20in%20events)%20%7B%5Cn%20%20let%20data%20%3A%3D%20run(f'select%20count()%2C%20toStartOfDay(timestamp)%20as%20day%20from%20events%20where%20event%20%3D%20%5C%5C'%7Bevent%7D%5C%5C'%20and%20timestamp%20%3E%20now()%20-%20interval%207%20day%20group%20by%20day%20order%20by%20day')%5Cn%20%20print(%5Cn%20%20%20%20event%2C%20%5Cn%20%20%20%20%3CSparkline%20%5Cn%20%20%20%20%20%20data%3D%7BarrayMap(a%20-%3E%20a.1%2C%20data.results)%7D%20%5Cn%20%20%20%20%20%20labels%3D%7BarrayMap(a%20-%3E%20a.2%2C%20data.results)%7D%20type%3D'line'%20%5Cn%20%20%20%20%2F%3E%5Cn%20%20)%5Cn%7D%5Cnprint('We%20are%20done!')%22%2C%22status%22%3A%22success%22%2C%22bytecode%22%3A%5B52%2C%22lambda%22%2C1%2C0%2C6%2C36%2C0%2C33%2C2%2C45%2C38%2C53%2C0%2C36%2C0%2C32%2C%22results%22%2C45%2C2%2C%22arrayMap%22%2C2%2C36%2C1%2C36%2C2%2C2%2C%22values%22%2C1%2C33%2C1%2C36%2C3%2C2%2C%22length%22%2C1%2C31%2C36%2C5%2C36%2C4%2C16%2C40%2C91%2C36%2C3%2C36%2C4%2C45%2C37%2C6%2C32%2C%22select%20count()%2C%20toStartOfDay(timestamp)%20as%20day%20from%20events%20where%20event%20%3D%20'%22%2C36%2C6%2C32%2C%22'%20and%20timestamp%20%3E%20now()%20-%20interval%207%20day%20group%20by%20day%20order%20by%20day%22%2C2%2C%22concat%22%2C3%2C2%2C%22run%22%2C1%2C36%2C6%2C32%2C%22__hx_tag%22%2C32%2C%22Sparkline%22%2C32%2C%22data%22%2C52%2C%22lambda%22%2C1%2C0%2C6%2C36%2C0%2C33%2C1%2C45%2C38%2C53%2C0%2C36%2C7%2C32%2C%22results%22%2C45%2C2%2C%22arrayMap%22%2C2%2C32%2C%22labels%22%2C52%2C%22lambda%22%2C1%2C0%2C6%2C36%2C0%2C33%2C2%2C45%2C38%2C53%2C0%2C36%2C7%2C32%2C%22results%22%2C45%2C2%2C%22arrayMap%22%2C2%2C32%2C%22type%22%2C32%2C%22line%22%2C42%2C4%2C2%2C%22print%22%2C2%2C35%2C35%2C36%2C4%2C33%2C1%2C6%2C37%2C4%2C39%2C-98%2C35%2C35%2C35%2C35%2C35%2C32%2C%22We%20are%20done!%22%2C2%2C%22print%22%2C1%2C35%5D%2C%22locals%22%3A%5B%5B%22results%22%2C1%2Cfalse%5D%2C%5B%22events%22%2C1%2Cfalse%5D%5D%2C%22print%22%3A%5B%5B%22%24feature_flag_called%22%2C%7B%22__hx_tag%22%3A%22Sparkline%22%2C%22data%22%3A%5B282%2C1536%5D%2C%22labels%22%3A%5B%222024-11-05T00%3A00%3A00Z%22%2C%222024-11-06T00%3A00%3A00Z%22%5D%2C%22type%22%3A%22line%22%7D%5D%2C%5B%22query%20completed%22%2C%7B%22__hx_tag%22%3A%22Sparkline%22%2C%22data%22%3A%5B475%2C584%5D%2C%22labels%22%3A%5B%222024-11-05T00%3A00%3A00Z%22%2C%222024-11-06T00%3A00%3A00Z%22%5D%2C%22type%22%3A%22line%22%7D%5D%2C%5B%22%24pageview%22%2C%7B%22__hx_tag%22%3A%22Sparkline%22%2C%22data%22%3A%5B65%2C906%5D%2C%22labels%22%3A%5B%222024-11-05T00%3A00%3A00Z%22%2C%222024-11-06T00%3A00%3A00Z%22%5D%2C%22type%22%3A%22line%22%7D%5D%2C%5B%22%24groupidentify%22%2C%7B%22__hx_tag%22%3A%22Sparkline%22%2C%22data%22%3A%5B71%2C340%5D%2C%22labels%22%3A%5B%222024-11-05T00%3A00%3A00Z%22%2C%222024-11-06T00%3A00%3A00Z%22%5D%2C%22type%22%3A%22line%22%7D%5D%2C%5B%22update%20user%20properties%22%2C%7B%22__hx_tag%22%3A%22Sparkline%22%2C%22data%22%3A%5B26%2C146%5D%2C%22labels%22%3A%5B%222024-11-05T00%3A00%3A00Z%22%2C%222024-11-06T00%3A00%3A00Z%22%5D%2C%22type%22%3A%22line%22%7D%5D%2C%5B%22We%20are%20done!%22%5D%5D%2C%22state%22%3A%7B%22bytecodes%22%3A%7B%22root%22%3A%7B%22bytecode%22%3A%5B%22_H%22%2C1%2C32%2C%22select%20count()%2C%20event%20from%20events%20group%20by%20event%20order%20by%20count()%20desc%20limit%205%22%2C2%2C%22run%22%2C1%2C52%2C%22lambda%22%2C1%2C0%2C6%2C36%2C0%2C33%2C2%2C45%2C38%2C53%2C0%2C36%2C0%2C32%2C%22results%22%2C45%2C2%2C%22arrayMap%22%2C2%2C36%2C1%2C36%2C2%2C2%2C%22values%22%2C1%2C33%2C1%2C36%2C3%2C2%2C%22length%22%2C1%2C31%2C36%2C5%2C36%2C4%2C16%2C40%2C91%2C36%2C3%2C36%2C4%2C45%2C37%2C6%2C32%2C%22select%20count()%2C%20toStartOfDay(timestamp)%20as%20day%20from%20events%20where%20event%20%3D%20'%22%2C36%2C6%2C32%2C%22'%20and%20timestamp%20%3E%20now()%20-%20interval%207%20day%20group%20by%20day%20order%20by%20day%22%2C2%2C%22concat%22%2C3%2C2%2C%22run%22%2C1%2C36%2C6%2C32%2C%22__hx_tag%22%2C32%2C%22Sparkline%22%2C32%2C%22data%22%2C52%2C%22lambda%22%2C1%2C0%2C6%2C36%2C0%2C33%2C1%2C45%2C38%2C53%2C0%2C36%2C7%2C32%2C%22results%22%2C45%2C2%2C%22arrayMap%22%2C2%2C32%2C%22labels%22%2C52%2C%22lambda%22%2C1%2C0%2C6%2C36%2C0%2C33%2C2%2C45%2C38%2C53%2C0%2C36%2C7%2C32%2C%22results%22%2C45%2C2%2C%22arrayMap%22%2C2%2C32%2C%22type%22%2C32%2C%22line%22%2C42%2C4%2C2%2C%22print%22%2C2%2C35%2C35%2C36%2C4%2C33%2C1%2C6%2C37%2C4%2C39%2C-98%2C35%2C35%2C35%2C35%2C35%2C32%2C%22We%20are%20done!%22%2C2%2C%22print%22%2C1%5D%7D%7D%2C%22stack%22%3A%5B%7B%22results%22%3A%5B%5B1818%2C%22%24feature_flag_called%22%5D%2C%5B1059%2C%22query%20completed%22%5D%2C%5B971%2C%22%24pageview%22%5D%2C%5B411%2C%22%24groupidentify%22%5D%2C%5B172%2C%22update%20user%20properties%22%5D%5D%2C%22columns%22%3A%5B%22count()%22%2C%22event%22%5D%7D%2C%5B%22%24feature_flag_called%22%2C%22query%20completed%22%2C%22%24pageview%22%2C%22%24groupidentify%22%2C%22update%20user%20properties%22%5D%2Cnull%5D%2C%22upvalues%22%3A%5B%5D%2C%22callStack%22%3A%5B%5D%2C%22throwStack%22%3A%5B%5D%2C%22declaredFunctions%22%3A%7B%7D%2C%22ops%22%3A1015%2C%22asyncSteps%22%3A6%2C%22syncDuration%22%3A20%2C%22maxMemUsed%22%3A1943%7D%7D%5D&code=)

```rust
let results := run('select count(), event from events group by event order by count() desc limit 5')
let events := arrayMap(a -> a.2, results.results)
for (let event in events) {
  let data := run(f'select count(), toStartOfDay(timestamp) as day from events where event = \'{event}\' and timestamp > now() - interval 7 day group by day order by day')
  print(
    event, 
    <Sparkline 
      data={arrayMap(a -> a.1, data.results)} 
      labels={arrayMap(a -> a.2, data.results)} type='line' 
    />
  )
}
```

### Pivot tables

![2024-11-07 12 06 57](https://github.com/user-attachments/assets/34dd8277-4591-4a69-9575-656ba41ccc8a)

[Local example link](http://localhost:8000/project/1/debug/hog#repl=%5B%7B%22code%22%3A%22fun%20pivot(result%2C%20label%2C%20default)%20%7B%5Cn%20%20%20%20let%20dates%20%3A%3D%20arrayMap(row%20-%3E%20row.1%2C%20result.results)%5Cn%20%20%20%20let%20columns%20%3A%3D%20%5Blabel%5D%5Cn%20%20%20%20for%20(let%20date%20in%20dates)%20%7B%20columns%20%3A%3D%20arrayPushBack(columns%2C%20date)%20%7D%5Cn%20%20%20%20let%20cache%20%3A%3D%20%7B%7D%5Cn%20%20%20%20let%20sessions%20%3A%3D%20%7B%7D%5Cn%20%20%20%20for%20(let%20row%20in%20result.results)%20%7B%5Cn%20%20%20%20%20%20%20%20cache%5Bf'%7Brow.1%7D-%7Brow.2%7D'%5D%20%3A%3D%20row.3%5Cn%20%20%20%20%20%20%20%20sessions%5Brow.2%5D%20%3A%3D%20true%5Cn%20%20%20%20%7D%5Cn%20%20%20%20let%20rows%20%3A%3D%20arrayMap(session%20-%3E%20%7B%5Cn%20%20%20%20%20%20%20%20let%20row%20%3A%3D%20%5Bsession%5D%5Cn%20%20%20%20%20%20%20%20for%20(let%20date%20in%20dates)%20%7B%20row%20%3A%3D%20arrayPushBack(row%2C%20ifNull(cache%5Bf'%7Bdate%7D-%7Bsession%7D'%5D%2C%20default))%20%7D%5Cn%20%20%20%20%20%20%20%20return%20row%5Cn%20%20%20%20%7D%2C%20keys(sessions))%5Cn%20%20%20%20let%20table%20%3A%3D%20%7B%20'columns'%3A%20columns%2C%20'results'%3A%20rows%20%7D%5Cn%20%20%20%20return%20table%5Cn%7D%22%2C%22status%22%3A%22success%22%2C%22bytecode%22%3A%5B52%2C%22pivot%22%2C3%2C0%2C274%2C52%2C%22lambda%22%2C1%2C0%2C6%2C36%2C0%2C33%2C1%2C45%2C38%2C53%2C0%2C36%2C0%2C32%2C%22results%22%2C45%2C2%2C%22arrayMap%22%2C2%2C36%2C1%2C43%2C1%2C36%2C3%2C36%2C5%2C2%2C%22values%22%2C1%2C33%2C1%2C36%2C6%2C2%2C%22length%22%2C1%2C31%2C36%2C8%2C36%2C7%2C16%2C40%2C25%2C36%2C6%2C36%2C7%2C45%2C37%2C9%2C36%2C4%2C36%2C9%2C2%2C%22arrayPushBack%22%2C2%2C37%2C4%2C36%2C7%2C33%2C1%2C6%2C37%2C7%2C39%2C-32%2C35%2C35%2C35%2C35%2C35%2C42%2C0%2C42%2C0%2C36%2C0%2C32%2C%22results%22%2C45%2C36%2C7%2C2%2C%22values%22%2C1%2C33%2C1%2C36%2C8%2C2%2C%22length%22%2C1%2C31%2C36%2C10%2C36%2C9%2C16%2C40%2C48%2C36%2C8%2C36%2C9%2C45%2C37%2C11%2C36%2C5%2C36%2C11%2C33%2C1%2C45%2C32%2C%22-%22%2C36%2C11%2C33%2C2%2C45%2C2%2C%22concat%22%2C3%2C36%2C11%2C33%2C3%2C45%2C46%2C36%2C6%2C36%2C11%2C33%2C2%2C45%2C29%2C46%2C36%2C9%2C33%2C1%2C6%2C37%2C9%2C39%2C-55%2C35%2C35%2C35%2C35%2C35%2C52%2C%22lambda%22%2C1%2C3%2C75%2C36%2C0%2C43%2C1%2C55%2C0%2C36%2C2%2C2%2C%22values%22%2C1%2C33%2C1%2C36%2C3%2C2%2C%22length%22%2C1%2C31%2C36%2C5%2C36%2C4%2C16%2C40%2C40%2C36%2C3%2C36%2C4%2C45%2C37%2C6%2C36%2C1%2C55%2C1%2C36%2C6%2C32%2C%22-%22%2C36%2C0%2C2%2C%22concat%22%2C3%2C45%2C47%2C3%2C35%2C55%2C2%2C2%2C%22arrayPushBack%22%2C2%2C37%2C1%2C36%2C4%2C33%2C1%2C6%2C37%2C4%2C39%2C-47%2C35%2C35%2C35%2C35%2C35%2C36%2C1%2C38%2C35%2C53%2C3%2Ctrue%2C3%2Ctrue%2C5%2Ctrue%2C2%2C36%2C6%2C2%2C%22keys%22%2C1%2C2%2C%22arrayMap%22%2C2%2C32%2C%22columns%22%2C36%2C4%2C32%2C%22results%22%2C36%2C7%2C42%2C2%2C36%2C8%2C38%2C35%2C35%2C35%2C57%2C35%2C57%2C53%2C0%5D%2C%22locals%22%3A%5B%5B%22pivot%22%2C1%2Cfalse%5D%5D%2C%22result%22%3A%7B%22__hogClosure__%22%3Atrue%2C%22callable%22%3A%7B%22__hogCallable__%22%3A%22local%22%2C%22name%22%3A%22pivot%22%2C%22chunk%22%3A%22root%22%2C%22argCount%22%3A3%2C%22upvalueCount%22%3A0%2C%22ip%22%3A7%7D%2C%22upvalues%22%3A%5B%5D%7D%2C%22state%22%3A%7B%22bytecodes%22%3A%7B%22root%22%3A%7B%22bytecode%22%3A%5B%22_H%22%2C1%2C52%2C%22pivot%22%2C3%2C0%2C274%2C52%2C%22lambda%22%2C1%2C0%2C6%2C36%2C0%2C33%2C1%2C45%2C38%2C53%2C0%2C36%2C0%2C32%2C%22results%22%2C45%2C2%2C%22arrayMap%22%2C2%2C36%2C1%2C43%2C1%2C36%2C3%2C36%2C5%2C2%2C%22values%22%2C1%2C33%2C1%2C36%2C6%2C2%2C%22length%22%2C1%2C31%2C36%2C8%2C36%2C7%2C16%2C40%2C25%2C36%2C6%2C36%2C7%2C45%2C37%2C9%2C36%2C4%2C36%2C9%2C2%2C%22arrayPushBack%22%2C2%2C37%2C4%2C36%2C7%2C33%2C1%2C6%2C37%2C7%2C39%2C-32%2C35%2C35%2C35%2C35%2C35%2C42%2C0%2C42%2C0%2C36%2C0%2C32%2C%22results%22%2C45%2C36%2C7%2C2%2C%22values%22%2C1%2C33%2C1%2C36%2C8%2C2%2C%22length%22%2C1%2C31%2C36%2C10%2C36%2C9%2C16%2C40%2C48%2C36%2C8%2C36%2C9%2C45%2C37%2C11%2C36%2C5%2C36%2C11%2C33%2C1%2C45%2C32%2C%22-%22%2C36%2C11%2C33%2C2%2C45%2C2%2C%22concat%22%2C3%2C36%2C11%2C33%2C3%2C45%2C46%2C36%2C6%2C36%2C11%2C33%2C2%2C45%2C29%2C46%2C36%2C9%2C33%2C1%2C6%2C37%2C9%2C39%2C-55%2C35%2C35%2C35%2C35%2C35%2C52%2C%22lambda%22%2C1%2C3%2C75%2C36%2C0%2C43%2C1%2C55%2C0%2C36%2C2%2C2%2C%22values%22%2C1%2C33%2C1%2C36%2C3%2C2%2C%22length%22%2C1%2C31%2C36%2C5%2C36%2C4%2C16%2C40%2C40%2C36%2C3%2C36%2C4%2C45%2C37%2C6%2C36%2C1%2C55%2C1%2C36%2C6%2C32%2C%22-%22%2C36%2C0%2C2%2C%22concat%22%2C3%2C45%2C47%2C3%2C35%2C55%2C2%2C2%2C%22arrayPushBack%22%2C2%2C37%2C1%2C36%2C4%2C33%2C1%2C6%2C37%2C4%2C39%2C-47%2C35%2C35%2C35%2C35%2C35%2C36%2C1%2C38%2C35%2C53%2C3%2Ctrue%2C3%2Ctrue%2C5%2Ctrue%2C2%2C36%2C6%2C2%2C%22keys%22%2C1%2C2%2C%22arrayMap%22%2C2%2C32%2C%22columns%22%2C36%2C4%2C32%2C%22results%22%2C36%2C7%2C42%2C2%2C36%2C8%2C38%2C35%2C35%2C35%2C57%2C35%2C57%2C53%2C0%5D%7D%7D%2C%22stack%22%3A%5B%7B%22__hogClosure__%22%3Atrue%2C%22callable%22%3A%7B%22__hogCallable__%22%3A%22local%22%2C%22name%22%3A%22pivot%22%2C%22chunk%22%3A%22root%22%2C%22argCount%22%3A3%2C%22upvalueCount%22%3A0%2C%22ip%22%3A7%7D%2C%22upvalues%22%3A%5B%5D%7D%5D%2C%22upvalues%22%3A%5B%5D%2C%22callStack%22%3A%5B%5D%2C%22throwStack%22%3A%5B%5D%2C%22declaredFunctions%22%3A%7B%7D%2C%22ops%22%3A2%2C%22asyncSteps%22%3A0%2C%22syncDuration%22%3A0%2C%22maxMemUsed%22%3A242%7D%7D%2C%7B%22code%22%3A%22let%20query%20%3A%3D%20'select%20toStartOfHour(timestamp)%2C%20properties.%24session_id%2C%20count()%20from%20events%20where%20event%20%3D%20%5C%5C'%24pageview%5C%5C'%20and%20timestamp%20%3E%20now()%20-%20interval%201%20month%20group%20by%20toStartOfHour(timestamp)%2C%20properties.%24session_id'%5Cn%5Cnpivot(run(query)%2C%20'Session'%2C%200)%5Cn%22%2C%22status%22%3A%22success%22%2C%22bytecode%22%3A%5B32%2C%22select%20toStartOfHour(timestamp)%2C%20properties.%24session_id%2C%20count()%20from%20events%20where%20event%20%3D%20'%24pageview'%20and%20timestamp%20%3E%20now()%20-%20interval%201%20month%20group%20by%20toStartOfHour(timestamp)%2C%20properties.%24session_id%22%2C36%2C1%2C2%2C%22run%22%2C1%2C32%2C%22Session%22%2C33%2C0%2C36%2C0%2C54%2C3%2C35%5D%2C%22locals%22%3A%5B%5B%22pivot%22%2C1%2Cfalse%5D%2C%5B%22query%22%2C1%2Cfalse%5D%5D%2C%22result%22%3A%7B%22columns%22%3A%5B%22Session%22%2C%222024-11-06T09%3A00%3A00Z%22%2C%222024-11-06T10%3A00%3A00Z%22%2C%222024-11-06T19%3A00%3A00Z%22%2C%222024-11-06T08%3A00%3A00Z%22%2C%222024-11-05T23%3A00%3A00Z%22%2C%222024-11-06T12%3A00%3A00Z%22%2C%222024-11-06T20%3A00%3A00Z%22%2C%222024-11-06T22%3A00%3A00Z%22%2C%222024-11-06T21%3A00%3A00Z%22%2C%222024-11-06T13%3A00%3A00Z%22%2C%222024-11-05T21%3A00%3A00Z%22%2C%222024-11-06T23%3A00%3A00Z%22%2C%222024-11-05T20%3A00%3A00Z%22%5D%2C%22results%22%3A%5B%5B%22019300e4-202a-79b6-9ae9-d952e746c760%22%2C14%2C5%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%5D%2C%5B%220193030a-feff-76eb-982f-490b104e00cb%22%2C0%2C0%2C15%2C0%2C0%2C0%2C55%2C0%2C0%2C0%2C0%2C0%2C0%5D%2C%5B%2201930096-1f18-759a-9cf3-694b09abc86f%22%2C0%2C0%2C0%2C42%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%5D%2C%5B%220192fe94-0457-763a-b02f-eda8bc46480c%22%2C0%2C0%2C0%2C0%2C2%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%5D%2C%5B%2201930156-cb8c-7b7f-bb8e-8f3e66d1aa9e%22%2C0%2C0%2C0%2C0%2C0%2C148%2C0%2C0%2C0%2C11%2C0%2C0%2C0%5D%2C%5B%220193038a-6c9e-7d6e-b02d-82056cdb746c%22%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C18%2C0%2C0%2C0%2C595%2C0%5D%2C%5B%2201930362-0e36-767a-9d92-5c608e0256f4%22%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C3%2C0%2C0%2C0%2C0%5D%2C%5B%220192fe14-d995-7c0e-8340-060e7c4969f6%22%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C24%2C0%2C39%5D%5D%7D%2C%22state%22%3A%7B%22bytecodes%22%3A%7B%22root%22%3A%7B%22bytecode%22%3A%5B%22_H%22%2C1%2C52%2C%22pivot%22%2C3%2C0%2C274%2C52%2C%22lambda%22%2C1%2C0%2C6%2C36%2C0%2C33%2C1%2C45%2C38%2C53%2C0%2C36%2C0%2C32%2C%22results%22%2C45%2C2%2C%22arrayMap%22%2C2%2C36%2C1%2C43%2C1%2C36%2C3%2C36%2C5%2C2%2C%22values%22%2C1%2C33%2C1%2C36%2C6%2C2%2C%22length%22%2C1%2C31%2C36%2C8%2C36%2C7%2C16%2C40%2C25%2C36%2C6%2C36%2C7%2C45%2C37%2C9%2C36%2C4%2C36%2C9%2C2%2C%22arrayPushBack%22%2C2%2C37%2C4%2C36%2C7%2C33%2C1%2C6%2C37%2C7%2C39%2C-32%2C35%2C35%2C35%2C35%2C35%2C42%2C0%2C42%2C0%2C36%2C0%2C32%2C%22results%22%2C45%2C36%2C7%2C2%2C%22values%22%2C1%2C33%2C1%2C36%2C8%2C2%2C%22length%22%2C1%2C31%2C36%2C10%2C36%2C9%2C16%2C40%2C48%2C36%2C8%2C36%2C9%2C45%2C37%2C11%2C36%2C5%2C36%2C11%2C33%2C1%2C45%2C32%2C%22-%22%2C36%2C11%2C33%2C2%2C45%2C2%2C%22concat%22%2C3%2C36%2C11%2C33%2C3%2C45%2C46%2C36%2C6%2C36%2C11%2C33%2C2%2C45%2C29%2C46%2C36%2C9%2C33%2C1%2C6%2C37%2C9%2C39%2C-55%2C35%2C35%2C35%2C35%2C35%2C52%2C%22lambda%22%2C1%2C3%2C75%2C36%2C0%2C43%2C1%2C55%2C0%2C36%2C2%2C2%2C%22values%22%2C1%2C33%2C1%2C36%2C3%2C2%2C%22length%22%2C1%2C31%2C36%2C5%2C36%2C4%2C16%2C40%2C40%2C36%2C3%2C36%2C4%2C45%2C37%2C6%2C36%2C1%2C55%2C1%2C36%2C6%2C32%2C%22-%22%2C36%2C0%2C2%2C%22concat%22%2C3%2C45%2C47%2C3%2C35%2C55%2C2%2C2%2C%22arrayPushBack%22%2C2%2C37%2C1%2C36%2C4%2C33%2C1%2C6%2C37%2C4%2C39%2C-47%2C35%2C35%2C35%2C35%2C35%2C36%2C1%2C38%2C35%2C53%2C3%2Ctrue%2C3%2Ctrue%2C5%2Ctrue%2C2%2C36%2C6%2C2%2C%22keys%22%2C1%2C2%2C%22arrayMap%22%2C2%2C32%2C%22columns%22%2C36%2C4%2C32%2C%22results%22%2C36%2C7%2C42%2C2%2C36%2C8%2C38%2C35%2C35%2C35%2C57%2C35%2C57%2C53%2C0%2C32%2C%22select%20toStartOfHour(timestamp)%2C%20properties.%24session_id%2C%20count()%20from%20events%20where%20event%20%3D%20'%24pageview'%20and%20timestamp%20%3E%20now()%20-%20interval%201%20month%20group%20by%20toStartOfHour(timestamp)%2C%20properties.%24session_id%22%2C36%2C1%2C2%2C%22run%22%2C1%2C32%2C%22Session%22%2C33%2C0%2C36%2C0%2C54%2C3%5D%7D%7D%2C%22stack%22%3A%5B%7B%22__hogClosure__%22%3Atrue%2C%22callable%22%3A%7B%22__hogCallable__%22%3A%22local%22%2C%22name%22%3A%22pivot%22%2C%22chunk%22%3A%22root%22%2C%22argCount%22%3A3%2C%22upvalueCount%22%3A0%2C%22ip%22%3A7%7D%2C%22upvalues%22%3A%5B%5D%7D%2C%22select%20toStartOfHour(timestamp)%2C%20properties.%24session_id%2C%20count()%20from%20events%20where%20event%20%3D%20'%24pageview'%20and%20timestamp%20%3E%20now()%20-%20interval%201%20month%20group%20by%20toStartOfHour(timestamp)%2C%20properties.%24session_id%22%2C%7B%22columns%22%3A%5B%22Session%22%2C%222024-11-06T09%3A00%3A00Z%22%2C%222024-11-06T10%3A00%3A00Z%22%2C%222024-11-06T19%3A00%3A00Z%22%2C%222024-11-06T08%3A00%3A00Z%22%2C%222024-11-05T23%3A00%3A00Z%22%2C%222024-11-06T12%3A00%3A00Z%22%2C%222024-11-06T20%3A00%3A00Z%22%2C%222024-11-06T22%3A00%3A00Z%22%2C%222024-11-06T21%3A00%3A00Z%22%2C%222024-11-06T13%3A00%3A00Z%22%2C%222024-11-05T21%3A00%3A00Z%22%2C%222024-11-06T23%3A00%3A00Z%22%2C%222024-11-05T20%3A00%3A00Z%22%5D%2C%22results%22%3A%5B%5B%22019300e4-202a-79b6-9ae9-d952e746c760%22%2C14%2C5%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%5D%2C%5B%220193030a-feff-76eb-982f-490b104e00cb%22%2C0%2C0%2C15%2C0%2C0%2C0%2C55%2C0%2C0%2C0%2C0%2C0%2C0%5D%2C%5B%2201930096-1f18-759a-9cf3-694b09abc86f%22%2C0%2C0%2C0%2C42%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%5D%2C%5B%220192fe94-0457-763a-b02f-eda8bc46480c%22%2C0%2C0%2C0%2C0%2C2%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%5D%2C%5B%2201930156-cb8c-7b7f-bb8e-8f3e66d1aa9e%22%2C0%2C0%2C0%2C0%2C0%2C148%2C0%2C0%2C0%2C11%2C0%2C0%2C0%5D%2C%5B%220193038a-6c9e-7d6e-b02d-82056cdb746c%22%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C18%2C0%2C0%2C0%2C595%2C0%5D%2C%5B%2201930362-0e36-767a-9d92-5c608e0256f4%22%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C3%2C0%2C0%2C0%2C0%5D%2C%5B%220192fe14-d995-7c0e-8340-060e7c4969f6%22%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C0%2C24%2C0%2C39%5D%5D%7D%5D%2C%22upvalues%22%3A%5B%7B%22__hogUpValue__%22%3Atrue%2C%22id%22%3A3%2C%22location%22%3A4%2C%22closed%22%3Atrue%2C%22value%22%3A0%7D%2C%7B%22__hogUpValue__%22%3Atrue%2C%22id%22%3A1%2C%22location%22%3A5%2C%22closed%22%3Atrue%2C%22value%22%3A%5B%222024-11-06T09%3A00%3A00Z%22%2C%222024-11-06T10%3A00%3A00Z%22%2C%222024-11-06T19%3A00%3A00Z%22%2C%222024-11-06T08%3A00%3A00Z%22%2C%222024-11-05T23%3A00%3A00Z%22%2C%222024-11-06T12%3A00%3A00Z%22%2C%222024-11-06T20%3A00%3A00Z%22%2C%222024-11-06T22%3A00%3A00Z%22%2C%222024-11-06T21%3A00%3A00Z%22%2C%222024-11-06T13%3A00%3A00Z%22%2C%222024-11-05T21%3A00%3A00Z%22%2C%222024-11-06T23%3A00%3A00Z%22%2C%222024-11-05T20%3A00%3A00Z%22%5D%7D%2C%7B%22__hogUpValue__%22%3Atrue%2C%22id%22%3A2%2C%22location%22%3A7%2C%22closed%22%3Atrue%2C%22value%22%3A%7B%222024-11-06T09%3A00%3A00Z-019300e4-202a-79b6-9ae9-d952e746c760%22%3A14%2C%222024-11-06T10%3A00%3A00Z-019300e4-202a-79b6-9ae9-d952e746c760%22%3A5%2C%222024-11-06T19%3A00%3A00Z-0193030a-feff-76eb-982f-490b104e00cb%22%3A15%2C%222024-11-06T08%3A00%3A00Z-01930096-1f18-759a-9cf3-694b09abc86f%22%3A42%2C%222024-11-05T23%3A00%3A00Z-0192fe94-0457-763a-b02f-eda8bc46480c%22%3A2%2C%222024-11-06T12%3A00%3A00Z-01930156-cb8c-7b7f-bb8e-8f3e66d1aa9e%22%3A148%2C%222024-11-06T20%3A00%3A00Z-0193030a-feff-76eb-982f-490b104e00cb%22%3A55%2C%222024-11-06T22%3A00%3A00Z-0193038a-6c9e-7d6e-b02d-82056cdb746c%22%3A18%2C%222024-11-06T21%3A00%3A00Z-01930362-0e36-767a-9d92-5c608e0256f4%22%3A3%2C%222024-11-06T13%3A00%3A00Z-01930156-cb8c-7b7f-bb8e-8f3e66d1aa9e%22%3A11%2C%222024-11-05T21%3A00%3A00Z-0192fe14-d995-7c0e-8340-060e7c4969f6%22%3A24%2C%222024-11-06T23%3A00%3A00Z-0193038a-6c9e-7d6e-b02d-82056cdb746c%22%3A595%2C%222024-11-05T20%3A00%3A00Z-0192fe14-d995-7c0e-8340-060e7c4969f6%22%3A39%7D%7D%5D%2C%22callStack%22%3A%5B%5D%2C%22throwStack%22%3A%5B%5D%2C%22declaredFunctions%22%3A%7B%7D%2C%22ops%22%3A3925%2C%22asyncSteps%22%3A1%2C%22syncDuration%22%3A2%2C%22maxMemUsed%22%3A8286%7D%7D%5D&code=)

```rust
fun pivot(result, label, default) {
    let dates := arrayMap(row -> row.1, result.results)
    let columns := [label]
    for (let date in dates) { columns := arrayPushBack(columns, date) }
    let cache := {}
    let sessions := {}
    for (let row in result.results) {
        cache[f'{row.1}-{row.2}'] := row.3
        sessions[row.2] := true
    }
    let rows := arrayMap(session -> {
        let row := [session]
        for (let date in dates) { row := arrayPushBack(row, ifNull(cache[f'{date}-{session}'], default)) }
        return row
    }, keys(sessions))
    let table := { 'columns': columns, 'results': rows }
    return table
}

let query := 'select toDate(toStartOfDay(timestamp)), properties.$browser, count() from events where event = \'$pageview\' and timestamp > now() - interval 1 week group by toStartOfDay(timestamp), properties.$browser'

pivot(run(query), 'Browser', 0)
```
