### PR TITLE
fix(paths): gracefully handle nulls for local cleaning filters

### DIFF
--- a/frontend/src/lib/components/PathCleanFilters/PathCleanFilters.tsx
+++ b/frontend/src/lib/components/PathCleanFilters/PathCleanFilters.tsx
@@ -9,11 +9,12 @@ import { PathCleanFilterAddItemButton } from './PathCleanFilterAddItemButton'
 import { PathCleanFilterItem } from './PathCleanFilterItem'
 
 export interface PathCleanFiltersProps {
-    filters?: PathCleaningFilter[]
+    filters?: PathCleaningFilter[] | null
     setFilters: (filters: PathCleaningFilter[]) => void
 }
 
-export function PathCleanFilters({ filters = [], setFilters: _setFilters }: PathCleanFiltersProps): JSX.Element {
+export function PathCleanFilters({ filters: _filters, setFilters: _setFilters }: PathCleanFiltersProps): JSX.Element {
+    const filters = _filters != null ? _filters : []
     const [localFilters, setLocalFilters] = useState(filters)
 
     const updateFilters = (filters: PathCleaningFilter[]): void => {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -7887,10 +7887,17 @@
                     "type": "array"
                 },
                 "local_path_cleaning_filters": {
-                    "items": {
-                        "$ref": "#/definitions/PathCleaningFilter"
-                    },
-                    "type": "array"
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/PathCleaningFilter"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "max_edge_weight": {
                     "type": "integer"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -7806,10 +7806,17 @@
                     "type": "array"
                 },
                 "localPathCleaningFilters": {
-                    "items": {
-                        "$ref": "#/definitions/PathCleaningFilter"
-                    },
-                    "type": "array"
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/definitions/PathCleaningFilter"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "maxEdgeWeight": {
                     "type": "integer"

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1100,7 +1100,7 @@ export type PathsFilter = {
     /** @default 5 */
     stepLimit?: integer
     pathReplacements?: PathsFilterLegacy['path_replacements']
-    localPathCleaningFilters?: PathsFilterLegacy['local_path_cleaning_filters']
+    localPathCleaningFilters?: PathsFilterLegacy['local_path_cleaning_filters'] | null
     minEdgeWeight?: PathsFilterLegacy['min_edge_weight']
     maxEdgeWeight?: PathsFilterLegacy['max_edge_weight']
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2356,7 +2356,7 @@ export interface PathsFilterType extends FilterType {
     /** @asType integer */
     step_limit?: number // Paths Step Limit
     path_replacements?: boolean
-    local_path_cleaning_filters?: PathCleaningFilter[]
+    local_path_cleaning_filters?: PathCleaningFilter[] | null
     /** @asType integer */
     edge_limit?: number | undefined // Paths edge limit
     /** @asType integer */


### PR DESCRIPTION
## Problem

Duplicating an insight leads to `null`s in the query. For the local path cleaning filters this resulted in a crash [for a customer](https://posthoghelp.zendesk.com/agent/tickets/20330).

## Changes

Gracefully handles `null` values for the local path cleaning filter.

## Follow-ups

- [x] ~Look into wether duplicating an insight creates these `null`s, and if so - fix that~ -> could not reproduce
- [ ] Python doesn't distinguish between `null` and `undefined`, meaning we have no protection from "faulty" queries like this in our backend side validation. Likely we should add `null`s to the whole `schema.ts` types where we have an optional value.

## How did you test this code?

Used the query from the customer locally to verify the issue and fix.
