### PR TITLE
fix(data-warehouse): Added full refresh workaround for team 2

### DIFF
--- a/posthog/temporal/data_imports/pipelines/test/test_pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/test/test_pipeline_sync.py
@@ -77,6 +77,7 @@ class TestDataImportPipeline(APIBaseTest):
             ) as mock_validate_schema_and_update_table,
             patch("posthog.temporal.data_imports.pipelines.pipeline_sync.get_delta_tables"),
             patch("posthog.temporal.data_imports.pipelines.pipeline_sync.update_last_synced_at_sync"),
+            patch("posthog.temporal.data_imports.pipelines.pipeline_sync.is_posthog_team", return_value=False),
         ):
             pipeline = self._create_pipeline("Customer", False)
             res = pipeline.run()
@@ -98,6 +99,7 @@ class TestDataImportPipeline(APIBaseTest):
             ) as mock_validate_schema_and_update_table,
             patch("posthog.temporal.data_imports.pipelines.pipeline_sync.get_delta_tables"),
             patch("posthog.temporal.data_imports.pipelines.pipeline_sync.update_last_synced_at_sync"),
+            patch("posthog.temporal.data_imports.pipelines.pipeline_sync.is_posthog_team", return_value=False),
         ):
             pipeline = self._create_pipeline("Customer", True)
             res = pipeline.run()

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -202,6 +202,7 @@ async def _execute_run(workflow_id: str, inputs: ExternalDataWorkflowInputs, moc
         ),
         mock.patch.object(AwsCredentials, "to_session_credentials", mock_to_session_credentials),
         mock.patch.object(AwsCredentials, "to_object_store_rs_credentials", mock_to_object_store_rs_credentials),
+        mock.patch("posthog.temporal.data_imports.pipelines.pipeline_sync.is_posthog_team", return_value=False),
     ):
         async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
             async with Worker(


### PR DESCRIPTION
## Problem
- [context](https://posthog.slack.com/archives/C019RAX2XBN/p1730990332204389)

## Changes
- For just PostHog, on full table refreshes, we:
  - Delete your deltalake table from S3 before the pipeline runs (if it exists)
    - You can still query data during this bit, querying happens from another folder
  - Change the write disposition to `append` instead of `replace`
    - This allows chunks of files to append to the table instead of replacing the previous chunk
- Only enabled for posthog team 2 in the US and team 1 in EU

## Does this work well for both Cloud and self-hosted?
Likely

## How did you test this code?
Tested locally extensively