### PR TITLE
chore(data-warehouse): use args for get_columns call

### DIFF
--- a/posthog/hogql/database/s3_table.py
+++ b/posthog/hogql/database/s3_table.py
@@ -47,8 +47,8 @@ def build_function_call(
         expr = f"s3({escaped_url}"
 
         if access_key and access_secret:
-            escaped_access_key = add_param(access_key, True)
-            escaped_access_secret = add_param(access_secret, True)
+            escaped_access_key = add_param(access_key)
+            escaped_access_secret = add_param(access_secret)
 
             expr += f", {escaped_access_key}, {escaped_access_secret}"
 
@@ -68,8 +68,8 @@ def build_function_call(
         expr = f"deltaLake({escaped_url}"
 
         if access_key and access_secret:
-            escaped_access_key = add_param(access_key, True)
-            escaped_access_secret = add_param(access_secret, True)
+            escaped_access_key = add_param(access_key)
+            escaped_access_secret = add_param(access_secret)
 
             expr += f", {escaped_access_key}, {escaped_access_secret}"
 
@@ -95,8 +95,8 @@ def build_function_call(
         if not access_key or not access_secret:
             raise ExposedHogQLError("Azure blob storage has no access key or secret")
 
-        escaped_access_key = add_param(access_key, True)
-        escaped_access_secret = add_param(access_secret, True)
+        escaped_access_key = add_param(access_key)
+        escaped_access_secret = add_param(access_secret)
         escaped_format = add_param(format, False)
 
         expr = f"azureBlobStorage({storage_account_url}, {container}, {blob_path}, {escaped_access_key}, {escaped_access_secret}, {escaped_format}, 'auto'"
@@ -116,8 +116,8 @@ def build_function_call(
     expr = f"s3({escaped_url}"
 
     if access_key and access_secret:
-        escaped_access_key = add_param(access_key, True)
-        escaped_access_secret = add_param(access_secret, True)
+        escaped_access_key = add_param(access_key)
+        escaped_access_secret = add_param(access_secret)
 
         expr += f", {escaped_access_key}, {escaped_access_secret}"
 

--- a/posthog/hogql/database/s3_table.py
+++ b/posthog/hogql/database/s3_table.py
@@ -47,8 +47,8 @@ def build_function_call(
         expr = f"s3({escaped_url}"
 
         if access_key and access_secret:
-            escaped_access_key = add_param(access_key)
-            escaped_access_secret = add_param(access_secret)
+            escaped_access_key = add_param(access_key, True)
+            escaped_access_secret = add_param(access_secret, True)
 
             expr += f", {escaped_access_key}, {escaped_access_secret}"
 
@@ -68,8 +68,8 @@ def build_function_call(
         expr = f"deltaLake({escaped_url}"
 
         if access_key and access_secret:
-            escaped_access_key = add_param(access_key)
-            escaped_access_secret = add_param(access_secret)
+            escaped_access_key = add_param(access_key, True)
+            escaped_access_secret = add_param(access_secret, True)
 
             expr += f", {escaped_access_key}, {escaped_access_secret}"
 
@@ -95,8 +95,8 @@ def build_function_call(
         if not access_key or not access_secret:
             raise ExposedHogQLError("Azure blob storage has no access key or secret")
 
-        escaped_access_key = add_param(access_key)
-        escaped_access_secret = add_param(access_secret)
+        escaped_access_key = add_param(access_key, True)
+        escaped_access_secret = add_param(access_secret, True)
         escaped_format = add_param(format, False)
 
         expr = f"azureBlobStorage({storage_account_url}, {container}, {blob_path}, {escaped_access_key}, {escaped_access_secret}, {escaped_format}, 'auto'"
@@ -116,8 +116,8 @@ def build_function_call(
     expr = f"s3({escaped_url}"
 
     if access_key and access_secret:
-        escaped_access_key = add_param(access_key)
-        escaped_access_secret = add_param(access_secret)
+        escaped_access_key = add_param(access_key, True)
+        escaped_access_secret = add_param(access_secret, True)
 
         expr += f", {escaped_access_key}, {escaped_access_secret}"
 

--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -180,15 +180,18 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
 
     def get_count(self, safe_expose_ch_error=True) -> int:
         try:
+            placeholder_context = HogQLContext(team_id=self.team.pk)
             s3_table_func = build_function_call(
                 url=self.url_pattern,
                 format=self.format,
                 access_key=self.credential.access_key,
                 access_secret=self.credential.access_secret,
+                context=placeholder_context,
             )
 
             result = sync_execute(
                 f"SELECT count() FROM {s3_table_func}",
+                args=placeholder_context.values,
             )
         except Exception as err:
             capture_exception(err)

--- a/posthog/warehouse/models/table.py
+++ b/posthog/warehouse/models/table.py
@@ -27,6 +27,7 @@ from sentry_sdk import capture_exception
 from posthog.warehouse.util import database_sync_to_async
 from posthog.warehouse.models.util import CLICKHOUSE_HOGQL_MAPPING, clean_type, STR_TO_HOGQL_MAPPING
 from .external_table_definitions import external_tables
+from posthog.hogql.context import HogQLContext
 
 SERIALIZED_FIELD_TO_CLICKHOUSE_MAPPING: dict[DatabaseSerializedFieldType, str] = {
     DatabaseSerializedFieldType.INTEGER: "Int64",
@@ -139,11 +140,13 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
 
     def get_columns(self, safe_expose_ch_error=True) -> DataWarehouseTableColumns:
         try:
+            placeholder_context = HogQLContext(team_id=self.team.pk)
             s3_table_func = build_function_call(
                 url=self.url_pattern,
                 format=self.format,
                 access_key=self.credential.access_key,
                 access_secret=self.credential.access_secret,
+                context=placeholder_context,
             )
 
             result = sync_execute(
@@ -151,7 +154,8 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
                     SELECT *
                     FROM {s3_table_func}
                     LIMIT 1
-                )"""
+                )""",
+                args=placeholder_context.values,
             )
         except Exception as err:
             capture_exception(err)


### PR DESCRIPTION

## Problem

- get_columns call doesn't use args

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- use args

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
