### PR TITLE
feat(data-warehouse): Added a sync temporal logger

### DIFF
--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -135,6 +135,7 @@ def configure_logger_sync(
 
     def worker_shutdown_handler():
         temporalio.activity.wait_for_worker_shutdown_sync()
+        log_queue.put(None)
         log_queue.join()
         listener_thread.join()
 

--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -103,9 +103,12 @@ def configure_logger_sync(
     log_queue = queue if queue is not None else sync_queue.Queue(maxsize=-1)
     log_producer = None
     log_producer_error = None
+    shutdown_signal = threading.Event()
 
     try:
-        log_producer = KafkaLogProducerFromQueueSync(queue=log_queue, topic=KAFKA_LOG_ENTRIES, producer=producer)
+        log_producer = KafkaLogProducerFromQueueSync(
+            queue=log_queue, shutdown_signal=shutdown_signal, topic=KAFKA_LOG_ENTRIES, producer=producer
+        )
     except Exception as e:
         # Skip putting logs in queue if we don't have a producer that can consume the queue.
         # We save the error to log it later as the logger hasn't yet been configured at this time.
@@ -139,9 +142,8 @@ def configure_logger_sync(
             return
 
         temporalio.activity.wait_for_worker_shutdown_sync()
+        shutdown_signal.set()
         log_queue.put(None)
-        log_queue.join()
-        listener_thread.join()
 
     context = copy_context()
     shutdown_thread = threading.Thread(target=context.run, args=(worker_shutdown_handler,), daemon=True)
@@ -431,8 +433,16 @@ class KafkaLogProducerFromQueueAsync:
 class KafkaLogProducerFromQueueSync:
     """Produce log messages to Kafka by getting them from a queue."""
 
-    def __init__(self, queue: sync_queue.Queue, topic: str = KAFKA_LOG_ENTRIES, key: str | None = None, producer=None):
+    def __init__(
+        self,
+        queue: sync_queue.Queue,
+        shutdown_signal: threading.Event,
+        topic: str = KAFKA_LOG_ENTRIES,
+        key: str | None = None,
+        producer=None,
+    ):
         self.queue = queue
+        self.shutdown_signal = shutdown_signal
         self.topic = topic
         self.key = key
         self.producer = producer or KafkaProducer(
@@ -447,7 +457,7 @@ class KafkaLogProducerFromQueueSync:
     def listen(self):
         """Listen to messages in the queue and produce them to Kafka."""
         try:
-            while True:
+            while not self.shutdown_signal.is_set():
                 msg = self.queue.get()
                 if msg is None:  # Stop signal
                     break

--- a/posthog/temporal/common/tests/test_logger_sync.py
+++ b/posthog/temporal/common/tests/test_logger_sync.py
@@ -1,0 +1,149 @@
+import json
+import queue as sync_queue
+from django.conf import settings
+import kafka
+import pytest
+import structlog
+
+from posthog.temporal.common.logger import bind_temporal_worker_logger_sync, configure_logger_sync
+
+
+class LogCapture:
+    """A test StructLog processor to capture logs."""
+
+    def __init__(self):
+        self.entries = []
+
+    def __call__(self, logger, method_name, event_dict):
+        """Append event_dict to entries and drop the log."""
+        self.entries.append(event_dict)
+        raise structlog.DropEvent()
+
+
+@pytest.fixture()
+def log_capture():
+    """Return a LogCapture processor for inspection in tests."""
+    return LogCapture()
+
+
+class QueueCapture(sync_queue.Queue):
+    """A test asyncio.Queue that captures items that we put into it."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.entries = []
+
+    def put_nowait(self, item):
+        """Append item to entries and delegate to asyncio.Queue."""
+        self.entries.append(item)
+        super().put_nowait(item)
+
+
+@pytest.fixture()
+def queue():
+    """Return a QueueCapture queue for inspection in tests."""
+    queue = QueueCapture(maxsize=-1)
+
+    yield queue
+
+
+class CaptureKafkaProducer:
+    """A test kafka.KafkaProducer that captures calls to send_and_wait."""
+
+    def __init__(self, *args, **kwargs):
+        self.entries = []
+        self._producer: None | kafka.KafkaProducer = None
+
+    @property
+    def producer(self) -> kafka.KafkaProducer:
+        if self._producer is None:
+            self._producer = kafka.KafkaProducer(
+                bootstrap_servers=[*settings.KAFKA_HOSTS, "localhost:9092"],
+                security_protocol=settings.KAFKA_SECURITY_PROTOCOL or "PLAINTEXT",
+                acks="all",
+                request_timeout_ms=1000000,
+                api_version=(2, 5, 0),
+            )
+        return self._producer
+
+    def send(self, topic, value=None, key=None, partition=None, timestamp_ms=None, headers=None):
+        """Append an entry and delegate to kafka.KafkaProducer."""
+
+        self.entries.append(
+            {
+                "topic": topic,
+                "value": value,
+                "key": key,
+                "partition": partition,
+                "timestamp_ms": timestamp_ms,
+                "headers": headers,
+            }
+        )
+        return self.producer.send(topic, value, key, partition, timestamp_ms, headers)
+
+    def flush(self):
+        self.producer.flush()
+
+    @property
+    def _closed(self):
+        return self.producer._closed
+
+
+@pytest.fixture(scope="function")
+def producer(event_loop):
+    """Yield a CaptureKafkaProducer to inspect entries captured.
+
+    After usage, we ensure the producer was closed to avoid leaking/warnings.
+    """
+    producer = CaptureKafkaProducer(bootstrap_servers=settings.KAFKA_HOSTS, loop=event_loop)
+
+    yield producer
+
+
+@pytest.fixture(autouse=True)
+def configure(log_capture, queue, producer):
+    """Configure StructLog logging for testing.
+
+    The extra parameters configured for testing are:
+    * Add a LogCapture processor to capture logs.
+    * Set the queue and producer to capture messages sent.
+    * Do not cache logger to ensure each test starts clean.
+    """
+    configure_logger_sync(
+        extra_processors=[log_capture], queue=queue, producer=producer, cache_logger_on_first_use=False
+    )
+
+    yield
+
+
+def test_logger_sync_binds_context(log_capture):
+    """Test whether we can bind context variables."""
+    logger = bind_temporal_worker_logger_sync(team_id=1, destination="Somewhere")
+
+    logger.info("Hi! This is an info log")
+    logger.error("Hi! This is an erro log")
+
+    assert len(log_capture.entries) == 2
+
+    info_entry, error_entry = log_capture.entries
+    info_dict, error_dict = json.loads(info_entry), json.loads(error_entry)
+    assert info_dict["team_id"] == 1
+    assert info_dict["destination"] == "Somewhere"
+
+    assert error_dict["team_id"] == 1
+    assert error_dict["destination"] == "Somewhere"
+
+
+def test_logger_sync_formats_positional_args(log_capture):
+    """Test whether positional arguments are formatted in the message."""
+    logger = bind_temporal_worker_logger_sync(team_id=1, destination="Somewhere")
+
+    logger.info("Hi! This is an %s log", "info")
+    logger.error("Hi! This is an %s log", "error")
+
+    assert len(log_capture.entries) == 2
+
+    info_entry, error_entry = log_capture.entries
+    info_dict, error_dict = json.loads(info_entry), json.loads(error_entry)
+    assert info_dict["msg"] == "Hi! This is an info log"
+    assert error_dict["msg"] == "Hi! This is an error log"

--- a/posthog/temporal/common/tests/test_logger_sync.py
+++ b/posthog/temporal/common/tests/test_logger_sync.py
@@ -27,14 +27,14 @@ def log_capture():
 
 
 class QueueCapture(sync_queue.Queue):
-    """A test asyncio.Queue that captures items that we put into it."""
+    """A test queue.Queue that captures items that we put into it."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.entries = []
 
     def put_nowait(self, item):
-        """Append item to entries and delegate to asyncio.Queue."""
+        """Append item to entries and delegate to queue.Queue."""
         self.entries.append(item)
         super().put_nowait(item)
 
@@ -89,13 +89,13 @@ class CaptureKafkaProducer:
         return self.producer._closed
 
 
-@pytest.fixture(scope="function")
-def producer(event_loop):
+@pytest.fixture
+def producer():
     """Yield a CaptureKafkaProducer to inspect entries captured.
 
     After usage, we ensure the producer was closed to avoid leaking/warnings.
     """
-    producer = CaptureKafkaProducer(bootstrap_servers=settings.KAFKA_HOSTS, loop=event_loop)
+    producer = CaptureKafkaProducer(bootstrap_servers=settings.KAFKA_HOSTS)
 
     yield producer
 

--- a/posthog/temporal/tests/batch_exports/test_logger.py
+++ b/posthog/temporal/tests/batch_exports/test_logger.py
@@ -26,7 +26,7 @@ from posthog.kafka_client.topics import KAFKA_LOG_ENTRIES
 from posthog.temporal.common.logger import (
     BACKGROUND_LOGGER_TASKS,
     bind_temporal_worker_logger,
-    configure_logger,
+    configure_logger_async,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -142,7 +142,9 @@ async def configure(log_capture, queue, producer):
     * Set the queue and producer to capture messages sent.
     * Do not cache logger to ensure each test starts clean.
     """
-    configure_logger(extra_processors=[log_capture], queue=queue, producer=producer, cache_logger_on_first_use=False)
+    configure_logger_async(
+        extra_processors=[log_capture], queue=queue, producer=producer, cache_logger_on_first_use=False
+    )
 
     yield
 


### PR DESCRIPTION
## Problem
- We need a sync temporal logger for the new sync activities
- [Context](https://posthog.slack.com/archives/C019RAX2XBN/p1731000266189869)

## Changes
- Added a sync logger with the same setup/implementation as the async version

## Does this work well for both Cloud and self-hosted?
Yarp

## How did you test this code?
Added tests
