### PR TITLE
fix(data-warehouse): Fix mounting series breakdown logic

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/seriesBreakdownLogic.ts
@@ -49,14 +49,14 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
     key((props) => props.key),
     props({ key: '' } as SeriesBreakdownLogicProps),
     connect({
-        actions: [dataVisualizationLogic, ['clearAxis', 'setQuery']],
+        actions: [dataVisualizationLogic, ['clearAxis', 'updateChartSettings']],
         values: [dataVisualizationLogic, ['query', 'response', 'columns', 'selectedXAxis', 'selectedYAxis']],
     }),
     actions(({ values }) => ({
         addSeriesBreakdown: (columnName: string | null) => ({ columnName, response: values.response }),
         deleteSeriesBreakdown: () => ({}),
     })),
-    reducers({
+    reducers(({ values }) => ({
         showSeriesBreakdown: [
             false as boolean,
             {
@@ -66,14 +66,14 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
             },
         ],
         selectedSeriesBreakdownColumn: [
-            null as string | null,
+            values.query?.chartSettings?.seriesBreakdownColumn ?? (null as string | null),
             {
                 clearAxis: () => null,
                 addSeriesBreakdown: (_, { columnName }) => columnName,
                 deleteSeriesBreakdown: () => null,
             },
         ],
-    }),
+    })),
     selectors({
         breakdownColumnValues: [
             (state) => [state.selectedSeriesBreakdownColumn, state.response, state.columns],
@@ -232,12 +232,9 @@ export const seriesBreakdownLogic = kea<seriesBreakdownLogicType>([
     }),
     subscriptions(({ values, actions }) => ({
         selectedSeriesBreakdownColumn: (value: string | null) => {
-            actions.setQuery({
-                ...values.query,
-                chartSettings: {
-                    ...(values.query.chartSettings ?? {}),
-                    seriesBreakdownColumn: value,
-                },
+            actions.updateChartSettings({
+                ...(values.query.chartSettings ?? {}),
+                seriesBreakdownColumn: value,
             })
         },
     })),


### PR DESCRIPTION
## Problem

Previously, there was a race condition between the query state in the data viz logic and the series breakdown logic which broke saving the visualization type (this was fixed in #26164). However this now seems to have caused a regression in the series breakdown logic.

It seems that the `selectedSeriesBreakdownColumn` subscription gets called even when the component is mounted for the first time. Because `selectedSeriesBreakdownColumn` is initialised to `null` this causes `setQuery` to be called with `selectedSeriesBreakdownColumn: null`. This all happens before the `afterMount` event handler, meaning the series breakdown is never added.

## Changes

- Initialize `selectedSeriesBreakdownColumn` using the value in `values.query`
- Use `updateChartSettings` rather than `setQuery` (not strictly necessary but feels neater to limit the scope of the update here)

## Does this work well for both Cloud and self-hosted?

Should do

## How did you test this code?

Tested saving a variety of insights and reloading them
