### PR TITLE
feat(data-warehouse): Allow saving of BI breakdown insights

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
@@ -1,4 +1,5 @@
-import { actions, connect, kea, key, path, props, reducers, selectors } from 'kea'
+import { actions, afterMount, connect, kea, key, path, props, reducers, selectors } from 'kea'
+import { subscriptions } from 'kea-subscriptions'
 
 import { AxisSeries, AxisSeriesSettings, dataVisualizationLogic } from '../dataVisualizationLogic'
 import type { seriesBreakdownLogicType } from './seriesBreakdownLogicType'
@@ -48,8 +49,8 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
     key((props) => props.key),
     props({ key: '' } as SeriesBreakdownLogicProps),
     connect({
-        actions: [dataVisualizationLogic, ['clearAxis']],
-        values: [dataVisualizationLogic, ['response', 'columns', 'selectedXAxis', 'selectedYAxis']],
+        actions: [dataVisualizationLogic, ['clearAxis', 'setQuery']],
+        values: [dataVisualizationLogic, ['query', 'response', 'columns', 'selectedXAxis', 'selectedYAxis']],
     }),
     actions(({ values }) => ({
         addSeriesBreakdown: (columnName: string | null) => ({ columnName, response: values.response }),
@@ -228,5 +229,21 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
                 }
             },
         ],
+    }),
+    subscriptions(({ values, actions }) => ({
+        selectedSeriesBreakdownColumn: (value: string | null) => {
+            actions.setQuery({
+                ...values.query,
+                chartSettings: {
+                    ...(values.query.chartSettings ?? {}),
+                    seriesBreakdownColumn: value,
+                },
+            })
+        },
+    })),
+    afterMount(({ values, actions }) => {
+        if (values.query?.chartSettings?.seriesBreakdownColumn) {
+            actions.addSeriesBreakdown(values.query.chartSettings.seriesBreakdownColumn)
+        }
     }),
 ])

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2940,6 +2940,9 @@
                 "rightYAxisSettings": {
                     "$ref": "#/definitions/YAxisSettings"
                 },
+                "seriesBreakdownColumn": {
+                    "type": ["string", "null"]
+                },
                 "stackBars100": {
                     "description": "Whether we fill the bars to 100% in stacked mode",
                     "type": "boolean"

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -692,6 +692,7 @@ export interface ChartSettings {
     rightYAxisSettings?: YAxisSettings
     /** Whether we fill the bars to 100% in stacked mode */
     stackBars100?: boolean
+    seriesBreakdownColumn?: string | null
 }
 
 export interface ConditionalFormattingRule {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -2396,6 +2396,7 @@ class ChartSettings(BaseModel):
     goalLines: Optional[list[GoalLine]] = None
     leftYAxisSettings: Optional[YAxisSettings] = None
     rightYAxisSettings: Optional[YAxisSettings] = None
+    seriesBreakdownColumn: Optional[str] = None
     stackBars100: Optional[bool] = Field(default=None, description="Whether we fill the bars to 100% in stacked mode")
     xAxis: Optional[ChartAxis] = None
     yAxis: Optional[list[ChartAxis]] = None


### PR DESCRIPTION
## Problem

Following up from #26025, where BI breakdowns were added as a new feature. It was previously not possible to save new insights (an oversight on my part). This new PR addresses this issue and allows insights with breakdowns to be saved.

## Changes

- Allows insights with breakdowns to be saved

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Should do

## How did you test this code?

Local testing
