### PR TITLE
chore: bump the max number of distinct_id's a user can delete

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -420,12 +420,12 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         This endpoint allows you to bulk delete persons, either by the PostHog person IDs or by distinct IDs. You can pass in a maximum of 100 IDs per call.
         """
         if distinct_ids := request.data.get("distinct_ids"):
-            if len(distinct_ids) > 100:
-                raise ValidationError("You can only pass 100 distinct_ids in one call")
+            if len(distinct_ids) > 1000:
+                raise ValidationError("You can only pass 1000 distinct_ids in one call")
             persons = Person.objects.filter(persondistinctid__distinct_id__in=distinct_ids, team_id=self.team_id)
         elif ids := request.data.get("ids"):
-            if len(ids) > 100:
-                raise ValidationError("You can only pass 100 ids in one call")
+            if len(ids) > 1000:
+                raise ValidationError("You can only pass 1000 ids in one call")
             persons = self.get_queryset().filter(uuid__in=ids, team_id=self.team_id)
         else:
             raise ValidationError("You need to specify either distinct_ids or ids")

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -426,7 +426,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         elif ids := request.data.get("ids"):
             if len(ids) > 100:
                 raise ValidationError("You can only pass 100 ids in one call")
-            persons = self.get_queryset().filter(uuid__in=ids)
+            persons = self.get_queryset().filter(uuid__in=ids, team_id=self.team_id)
         else:
             raise ValidationError("You need to specify either distinct_ids or ids")
 

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -422,7 +422,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if distinct_ids := request.data.get("distinct_ids"):
             if len(distinct_ids) > 100:
                 raise ValidationError("You can only pass 100 distinct_ids in one call")
-            persons = self.get_queryset().filter(persondistinctid__distinct_id__in=distinct_ids)
+            persons = Person.objects.filter(persondistinctid__distinct_id__in=distinct_ids, team_id=self.team_id)
         elif ids := request.data.get("ids"):
             if len(ids) > 100:
                 raise ValidationError("You can only pass 100 ids in one call")
@@ -438,7 +438,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 team_id=self.team_id,
                 user=cast(User, request.user),
                 was_impersonated=is_impersonated_session(request),
-                item_id=person.id,
+                item_id=person.pk,
                 scope="Person",
                 activity="deleted",
                 detail=Detail(name=str(person.uuid)),

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -422,11 +422,11 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if distinct_ids := request.data.get("distinct_ids"):
             if len(distinct_ids) > 1000:
                 raise ValidationError("You can only pass 1000 distinct_ids in one call")
-            persons = Person.objects.filter(persondistinctid__distinct_id__in=distinct_ids, team_id=self.team_id)
+            persons = self.get_queryset().filter(persondistinctid__distinct_id__in=distinct_ids)
         elif ids := request.data.get("ids"):
             if len(ids) > 1000:
                 raise ValidationError("You can only pass 1000 ids in one call")
-            persons = self.get_queryset().filter(uuid__in=ids, team_id=self.team_id)
+            persons = self.get_queryset().filter(uuid__in=ids)
         else:
             raise ValidationError("You need to specify either distinct_ids or ids")
 


### PR DESCRIPTION
## Problem

A user is trying to remove a number of distinct IDs, let's bump this to make this easier.

## Changes

on the tin!

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
