### PR TITLE
feat(product-assistant): improve the trends generation

### DIFF
--- a/ee/hogai/funnels/prompts.py
+++ b/ee/hogai/funnels/prompts.py
@@ -1,12 +1,10 @@
-from ee.hogai.taxonomy_agent.prompts import REACT_FORMAT_PROMPT, REACT_FORMAT_REMINDER_PROMPT
-
-REACT_SYSTEM_PROMPT = f"""
+REACT_SYSTEM_PROMPT = """
 You're a product analyst agent. Your task is to define a sequence for funnels: events, property filters, and values of property filters from the user's data in order to correctly answer on the user's question.
 
 The product being analyzed is described as follows:
-{{{{product_description}}}}
+{{product_description}}
 
-{REACT_FORMAT_PROMPT}
+{{react_format}}
 
 Below you will find information on how to correctly discover the taxonomy of the user's data.
 
@@ -88,7 +86,7 @@ When using a breakdown, you must:
 
 ---
 
-{REACT_FORMAT_REMINDER_PROMPT}
+{{react_format_reminder}}
 """
 
 FUNNEL_SYSTEM_PROMPT = """

--- a/ee/hogai/funnels/toolkit.py
+++ b/ee/hogai/funnels/toolkit.py
@@ -56,23 +56,6 @@ class FunnelsTaxonomyAgentToolkit(TaxonomyAgentToolkit):
 
 def generate_funnel_schema() -> dict:
     schema = AssistantFunnelsQuery.model_json_schema()
-
-    # Patch `numeric` types
-    property_filters = (
-        "EventPropertyFilter",
-        "PersonPropertyFilter",
-        "SessionPropertyFilter",
-        "FeaturePropertyFilter",
-        "GroupPropertyFilter",
-    )
-
-    # Clean up the property filters
-    for key in property_filters:
-        property_schema = schema["$defs"][key]
-        property_schema["properties"]["key"]["description"] = (
-            f"Use one of the properties the user has provided in the plan."
-        )
-
     return {
         "name": "output_insight_schema",
         "description": "Outputs the JSON schema of a product analytics insight",

--- a/ee/hogai/taxonomy.py
+++ b/ee/hogai/taxonomy.py
@@ -139,7 +139,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$identify": {
             "label": "Identify",
-            "description": "Identifies an anonymous user. This event doesn't show how many users you have but rather how many users used an account.",
+            "description": "Identifies an anonymous user. The event shows how many users used an account, so do not use it for active users metrics because a user may skip identification.",
         },
         "$create_alias": {
             "label": "Alias",

--- a/ee/hogai/taxonomy.py
+++ b/ee/hogai/taxonomy.py
@@ -76,7 +76,7 @@ SESSION_INITIAL_PROPERTIES_ADAPTED_FROM_EVENTS = {
 
 CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
     "events": {
-        "": {
+        "All Events": {
             "label": "All events",
             "description": "This is a wildcard that matches all events.",
         },

--- a/ee/hogai/taxonomy_agent/nodes.py
+++ b/ee/hogai/taxonomy_agent/nodes.py
@@ -1,6 +1,6 @@
-from abc import ABC
 import itertools
 import xml.etree.ElementTree as ET
+from abc import ABC
 from functools import cached_property
 from typing import cast
 
@@ -22,6 +22,8 @@ from ee.hogai.taxonomy_agent.parsers import (
 from ee.hogai.taxonomy_agent.prompts import (
     REACT_DEFINITIONS_PROMPT,
     REACT_FOLLOW_UP_PROMPT,
+    REACT_FORMAT_PROMPT,
+    REACT_FORMAT_REMINDER_PROMPT,
     REACT_MALFORMED_JSON_PROMPT,
     REACT_MISSING_ACTION_CORRECTION_PROMPT,
     REACT_MISSING_ACTION_PROMPT,
@@ -30,7 +32,7 @@ from ee.hogai.taxonomy_agent.prompts import (
     REACT_USER_PROMPT,
 )
 from ee.hogai.taxonomy_agent.toolkit import TaxonomyAgentTool, TaxonomyAgentToolkit
-from ee.hogai.utils import AssistantState, AssistantNode, filter_visualization_conversation, remove_line_breaks
+from ee.hogai.utils import AssistantNode, AssistantState, filter_visualization_conversation, remove_line_breaks
 from posthog.hogql_queries.ai.team_taxonomy_query_runner import TeamTaxonomyQueryRunner
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models.group_type_mapping import GroupTypeMapping
@@ -73,6 +75,8 @@ class TaxonomyAgentPlannerNode(AssistantNode):
                 AgentAction,
                 agent.invoke(
                     {
+                        "react_format": REACT_FORMAT_PROMPT,
+                        "react_format_reminder": REACT_FORMAT_REMINDER_PROMPT,
                         "tools": toolkit.render_text_description(),
                         "tool_names": ", ".join([t["name"] for t in toolkit.tools]),
                         "product_description": self._team.project.product_description,

--- a/ee/hogai/taxonomy_agent/test/test_nodes.py
+++ b/ee/hogai/taxonomy_agent/test/test_nodes.py
@@ -123,7 +123,7 @@ class TestTaxonomyAgentPlannerNode(ClickhouseTestMixin, APIBaseTest):
         node = self._get_node()
         self.assertEqual(
             node._events_prompt,
-            "<list of available events for filtering>\nall events\ndistinctevent\n</list of available events for filtering>",
+            "<defined_events><event><name>All Events</name><description>All events. This is a wildcard that matches all events.</description></event><event><name>distinctevent</name></event></defined_events>",
         )
 
     def test_agent_preserves_low_count_events_for_smaller_teams(self):
@@ -171,6 +171,14 @@ class TestTaxonomyAgentPlannerNode(ClickhouseTestMixin, APIBaseTest):
             self.assertIn("Thought.\nAction: abc", action.log)
             self.assertIn("action", action.tool_input)
             self.assertIn("action_input", action.tool_input)
+
+    def test_node_outputs_all_events_prompt(self):
+        node = self._get_node()
+        self.assertIn("All Events", node._events_prompt)
+        self.assertIn(
+            "<event><name>All Events</name><description>All events. This is a wildcard that matches all events.</description></event>",
+            node._events_prompt,
+        )
 
 
 @override_settings(IN_UNIT_TESTING=True)

--- a/ee/hogai/trends/nodes.py
+++ b/ee/hogai/trends/nodes.py
@@ -4,10 +4,7 @@ from langchain_core.runnables import RunnableConfig
 from ee.hogai.schema_generator.nodes import SchemaGeneratorNode, SchemaGeneratorToolsNode
 from ee.hogai.schema_generator.utils import SchemaGeneratorOutput
 from ee.hogai.taxonomy_agent.nodes import TaxonomyAgentPlannerNode, TaxonomyAgentPlannerToolsNode
-from ee.hogai.trends.prompts import (
-    REACT_SYSTEM_PROMPT,
-    trends_system_prompt,
-)
+from ee.hogai.trends.prompts import REACT_SYSTEM_PROMPT, TRENDS_SYSTEM_PROMPT
 from ee.hogai.trends.toolkit import TRENDS_SCHEMA, TrendsTaxonomyAgentToolkit
 from ee.hogai.utils import AssistantState
 from posthog.schema import AssistantTrendsQuery
@@ -42,7 +39,7 @@ class TrendsGeneratorNode(SchemaGeneratorNode[AssistantTrendsQuery]):
     def run(self, state: AssistantState, config: RunnableConfig) -> AssistantState:
         prompt = ChatPromptTemplate.from_messages(
             [
-                ("system", trends_system_prompt),
+                ("system", TRENDS_SYSTEM_PROMPT),
             ],
             template_format="mustache",
         )

--- a/ee/hogai/trends/prompts.py
+++ b/ee/hogai/trends/prompts.py
@@ -80,14 +80,14 @@ Examples of using math formulas:
 Only include property filters when they are essential to directly answer the user’s question. Avoid adding them if the question can be addressed without additional segmentation and always use the minimum set of property filters needed to answer the question. Do not check if a property is set unless the user explicitly asks for it.
 
 When using a property filter, you must:
-- **Prioritize properties that are directly related to the context or objective of the user's query.** Avoid using properties for identification like IDs because neither the user nor you can retrieve the data. Instead, prioritize filtering based on general properties like `paidCustomer` or `icp_score`. You don't need to find properties for a time frame.
+- **Prioritize properties directly related to the context or objective of the user's query.** Avoid using properties for identification like IDs because neither the user nor you can retrieve the data. Instead, prioritize filtering based on general properties like `paidCustomer` or `icp_score`. You don't need to find properties for a time frame.
 - **Ensure that you find both the property group and name.** Property groups must be one of the following: event, person, session{{#groups}}, {{.}}{{/groups}}.
 - After selecting a property, **validate that the property value accurately reflects the intended criteria**.
 - **Find the suitable operator for type** (e.g., `contains`, `is set`). The operators are listed below.
 - If the operator requires a value, use the tool to find the property values. Verify that you can answer the question with given property values. If you can't, try to find a different property or event.
 - You set logical operators to combine multiple properties of a single series: AND or OR.
 
-Infer the property groups from the user's request. If your first guess doesn't return any results, try to adjust the property group. You must make sure that the property name matches the lookup value, e.g. if the user asks to find data about organizations with the name "ACME", you must look for the property like "organization name".
+Infer the property groups from the user's request. If your first guess doesn't yield any results, try to adjust the property group. You must make sure that the property name matches the lookup value, e.g. if the user asks to find data about organizations with the name "ACME", you must look for the property like "organization name".
 
 Supported operators for the String type are:
 - contains

--- a/ee/hogai/trends/prompts.py
+++ b/ee/hogai/trends/prompts.py
@@ -1,7 +1,7 @@
 from ee.hogai.taxonomy_agent.prompts import REACT_FORMAT_PROMPT, REACT_FORMAT_REMINDER_PROMPT
 
 REACT_SYSTEM_PROMPT = f"""
-You're a product analyst agent. Your task is to define trends series: events, property filters, and values of property filters from the user's data in order to correctly answer on the user's question.
+You're a product analyst agent. Your task is to create a plan defining trends series: events, property filters, and values of property filters from the user's data in order to correctly answer on the user's question.
 
 The product being analyzed is described as follows:
 {{{{product_description}}}}
@@ -16,7 +16,7 @@ Trends insights enable users to plot data from people, events, and properties ho
 
 ## Events
 
-You’ll be given a list of events in addition to the user’s question. Events are sorted by their popularity where the most popular events are at the top of the list. Prioritize popular events. You must always specify events to use.
+You’ll be given a list of events in addition to the user’s question. Events are sorted by their popularity where the most popular events are at the top of the list. Prioritize popular events. You must always specify events to use. Assess whether the sequence of events suffices to answer the question before applying property filters or breakdowns.
 
 ## Aggregation
 
@@ -67,7 +67,9 @@ Examples of using math formulas:
 
 ## Property Filters
 
-**Look for property filters** that the user wants to apply. Understand the user's intent and identify the minimum set of properties needed to answer the question. Do not use property filters excessively. Property filters can include filtering by person's geography, event's browser, session duration, or any custom properties. They can be one of four data types: String, Numeric, Boolean, and DateTime.
+**Look for property filters** that the user wants to apply. Property filters can include filtering by person's geography, event's browser, session duration, or any custom properties. They can be one of four data types: String, Numeric, Boolean, and DateTime.
+
+Only include property filters when they are essential to directly answer the user’s question. Avoid adding them if the question can be addressed without additional segmentation and always use the minimum set of property filters needed to answer the question.
 
 When using a property filter, you must:
 - **Prioritize properties that are directly related to the context or objective of the user's query.** Avoid using properties for identification like IDs because neither the user nor you can retrieve the data. Instead, prioritize filtering based on general properties like `paidCustomer` or `icp_score`. You don't need to find properties for a time frame.
@@ -113,12 +115,21 @@ Supported operators for the Boolean type are:
 
 ## Breakdown Series by Properties
 
-Optionally, if you understand that the user wants to split the data by a property, you can break down all series by multiple properties. Users can use breakdowns to split up trends insights by the values of a specific property, such as by `$current_url`, `$geoip_country`, `email`, or company's name like `company name`. Always use the minimum set of breakdowns needed to answer the question.
+Breakdowns are used to segment data by property values of maximum three properties. They divide all defined trends series to multiple subseries based on the values of the property. Include breakdowns **only when they are essential to directly answer the user’s question**. You must not add breakdowns if the question can be addressed without additional segmentation. Always use the minimum set of breakdowns needed to answer the question.
 
 When using breakdowns, you must:
 - **Identify the property group** and name for each breakdown.
 - **Provide the property name** for each breakdown.
 - **Validate that the property value accurately reflects the intended criteria**.
+
+Examples of using breakdowns:
+- page views trend by country: you need to find a property such as `$geoip_country_code` and set it as a breakdown.
+- number of users who have completed onboarding by an organization: you need to find a property such as `organization name` and set it as a breakdown.
+
+## Reminders
+
+- Ensure that any properties or breakdowns included are directly relevant to the context and objectives of the user’s question. Avoid unnecessary or unrelated details.
+- Avoid overcomplicating the response with excessive property filters or breakdowns. Focus on the simplest solution that effectively answers the user’s question.
 
 ---
 

--- a/ee/hogai/trends/prompts.py
+++ b/ee/hogai/trends/prompts.py
@@ -1,12 +1,10 @@
-from ee.hogai.taxonomy_agent.prompts import REACT_FORMAT_PROMPT, REACT_FORMAT_REMINDER_PROMPT
-
-REACT_SYSTEM_PROMPT = f"""
+REACT_SYSTEM_PROMPT = """
 You're a product analyst agent. Your task is to create a plan defining trends series: events, property filters, and values of property filters from the user's data in order to correctly answer on the user's question.
 
 The product being analyzed is described as follows:
-{{{{product_description}}}}
+{{product_description}}
 
-{REACT_FORMAT_PROMPT}
+{{react_format}}
 
 Below you will find information on how to correctly discover the taxonomy of the user's data.
 
@@ -16,11 +14,11 @@ Trends insights enable users to plot data from people, events, and properties ho
 
 ## Events
 
-You’ll be given a list of events in addition to the user’s question. Events are sorted by their popularity where the most popular events are at the top of the list. Prioritize popular events. You must always specify events to use. Assess whether the sequence of events suffices to answer the question before applying property filters or breakdowns.
+You’ll be given a list of events in addition to the user’s question. Events are sorted by their popularity with the most popular events at the top of the list. Prioritize popular events. You must always specify events to use. Events always have an associated user’s profile. Assess whether the sequence of events suffices to answer the question before applying property filters or breakdowns.
 
 ## Aggregation
 
-**Determine the math aggregation** the user is asking for, such as totals, averages, ratios, or custom formulas. If not specified, choose a reasonable default based on the event type (e.g., total count). By default, total count should be used. You can use aggregation types for a series with an event or with an event aggregating by a property.
+**Determine the math aggregation** the user is asking for, such as totals, averages, ratios, or custom formulas. If not specified, choose a reasonable default based on the event type (e.g., total count). By default, the total count should be used. You can aggregate data by events, event's property values,{{#groups}} {{.}}s,{{/groups}} or users. If you're aggregating by users or groups, there’s no need to check for their existence, as events without required associations will automatically be filtered out.
 
 Available math aggregations types for the event count are:
 - total count
@@ -35,9 +33,9 @@ Available math aggregations types for the event count are:
 - weekly active users
 - daily active users
 - first time for a user
-{{{{#groups}}}}
-- unique {{{{this}}}}
-{{{{/groups}}}}
+{{#groups}}
+- unique {{.}}s
+{{/groups}}
 
 Available math aggregation types for event's property values are:
 - average
@@ -83,7 +81,7 @@ Only include property filters when they are essential to directly answer the use
 
 When using a property filter, you must:
 - **Prioritize properties that are directly related to the context or objective of the user's query.** Avoid using properties for identification like IDs because neither the user nor you can retrieve the data. Instead, prioritize filtering based on general properties like `paidCustomer` or `icp_score`. You don't need to find properties for a time frame.
-- **Ensure that you find both the property group and name.** Property groups must be one of the following: event, person, session{{#groups}}, {{this}}{{/groups}}.
+- **Ensure that you find both the property group and name.** Property groups must be one of the following: event, person, session{{#groups}}, {{.}}{{/groups}}.
 - After selecting a property, **validate that the property value accurately reflects the intended criteria**.
 - **Find the suitable operator for type** (e.g., `contains`, `is set`). The operators are listed below.
 - If the operator requires a value, use the tool to find the property values. Verify that you can answer the question with given property values. If you can't, try to find a different property or event.
@@ -143,10 +141,10 @@ Examples of using breakdowns:
 
 ---
 
-{REACT_FORMAT_REMINDER_PROMPT}
+{{react_format_reminder}}
 """
 
-trends_system_prompt = """
+TRENDS_SYSTEM_PROMPT = """
 Act as an expert product manager. Your task is to generate a JSON schema of trends insights. You will be given a generation plan describing series, filters, and breakdowns. Use the plan and following instructions to create a correct query answering the user's question.
 
 Below is the additional context.
@@ -232,43 +230,4 @@ Obey these rules:
 - Only use events and properties defined by the user. You can't create new events or property definitions.
 
 Remember, your efforts will be rewarded with a $100 tip if you manage to implement a perfect query that follows the user's instructions and return the desired result. Do not hallucinate.
-"""
-
-TRENDS_GROUP_MAPPING_PROMPT = """
-Here is the group mapping:
-{{group_mapping}}
-"""
-
-TRENDS_PLAN_PROMPT = """
-Here is the plan:
-{{plan}}
-"""
-
-TRENDS_NEW_PLAN_PROMPT = """
-Here is the new plan:
-{{plan}}
-"""
-
-TRENDS_QUESTION_PROMPT = """
-Answer to this question: {{question}}
-"""
-
-TRENDS_FAILOVER_OUTPUT_PROMPT = """
-Generation output:
-```
-{{output}}
-```
-
-Exception message:
-```
-{{exception_message}}
-```
-"""
-
-TRENDS_FAILOVER_PROMPT = """
-The result of the previous generation raised the Pydantic validation exception.
-
-{{validation_error_message}}
-
-Fix the error and return the correct response.
 """

--- a/ee/hogai/trends/prompts.py
+++ b/ee/hogai/trends/prompts.py
@@ -35,9 +35,9 @@ Available math aggregations types for the event count are:
 - weekly active users
 - daily active users
 - first time for a user
-{{#groups}}
-- unique {{this}}
-{{/groups}}
+{{{{#groups}}}}
+- unique {{{{this}}}}
+{{{{/groups}}}}
 
 Available math aggregation types for event's property values are:
 - average
@@ -49,9 +49,19 @@ Available math aggregation types for event's property values are:
 - 95th percentile
 - 99th percentile
 
+Available math aggregation types counting by users who completed an event are:
+- average
+- minimum
+- maximum
+- median
+- 90th percentile
+- 95th percentile
+- 99th percentile
+
 Examples of using aggregation types:
 - `unique users` to find how many distinct users have logged the event per a day.
 - `average` by the `$session_diration` property to find out what was the average session duration of an event.
+- `99th percentile by users` to find out what was the 99th percentile of the event count by users.
 
 ## Math Formulas
 
@@ -69,7 +79,7 @@ Examples of using math formulas:
 
 **Look for property filters** that the user wants to apply. Property filters can include filtering by person's geography, event's browser, session duration, or any custom properties. They can be one of four data types: String, Numeric, Boolean, and DateTime.
 
-Only include property filters when they are essential to directly answer the user’s question. Avoid adding them if the question can be addressed without additional segmentation and always use the minimum set of property filters needed to answer the question.
+Only include property filters when they are essential to directly answer the user’s question. Avoid adding them if the question can be addressed without additional segmentation and always use the minimum set of property filters needed to answer the question. Do not check if a property is set unless the user explicitly asks for it.
 
 When using a property filter, you must:
 - **Prioritize properties that are directly related to the context or objective of the user's query.** Avoid using properties for identification like IDs because neither the user nor you can retrieve the data. Instead, prioritize filtering based on general properties like `paidCustomer` or `icp_score`. You don't need to find properties for a time frame.

--- a/ee/hogai/trends/test/test_prompt.py
+++ b/ee/hogai/trends/test/test_prompt.py
@@ -1,0 +1,22 @@
+from langchain_core.prompts import ChatPromptTemplate
+
+from ee.hogai.trends.prompts import REACT_SYSTEM_PROMPT
+from posthog.test.base import BaseTest
+
+
+class TestTrendsPrompts(BaseTest):
+    def test_planner_prompt_has_groups(self):
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                ("system", REACT_SYSTEM_PROMPT),
+            ],
+            template_format="mustache",
+        ).format(
+            groups=["org", "account"],
+            react_format="",
+            react_format_reminder="",
+        )
+        self.assertIn("unique orgs", prompt)
+        self.assertIn("unique accounts", prompt)
+        self.assertIn("orgs, accounts,", prompt)
+        self.assertIn("org, account.", prompt)

--- a/ee/hogai/trends/toolkit.py
+++ b/ee/hogai/trends/toolkit.py
@@ -59,24 +59,6 @@ class TrendsTaxonomyAgentToolkit(TaxonomyAgentToolkit):
 
 def generate_trends_schema() -> dict:
     schema = AssistantTrendsQuery.model_json_schema()
-
-    # Patch `numeric` types
-    schema["$defs"]["MathGroupTypeIndex"]["type"] = "number"
-    property_filters = (
-        "EventPropertyFilter",
-        "PersonPropertyFilter",
-        "SessionPropertyFilter",
-        "FeaturePropertyFilter",
-        "GroupPropertyFilter",
-    )
-
-    # Clean up the property filters
-    for key in property_filters:
-        property_schema = schema["$defs"][key]
-        property_schema["properties"]["key"]["description"] = (
-            f"Use one of the properties the user has provided in the plan."
-        )
-
     return {
         "name": "output_insight_schema",
         "description": "Outputs the JSON schema of a funnel insight",

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -1152,7 +1152,7 @@
             "type": "object"
         },
         "AssistantSingleValuePropertyFilterOperator": {
-            "enum": ["icontains", "not_icontains", "regex", "not_regex"],
+            "enum": ["exact", "is_not", "icontains", "not_icontains", "regex", "not_regex"],
             "type": "string"
         },
         "AssistantStringNumberOrBooleanPropertyFilter": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -486,6 +486,59 @@
                 }
             ]
         },
+        "AssistantArrayPropertyFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "operator": {
+                    "$ref": "#/definitions/AssistantArrayPropertyFilterOperator",
+                    "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values."
+                },
+                "value": {
+                    "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["operator", "value"],
+            "type": "object"
+        },
+        "AssistantArrayPropertyFilterOperator": {
+            "enum": ["exact", "is_not"],
+            "type": "string"
+        },
+        "AssistantBasePropertyFilter": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/AssistantStringNumberOrBooleanPropertyFilter"
+                },
+                {
+                    "$ref": "#/definitions/AssistantDateTimePropertyFilter"
+                },
+                {
+                    "$ref": "#/definitions/AssistantSetPropertyFilter"
+                }
+            ]
+        },
+        "AssistantDateTimePropertyFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "operator": {
+                    "$ref": "#/definitions/AssistantDateTimePropertyFilterOperator"
+                },
+                "value": {
+                    "description": "Value must be a date in ISO 8601 format.",
+                    "type": "string"
+                }
+            },
+            "required": ["operator", "value"],
+            "type": "object"
+        },
+        "AssistantDateTimePropertyFilterOperator": {
+            "enum": ["is_date_exact", "is_date_before", "is_date_after"],
+            "type": "string"
+        },
         "AssistantEventType": {
             "enum": ["status", "message"],
             "type": "string"
@@ -706,6 +759,210 @@
             "enum": ["ack", "generation_error"],
             "type": "string"
         },
+        "AssistantGenericPropertyFilter": {
+            "anyOf": [
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "key": {
+                            "description": "Use one of the properties the user has provided in the plan.",
+                            "type": "string"
+                        },
+                        "operator": {
+                            "$ref": "#/definitions/AssistantSingleValuePropertyFilterOperator",
+                            "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern."
+                        },
+                        "type": {
+                            "enum": ["event", "person", "session", "feature"],
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["key", "operator", "type", "value"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "key": {
+                            "description": "Use one of the properties the user has provided in the plan.",
+                            "type": "string"
+                        },
+                        "operator": {
+                            "$ref": "#/definitions/AssistantArrayPropertyFilterOperator",
+                            "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values."
+                        },
+                        "type": {
+                            "enum": ["event", "person", "session", "feature"],
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["key", "operator", "type", "value"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "key": {
+                            "description": "Use one of the properties the user has provided in the plan.",
+                            "type": "string"
+                        },
+                        "operator": {
+                            "$ref": "#/definitions/AssistantDateTimePropertyFilterOperator"
+                        },
+                        "type": {
+                            "enum": ["event", "person", "session", "feature"],
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "Value must be a date in ISO 8601 format.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["key", "operator", "type", "value"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "key": {
+                            "description": "Use one of the properties the user has provided in the plan.",
+                            "type": "string"
+                        },
+                        "operator": {
+                            "$ref": "#/definitions/AssistantSetPropertyFilterOperator",
+                            "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected."
+                        },
+                        "type": {
+                            "enum": ["event", "person", "session", "feature"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["key", "operator", "type"],
+                    "type": "object"
+                }
+            ]
+        },
+        "AssistantGroupPropertyFilter": {
+            "anyOf": [
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "group_type_index": {
+                            "description": "Index of the group type from the group mapping.",
+                            "type": "integer"
+                        },
+                        "key": {
+                            "description": "Use one of the properties the user has provided in the plan.",
+                            "type": "string"
+                        },
+                        "operator": {
+                            "$ref": "#/definitions/AssistantSingleValuePropertyFilterOperator",
+                            "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern."
+                        },
+                        "type": {
+                            "const": "group",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["group_type_index", "key", "operator", "type", "value"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "group_type_index": {
+                            "description": "Index of the group type from the group mapping.",
+                            "type": "integer"
+                        },
+                        "key": {
+                            "description": "Use one of the properties the user has provided in the plan.",
+                            "type": "string"
+                        },
+                        "operator": {
+                            "$ref": "#/definitions/AssistantArrayPropertyFilterOperator",
+                            "description": "`exact` - exact match of any of the values. `is_not` - does not match any of the values."
+                        },
+                        "type": {
+                            "const": "group",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string \"true\" or \"false\".",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["group_type_index", "key", "operator", "type", "value"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "group_type_index": {
+                            "description": "Index of the group type from the group mapping.",
+                            "type": "integer"
+                        },
+                        "key": {
+                            "description": "Use one of the properties the user has provided in the plan.",
+                            "type": "string"
+                        },
+                        "operator": {
+                            "$ref": "#/definitions/AssistantDateTimePropertyFilterOperator"
+                        },
+                        "type": {
+                            "const": "group",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "Value must be a date in ISO 8601 format.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["group_type_index", "key", "operator", "type", "value"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "group_type_index": {
+                            "description": "Index of the group type from the group mapping.",
+                            "type": "integer"
+                        },
+                        "key": {
+                            "description": "Use one of the properties the user has provided in the plan.",
+                            "type": "string"
+                        },
+                        "operator": {
+                            "$ref": "#/definitions/AssistantSetPropertyFilterOperator",
+                            "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected."
+                        },
+                        "type": {
+                            "const": "group",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["group_type_index", "key", "operator", "type"],
+                    "type": "object"
+                }
+            ]
+        },
         "AssistantInsightsQueryBase": {
             "additionalProperties": false,
             "properties": {
@@ -754,19 +1011,54 @@
         "AssistantPropertyFilter": {
             "anyOf": [
                 {
-                    "$ref": "#/definitions/EventPropertyFilter"
+                    "$ref": "#/definitions/AssistantGenericPropertyFilter"
                 },
                 {
-                    "$ref": "#/definitions/PersonPropertyFilter"
+                    "$ref": "#/definitions/AssistantGroupPropertyFilter"
+                }
+            ]
+        },
+        "AssistantSetPropertyFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "operator": {
+                    "$ref": "#/definitions/AssistantSetPropertyFilterOperator",
+                    "description": "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't collected."
+                }
+            },
+            "required": ["operator"],
+            "type": "object"
+        },
+        "AssistantSetPropertyFilterOperator": {
+            "enum": ["is_set", "is_not_set"],
+            "type": "string"
+        },
+        "AssistantSingleValuePropertyFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "operator": {
+                    "$ref": "#/definitions/AssistantSingleValuePropertyFilterOperator",
+                    "description": "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` - matches the regex pattern. `not_regex` - does not match the regex pattern."
+                },
+                "value": {
+                    "description": "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be matched against the property value.",
+                    "type": "string"
+                }
+            },
+            "required": ["operator", "value"],
+            "type": "object"
+        },
+        "AssistantSingleValuePropertyFilterOperator": {
+            "enum": ["icontains", "not_icontains", "regex", "not_regex"],
+            "type": "string"
+        },
+        "AssistantStringNumberOrBooleanPropertyFilter": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/AssistantSingleValuePropertyFilter"
                 },
                 {
-                    "$ref": "#/definitions/SessionPropertyFilter"
-                },
-                {
-                    "$ref": "#/definitions/GroupPropertyFilter"
-                },
-                {
-                    "$ref": "#/definitions/FeaturePropertyFilter"
+                    "$ref": "#/definitions/AssistantArrayPropertyFilter"
                 }
             ]
         },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -508,6 +508,17 @@
             "enum": ["exact", "is_not"],
             "type": "string"
         },
+        "AssistantBaseMultipleBreakdownFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "property": {
+                    "description": "Property name from the plan to break down by.",
+                    "type": "string"
+                }
+            },
+            "required": ["property"],
+            "type": "object"
+        },
         "AssistantBasePropertyFilter": {
             "anyOf": [
                 {
@@ -520,6 +531,17 @@
                     "$ref": "#/definitions/AssistantSetPropertyFilter"
                 }
             ]
+        },
+        "AssistantBreakdownFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "breakdown_limit": {
+                    "default": 25,
+                    "description": "How many distinct values to show.",
+                    "type": "integer"
+                }
+            },
+            "type": "object"
         },
         "AssistantDateTimePropertyFilter": {
             "additionalProperties": false,
@@ -537,6 +559,10 @@
         },
         "AssistantDateTimePropertyFilterOperator": {
             "enum": ["is_date_exact", "is_date_before", "is_date_after"],
+            "type": "string"
+        },
+        "AssistantEventMultipleBreakdownFilterType": {
+            "enum": ["person", "event", "session", "hogql"],
             "type": "string"
         },
         "AssistantEventType": {
@@ -560,11 +586,6 @@
                         }
                     ],
                     "description": "If `breakdown_type` is `group`, this is the index of the group. Use the index from the group mapping."
-                },
-                "breakdown_histogram_bin_count": {
-                    "default": 10,
-                    "description": "Number of bins to show in the histogram. Only applicable for the numeric properties.",
-                    "type": "integer"
                 },
                 "breakdown_limit": {
                     "default": 25,
@@ -759,6 +780,20 @@
             "enum": ["ack", "generation_error"],
             "type": "string"
         },
+        "AssistantGenericMultipleBreakdownFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "property": {
+                    "description": "Property name from the plan to break down by.",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/AssistantEventMultipleBreakdownFilterType"
+                }
+            },
+            "required": ["property", "type"],
+            "type": "object"
+        },
         "AssistantGenericPropertyFilter": {
             "anyOf": [
                 {
@@ -852,6 +887,32 @@
                     "type": "object"
                 }
             ]
+        },
+        "AssistantGroupMultipleBreakdownFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "group_type_index": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Index of the group type from the group mapping."
+                },
+                "property": {
+                    "description": "Property name from the plan to break down by.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "group",
+                    "type": "string"
+                }
+            },
+            "required": ["property", "type"],
+            "type": "object"
         },
         "AssistantGroupPropertyFilter": {
             "anyOf": [
@@ -1008,6 +1069,16 @@
             "enum": ["human", "ai", "ai/viz", "ai/failure", "ai/router"],
             "type": "string"
         },
+        "AssistantMultipleBreakdownFilter": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/AssistantGroupMultipleBreakdownFilter"
+                },
+                {
+                    "$ref": "#/definitions/AssistantGenericMultipleBreakdownFilter"
+                }
+            ]
+        },
         "AssistantPropertyFilter": {
             "anyOf": [
                 {
@@ -1065,23 +1136,21 @@
         "AssistantTrendsBreakdownFilter": {
             "additionalProperties": false,
             "properties": {
-                "breakdown_hide_other_aggregation": {
-                    "type": ["boolean", "null"]
-                },
-                "breakdown_histogram_bin_count": {
-                    "type": "integer"
-                },
                 "breakdown_limit": {
+                    "default": 25,
+                    "description": "How many distinct values to show.",
                     "type": "integer"
                 },
                 "breakdowns": {
+                    "description": "Use this field to define breakdowns.",
                     "items": {
-                        "$ref": "#/definitions/Breakdown"
+                        "$ref": "#/definitions/AssistantMultipleBreakdownFilter"
                     },
                     "maxLength": 3,
                     "type": "array"
                 }
             },
+            "required": ["breakdowns"],
             "type": "object"
         },
         "AssistantTrendsEventsNode": {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -543,6 +543,22 @@
             },
             "type": "object"
         },
+        "AssistantCompareFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "compare": {
+                    "default": false,
+                    "description": "Whether to compare the current date range to a previous date range.",
+                    "type": "boolean"
+                },
+                "compare_to": {
+                    "default": "-7d",
+                    "description": "The date range to compare to. The value is a relative date. Examples of relative dates are: `-1y` for 1 year ago, `-14m` for 14 months ago, `-100w` for 100 weeks ago, `-14d` for 14 days ago, `-30h` for 30 hours ago.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AssistantDateTimePropertyFilter": {
             "additionalProperties": false,
             "properties": {
@@ -723,7 +739,7 @@
                     "description": "Breakdown the chart by a property"
                 },
                 "dateRange": {
-                    "$ref": "#/definitions/InsightDateRange",
+                    "$ref": "#/definitions/AssistantInsightDateRange",
                     "description": "Date range for the query"
                 },
                 "filterTestAccounts": {
@@ -752,7 +768,7 @@
                     "type": "array"
                 },
                 "samplingFactor": {
-                    "description": "Sampling rate",
+                    "description": "Sampling rate from 0 to 1 where 1 is 100% of the data.",
                     "type": ["number", "null"]
                 },
                 "series": {
@@ -1024,11 +1040,27 @@
                 }
             ]
         },
+        "AssistantInsightDateRange": {
+            "additionalProperties": false,
+            "properties": {
+                "date_from": {
+                    "default": "-7d",
+                    "description": "Start date. The value can be:\n- a relative date. Examples of relative dates are: `-1y` for 1 year ago, `-14m` for 14 months ago, `-1w` for 1 week ago, `-14d` for 14 days ago, `-30h` for 30 hours ago.\n- an absolute ISO 8601 date string. a constant `yStart` for the current year start. a constant `mStart` for the current month start. a constant `dStart` for the current day start. Prefer using relative dates.",
+                    "type": ["string", "null"]
+                },
+                "date_to": {
+                    "default": null,
+                    "description": "Right boundary of the date range. Use `null` for the current date. You can not use relative dates here.",
+                    "type": ["string", "null"]
+                }
+            },
+            "type": "object"
+        },
         "AssistantInsightsQueryBase": {
             "additionalProperties": false,
             "properties": {
                 "dateRange": {
-                    "$ref": "#/definitions/InsightDateRange",
+                    "$ref": "#/definitions/AssistantInsightDateRange",
                     "description": "Date range for the query"
                 },
                 "filterTestAccounts": {
@@ -1045,7 +1077,7 @@
                     "type": "array"
                 },
                 "samplingFactor": {
-                    "description": "Sampling rate",
+                    "description": "Sampling rate from 0 to 1 where 1 is 100% of the data.",
                     "type": ["number", "null"]
                 }
             },
@@ -1153,6 +1185,49 @@
             "required": ["breakdowns"],
             "type": "object"
         },
+        "AssistantTrendsDisplayType": {
+            "anyOf": [
+                {
+                    "const": "ActionsLineGraph",
+                    "type": "string"
+                },
+                {
+                    "const": "ActionsBar",
+                    "type": "string"
+                },
+                {
+                    "const": "ActionsAreaGraph",
+                    "type": "string"
+                },
+                {
+                    "const": "ActionsLineGraphCumulative",
+                    "type": "string"
+                },
+                {
+                    "const": "BoldNumber",
+                    "type": "string"
+                },
+                {
+                    "const": "ActionsPie",
+                    "type": "string"
+                },
+                {
+                    "const": "ActionsBarValue",
+                    "type": "string"
+                },
+                {
+                    "const": "ActionsTable",
+                    "type": "string"
+                },
+                {
+                    "const": "WorldMap",
+                    "type": "string"
+                },
+                {
+                    "not": {}
+                }
+            ]
+        },
         "AssistantTrendsEventsNode": {
             "additionalProperties": false,
             "properties": {
@@ -1203,6 +1278,70 @@
             "required": ["kind"],
             "type": "object"
         },
+        "AssistantTrendsFilter": {
+            "additionalProperties": false,
+            "properties": {
+                "aggregationAxisFormat": {
+                    "$ref": "#/definitions/AggregationAxisFormat",
+                    "default": "numeric",
+                    "description": "Formats the trends value axis. Do not use the formatting unless you are absolutely sure that formatting will match the data. `numeric` - no formatting. Prefer this option by default. `duration` - formats the value in seconds to a human-readable duration, e.g., `132` becomes `2 minutes 12 seconds`. Use this option only if you are sure that the values are in seconds. `duration_ms` - formats the value in miliseconds to a human-readable duration, e.g., `1050` becomes `1 second 50 milliseconds`. Use this option only if you are sure that the values are in miliseconds. `percentage` - adds a percentage sign to the value, e.g., `50` becomes `50%`. `percentage_scaled` - formats the value as a percentage scaled to 0-100, e.g., `0.5` becomes `50%`."
+                },
+                "aggregationAxisPostfix": {
+                    "description": "Custom postfix to add to the aggregation axis, e.g., ` clicks` to format 5 as `5 clicks`. You may need to add a space before postfix.",
+                    "type": "string"
+                },
+                "aggregationAxisPrefix": {
+                    "description": "Custom prefix to add to the aggregation axis, e.g., `$` for USD dollars. You may need to add a space after prefix.",
+                    "type": "string"
+                },
+                "decimalPlaces": {
+                    "description": "Number of decimal places to show. Do not add this unless you are sure that values will have a decimal point.",
+                    "type": "number"
+                },
+                "display": {
+                    "default": "ActionsLineGraph",
+                    "description": "Changes the visualization type. `ActionsLineGraph` - if the user wants to see dynamics in time like a line graph. Prefer this option. `ActionsLineGraphCumulative` - if the user wants to see cumulative dynamics across time. `ActionsBarValue` - if the data is categorical and needs to be visualized as a bar chart. `ActionsBar` - if the data is categorical and can be visualized as a stacked bar chart. `ActionsPie` - if the data is easy to understand in a pie chart. `BoldNumber` - if the user asks a question where you can answer with a single number. You can't use this option with breakdowns. `ActionsTable` - if the user wants to see a table. `ActionsAreaGraph` - if the data is better visualized in an area graph. `WorldMap` - if the user has only one series and wants to see data from particular countries. It can only be used with the `$geoip_country_name` breakdown.",
+                    "enum": [
+                        "ActionsLineGraph",
+                        "ActionsBar",
+                        "ActionsAreaGraph",
+                        "ActionsLineGraphCumulative",
+                        "BoldNumber",
+                        "ActionsPie",
+                        "ActionsBarValue",
+                        "ActionsTable",
+                        "WorldMap"
+                    ],
+                    "type": "string"
+                },
+                "formula": {
+                    "description": "If the formula is provided, apply it here.",
+                    "type": "string"
+                },
+                "showLegend": {
+                    "default": false,
+                    "description": "Whether to show the legend describing series and breakdowns.",
+                    "type": "boolean"
+                },
+                "showPercentStackView": {
+                    "default": false,
+                    "description": "Whether to show a percentage of each series. Use only with",
+                    "type": "boolean"
+                },
+                "showValuesOnSeries": {
+                    "default": false,
+                    "description": "Whether to show a value on each data point.",
+                    "type": "boolean"
+                },
+                "yAxisScaleType": {
+                    "default": "linear",
+                    "description": "Whether to scale the y-axis.",
+                    "enum": ["log10", "linear"],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "AssistantTrendsMath": {
             "enum": ["first_time_for_user", "first_time_for_user_with_filters"],
             "type": "string"
@@ -1219,7 +1358,7 @@
                     "description": "Compare to date range"
                 },
                 "dateRange": {
-                    "$ref": "#/definitions/InsightDateRange",
+                    "$ref": "#/definitions/AssistantInsightDateRange",
                     "description": "Date range for the query"
                 },
                 "filterTestAccounts": {
@@ -1245,7 +1384,7 @@
                     "type": "array"
                 },
                 "samplingFactor": {
-                    "description": "Sampling rate",
+                    "description": "Sampling rate from 0 to 1 where 1 is 100% of the data.",
                     "type": ["number", "null"]
                 },
                 "series": {
@@ -1256,7 +1395,7 @@
                     "type": "array"
                 },
                 "trendsFilter": {
-                    "$ref": "#/definitions/TrendsFilter",
+                    "$ref": "#/definitions/AssistantTrendsFilter",
                     "description": "Properties specific to the trends insight"
                 }
             },

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -12,13 +12,11 @@ import {
     CountPerActorMathType,
     EventPropertyFilter,
     EventType,
-    FeaturePropertyFilter,
     FilterLogicalOperator,
     FilterType,
     FunnelMathType,
     FunnelsFilterType,
     GroupMathType,
-    GroupPropertyFilter,
     HogQLMathType,
     InsightShortId,
     InsightType,
@@ -28,8 +26,10 @@ import {
     LogEntryPropertyFilter,
     PathsFilterType,
     PersonPropertyFilter,
+    PropertyFilterType,
     PropertyGroupFilter,
     PropertyMathType,
+    PropertyOperator,
     RetentionFilterType,
     SessionPropertyFilter,
     SessionRecordingType,
@@ -905,12 +905,93 @@ export interface TrendsQuery extends InsightsQueryBase<TrendsQueryResponse> {
     compareFilter?: CompareFilter
 }
 
-export type AssistantPropertyFilter =
-    | EventPropertyFilter
-    | PersonPropertyFilter
-    | SessionPropertyFilter
-    | GroupPropertyFilter
-    | FeaturePropertyFilter
+export type AssistantArrayPropertyFilterOperator = PropertyOperator.Exact | PropertyOperator.IsNot
+export interface AssistantArrayPropertyFilter {
+    /**
+     * `exact` - exact match of any of the values.
+     * `is_not` - does not match any of the values.
+     */
+    operator: AssistantArrayPropertyFilterOperator
+    /**
+     * Only use property values from the plan. Always use strings as values. If you have a number, convert it to a string first. If you have a boolean, convert it to a string "true" or "false".
+     */
+    value: string[]
+}
+
+export type AssistantSetPropertyFilterOperator = PropertyOperator.IsSet | PropertyOperator.IsNotSet
+
+export interface AssistantSetPropertyFilter {
+    /**
+     * `is_set` - the property has any value.
+     * `is_not_set` - the property doesn't have a value or wasn't collected.
+     */
+    operator: AssistantSetPropertyFilterOperator
+}
+
+export type AssistantSingleValuePropertyFilterOperator =
+    | PropertyOperator.IContains
+    | PropertyOperator.NotIContains
+    | PropertyOperator.Regex
+    | PropertyOperator.NotRegex
+
+export interface AssistantSingleValuePropertyFilter {
+    /**
+     * `icontains` - case insensitive contains.
+     * `not_icontains` - case insensitive does not contain.
+     * `regex` - matches the regex pattern.
+     * `not_regex` - does not match the regex pattern.
+     */
+    operator: AssistantSingleValuePropertyFilterOperator
+    /**
+     * Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a valid ClickHouse regex pattern to match against.
+     * Otherwise, the value must be a substring that will be matched against the property value.
+     */
+    value: string
+}
+
+export type AssistantStringNumberOrBooleanPropertyFilter =
+    | AssistantSingleValuePropertyFilter
+    | AssistantArrayPropertyFilter
+
+export type AssistantDateTimePropertyFilterOperator =
+    | PropertyOperator.IsDateExact
+    | PropertyOperator.IsDateBefore
+    | PropertyOperator.IsDateAfter
+
+export interface AssistantDateTimePropertyFilter {
+    operator: AssistantDateTimePropertyFilterOperator
+    /**
+     * Value must be a date in ISO 8601 format.
+     */
+    value: string
+}
+
+export type AssistantBasePropertyFilter =
+    | AssistantStringNumberOrBooleanPropertyFilter
+    | AssistantDateTimePropertyFilter
+    | AssistantSetPropertyFilter
+
+export type AssistantGenericPropertyFilter = AssistantBasePropertyFilter & {
+    type: PropertyFilterType.Event | PropertyFilterType.Person | PropertyFilterType.Session | PropertyFilterType.Feature
+    /**
+     * Use one of the properties the user has provided in the plan.
+     */
+    key: string
+}
+
+export type AssistantGroupPropertyFilter = AssistantBasePropertyFilter & {
+    type: PropertyFilterType.Group
+    /**
+     * Use one of the properties the user has provided in the plan.
+     */
+    key: string
+    /**
+     * Index of the group type from the group mapping.
+     */
+    group_type_index: integer
+}
+
+export type AssistantPropertyFilter = AssistantGenericPropertyFilter | AssistantGroupPropertyFilter
 
 export interface AssistantInsightsQueryBase {
     /** Date range for the query */

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -993,22 +993,49 @@ export type AssistantGroupPropertyFilter = AssistantBasePropertyFilter & {
 
 export type AssistantPropertyFilter = AssistantGenericPropertyFilter | AssistantGroupPropertyFilter
 
+export interface AssistantInsightDateRange {
+    /**
+     * Start date. The value can be:
+     * - a relative date. Examples of relative dates are: `-1y` for 1 year ago, `-14m` for 14 months ago, `-1w` for 1 week ago, `-14d` for 14 days ago, `-30h` for 30 hours ago.
+     * - an absolute ISO 8601 date string.
+     * a constant `yStart` for the current year start.
+     * a constant `mStart` for the current month start.
+     * a constant `dStart` for the current day start.
+     * Prefer using relative dates.
+     * @default -7d
+     */
+    date_from?: string | null
+
+    /**
+     * Right boundary of the date range. Use `null` for the current date. You can not use relative dates here.
+     * @default null
+     */
+    date_to?: string | null
+}
+
 export interface AssistantInsightsQueryBase {
-    /** Date range for the query */
-    dateRange?: InsightDateRange
+    /**
+     * Date range for the query
+     */
+    dateRange?: AssistantInsightDateRange
+
     /**
      * Exclude internal and test users by applying the respective filters
      *
      * @default false
      */
     filterTestAccounts?: boolean
+
     /**
      * Property filters for all series
      *
      * @default []
      */
     properties?: AssistantPropertyFilter[]
-    /** Sampling rate */
+
+    /**
+     * Sampling rate from 0 to 1 where 1 is 100% of the data.
+     */
     samplingFactor?: number | null
 }
 
@@ -1058,21 +1085,123 @@ export interface AssistantTrendsBreakdownFilter extends AssistantBreakdownFilter
     breakdowns: AssistantMultipleBreakdownFilter[]
 }
 
+// Remove deprecated display types.
+export type AssistantTrendsDisplayType = Exclude<TrendsFilterLegacy['display'], 'ActionsStackedBar'>
+
+export interface AssistantTrendsFilter {
+    /**
+     * If the formula is provided, apply it here.
+     */
+    formula?: TrendsFilterLegacy['formula']
+
+    /**
+     * Changes the visualization type.
+     * `ActionsLineGraph` - if the user wants to see dynamics in time like a line graph. Prefer this option.
+     * `ActionsLineGraphCumulative` - if the user wants to see cumulative dynamics across time.
+     * `ActionsBarValue` - if the data is categorical and needs to be visualized as a bar chart.
+     * `ActionsBar` - if the data is categorical and can be visualized as a stacked bar chart.
+     * `ActionsPie` - if the data is easy to understand in a pie chart.
+     * `BoldNumber` - if the user asks a question where you can answer with a single number. You can't use this option with breakdowns.
+     * `ActionsTable` - if the user wants to see a table.
+     * `ActionsAreaGraph` - if the data is better visualized in an area graph.
+     * `WorldMap` - if the user has only one series and wants to see data from particular countries. It can only be used with the `$geoip_country_name` breakdown.
+     * @default ActionsLineGraph
+     */
+    display?: AssistantTrendsDisplayType
+
+    /**
+     * Whether to show the legend describing series and breakdowns.
+     * @default false
+     */
+    showLegend?: TrendsFilterLegacy['show_legend']
+
+    /**
+     * Formats the trends value axis. Do not use the formatting unless you are absolutely sure that formatting will match the data.
+     * `numeric` - no formatting. Prefer this option by default.
+     * `duration` - formats the value in seconds to a human-readable duration, e.g., `132` becomes `2 minutes 12 seconds`. Use this option only if you are sure that the values are in seconds.
+     * `duration_ms` - formats the value in miliseconds to a human-readable duration, e.g., `1050` becomes `1 second 50 milliseconds`. Use this option only if you are sure that the values are in miliseconds.
+     * `percentage` - adds a percentage sign to the value, e.g., `50` becomes `50%`.
+     * `percentage_scaled` - formats the value as a percentage scaled to 0-100, e.g., `0.5` becomes `50%`.
+     * @default numeric
+     */
+    aggregationAxisFormat?: TrendsFilterLegacy['aggregation_axis_format']
+
+    /**
+     * Custom prefix to add to the aggregation axis, e.g., `$` for USD dollars. You may need to add a space after prefix.
+     */
+    aggregationAxisPrefix?: TrendsFilterLegacy['aggregation_axis_prefix']
+
+    /**
+     * Custom postfix to add to the aggregation axis, e.g., ` clicks` to format 5 as `5 clicks`. You may need to add a space before postfix.
+     */
+    aggregationAxisPostfix?: TrendsFilterLegacy['aggregation_axis_postfix']
+
+    /**
+     * Number of decimal places to show. Do not add this unless you are sure that values will have a decimal point.
+     */
+    decimalPlaces?: TrendsFilterLegacy['decimal_places']
+
+    /**
+     * Whether to show a value on each data point.
+     * @default false
+     */
+    showValuesOnSeries?: TrendsFilterLegacy['show_values_on_series']
+
+    /**
+     * Whether to show a percentage of each series. Use only with
+     * @default false
+     */
+    showPercentStackView?: TrendsFilterLegacy['show_percent_stack_view']
+
+    /**
+     * Whether to scale the y-axis.
+     * @default linear
+     */
+    yAxisScaleType?: TrendsFilterLegacy['y_axis_scale_type']
+}
+
+export interface AssistantCompareFilter {
+    /**
+     * Whether to compare the current date range to a previous date range.
+     * @default false
+     */
+    compare?: boolean
+
+    /**
+     * The date range to compare to. The value is a relative date. Examples of relative dates are: `-1y` for 1 year ago, `-14m` for 14 months ago, `-100w` for 100 weeks ago, `-14d` for 14 days ago, `-30h` for 30 hours ago.
+     * @default -7d
+     */
+    compare_to?: string
+}
+
 export interface AssistantTrendsQuery extends AssistantInsightsQueryBase {
     kind: NodeKind.TrendsQuery
+
     /**
      * Granularity of the response. Can be one of `hour`, `day`, `week` or `month`
      *
      * @default day
      */
     interval?: IntervalType
-    /** Events to include */
+
+    /**
+     * Events to include
+     */
     series: AssistantTrendsEventsNode[]
-    /** Properties specific to the trends insight */
-    trendsFilter?: TrendsFilter
-    /** Breakdown of the events */
+
+    /**
+     * Properties specific to the trends insight
+     */
+    trendsFilter?: AssistantTrendsFilter
+
+    /**
+     * Breakdown of the events
+     */
     breakdownFilter?: AssistantTrendsBreakdownFilter
-    /** Compare to date range */
+
+    /**
+     * Compare to date range
+     */
     compareFilter?: CompareFilter
 }
 

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1017,10 +1017,46 @@ export interface AssistantTrendsEventsNode
     properties?: AssistantPropertyFilter[]
 }
 
-export type AssistantTrendsBreakdownFilter = Pick<
-    BreakdownFilter,
-    'breakdowns' | 'breakdown_limit' | 'breakdown_histogram_bin_count' | 'breakdown_hide_other_aggregation'
->
+export interface AssistantBaseMultipleBreakdownFilter {
+    /**
+     * Property name from the plan to break down by.
+     */
+    property: string
+}
+
+export interface AssistantGroupMultipleBreakdownFilter extends AssistantBaseMultipleBreakdownFilter {
+    type: 'group'
+    /**
+     * Index of the group type from the group mapping.
+     */
+    group_type_index?: integer | null
+}
+
+export type AssistantEventMultipleBreakdownFilterType = Exclude<MultipleBreakdownType, 'group'>
+
+export interface AssistantGenericMultipleBreakdownFilter extends AssistantBaseMultipleBreakdownFilter {
+    type: AssistantEventMultipleBreakdownFilterType
+}
+
+export type AssistantMultipleBreakdownFilter =
+    | AssistantGroupMultipleBreakdownFilter
+    | AssistantGenericMultipleBreakdownFilter
+
+export interface AssistantBreakdownFilter {
+    /**
+     * How many distinct values to show.
+     * @default 25
+     */
+    breakdown_limit?: integer
+}
+
+export interface AssistantTrendsBreakdownFilter extends AssistantBreakdownFilter {
+    /**
+     * Use this field to define breakdowns.
+     * @maxLength 3
+     */
+    breakdowns: AssistantMultipleBreakdownFilter[]
+}
 
 export interface AssistantTrendsQuery extends AssistantInsightsQueryBase {
     kind: NodeKind.TrendsQuery
@@ -1126,7 +1162,7 @@ export interface AssistantFunnelsFilter {
 
 export type AssistantFunnelsBreakdownType = Extract<BreakdownType, 'person' | 'event' | 'group' | 'session'>
 
-export interface AssistantFunnelsBreakdownFilter {
+export interface AssistantFunnelsBreakdownFilter extends AssistantBreakdownFilter {
     /**
      * Type of the entity to break down by. If `group` is used, you must also provide `breakdown_group_type_index` from the group mapping.
      * @default event
@@ -1137,19 +1173,9 @@ export interface AssistantFunnelsBreakdownFilter {
      */
     breakdown: string
     /**
-     * How many distinct values to show.
-     * @default 25
-     */
-    breakdown_limit?: integer
-    /**
      * If `breakdown_type` is `group`, this is the index of the group. Use the index from the group mapping.
      */
     breakdown_group_type_index?: integer | null
-    /**
-     * Number of bins to show in the histogram. Only applicable for the numeric properties.
-     * @default 10
-     */
-    breakdown_histogram_bin_count?: integer
 }
 
 export interface AssistantFunnelsQuery extends AssistantInsightsQueryBase {

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -929,6 +929,8 @@ export interface AssistantSetPropertyFilter {
 }
 
 export type AssistantSingleValuePropertyFilterOperator =
+    | PropertyOperator.Exact
+    | PropertyOperator.IsNot
     | PropertyOperator.IContains
     | PropertyOperator.NotIContains
     | PropertyOperator.Regex

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -264,6 +264,8 @@ class AssistantSetPropertyFilterOperator(StrEnum):
 
 
 class AssistantSingleValuePropertyFilterOperator(StrEnum):
+    EXACT = "exact"
+    IS_NOT = "is_not"
     ICONTAINS = "icontains"
     NOT_ICONTAINS = "not_icontains"
     REGEX = "regex"

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -68,10 +68,31 @@ class AssistantArrayPropertyFilterOperator(StrEnum):
     IS_NOT = "is_not"
 
 
+class AssistantBaseMultipleBreakdownFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    property: str = Field(..., description="Property name from the plan to break down by.")
+
+
+class AssistantBreakdownFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    breakdown_limit: Optional[int] = Field(default=25, description="How many distinct values to show.")
+
+
 class AssistantDateTimePropertyFilterOperator(StrEnum):
     IS_DATE_EXACT = "is_date_exact"
     IS_DATE_BEFORE = "is_date_before"
     IS_DATE_AFTER = "is_date_after"
+
+
+class AssistantEventMultipleBreakdownFilterType(StrEnum):
+    PERSON = "person"
+    EVENT = "event"
+    SESSION = "session"
+    HOGQL = "hogql"
 
 
 class AssistantEventType(StrEnum):
@@ -99,6 +120,14 @@ class AssistantFunnelsExclusionEventsNode(BaseModel):
 class AssistantGenerationStatusType(StrEnum):
     ACK = "ack"
     GENERATION_ERROR = "generation_error"
+
+
+class AssistantGenericMultipleBreakdownFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    property: str = Field(..., description="Property name from the plan to break down by.")
+    type: AssistantEventMultipleBreakdownFilterType
 
 
 class Type(StrEnum):
@@ -134,6 +163,15 @@ class AssistantGenericPropertyFilter3(BaseModel):
     operator: AssistantDateTimePropertyFilterOperator
     type: Type
     value: str = Field(..., description="Value must be a date in ISO 8601 format.")
+
+
+class AssistantGroupMultipleBreakdownFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    group_type_index: Optional[int] = Field(default=None, description="Index of the group type from the group mapping.")
+    property: str = Field(..., description="Property name from the plan to break down by.")
+    type: Literal["group"] = "group"
 
 
 class AssistantGroupPropertyFilter2(BaseModel):
@@ -192,6 +230,16 @@ class AssistantSingleValuePropertyFilterOperator(StrEnum):
     NOT_ICONTAINS = "not_icontains"
     REGEX = "regex"
     NOT_REGEX = "not_regex"
+
+
+class AssistantTrendsBreakdownFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    breakdown_limit: Optional[int] = Field(default=25, description="How many distinct values to show.")
+    breakdowns: list[Union[AssistantGroupMultipleBreakdownFilter, AssistantGenericMultipleBreakdownFilter]] = Field(
+        ..., description="Use this field to define breakdowns.", max_length=3
+    )
 
 
 class AssistantTrendsMath(StrEnum):
@@ -1842,9 +1890,6 @@ class AssistantFunnelsBreakdownFilter(BaseModel):
         description=(
             "If `breakdown_type` is `group`, this is the index of the group. Use the index from the group mapping."
         ),
-    )
-    breakdown_histogram_bin_count: Optional[int] = Field(
-        default=10, description="Number of bins to show in the histogram. Only applicable for the numeric properties."
     )
     breakdown_limit: Optional[int] = Field(default=25, description="How many distinct values to show.")
     breakdown_type: Optional[AssistantFunnelsBreakdownType] = Field(
@@ -4528,16 +4573,6 @@ class AssistantInsightsQueryBase(BaseModel):
         ]
     ] = Field(default=[], description="Property filters for all series")
     samplingFactor: Optional[float] = Field(default=None, description="Sampling rate")
-
-
-class AssistantTrendsBreakdownFilter(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    breakdown_hide_other_aggregation: Optional[bool] = None
-    breakdown_histogram_bin_count: Optional[int] = None
-    breakdown_limit: Optional[int] = None
-    breakdowns: Optional[list[Breakdown]] = Field(default=None, max_length=3)
 
 
 class AssistantTrendsEventsNode(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -63,6 +63,17 @@ class AlertState(StrEnum):
     SNOOZED = "Snoozed"
 
 
+class AssistantArrayPropertyFilterOperator(StrEnum):
+    EXACT = "exact"
+    IS_NOT = "is_not"
+
+
+class AssistantDateTimePropertyFilterOperator(StrEnum):
+    IS_DATE_EXACT = "is_date_exact"
+    IS_DATE_BEFORE = "is_date_before"
+    IS_DATE_AFTER = "is_date_after"
+
+
 class AssistantEventType(StrEnum):
     STATUS = "status"
     MESSAGE = "message"
@@ -90,6 +101,71 @@ class AssistantGenerationStatusType(StrEnum):
     GENERATION_ERROR = "generation_error"
 
 
+class Type(StrEnum):
+    EVENT = "event"
+    PERSON = "person"
+    SESSION = "session"
+    FEATURE = "feature"
+
+
+class AssistantGenericPropertyFilter2(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    key: str = Field(..., description="Use one of the properties the user has provided in the plan.")
+    operator: AssistantArrayPropertyFilterOperator = Field(
+        ..., description="`exact` - exact match of any of the values. `is_not` - does not match any of the values."
+    )
+    type: Type
+    value: list[str] = Field(
+        ...,
+        description=(
+            "Only use property values from the plan. Always use strings as values. If you have a number, convert it to"
+            ' a string first. If you have a boolean, convert it to a string "true" or "false".'
+        ),
+    )
+
+
+class AssistantGenericPropertyFilter3(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    key: str = Field(..., description="Use one of the properties the user has provided in the plan.")
+    operator: AssistantDateTimePropertyFilterOperator
+    type: Type
+    value: str = Field(..., description="Value must be a date in ISO 8601 format.")
+
+
+class AssistantGroupPropertyFilter2(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    group_type_index: int = Field(..., description="Index of the group type from the group mapping.")
+    key: str = Field(..., description="Use one of the properties the user has provided in the plan.")
+    operator: AssistantArrayPropertyFilterOperator = Field(
+        ..., description="`exact` - exact match of any of the values. `is_not` - does not match any of the values."
+    )
+    type: Literal["group"] = "group"
+    value: list[str] = Field(
+        ...,
+        description=(
+            "Only use property values from the plan. Always use strings as values. If you have a number, convert it to"
+            ' a string first. If you have a boolean, convert it to a string "true" or "false".'
+        ),
+    )
+
+
+class AssistantGroupPropertyFilter3(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    group_type_index: int = Field(..., description="Index of the group type from the group mapping.")
+    key: str = Field(..., description="Use one of the properties the user has provided in the plan.")
+    operator: AssistantDateTimePropertyFilterOperator
+    type: Literal["group"] = "group"
+    value: str = Field(..., description="Value must be a date in ISO 8601 format.")
+
+
 class AssistantMessage(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -104,6 +180,18 @@ class AssistantMessageType(StrEnum):
     AI_VIZ = "ai/viz"
     AI_FAILURE = "ai/failure"
     AI_ROUTER = "ai/router"
+
+
+class AssistantSetPropertyFilterOperator(StrEnum):
+    IS_SET = "is_set"
+    IS_NOT_SET = "is_not_set"
+
+
+class AssistantSingleValuePropertyFilterOperator(StrEnum):
+    ICONTAINS = "icontains"
+    NOT_ICONTAINS = "not_icontains"
+    REGEX = "regex"
+    NOT_REGEX = "not_regex"
 
 
 class AssistantTrendsMath(StrEnum):
@@ -339,7 +427,7 @@ class DatabaseSchemaSource(BaseModel):
     status: str
 
 
-class Type(StrEnum):
+class Type4(StrEnum):
     POSTHOG = "posthog"
     DATA_WAREHOUSE = "data_warehouse"
     VIEW = "view"
@@ -1720,6 +1808,30 @@ class AlertCondition(BaseModel):
     type: AlertConditionType
 
 
+class AssistantArrayPropertyFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    operator: AssistantArrayPropertyFilterOperator = Field(
+        ..., description="`exact` - exact match of any of the values. `is_not` - does not match any of the values."
+    )
+    value: list[str] = Field(
+        ...,
+        description=(
+            "Only use property values from the plan. Always use strings as values. If you have a number, convert it to"
+            ' a string first. If you have a boolean, convert it to a string "true" or "false".'
+        ),
+    )
+
+
+class AssistantDateTimePropertyFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    operator: AssistantDateTimePropertyFilterOperator
+    value: str = Field(..., description="Value must be a date in ISO 8601 format.")
+
+
 class AssistantFunnelsBreakdownFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1821,6 +1933,118 @@ class AssistantGenerationStatusEvent(BaseModel):
         extra="forbid",
     )
     type: AssistantGenerationStatusType
+
+
+class AssistantGenericPropertyFilter1(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    key: str = Field(..., description="Use one of the properties the user has provided in the plan.")
+    operator: AssistantSingleValuePropertyFilterOperator = Field(
+        ...,
+        description=(
+            "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` -"
+            " matches the regex pattern. `not_regex` - does not match the regex pattern."
+        ),
+    )
+    type: Type
+    value: str = Field(
+        ...,
+        description=(
+            "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a"
+            " valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be"
+            " matched against the property value."
+        ),
+    )
+
+
+class AssistantGenericPropertyFilter4(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    key: str = Field(..., description="Use one of the properties the user has provided in the plan.")
+    operator: AssistantSetPropertyFilterOperator = Field(
+        ...,
+        description=(
+            "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't"
+            " collected."
+        ),
+    )
+    type: Type
+
+
+class AssistantGroupPropertyFilter1(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    group_type_index: int = Field(..., description="Index of the group type from the group mapping.")
+    key: str = Field(..., description="Use one of the properties the user has provided in the plan.")
+    operator: AssistantSingleValuePropertyFilterOperator = Field(
+        ...,
+        description=(
+            "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` -"
+            " matches the regex pattern. `not_regex` - does not match the regex pattern."
+        ),
+    )
+    type: Literal["group"] = "group"
+    value: str = Field(
+        ...,
+        description=(
+            "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a"
+            " valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be"
+            " matched against the property value."
+        ),
+    )
+
+
+class AssistantGroupPropertyFilter4(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    group_type_index: int = Field(..., description="Index of the group type from the group mapping.")
+    key: str = Field(..., description="Use one of the properties the user has provided in the plan.")
+    operator: AssistantSetPropertyFilterOperator = Field(
+        ...,
+        description=(
+            "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't"
+            " collected."
+        ),
+    )
+    type: Literal["group"] = "group"
+
+
+class AssistantSetPropertyFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    operator: AssistantSetPropertyFilterOperator = Field(
+        ...,
+        description=(
+            "`is_set` - the property has any value. `is_not_set` - the property doesn't have a value or wasn't"
+            " collected."
+        ),
+    )
+
+
+class AssistantSingleValuePropertyFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    operator: AssistantSingleValuePropertyFilterOperator = Field(
+        ...,
+        description=(
+            "`icontains` - case insensitive contains. `not_icontains` - case insensitive does not contain. `regex` -"
+            " matches the regex pattern. `not_regex` - does not match the regex pattern."
+        ),
+    )
+    value: str = Field(
+        ...,
+        description=(
+            "Only use property values from the plan. If the operator is `regex` or `not_regex`, the value must be a"
+            " valid ClickHouse regex pattern to match against. Otherwise, the value must be a substring that will be"
+            " matched against the property value."
+        ),
+    )
 
 
 class AutocompleteCompletionItem(BaseModel):
@@ -2778,7 +3002,7 @@ class DatabaseSchemaTableCommon(BaseModel):
     fields: dict[str, DatabaseSchemaField]
     id: str
     name: str
-    type: Type
+    type: Type4
 
 
 class ElementPropertyFilter(BaseModel):
@@ -4175,6 +4399,137 @@ class AnyResponseType(
     ]
 
 
+class AssistantBasePropertyFilter(
+    RootModel[
+        Union[
+            AssistantDateTimePropertyFilter,
+            AssistantSetPropertyFilter,
+            Union[AssistantSingleValuePropertyFilter, AssistantArrayPropertyFilter],
+        ]
+    ]
+):
+    root: Union[
+        AssistantDateTimePropertyFilter,
+        AssistantSetPropertyFilter,
+        Union[AssistantSingleValuePropertyFilter, AssistantArrayPropertyFilter],
+    ]
+
+
+class AssistantFunnelsEventsNode(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    custom_name: Optional[str] = Field(
+        default=None, description="Optional custom name for the event if it is needed to be renamed."
+    )
+    event: str = Field(..., description="Name of the event.")
+    kind: Literal["EventsNode"] = "EventsNode"
+    math: Optional[AssistantTrendsMath] = Field(
+        default=None,
+        description=(
+            "Optional math aggregation type for the series. Only specify this math type if the user wants one of these."
+            " `first_time_for_user` - counts the number of users who have completed the event for the first time ever."
+            " `first_time_for_user_with_filters` - counts the number of users who have completed the event with"
+            " specified filters for the first time."
+        ),
+    )
+    properties: Optional[
+        list[
+            Union[
+                Union[
+                    AssistantGenericPropertyFilter1,
+                    AssistantGenericPropertyFilter2,
+                    AssistantGenericPropertyFilter3,
+                    AssistantGenericPropertyFilter4,
+                ],
+                Union[
+                    AssistantGroupPropertyFilter1,
+                    AssistantGroupPropertyFilter2,
+                    AssistantGroupPropertyFilter3,
+                    AssistantGroupPropertyFilter4,
+                ],
+            ]
+        ]
+    ] = None
+    response: Optional[dict[str, Any]] = None
+
+
+class AssistantFunnelsQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    aggregation_group_type_index: Optional[int] = Field(
+        default=None,
+        description=(
+            "Use this field to define the aggregation by a specific group from the group mapping that the user has"
+            " provided."
+        ),
+    )
+    breakdownFilter: Optional[AssistantFunnelsBreakdownFilter] = Field(
+        default=None, description="Breakdown the chart by a property"
+    )
+    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
+    filterTestAccounts: Optional[bool] = Field(
+        default=False, description="Exclude internal and test users by applying the respective filters"
+    )
+    funnelsFilter: Optional[AssistantFunnelsFilter] = Field(
+        default=None, description="Properties specific to the funnels insight"
+    )
+    interval: Optional[IntervalType] = Field(
+        default=None, description="Granularity of the response. Can be one of `hour`, `day`, `week` or `month`"
+    )
+    kind: Literal["FunnelsQuery"] = "FunnelsQuery"
+    properties: Optional[
+        list[
+            Union[
+                Union[
+                    AssistantGenericPropertyFilter1,
+                    AssistantGenericPropertyFilter2,
+                    AssistantGenericPropertyFilter3,
+                    AssistantGenericPropertyFilter4,
+                ],
+                Union[
+                    AssistantGroupPropertyFilter1,
+                    AssistantGroupPropertyFilter2,
+                    AssistantGroupPropertyFilter3,
+                    AssistantGroupPropertyFilter4,
+                ],
+            ]
+        ]
+    ] = Field(default=[], description="Property filters for all series")
+    samplingFactor: Optional[float] = Field(default=None, description="Sampling rate")
+    series: list[AssistantFunnelsEventsNode] = Field(..., description="Events to include")
+
+
+class AssistantInsightsQueryBase(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
+    filterTestAccounts: Optional[bool] = Field(
+        default=False, description="Exclude internal and test users by applying the respective filters"
+    )
+    properties: Optional[
+        list[
+            Union[
+                Union[
+                    AssistantGenericPropertyFilter1,
+                    AssistantGenericPropertyFilter2,
+                    AssistantGenericPropertyFilter3,
+                    AssistantGenericPropertyFilter4,
+                ],
+                Union[
+                    AssistantGroupPropertyFilter1,
+                    AssistantGroupPropertyFilter2,
+                    AssistantGroupPropertyFilter3,
+                    AssistantGroupPropertyFilter4,
+                ],
+            ]
+        ]
+    ] = Field(default=[], description="Property filters for all series")
+    samplingFactor: Optional[float] = Field(default=None, description="Sampling rate")
+
+
 class AssistantTrendsBreakdownFilter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -4210,11 +4565,18 @@ class AssistantTrendsEventsNode(BaseModel):
     properties: Optional[
         list[
             Union[
-                EventPropertyFilter,
-                PersonPropertyFilter,
-                SessionPropertyFilter,
-                GroupPropertyFilter,
-                FeaturePropertyFilter,
+                Union[
+                    AssistantGenericPropertyFilter1,
+                    AssistantGenericPropertyFilter2,
+                    AssistantGenericPropertyFilter3,
+                    AssistantGenericPropertyFilter4,
+                ],
+                Union[
+                    AssistantGroupPropertyFilter1,
+                    AssistantGroupPropertyFilter2,
+                    AssistantGroupPropertyFilter3,
+                    AssistantGroupPropertyFilter4,
+                ],
             ]
         ]
     ] = None
@@ -4241,11 +4603,18 @@ class AssistantTrendsQuery(BaseModel):
     properties: Optional[
         list[
             Union[
-                EventPropertyFilter,
-                PersonPropertyFilter,
-                SessionPropertyFilter,
-                GroupPropertyFilter,
-                FeaturePropertyFilter,
+                Union[
+                    AssistantGenericPropertyFilter1,
+                    AssistantGenericPropertyFilter2,
+                    AssistantGenericPropertyFilter3,
+                    AssistantGenericPropertyFilter4,
+                ],
+                Union[
+                    AssistantGroupPropertyFilter1,
+                    AssistantGroupPropertyFilter2,
+                    AssistantGroupPropertyFilter3,
+                    AssistantGroupPropertyFilter4,
+                ],
             ]
         ]
     ] = Field(default=[], description="Property filters for all series")
@@ -5086,6 +5455,16 @@ class TeamTaxonomyQuery(BaseModel):
     response: Optional[TeamTaxonomyQueryResponse] = None
 
 
+class VisualizationMessage(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    answer: Optional[Union[AssistantTrendsQuery, AssistantFunnelsQuery]] = None
+    plan: Optional[str] = None
+    reasoning_steps: Optional[list[str]] = None
+    type: Literal["ai/viz"] = "ai/viz"
+
+
 class WebOverviewQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -5169,100 +5548,6 @@ class ActionsNode(BaseModel):
         ]
     ] = Field(default=None, description="Properties configurable in the interface")
     response: Optional[dict[str, Any]] = None
-
-
-class AssistantFunnelsEventsNode(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    custom_name: Optional[str] = Field(
-        default=None, description="Optional custom name for the event if it is needed to be renamed."
-    )
-    event: str = Field(..., description="Name of the event.")
-    kind: Literal["EventsNode"] = "EventsNode"
-    math: Optional[AssistantTrendsMath] = Field(
-        default=None,
-        description=(
-            "Optional math aggregation type for the series. Only specify this math type if the user wants one of these."
-            " `first_time_for_user` - counts the number of users who have completed the event for the first time ever."
-            " `first_time_for_user_with_filters` - counts the number of users who have completed the event with"
-            " specified filters for the first time."
-        ),
-    )
-    properties: Optional[
-        list[
-            Union[
-                EventPropertyFilter,
-                PersonPropertyFilter,
-                SessionPropertyFilter,
-                GroupPropertyFilter,
-                FeaturePropertyFilter,
-            ]
-        ]
-    ] = None
-    response: Optional[dict[str, Any]] = None
-
-
-class AssistantFunnelsQuery(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    aggregation_group_type_index: Optional[int] = Field(
-        default=None,
-        description=(
-            "Use this field to define the aggregation by a specific group from the group mapping that the user has"
-            " provided."
-        ),
-    )
-    breakdownFilter: Optional[AssistantFunnelsBreakdownFilter] = Field(
-        default=None, description="Breakdown the chart by a property"
-    )
-    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
-    filterTestAccounts: Optional[bool] = Field(
-        default=False, description="Exclude internal and test users by applying the respective filters"
-    )
-    funnelsFilter: Optional[AssistantFunnelsFilter] = Field(
-        default=None, description="Properties specific to the funnels insight"
-    )
-    interval: Optional[IntervalType] = Field(
-        default=None, description="Granularity of the response. Can be one of `hour`, `day`, `week` or `month`"
-    )
-    kind: Literal["FunnelsQuery"] = "FunnelsQuery"
-    properties: Optional[
-        list[
-            Union[
-                EventPropertyFilter,
-                PersonPropertyFilter,
-                SessionPropertyFilter,
-                GroupPropertyFilter,
-                FeaturePropertyFilter,
-            ]
-        ]
-    ] = Field(default=[], description="Property filters for all series")
-    samplingFactor: Optional[float] = Field(default=None, description="Sampling rate")
-    series: list[AssistantFunnelsEventsNode] = Field(..., description="Events to include")
-
-
-class AssistantInsightsQueryBase(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
-    filterTestAccounts: Optional[bool] = Field(
-        default=False, description="Exclude internal and test users by applying the respective filters"
-    )
-    properties: Optional[
-        list[
-            Union[
-                EventPropertyFilter,
-                PersonPropertyFilter,
-                SessionPropertyFilter,
-                GroupPropertyFilter,
-                FeaturePropertyFilter,
-            ]
-        ]
-    ] = Field(default=[], description="Property filters for all series")
-    samplingFactor: Optional[float] = Field(default=None, description="Sampling rate")
 
 
 class DataVisualizationNode(BaseModel):
@@ -5437,6 +5722,12 @@ class RetentionQuery(BaseModel):
     samplingFactor: Optional[float] = Field(default=None, description="Sampling rate")
 
 
+class RootAssistantMessage(
+    RootModel[Union[VisualizationMessage, AssistantMessage, HumanMessage, FailureMessage, RouterMessage]]
+):
+    root: Union[VisualizationMessage, AssistantMessage, HumanMessage, FailureMessage, RouterMessage]
+
+
 class StickinessQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -5533,16 +5824,6 @@ class TrendsQuery(BaseModel):
         ..., description="Events and actions to include"
     )
     trendsFilter: Optional[TrendsFilter] = Field(default=None, description="Properties specific to the trends insight")
-
-
-class VisualizationMessage(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    answer: Optional[Union[AssistantTrendsQuery, AssistantFunnelsQuery]] = None
-    plan: Optional[str] = None
-    reasoning_steps: Optional[list[str]] = None
-    type: Literal["ai/viz"] = "ai/viz"
 
 
 class CachedExperimentTrendsQueryResponse(BaseModel):
@@ -6151,12 +6432,6 @@ class QueryResponseAlternative(
         QueryResponseAlternative40,
         QueryResponseAlternative41,
     ]
-
-
-class RootAssistantMessage(
-    RootModel[Union[VisualizationMessage, AssistantMessage, HumanMessage, FailureMessage, RouterMessage]]
-):
-    root: Union[VisualizationMessage, AssistantMessage, HumanMessage, FailureMessage, RouterMessage]
 
 
 class CachedExperimentFunnelsQueryResponse(BaseModel):


### PR DESCRIPTION
## Problem

The Trends schema wasn't properly described. Many details are now encapsulated in the JSON schema rather than being kept at the prompt.

## Changes

- Describe the Trends schema.
- Remove confusing properties.
- Remove details from the prompt.
- Rewrite the prompt to fight breakdowns and `is set` filters.
- Add a test checking for groups.
- Remove examples from events.
- Fix some edge cases with system properties.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Manual testing, unit testing, more tests.
