### PR TITLE
fix: alerts getting stuck when celery task crashes

### DIFF
--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -31,6 +31,7 @@ from posthog.tasks.alerts.utils import (
     AlertEvaluationResult,
     calculation_interval_to_order,
     send_notifications_for_breaches,
+    send_notifications_for_errors,
     WRAPPER_NODE_KINDS,
     alert_calculation_interval_to_relativedelta,
 )
@@ -309,7 +310,7 @@ def check_alert_and_notify_atomically(alert: AlertConfiguration) -> None:
             case AlertState.ERRORED:
                 logger.info("Sending alert error notifications", alert_id=alert.id, error=alert_check.error)
                 # TODO: uncomment this after checking errors sent
-                # send_notifications_for_errors(alert, alert_check.error)
+                send_notifications_for_errors(alert, alert_check.error)
             case AlertState.FIRING:
                 assert breaches is not None
                 send_notifications_for_breaches(alert, breaches)

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -126,8 +126,13 @@ def reset_stuck_alerts_task() -> None:
     # the finally block below isn't run and the alert gets stuck with is_calculating = True
     # hence when checking is_calculating, we also need to check if task has been stuck in is_calculating for too long
     stuck_alerts = AlertConfiguration.objects.filter(
-        Q(enabled=True, is_calculating=True, last_checked_at__isnull=now - relativedelta(minutes=45))
-        | Q(enabled=True, is_calculating=True, last_checked_at__isnull=True)
+        Q(enabled=True, is_calculating=True, last_checked_at__lte=now - relativedelta(minutes=45))
+        | Q(
+            enabled=True,
+            is_calculating=True,
+            last_checked_at__isnull=True,
+            created_at__lte=now - relativedelta(minutes=45),
+        )
     )
 
     for alert in stuck_alerts:

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -84,27 +84,29 @@ def send_notifications_for_breaches(alert: AlertConfiguration, breaches: list[st
 
 
 def send_notifications_for_errors(alert: AlertConfiguration, error: dict) -> None:
-    subject = f"PostHog alert {alert.name} check failed to evaluate"
-    campaign_key = f"alert-firing-notification-{alert.id}-{timezone.now().timestamp()}"
-    insight_url = f"/project/{alert.team.pk}/insights/{alert.insight.short_id}"
-    alert_url = f"{insight_url}?alert_id={alert.id}"
-    message = EmailMessage(
-        campaign_key=campaign_key,
-        subject=subject,
-        template_name="alert_check_failed_to_evaluate",
-        template_context={
-            "alert_error": error,
-            "insight_url": insight_url,
-            "insight_name": alert.insight.name,
-            "alert_url": alert_url,
-            "alert_name": alert.name,
-        },
-    )
-    targets = alert.subscribed_users.all().values_list("email", flat=True)
-    if not targets:
-        raise RuntimeError(f"no targets configured for the alert {alert.id}")
-    for target in targets:
-        message.add_recipient(email=target)
+    logger.info("Sending alert error notifications", alert_id=alert.id, error=error)
 
-    logger.info(f"Send notifications about alert checking error", alert_id=alert.id)
-    message.send()
+    # TODO: uncomment this after checking errors sent
+    # subject = f"PostHog alert {alert.name} check failed to evaluate"
+    # campaign_key = f"alert-firing-notification-{alert.id}-{timezone.now().timestamp()}"
+    # insight_url = f"/project/{alert.team.pk}/insights/{alert.insight.short_id}"
+    # alert_url = f"{insight_url}?alert_id={alert.id}"
+    # message = EmailMessage(
+    #     campaign_key=campaign_key,
+    #     subject=subject,
+    #     template_name="alert_check_failed_to_evaluate",
+    #     template_context={
+    #         "alert_error": error,
+    #         "insight_url": insight_url,
+    #         "insight_name": alert.insight.name,
+    #         "alert_url": alert_url,
+    #         "alert_name": alert.name,
+    #     },
+    # )
+    # targets = alert.subscribed_users.all().values_list("email", flat=True)
+    # if not targets:
+    #     raise RuntimeError(f"no targets configured for the alert {alert.id}")
+    # for target in targets:
+    #     message.add_recipient(email=target)
+
+    # message.send()

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -12,6 +12,7 @@ from posthog.tasks.alerts.checks import (
     check_alerts_task,
     checks_cleanup_task,
     alerts_backlog_task,
+    reset_stuck_alerts_task,
 )
 from posthog.tasks.integrations import refresh_integrations
 from posthog.tasks.tasks import (
@@ -265,6 +266,12 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="*", minute="*/12"),
         alerts_backlog_task.s(),
         name="alerts_backlog_task",
+    )
+
+    sender.add_periodic_task(
+        crontab(hour="*", minute="*/15"),
+        reset_stuck_alerts_task.s(),
+        name="reset_stuck_alerts_task",
     )
 
     sender.add_periodic_task(

--- a/posthog/templates/email/alert_check_failed_to_evaluate.html
+++ b/posthog/templates/email/alert_check_failed_to_evaluate.html
@@ -1,7 +1,7 @@
 {% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
     <p>
         The <a href="{% absolute_uri alert_url %}">{{ alert_name }}</a> alert failed to evaluate for insight <a
-            href="{% absolute_uri insight_url %}">{{ insight_name }}</> with the following error:
+            href="{% absolute_uri insight_url %}">{{ insight_name }}</> with the error, below. There could be something wrong with the alert or the insight config.
     </p>
     <p><i>{{ alert_error }}</i></p>
     <div class="mb mt text-center">


### PR DESCRIPTION
## Problem
Some alerts get stuck in state `is_calculating=True`. Think it happens when the insight is being calculated and celery task exits due to timeout/expiry and the finally code block to reset `is_calculating` isn't run

## Changes
Check if the alert has been stuck in `is_calculating=True` for too long and recalculate alert

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
