### PR TITLE
fix(product-assistant): merge schema definitions

### DIFF
--- a/ee/hogai/funnels/toolkit.py
+++ b/ee/hogai/funnels/toolkit.py
@@ -1,5 +1,5 @@
 from ee.hogai.taxonomy_agent.toolkit import TaxonomyAgentToolkit, ToolkitTool
-from ee.hogai.utils import flatten_schema
+from ee.hogai.utils import dereference_schema
 from posthog.schema import AssistantFunnelsQuery
 
 
@@ -84,7 +84,7 @@ def generate_funnel_schema() -> dict:
                     "items": {"type": "string"},
                     "description": "The reasoning steps leading to the final conclusion that will be shown to the user. Use 'you' if you want to refer to the user.",
                 },
-                "answer": flatten_schema(schema),
+                "answer": dereference_schema(schema),
             },
             "additionalProperties": False,
             "required": ["reasoning_steps", "answer"],

--- a/ee/hogai/trends/toolkit.py
+++ b/ee/hogai/trends/toolkit.py
@@ -1,5 +1,5 @@
 from ee.hogai.taxonomy_agent.toolkit import TaxonomyAgentToolkit, ToolkitTool
-from ee.hogai.utils import flatten_schema
+from ee.hogai.utils import dereference_schema
 from posthog.schema import (
     AssistantTrendsQuery,
 )
@@ -88,7 +88,7 @@ def generate_trends_schema() -> dict:
                     "items": {"type": "string"},
                     "description": "The reasoning steps leading to the final conclusion that will be shown to the user. Use 'you' if you want to refer to the user.",
                 },
-                "answer": flatten_schema(schema),
+                "answer": dereference_schema(schema),
             },
             "additionalProperties": False,
             "required": ["reasoning_steps", "answer"],

--- a/ee/hogai/utils.py
+++ b/ee/hogai/utils.py
@@ -1,10 +1,10 @@
-import json
 import operator
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from enum import StrEnum
-from typing import Annotated, Any, Optional, TypedDict, Union
+from typing import Annotated, Optional, TypedDict, Union
 
+from jsonref import replace_refs
 from langchain_core.agents import AgentAction
 from langchain_core.messages import (
     HumanMessage as LangchainHumanMessage,
@@ -106,26 +106,8 @@ def filter_visualization_conversation(
     return human_messages, visualization_messages
 
 
-def replace_value_in_dict(item: Any, original_schema: Any):
-    if isinstance(item, list):
-        return [replace_value_in_dict(i, original_schema) for i in item]
-    elif isinstance(item, dict):
-        if list(item.keys()) == ["$ref"]:
-            definitions = item["$ref"][2:].split("/")
-            res = original_schema.copy()
-            for definition in definitions:
-                res = res[definition]
-            return res
-        else:
-            return {key: replace_value_in_dict(i, original_schema) for key, i in item.items()}
-    else:
-        return item
-
-
-def flatten_schema(schema: dict):
-    for _ in range(100):
-        if "$ref" not in json.dumps(schema):
-            break
-        schema = replace_value_in_dict(schema.copy(), schema.copy())
-    del schema["$defs"]
-    return schema
+def dereference_schema(schema: dict) -> dict:
+    new_schema: dict = replace_refs(schema, proxies=False, lazy_load=False)
+    if "$defs" in new_schema:
+        new_schema.pop("$defs")
+    return new_schema

--- a/requirements.in
+++ b/requirements.in
@@ -42,6 +42,7 @@ geoip2==4.6.0
 google-cloud-bigquery==3.26
 gunicorn==20.1.0
 infi-clickhouse-orm@ git+https://github.com/PostHog/infi.clickhouse_orm@9578c79f29635ee2c1d01b7979e89adab8383de2
+jsonref==1.1.0
 kafka-python==2.0.2
 kombu==5.3.2
 langchain==0.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -327,6 +327,8 @@ jsonpath-ng==1.6.0
     # via dlt
 jsonpointer==3.0.0
     # via jsonpatch
+jsonref==1.1.0
+    # via -r requirements.in
 jsonschema==4.20.0
     # via drf-spectacular
 jsonschema-specifications==2023.12.1


### PR DESCRIPTION
## Problem

JSON schemas without references perform an order of magnitude better. Currently, we remove references using a simple recursion function, but it doesn't handle edge cases like merging definitions and the JSON schema spec.

## Changes

- Use the `jsonref` package that dereferences a schema.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Manual testing.
 