### PR TITLE
feat(alerts): alerts button on top of insight

### DIFF
--- a/cypress/e2e/alerts.cy.ts
+++ b/cypress/e2e/alerts.cy.ts
@@ -19,8 +19,7 @@ describe('Alerts', () => {
         upperThreshold: string = '200',
         condition?: string
     ): void => {
-        cy.get('[data-attr=more-button]').click()
-        cy.contains('Manage alerts').click()
+        cy.contains('Alerts').click()
         cy.contains('New alert').click()
 
         cy.get('[data-attr=alertForm-name]').clear().type(name)
@@ -52,9 +51,8 @@ describe('Alerts', () => {
     }
 
     it('Should allow create and delete an alert', () => {
-        cy.get('[data-attr=more-button]').click()
         // Alerts should be disabled for trends represented with graphs
-        cy.get('[data-attr=manage-alerts-button]').should('have.attr', 'aria-disabled', 'true')
+        cy.contains('Alerts').should('have.attr', 'aria-disabled', 'true')
 
         setInsightDisplayTypeAndSave('Number')
 
@@ -62,8 +60,7 @@ describe('Alerts', () => {
         cy.reload()
 
         // Check the alert has the same values as when it was created
-        cy.get('[data-attr=more-button]').click()
-        cy.contains('Manage alerts').click()
+        cy.contains('Alerts').click()
         cy.get('[data-attr=alert-list-item]').contains('Alert name').click()
         cy.get('[data-attr=alertForm-name]').should('have.value', 'Alert name')
         cy.get('[data-attr=alertForm-lower-threshold').should('have.value', '100')
@@ -93,15 +90,13 @@ describe('Alerts', () => {
         cy.contains('span', 'Funnels').click()
         cy.get('[data-attr=insight-save-button]').contains('Save').click()
 
-        cy.get('[data-attr=more-button]').click()
-        cy.contains('Manage alerts').click()
+        cy.contains('Alerts').click()
         cy.contains('Alert to be deleted because of a changed insight').should('not.exist')
     })
 
     it('Should allow create and delete a relative alert', () => {
-        cy.get('[data-attr=more-button]').click()
         // Alerts should be disabled for trends represented with graphs
-        cy.get('[data-attr=manage-alerts-button]').should('have.attr', 'aria-disabled', 'true')
+        cy.contains('Alerts').should('have.attr', 'aria-disabled', 'true')
 
         setInsightDisplayTypeAndSave('Bar chart')
 
@@ -109,8 +104,7 @@ describe('Alerts', () => {
         cy.reload()
 
         // Check the alert has the same values as when it was created
-        cy.get('[data-attr=more-button]').click()
-        cy.contains('Manage alerts').click()
+        cy.contains('Alerts').click()
         cy.get('[data-attr=alert-list-item]').contains('Alert name').click()
         cy.get('[data-attr=alertForm-name]').should('have.value', 'Alert name')
         cy.get('[data-attr=alertForm-lower-threshold').should('have.value', '10')

--- a/frontend/src/lib/components/Alerts/AlertsButton.tsx
+++ b/frontend/src/lib/components/Alerts/AlertsButton.tsx
@@ -1,23 +1,29 @@
+import { IconBell } from '@posthog/icons'
 import { LemonButton, LemonButtonProps } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { FEATURE_FLAGS } from 'lib/constants'
+import { IconWithCount } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 
-import { QueryBasedInsightModel } from '~/types'
+import { InsightLogicProps, QueryBasedInsightModel } from '~/types'
 
-import { areAlertsSupportedForInsight } from './insightAlertsLogic'
+import { areAlertsSupportedForInsight, insightAlertsLogic } from './insightAlertsLogic'
 
 export type AlertsButtonProps = LemonButtonProps & {
     insight: Partial<QueryBasedInsightModel>
+    insightLogicProps: InsightLogicProps
     text: string
 }
 
-export function AlertsButton({ insight, text, ...props }: AlertsButtonProps): JSX.Element {
+export function AlertsButton({ insight, insightLogicProps, text, ...props }: AlertsButtonProps): JSX.Element {
     const { push } = useActions(router)
     const { featureFlags } = useValues(featureFlagLogic)
     const showAlerts = featureFlags[FEATURE_FLAGS.ALERTS]
+
+    const logic = insightAlertsLogic({ insightId: insight.id!, insightLogicProps })
+    const { alerts } = useValues(logic)
 
     if (!showAlerts) {
         return <></>
@@ -33,6 +39,11 @@ export function AlertsButton({ insight, text, ...props }: AlertsButtonProps): JS
                     : undefined
             }
             {...props}
+            icon={
+                <IconWithCount count={alerts?.length} showZero={false}>
+                    <IconBell />
+                </IconWithCount>
+            }
         >
             {text}
         </LemonButton>

--- a/frontend/src/lib/components/Alerts/AlertsButton.tsx
+++ b/frontend/src/lib/components/Alerts/AlertsButton.tsx
@@ -1,4 +1,4 @@
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, LemonButtonProps } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -9,11 +9,12 @@ import { QueryBasedInsightModel } from '~/types'
 
 import { areAlertsSupportedForInsight } from './insightAlertsLogic'
 
-export interface AlertsButtonProps {
+export type AlertsButtonProps = LemonButtonProps & {
     insight: Partial<QueryBasedInsightModel>
+    text: string
 }
 
-export function AlertsButton({ insight }: AlertsButtonProps): JSX.Element {
+export function AlertsButton({ insight, text, ...props }: AlertsButtonProps): JSX.Element {
     const { push } = useActions(router)
     const { featureFlags } = useValues(featureFlagLogic)
     const showAlerts = featureFlags[FEATURE_FLAGS.ALERTS]
@@ -26,14 +27,14 @@ export function AlertsButton({ insight }: AlertsButtonProps): JSX.Element {
         <LemonButton
             data-attr="manage-alerts-button"
             onClick={() => push(urls.insightAlerts(insight.short_id!))}
-            fullWidth
             disabledReason={
                 !areAlertsSupportedForInsight(insight.query)
                     ? 'Insights are only available for trends without breakdowns. Change the insight representation to add alerts.'
                     : undefined
             }
+            {...props}
         >
-            Manage alerts
+            {text}
         </LemonButton>
     )
 }

--- a/frontend/src/lib/components/Alerts/AlertsButton.tsx
+++ b/frontend/src/lib/components/Alerts/AlertsButton.tsx
@@ -35,7 +35,7 @@ export function AlertsButton({ insight, insightLogicProps, text, ...props }: Ale
             onClick={() => push(urls.insightAlerts(insight.short_id!))}
             disabledReason={
                 !areAlertsSupportedForInsight(insight.query)
-                    ? 'Insights are only available for trends without breakdowns. Change the insight representation to add alerts.'
+                    ? 'Alerts are only available for trends without breakdowns. Change the insight representation to add alerts.'
                     : undefined
             }
             {...props}

--- a/frontend/src/lib/components/PageHeader.tsx
+++ b/frontend/src/lib/components/PageHeader.tsx
@@ -12,9 +12,10 @@ interface PageHeaderProps {
     tabbedPage?: boolean // Whether the page has tabs for secondary navigation
     delimited?: boolean
     notebookProps?: Pick<DraggableToNotebookProps, 'href' | 'node' | 'properties'>
+    maxWidthCaption?: boolean
 }
 
-export function PageHeader({ caption, buttons, tabbedPage }: PageHeaderProps): JSX.Element | null {
+export function PageHeader({ caption, buttons, tabbedPage, maxWidthCaption }: PageHeaderProps): JSX.Element | null {
     const { actionsContainer } = useValues(breadcrumbsLogic)
 
     return (
@@ -26,7 +27,11 @@ export function PageHeader({ caption, buttons, tabbedPage }: PageHeaderProps): J
                     actionsContainer
                 )}
 
-            {caption && <div className={clsx('page-caption', tabbedPage && 'tabbed')}>{caption}</div>}
+            {caption && (
+                <div className={clsx('page-caption', tabbedPage && 'tabbed', maxWidthCaption && 'max-w-full')}>
+                    {caption}
+                </div>
+            )}
         </>
     )
 }

--- a/frontend/src/lib/components/PageHeader.tsx
+++ b/frontend/src/lib/components/PageHeader.tsx
@@ -12,10 +12,9 @@ interface PageHeaderProps {
     tabbedPage?: boolean // Whether the page has tabs for secondary navigation
     delimited?: boolean
     notebookProps?: Pick<DraggableToNotebookProps, 'href' | 'node' | 'properties'>
-    maxWidthCaption?: boolean
 }
 
-export function PageHeader({ caption, buttons, tabbedPage, maxWidthCaption }: PageHeaderProps): JSX.Element | null {
+export function PageHeader({ caption, buttons, tabbedPage }: PageHeaderProps): JSX.Element | null {
     const { actionsContainer } = useValues(breadcrumbsLogic)
 
     return (
@@ -27,11 +26,7 @@ export function PageHeader({ caption, buttons, tabbedPage, maxWidthCaption }: Pa
                     actionsContainer
                 )}
 
-            {caption && (
-                <div className={clsx('page-caption', tabbedPage && 'tabbed', maxWidthCaption && 'max-w-full')}>
-                    {caption}
-                </div>
-            )}
+            {caption && <div className={clsx('page-caption', tabbedPage && 'tabbed')}>{caption}</div>}
         </>
     )
 }

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -1,4 +1,3 @@
-import { IconBell } from '@posthog/icons'
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
 import { AddToDashboard } from 'lib/components/AddToDashboard/AddToDashboard'
@@ -143,7 +142,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                 </>
             )}
             <PageHeader
-                maxWidthCaption
                 buttons={
                     <div className="flex justify-between items-center gap-2">
                         <More
@@ -347,6 +345,12 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                         )}
                         {insightMode !== ItemMode.Edit && hasDashboardItemId && (
                             <>
+                                <AlertsButton
+                                    insight={insight}
+                                    insightLogicProps={insightLogicProps}
+                                    type="secondary"
+                                    text="Alerts"
+                                />
                                 <NotebookSelectButton
                                     resource={{
                                         type: NotebookNodeType.Query,
@@ -420,16 +424,11 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                 staticOnly
                             />
                         ) : null}
-                        <div className="flex items-center justify-between">
-                            <UserActivityIndicator
-                                at={insight.last_modified_at}
-                                by={insight.last_modified_by}
-                                className="mt-2"
-                            />
-                            {insightMode === ItemMode.View && (
-                                <AlertsButton insight={insight} type="secondary" icon={<IconBell />} text="Alerts" />
-                            )}
-                        </div>
+                        <UserActivityIndicator
+                            at={insight.last_modified_at}
+                            by={insight.last_modified_by}
+                            className="mt-2"
+                        />
                     </>
                 }
                 tabbedPage={insightMode === ItemMode.Edit} // Insight type tabs are only shown in edit mode

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -1,3 +1,4 @@
+import { IconBell } from '@posthog/icons'
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { router } from 'kea-router'
 import { AddToDashboard } from 'lib/components/AddToDashboard/AddToDashboard'
@@ -142,6 +143,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                 </>
             )}
             <PageHeader
+                maxWidthCaption
                 buttons={
                     <div className="flex justify-between items-center gap-2">
                         <More
@@ -206,7 +208,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                     ]}
                                                 />
                                             ) : null}
-                                            <AlertsButton insight={insight} />
                                             <LemonDivider />
                                         </>
                                     )}
@@ -419,11 +420,16 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                 staticOnly
                             />
                         ) : null}
-                        <UserActivityIndicator
-                            at={insight.last_modified_at}
-                            by={insight.last_modified_by}
-                            className="mt-2"
-                        />
+                        <div className="flex items-center justify-between">
+                            <UserActivityIndicator
+                                at={insight.last_modified_at}
+                                by={insight.last_modified_by}
+                                className="mt-2"
+                            />
+                            {insightMode === ItemMode.View && (
+                                <AlertsButton insight={insight} type="secondary" icon={<IconBell />} text="Alerts" />
+                            )}
+                        </div>
                     </>
                 }
                 tabbedPage={insightMode === ItemMode.Edit} // Insight type tabs are only shown in edit mode

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -285,12 +285,12 @@ def check_alert_and_notify_atomically(alert: AlertConfiguration) -> None:
             case AlertState.FIRING:
                 assert breaches is not None
                 send_notifications_for_breaches(alert, breaches)
-    except Exception as err:
+    except Exception:
         error_message = f"AlertCheckError: error sending notifications for alert_id = {alert.id}"
         logger.exception(error_message)
 
         set_tag("alert_config_id", alert.id)
-        set_tag("evaluation_error_message", str(err))
+        set_tag("evaluation_error_message", traceback.format_exc())
 
         capture_exception(Exception(error_message))
 

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -99,7 +99,7 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
 
         anomalies_descriptions = self.get_breach_description(mock_send_notifications_for_breaches, call_index=0)
         assert len(anomalies_descriptions) == 1
-        assert "The insight value for previous day is (1) more than upper threshold (0.0)" in anomalies_descriptions[0]
+        assert "The insight value for previous day (1) is more than upper threshold (0.0)" in anomalies_descriptions[0]
 
     def test_alert_is_not_triggered_for_events_beyond_interval(
         self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
@@ -127,7 +127,7 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
 
         assert mock_send_notifications_for_breaches.call_count == 1
         anomalies = self.get_breach_description(mock_send_notifications_for_breaches, call_index=0)
-        assert "The insight value for previous day is (0) less than lower threshold (1.0)" in anomalies
+        assert "The insight value for previous day (0) is less than lower threshold (1.0)" in anomalies
 
     def test_alert_triggers_but_does_not_send_notification_during_firing(
         self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
@@ -315,7 +315,7 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
 
         assert mock_send_notifications_for_breaches.call_count == 1
         anomalies = self.get_breach_description(mock_send_notifications_for_breaches, call_index=0)
-        assert "The insight value for previous day is (0) less than lower threshold (1.0)" in anomalies
+        assert "The insight value for previous day (0) is less than lower threshold (1.0)" in anomalies
 
     @patch("posthog.tasks.alerts.utils.EmailMessage")
     def test_send_emails(

--- a/posthog/tasks/alerts/test/test_trends_absolute_alerts.py
+++ b/posthog/tasks/alerts/test/test_trends_absolute_alerts.py
@@ -119,7 +119,7 @@ class TestTimeSeriesTrendsAbsoluteAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value for previous week is (0) less than lower threshold (1.0)"]
+            ANY, ["The insight value for previous week (0) is less than lower threshold (1.0)"]
         )
 
     def test_trend_high_threshold_breached(self, mock_send_breaches: MagicMock, mock_send_errors: MagicMock) -> None:
@@ -153,7 +153,7 @@ class TestTimeSeriesTrendsAbsoluteAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value for previous week is (2) more than upper threshold (1.0)"]
+            ANY, ["The insight value for previous week (2) is more than upper threshold (1.0)"]
         )
 
     def test_trend_no_threshold_breached(self, mock_send_breaches: MagicMock, mock_send_errors: MagicMock) -> None:

--- a/posthog/tasks/alerts/test/test_trends_relative_alerts.py
+++ b/posthog/tasks/alerts/test/test_trends_relative_alerts.py
@@ -185,7 +185,7 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value for previous week increased (2) more than upper threshold (1.0)"]
+            ANY, ["The insight value for previous week (2) increased more than upper threshold (1.0)"]
         )
 
     def test_relative_increase_upper_threshold_breached(
@@ -346,7 +346,7 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value for previous week increased (-1) less than lower threshold (2.0)"]
+            ANY, ["The insight value for previous week (-1) increased less than lower threshold (2.0)"]
         )
 
         # check percentage alert
@@ -363,7 +363,7 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_with(
-            ANY, ["The insight value for previous week increased (-50.00%) less than lower threshold (50.00%)"]
+            ANY, ["The insight value for previous week (-50.00%) increased less than lower threshold (50.00%)"]
         )
 
     def test_relative_increase_lower_threshold_breached_2(
@@ -524,7 +524,7 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value for previous week decreased (2) more than upper threshold (1.0)"]
+            ANY, ["The insight value for previous week (2) decreased more than upper threshold (1.0)"]
         )
 
         check_alert(percentage_alert["id"])
@@ -540,7 +540,7 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_with(
-            ANY, ["The insight value for previous week decreased (66.67%) more than upper threshold (20.00%)"]
+            ANY, ["The insight value for previous week (66.67%) decreased more than upper threshold (20.00%)"]
         )
 
     def test_relative_decrease_lower_threshold_breached(
@@ -613,7 +613,7 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_once_with(
-            ANY, ["The insight value for previous week decreased (1) less than lower threshold (2.0)"]
+            ANY, ["The insight value for previous week (1) decreased less than lower threshold (2.0)"]
         )
 
         check_alert(percentage_alert["id"])
@@ -629,7 +629,7 @@ class TestTimeSeriesTrendsRelativeAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_called_with(
-            ANY, ["The insight value for previous week decreased (50.00%) less than lower threshold (80.00%)"]
+            ANY, ["The insight value for previous week (50.00%) decreased less than lower threshold (80.00%)"]
         )
 
     def test_relative_increase_no_threshold_breached(

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -228,12 +228,12 @@ def _validate_bounds(
     if bounds.lower is not None and calculated_value < bounds.lower:
         lower_value = f"{bounds.lower:.2%}" if is_percentage else bounds.lower
         return [
-            f"The insight value for previous {interval_type or 'interval'} {condition_text} ({formatted_value}) less than lower threshold ({lower_value})"
+            f"The insight value for previous {interval_type or 'interval'} ({formatted_value}) {condition_text} less than lower threshold ({lower_value})"
         ]
     if bounds.upper is not None and calculated_value > bounds.upper:
         upper_value = f"{bounds.upper:.2%}" if is_percentage else bounds.upper
         return [
-            f"The insight value for previous {interval_type or 'interval'} {condition_text} ({formatted_value}) more than upper threshold ({upper_value})"
+            f"The insight value for previous {interval_type or 'interval'} ({formatted_value}) {condition_text} more than upper threshold ({upper_value})"
         ]
 
     return []


### PR DESCRIPTION
## Problem
Hard to discover that you can set alerts on insight

## Changes
Added a button to manage alerts right on top of the insight so users can easily access it. Can also show count of alerts set in the button but first wanted to check people are happy with the UX change.

Note: I've added it as part of the 'caption' of the page header. Thought this was cleaner as the user activity indicator doesn't need the full space.

<img width="836" alt="image" src="https://github.com/user-attachments/assets/33c7c167-9819-453d-b5d3-3f0b4af6285a">

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
