### PR TITLE
fix: only let someone use the dashboard templates if they've ingested events

### DIFF
--- a/frontend/src/scenes/onboarding/Onboarding.tsx
+++ b/frontend/src/scenes/onboarding/Onboarding.tsx
@@ -26,6 +26,7 @@ import { ExperimentsSDKInstructions } from './sdks/experiments/ExperimentsSDKIns
 import { FeatureFlagsSDKInstructions } from './sdks/feature-flags/FeatureFlagsSDKInstructions'
 import { ProductAnalyticsSDKInstructions } from './sdks/product-analytics/ProductAnalyticsSDKInstructions'
 import { SDKs } from './sdks/SDKs'
+import { sdksLogic } from './sdks/sdksLogic'
 import { SessionReplaySDKInstructions } from './sdks/session-replay/SessionReplaySDKInstructions'
 import { SurveysSDKInstructions } from './sdks/surveys/SurveysSDKInstructions'
 
@@ -105,12 +106,16 @@ const OnboardingWrapper = ({ children }: { children: React.ReactNode }): JSX.Ele
 const ProductAnalyticsOnboarding = (): JSX.Element => {
     const { currentTeam } = useValues(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+    const { combinedSnippetAndLiveEventsHosts } = useValues(sdksLogic)
+
     // mount the logic here so that it stays mounted for the entire onboarding flow
     // not sure if there is a better way to do this
     useValues(newDashboardLogic)
 
     const showTemplateSteps =
-        featureFlags[FEATURE_FLAGS.ONBOARDING_DASHBOARD_TEMPLATES] == 'test' && window.innerWidth > 1000
+        featureFlags[FEATURE_FLAGS.ONBOARDING_DASHBOARD_TEMPLATES] == 'test' &&
+        window.innerWidth > 1000 &&
+        combinedSnippetAndLiveEventsHosts.length > 0
 
     const options: ProductConfigOption[] = [
         {

--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
@@ -52,8 +52,8 @@ const UrlInput = ({ iframeRef }: { iframeRef: React.RefObject<HTMLIFrameElement>
     return (
         <div className="w-full flex gap-x-2 border-b border-1 border-border-bold p-2">
             <LemonInput
-                size="small"
-                className="grow font-mono text-sm"
+                size="medium"
+                className="grow font-mono text-sm pl-0.5"
                 defaultValue={currentPath}
                 value={inputValue}
                 onChange={(v) => setInputValue(v)}


### PR DESCRIPTION
## Problem

If someone hasn't ingested events, the dashboard templates might be confusing. I think we can maybe use this as a lever to try to get people to install an SDK... but right now I just want to see if this works for people who _have_ installed one.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Only let someone use the dashboard templates in onboarding if they've ingested events from an allowed domain (ie one that matches the site protocol).

Also fixes a bit of CSS that was bothering me.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

It works on my machine.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
