### PR TITLE
chore(data-warehouse): Link to all debugging opportunities

### DIFF
--- a/posthog/warehouse/README.md
+++ b/posthog/warehouse/README.md
@@ -19,3 +19,5 @@ If the issue persists, install from source without cache again
 ```
 pip install --pre --no-binary :all: pymssql --no-cache
 ```
+
+See https://github.com/pymssql/pymssql/issues/769 for a full set of debugging opportunities.


### PR DESCRIPTION
## Changes

Links to a GitHub issue with a wide range of possibilities for solving "symbol not found in flat namespace (_bcp_batch)" when connecting to a local MySQL data warehouse.