### PR TITLE
feat(experiments): Add type to experiment created event

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -988,6 +988,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             posthog.capture('experiment created', {
                 name: experiment.name,
                 id: experiment.id,
+                type: experiment.type,
                 filters: sanitizeFilterParams(experiment.filters),
                 parameters: experiment.parameters,
                 secondary_metrics_count: experiment.secondary_metrics.length,


### PR DESCRIPTION
## Problem

This PR adds the experiment type to the `experiment created` event

## Changes

Adds the experiment type to the `experiment created` event

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually