### PR TITLE
fix: allow more tracing headers

### DIFF
--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -1756,6 +1756,15 @@ class TestCapture(BaseTest):
                 ["x-highlight-request"],
             ),
             ("DateDome", ["x-datadome-clientid"]),
+            (
+                "zipkin",
+                [
+                    "x-b3-sampled",
+                    "x-b3-spanid",
+                    "x-b3-traceid",
+                    "x-b3-parentspanid",
+                ],
+            ),
         ]
     )
     def test_cors_allows_tracing_headers(self, _: str, path: str, headers: list[str]) -> None:

--- a/posthog/utils_cors.py
+++ b/posthog/utils_cors.py
@@ -11,6 +11,10 @@ CORS_ALLOWED_TRACING_HEADERS = (
     "x-highlight-request",
     "x-datadome-clientid",
     "x-posthog-token",
+    "x-b3-sampled",
+    "x-b3-spanid",
+    "x-b3-traceid",
+    "x-b3-parentspanid",
 )
 
 


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/20270 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/22392) 

API call is being blocked by CORS because of some tracing headers from zipkin