### PR TITLE
fix: data viz node doesn't persist display type

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -472,7 +472,11 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
 
                     return open
                 },
-                setVisualizationType: (_, { visualizationType }) => {
+                setVisualizationType: (state, { visualizationType }) => {
+                    if (state) {
+                        return true
+                    }
+
                     return visualizationType !== ChartDisplayType.ActionsTable
                 },
             },

--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -283,6 +283,12 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
         setConditionalFormattingRulesPanelActiveKeys: (keys: string[]) => ({ keys }),
     })),
     reducers(({ props }) => ({
+        query: [
+            props.query,
+            {
+                setQuery: (_, { node }) => node,
+            },
+        ],
         visualizationType: [
             ChartDisplayType.ActionsTable as ChartDisplayType,
             {
@@ -466,11 +472,7 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
 
                     return open
                 },
-                setVisualizationType: (state, { visualizationType }) => {
-                    if (state) {
-                        return true
-                    }
-
+                setVisualizationType: (_, { visualizationType }) => {
                     return visualizationType !== ChartDisplayType.ActionsTable
                 },
             },
@@ -553,7 +555,6 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
                 return columns.filter((n) => n.type.isNumerical)
             },
         ],
-        query: [(_state, props) => [props.query], (query) => query],
         showEditingUI: [
             (state, props) => [state.insightMode, props.insightLogicProps],
             (insightMode, insightLogicProps) => {


### PR DESCRIPTION
## Problem
- When you save/edit a sql tab and change display type to line graph from an actions table, it doesn't let you save. When creating a new insight in sql tab and select line graph, on saving it reverts to being a table. This is due to a race condition [here](https://github.com/PostHog/posthog/blob/master/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts#L236) which resets the display to be an ActionsTable (which was the original type passed in the props query)


https://github.com/user-attachments/assets/62abcfb9-2e1d-4f3a-9713-3c7f795dbb07



- When you set display type as LineGraph and revert back to ActionsTable, the series picker is still shown

https://github.com/user-attachments/assets/b5e8c531-a5ea-4c80-bf42-d406b4f90a9c


## Changes
Created a reducer for query to fix the race condition.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
