### PR TITLE
chore(flags): add cypress regression test around toggling flags from list, type annotations on kea loaders

### DIFF
--- a/cypress/e2e/featureFlags.cy.ts
+++ b/cypress/e2e/featureFlags.cy.ts
@@ -80,7 +80,7 @@ describe('Feature Flags', () => {
             .should('have.value', name + '-updated')
         cy.get('[data-attr=rollout-percentage]').type('{selectall}50').should('have.value', '50')
         cy.get('[data-attr=save-feature-flag]').first().click()
-        cy.wait(100)
+        cy.get('[data-attr=toast-close-button]').click()
         cy.clickNavMenu('featureflags')
         cy.get('[data-attr=feature-flag-table]').should('contain', name + '-updated')
 
@@ -117,7 +117,7 @@ describe('Feature Flags', () => {
         cy.get('[data-attr=feature-flag-key]').click().type(searchableFlagName).should('have.value', searchableFlagName)
         cy.get('[data-attr=rollout-percentage]').clear().type('0')
         cy.get('[data-attr=save-feature-flag]').first().click()
-        cy.wait(100)
+        cy.get('[data-attr=toast-close-button]').click()
         cy.clickNavMenu('featureflags')
 
         // create a flag with a name that should not show up in search results
@@ -129,7 +129,7 @@ describe('Feature Flags', () => {
             .should('have.value', nonSearchableFlagName)
         cy.get('[data-attr=rollout-percentage]').clear().type('0')
         cy.get('[data-attr=save-feature-flag]').first().click()
-        cy.wait(100)
+        cy.get('[data-attr=toast-close-button]').click()
         cy.clickNavMenu('featureflags')
 
         cy.get('[data-attr=top-bar-name]').should('contain', 'Feature flags')
@@ -164,7 +164,7 @@ describe('Feature Flags', () => {
         cy.get('[data-attr=feature-flag-enabled-checkbox]').click()
         cy.get('[data-attr=rollout-percentage]').clear().type('0').should('have.value', '0')
         cy.get('[data-attr=save-feature-flag]').first().click()
-        cy.wait(100)
+        cy.get('[data-attr=toast-close-button]').click()
         cy.clickNavMenu('featureflags')
 
         cy.get('[data-attr=feature-flag-select-status').click()
@@ -186,7 +186,7 @@ describe('Feature Flags', () => {
         cy.get(`[data-row-key=${disabledPrefixFlagName}]`).parent().first().contains('Disabled')
     })
 
-    it('Enablle and disable feature flags from list', () => {
+    it('Enable and disable feature flags from list', () => {
         cy.get('[data-attr=top-bar-name]').should('contain', 'Feature flags')
 
         cy.get('[data-attr=feature-flag-select-type').click()
@@ -205,7 +205,7 @@ describe('Feature Flags', () => {
             .should('have.value', togglablePrefixFlagName)
         cy.get('[data-attr=rollout-percentage]').clear().type('0').should('have.value', '0')
         cy.get('[data-attr=save-feature-flag]').first().click()
-        cy.wait(100)
+        cy.get('[data-attr=toast-close-button]').click()
         cy.clickNavMenu('featureflags')
 
         cy.get('[data-attr=top-bar-name]').should('contain', 'Feature flags')
@@ -219,15 +219,13 @@ describe('Feature Flags', () => {
         cy.get(`[data-row-key=${togglablePrefixFlagName}]`).get('[data-attr=more-button]').click()
         cy.get(`[data-attr=feature-flag-${togglablePrefixFlagName}-switch]`).click()
         cy.get('.LemonModal__layout').should('contain', 'Disable this flag?').contains('Confirm').click()
-        cy.wait(100)
-        cy.get(`[data-row-key=${togglablePrefixFlagName}]`).should('contain', 'DISABLED')
+        cy.get(`[data-row-key=${togglablePrefixFlagName}]`).should('contain', 'Disabled')
 
         // Enable the flag from the list
         cy.get(`[data-row-key=${togglablePrefixFlagName}]`).get('[data-attr=more-button]').click()
         cy.get(`[data-attr=feature-flag-${togglablePrefixFlagName}-switch]`).click()
         cy.get('.LemonModal__layout').should('contain', 'Enable this flag?').contains('Confirm').click()
-        cy.wait(100)
-        cy.get(`[data-row-key=${togglablePrefixFlagName}]`).should('contain', 'ENABLED')
+        cy.get(`[data-row-key=${togglablePrefixFlagName}]`).should('contain', 'Enabled')
     })
 
     it('Move between property types smoothly, and support relative dates', () => {

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -187,6 +187,7 @@ export function OverViewTab({
                                     Copy feature flag key
                                 </LemonButton>
                                 <LemonButton
+                                    data-attr={`feature-flag-${featureFlag.key}-switch`}
                                     onClick={() => {
                                         const newValue = !featureFlag.active
                                         LemonDialog.open({

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
@@ -63,7 +63,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
     loaders(({ values }) => ({
         featureFlags: {
             __default: { results: [], count: 0, filters: null, offset: 0 } as FeatureFlagsResult,
-            loadFeatureFlags: async () => {
+            loadFeatureFlags: async (): Promise<FeatureFlagsResult> => {
                 const response = await api.get(
                     `api/projects/${values.currentTeamId}/feature_flags/?${toParams(values.paramsFromFilters)}`
                 )
@@ -73,7 +73,13 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
                     offset: values.paramsFromFilters.offset,
                 }
             },
-            updateFeatureFlag: async ({ id, payload }: { id: number; payload: Partial<FeatureFlagType> }) => {
+            updateFeatureFlag: async ({
+                id,
+                payload,
+            }: {
+                id: number
+                payload: Partial<FeatureFlagType>
+            }): Promise<FeatureFlagsResult> => {
                 const response = await api.update(`api/projects/${values.currentTeamId}/feature_flags/${id}`, payload)
                 const updatedFlags = [...values.featureFlags.results].map((flag) =>
                     flag.id === response.id ? response : flag


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Follow up to https://github.com/PostHog/posthog/issues/26110 / https://github.com/PostHog/posthog/pull/26118

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Ensured all cypress tests pass locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
