### PR TITLE
fix: cannot launch wildcarded domains

### DIFF
--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -193,6 +193,11 @@ export function AuthorizedUrlList({
                                                 }
                                                 center
                                                 data-attr="toolbar-open"
+                                                disabledReason={
+                                                    keyedURL.url.includes('*')
+                                                        ? 'Wildcard domains cannot be launched'
+                                                        : undefined
+                                                }
                                             >
                                                 Launch
                                             </LemonButton>


### PR DESCRIPTION
we let you add wildcard domains when setting authorized urls for replay

e.g. https://*.example.com/

and next to that we put a `launch` button which opens the URL for you

but, it isn't possible to open a wild-carded domain, only a specific one

so, let's disable the button in those cases