### PR TITLE
fix(Surveys): Allow more than 6 single choice options if the survey is not of type Popover

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
+++ b/frontend/src/scenes/surveys/SurveyEditQuestionRow.tsx
@@ -10,7 +10,7 @@ import { Group } from 'kea-forms'
 import { SortableDragIcon } from 'lib/lemon-ui/icons'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
-import { Survey, SurveyQuestionType } from '~/types'
+import { Survey, SurveyQuestionType, SurveyType } from '~/types'
 
 import { defaultSurveyFieldValues, NewSurvey, SurveyQuestionLabel } from './constants'
 import { QuestionBranchingInput } from './QuestionBranchingInput'
@@ -315,7 +315,7 @@ export function SurveyEditQuestionGroup({ index, question }: { index: number; qu
                                                 )
                                             })}
                                             <div className="w-fit flex flex-row flex-wrap gap-2">
-                                                {(value || []).length < 6 && (
+                                                {((value || []).length < 6 || survey.type != SurveyType.Popover) && (
                                                     <>
                                                         <LemonButton
                                                             icon={<IconPlusSmall />}


### PR DESCRIPTION
## Problem

From a [customer request](https://posthoghelp.zendesk.com/agent/tickets/20698), we seem to have a hard-coded limit of 6 options for a single-choice question. This makes sense for a PopOver survey, but not an API survey. 

## Changes

Enforce the 6 choices limit only if Survey is of type PopOver

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing