### PR TITLE
fix: saml invite flow

### DIFF
--- a/frontend/src/scenes/authentication/InviteSignup.tsx
+++ b/frontend/src/scenes/authentication/InviteSignup.tsx
@@ -196,7 +196,7 @@ function UnauthenticatedAcceptInvite({ invite }: { invite: PrevalidatedInvite })
     const { preflight } = useValues(preflightLogic)
 
     const { precheck } = useActions(loginLogic)
-    const { precheckResponse, precheckResponseLoading, login } = useValues(loginLogic)
+    const { precheckResponse, precheckResponseLoading } = useValues(loginLogic)
 
     const areExtraFieldsHidden = precheckResponse.sso_enforcement
 
@@ -290,7 +290,7 @@ function UnauthenticatedAcceptInvite({ invite }: { invite: PrevalidatedInvite })
                 {precheckResponse.sso_enforcement && (
                     <SSOEnforcedLoginButton
                         provider={precheckResponse.sso_enforcement}
-                        email={login.email}
+                        email={invite?.target_email}
                         actionText="Continue"
                         extraQueryParams={invite ? { invite_id: invite.id } : undefined}
                     />
@@ -300,7 +300,7 @@ function UnauthenticatedAcceptInvite({ invite }: { invite: PrevalidatedInvite })
                 {precheckResponse.saml_available && !precheckResponse.sso_enforcement && (
                     <SSOEnforcedLoginButton
                         provider="saml"
-                        email={login.email}
+                        email={invite?.target_email}
                         actionText="Continue"
                         extraQueryParams={invite ? { invite_id: invite.id } : undefined}
                     />

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -418,21 +418,21 @@ def process_social_invite_signup(
             )
 
     if user:
-        invite.validate(user=None, email=email)
+        invite.validate(user=user, email=email)
         invite.use(user, prevalidated=True)
+        return user
     else:
         invite.validate(user=None, email=email)
 
         try:
-            user = strategy.create_user(email=email, first_name=full_name, password=None, is_email_verified=True)
+            _user = strategy.create_user(email=email, first_name=full_name, password=None, is_email_verified=True)
+            invite.use(_user, prevalidated=True)
         except Exception as e:
             capture_exception(e)
             message = "Account unable to be created. This account may already exist. Please try again or use different credentials."
             raise ValidationError(message, code="unknown", params={"source": "social_create_user"})
 
-        invite.use(user, prevalidated=True)
-
-    return user
+        return _user
 
 
 def process_social_domain_jit_provisioning_signup(

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -321,7 +321,6 @@ class SocialSignupSerializer(serializers.Serializer):
     organization_name: serializers.Field = serializers.CharField(max_length=128)
     first_name: serializers.Field = serializers.CharField(max_length=128)
     role_at_organization: serializers.Field = serializers.CharField(max_length=123, required=False, default="")
-    invite_id: serializers.Field = serializers.CharField(max_length=123, required=False, default="")
 
     def create(self, validated_data, **kwargs):
         request = self.context["request"]
@@ -335,7 +334,6 @@ class SocialSignupSerializer(serializers.Serializer):
         organization_name = validated_data["organization_name"]
         role_at_organization = validated_data["role_at_organization"]
         first_name = validated_data["first_name"]
-        invite_id = validated_data["invite_id"]
 
         serializer = SignupSerializer(
             data={
@@ -344,7 +342,6 @@ class SocialSignupSerializer(serializers.Serializer):
                 "email": email,
                 "password": None,
                 "role_at_organization": role_at_organization,
-                "invite_id": invite_id,
             },
             context={"request": request},
         )

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -1,4 +1,7 @@
 # serializer version: 1
+# name: TestDatabaseCheckForDecide.test_decide_doesnt_error_out_when_database_is_down_and_database_check_isnt_cached
+  'SELECT 1'
+# ---
 # name: TestDecide.test_decide_doesnt_error_out_when_database_is_down
   '''
   SELECT "posthog_user"."id",


### PR DESCRIPTION
## Changes

Two issues this fixes:
- email is not being passed to backend on a invite flow for saml where sso is enforced
- invite id was not being passed through saml request so it wasn't able to connect the login/signup to the invite and accept the invite.

Since invite id is not being passed through the SAML request, this PR is doing a lookup based on the email and relay state (org domain) and looking for a valid invite. This works for a new user signing up and an existing user logging in.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Tested extensively manually. Planning out how to improve our testing here.
