### PR TITLE
feat: Support marking materialized columns as disabled and dropping

### DIFF
--- a/ee/benchmarks/helpers.py
+++ b/ee/benchmarks/helpers.py
@@ -14,7 +14,7 @@ import django  # noqa: E402
 
 django.setup()
 
-from posthog.clickhouse.materialized_columns import get_materialized_columns_cached  # noqa: E402
+from posthog.clickhouse.materialized_columns import get_enabled_materialized_columns  # noqa: E402
 from posthog import client  # noqa: E402
 from posthog.clickhouse.query_tagging import reset_query_tags, tag_queries  # noqa: E402
 from posthog.models.utils import UUIDT  # noqa: E402
@@ -71,9 +71,9 @@ def benchmark_clickhouse(fn):
 @contextmanager
 def no_materialized_columns():
     "Allows running a function without any materialized columns being used in query"
-    get_materialized_columns_cached._cache = {
+    get_enabled_materialized_columns._cache = {
         ("events",): (now(), {}),
         ("person",): (now(), {}),
     }
     yield
-    get_materialized_columns_cached._cache = {}
+    get_enabled_materialized_columns._cache = {}

--- a/ee/benchmarks/helpers.py
+++ b/ee/benchmarks/helpers.py
@@ -14,7 +14,7 @@ import django  # noqa: E402
 
 django.setup()
 
-from ee.clickhouse.materialized_columns.columns import get_materialized_columns  # noqa: E402
+from posthog.clickhouse.materialized_columns import get_materialized_columns_cached  # noqa: E402
 from posthog import client  # noqa: E402
 from posthog.clickhouse.query_tagging import reset_query_tags, tag_queries  # noqa: E402
 from posthog.models.utils import UUIDT  # noqa: E402
@@ -71,9 +71,9 @@ def benchmark_clickhouse(fn):
 @contextmanager
 def no_materialized_columns():
     "Allows running a function without any materialized columns being used in query"
-    get_materialized_columns._cache = {
+    get_materialized_columns_cached._cache = {
         ("events",): (now(), {}),
         ("person",): (now(), {}),
     }
     yield
-    get_materialized_columns._cache = {}
+    get_materialized_columns_cached._cache = {}

--- a/ee/clickhouse/materialized_columns/analyze.py
+++ b/ee/clickhouse/materialized_columns/analyze.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import re
 from datetime import timedelta
 from typing import Optional
@@ -177,11 +178,17 @@ def materialize_properties_task(
 
     if columns_to_materialize is None:
         columns_to_materialize = _analyze(time_to_analyze_hours, min_query_time, team_id_to_analyze)
-    result = []
-    for suggestion in columns_to_materialize:
-        table, table_column, property_name = suggestion
-        if (property_name, table_column) not in get_materialized_columns(table):
-            result.append(suggestion)
+
+    columns_by_table: dict[TableWithProperties, list[tuple[TableColumn, PropertyName]]] = defaultdict(list)
+    for table, table_column, property_name in columns_to_materialize:
+        columns_by_table[table].append((table_column, property_name))
+
+    result: list[Suggestion] = []
+    for table, columns in columns_by_table.items():
+        existing_materialized_columns = get_materialized_columns(table)
+        for table_column, property_name in columns:
+            if (property_name, table_column) not in existing_materialized_columns:
+                result.append((table, table_column, property_name))
 
     if len(result) > 0:
         logger.info(f"Calculated columns that could be materialized. count={len(result)}")

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -33,7 +33,7 @@ SHORT_TABLE_COLUMN_NAME = {
 }
 
 
-@dataclass
+@dataclass(frozen=True)
 class MaterializedColumnDetails:
     table_column: TableColumn
     property_name: PropertyName

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -4,7 +4,7 @@ import re
 from collections.abc import Iterator
 from dataclasses import dataclass, replace
 from datetime import timedelta
-from typing import Literal
+from typing import Literal, cast
 
 from clickhouse_driver.errors import ServerException
 from django.utils.timezone import now
@@ -57,10 +57,10 @@ class MaterializedColumnDetails:
                 return MaterializedColumnDetails(DEFAULT_TABLE_COLUMN, property_name, is_disabled=False)
             # Otherwise, it's "column_materializer::table_column::property" for columns that are active.
             case [cls.COMMENT_PREFIX, table_column, property_name]:
-                return MaterializedColumnDetails(table_column, property_name, is_disabled=False)
+                return MaterializedColumnDetails(cast(TableColumn, table_column), property_name, is_disabled=False)
             # Columns that are marked as disabled have an extra trailer indicating their status.
             case [cls.COMMENT_PREFIX, table_column, property_name, cls.COMMENT_DISABLED_MARKER]:
-                return MaterializedColumnDetails(table_column, property_name, is_disabled=True)
+                return MaterializedColumnDetails(cast(TableColumn, table_column), property_name, is_disabled=True)
             case _:
                 raise ValueError(f"unexpected comment format: {comment!r}")
 
@@ -105,7 +105,7 @@ def materialize(
 ) -> ColumnName | None:
     if (property, table_column) in get_materialized_columns(table):
         if TEST:
-            return
+            return None
 
         raise ValueError(f"Property already materialized. table={table}, property={property}, column={table_column}")
 

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -36,7 +36,7 @@ SHORT_TABLE_COLUMN_NAME = {
 class MaterializedColumnDetails:
     table_column: TableColumn
     property_name: PropertyName
-    is_enabled: bool
+    is_disabled: bool
 
     COMMENT_PREFIX = "column_materializer"
     COMMENT_SEPARATOR = "::"
@@ -47,9 +47,9 @@ class MaterializedColumnDetails:
         # Otherwise, it's "column_materializer::table_column::property"
         match comment.split(cls.COMMENT_SEPARATOR, 2):
             case [cls.COMMENT_PREFIX, property_name]:
-                return MaterializedColumnDetails(DEFAULT_TABLE_COLUMN, property_name, True)
+                return MaterializedColumnDetails(DEFAULT_TABLE_COLUMN, property_name, False)
             case [cls.COMMENT_PREFIX, table_column, property_name]:
-                return MaterializedColumnDetails(table_column, property_name, True)
+                return MaterializedColumnDetails(table_column, property_name, False)
             case _:
                 raise ValueError(f"unexpected comment format: {comment!r}")
 
@@ -76,7 +76,7 @@ def get_materialized_columns(
     materialized_columns = {}
     for comment, column_name in rows:
         details = MaterializedColumnDetails.from_column_comment(comment)
-        if not (exclude_disabled_columns and not details.is_enabled):
+        if not (exclude_disabled_columns and details.is_disabled):
             materialized_columns[(details.property_name, details.table_column)] = column_name
     return materialized_columns
 

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -94,10 +94,10 @@ def get_materialized_columns(
 def materialize(
     table: TableWithProperties,
     property: PropertyName,
-    column_name=None,
+    column_name: ColumnName | None = None,
     table_column: TableColumn = DEFAULT_TABLE_COLUMN,
     create_minmax_index=not TEST,
-) -> None:
+) -> ColumnName | None:
     if (property, table_column) in get_materialized_columns(table):
         if TEST:
             return
@@ -152,6 +152,8 @@ def materialize(
     if create_minmax_index:
         add_minmax_index(table, column_name)
 
+    return column_name
+
 
 def update_column_is_disabled(table: TablesWithMaterializedColumns, column_name: str, is_disabled: bool) -> None:
     # XXX: copy/pasted from `get_materialized_columns`
@@ -187,7 +189,7 @@ def update_column_is_disabled(table: TablesWithMaterializedColumns, column_name:
     )
 
 
-def add_minmax_index(table: TablesWithMaterializedColumns, column_name: str):
+def add_minmax_index(table: TablesWithMaterializedColumns, column_name: ColumnName):
     # Note: This will be populated on backfill
     execute_on_cluster = f"ON CLUSTER '{CLICKHOUSE_CLUSTER}'" if table == "events" else ""
 
@@ -269,7 +271,7 @@ def _materialized_column_name(
     table: TableWithProperties,
     property: PropertyName,
     table_column: TableColumn = DEFAULT_TABLE_COLUMN,
-) -> str:
+) -> ColumnName:
     "Returns a sanitized and unique column name to use for materialized column"
 
     prefix = "pmat_" if table == "person" else "mat_"

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -39,14 +39,17 @@ class MaterializedColumnDetails:
     property_name: PropertyName
     is_enabled: bool
 
-    @staticmethod
-    def from_column_comment(comment: str) -> MaterializedColumnDetails:
+    COMMENT_PREFIX = "column_materializer"
+    COMMENT_SEPARATOR = "::"
+
+    @classmethod
+    def from_column_comment(cls, comment: str) -> MaterializedColumnDetails:
         # Old style comments have the format "column_materializer::property", dealing with the default table column.
         # Otherwise, it's "column_materializer::table_column::property"
-        match comment.split("::", 2):
-            case ["column_materializer", property_name]:
+        match comment.split(cls.COMMENT_SEPARATOR, 2):
+            case [cls.COMMENT_PREFIX, property_name]:
                 return MaterializedColumnDetails(DEFAULT_TABLE_COLUMN, property_name, True)
-            case ["column_materializer", table_column, property_name]:
+            case [cls.COMMENT_PREFIX, table_column, property_name]:
                 return MaterializedColumnDetails(table_column, property_name, True)
             case _:
                 raise ValueError(f"unexpected comment format: {comment!r}")

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -195,6 +195,10 @@ def update_column_is_disabled(table: TablesWithMaterializedColumns, column_name:
     )
 
 
+def drop_column(table: TablesWithMaterializedColumns, column_name: str) -> None:
+    raise NotImplementedError
+
+
 def add_minmax_index(table: TablesWithMaterializedColumns, column_name: ColumnName):
     # Note: This will be populated on backfill
     execute_on_cluster = f"ON CLUSTER '{CLICKHOUSE_CLUSTER}'" if table == "events" else ""

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -56,6 +56,7 @@ class MaterializedColumnDetails:
 
 def get_materialized_columns(
     table: TablesWithMaterializedColumns,
+    exclude_disabled_columns: bool = False,
 ) -> dict[tuple[PropertyName, TableColumn], ColumnName]:
     if not get_instance_setting("MATERIALIZED_COLUMNS_ENABLED"):
         return {}
@@ -75,7 +76,8 @@ def get_materialized_columns(
     materialized_columns = {}
     for comment, column_name in rows:
         details = MaterializedColumnDetails.from_column_comment(comment)
-        materialized_columns[(details.property_name, details.table_column)] = column_name
+        if not (exclude_disabled_columns and not details.is_enabled):
+            materialized_columns[(details.property_name, details.table_column)] = column_name
     return materialized_columns
 
 

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import timedelta
 from typing import Literal
 
@@ -173,8 +173,10 @@ def update_column_is_disabled(table: TablesWithMaterializedColumns, column_name:
 
     [(comment,)] = rows
 
-    details = MaterializedColumnDetails.from_column_comment(comment)
-    details.is_disabled = is_disabled
+    details = replace(
+        MaterializedColumnDetails.from_column_comment(comment),
+        is_disabled=is_disabled,
+    )
 
     # XXX: copy/pasted from `materialize`
     execute_on_cluster = f"ON CLUSTER '{CLICKHOUSE_CLUSTER}'" if table == "events" else ""

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -199,19 +199,13 @@ def drop_column(table: TablesWithMaterializedColumns, column_name: str) -> None:
 
     on_cluster = get_on_cluster_clause_for_table(table)
     sync_execute(
-        f"""
-        ALTER TABLE {table} {on_cluster}
-        DROP COLUMN IF EXISTS {column_name}
-    """,
+        f"ALTER TABLE {table} {on_cluster} DROP COLUMN IF EXISTS {column_name}",
         settings={"alter_sync": 2 if TEST else 1},
     )
 
     if table == "events":
         sync_execute(
-            f"""
-            ALTER TABLE sharded_{table} {on_cluster}
-            DROP COLUMN IF EXISTS {column_name}
-        """,
+            f"ALTER TABLE sharded_{table} {on_cluster} DROP COLUMN IF EXISTS {column_name}",
             {"property": property},
             settings={"alter_sync": 2 if TEST else 1},
         )
@@ -247,10 +241,7 @@ def drop_minmax_index(table: TablesWithMaterializedColumns, column_name: ColumnN
     index_name = f"minmax_{column_name}"
 
     sync_execute(
-        f"""
-        ALTER TABLE {updated_table} {on_cluster}
-        DROP INDEX IF EXISTS {index_name}
-        """,
+        f"ALTER TABLE {updated_table} {on_cluster} DROP INDEX IF EXISTS {index_name}",
         settings={"alter_sync": 2 if TEST else 1},
     )
 

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -41,6 +41,9 @@ class MaterializedColumnDetails:
     COMMENT_PREFIX = "column_materializer"
     COMMENT_SEPARATOR = "::"
 
+    def as_column_comment(self) -> str:
+        return self.COMMENT_SEPARATOR.join([self.COMMENT_PREFIX, self.table_column, self.property_name])
+
     @classmethod
     def from_column_comment(cls, comment: str) -> MaterializedColumnDetails:
         # Old style comments have the format "column_materializer::property", dealing with the default table column.
@@ -135,7 +138,7 @@ def materialize(
 
     sync_execute(
         f"ALTER TABLE {table} {execute_on_cluster} COMMENT COLUMN {column_name} %(comment)s",
-        {"comment": f"column_materializer::{table_column}::{property}"},
+        {"comment": MaterializedColumnDetails(table_column, property, is_disabled=False).as_column_comment()},
         settings={"alter_sync": 2 if TEST else 1},
     )
 

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -44,9 +44,9 @@ class MaterializedColumn(NamedTuple):
             SELECT name, comment
             FROM system.columns
             WHERE database = %(database)s
-            AND table = %(table)s
-            AND comment LIKE '%%column_materializer::%%'
-            AND comment not LIKE '%%column_materializer::elements_chain::%%'
+                AND table = %(table)s
+                AND comment LIKE '%%column_materializer::%%'
+                AND comment not LIKE '%%column_materializer::elements_chain::%%'
         """,
             {"database": CLICKHOUSE_DATABASE, "table": table},
         )
@@ -56,6 +56,9 @@ class MaterializedColumn(NamedTuple):
 
     @staticmethod
     def get(table: TablesWithMaterializedColumns, column_name: ColumnName) -> MaterializedColumn | None:
+        # TODO: It would be more efficient to push the filter here down into the `get_all` query, but that would require
+        # more a sophisticated method of constructing queries than we have right now, and this data set should be small
+        # enough that this doesn't really matter (at least as of writing.)
         columns = [column for column in MaterializedColumn.get_all(table) if column.name == column_name]
         match columns:
             case []:

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -52,7 +52,7 @@ class MaterializedColumn(NamedTuple):
         )
 
         for name, comment in rows:
-            yield (name, MaterializedColumnDetails.from_column_comment(comment))
+            yield MaterializedColumn(name, MaterializedColumnDetails.from_column_comment(comment))
 
     @staticmethod
     def get(table: TablesWithMaterializedColumns, column_name: ColumnName) -> MaterializedColumn:

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -9,7 +9,7 @@ from ee.clickhouse.materialized_columns.columns import (
     get_materialized_columns,
     materialize,
 )
-from posthog.clickhouse.materialized_columns import get_materialized_columns_cached
+from posthog.clickhouse.materialized_columns import get_enabled_materialized_columns
 from posthog.client import sync_execute
 from posthog.conftest import create_clickhouse_tables
 from posthog.constants import GROUP_TYPES_LIMIT
@@ -53,12 +53,12 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
             self.assertCountEqual(
                 [
                     property_name
-                    for property_name, _ in get_materialized_columns_cached("events", use_cache=True).keys()
+                    for property_name, _ in get_enabled_materialized_columns("events", use_cache=True).keys()
                 ],
                 ["$foo", "$bar", *EVENTS_TABLE_DEFAULT_MATERIALIZED_COLUMNS],
             )
             self.assertCountEqual(
-                get_materialized_columns_cached("person", use_cache=True).keys(),
+                get_enabled_materialized_columns("person", use_cache=True).keys(),
                 [("$zeta", "properties")],
             )
 
@@ -67,7 +67,7 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
             self.assertCountEqual(
                 [
                     property_name
-                    for property_name, _ in get_materialized_columns_cached("events", use_cache=True).keys()
+                    for property_name, _ in get_enabled_materialized_columns("events", use_cache=True).keys()
                 ],
                 ["$foo", "$bar", *EVENTS_TABLE_DEFAULT_MATERIALIZED_COLUMNS],
             )
@@ -76,7 +76,7 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
             self.assertCountEqual(
                 [
                     property_name
-                    for property_name, _ in get_materialized_columns_cached("events", use_cache=True).keys()
+                    for property_name, _ in get_enabled_materialized_columns("events", use_cache=True).keys()
                 ],
                 ["$foo", "$bar", "abc", *EVENTS_TABLE_DEFAULT_MATERIALIZED_COLUMNS],
             )

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -298,6 +298,8 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
         source_column = "properties"
 
         destination_column = materialize(table, property, table_column=source_column, create_minmax_index=True)
+        assert destination_column is not None
+
         key = (property, source_column)
         assert get_materialized_columns("events")[key] == destination_column
 

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -12,11 +12,12 @@ from ee.clickhouse.materialized_columns.columns import (
     materialize,
     update_column_is_disabled,
 )
-from posthog.clickhouse.materialized_columns import get_enabled_materialized_columns
+from posthog.clickhouse.materialized_columns import TablesWithMaterializedColumns, get_enabled_materialized_columns
 from posthog.client import sync_execute
 from posthog.conftest import create_clickhouse_tables
 from posthog.constants import GROUP_TYPES_LIMIT
 from posthog.models.event.sql import EVENTS_DATA_TABLE
+from posthog.models.property import PropertyName, TableColumn
 from posthog.settings import CLICKHOUSE_DATABASE
 from posthog.test.base import BaseTest, ClickhouseTestMixin, _create_event
 
@@ -293,9 +294,9 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
         )[0]
 
     def test_update_column_is_disabled(self):
-        table = "events"
-        property = "myprop"
-        source_column = "properties"
+        table: TablesWithMaterializedColumns = "events"
+        property: PropertyName = "myprop"
+        source_column: TableColumn = "properties"
 
         destination_column = materialize(table, property, table_column=source_column, create_minmax_index=True)
         assert destination_column is not None

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -301,12 +301,12 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
         assert destination_column is not None
 
         key = (property, source_column)
-        assert get_materialized_columns("events")[key] == destination_column
+        assert get_materialized_columns(table)[key] == destination_column
 
         update_column_is_disabled(table, destination_column, is_disabled=True)
-        assert get_materialized_columns("events", exclude_disabled_columns=False)[key] == destination_column
-        assert key not in get_materialized_columns("events", exclude_disabled_columns=True)
+        assert get_materialized_columns(table)[key] == destination_column
+        assert key not in get_materialized_columns(table, exclude_disabled_columns=True)
 
         update_column_is_disabled(table, destination_column, is_disabled=False)
-        assert get_materialized_columns("events", exclude_disabled_columns=False)[key] == destination_column
-        assert get_materialized_columns("events", exclude_disabled_columns=True)[key] == destination_column
+        assert get_materialized_columns(table, exclude_disabled_columns=False)[key] == destination_column
+        assert get_materialized_columns(table, exclude_disabled_columns=True)[key] == destination_column

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -9,6 +9,7 @@ from ee.clickhouse.materialized_columns.columns import (
     get_materialized_columns,
     materialize,
 )
+from posthog.clickhouse.materialized_columns import get_materialized_columns_cached
 from posthog.client import sync_execute
 from posthog.conftest import create_clickhouse_tables
 from posthog.constants import GROUP_TYPES_LIMIT
@@ -50,24 +51,33 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
             materialize("person", "$zeta", create_minmax_index=True)
 
             self.assertCountEqual(
-                [property_name for property_name, _ in get_materialized_columns("events", use_cache=True).keys()],
+                [
+                    property_name
+                    for property_name, _ in get_materialized_columns_cached("events", use_cache=True).keys()
+                ],
                 ["$foo", "$bar", *EVENTS_TABLE_DEFAULT_MATERIALIZED_COLUMNS],
             )
             self.assertCountEqual(
-                get_materialized_columns("person", use_cache=True).keys(),
+                get_materialized_columns_cached("person", use_cache=True).keys(),
                 [("$zeta", "properties")],
             )
 
             materialize("events", "abc", create_minmax_index=True)
 
             self.assertCountEqual(
-                [property_name for property_name, _ in get_materialized_columns("events", use_cache=True).keys()],
+                [
+                    property_name
+                    for property_name, _ in get_materialized_columns_cached("events", use_cache=True).keys()
+                ],
                 ["$foo", "$bar", *EVENTS_TABLE_DEFAULT_MATERIALIZED_COLUMNS],
             )
 
         with freeze_time("2020-01-04T14:00:01Z"):
             self.assertCountEqual(
-                [property_name for property_name, _ in get_materialized_columns("events", use_cache=True).keys()],
+                [
+                    property_name
+                    for property_name, _ in get_materialized_columns_cached("events", use_cache=True).keys()
+                ],
                 ["$foo", "$bar", "abc", *EVENTS_TABLE_DEFAULT_MATERIALIZED_COLUMNS],
             )
 

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -13,7 +13,7 @@ from rest_framework.exceptions import ValidationError
 
 from ee.clickhouse.queries.column_optimizer import EnterpriseColumnOptimizer
 from ee.clickhouse.queries.groups_join_query import GroupsJoinQuery
-from posthog.clickhouse.materialized_columns import get_materialized_columns
+from posthog.clickhouse.materialized_columns import get_materialized_columns_cached
 from posthog.constants import (
     AUTOCAPTURE_EVENT,
     TREND_FILTER_TYPE_ACTIONS,
@@ -156,7 +156,7 @@ class FunnelCorrelation:
         ):
             # When dealing with properties, make sure funnel response comes with properties
             # so we don't have to join on persons/groups to get these properties again
-            mat_event_cols = get_materialized_columns("events")
+            mat_event_cols = get_materialized_columns_cached("events")
 
             for property_name in cast(list, self._filter.correlation_property_names):
                 if self._filter.aggregation_group_type_index is not None:

--- a/ee/clickhouse/queries/funnels/funnel_correlation.py
+++ b/ee/clickhouse/queries/funnels/funnel_correlation.py
@@ -13,7 +13,7 @@ from rest_framework.exceptions import ValidationError
 
 from ee.clickhouse.queries.column_optimizer import EnterpriseColumnOptimizer
 from ee.clickhouse.queries.groups_join_query import GroupsJoinQuery
-from posthog.clickhouse.materialized_columns import get_materialized_columns_cached
+from posthog.clickhouse.materialized_columns import get_enabled_materialized_columns
 from posthog.constants import (
     AUTOCAPTURE_EVENT,
     TREND_FILTER_TYPE_ACTIONS,
@@ -156,7 +156,7 @@ class FunnelCorrelation:
         ):
             # When dealing with properties, make sure funnel response comes with properties
             # so we don't have to join on persons/groups to get these properties again
-            mat_event_cols = get_materialized_columns_cached("events")
+            mat_event_cols = get_enabled_materialized_columns("events")
 
             for property_name in cast(list, self._filter.correlation_property_names):
                 if self._filter.aggregation_group_type_index is not None:

--- a/ee/management/commands/update_materialized_column.py
+++ b/ee/management/commands/update_materialized_column.py
@@ -1,0 +1,15 @@
+from argparse import BooleanOptionalAction
+from django.core.management.base import BaseCommand, CommandParser
+
+from posthog.clickhouse.materialized_columns import ColumnName, TablesWithMaterializedColumns
+from ee.clickhouse.materialized_columns.columns import update_column_is_disabled
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument("table")
+        parser.add_argument("column_name")
+        parser.add_argument("--enable", action=BooleanOptionalAction, required=True)
+
+    def handle(self, table: TablesWithMaterializedColumns, column_name: ColumnName, enable: bool, **options):
+        update_column_is_disabled(table, column_name, is_disabled=not enable)

--- a/ee/management/commands/update_materialized_column.py
+++ b/ee/management/commands/update_materialized_column.py
@@ -1,3 +1,5 @@
+import logging
+
 from typing import Any
 from collections.abc import Callable
 from django.core.management.base import BaseCommand, CommandParser
@@ -5,6 +7,7 @@ from django.core.management.base import BaseCommand, CommandParser
 from posthog.clickhouse.materialized_columns import ColumnName, TablesWithMaterializedColumns
 from ee.clickhouse.materialized_columns.columns import update_column_is_disabled, drop_column
 
+logger = logging.getLogger(__name__)
 
 COLUMN_OPERATIONS: dict[str, Callable[[TablesWithMaterializedColumns, ColumnName], Any]] = {
     "enable": lambda table, column_name: update_column_is_disabled(table, column_name, is_disabled=False),
@@ -20,5 +23,7 @@ class Command(BaseCommand):
         parser.add_argument("column_name")
 
     def handle(self, operation: str, table: TablesWithMaterializedColumns, column_name: ColumnName, **options):
+        logger.info("Running %r for %r.%r...", operation, table, column_name)
         fn = COLUMN_OPERATIONS[operation]
         fn(table, column_name)
+        logger.info("Success!")

--- a/ee/tasks/materialized_columns.py
+++ b/ee/tasks/materialized_columns.py
@@ -6,7 +6,7 @@ from ee.clickhouse.materialized_columns.columns import (
 )
 from posthog.client import sync_execute
 from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE
-from posthog.clickhouse.materialized_columns import ColumnName
+from posthog.clickhouse.materialized_columns import ColumnName, TablesWithMaterializedColumns
 
 logger = get_task_logger(__name__)
 
@@ -39,7 +39,8 @@ def mark_all_materialized() -> None:
 
 
 def get_materialized_columns_with_default_expression():
-    for table in ["events", "person"]:
+    tables: list[TablesWithMaterializedColumns] = ["events", "person"]
+    for table in tables:
         materialized_columns = get_materialized_columns(table)
         for (property_name, table_column), column_name in materialized_columns.items():
             if is_default_expression(table, column_name):

--- a/ee/tasks/materialized_columns.py
+++ b/ee/tasks/materialized_columns.py
@@ -40,7 +40,7 @@ def mark_all_materialized() -> None:
 
 def get_materialized_columns_with_default_expression():
     for table in ["events", "person"]:
-        materialized_columns = get_materialized_columns(table, use_cache=False)
+        materialized_columns = get_materialized_columns(table)
         for (property_name, table_column), column_name in materialized_columns.items():
             if is_default_expression(table, column_name):
                 yield table, property_name, table_column, column_name

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -873,7 +873,7 @@ class TestPerson(ClickhouseTestMixin, APIBaseTest):
         create_person(team_id=self.team.pk, version=0)
 
         returned_ids = []
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             response = self.client.get("/api/person/?limit=10").json()
         self.assertEqual(len(response["results"]), 9)
         returned_ids += [x["distinct_ids"][0] for x in response["results"]]

--- a/posthog/clickhouse/materialized_columns.py
+++ b/posthog/clickhouse/materialized_columns.py
@@ -14,12 +14,13 @@ else:
 
     def get_materialized_columns(
         table: TablesWithMaterializedColumns,
+        exclude_disabled_columns: bool = False,
     ) -> dict[tuple[PropertyName, TableColumn], ColumnName]:
         return {}
 
 
 @cache_for(timedelta(minutes=15))
-def get_materialized_columns_cached(
+def get_enabled_materialized_columns(
     table: TablesWithMaterializedColumns,
 ) -> dict[tuple[PropertyName, TableColumn], ColumnName]:
-    return get_materialized_columns(table)
+    return get_materialized_columns(table, exclude_disabled_columns=True)

--- a/posthog/clickhouse/materialized_columns.py
+++ b/posthog/clickhouse/materialized_columns.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from posthog.cache_utils import cache_for
-from posthog.models.property import TableWithProperties
+from posthog.models.property import PropertyName, TableColumn, TableWithProperties
 from posthog.settings import EE_AVAILABLE
 
 
@@ -11,7 +11,6 @@ TablesWithMaterializedColumns = TableWithProperties
 if EE_AVAILABLE:
     from ee.clickhouse.materialized_columns.columns import get_materialized_columns
 else:
-    from posthog.models.property import PropertyName, TableColumn
 
     def get_materialized_columns(
         table: TablesWithMaterializedColumns,
@@ -19,4 +18,8 @@ else:
         return {}
 
 
-get_materialized_columns_cached = cache_for(timedelta(minutes=15))(get_materialized_columns)
+@cache_for(timedelta(minutes=15))
+def get_materialized_columns_cached(
+    table: TablesWithMaterializedColumns,
+) -> dict[tuple[PropertyName, TableColumn], ColumnName]:
+    return get_materialized_columns(table)

--- a/posthog/clickhouse/materialized_columns.py
+++ b/posthog/clickhouse/materialized_columns.py
@@ -1,5 +1,9 @@
+from datetime import timedelta
+
+from posthog.cache_utils import cache_for
 from posthog.models.property import TableWithProperties
 from posthog.settings import EE_AVAILABLE
+
 
 ColumnName = str
 TablesWithMaterializedColumns = TableWithProperties
@@ -7,13 +11,12 @@ TablesWithMaterializedColumns = TableWithProperties
 if EE_AVAILABLE:
     from ee.clickhouse.materialized_columns.columns import get_materialized_columns
 else:
-    from datetime import timedelta
-
-    from posthog.cache_utils import cache_for
     from posthog.models.property import PropertyName, TableColumn
 
-    @cache_for(timedelta(minutes=15))
     def get_materialized_columns(
         table: TablesWithMaterializedColumns,
     ) -> dict[tuple[PropertyName, TableColumn], ColumnName]:
         return {}
+
+
+get_materialized_columns_cached = cache_for(timedelta(minutes=15))(get_materialized_columns)

--- a/posthog/clickhouse/migrations/0026_fix_materialized_window_and_session_ids.py
+++ b/posthog/clickhouse/migrations/0026_fix_materialized_window_and_session_ids.py
@@ -45,7 +45,7 @@ def materialize_session_and_window_id(database):
 
     properties = ["$session_id", "$window_id"]
     for property_name in properties:
-        materialized_columns = get_materialized_columns("events", use_cache=False)
+        materialized_columns = get_materialized_columns("events")
         # If the column is not materialized, materialize it
         if (property_name, "properties") not in materialized_columns:
             materialize("events", property_name, property_name)

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -6,7 +6,7 @@ from difflib import get_close_matches
 from typing import Literal, Optional, Union, cast
 from uuid import UUID
 
-from posthog.clickhouse.materialized_columns import TablesWithMaterializedColumns, get_materialized_columns
+from posthog.clickhouse.materialized_columns import TablesWithMaterializedColumns, get_materialized_columns_cached
 from posthog.clickhouse.property_groups import property_groups
 from posthog.hogql import ast
 from posthog.hogql.base import AST, _T_AST
@@ -1510,7 +1510,7 @@ class _Printer(Visitor):
     def _get_materialized_column(
         self, table_name: str, property_name: PropertyName, field_name: TableColumn
     ) -> Optional[str]:
-        materialized_columns = get_materialized_columns(cast(TablesWithMaterializedColumns, table_name))
+        materialized_columns = get_materialized_columns_cached(cast(TablesWithMaterializedColumns, table_name))
         return materialized_columns.get((property_name, field_name), None)
 
     def _get_timezone(self) -> str:

--- a/posthog/hogql/printer.py
+++ b/posthog/hogql/printer.py
@@ -6,7 +6,7 @@ from difflib import get_close_matches
 from typing import Literal, Optional, Union, cast
 from uuid import UUID
 
-from posthog.clickhouse.materialized_columns import TablesWithMaterializedColumns, get_materialized_columns_cached
+from posthog.clickhouse.materialized_columns import TablesWithMaterializedColumns, get_enabled_materialized_columns
 from posthog.clickhouse.property_groups import property_groups
 from posthog.hogql import ast
 from posthog.hogql.base import AST, _T_AST
@@ -1510,7 +1510,7 @@ class _Printer(Visitor):
     def _get_materialized_column(
         self, table_name: str, property_name: PropertyName, field_name: TableColumn
     ) -> Optional[str]:
-        materialized_columns = get_materialized_columns_cached(cast(TablesWithMaterializedColumns, table_name))
+        materialized_columns = get_enabled_materialized_columns(cast(TablesWithMaterializedColumns, table_name))
         return materialized_columns.get((property_name, field_name), None)
 
     def _get_timezone(self) -> str:

--- a/posthog/hogql/transforms/property_types.py
+++ b/posthog/hogql/transforms/property_types.py
@@ -1,6 +1,6 @@
 from typing import Literal, Optional, cast
 
-from posthog.clickhouse.materialized_columns import TablesWithMaterializedColumns, get_materialized_columns
+from posthog.clickhouse.materialized_columns import TablesWithMaterializedColumns, get_materialized_columns_cached
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import (
@@ -273,5 +273,5 @@ class PropertySwapper(CloningVisitor):
     def _get_materialized_column(
         self, table_name: str, property_name: PropertyName, field_name: TableColumn
     ) -> Optional[str]:
-        materialized_columns = get_materialized_columns(cast(TablesWithMaterializedColumns, table_name))
+        materialized_columns = get_materialized_columns_cached(cast(TablesWithMaterializedColumns, table_name))
         return materialized_columns.get((property_name, field_name), None)

--- a/posthog/hogql/transforms/property_types.py
+++ b/posthog/hogql/transforms/property_types.py
@@ -1,6 +1,6 @@
 from typing import Literal, Optional, cast
 
-from posthog.clickhouse.materialized_columns import TablesWithMaterializedColumns, get_materialized_columns_cached
+from posthog.clickhouse.materialized_columns import TablesWithMaterializedColumns, get_enabled_materialized_columns
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import (
@@ -273,5 +273,5 @@ class PropertySwapper(CloningVisitor):
     def _get_materialized_column(
         self, table_name: str, property_name: PropertyName, field_name: TableColumn
     ) -> Optional[str]:
-        materialized_columns = get_materialized_columns_cached(cast(TablesWithMaterializedColumns, table_name))
+        materialized_columns = get_enabled_materialized_columns(cast(TablesWithMaterializedColumns, table_name))
         return materialized_columns.get((property_name, field_name), None)

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -16,7 +16,7 @@ from rest_framework import exceptions
 from posthog.clickhouse.kafka_engine import trim_quotes_expr
 from posthog.clickhouse.materialized_columns import (
     TableWithProperties,
-    get_materialized_columns_cached,
+    get_enabled_materialized_columns,
 )
 from posthog.constants import PropertyOperatorType
 from posthog.hogql import ast
@@ -711,7 +711,7 @@ def get_property_string_expr(
         (optional) alias of the table being queried
     :return:
     """
-    materialized_columns = get_materialized_columns_cached(table) if allow_denormalized_props else {}
+    materialized_columns = get_enabled_materialized_columns(table) if allow_denormalized_props else {}
 
     table_string = f"{table_alias}." if table_alias is not None and table_alias != "" else ""
 

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -16,7 +16,7 @@ from rest_framework import exceptions
 from posthog.clickhouse.kafka_engine import trim_quotes_expr
 from posthog.clickhouse.materialized_columns import (
     TableWithProperties,
-    get_materialized_columns,
+    get_materialized_columns_cached,
 )
 from posthog.constants import PropertyOperatorType
 from posthog.hogql import ast
@@ -711,7 +711,7 @@ def get_property_string_expr(
         (optional) alias of the table being queried
     :return:
     """
-    materialized_columns = get_materialized_columns(table) if allow_denormalized_props else {}
+    materialized_columns = get_materialized_columns_cached(table) if allow_denormalized_props else {}
 
     table_string = f"{table_alias}." if table_alias is not None and table_alias != "" else ""
 

--- a/posthog/queries/column_optimizer/foss_column_optimizer.py
+++ b/posthog/queries/column_optimizer/foss_column_optimizer.py
@@ -3,7 +3,7 @@ from collections import Counter as TCounter
 from typing import Union, cast
 from collections.abc import Generator
 
-from posthog.clickhouse.materialized_columns import ColumnName, get_materialized_columns_cached
+from posthog.clickhouse.materialized_columns import ColumnName, get_enabled_materialized_columns
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, FunnelCorrelationType
 from posthog.models.action.util import (
     get_action_tables_and_properties,
@@ -73,7 +73,7 @@ class FOSSColumnOptimizer:
     ) -> set[ColumnName]:
         "Transforms a list of property names to what columns are needed for that query"
 
-        materialized_columns = get_materialized_columns_cached(table)
+        materialized_columns = get_enabled_materialized_columns(table)
         return {
             materialized_columns.get((property_name, table_column), table_column)
             for property_name, _, _ in used_properties

--- a/posthog/queries/column_optimizer/foss_column_optimizer.py
+++ b/posthog/queries/column_optimizer/foss_column_optimizer.py
@@ -3,7 +3,7 @@ from collections import Counter as TCounter
 from typing import Union, cast
 from collections.abc import Generator
 
-from posthog.clickhouse.materialized_columns import ColumnName, get_materialized_columns
+from posthog.clickhouse.materialized_columns import ColumnName, get_materialized_columns_cached
 from posthog.constants import TREND_FILTER_TYPE_ACTIONS, FunnelCorrelationType
 from posthog.models.action.util import (
     get_action_tables_and_properties,
@@ -73,7 +73,7 @@ class FOSSColumnOptimizer:
     ) -> set[ColumnName]:
         "Transforms a list of property names to what columns are needed for that query"
 
-        materialized_columns = get_materialized_columns(table)
+        materialized_columns = get_materialized_columns_cached(table)
         return {
             materialized_columns.get((property_name, table_column), table_column)
             for property_name, _, _ in used_properties

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -19,7 +19,7 @@ from sentry_sdk import capture_exception
 
 from posthog import version_requirement
 from posthog.clickhouse.client.connection import Workload
-from posthog.clickhouse.materialized_columns import get_materialized_columns
+from posthog.clickhouse.materialized_columns import get_materialized_columns_cached
 from posthog.client import sync_execute
 from posthog.cloud_utils import get_cached_instance_license, is_cloud
 from posthog.constants import FlagRequestType
@@ -459,7 +459,7 @@ def get_teams_with_event_count_with_groups_in_period(begin: datetime, end: datet
 @timed_log()
 @retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_all_event_metrics_in_period(begin: datetime, end: datetime) -> dict[str, list[tuple[int, int]]]:
-    materialized_columns = get_materialized_columns("events")
+    materialized_columns = get_materialized_columns_cached("events")
 
     # Check if $lib is materialized
     lib_expression = materialized_columns.get(("$lib", "properties"), "JSONExtractString(properties, '$lib')")

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -19,7 +19,7 @@ from sentry_sdk import capture_exception
 
 from posthog import version_requirement
 from posthog.clickhouse.client.connection import Workload
-from posthog.clickhouse.materialized_columns import get_materialized_columns_cached
+from posthog.clickhouse.materialized_columns import get_enabled_materialized_columns
 from posthog.client import sync_execute
 from posthog.cloud_utils import get_cached_instance_license, is_cloud
 from posthog.constants import FlagRequestType
@@ -459,7 +459,7 @@ def get_teams_with_event_count_with_groups_in_period(begin: datetime, end: datet
 @timed_log()
 @retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_all_event_metrics_in_period(begin: datetime, end: datetime) -> dict[str, list[tuple[int, int]]]:
-    materialized_columns = get_materialized_columns_cached("events")
+    materialized_columns = get_enabled_materialized_columns("events")
 
     # Check if $lib is materialized
     lib_expression = materialized_columns.get(("$lib", "properties"), "JSONExtractString(properties, '$lib')")


### PR DESCRIPTION
## Problem

Materialized columns that provide little performance benefit but are still occasionally used cannot be safely dropped in one step since references to the columns to be dropped may still be held in the `get_materialized_columns` cache until their expiry.

## Changes

Builds on top of #26050, #26052 to add the ability to mark materialized columns as "disabled". Disabled columns remain in the table schema (i.e. referencing them in a query due to stale cache values doesn't error), but these columns will not be included when initializing/refreshing the column materialized cache. After all caches have expired, these columns should be able to be safely dropped without issue.

Also adds the ability to drop materialized columns along with associated indices.

All of these operations can be run with the `update_materialized_column` management command:

```
usage: manage.py update_materialized_column […] {enable,disable,drop} table column_name
```

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Existing tests, added test, improved type checks, manually tested management command.