### PR TITLE
feat(experiments): Support holdouts in QueryRunners

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_funnels_query_runner.py
@@ -37,6 +37,9 @@ class ExperimentFunnelsQueryRunner(QueryRunner):
         self.experiment = Experiment.objects.get(id=self.query.experiment_id)
         self.feature_flag = self.experiment.feature_flag
         self.variants = [variant["key"] for variant in self.feature_flag.variants]
+        if self.experiment.holdout:
+            self.variants.append(f"holdout-{self.experiment.holdout.id}")
+
         self.prepared_funnels_query = self._prepare_funnel_query()
         self.funnels_query_runner = FunnelsQueryRunner(
             query=self.prepared_funnels_query, team=self.team, timings=self.timings, limit_context=self.limit_context

--- a/posthog/hogql_queries/experiments/experiment_trends_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_trends_query_runner.py
@@ -45,6 +45,8 @@ class ExperimentTrendsQueryRunner(QueryRunner):
         self.experiment = Experiment.objects.get(id=self.query.experiment_id)
         self.feature_flag = self.experiment.feature_flag
         self.variants = [variant["key"] for variant in self.feature_flag.variants]
+        if self.experiment.holdout:
+            self.variants.append(f"holdout-{self.experiment.holdout.id}")
         self.breakdown_key = f"$feature/{self.feature_flag.key}"
 
         self.prepared_count_query = self._prepare_count_query()

--- a/posthog/hogql_queries/experiments/experiment_trends_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_trends_query_runner.py
@@ -118,7 +118,7 @@ class ExperimentTrendsQueryRunner(QueryRunner):
         prepared_count_query.properties = [
             EventPropertyFilter(
                 key=self.breakdown_key,
-                value=[variant["key"] for variant in self.feature_flag.variants],
+                value=self.variants,
                 operator="exact",
                 type="event",
             )
@@ -158,7 +158,7 @@ class ExperimentTrendsQueryRunner(QueryRunner):
                 prepared_exposure_query.properties = [
                     EventPropertyFilter(
                         key=self.breakdown_key,
-                        value=[variant["key"] for variant in self.feature_flag.variants],
+                        value=self.variants,
                         operator="exact",
                         type="event",
                     )
@@ -174,7 +174,7 @@ class ExperimentTrendsQueryRunner(QueryRunner):
             prepared_exposure_query.properties = [
                 EventPropertyFilter(
                     key=self.breakdown_key,
-                    value=[variant["key"] for variant in self.feature_flag.variants],
+                    value=self.variants,
                     operator="exact",
                     type="event",
                 )
@@ -193,7 +193,7 @@ class ExperimentTrendsQueryRunner(QueryRunner):
                 properties=[
                     EventPropertyFilter(
                         key=self.breakdown_key,
-                        value=[variant["key"] for variant in self.feature_flag.variants],
+                        value=self.variants,
                         operator="exact",
                         type="event",
                     ),

--- a/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
@@ -1,6 +1,6 @@
 from typing import cast
 from posthog.hogql_queries.experiments.experiment_funnels_query_runner import ExperimentFunnelsQueryRunner
-from posthog.models.experiment import Experiment
+from posthog.models.experiment import Experiment, ExperimentHoldout
 from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.schema import (
     EventsNode,
@@ -54,6 +54,18 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             start_date=timezone.now(),
             end_date=timezone.now() + timedelta(days=14),
         )
+
+    def create_holdout_for_experiment(self, experiment):
+        holdout = ExperimentHoldout.objects.create(
+            experiment=experiment,
+            team=self.team,
+            name="Test Experiment holdout",
+        )
+        holdout.filters = [{"properties": [], "rollout_percentage": 20, "variant": f"holdout-{holdout.id}"}]
+        holdout.save()
+        experiment.holdout = holdout
+        experiment.save()
+        return holdout
 
     @freeze_time("2020-01-01T12:00:00Z")
     def test_query_runner(self):
@@ -200,6 +212,74 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertFalse(result.significant)
         self.assertEqual(len(result.variants), 2)
         self.assertAlmostEqual(result.expected_loss, 1.0, places=1)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_query_runner_with_holdout(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+        holdout = self.create_holdout_for_experiment(experiment)
+
+        feature_flag_property = f"$feature/{feature_flag.key}"
+
+        funnels_query = FunnelsQuery(
+            series=[EventsNode(event="$pageview"), EventsNode(event="purchase")],
+            dateRange={"date_from": "2020-01-01", "date_to": "2020-01-14"},
+        )
+        experiment_query = ExperimentFunnelsQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentFunnelsQuery",
+            funnels_query=funnels_query,
+        )
+
+        experiment.metrics = [{"type": "primary", "query": experiment_query.model_dump()}]
+        experiment.save()
+
+        for variant, purchase_count in [("control", 6), ("test", 8), (f"holdout-{holdout.id}", 3)]:
+            for i in range(10):
+                _create_person(distinct_ids=[f"user_{variant}_{i}"], team_id=self.team.pk)
+                _create_event(
+                    team=self.team,
+                    event="$pageview",
+                    distinct_id=f"user_{variant}_{i}",
+                    timestamp="2020-01-02T12:00:00Z",
+                    properties={feature_flag_property: variant},
+                )
+                if i < purchase_count:
+                    _create_event(
+                        team=self.team,
+                        event="purchase",
+                        distinct_id=f"user_{variant}_{i}",
+                        timestamp="2020-01-02T12:01:00Z",
+                        properties={feature_flag_property: variant},
+                    )
+
+        flush_persons_and_events()
+
+        query_runner = ExperimentFunnelsQueryRunner(
+            query=ExperimentFunnelsQuery(**experiment.metrics[0]["query"]), team=self.team
+        )
+        result = query_runner.calculate()
+
+        self.assertEqual(len(result.variants), 3)
+
+        control_variant = next(variant for variant in result.variants if variant.key == "control")
+        test_variant = next(variant for variant in result.variants if variant.key == "test")
+        holdout_variant = next(variant for variant in result.variants if variant.key == f"holdout-{holdout.id}")
+
+        self.assertEqual(control_variant.success_count, 6)
+        self.assertEqual(control_variant.failure_count, 4)
+        self.assertEqual(test_variant.success_count, 8)
+        self.assertEqual(test_variant.failure_count, 2)
+        self.assertEqual(holdout_variant.success_count, 3)
+        self.assertEqual(holdout_variant.failure_count, 7)
+
+        self.assertIn("control", result.probability)
+        self.assertIn("test", result.probability)
+        self.assertIn(f"holdout-{holdout.id}", result.probability)
+
+        self.assertIn("control", result.credible_intervals)
+        self.assertIn("test", result.credible_intervals)
+        self.assertIn(f"holdout-{holdout.id}", result.credible_intervals)
 
     @freeze_time("2020-01-01T12:00:00Z")
     def test_validate_event_variants_no_events(self):

--- a/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
@@ -57,7 +57,6 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
     def create_holdout_for_experiment(self, experiment):
         holdout = ExperimentHoldout.objects.create(
-            experiment=experiment,
             team=self.team,
             name="Test Experiment holdout",
         )

--- a/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
@@ -338,7 +338,7 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         experiment.save()
 
         # Populate experiment events
-        for variant, count in [("control", 11), ("test", 15), (f"holdout-{holdout.id}", 18)]:
+        for variant, count in [("control", 11), ("test", 15), (f"holdout-{holdout.id}", 8)]:
             for i in range(count):
                 _create_event(
                     team=self.team,
@@ -348,7 +348,7 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 )
 
         # Populate exposure events
-        for variant, count in [("control", 7), ("test", 9), (f"holdout-{holdout.id}", 10)]:
+        for variant, count in [("control", 7), ("test", 9), (f"holdout-{holdout.id}", 4)]:
             for i in range(count):
                 _create_event(
                     team=self.team,
@@ -372,10 +372,10 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(control_result.count, 11)
         self.assertEqual(test_result.count, 15)
-        self.assertEqual(holdout_result.count, 18)
+        self.assertEqual(holdout_result.count, 4)
         self.assertEqual(control_result.absolute_exposure, 7)
         self.assertEqual(test_result.absolute_exposure, 9)
-        self.assertEqual(holdout_result.absolute_exposure, 10)
+        self.assertEqual(holdout_result.absolute_exposure, 8)
 
     @freeze_time("2020-01-01T12:00:00Z")
     def test_query_runner_with_avg_math(self):

--- a/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
@@ -372,10 +372,10 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(control_result.count, 11)
         self.assertEqual(test_result.count, 15)
-        self.assertEqual(holdout_result.count, 4)
+        self.assertEqual(holdout_result.count, 8)
         self.assertEqual(control_result.absolute_exposure, 7)
         self.assertEqual(test_result.absolute_exposure, 9)
-        self.assertEqual(holdout_result.absolute_exposure, 8)
+        self.assertEqual(holdout_result.absolute_exposure, 4)
 
     @freeze_time("2020-01-01T12:00:00Z")
     def test_query_runner_with_avg_math(self):

--- a/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
@@ -60,7 +60,6 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
     def create_holdout_for_experiment(self, experiment: Experiment):
         holdout = ExperimentHoldout.objects.create(
-            experiment=experiment,
             team=self.team,
             name="Test Experiment holdout",
         )


### PR DESCRIPTION
## Changes

Updates `ExperimentFunnelsQueryRunner` and `ExperimentTrendsQueryRunner` to include support for holdouts too.

## How did you test this code?

Tests should pass.