### PR TITLE
feat: Switch algorithm for JOIN in persons batch export

### DIFF
--- a/posthog/batch_exports/sql.py
+++ b/posthog/batch_exports/sql.py
@@ -21,21 +21,6 @@ CREATE OR REPLACE VIEW persons_batch_export ON CLUSTER {settings.CLICKHOUSE_CLUS
     FROM (
         SELECT
             team_id,
-            id,
-            max(version) AS version,
-            argMax(properties, person.version) AS properties,
-            argMax(_timestamp, person.version) AS _timestamp
-        FROM
-            person
-        PREWHERE
-            team_id = {{team_id:Int64}}
-        GROUP BY
-            team_id,
-            id
-    ) AS p
-    INNER JOIN (
-        SELECT
-            team_id,
             distinct_id,
             max(version) AS version,
             argMax(person_id, person_distinct_id2.version) AS person_id,
@@ -47,7 +32,22 @@ CREATE OR REPLACE VIEW persons_batch_export ON CLUSTER {settings.CLICKHOUSE_CLUS
         GROUP BY
             team_id,
             distinct_id
-    ) AS pd ON p.id = pd.person_id AND p.team_id = pd.team_id
+    ) AS pd
+    INNER JOIN (
+        SELECT
+            team_id,
+            id,
+            max(version) AS version,
+            argMax(properties, person.version) AS properties,
+            argMax(_timestamp, person.version) AS _timestamp
+        FROM
+            person
+        PREWHERE
+            team_id = {{team_id:Int64}}
+        GROUP BY
+            team_id,
+            id
+    ) AS p ON p.id = pd.person_id AND p.team_id = pd.team_id
     WHERE
         pd.team_id = {{team_id:Int64}}
         AND p.team_id = {{team_id:Int64}}
@@ -81,21 +81,6 @@ CREATE OR REPLACE VIEW persons_batch_export_backfill ON CLUSTER {settings.CLICKH
     FROM (
         SELECT
             team_id,
-            id,
-            max(version) AS version,
-            argMax(properties, person.version) AS properties,
-            argMax(_timestamp, person.version) AS _timestamp
-        FROM
-            person
-        PREWHERE
-            team_id = {{team_id:Int64}}
-        GROUP BY
-            team_id,
-            id
-    ) AS p
-    INNER JOIN (
-        SELECT
-            team_id,
             distinct_id,
             max(version) AS version,
             argMax(person_id, person_distinct_id2.version) AS person_id,
@@ -107,7 +92,22 @@ CREATE OR REPLACE VIEW persons_batch_export_backfill ON CLUSTER {settings.CLICKH
         GROUP BY
             team_id,
             distinct_id
-    ) AS pd ON p.id = pd.person_id AND p.team_id = pd.team_id
+    ) AS pd
+    INNER JOIN (
+        SELECT
+            team_id,
+            id,
+            max(version) AS version,
+            argMax(properties, person.version) AS properties,
+            argMax(_timestamp, person.version) AS _timestamp
+        FROM
+            person
+        PREWHERE
+            team_id = {{team_id:Int64}}
+        GROUP BY
+            team_id,
+            id
+    ) AS p ON p.id = pd.person_id AND p.team_id = pd.team_id
     WHERE
         pd.team_id = {{team_id:Int64}}
         AND p.team_id = {{team_id:Int64}}

--- a/posthog/clickhouse/migrations/0084_persons_batch_export_update.py
+++ b/posthog/clickhouse/migrations/0084_persons_batch_export_update.py
@@ -1,0 +1,13 @@
+from posthog.batch_exports.sql import (
+    CREATE_PERSONS_BATCH_EXPORT_VIEW,
+    CREATE_PERSONS_BATCH_EXPORT_VIEW_BACKFILL,
+)
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+operations = map(
+    run_sql_with_exceptions,
+    [
+        CREATE_PERSONS_BATCH_EXPORT_VIEW,
+        CREATE_PERSONS_BATCH_EXPORT_VIEW_BACKFILL,
+    ],
+)

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -63,7 +63,10 @@ FROM
 FORMAT ArrowStream
 SETTINGS
     max_bytes_before_external_group_by=50000000000,
-    max_bytes_before_external_sort=50000000000
+    max_bytes_before_external_sort=50000000000,
+    optimize_aggregation_in_order=1,
+    max_threads=16,
+    join_algorithm='partial_merge'
 """
 
 SELECT_FROM_PERSONS_VIEW_BACKFILL = """
@@ -84,7 +87,9 @@ FORMAT ArrowStream
 SETTINGS
     max_bytes_before_external_group_by=50000000000,
     max_bytes_before_external_sort=50000000000,
-    optimize_aggregation_in_order=1
+    optimize_aggregation_in_order=1,
+    max_threads=16,
+    join_algorithm='partial_merge'
 """
 
 SELECT_FROM_EVENTS_VIEW = Template(


### PR DESCRIPTION
## Problem

Partial merge JOIN algorithm sorts the right table and then performs a sort-merge. We can switch tables to have `person` on the right side of the join, since it's already sorted by the join key, effectively removing the sort operation of a partial merge.

In testing, this makes two things possible:
* We can limit the number of threads used to 16 while the query still takes roughly the same time as current query. Without this algorithm change the existing query won't run with `max_threads=16` and instead requiring all. So, we should be saving CPU resources without a cost in execution time.
* Peak memory usage goes down by around a 27% (likely because merge table is dumped to disk instead of held in memory as a hash table).

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Create a clickhouse migration to switch table order in JOIN for persons batch export (both views). This just re-creates views, so it should be very quick to execute.
* Add `max_threads=16` and `join_algorithm='partial_merge'` to batch exports query for persons.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Ran both queries in cluster.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
