### PR TITLE
fix: password validation correction

### DIFF
--- a/frontend/src/scenes/authentication/signup/signupForm/panels/SignupPanel1.tsx
+++ b/frontend/src/scenes/authentication/signup/signupForm/panels/SignupPanel1.tsx
@@ -49,7 +49,6 @@ export function SignupPanel1(): JSX.Element | null {
                                 <PasswordStrength validatedPassword={validatedPassword} />
                             </div>
                         }
-                        validateStatus={!validatedPassword?.password ? undefined : validatedPassword.valid ? 'success' : 'error'}
                     >
                         <LemonInput
                             type="password"

--- a/frontend/src/scenes/authentication/signup/signupForm/panels/SignupPanel1.tsx
+++ b/frontend/src/scenes/authentication/signup/signupForm/panels/SignupPanel1.tsx
@@ -49,6 +49,7 @@ export function SignupPanel1(): JSX.Element | null {
                                 <PasswordStrength validatedPassword={validatedPassword} />
                             </div>
                         }
+                        validateStatus={!validatedPassword?.password ? undefined : validatedPassword.valid ? 'success' : 'error'}
                     >
                         <LemonInput
                             type="password"

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -67,7 +67,7 @@ export const signupLogic = kea<signupLogicType>([
                 password: !values.preflight?.demo
                     ? !password
                         ? 'Please enter your password to continue'
-                        : values.validatedPassword.feedback
+                        : values.validatedPassword.feedback || undefined
                     : undefined,
             }),
             submit: async () => {


### PR DESCRIPTION
## Problem

The password validator wasn't clearing correctly leaving behind an error even after the user inputs a valid password.

Example:
![Screenshot 2024-11-14 at 11 29 21 AM](https://github.com/user-attachments/assets/cc31a07e-ee0c-4931-b863-6ced23727f63)


## Changes

 1 Return undefined when there's no feedback (empty string or null/undefined)                                            
 2 Only show the feedback message when it actually contains text                                                         
 3 Properly clear the error state when the password is valid   


https://github.com/user-attachments/assets/8b45a39b-e106-4fd5-b2a1-73d2081b6378



👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Cloud

## How did you test this code?

1. I tested this in my localhost: http://localhost:8000/signup
2. Will verify if all tests pass before shipping
