### PR TITLE
fix(Feature flags): use response.results when showing feature flags in an infinite list

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -246,7 +246,10 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                     const group = taxonomicGroups.find((g) => g.type === props.listGroupType)
 
                     if (group?.logic && group?.value) {
-                        const items = group.logic.selectors[group.value]?.(state)
+                        let items = group.logic.selectors[group.value]?.(state)
+                        if (group?.value === 'featureFlags' && items.results) {
+                            items = items.results
+                        }
                         // TRICKY: Feature flags don't support dynamic behavioral cohorts,
                         // so we don't want to show them as selectable options in the taxonomic filter
                         // in the feature flag UI.
@@ -255,6 +258,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                         if (Array.isArray(items) && items.every((item) => 'filters' in item)) {
                             return filterOutBehavioralCohorts(items, props.hideBehavioralCohorts)
                         }
+
                         return items
                     }
                     if (group?.options) {

--- a/posthog/api/web_experiment.py
+++ b/posthog/api/web_experiment.py
@@ -186,7 +186,10 @@ def web_experiments(request: Request):
             )
 
         result = WebExperimentsAPISerializer(
-            WebExperiment.objects.filter(team_id=team.id).exclude(archived=True).select_related("feature_flag"),
+            WebExperiment.objects.filter(team_id=team.id)
+            .exclude(archived=True)
+            .exclude("end_date__isnull", False)
+            .select_related("feature_flag"),
             many=True,
         ).data
 


### PR DESCRIPTION
## Problem

Customers started complaining that we cannot create surveys which use linked feature flags anymore, starting last night.

![image](https://github.com/user-attachments/assets/d3974e9f-604b-4b2d-804f-c9720426a397)


Sentry : https://posthog.sentry.io/issues/6050635251/?project=1899813&query=is%3Aunresolved%20map%20is%20not%20a%20function&referrer=issue-stream&statsPeriod=24h&stream_index=0

## Changes

Use response.results, if the groupType is feature flags, since the response value changed recently.


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually loading the dialog and trying out the action.