### PR TITLE
feat(experiments HogQL): add disabled UI placeholder

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -229,6 +229,7 @@ export const FEATURE_FLAGS = {
     EDIT_DWH_SOURCE_CONFIG: 'edit_dwh_source_config', // owner: @Gilbert09 #team-data-warehouse
     AI_SURVEY_RESPONSE_SUMMARY: 'ai-survey-response-summary', // owner: @pauldambra
     CUSTOM_CHANNEL_TYPE_RULES: 'custom-channel-type-rules', // owner: @robbie-c #team-web-analytics
+    EXPERIMENTS_MIGRATION_DISABLE_UI: 'experiments-migration-disable-ui', // owner: @jurajmajerik #team-experiments
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -14,6 +14,7 @@ import { capitalizeFirstLetter } from 'lib/utils'
 import { experimentsLogic } from 'scenes/experiments/experimentsLogic'
 
 import { experimentLogic } from './experimentLogic'
+import { ExperimentsDisabledBanner } from './Experiments'
 
 const ExperimentFormFields = (): JSX.Element => {
     const { experiment, featureFlags, groupTypes, aggregationLabel, dynamicFeatureFlagKey } = useValues(experimentLogic)
@@ -21,7 +22,9 @@ const ExperimentFormFields = (): JSX.Element => {
         useActions(experimentLogic)
     const { webExperimentsAvailable } = useValues(experimentsLogic)
 
-    return (
+    return featureFlags[FEATURE_FLAGS.EXPERIMENTS_MIGRATION_DISABLE_UI] ? (
+        <ExperimentsDisabledBanner />
+    ) : (
         <div>
             <div className="space-y-8">
                 <div className="space-y-6 max-w-120">

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -2,11 +2,13 @@ import '../Experiment.scss'
 
 import { LemonDivider, LemonTabs } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { PostHogFeature } from 'posthog-js/react'
 import { WebExperimentImplementationDetails } from 'scenes/experiments/WebExperimentImplementationDetails'
 
 import { ExperimentImplementationDetails } from '../ExperimentImplementationDetails'
 import { experimentLogic } from '../experimentLogic'
+import { ExperimentsDisabledBanner } from '../Experiments'
 import {
     ExperimentLoadingAnimation,
     LoadingState,
@@ -67,14 +69,16 @@ const VariantsTab = (): JSX.Element => {
 }
 
 export function ExperimentView(): JSX.Element {
-    const { experimentLoading, experimentResultsLoading, experimentId, experimentResults, tabKey } =
+    const { experimentLoading, experimentResultsLoading, experimentId, experimentResults, tabKey, featureFlags } =
         useValues(experimentLogic)
 
     const { setTabKey } = useActions(experimentLogic)
 
     const hasResultsInsight = experimentResults && experimentResults.insight
 
-    return (
+    return featureFlags[FEATURE_FLAGS.EXPERIMENTS_MIGRATION_DISABLE_UI] ? (
+        <ExperimentsDisabledBanner />
+    ) : (
         <>
             <PageHeaderCustom />
             <div className="space-y-8 experiment-view">

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -1,7 +1,7 @@
 import { LemonDialog, LemonInput, LemonSelect } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import { ExperimentsHog } from 'lib/components/hedgehogs'
+import { DetectiveHog, ExperimentsHog } from 'lib/components/hedgehogs'
 import { MemberSelect } from 'lib/components/MemberSelect'
 import { PageHeader } from 'lib/components/PageHeader'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
@@ -16,6 +16,7 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { Link } from 'lib/lemon-ui/Link'
 import stringWithWBR from 'lib/utils/stringWithWBR'
+import posthog from 'posthog-js'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -28,6 +29,33 @@ import { Holdouts } from './Holdouts'
 export const scene: SceneExport = {
     component: Experiments,
     logic: experimentsLogic,
+}
+
+export const ExperimentsDisabledBanner = (): JSX.Element => {
+    const payload = posthog.getFeatureFlagPayload(FEATURE_FLAGS.EXPERIMENTS_MIGRATION_DISABLE_UI)
+
+    return (
+        <div className="border-2 border-dashed border-border w-full p-8 justify-center rounded mt-2 mb-4">
+            <div className="flex items-center gap-8 w-full justify-center flex-wrap">
+                <div>
+                    <div className="w-50 mx-auto mb-4">
+                        <DetectiveHog className="w-full h-full" />
+                    </div>
+                </div>
+                <div className="flex-shrink max-w-140">
+                    <h2>We'll be right back!</h2>
+                    <p>
+                        We’re upgrading experiments to a new schema to make them faster, more reliable, and ready for
+                        future improvements.
+                    </p>
+                    <p>
+                        We expect to be done by <span className="font-semibold">{payload}</span>. Thanks for your
+                        patience!
+                    </p>
+                </div>
+            </div>
+        </div>
+    )
 }
 
 export function Experiments(): JSX.Element {
@@ -189,7 +217,9 @@ export function Experiments(): JSX.Element {
         },
     ]
 
-    return (
+    return featureFlags[FEATURE_FLAGS.EXPERIMENTS_MIGRATION_DISABLE_UI] ? (
+        <ExperimentsDisabledBanner />
+    ) : (
         <div>
             <PageHeader
                 buttons={


### PR DESCRIPTION
## Changes
Feature flag: `experiments-migration-disable-ui`

- Disable the experiments view, the results page, and the form for the duration of the records migration
- The time is TBD and will be passed to the banner via a feature flag payload.

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/9c83b7b6-9bb5-4fd5-8e66-320ec8537280">

## How did you test this code?
👀 