### PR TITLE
fix(data-warehouse): Clean up any old django connections

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -2,6 +2,7 @@ import dataclasses
 import datetime as dt
 import json
 
+from django.db import close_old_connections
 import posthoganalytics
 from temporalio import activity, exceptions, workflow
 from temporalio.common import RetryPolicy
@@ -68,6 +69,8 @@ class UpdateExternalDataJobStatusInputs:
 @activity.defn
 def update_external_data_job_model(inputs: UpdateExternalDataJobStatusInputs) -> None:
     logger = bind_temporal_worker_logger_sync(team_id=inputs.team_id)
+
+    close_old_connections()
 
     if inputs.job_id is None:
         job: ExternalDataJob | None = (

--- a/posthog/temporal/data_imports/workflow_activities/check_billing_limits.py
+++ b/posthog/temporal/data_imports/workflow_activities/check_billing_limits.py
@@ -1,4 +1,5 @@
 import dataclasses
+from django.db import close_old_connections
 from temporalio import activity
 
 
@@ -16,6 +17,7 @@ class CheckBillingLimitsActivityInputs:
 @activity.defn
 def check_billing_limits_activity(inputs: CheckBillingLimitsActivityInputs) -> bool:
     logger = bind_temporal_worker_logger_sync(team_id=inputs.team_id)
+    close_old_connections()
 
     team: Team = Team.objects.get(id=inputs.team_id)
 

--- a/posthog/temporal/data_imports/workflow_activities/create_job_model.py
+++ b/posthog/temporal/data_imports/workflow_activities/create_job_model.py
@@ -1,6 +1,7 @@
 import dataclasses
 import uuid
 
+from django.db import close_old_connections
 from temporalio import activity
 
 # TODO: remove dependency
@@ -24,6 +25,8 @@ def create_external_data_job_model_activity(
     inputs: CreateExternalDataJobModelActivityInputs,
 ) -> tuple[str, bool, str]:
     logger = bind_temporal_worker_logger_sync(team_id=inputs.team_id)
+
+    close_old_connections()
 
     try:
         job = ExternalDataJob.objects.create(

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -37,9 +37,6 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
     logger = bind_temporal_worker_logger_sync(team_id=inputs.team_id)
 
     with HeartbeaterSync(factor=30, logger=logger):
-        # The start of a thread in the heartbeater may be intefering with the
-        # Django connection and thus we wanna make sure any old connections
-        # get cleaned up before we continue
         close_old_connections()
 
         model = ExternalDataJob.objects.prefetch_related(

--- a/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
+++ b/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
@@ -1,5 +1,6 @@
 import dataclasses
 
+from django.db import close_old_connections
 from temporalio import activity
 
 from posthog.temporal.common.logger import bind_temporal_worker_logger_sync
@@ -22,6 +23,7 @@ class SyncNewSchemasActivityInputs:
 @activity.defn
 def sync_new_schemas_activity(inputs: SyncNewSchemasActivityInputs) -> None:
     logger = bind_temporal_worker_logger_sync(team_id=inputs.team_id)
+    close_old_connections()
 
     logger.info("Syncing new -> old schemas")
 

--- a/posthog/warehouse/data_load/source_templates.py
+++ b/posthog/warehouse/data_load/source_templates.py
@@ -1,3 +1,4 @@
+from django.db import close_old_connections
 from posthog.temporal.common.logger import bind_temporal_worker_logger_sync
 from posthog.warehouse.models.external_data_job import ExternalDataJob
 from posthog.warehouse.models.external_data_source import ExternalDataSource
@@ -54,6 +55,7 @@ def database_operations(team_id: int, table_prefix: str) -> None:
 
 def create_warehouse_templates_for_source(team_id: int, run_id: str) -> None:
     logger = bind_temporal_worker_logger_sync(team_id=team_id)
+    close_old_connections()
 
     job: ExternalDataJob = ExternalDataJob.objects.get(pk=run_id)
     last_successful_job: ExternalDataJob | None = (


### PR DESCRIPTION
## Problem
- We still have a bunch of inconsistent `django.db.utils.OperationalError: the connection is closed` errors from the temporal jobs
- This always occurs on the same line of code - the first django func after starting the heartbeater thread
- Chatting to chatgpt, here's what it thinks:
<img width="744" alt="image" src="https://github.com/user-attachments/assets/230f3d1c-be38-4182-b55e-0b1d037b6f29">


## Changes
Give this a whirl and close any old connections before continuing and see what happens 🤷 
