### PR TITLE
chore(flags): document server-side filtering params on GET /api/projects/:project_id/feature_flags

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -502,34 +502,33 @@ class FeatureFlagViewSet(
             OpenApiParameter(
                 "active",
                 OpenApiTypes.STR,
-                in_=OpenApiParameter.QUERY,
+                location=OpenApiParameter.QUERY,
                 required=False,
                 enum=["true", "false"],
             ),
             OpenApiParameter(
                 "created_by_id",
                 OpenApiTypes.STR,
-                in_=OpenApiParameter.QUERY,
+                location=OpenApiParameter.QUERY,
                 required=False,
                 description="The User ID which initially created the feature flag.",
             ),
             OpenApiParameter(
                 "search",
                 OpenApiTypes.STR,
-                in_=OpenApiParameter.QUERY,
+                location=OpenApiParameter.QUERY,
                 required=False,
                 description="Search by feature flag key or name. Case insensitive.",
             ),
             OpenApiParameter(
                 "type",
                 OpenApiTypes.STR,
-                in_=OpenApiParameter.QUERY,
+                location=OpenApiParameter.QUERY,
                 required=False,
                 enum=["boolean", "multivariant", "experiment"],
             ),
         ]
     )
-    @action(methods=["GET"], detail=True)
     def list(self, request, *args, **kwargs):
         if isinstance(request.successful_authenticator, PersonalAPIKeyAuthentication):
             # Add request for analytics only if request coming with personal API key authentication


### PR DESCRIPTION
<!-- Who are we building for, what are their needs, why is this important? -->

Follow up to https://github.com/PostHog/posthog/pull/26041

## Changes

<!-- If there are frontend changes, please include screenshots. -->

Local posthog.com:
<img width="821" alt="Screenshot 2024-11-07 at 3 11 51 PM" src="https://github.com/user-attachments/assets/c849fd71-3e1a-4a4f-8927-07fbc8b15f2a">

spec fetched from http://127.0.0.1:8000/api/schema/ :
<img width="1081" alt="Screenshot 2024-11-07 at 3 11 13 PM" src="https://github.com/user-attachments/assets/af496833-169c-49d0-bc7b-d3c9ba31f6d1">


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Ran posthog.com and frontend server locally (see screenshots above)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
