### PR TITLE
perf: Speed up persons batch export

### DIFF
--- a/posthog/batch_exports/sql.py
+++ b/posthog/batch_exports/sql.py
@@ -102,6 +102,8 @@ CREATE OR REPLACE VIEW persons_batch_export ON CLUSTER {settings.CLICKHOUSE_CLUS
     WHERE
         p.team_id = {{team_id:Int64}} AND
         (p.id, p.version) IN (SELECT id, version FROM all_new_persons)
+    ORDER BY
+        _inserted_at
 )
 
 """

--- a/posthog/batch_exports/sql.py
+++ b/posthog/batch_exports/sql.py
@@ -2,62 +2,108 @@ from django.conf import settings
 
 CREATE_PERSONS_BATCH_EXPORT_VIEW = f"""
 CREATE OR REPLACE VIEW persons_batch_export ON CLUSTER {settings.CLICKHOUSE_CLUSTER} AS (
+    WITH
+        new_persons AS (
+            SELECT
+                id,
+                MAX(version) AS version,
+                argMax(_timestamp, version) AS _timestamp2
+            FROM
+                person
+            WHERE
+                team_id = {{team_id:Int64}} AND
+                id IN (
+                    SELECT id
+                    FROM person
+                    WHERE
+                        team_id = {{team_id:Int64}} AND
+                        _timestamp >= {{interval_start:DateTime64}} AND
+                        _timestamp < {{interval_end:DateTime64}}
+                )
+            GROUP BY id
+            HAVING
+                _timestamp2 >= {{interval_start:DateTime64}} AND
+                _timestamp2 < {{interval_end:DateTime64}}
+        ),
+        new_distinct_ids AS (
+            SELECT
+                argMax(person_id, version) AS person_id
+            FROM
+                person_distinct_id2
+            WHERE
+                team_id = {{team_id:Int64}}
+                AND
+                    distinct_id in (
+                        SELECT
+                            distinct_id
+                        FROM
+                            person_distinct_id2
+                        WHERE
+                            team_id = {{team_id:Int64}} AND
+                            _timestamp  >= {{interval_start:DateTime64}} AND
+                            _timestamp < {{interval_end:DateTime64}}
+                    )
+            GROUP BY
+                distinct_id
+            HAVING
+                argMax(_timestamp, version) >= {{interval_start:DateTime64}} AND
+                argMax(_timestamp, version) < {{interval_end:DateTime64}}
+        ),
+        all_new_persons AS (
+            SELECT
+                id,
+                version
+            FROM
+                new_persons
+            UNION ALL
+            SELECT
+                id,
+                MAX(version) AS version
+            FROM
+                person
+            WHERE
+                team_id = {{team_id:Int64}} AND
+                id IN (SELECT person_id FROM new_distinct_ids)
+            GROUP BY
+                id
+        )
     SELECT
-        pd.team_id AS team_id,
+        p.team_id AS team_id,
         pd.distinct_id AS distinct_id,
         toString(p.id) AS person_id,
         p.properties AS properties,
         pd.version AS person_distinct_id_version,
         p.version AS person_version,
         multiIf(
-            (pd._timestamp  >= {{interval_start:DateTime64}} AND pd._timestamp < {{interval_end:DateTime64}})
+            (pd._timestamp >= {{interval_start:DateTime64}} AND pd._timestamp < {{interval_end:DateTime64}})
                 AND NOT (p._timestamp >= {{interval_start:DateTime64}} AND p._timestamp < {{interval_end:DateTime64}}),
             pd._timestamp,
-            (p._timestamp  >= {{interval_start:DateTime64}} AND p._timestamp < {{interval_end:DateTime64}})
+            (p._timestamp >= {{interval_start:DateTime64}} AND p._timestamp < {{interval_end:DateTime64}})
                 AND NOT (pd._timestamp >= {{interval_start:DateTime64}} AND pd._timestamp < {{interval_end:DateTime64}}),
             p._timestamp,
             least(p._timestamp, pd._timestamp)
         ) AS _inserted_at
-    FROM (
-        SELECT
-            team_id,
-            distinct_id,
-            max(version) AS version,
-            argMax(person_id, person_distinct_id2.version) AS person_id,
-            argMax(_timestamp, person_distinct_id2.version) AS _timestamp
-        FROM
-            person_distinct_id2
-        PREWHERE
-            team_id = {{team_id:Int64}}
-        GROUP BY
-            team_id,
-            distinct_id
-    ) AS pd
+    FROM
+        person AS p
     INNER JOIN (
         SELECT
-            team_id,
-            id,
-            max(version) AS version,
-            argMax(properties, person.version) AS properties,
-            argMax(_timestamp, person.version) AS _timestamp
+            distinct_id,
+            MAX(version) AS version,
+            argMax(person_id, version) AS person_id,
+            argMax(_timestamp, version) AS _timestamp
         FROM
-            person
-        PREWHERE
-            team_id = {{team_id:Int64}}
+            person_distinct_id2
+        WHERE
+            team_id = {{team_id:Int64}} AND
+            person_id IN (SELECT id FROM all_new_persons)
         GROUP BY
-            team_id,
-            id
-    ) AS p ON p.id = pd.person_id AND p.team_id = pd.team_id
+            distinct_id
+    ) AS pd ON p.id = pd.person_id
     WHERE
-        pd.team_id = {{team_id:Int64}}
-        AND p.team_id = {{team_id:Int64}}
-        AND (
-            (pd._timestamp  >= {{interval_start:DateTime64}} AND pd._timestamp < {{interval_end:DateTime64}})
-            OR (p._timestamp  >= {{interval_start:DateTime64}} AND p._timestamp < {{interval_end:DateTime64}})
-        )
-    ORDER BY
-        _inserted_at
+        p.team_id = {{team_id:Int64}} AND
+        (p.id, p.version) IN (SELECT id, version FROM all_new_persons)
 )
+
 """
 
 CREATE_PERSONS_BATCH_EXPORT_VIEW_BACKFILL = f"""

--- a/posthog/batch_exports/sql.py
+++ b/posthog/batch_exports/sql.py
@@ -7,7 +7,7 @@ CREATE OR REPLACE VIEW persons_batch_export ON CLUSTER {settings.CLICKHOUSE_CLUS
             SELECT
                 id,
                 MAX(version) AS version,
-                argMax(_timestamp, version) AS _timestamp2
+                argMax(_timestamp, person.version) AS _timestamp2
             FROM
                 person
             WHERE
@@ -27,7 +27,7 @@ CREATE OR REPLACE VIEW persons_batch_export ON CLUSTER {settings.CLICKHOUSE_CLUS
         ),
         new_distinct_ids AS (
             SELECT
-                argMax(person_id, version) AS person_id
+                argMax(person_id, person_distinct_id2.version) AS person_id
             FROM
                 person_distinct_id2
             WHERE
@@ -46,8 +46,8 @@ CREATE OR REPLACE VIEW persons_batch_export ON CLUSTER {settings.CLICKHOUSE_CLUS
             GROUP BY
                 distinct_id
             HAVING
-                argMax(_timestamp, version) >= {{interval_start:DateTime64}} AND
-                argMax(_timestamp, version) < {{interval_end:DateTime64}}
+                argMax(_timestamp, person_distinct_id2.version) >= {{interval_start:DateTime64}} AND
+                argMax(_timestamp, person_distinct_id2.version) < {{interval_end:DateTime64}}
         ),
         all_new_persons AS (
             SELECT

--- a/posthog/batch_exports/sql.py
+++ b/posthog/batch_exports/sql.py
@@ -89,7 +89,7 @@ CREATE OR REPLACE VIEW persons_batch_export ON CLUSTER {settings.CLICKHOUSE_CLUS
         SELECT
             distinct_id,
             MAX(version) AS version,
-            argMax(person_id, version) AS person_id,
+            argMax(person_id, version) AS person_id2,
             argMax(_timestamp, version) AS _timestamp
         FROM
             person_distinct_id2
@@ -98,7 +98,7 @@ CREATE OR REPLACE VIEW persons_batch_export ON CLUSTER {settings.CLICKHOUSE_CLUS
             person_id IN (SELECT id FROM all_new_persons)
         GROUP BY
             distinct_id
-    ) AS pd ON p.id = pd.person_id
+    ) AS pd ON p.id = pd.person_id2
     WHERE
         p.team_id = {{team_id:Int64}} AND
         (p.id, p.version) IN (SELECT id, version FROM all_new_persons)

--- a/posthog/clickhouse/migrations/0085_update_person_batch_exports_query_for_performance.py
+++ b/posthog/clickhouse/migrations/0085_update_person_batch_exports_query_for_performance.py
@@ -1,0 +1,11 @@
+from posthog.batch_exports.sql import (
+    CREATE_PERSONS_BATCH_EXPORT_VIEW,
+)
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+
+operations = map(
+    run_sql_with_exceptions,
+    [
+        CREATE_PERSONS_BATCH_EXPORT_VIEW,
+    ],
+)


### PR DESCRIPTION
## Problem

Persons batch exports are heavy queries. We can optimize them by pre-filtering persons first, then doing the heavier aggregations. Similar optimization to https://github.com/PostHog/posthog/pull/25824/files#diff-6a672c197b2cdb95dbf2dac797c499ceff442d42e872a96f5b1f95c16ffe4513

Note: this does change the behaviour. In the original query we didn't deduplicate persons, so if a person was created/changed, and a person_distinct_id was changed (which is obviously pretty common), the person would be exported twice within the same batch.

## Changes

Before:
<img width="582" alt="image" src="https://github.com/user-attachments/assets/73228850-f138-4e9a-987b-3652c67dacd2">


After:
<img width="572" alt="image" src="https://github.com/user-attachments/assets/69a05043-3713-4763-91e9-b6f9cf2a3dd7">


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
