### PR TITLE
chore(dev-x): add Jest test debugger configuration for VS code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -160,6 +160,13 @@
             "justMyCode": true
         },
         {
+            "name": "Frontend: Debug Jest Tests",
+            "type": "node-terminal",
+            "command": "pnpm test:unit",
+            "request": "launch",
+            "cwd": "${workspaceFolder}"
+        },
+        {
             "name": "(lldb) Attach",
             "type": "cppdbg",
             "request": "attach",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -162,7 +162,7 @@
         {
             "name": "Frontend: Debug Jest Tests",
             "type": "node-terminal",
-            "command": "pnpm test:unit",
+            "command": "pnpm test:unit --runInBand",
             "request": "launch",
             "cwd": "${workspaceFolder}"
         },


### PR DESCRIPTION
## Problem

Adds a debugger configuration called `Frontend: Debug Jest Tests` to our .vscode/launch.json

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
![Screenshot 2024-11-12 at 5 07 43 PM](https://github.com/user-attachments/assets/980f9e5a-c4d3-4a25-98aa-08a6e3d6294a)
![Screenshot 2024-11-12 at 5 07 54 PM](https://github.com/user-attachments/assets/e467dca7-4794-4007-89fc-b0a06cc76d8a)

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
