### PR TITLE
chore(data-warehouse): Saving as view shouldn't require aliasing every field

### DIFF
--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -290,7 +290,7 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
                                         hasErrors
                                             ? error ?? 'Query has errors'
                                             : !isValidView
-                                            ? 'All fields must have an alias'
+                                            ? 'Some fields may need an alias'
                                             : ''
                                     }
                                     data-attr="hogql-query-editor-update-view"
@@ -307,7 +307,7 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
                                         hasErrors
                                             ? error ?? 'Query has errors'
                                             : !isValidView
-                                            ? 'All fields must have an alias'
+                                            ? 'Some fields may need an alias'
                                             : ''
                                     }
                                     data-attr="hogql-query-editor-save-as-view"

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -60,7 +60,7 @@ export function QueryWindow(): JSX.Element {
                 onQueryInputChange={runQuery}
                 onSave={saveAsView}
                 saveDisabledReason={
-                    hasErrors ? error ?? 'Query has errors' : !isValidView ? 'All fields must have an alias' : ''
+                    hasErrors ? error ?? 'Query has errors' : !isValidView ? 'Some fields may need an alias' : ''
                 }
             />
         </div>

--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -451,3 +451,16 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
                 "errors": [],
             },
         )
+
+    def test_is_valid_view_is_false_when_using_scoped_asterisk(self):
+        metadata = self._select("SELECT e.* FROM events e")
+        self.assertEqual(
+            metadata.dict(),
+            metadata.dict()
+            | {
+                "isValid": True,
+                "isValidView": False,
+                "query": "SELECT e.* FROM events e",
+                "errors": [],
+            },
+        )

--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -398,14 +398,14 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
             },
         )
 
-    def test_is_valid_view_is_false_when_not_all_fields_have_aliases(self):
+    def test_is_valid_view_is_true_when_not_all_fields_have_aliases(self):
         metadata = self._select("SELECT event AS event, uuid FROM events")
         self.assertEqual(
             metadata.dict(),
             metadata.dict()
             | {
                 "isValid": True,
-                "isValidView": False,
+                "isValidView": True,
                 "query": "SELECT event AS event, uuid FROM events",
                 "errors": [],
             },
@@ -435,6 +435,19 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
                 "isValid": True,
                 "isValidView": True,
                 "query": "SELECT toDate(timestamp) as timestamp, count() as total_count FROM events GROUP BY timestamp",
+                "errors": [],
+            },
+        )
+
+    def test_is_valid_view_is_false_when_using_asterisk(self):
+        metadata = self._select("SELECT * FROM events")
+        self.assertEqual(
+            metadata.dict(),
+            metadata.dict()
+            | {
+                "isValid": True,
+                "isValidView": False,
+                "query": "SELECT * FROM events",
                 "errors": [],
             },
         )

--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -1,10 +1,11 @@
 from typing import Optional
 
-from posthog.hogql.metadata import get_hogql_metadata
-from posthog.models import PropertyDefinition, Cohort
-from posthog.schema import HogQLMetadata, HogQLMetadataResponse, HogQLQuery, HogLanguage
-from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 from django.test import override_settings
+
+from posthog.hogql.metadata import get_hogql_metadata
+from posthog.models import Cohort, PropertyDefinition
+from posthog.schema import HogLanguage, HogQLMetadata, HogQLMetadataResponse, HogQLQuery
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
 
 class TestMetadata(ClickhouseTestMixin, APIBaseTest):
@@ -381,5 +382,59 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
             | {
                 "isValid": False,
                 "errors": [{"end": 17, "fix": None, "message": "Hog function `NONO` is not implemented", "start": 11}],
+            },
+        )
+
+    def test_is_valid_view_when_all_fields_have_aliases(self):
+        metadata = self._select("SELECT event AS event FROM events")
+        self.assertEqual(
+            metadata.dict(),
+            metadata.dict()
+            | {
+                "isValid": True,
+                "isValidView": True,
+                "query": "SELECT event AS event FROM events",
+                "errors": [],
+            },
+        )
+
+    def test_is_valid_view_is_false_when_not_all_fields_have_aliases(self):
+        metadata = self._select("SELECT event AS event, uuid FROM events")
+        self.assertEqual(
+            metadata.dict(),
+            metadata.dict()
+            | {
+                "isValid": True,
+                "isValidView": False,
+                "query": "SELECT event AS event, uuid FROM events",
+                "errors": [],
+            },
+        )
+
+    def test_is_valid_view_is_false_when_fields_that_are_transformations_dont_have_aliases(self):
+        metadata = self._select("SELECT toDate(timestamp), count() FROM events GROUP BY toDate(timestamp)")
+        self.assertEqual(
+            metadata.dict(),
+            metadata.dict()
+            | {
+                "isValid": True,
+                "isValidView": False,
+                "query": "SELECT toDate(timestamp), count() FROM events GROUP BY toDate(timestamp)",
+                "errors": [],
+            },
+        )
+
+    def test_is_valid_view_is_true_when_fields_that_are_transformations_have_aliases(self):
+        metadata = self._select(
+            "SELECT toDate(timestamp) as timestamp, count() as total_count FROM events GROUP BY timestamp"
+        )
+        self.assertEqual(
+            metadata.dict(),
+            metadata.dict()
+            | {
+                "isValid": True,
+                "isValidView": True,
+                "query": "SELECT toDate(timestamp) as timestamp, count() as total_count FROM events GROUP BY timestamp",
+                "errors": [],
             },
         )

--- a/posthog/warehouse/api/test/test_saved_query.py
+++ b/posthog/warehouse/api/test/test_saved_query.py
@@ -124,7 +124,7 @@ class TestSavedQuery(APIBaseTest):
                 },
             },
         )
-        self.assertEqual(saved_view_2_response.status_code, 400, saved_view_2_response.content)
+        self.assertEqual(saved_view_2_response.status_code, 201, saved_view_2_response.content)
 
     def test_create_with_saved_query(self):
         response = self.client.post(


### PR DESCRIPTION
## Problem

Right now, to save a query as a view, you need to alias every field. This was a workaround in making it easy for field identification for MVP. This should actually just work by inferring the name of the field. If the field is a transformation (functions are applied on the field), only then return a syntax error/note and prompt the user to name that field.

## Changes

- Allow creation of views without aliasing every field
- The only case in which an alias is required is if it is a function call
- Wildcard/asterisk queries are not allowed

As a follow up it would be good to investigate if we can relax these restrictions further.

## Does this work well for both Cloud and self-hosted?

Should do

## How did you test this code?

- Added unit tests to cover various cases
- Tested in the SQL editor on my local deployment
