### PR TITLE
fix(flags): do not attempt to load usage tab for deleted flags

### DIFF
--- a/cypress/e2e/featureFlags.cy.ts
+++ b/cypress/e2e/featureFlags.cy.ts
@@ -116,10 +116,20 @@ describe('Feature Flags', () => {
         cy.go('back')
         cy.get('button[data-attr="edit-feature-flag"]').should('have.attr', 'aria-disabled', 'true')
 
+        // make sure the usage tab does not attempt to load
+        cy.get('.LemonTabs__tab-content').contains('Usage').click()
+        cy.get('[data-attr=feature-flag-usage-container]').should('not.exist')
+        cy.get('[data-attr=feature-flag-usage-deleted-banner]').should('exist')
+
         // undo the deletion
         cy.get('[data-attr="more-button"]').click()
         cy.get('button[data-attr="restore-feature-flag"]').should('have.text', 'Restore feature flag')
         cy.get('button[data-attr="restore-feature-flag"]').click()
+
+        // make sure the usage tab attempts to load
+        cy.get('.LemonTabs__tab-content').contains('Usage').click()
+        cy.get('[data-attr=feature-flag-usage-container]').should('exist')
+        cy.get('[data-attr=feature-flag-usage-deleted-banner]').should('not.exist')
 
         // refresh page and make sure the flag is restored as expected
         cy.reload()

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -653,11 +653,15 @@ function UsageTab({ featureFlag }: { id: string; featureFlag: FeatureFlagType })
     ]
 
     if (featureFlag.deleted) {
-        return <LemonBanner type="error">This feature flag has been deleted</LemonBanner>
+        return (
+            <div data-attr="feature-flag-usage-deleted-banner">
+                <LemonBanner type="error">This feature flag has been deleted</LemonBanner>
+            </div>
+        )
     }
 
     return (
-        <div>
+        <div data-attr="feature-flag-usage-container">
             {dashboard ? (
                 <>
                     {!hasEnrichedAnalytics && !enrichAnalyticsNoticeAcknowledged && (

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -652,6 +652,10 @@ function UsageTab({ featureFlag }: { id: string; featureFlag: FeatureFlagType })
         },
     ]
 
+    if (featureFlag.deleted) {
+        return <LemonBanner type="error">This feature flag has been deleted</LemonBanner>
+    }
+
     return (
         <div>
             {dashboard ? (

--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -655,7 +655,7 @@ function UsageTab({ featureFlag }: { id: string; featureFlag: FeatureFlagType })
     if (featureFlag.deleted) {
         return (
             <div data-attr="feature-flag-usage-deleted-banner">
-                <LemonBanner type="error">This feature flag has been deleted</LemonBanner>
+                <LemonBanner type="error">This feature flag has been deleted.</LemonBanner>
             </div>
         )
     }


### PR DESCRIPTION
## Problem

Closes https://github.com/PostHog/posthog/issues/24454

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

![Screenshot 2024-11-11 at 11 34 41 AM](https://github.com/user-attachments/assets/202e5b03-d1ac-47af-ab8d-82f04180b455)
![Screenshot 2024-11-11 at 11 24 29 AM](https://github.com/user-attachments/assets/4c06da07-e0b2-46b5-9107-31e0efd0ccbb)



## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->
Yes

## How did you test this code?

- Added a cypress assertion validating the functionality
- Tested functionality locally
