### PR TITLE
feat: Add sensitive values separately to fetch calls

### DIFF
--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -199,6 +199,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         CDP_CYCLOTRON_BATCH_DELAY_MS: 50,
         CDP_CYCLOTRON_BATCH_SIZE: 500,
 
+        CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: '',
+
         // Cyclotron
         CYCLOTRON_DATABASE_URL: isTestEnv()
             ? 'postgres://posthog:posthog@localhost:5432/test_cyclotron'

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -123,6 +123,7 @@ export type CdpConfig = {
     CDP_REDIS_PORT: number
     CDP_REDIS_PASSWORD: string
     CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: boolean
+    CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: string
 }
 
 export interface PluginsServerConfig extends CdpConfig {

--- a/plugin-server/tests/cdp/hog-executor.test.ts
+++ b/plugin-server/tests/cdp/hog-executor.test.ts
@@ -565,6 +565,41 @@ describe('Hog Executor', () => {
                 'Error executing function: HogVMException: Exceeded maximum number of async steps: 5',
             ])
         })
+
+        it('adds secret headers for certain endpoints', () => {
+            hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN = 'ADWORDS_TOKEN'
+
+            const fn = createHogFunction({
+                ...HOG_EXAMPLES.simple_fetch,
+                ...HOG_FILTERS_EXAMPLES.no_filters,
+                ...HOG_INPUTS_EXAMPLES.simple_fetch,
+                inputs: {
+                    ...HOG_INPUTS_EXAMPLES.simple_fetch.inputs,
+                    url: {
+                        value: 'https://googleads.googleapis.com/1234',
+                        bytecode: ['_h', 32, 'https://googleads.googleapis.com/1234'],
+                    },
+                },
+            })
+
+            const invocation = createInvocation(fn)
+            const result1 = executor.execute(invocation)
+            expect((result1.invocation.queueParameters as any)?.headers).toMatchInlineSnapshot(`
+                Object {
+                  "developer-token": "ADWORDS_TOKEN",
+                  "version": "v=1.2.3",
+                }
+            `)
+            // Check it doesn't do it for redirect
+            fn.inputs!.url.bytecode = ['_h', 32, 'https://nasty.com?redirect=https://googleads.googleapis.com/1234']
+            const invocation2 = createInvocation(fn)
+            const result2 = executor.execute(invocation2)
+            expect((result2.invocation.queueParameters as any)?.headers).toMatchInlineSnapshot(`
+                Object {
+                  "version": "v=1.2.3",
+                }
+            `)
+        })
     })
 
     describe('slow functions', () => {

--- a/posthog/cdp/templates/google_ads/template_google_ads.py
+++ b/posthog/cdp/templates/google_ads/template_google_ads.py
@@ -39,8 +39,7 @@ let res := fetch(f'https://googleads.googleapis.com/v17/customers/{replaceAll(in
     'method': 'POST',
     'headers': {
         'Authorization': f'Bearer {inputs.oauth.access_token}',
-        'Content-Type': 'application/json',
-        'developer-token': inputs.developerToken
+        'Content-Type': 'application/json'
     },
     'body': body
 })
@@ -78,14 +77,6 @@ if (res.status >= 400) {
             "required_field": "customerId",
             "label": "Conversion action",
             "description": "The Conversion action associated with this conversion.",
-            "secret": False,
-            "required": True,
-        },
-        {
-            "key": "developerToken",
-            "type": "string",
-            "label": "Developer token",
-            "description": "This should be a 22-character long alphanumeric string. Check out this page on how to obtain such a token: https://developers.google.com/google-ads/api/docs/get-started/dev-token",
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/google_ads/test_template_google_ads.py
+++ b/posthog/cdp/templates/google_ads/test_template_google_ads.py
@@ -13,7 +13,6 @@ class TestTemplateGoogleAds(BaseHogFunctionTemplateTest):
             "oauth": {
                 "access_token": "oauth-1234",
             },
-            "developerToken": "developer-token1234",
             "customerId": "123-123-1234",
             "conversionActionId": "123456789",
             "gclid": "89y4thuergnjkd34oihroh3uhg39uwhgt9",
@@ -33,7 +32,6 @@ class TestTemplateGoogleAds(BaseHogFunctionTemplateTest):
                     "headers": {
                         "Authorization": "Bearer oauth-1234",
                         "Content-Type": "application/json",
-                        "developer-token": "developer-token1234",
                     },
                     "body": {
                         "conversions": [


### PR DESCRIPTION
## Problem

I think this solves the issue in [this PR](https://github.com/PostHog/posthog/pull/26088). We need to send our developer token but we don't want to expose it so we ask people to provide one. To get around this I figured the easiest is to just detect the endpoint and add it automatically. We're gonna have a bunch of things like this so I think its the safest way whilst still allowing customization.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
