### PR TITLE
fix(data-warehouse): Only monkey patch DLT on incremental syncs

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -141,16 +141,19 @@ class DataImportPipelineSync:
                 yield lst[i : i + n]
 
         # Monkey patch to fix large memory consumption until https://github.com/dlt-hub/dlt/pull/2031 gets merged in
-        FilesystemDestinationClientConfiguration.delta_jobs_per_write = 1
-        FilesystemClient.create_table_chain_completed_followup_jobs = create_table_chain_completed_followup_jobs  # type: ignore
-        FilesystemClient._iter_chunks = _iter_chunks  # type: ignore
+        # This only works on incremental syncs right now though
+        if self._incremental:
+            FilesystemDestinationClientConfiguration.delta_jobs_per_write = 1
+            FilesystemClient.create_table_chain_completed_followup_jobs = create_table_chain_completed_followup_jobs  # type: ignore
+            FilesystemClient._iter_chunks = _iter_chunks  # type: ignore
+
+            dlt.config["data_writer.file_max_items"] = 500_000
+            dlt.config["data_writer.file_max_bytes"] = 500_000_000  # 500 MB
+            dlt.config["loader_parallelism_strategy"] = "table-sequential"
+            dlt.config["delta_jobs_per_write"] = 1
 
         dlt.config["normalize.parquet_normalizer.add_dlt_load_id"] = True
         dlt.config["normalize.parquet_normalizer.add_dlt_id"] = True
-        dlt.config["data_writer.file_max_items"] = 500_000
-        dlt.config["data_writer.file_max_bytes"] = 500_000_000  # 500 MB
-        dlt.config["loader_parallelism_strategy"] = "table-sequential"
-        dlt.config["delta_jobs_per_write"] = 1
 
         return dlt.pipeline(
             pipeline_name=pipeline_name, destination=destination, dataset_name=self.inputs.dataset_name, progress="log"


### PR DESCRIPTION
## Problem
- The monkey patch I added should only be applied to incremental syncs, otherwise we get inconsistent data
  - (this is only enabled for team 2 right now)
