### PR TITLE
feat: making role in organization as a required field

### DIFF
--- a/cypress/e2e/signup.cy.ts
+++ b/cypress/e2e/signup.cy.ts
@@ -78,7 +78,6 @@ describe('Signup', () => {
         cy.get('[data-attr=signup-start]').click()
         cy.get('[data-attr=signup-name]').type('Alice Bob').should('have.value', 'Alice Bob')
         cy.get('[data-attr=signup-submit]').click()
-
         cy.wait('@signupRequest').then((interception) => {
             expect(interception.request.body).to.have.property('first_name')
             expect(interception.request.body.first_name).to.equal('Alice')

--- a/cypress/e2e/signup.cy.ts
+++ b/cypress/e2e/signup.cy.ts
@@ -77,7 +77,11 @@ describe('Signup', () => {
         cy.get('[data-attr=password]').type(VALID_PASSWORD).should('have.value', VALID_PASSWORD)
         cy.get('[data-attr=signup-start]').click()
         cy.get('[data-attr=signup-name]').type('Alice Bob').should('have.value', 'Alice Bob')
+        cy.get('[data-attr=signup-role-at-organization]').click()
+        cy.get('.Popover li:first-child').click()
+        cy.get('[data-attr=signup-role-at-organization]').contains('Engineering')
         cy.get('[data-attr=signup-submit]').click()
+
         cy.wait('@signupRequest').then((interception) => {
             expect(interception.request.body).to.have.property('first_name')
             expect(interception.request.body.first_name).to.equal('Alice')
@@ -92,6 +96,9 @@ describe('Signup', () => {
         cy.get('[data-attr=password]').type(VALID_PASSWORD).should('have.value', VALID_PASSWORD)
         cy.get('[data-attr=signup-start]').click()
         cy.get('[data-attr=signup-name]').type('Alice Bob').should('have.value', 'Alice Bob')
+        cy.get('[data-attr=signup-role-at-organization]').click()
+        cy.get('.Popover li:first-child').click()
+        cy.get('[data-attr=signup-role-at-organization]').contains('Engineering')
         cy.get('[data-attr=signup-submit]').click()
 
         cy.wait('@signupRequest').then(() => {
@@ -104,6 +111,9 @@ describe('Signup', () => {
         const newEmail = `new_user+${Math.floor(Math.random() * 10000)}@posthog.com`
         cy.get('[data-attr=signup-email]').clear().type(newEmail).should('have.value', newEmail)
         cy.get('[data-attr=signup-start]').click()
+        cy.get('[data-attr=signup-role-at-organization]').click()
+        cy.get('.Popover li:first-child').click()
+        cy.get('[data-attr=signup-role-at-organization]').contains('Engineering')
         cy.get('[data-attr=signup-submit]').click()
 
         cy.wait('@signupRequest').then((interception) => {

--- a/frontend/src/lib/components/SignupRoleSelect.tsx
+++ b/frontend/src/lib/components/SignupRoleSelect.tsx
@@ -3,7 +3,7 @@ import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 
 export default function SignupRoleSelect({ className }: { className?: string }): JSX.Element {
     return (
-        <LemonField name="role_at_organization" label="What is your role?" className={className} showOptional>
+        <LemonField name="role_at_organization" label="What is your role?" className={className} required={true}>
             <LemonSelect
                 fullWidth
                 data-attr="signup-role-at-organization"

--- a/frontend/src/lib/components/SignupRoleSelect.tsx
+++ b/frontend/src/lib/components/SignupRoleSelect.tsx
@@ -3,7 +3,7 @@ import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 
 export default function SignupRoleSelect({ className }: { className?: string }): JSX.Element {
     return (
-        <LemonField name="role_at_organization" label="What is your role?" className={className} required={true}>
+        <LemonField name="role_at_organization" label="What is your role?" className={className}>
             <LemonSelect
                 fullWidth
                 data-attr="signup-role-at-organization"

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -96,7 +96,7 @@ export const signupLogic = kea<signupLogicType>([
                         first_name: payload.name.split(' ')[0],
                         last_name: payload.name.split(' ')[1] || undefined,
                         organization_name: payload.organization_name || undefined,
-                        role_at_organization: payload.organization_name || undefined,
+                        role_at_organization: payload.role_at_organization || undefined,
                     })
                     if (!payload.organization_name) {
                         posthog.capture('sign up organization name not provided')

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -96,13 +96,9 @@ export const signupLogic = kea<signupLogicType>([
                         first_name: payload.name.split(' ')[0],
                         last_name: payload.name.split(' ')[1] || undefined,
                         organization_name: payload.organization_name || undefined,
-                        role_at_organization: payload.role_at_organization || undefined,
                     })
                     if (!payload.organization_name) {
                         posthog.capture('sign up organization name not provided')
-                    }
-                    if (!payload.role_at_organization) {
-                        posthog.capture('role at organization not provided')
                     }
                     location.href = res.redirect_url || '/'
                 } catch (e) {

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -95,9 +95,13 @@ export const signupLogic = kea<signupLogicType>([
                         first_name: payload.name.split(' ')[0],
                         last_name: payload.name.split(' ')[1] || undefined,
                         organization_name: payload.organization_name || undefined,
+                        role_at_organization: payload.organization_name || undefined,
                     })
                     if (!payload.organization_name) {
                         posthog.capture('sign up organization name not provided')
+                    }
+                    if (!payload.role_at_organization) {
+                        posthog.capture('role at organization not provided')
                     }
                     location.href = res.redirect_url || '/'
                 } catch (e) {

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -83,8 +83,9 @@ export const signupLogic = kea<signupLogicType>([
                 role_at_organization: '',
                 referral_source: '',
             } as SignupForm,
-            errors: ({ name }) => ({
+            errors: ({ name, role_at_organization }) => ({
                 name: !name ? 'Please enter your name' : undefined,
+                role_at_organization: !role_at_organization ? 'Please select your role in the organization' : undefined,
             }),
             submit: async (payload, breakpoint) => {
                 breakpoint()


### PR DESCRIPTION
## Problem

since we want to understand the type of users using our product, having the role information is crucial and we want to try to make it as a required field. 

## Changes

### Comparison: Before vs. After

| **Before**                                                                                              | **After**                                                                                                 |
|---------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
| The role was optional                                                                                   | Changes don't allow the user to proceed without adding in a role.                                         |
| ![Before](https://github.com/user-attachments/assets/5744d134-db0e-4096-8085-4ec49167b4ad)              | ![After](https://github.com/user-attachments/assets/c90b1ece-619a-4b75-9ccc-38634b1742b2)                |


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

self-hosted

## How did you test this code?

Tested locally after commenting out the signup reroute in `sceneLogic.ts`. I verified that a new user was created and could access their posthog account. 

```
           // if (scene === Scene.Signup && preflight && !preflight.can_create_org) {
            //     // If user is on an already initiated self-hosted instance, redirect away from signup
            //     router.actions.replace(urls.login())
            //     return
            // }
```

NOTE:
ran  `DEBUG=1 CLOUD_DEPLOYMENT=1 bin/start` to clear the authentication credential issue when there are more than one users created in the same flow


