### PR TITLE
fix(product-assistant): planner nodes didn't output tools

### DIFF
--- a/ee/hogai/taxonomy_agent/nodes.py
+++ b/ee/hogai/taxonomy_agent/nodes.py
@@ -120,13 +120,14 @@ class TaxonomyAgentPlannerNode(AssistantNode):
         return ChatOpenAI(model="gpt-4o", temperature=0.2, streaming=True)
 
     def _get_react_format_prompt(self, toolkit: TaxonomyAgentToolkit) -> str:
-        return (
+        return cast(
+            str,
             ChatPromptTemplate.from_template(REACT_FORMAT_PROMPT, template_format="mustache")
             .format_messages(
                 tools=toolkit.render_text_description(),
                 tool_names=", ".join([t["name"] for t in toolkit.tools]),
             )[0]
-            .content
+            .content,
         )
 
     @cached_property

--- a/ee/hogai/taxonomy_agent/nodes.py
+++ b/ee/hogai/taxonomy_agent/nodes.py
@@ -75,10 +75,8 @@ class TaxonomyAgentPlannerNode(AssistantNode):
                 AgentAction,
                 agent.invoke(
                     {
-                        "react_format": REACT_FORMAT_PROMPT,
+                        "react_format": self._get_react_format_prompt(toolkit),
                         "react_format_reminder": REACT_FORMAT_REMINDER_PROMPT,
-                        "tools": toolkit.render_text_description(),
-                        "tool_names": ", ".join([t["name"] for t in toolkit.tools]),
                         "product_description": self._team.project.product_description,
                         "groups": self._team_group_types,
                         "events": self._events_prompt,
@@ -120,6 +118,16 @@ class TaxonomyAgentPlannerNode(AssistantNode):
     @property
     def _model(self) -> ChatOpenAI:
         return ChatOpenAI(model="gpt-4o", temperature=0.2, streaming=True)
+
+    def _get_react_format_prompt(self, toolkit: TaxonomyAgentToolkit) -> str:
+        return (
+            ChatPromptTemplate.from_template(REACT_FORMAT_PROMPT, template_format="mustache")
+            .format_messages(
+                tools=toolkit.render_text_description(),
+                tool_names=", ".join([t["name"] for t in toolkit.tools]),
+            )[0]
+            .content
+        )
 
     @cached_property
     def _events_prompt(self) -> str:

--- a/ee/hogai/taxonomy_agent/test/test_nodes.py
+++ b/ee/hogai/taxonomy_agent/test/test_nodes.py
@@ -22,7 +22,7 @@ from posthog.schema import (
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person
 
 
-class TestToolkit(TaxonomyAgentToolkit):
+class DummyToolkit(TaxonomyAgentToolkit):
     def _get_tools(self) -> list[ToolkitTool]:
         return self._default_tools
 
@@ -36,8 +36,8 @@ class TestTaxonomyAgentPlannerNode(ClickhouseTestMixin, APIBaseTest):
     def _get_node(self):
         class Node(TaxonomyAgentPlannerNode):
             def run(self, state: AssistantState, config: RunnableConfig) -> AssistantState:
-                prompt = ChatPromptTemplate.from_messages([("user", "test")])
-                toolkit = TestToolkit(self._team)
+                prompt: ChatPromptTemplate = ChatPromptTemplate.from_messages([("user", "test")])
+                toolkit = DummyToolkit(self._team)
                 return super()._run_with_prompt_and_toolkit(state, prompt, toolkit, config=config)
 
         return Node(self.team)
@@ -180,13 +180,21 @@ class TestTaxonomyAgentPlannerNode(ClickhouseTestMixin, APIBaseTest):
             node._events_prompt,
         )
 
+    def test_format_prompt(self):
+        node = self._get_node()
+        self.assertNotIn("Human:", node._get_react_format_prompt(DummyToolkit(self.team)))
+        self.assertIn("retrieve_event_properties,", node._get_react_format_prompt(DummyToolkit(self.team)))
+        self.assertIn(
+            "retrieve_event_properties(event_name: str)", node._get_react_format_prompt(DummyToolkit(self.team))
+        )
+
 
 @override_settings(IN_UNIT_TESTING=True)
 class TestTaxonomyAgentPlannerToolsNode(ClickhouseTestMixin, APIBaseTest):
     def _get_node(self):
         class Node(TaxonomyAgentPlannerToolsNode):
             def run(self, state: AssistantState, config: RunnableConfig) -> AssistantState:
-                toolkit = TestToolkit(self._team)
+                toolkit = DummyToolkit(self._team)
                 return super()._run_with_toolkit(state, toolkit, config=config)
 
         return Node(self.team)


### PR DESCRIPTION
## Problem

Fixes a regression introduced in #26166: the planner nodes didn't output tools because I changed how variables were injected to the system prompt.

## Changes

- Ensure nodes always have tools.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Added a test.
