### PR TITLE
feat(cdp): detect if a string is a timestamp

### DIFF
--- a/posthog/cdp/templates/hubspot/template_hubspot.py
+++ b/posthog/cdp/templates/hubspot/template_hubspot.py
@@ -149,7 +149,7 @@ let eventSchema := fetch(f'https://api.hubapi.com/events/v3/event-definitions/{i
 
 fun getPropValueType(propValue) {
     let propType := typeof(propValue)
-    if (propType == 'string' and match(propValue, '^[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{2}:[\\d]{2}:[\\d]{2}.[\\d]{3}Z$')) {
+    if (propType == 'string' and match(propValue, '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$')) {
         return 'datetime'
     } else if (propType == 'string') {
         return 'string'

--- a/posthog/cdp/templates/hubspot/template_hubspot.py
+++ b/posthog/cdp/templates/hubspot/template_hubspot.py
@@ -149,9 +149,10 @@ let eventSchema := fetch(f'https://api.hubapi.com/events/v3/event-definitions/{i
 
 fun getPropValueType(propValue) {
     let propType := typeof(propValue)
-    if (propType == 'string' and match(propValue, '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$')) {
-        return 'datetime'
-    } else if (propType == 'string') {
+    if (propType == 'string') {
+        if (match(propValue, '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$')) {
+            return 'datetime'
+        }
         return 'string'
     } else if (propType == 'integer') {
         return 'number'
@@ -168,14 +169,15 @@ fun getPropValueType(propValue) {
 
 fun getPropValueTypeDefinition(name, propValue) {
     let propType := typeof(propValue)
-    if (propType == 'string' and match(propValue, '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$')) {
-        return {
-            'name': name,
-            'label': name,
-            'type': 'datetime',
-            'description': f'{name} - (created by PostHog)'
+    if (propType == 'string' or propType == 'object' or propType == 'array' or propType == 'tuple') {
+        if (match(propValue, '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$')) {
+            return {
+                'name': name,
+                'label': name,
+                'type': 'datetime',
+                'description': f'{name} - (created by PostHog)'
+            }
         }
-    } else if (propType == 'string' or propType == 'object' or propType == 'array' or propType == 'tuple') {
         return {
             'name': name,
             'label': name,

--- a/posthog/cdp/templates/hubspot/template_hubspot.py
+++ b/posthog/cdp/templates/hubspot/template_hubspot.py
@@ -149,7 +149,9 @@ let eventSchema := fetch(f'https://api.hubapi.com/events/v3/event-definitions/{i
 
 fun getPropValueType(propValue) {
     let propType := typeof(propValue)
-    if (propType == 'string') {
+    if (propType == 'string' and match(propValue, '^[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{2}:[\\d]{2}:[\\d]{2}.[\\d]{3}Z$')) {
+        return 'datetime'
+    } else if (propType == 'string') {
         return 'string'
     } else if (propType == 'integer') {
         return 'number'
@@ -166,7 +168,14 @@ fun getPropValueType(propValue) {
 
 fun getPropValueTypeDefinition(name, propValue) {
     let propType := typeof(propValue)
-    if (propType == 'string' or propType == 'object' or propType == 'array' or propType == 'tuple') {
+    if (propType == 'string' and match(propValue, '^[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{2}:[\\d]{2}:[\\d]{2}.[\\d]{3}Z$')) {
+        return {
+            'name': name,
+            'label': name,
+            'type': 'datetime',
+            'description': f'{name} - (created by PostHog)'
+        }
+    } else if (propType == 'string' or propType == 'object' or propType == 'array' or propType == 'tuple') {
         return {
             'name': name,
             'label': name,

--- a/posthog/cdp/templates/hubspot/template_hubspot.py
+++ b/posthog/cdp/templates/hubspot/template_hubspot.py
@@ -168,7 +168,7 @@ fun getPropValueType(propValue) {
 
 fun getPropValueTypeDefinition(name, propValue) {
     let propType := typeof(propValue)
-    if (propType == 'string' and match(propValue, '^[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{2}:[\\d]{2}:[\\d]{2}.[\\d]{3}Z$')) {
+    if (propType == 'string' and match(propValue, '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}Z$')) {
         return {
             'name': name,
             'label': name,

--- a/posthog/cdp/templates/hubspot/test_template_hubspot.py
+++ b/posthog/cdp/templates/hubspot/test_template_hubspot.py
@@ -249,7 +249,13 @@ class TestTemplateHubspotEvent(BaseHogFunctionTemplateTest):
             inputs=self._inputs(include_all_properties=True, event="purchase"),
             globals={
                 "event": {
-                    "properties": {"price": 50, "currency": "USD", "expressDelivery": True, "location": "Planet Earth"},
+                    "properties": {
+                        "price": 50,
+                        "currency": "USD",
+                        "expressDelivery": True,
+                        "location": "Planet Earth",
+                        "timestamp": "2024-11-11T17:25:59.812Z",
+                    },
                 },
             },
         )
@@ -298,6 +304,22 @@ class TestTemplateHubspotEvent(BaseHogFunctionTemplateTest):
 
         assert self.get_mock_fetch_calls()[3] == snapshot(
             (
+                "https://api.hubapi.com/events/v3/event-definitions/purchase/property",
+                {
+                    "method": "POST",
+                    "headers": {"Authorization": "Bearer TOKEN", "Content-Type": "application/json"},
+                    "body": {
+                        "name": "timestamp",
+                        "label": "timestamp",
+                        "type": "datetime",
+                        "description": "timestamp - (created by PostHog)",
+                    },
+                },
+            )
+        )
+
+        assert self.get_mock_fetch_calls()[4] == snapshot(
+            (
                 "https://api.hubapi.com/events/v3/send",
                 {
                     "method": "POST",
@@ -311,6 +333,7 @@ class TestTemplateHubspotEvent(BaseHogFunctionTemplateTest):
                             "currency": "USD",
                             "expressDelivery": True,
                             "location": "Planet Earth",
+                            "timestamp": "2024-11-11T17:25:59.812Z",
                         },
                     },
                 },


### PR DESCRIPTION
## Problem

We weren't detecting timestamps as a property.

## Changes

- Automatically create a datetime property definition in Hubspot if the value matches the following regex: `^[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{2}:[\\d]{2}:[\\d]{2}.[\\d]{3}Z$` (example: `2024-11-12T11:07:49.168Z`)

## How did you test this code?

- [x] added tests
