### PR TITLE
feat(insights): Support HogQL for data warehouse filters

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -40,6 +40,7 @@ import {
 } from 'scenes/trends/mathsLogic'
 
 import { actionsModel } from '~/models/actionsModel'
+import { NodeKind } from '~/queries/schema'
 import { isInsightVizNode, isStickinessQuery } from '~/queries/utils'
 import {
     ActionFilter,
@@ -596,9 +597,20 @@ export function ActionFilterRow({
                         onChange={(properties) => updateFilterProperty({ properties, index })}
                         showNestedArrow={showNestedArrow}
                         disablePopover={!propertyFiltersPopover}
+                        metadataSource={
+                            filter.type == TaxonomicFilterGroupType.DataWarehouse
+                                ? {
+                                      kind: NodeKind.HogQLQuery,
+                                      query: `select ${filter.distinct_id_field} from ${filter.table_name}`,
+                                  }
+                                : undefined
+                        }
                         taxonomicGroupTypes={
                             filter.type == TaxonomicFilterGroupType.DataWarehouse
-                                ? [TaxonomicFilterGroupType.DataWarehouseProperties]
+                                ? [
+                                      TaxonomicFilterGroupType.DataWarehouseProperties,
+                                      TaxonomicFilterGroupType.HogQLExpression,
+                                  ]
                                 : propertiesTaxonomicGroupTypes
                         }
                         eventNames={


### PR DESCRIPTION
## Changes

Adds support for HogQL in data warehouse filters, with proper column name validation.

![CleanShot 2024-11-18 at 06 47 25](https://github.com/user-attachments/assets/0204f7b5-7555-46de-95a6-36fc1fb7397f)

See https://posthog.slack.com/archives/C019RAX2XBN/p1731680507422479

## How did you test this code?

I created a new Insight, selected my data warehouse table as the series, and added an ActionRowFilter with a HogQL expression.

I verified that my column name was validated as expected. A valid column name showed the correct type, and an invalid column name showed an error.

I saved the Insight and verified the filter persisted on reload.