### PR TITLE
chore(flags): add cypress regression test to ensure flags rendering as expected in FlagSelector component

### DIFF
--- a/cypress/e2e/featureFlags.cy.ts
+++ b/cypress/e2e/featureFlags.cy.ts
@@ -229,4 +229,27 @@ describe('Feature Flags', () => {
         cy.get('[data-attr=taxonomic-operator]').contains('= equals').click({ force: true })
         cy.get('.operator-value-option').contains('> after').should('not.exist')
     })
+
+    it('Renders flags in FlagSelector', () => {
+        // Create flag name
+        cy.get('[data-attr=top-bar-name]').should('contain', 'Feature flags')
+        cy.get('[data-attr=new-feature-flag]').click()
+        cy.get('[data-attr=feature-flag-key]').click().type(`{moveToEnd}${name}`).should('have.value', name)
+        cy.get('[data-attr=rollout-percentage]').clear().type('50').should('have.value', '50')
+
+        // save the feature flag
+        cy.get('[data-attr=save-feature-flag]').first().click()
+
+        // go to surveys page to check if the flag is rendered in the FlagSelector
+        cy.reload()
+        cy.clickNavMenu('surveys')
+        cy.get('[data-attr="new-survey"]').click()
+        cy.get('[data-attr="new-blank-survey"]').click()
+
+        cy.get('[data-attr="survey-display-conditions"]').click()
+        cy.get('[data-attr="survey-display-conditions-select"]').click()
+        cy.get('[data-attr="survey-display-conditions-select-users"]').click()
+        cy.get('[data-attr="survey-display-conditions-linked-flag"]').contains('Select flag').click()
+        cy.get('.Popover__box').should('contain', name)
+    })
 })

--- a/frontend/src/lib/lemon-ui/LemonCollapse/LemonCollapse.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCollapse/LemonCollapse.tsx
@@ -13,6 +13,7 @@ export interface LemonCollapsePanel<K extends React.Key> {
     key: K
     header: ReactNode
     content: ReactNode
+    dataAttr?: string
     className?: string
 }
 

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -511,7 +511,7 @@ export default function SurveyEdit(): JSX.Element {
                             : []),
                         {
                             key: SurveyEditSection.DisplayConditions,
-                            header: 'Display conditions',
+                            header: <div data-attr="survey-display-conditions">Display conditions</div>,
                             content: (
                                 <LemonField.Pure>
                                     <LemonSelect
@@ -528,8 +528,13 @@ export default function SurveyEdit(): JSX.Element {
                                         value={!hasTargetingSet}
                                         options={[
                                             { label: 'All users', value: true },
-                                            { label: 'Users who match all of the following...', value: false },
+                                            {
+                                                label: 'Users who match all of the following...',
+                                                value: false,
+                                                'data-attr': 'survey-display-conditions-select-users',
+                                            },
                                         ]}
+                                        data-attr="survey-display-conditions-select"
                                     />
                                     {!hasTargetingSet ? (
                                         <span className="text-muted">
@@ -548,7 +553,10 @@ export default function SurveyEdit(): JSX.Element {
                                                 }
                                             >
                                                 {({ value, onChange }) => (
-                                                    <div className="flex">
+                                                    <div
+                                                        className="flex"
+                                                        data-attr="survey-display-conditions-linked-flag"
+                                                    >
                                                         <FlagSelector value={value} onChange={onChange} />
                                                         {value && (
                                                             <LemonButton

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -511,7 +511,8 @@ export default function SurveyEdit(): JSX.Element {
                             : []),
                         {
                             key: SurveyEditSection.DisplayConditions,
-                            header: <div data-attr="survey-display-conditions">Display conditions</div>,
+                            header: 'Display conditions',
+                            dataAttr: 'survey-display-conditions',
                             content: (
                                 <LemonField.Pure>
                                     <LemonSelect


### PR DESCRIPTION
## Problem

Adding a regression test to catch breakages like the one that was fixed here: https://github.com/PostHog/posthog/pull/26099

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Ran cypress locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
