### PR TITLE
fix: delay the payment intent auth

### DIFF
--- a/frontend/src/scenes/billing/PaymentEntryModal.tsx
+++ b/frontend/src/scenes/billing/PaymentEntryModal.tsx
@@ -71,18 +71,22 @@ export const PaymentEntryModal = ({
     const [stripePromise, setStripePromise] = useState<any>(null)
 
     useEffect(() => {
-        // Load Stripe.js asynchronously
-        const loadStripeJs = async (): Promise<void> => {
-            const { loadStripe } = await stripeJs()
-            const publicKey = window.STRIPE_PUBLIC_KEY!
-            setStripePromise(await loadStripe(publicKey))
+        // Only load Stripe.js when the modal is opened
+        if (paymentEntryModalOpen && !stripePromise) {
+            const loadStripeJs = async (): Promise<void> => {
+                const { loadStripe } = await stripeJs()
+                const publicKey = window.STRIPE_PUBLIC_KEY!
+                setStripePromise(await loadStripe(publicKey))
+            }
+            void loadStripeJs()
         }
-        void loadStripeJs()
-    }, [])
+    }, [paymentEntryModalOpen, stripePromise])
 
     useEffect(() => {
-        initiateAuthorization(redirectPath)
-    }, [initiateAuthorization, redirectPath])
+        if (paymentEntryModalOpen) {
+            initiateAuthorization(redirectPath)
+        }
+    }, [paymentEntryModalOpen, initiateAuthorization, redirectPath])
 
     return (
         <LemonModal


### PR DESCRIPTION
## Changes

On Friday I shipped the PR for rendering the payment modal to test out credit card entry in app. This is making a request to billing to authorize the payment intent. We don't want this to happen until they open the modal.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

## How did you test this code?

Manually
