### PR TITLE
chore: Add .temporal-worker-settings to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ plugin-transpiler/dist
 *.log
 # pyright config (keep this until we have a standardized one)
 pyrightconfig.json
+.temporal-worker-settings


### PR DESCRIPTION
## Changes

Adds `.temporal-worker-settings` to `.gitignore`

I decided to create a new `.temporal-worker-settings` file instead of putting these values in `.env` because I don't think they should necessarily be read into any application located in the mono repo. Open to other ideas, though.

Related https://github.com/PostHog/posthog.com/pull/9892