### PR TITLE
fix(toolbar): remove jsURL

### DIFF
--- a/cypress/fixtures/api/decide.js
+++ b/cypress/fixtures/api/decide.js
@@ -5,7 +5,6 @@ export function decideResponse(featureFlags) {
         },
         toolbarParams: {
             toolbarVersion: 'toolbar',
-            jsURL: 'http://localhost:8234/',
         },
         isAuthenticated: true,
         supportedCompression: ['gzip', 'gzip-js', 'lz64'],

--- a/frontend/src/toolbar/Toolbar.stories.tsx
+++ b/frontend/src/toolbar/Toolbar.stories.tsx
@@ -55,7 +55,6 @@ const BasicTemplate: StoryFn<ToolbarStoryProps> = (props) => {
         userIntent: undefined,
         dataAttributes: ['data-attr'],
         apiURL: '/',
-        jsURL: 'http://localhost:8234/',
         userEmail: 'foobar@posthog.com',
     }
     useToolbarStyles()
@@ -68,7 +67,6 @@ const BasicTemplate: StoryFn<ToolbarStoryProps> = (props) => {
                 },
                 toolbarParams: {
                     toolbarVersion: 'toolbar',
-                    jsURL: 'http://localhost:8234/',
                 },
                 isAuthenticated: props.unauthenticated ?? true,
                 supportedCompression: ['gzip', 'gzip-js', 'lz64'],

--- a/frontend/src/toolbar/ToolbarApp.tsx
+++ b/frontend/src/toolbar/ToolbarApp.tsx
@@ -13,7 +13,7 @@ import { TOOLBAR_ID } from './utils'
 type HTMLElementWithShadowRoot = HTMLElement & { shadowRoot: ShadowRoot }
 
 export function ToolbarApp(props: ToolbarProps = {}): JSX.Element {
-    const { jsURL } = useValues(toolbarConfigLogic(props))
+    const { apiURL } = useValues(toolbarConfigLogic(props))
 
     const shadowRef = useRef<HTMLElementWithShadowRoot | null>(null)
     const [didLoadStyles, setDidLoadStyles] = useState(false)
@@ -32,7 +32,7 @@ export function ToolbarApp(props: ToolbarProps = {}): JSX.Element {
                   // this ensures that we bust the cache periodically
                   const timestampToNearestFiveMinutes =
                       Math.floor(Date.now() / fiveMinutesInMillis) * fiveMinutesInMillis
-                  styleLink.href = `${jsURL}/static/toolbar.css?t=${timestampToNearestFiveMinutes}`
+                  styleLink.href = `${apiURL}/static/toolbar.css?t=${timestampToNearestFiveMinutes}`
                   styleLink.onload = () => setDidLoadStyles(true)
                   const shadowRoot =
                       shadowRef.current?.shadowRoot || window.document.getElementById(TOOLBAR_ID)?.shadowRoot

--- a/frontend/src/toolbar/index.tsx
+++ b/frontend/src/toolbar/index.tsx
@@ -25,7 +25,6 @@ import { ToolbarParams } from '~/types'
             {...toolbarParams}
             actionId={parseInt(String(toolbarParams.actionId))}
             experimentId={parseInt(String(toolbarParams.experimentId))}
-            jsURL={toolbarParams.jsURL || toolbarParams.apiURL}
             posthog={posthog}
         />
     )

--- a/frontend/src/toolbar/stats/currentPageLogic.test.ts
+++ b/frontend/src/toolbar/stats/currentPageLogic.test.ts
@@ -1,7 +1,7 @@
 import { withoutPostHogInit } from '~/toolbar/stats/currentPageLogic'
 
 const posthogInitHashParam =
-    '__posthog={%22action%22:%20%22ph_authorize%22,%20%22token%22:%20%the-ph-token%22,%20%22temporaryToken%22:%20%the-posthog-token%22,%20%22actionId%22:%20null,%20%22userIntent%22:%20%22heatmaps%22,%20%22toolbarVersion%22:%20%22toolbar%22,%20%22apiURL%22:%20%22https://eu.posthog.com%22,%20%22dataAttributes%22:%20[%22data-attr%22],%20%22jsURL%22:%20%22https://app-static.eu.posthog.com%22,%20%22instrument%22:%20true,%20%22userEmail%22:%20%user-email@gmail.com%22,%20%22distinctId%22:%20%the-distinct-id%22}'
+    '__posthog={%22action%22:%20%22ph_authorize%22,%20%22token%22:%20%the-ph-token%22,%20%22temporaryToken%22:%20%the-posthog-token%22,%20%22actionId%22:%20null,%20%22userIntent%22:%20%22heatmaps%22,%20%22toolbarVersion%22:%20%22toolbar%22,%20%22apiURL%22:%20%22https://eu.posthog.com%22,%20%22dataAttributes%22:%20[%22data-attr%22],%20%22instrument%22:%20true,%20%22userEmail%22:%20%user-email@gmail.com%22,%20%22distinctId%22:%20%the-distinct-id%22}'
 
 describe('current page logic', () => {
     describe('cleaning href', () => {

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -41,11 +41,6 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
             (s) => [s.props],
             (props: ToolbarProps) => `${props.apiURL?.endsWith('/') ? props.apiURL.replace(/\/+$/, '') : props.apiURL}`,
         ],
-        jsURL: [
-            (s) => [s.props, s.apiURL],
-            (props: ToolbarProps, apiUrl) =>
-                `${props.jsURL ? (props.jsURL.endsWith('/') ? props.jsURL.replace(/\/+$/, '') : props.jsURL) : apiUrl}`,
-        ],
         dataAttributes: [(s) => [s.props], (props): string[] => props.dataAttributes ?? []],
         isAuthenticated: [(s) => [s.temporaryToken], (temporaryToken) => !!temporaryToken],
     }),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -626,7 +626,6 @@ export type ExperimentIdType = number | 'new' | 'web'
 /* sync with posthog-js */
 export interface ToolbarParams {
     apiURL?: string
-    jsURL?: string
     token?: string /** public posthog-js token */
     temporaryToken?: string /** private temporary user token */
     actionId?: number

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -864,7 +864,7 @@ class TestUserAPI(APIBaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         locationHeader = response.headers.get("location", "not found")
-        self.assertIn("%apiUrl%22%3A%20%22http%3A%2F%2Ftestserver", locationHeader)
+        self.assertIn("22apiURL%22%3A%20%22http%3A%2F%2Ftestserver%22", locationHeader)
         self.maxDiff = None
         self.assertEqual(
             unquote(locationHeader),
@@ -883,7 +883,7 @@ class TestUserAPI(APIBaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         locationHeader = response.headers.get("location", "not found")
-        self.assertIn("%apiUrl%22%3A%20%22http%3A%2F%2Ftestserver", locationHeader)
+        self.assertIn("22apiURL%22%3A%20%22http%3A%2F%2Ftestserver%22", locationHeader)
         self.maxDiff = None
         self.assertEqual(
             unquote(locationHeader),

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -864,11 +864,11 @@ class TestUserAPI(APIBaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         locationHeader = response.headers.get("location", "not found")
-        self.assertIn("%22jsURL%22%3A%20%22http%3A%2F%2Flocalhost%3A8234%22", locationHeader)
+        self.assertIn("%apiUrl%22%3A%20%22http%3A%2F%2Ftestserver", locationHeader)
         self.maxDiff = None
         self.assertEqual(
             unquote(locationHeader),
-            'http://127.0.0.1:8000#__posthog={"action": "ph_authorize", "token": "token123", "temporaryToken": "tokenvalue", "actionId": null, "experimentId": null, "userIntent": "add-action", "toolbarVersion": "toolbar", "apiURL": "http://testserver", "dataAttributes": ["data-attr"], "jsURL": "http://localhost:8234"}',
+            'http://127.0.0.1:8000#__posthog={"action": "ph_authorize", "token": "token123", "temporaryToken": "tokenvalue", "actionId": null, "experimentId": null, "userIntent": "add-action", "toolbarVersion": "toolbar", "apiURL": "http://testserver", "dataAttributes": ["data-attr"]}',
         )
 
     @patch("posthog.api.user.secrets.token_urlsafe")
@@ -883,11 +883,11 @@ class TestUserAPI(APIBaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         locationHeader = response.headers.get("location", "not found")
-        self.assertIn("%22jsURL%22%3A%20%22http%3A%2F%2Flocalhost%3A8234%22", locationHeader)
+        self.assertIn("%apiUrl%22%3A%20%22http%3A%2F%2Ftestserver", locationHeader)
         self.maxDiff = None
         self.assertEqual(
             unquote(locationHeader),
-            'http://127.0.0.1:8000#__posthog={"action": "ph_authorize", "token": "token123", "temporaryToken": "tokenvalue", "actionId": null, "experimentId": "12", "userIntent": "edit-experiment", "toolbarVersion": "toolbar", "apiURL": "http://testserver", "dataAttributes": ["data-attr"], "jsURL": "http://localhost:8234"}',
+            'http://127.0.0.1:8000#__posthog={"action": "ph_authorize", "token": "token123", "temporaryToken": "tokenvalue", "actionId": null, "experimentId": "12", "userIntent": "edit-experiment", "toolbarVersion": "toolbar", "apiURL": "http://testserver", "dataAttributes": ["data-attr"]}',
         )
 
     @patch("posthog.api.user.secrets.token_urlsafe")

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -63,7 +63,6 @@ from posthog.rate_limit import UserAuthenticationThrottle, UserEmailVerification
 from posthog.tasks import user_identify
 from posthog.tasks.email import send_email_change_emails
 from posthog.user_permissions import UserPermissions
-from posthog.utils import get_js_url
 
 REDIRECT_TO_SITE_COUNTER = Counter("posthog_redirect_to_site", "Redirect to site")
 REDIRECT_TO_SITE_FAILED_COUNTER = Counter("posthog_redirect_to_site_failed", "Redirect to site failed")
@@ -517,9 +516,6 @@ def redirect_to_site(request):
         "apiURL": request.build_absolute_uri("/")[:-1],
         "dataAttributes": team.data_attributes,
     }
-
-    if get_js_url(request):
-        params["jsURL"] = get_js_url(request)
 
     if not settings.TEST and not os.environ.get("OPT_OUT_CAPTURE"):
         params["instrument"] = True


### PR DESCRIPTION
## Problem

- The toolbar's `jsURL` var can be overridden client side when loading the toolbar
- The toolbar's `apiURL` is stable --> [posthog-js overrides it](https://github.com/PostHog/posthog-js/blob/8880713a6b9db8c393adb75cad3309bd3d55cf94/src/extensions/toolbar.ts#L144) into the actual URL of your PostHog instance

## Changes

The `jsURL` parameter is really ever used for debugging locally, when `esbuild` is serving fresh files over port 8123. More specifically, this was built for the webpack days. `esbuild` _also_ stores built files under the `/static` URL, meaning it doesn't matter if locally we access them over port 8000 (django) or 8123 (esbuild), it should be the same file.

The only thing we might lose is automatic reloads _if and only if_ you're working on the toolbar on top of some site that's not PostHog... which is rather unlikely.

## Does this work well for both Cloud and self-hosted?

I believe so.

## How did you test this code?

Checked that the toolbar still opened locally.