### PR TITLE
feat(cdp): add sha256HexWithNull function

### DIFF
--- a/hogvm/python/stl/__init__.py
+++ b/hogvm/python/stl/__init__.py
@@ -22,7 +22,7 @@ from .date import (
     is_hog_datetime,
     is_hog_date,
 )
-from .crypto import sha256Hex, md5Hex, sha256HmacChainHex
+from .crypto import sha256Hex, md5Hex, sha256HmacChainHex, sha256HexWithNull
 from ..objects import is_hog_error, new_hog_error, is_hog_callable, is_hog_closure
 from ..utils import like, get_nested_value
 
@@ -491,6 +491,9 @@ STL: dict[str, STLFunction] = {
     "splitByString": STLFunction(fn=splitByString, minArgs=2, maxArgs=3),
     "generateUUIDv4": STLFunction(fn=generateUUIDv4, minArgs=0, maxArgs=0),
     "sha256Hex": STLFunction(fn=lambda args, team, stdout, timeout: sha256Hex(args[0]), minArgs=1, maxArgs=1),
+    "sha256HexWithNull": STLFunction(
+        fn=lambda args, team, stdout, timeout: sha256HexWithNull(args[0]), minArgs=1, maxArgs=1
+    ),
     "md5Hex": STLFunction(fn=lambda args, team, stdout, timeout: md5Hex(args[0]), minArgs=1, maxArgs=1),
     "sha256HmacChainHex": STLFunction(
         fn=lambda args, team, stdout, timeout: sha256HmacChainHex(args[0]), minArgs=1, maxArgs=1

--- a/hogvm/python/stl/crypto.py
+++ b/hogvm/python/stl/crypto.py
@@ -10,6 +10,12 @@ def sha256Hex(data: str) -> str:
     return hashlib.sha256(data.encode()).hexdigest()
 
 
+def sha256HexWithNull(data: str | None) -> str | None:
+    if data is None:
+        return None
+    return hashlib.sha256(data.encode()).hexdigest()
+
+
 def sha256HmacChainHex(data: list) -> str:
     if len(data) < 2:
         raise ValueError("Data array must contain at least two elements.")

--- a/hogvm/typescript/src/stl/crypto.ts
+++ b/hogvm/typescript/src/stl/crypto.ts
@@ -8,6 +8,17 @@ export function sha256Hex(data: string, options?: ExecOptions): string {
     return crypto.createHash('sha256').update(data).digest('hex')
 }
 
+export function sha256HexWithNull(data: string | null, options?: ExecOptions): string | null {
+    const crypto = options?.external?.crypto
+    if (!crypto) {
+        throw new Error('The crypto module is required for "sha256Hex" to work.')
+    }
+    if (data === null) {
+        return null
+    }
+    return crypto.createHash('sha256').update(data).digest('hex')
+}
+
 export function md5Hex(data: string, options?: ExecOptions): string {
     const crypto = options?.external?.crypto
     if (!crypto) {

--- a/hogvm/typescript/src/stl/stl.ts
+++ b/hogvm/typescript/src/stl/stl.ts
@@ -3,7 +3,7 @@ import { DateTime } from 'luxon'
 import { isHogCallable, isHogClosure, isHogDate, isHogDateTime, isHogError, newHogError } from '../objects'
 import { AsyncSTLFunction, STLFunction } from '../types'
 import { getNestedValue, like } from '../utils'
-import { md5Hex, sha256Hex, sha256HmacChainHex } from './crypto'
+import {md5Hex, sha256Hex, sha256HexWithNull, sha256HmacChainHex} from './crypto'
 import {
     formatDateTime,
     fromUnixTimestamp,
@@ -517,6 +517,11 @@ export const STL: Record<string, STLFunction> = {
     },
     sha256Hex: {
         fn: ([str], _, options) => sha256Hex(str, options),
+        minArgs: 1,
+        maxArgs: 1,
+    },
+    sha256HexWithNull: {
+        fn: ([str], _, options) => sha256HexWithNull(str, options),
         minArgs: 1,
         maxArgs: 1,
     },

--- a/posthog/cdp/templates/snapchat_ads/template_snapchat_ads.py
+++ b/posthog/cdp/templates/snapchat_ads/template_snapchat_ads.py
@@ -112,8 +112,8 @@ if (res.status >= 400) {
             "label": "User data",
             "description": "A map that contains customer information data. See this page for options: https://developers.snap.com/api/marketing-api/Conversions-API/Parameters#user-data-parameters",
             "default": {
-                "em": "{sha256Hex(person.properties.email ?? '')}",
-                "ph": "{sha256Hex(person.properties.phone ?? '')}",
+                "em": "{sha256HexWithNull(person.properties.email)}",
+                "ph": "{sha256HexWithNull(person.properties.phone)}",
                 "sc_click_id": "{person.properties.sccid ?? person.properties.$initial_sccid ?? ''}",
             },
             "secret": False,


### PR DESCRIPTION
## Problem

a way to avoid using this code: https://github.com/PostHog/posthog/pull/26173/files#diff-684d0c69e11a4582b9968d3ad3cd9680c4044e13d122a9bcc2dcc551fac19010R26-R31

## Changes

- adds a new `sha256HexWithNull` function that will return null if the input is null.

TODO: (@mariusandra I need your help with these ones)
- [ ] There is something missing to access the new function in posthog locally
- [ ] update the `crypto.hoge` file

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
