### PR TITLE
chore(flags): filter unrelated flags out of the match section

### DIFF
--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -221,8 +221,13 @@ export function Group(): JSX.Element {
                     {
                         key: PersonsTabType.FEATURE_FLAGS,
                         label: <span data-attr="groups-related-flags-tab">Feature flags</span>,
+                        tooltip: `Only shows feature flags with targeting conditions based on ${groupTypeName} properties.`,
                         content: (
-                            <RelatedFeatureFlags distinctId={groupData.group_key} groups={{ [groupType]: groupKey }} />
+                            <RelatedFeatureFlags
+                                distinctId={groupData.group_key}
+                                groupTypeIndex={groupTypeIndex}
+                                groups={{ [groupType]: groupKey }}
+                            />
                         ),
                     },
                     showCustomerSuccessDashboards

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -261,6 +261,7 @@ export function PersonScene(): JSX.Element | null {
                     person.uuid
                         ? {
                               key: PersonsTabType.FEATURE_FLAGS,
+                              tooltip: `Only shows feature flags with targeting conditions based on person properties.`,
                               label: <span data-attr="persons-related-flags-tab">Feature flags</span>,
                               content: (
                                   <>
@@ -302,10 +303,7 @@ export function PersonScene(): JSX.Element | null {
                                           />
                                       </div>
                                       <LemonDivider className="mb-4" />
-                                      <RelatedFeatureFlags
-                                          distinctId={distinctId || person.distinct_ids[0]}
-                                          personId={person.uuid}
-                                      />
+                                      <RelatedFeatureFlags distinctId={distinctId || person.distinct_ids[0]} />
                                   </>
                               ),
                           }

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -302,7 +302,10 @@ export function PersonScene(): JSX.Element | null {
                                           />
                                       </div>
                                       <LemonDivider className="mb-4" />
-                                      <RelatedFeatureFlags distinctId={distinctId || person.distinct_ids[0]} />
+                                      <RelatedFeatureFlags
+                                          distinctId={distinctId || person.distinct_ids[0]}
+                                          personId={person.uuid}
+                                      />
                                   </>
                               ),
                           }

--- a/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
+++ b/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
@@ -13,6 +13,7 @@ import { RelatedFeatureFlag, relatedFeatureFlagsLogic } from './relatedFeatureFl
 
 interface Props {
     distinctId: string
+    personId?: string
     groups?: { [key: string]: string }
 }
 
@@ -34,11 +35,11 @@ const featureFlagMatchMapping = {
     [FeatureFlagMatchReason.Disabled]: 'Disabled',
 }
 
-export function RelatedFeatureFlags({ distinctId, groups }: Props): JSX.Element {
+export function RelatedFeatureFlags({ distinctId, personId, groups }: Props): JSX.Element {
     const { filteredMappedFlags, relatedFeatureFlagsLoading, searchTerm, filters } = useValues(
-        relatedFeatureFlagsLogic({ distinctId, groups })
+        relatedFeatureFlagsLogic({ distinctId, personId, groups })
     )
-    const { setSearchTerm, setFilters } = useActions(relatedFeatureFlagsLogic({ distinctId, groups }))
+    const { setSearchTerm, setFilters } = useActions(relatedFeatureFlagsLogic({ distinctId, personId, groups }))
 
     const columns: LemonTableColumns<RelatedFeatureFlag> = [
         {
@@ -123,7 +124,11 @@ export function RelatedFeatureFlags({ distinctId, groups }: Props): JSX.Element 
                 const matchesSet = featureFlag.evaluation.reason === FeatureFlagMatchReason.ConditionMatch
                 return (
                     <div>
-                        {featureFlag.active ? <>{featureFlagMatchMapping[featureFlag.evaluation.reason]}</> : '--'}
+                        {featureFlag.active ? (
+                            <>{featureFlagMatchMapping[featureFlag.evaluation.reason as FeatureFlagMatchReason]}</>
+                        ) : (
+                            '--'
+                        )}
 
                         {matchesSet && <LemonSnack>Set {(featureFlag.evaluation.condition_index ?? 0) + 1}</LemonSnack>}
                     </div>

--- a/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
+++ b/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
@@ -13,7 +13,7 @@ import { RelatedFeatureFlag, relatedFeatureFlagsLogic } from './relatedFeatureFl
 
 interface Props {
     distinctId: string
-    personId?: string
+    groupTypeIndex?: number
     groups?: { [key: string]: string }
 }
 
@@ -35,11 +35,11 @@ const featureFlagMatchMapping = {
     [FeatureFlagMatchReason.Disabled]: 'Disabled',
 }
 
-export function RelatedFeatureFlags({ distinctId, personId, groups }: Props): JSX.Element {
+export function RelatedFeatureFlags({ distinctId, groupTypeIndex, groups }: Props): JSX.Element {
     const { filteredMappedFlags, relatedFeatureFlagsLoading, searchTerm, filters } = useValues(
-        relatedFeatureFlagsLogic({ distinctId, personId, groups })
+        relatedFeatureFlagsLogic({ distinctId, groupTypeIndex, groups })
     )
-    const { setSearchTerm, setFilters } = useActions(relatedFeatureFlagsLogic({ distinctId, personId, groups }))
+    const { setSearchTerm, setFilters } = useActions(relatedFeatureFlagsLogic({ distinctId, groupTypeIndex, groups }))
 
     const columns: LemonTableColumns<RelatedFeatureFlag> = [
         {

--- a/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
+++ b/frontend/src/scenes/persons/RelatedFeatureFlags.tsx
@@ -124,11 +124,7 @@ export function RelatedFeatureFlags({ distinctId, groupTypeIndex, groups }: Prop
                 const matchesSet = featureFlag.evaluation.reason === FeatureFlagMatchReason.ConditionMatch
                 return (
                     <div>
-                        {featureFlag.active ? (
-                            <>{featureFlagMatchMapping[featureFlag.evaluation.reason as FeatureFlagMatchReason]}</>
-                        ) : (
-                            '--'
-                        )}
+                        {featureFlag.active ? <>{featureFlagMatchMapping[featureFlag.evaluation.reason]}</> : '--'}
 
                         {matchesSet && <LemonSnack>Set {(featureFlag.evaluation.condition_index ?? 0) + 1}</LemonSnack>}
                     </div>

--- a/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
+++ b/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
@@ -17,7 +17,7 @@ export interface RelatedFeatureFlag extends FeatureFlagType {
 }
 
 export interface FeatureFlagEvaluationType {
-    reason: string
+    reason: FeatureFlagMatchReason
     condition_index?: number
 }
 

--- a/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
+++ b/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
@@ -40,6 +40,7 @@ export const relatedFeatureFlagsLogic = kea<relatedFeatureFlagsLogicType>([
     props(
         {} as {
             distinctId: string
+            groupTypeIndex?: number
             groups?: { [key: string]: string }
         }
     ),
@@ -93,8 +94,15 @@ export const relatedFeatureFlagsLogic = kea<relatedFeatureFlagsLogicType>([
                         .map((flag) => ({ ...relatedFlags[flag.key], ...flag }))
                         .filter((flag) => flag.evaluation !== undefined)
 
-                    // show non-group (person) flags if props.groups is empty
-                    if (!props.groups || Object.keys(props.groups).length === 0) {
+                    // return related feature flags for group property targeting or person property targeting, but not both
+                    if (props.groupTypeIndex && props.groups && Object.keys(props.groups).length > 0) {
+                        flags = flags.filter(
+                            (flag) =>
+                                flag.filters.aggregation_group_type_index !== undefined &&
+                                flag.filters.aggregation_group_type_index !== null &&
+                                flag.filters.aggregation_group_type_index === props.groupTypeIndex
+                        )
+                    } else {
                         flags = flags.filter(
                             (flag) =>
                                 flag.filters.aggregation_group_type_index === undefined ||


### PR DESCRIPTION
## Problem

I don't want to show flags that don't match people in the "people" section where we show the feature flags for which they're associated – if a flag doesn't match on person properties, I don't think we should show that to our users.  Context: https://posthog.slack.com/archives/C07Q2U4BH4L/p1731539410714099

## Changes

- filters group flags from person properties
- filters person flags from group properties
- add tooltips to each section explaining what they should expect

Loom: https://www.loom.com/share/af638a71d0674572bcf15b44b92c4108

## How did you test this code?

Visual UI tests, didn't think it was worth a cypress test.  Maybe worth a logic test?  Idk.  
