### PR TITLE
chore: Update pymssql to 2.3.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -63,7 +63,7 @@ pdpyras==5.2.0
 posthoganalytics==3.6.6
 psutil==6.0.0
 psycopg2-binary==2.9.7
-pymssql==2.3.0
+pymssql==2.3.1
 PyMySQL==1.1.1
 psycopg[binary]==3.1.20
 pyarrow==17.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -514,7 +514,7 @@ pyjwt==2.4.0
     #   simple-salesforce
     #   snowflake-connector-python
     #   social-auth-core
-pymssql==2.3.0
+pymssql==2.3.1
     # via -r requirements.in
 pymysql==1.1.1
     # via -r requirements.in


### PR DESCRIPTION
## Changes

Update pymssql from 2.3.0 to 2.3.1. It seems to resolve "symbol not found in flat namespace '_bcp_batch'" on Mac.

See https://github.com/pymssql/pymssql/issues/769#issuecomment-2476865954
See https://github.com/pymssql/pymssql/compare/v2.3.0...v2.3.1
See https://posthog.slack.com/archives/C019RAX2XBN/p1731599369565269?thread_ts=1729084252.489339&cid=C019RAX2XBN

## How did you test this code?

Created a new data warehouse MySQL source and connected to it.