### PR TITLE
fix(data-warehouse): Ambiguous query on any asterisk query with join with multiple id fields

### DIFF
--- a/posthog/hogql/test/__snapshots__/test_query.ambr
+++ b/posthog/hogql/test/__snapshots__/test_query.ambr
@@ -995,7 +995,7 @@
   
   -- HogQL
   
-  SELECT col_a, r 
+  SELECT PIVOT_FUNCTION_2.col_a, PIVOT_FUNCTION_2.r 
   FROM (
   SELECT col_a, arrayZip((sumMap((g).1, (g).2) AS x).1, x.2) AS r 
   FROM (
@@ -1032,9 +1032,9 @@
   
   -- HogQL
   
-  SELECT col_a, r 
+  SELECT final.col_a, final.r 
   FROM (
-  SELECT col_a, r 
+  SELECT PIVOT_FUNCTION_2.col_a, PIVOT_FUNCTION_2.r 
   FROM (
   SELECT col_a, arrayZip((sumMap((g).1, (g).2) AS x).1, x.2) AS r 
   FROM (

--- a/posthog/hogql/test/__snapshots__/test_query.ambr
+++ b/posthog/hogql/test/__snapshots__/test_query.ambr
@@ -995,7 +995,7 @@
   
   -- HogQL
   
-  SELECT PIVOT_FUNCTION_2.col_a, PIVOT_FUNCTION_2.r 
+  SELECT col_a, r 
   FROM (
   SELECT col_a, arrayZip((sumMap((g).1, (g).2) AS x).1, x.2) AS r 
   FROM (
@@ -1032,9 +1032,9 @@
   
   -- HogQL
   
-  SELECT final.col_a, final.r 
+  SELECT col_a, r 
   FROM (
-  SELECT PIVOT_FUNCTION_2.col_a, PIVOT_FUNCTION_2.r 
+  SELECT col_a, r 
   FROM (
   SELECT col_a, arrayZip((sumMap((g).1, (g).2) AS x).1, x.2) AS r 
   FROM (

--- a/posthog/hogql/test/__snapshots__/test_resolver.ambr
+++ b/posthog/hogql/test/__snapshots__/test_resolver.ambr
@@ -1511,6 +1511,681 @@
   }
   '''
 # ---
+# name: TestResolver.test_asterisk_expander_multiple_base_table_with_scope
+  '''
+  {
+    select: [
+      {
+        alias: "session_id"
+        expr: {
+          chain: [
+            "e",
+            "session_id"
+          ]
+          type: {
+            name: "session_id"
+            table_type: {
+              alias: "e"
+              table_type: {
+                table: {
+                  fields: {
+                    active_milliseconds: {},
+                    click_count: {},
+                    console_error_count: {},
+                    console_log_count: {},
+                    console_logs: {},
+                    console_warn_count: {},
+                    distinct_id: {},
+                    end_time: {},
+                    event_count: {},
+                    events: {},
+                    first_url: {},
+                    keypress_count: {},
+                    message_count: {},
+                    mouse_activity_count: {},
+                    pdi: {},
+                    person: {},
+                    person_id: {},
+                    properties: {},
+                    session: {},
+                    session_id: {},
+                    size: {},
+                    snapshot_source: {},
+                    start_time: {},
+                    team_id: {}
+                  }
+                }
+              }
+            }
+          }
+        }
+        hidden: True
+        type: {
+          alias: "session_id"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "distinct_id"
+        expr: {
+          chain: [
+            "e",
+            "distinct_id"
+          ]
+          type: {
+            name: "distinct_id"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "distinct_id"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "first_url"
+        expr: {
+          chain: [
+            "e",
+            "first_url"
+          ]
+          type: {
+            name: "first_url"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "first_url"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "click_count"
+        expr: {
+          chain: [
+            "e",
+            "click_count"
+          ]
+          type: {
+            name: "click_count"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "click_count"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "keypress_count"
+        expr: {
+          chain: [
+            "e",
+            "keypress_count"
+          ]
+          type: {
+            name: "keypress_count"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "keypress_count"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "mouse_activity_count"
+        expr: {
+          chain: [
+            "e",
+            "mouse_activity_count"
+          ]
+          type: {
+            name: "mouse_activity_count"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "mouse_activity_count"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "active_milliseconds"
+        expr: {
+          chain: [
+            "e",
+            "active_milliseconds"
+          ]
+          type: {
+            name: "active_milliseconds"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "active_milliseconds"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "console_log_count"
+        expr: {
+          chain: [
+            "e",
+            "console_log_count"
+          ]
+          type: {
+            name: "console_log_count"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "console_log_count"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "console_warn_count"
+        expr: {
+          chain: [
+            "e",
+            "console_warn_count"
+          ]
+          type: {
+            name: "console_warn_count"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "console_warn_count"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "console_error_count"
+        expr: {
+          chain: [
+            "e",
+            "console_error_count"
+          ]
+          type: {
+            name: "console_error_count"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "console_error_count"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "size"
+        expr: {
+          chain: [
+            "e",
+            "size"
+          ]
+          type: {
+            name: "size"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "size"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "event_count"
+        expr: {
+          chain: [
+            "e",
+            "event_count"
+          ]
+          type: {
+            name: "event_count"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "event_count"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "message_count"
+        expr: {
+          chain: [
+            "e",
+            "message_count"
+          ]
+          type: {
+            name: "message_count"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "message_count"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "snapshot_source"
+        expr: {
+          chain: [
+            "e",
+            "snapshot_source"
+          ]
+          type: {
+            name: "snapshot_source"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "snapshot_source"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "start_time"
+        expr: {
+          chain: [
+            "e",
+            "start_time"
+          ]
+          type: {
+            name: "start_time"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "start_time"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "end_time"
+        expr: {
+          chain: [
+            "e",
+            "end_time"
+          ]
+          type: {
+            name: "end_time"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "end_time"
+          type: <recursion ...>
+        }
+      }
+    ]
+    select_from: {
+      alias: "e"
+      next_join: {
+        alias: "s"
+        constraint: {
+          constraint_type: "ON"
+          expr: {
+            left: {
+              alias: "session_id"
+              expr: {
+                chain: [
+                  "s",
+                  "session_id"
+                ]
+                type: {
+                  name: "session_id"
+                  table_type: {
+                    alias: "s"
+                    table_type: {
+                      table: {
+                        fields: {
+                          $autocapture_count: {},
+                          $channel_type: {},
+                          $end_current_url: {},
+                          $end_pathname: {},
+                          $end_timestamp: {},
+                          $entry_current_url: {},
+                          $entry_gad_source: {},
+                          $entry_gclid: {},
+                          $entry_pathname: {},
+                          $entry_referring_domain: {},
+                          $entry_utm_campaign: {},
+                          $entry_utm_content: {},
+                          $entry_utm_medium: {},
+                          $entry_utm_source: {},
+                          $entry_utm_term: {},
+                          $exit_current_url: {},
+                          $exit_pathname: {},
+                          $is_bounce: {},
+                          $last_external_click_url: {},
+                          $num_uniq_urls: {},
+                          $page_screen_autocapture_count_up_to: {},
+                          $pageview_count: {},
+                          $screen_count: {},
+                          $session_duration: {},
+                          $start_timestamp: {},
+                          $urls: {},
+                          $vitals_lcp: {},
+                          distinct_id: {},
+                          duration: {},
+                          id: {},
+                          session_id: {},
+                          session_id_v7: {},
+                          team_id: {}
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              hidden: True
+              type: {
+                alias: "session_id"
+                type: <recursion ...>
+              }
+            }
+            op: "=="
+            right: {
+              alias: "session_id"
+              expr: {
+                chain: [
+                  "e",
+                  "session_id"
+                ]
+                type: {
+                  name: "session_id"
+                  table_type: <recursion ...>
+                }
+              }
+              hidden: True
+              type: {
+                alias: "session_id"
+                type: <recursion ...>
+              }
+            }
+            type: {
+              data_type: "bool"
+              nullable: False
+            }
+          }
+        }
+        join_type: "JOIN"
+        table: {
+          chain: [
+            "sessions"
+          ]
+          type: <recursion ...>
+        }
+        type: <recursion ...>
+      }
+      table: {
+        chain: [
+          "session_replay_events"
+        ]
+        type: <recursion ...>
+      }
+      type: <recursion ...>
+    }
+    type: {
+      aliases: {}
+      anonymous_tables: []
+      columns: {
+        active_milliseconds: <recursion ...>,
+        click_count: <recursion ...>,
+        console_error_count: <recursion ...>,
+        console_log_count: <recursion ...>,
+        console_warn_count: <recursion ...>,
+        distinct_id: <recursion ...>,
+        end_time: <recursion ...>,
+        event_count: <recursion ...>,
+        first_url: <recursion ...>,
+        keypress_count: <recursion ...>,
+        message_count: <recursion ...>,
+        mouse_activity_count: <recursion ...>,
+        session_id: <recursion ...>,
+        size: <recursion ...>,
+        snapshot_source: <recursion ...>,
+        start_time: <recursion ...>
+      }
+      ctes: {}
+      tables: {
+        e: <recursion ...>,
+        s: <recursion ...>
+      }
+    }
+  }
+  '''
+# ---
+# name: TestResolver.test_asterisk_expander_multiple_table_with_scope
+  '''
+  {
+    select: [
+      {
+        alias: "a"
+        expr: {
+          chain: [
+            "x",
+            "a"
+          ]
+          type: {
+            name: "a"
+            table_type: {
+              alias: "x"
+              select_query_type: {
+                aliases: {
+                  a: {
+                    alias: "a"
+                    type: {
+                      data_type: "int"
+                      nullable: False
+                    }
+                  },
+                  b: {
+                    alias: "b"
+                    type: {
+                      data_type: "int"
+                      nullable: False
+                    }
+                  }
+                }
+                anonymous_tables: []
+                columns: {
+                  a: <recursion ...>,
+                  b: <recursion ...>
+                }
+                ctes: {}
+                tables: {}
+              }
+            }
+          }
+        }
+        hidden: True
+        type: {
+          alias: "a"
+          type: <recursion ...>
+        }
+      },
+      {
+        alias: "b"
+        expr: {
+          chain: [
+            "x",
+            "b"
+          ]
+          type: {
+            name: "b"
+            table_type: <recursion ...>
+          }
+        }
+        hidden: True
+        type: {
+          alias: "b"
+          type: <recursion ...>
+        }
+      }
+    ]
+    select_from: {
+      alias: "x"
+      next_join: {
+        alias: "y"
+        constraint: {
+          constraint_type: "ON"
+          expr: {
+            left: {
+              alias: "a"
+              expr: {
+                chain: [
+                  "x",
+                  "a"
+                ]
+                type: {
+                  name: "a"
+                  table_type: <recursion ...>
+                }
+              }
+              hidden: True
+              type: {
+                alias: "a"
+                type: <recursion ...>
+              }
+            }
+            op: "=="
+            right: {
+              alias: "a"
+              expr: {
+                chain: [
+                  "y",
+                  "a"
+                ]
+                type: {
+                  name: "a"
+                  table_type: {
+                    alias: "y"
+                    select_query_type: {
+                      aliases: {
+                        a: {
+                          alias: "a"
+                          type: {
+                            data_type: "int"
+                            nullable: False
+                          }
+                        },
+                        b: {
+                          alias: "b"
+                          type: {
+                            data_type: "int"
+                            nullable: False
+                          }
+                        }
+                      }
+                      anonymous_tables: []
+                      columns: {
+                        a: <recursion ...>,
+                        b: <recursion ...>
+                      }
+                      ctes: {}
+                      tables: {}
+                    }
+                  }
+                }
+              }
+              hidden: True
+              type: {
+                alias: "a"
+                type: <recursion ...>
+              }
+            }
+            type: {
+              data_type: "bool"
+              nullable: False
+            }
+          }
+        }
+        join_type: "LEFT JOIN"
+        table: {
+          select: [
+            {
+              alias: "a"
+              expr: {
+                type: <recursion ...>
+                value: 1
+              }
+              hidden: False
+              type: <recursion ...>
+            },
+            {
+              alias: "b"
+              expr: {
+                type: <recursion ...>
+                value: 2
+              }
+              hidden: False
+              type: <recursion ...>
+            }
+          ]
+          type: <recursion ...>
+        }
+        type: <recursion ...>
+      }
+      table: {
+        select: [
+          {
+            alias: "a"
+            expr: {
+              type: <recursion ...>
+              value: 1
+            }
+            hidden: False
+            type: <recursion ...>
+          },
+          {
+            alias: "b"
+            expr: {
+              type: <recursion ...>
+              value: 2
+            }
+            hidden: False
+            type: <recursion ...>
+          }
+        ]
+        type: <recursion ...>
+      }
+      type: <recursion ...>
+    }
+    type: {
+      aliases: {}
+      anonymous_tables: []
+      columns: {
+        a: <recursion ...>,
+        b: <recursion ...>
+      }
+      ctes: {}
+      tables: {
+        x: <recursion ...>,
+        y: <recursion ...>
+      }
+    }
+  }
+  '''
+# ---
 # name: TestResolver.test_asterisk_expander_select_union
   '''
   {
@@ -3143,6 +3818,7 @@
         alias: "a"
         expr: {
           chain: [
+            "x",
             "a"
           ]
           type: {
@@ -3187,6 +3863,7 @@
         alias: "b"
         expr: {
           chain: [
+            "x",
             "b"
           ]
           type: {
@@ -3818,6 +4495,7 @@
         alias: "uuid"
         expr: {
           chain: [
+            "e",
             "uuid"
           ]
           type: {
@@ -3879,6 +4557,7 @@
         alias: "event"
         expr: {
           chain: [
+            "e",
             "event"
           ]
           type: {
@@ -3896,6 +4575,7 @@
         alias: "properties"
         expr: {
           chain: [
+            "e",
             "properties"
           ]
           type: {
@@ -3913,6 +4593,7 @@
         alias: "timestamp"
         expr: {
           chain: [
+            "e",
             "timestamp"
           ]
           type: {
@@ -3930,6 +4611,7 @@
         alias: "distinct_id"
         expr: {
           chain: [
+            "e",
             "distinct_id"
           ]
           type: {
@@ -3947,6 +4629,7 @@
         alias: "elements_chain"
         expr: {
           chain: [
+            "e",
             "elements_chain"
           ]
           type: {
@@ -3964,6 +4647,7 @@
         alias: "created_at"
         expr: {
           chain: [
+            "e",
             "created_at"
           ]
           type: {
@@ -3981,6 +4665,7 @@
         alias: "$session_id"
         expr: {
           chain: [
+            "e",
             "$session_id"
           ]
           type: {
@@ -3998,6 +4683,7 @@
         alias: "$window_id"
         expr: {
           chain: [
+            "e",
             "$window_id"
           ]
           type: {
@@ -4171,6 +4857,7 @@
         alias: "$group_0"
         expr: {
           chain: [
+            "e",
             "$group_0"
           ]
           type: {
@@ -4188,6 +4875,7 @@
         alias: "$group_1"
         expr: {
           chain: [
+            "e",
             "$group_1"
           ]
           type: {
@@ -4205,6 +4893,7 @@
         alias: "$group_2"
         expr: {
           chain: [
+            "e",
             "$group_2"
           ]
           type: {
@@ -4222,6 +4911,7 @@
         alias: "$group_3"
         expr: {
           chain: [
+            "e",
             "$group_3"
           ]
           type: {
@@ -4239,6 +4929,7 @@
         alias: "$group_4"
         expr: {
           chain: [
+            "e",
             "$group_4"
           ]
           type: {
@@ -4256,6 +4947,7 @@
         alias: "elements_chain_href"
         expr: {
           chain: [
+            "e",
             "elements_chain_href"
           ]
           type: {
@@ -4273,6 +4965,7 @@
         alias: "elements_chain_texts"
         expr: {
           chain: [
+            "e",
             "elements_chain_texts"
           ]
           type: {
@@ -4290,6 +4983,7 @@
         alias: "elements_chain_ids"
         expr: {
           chain: [
+            "e",
             "elements_chain_ids"
           ]
           type: {
@@ -4307,6 +5001,7 @@
         alias: "elements_chain_elements"
         expr: {
           chain: [
+            "e",
             "elements_chain_elements"
           ]
           type: {
@@ -4324,6 +5019,7 @@
         alias: "event_person_id"
         expr: {
           chain: [
+            "e",
             "event_person_id"
           ]
           type: {

--- a/posthog/hogql/test/__snapshots__/test_resolver.ambr
+++ b/posthog/hogql/test/__snapshots__/test_resolver.ambr
@@ -4495,7 +4495,6 @@
         alias: "uuid"
         expr: {
           chain: [
-            "e",
             "uuid"
           ]
           type: {
@@ -4557,7 +4556,6 @@
         alias: "event"
         expr: {
           chain: [
-            "e",
             "event"
           ]
           type: {
@@ -4575,7 +4573,6 @@
         alias: "properties"
         expr: {
           chain: [
-            "e",
             "properties"
           ]
           type: {
@@ -4593,7 +4590,6 @@
         alias: "timestamp"
         expr: {
           chain: [
-            "e",
             "timestamp"
           ]
           type: {
@@ -4611,7 +4607,6 @@
         alias: "distinct_id"
         expr: {
           chain: [
-            "e",
             "distinct_id"
           ]
           type: {
@@ -4629,7 +4624,6 @@
         alias: "elements_chain"
         expr: {
           chain: [
-            "e",
             "elements_chain"
           ]
           type: {
@@ -4647,7 +4641,6 @@
         alias: "created_at"
         expr: {
           chain: [
-            "e",
             "created_at"
           ]
           type: {
@@ -4665,7 +4658,6 @@
         alias: "$session_id"
         expr: {
           chain: [
-            "e",
             "$session_id"
           ]
           type: {
@@ -4683,7 +4675,6 @@
         alias: "$window_id"
         expr: {
           chain: [
-            "e",
             "$window_id"
           ]
           type: {
@@ -4857,7 +4848,6 @@
         alias: "$group_0"
         expr: {
           chain: [
-            "e",
             "$group_0"
           ]
           type: {
@@ -4875,7 +4865,6 @@
         alias: "$group_1"
         expr: {
           chain: [
-            "e",
             "$group_1"
           ]
           type: {
@@ -4893,7 +4882,6 @@
         alias: "$group_2"
         expr: {
           chain: [
-            "e",
             "$group_2"
           ]
           type: {
@@ -4911,7 +4899,6 @@
         alias: "$group_3"
         expr: {
           chain: [
-            "e",
             "$group_3"
           ]
           type: {
@@ -4929,7 +4916,6 @@
         alias: "$group_4"
         expr: {
           chain: [
-            "e",
             "$group_4"
           ]
           type: {
@@ -4947,7 +4933,6 @@
         alias: "elements_chain_href"
         expr: {
           chain: [
-            "e",
             "elements_chain_href"
           ]
           type: {
@@ -4965,7 +4950,6 @@
         alias: "elements_chain_texts"
         expr: {
           chain: [
-            "e",
             "elements_chain_texts"
           ]
           type: {
@@ -4983,7 +4967,6 @@
         alias: "elements_chain_ids"
         expr: {
           chain: [
-            "e",
             "elements_chain_ids"
           ]
           type: {
@@ -5001,7 +4984,6 @@
         alias: "elements_chain_elements"
         expr: {
           chain: [
-            "e",
             "elements_chain_elements"
           ]
           type: {
@@ -5019,7 +5001,6 @@
         alias: "event_person_id"
         expr: {
           chain: [
-            "e",
             "event_person_id"
           ]
           type: {

--- a/posthog/hogql/test/test_resolver.py
+++ b/posthog/hogql/test/test_resolver.py
@@ -1,9 +1,9 @@
-from datetime import datetime, date, UTC
+from datetime import UTC, date, datetime
 from typing import Any, Optional, cast
-import pytest
-from django.test import override_settings
 from uuid import UUID
 
+import pytest
+from django.test import override_settings
 from freezegun import freeze_time
 
 from posthog.hogql import ast
@@ -11,18 +11,18 @@ from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import create_hogql_database
 from posthog.hogql.database.models import (
+    DateTimeDatabaseField,
     ExpressionField,
     FieldTraverser,
-    StringJSONDatabaseField,
     StringDatabaseField,
-    DateTimeDatabaseField,
+    StringJSONDatabaseField,
 )
 from posthog.hogql.errors import QueryError
-from posthog.hogql.test.utils import pretty_dataclasses
-from posthog.hogql.visitor import clone_expr
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import print_ast, print_prepared_ast
 from posthog.hogql.resolver import ResolutionError, resolve_types
+from posthog.hogql.test.utils import pretty_dataclasses
+from posthog.hogql.visitor import clone_expr
 from posthog.test.base import BaseTest
 
 
@@ -355,6 +355,21 @@ class TestResolver(BaseTest):
             str(e.exception),
             "Cannot use '*' without table name when there are multiple tables in the query",
         )
+
+    @override_settings(PERSON_ON_EVENTS_OVERRIDE=False, PERSON_ON_EVENTS_V2_OVERRIDE=False)
+    @pytest.mark.usefixtures("unittest_snapshot")
+    def test_asterisk_expander_multiple_table_with_scope(self):
+        node = self._select(
+            "select x.* from (select 1 as a, 2 as b) x left join (select 1 as a, 2 as b) y on x.a = y.a"
+        )
+        node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
+        assert pretty_dataclasses(node) == self.snapshot
+
+    @pytest.mark.usefixtures("unittest_snapshot")
+    def test_asterisk_expander_multiple_base_table_with_scope(self):
+        node = self._select("select e.* from session_replay_events e join sessions s on s.session_id=e.session_id")
+        node = cast(ast.SelectQuery, resolve_types(node, self.context, dialect="clickhouse"))
+        assert pretty_dataclasses(node) == self.snapshot
 
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=False, PERSON_ON_EVENTS_V2_OVERRIDE=False)
     @pytest.mark.usefixtures("unittest_snapshot")


### PR DESCRIPTION
## Problem

At the moment, if you try to perform a `SELECT *` query that involves a join with the same column name, you get the following error: `Ambiguous query. Found multiple sources for field: id`.

An example is:

```sql
select s.* from postgres_posthog_externaldatajob j
left join postgres_posthog_externaldataschema s
on j.team_id = s.team_id
```

In this case the error returned is `Ambiguous query. Found multiple sources for field: team_id`. Note that this only happens if performing a `SELECT *`, so the join itself resolves fine, it's just when expanding the asterisk.

## Changes

From my investigation, the error seems to be related to the fact that when we're expanding the asterisk we're removing the table/view alias then resolving the column names.

So, with the example above, we're resolving `s.*` into `['s', '*']`, then `['*']`, then `['team_id']` but `team_id` by itself is ambiguous.

My changes resolve `['*']` to `['s', 'team_id']` (i.e. preserving the table alias in the chain), which can then be resolved without any ambiguity.

This is my first time working with HogQL so this may not be the best way of achieving the desired result. Happy for feedback here!

## Does this work well for both Cloud and self-hosted?

Should do.

## How did you test this code?

- Added 2 new unit tests.
- Existing tests all passed except 4 tests where the snapshots needed to be updated - you can see the chain is being updated as mentioned above
- Manual testing using the HogQL editor.
