### PR TITLE
fix(flags): prevent kea logic loop when switching tabs in FF UI

### DIFF
--- a/cypress/e2e/featureFlags.cy.ts
+++ b/cypress/e2e/featureFlags.cy.ts
@@ -308,7 +308,8 @@ describe('Feature Flags', () => {
         cy.get('.operator-value-option').contains('> after').should('not.exist')
     })
 
-    it('Allow setting multivariant rollout percentage to zero', () => {
+    it('Allows setting multivariant rollout percentage to zero', () => {
+        cy.get('[data-attr=top-bar-name]').should('contain', 'Feature flags')
         // Start creating a multivariant flag
         cy.get('[data-attr=new-feature-flag]').click()
         cy.get('[data-attr=feature-flag-served-value-segmented-button]')
@@ -326,6 +327,15 @@ describe('Feature Flags', () => {
             .type(`{backspace}{backspace}`)
             .should('have.value', 0)
         cy.get('[data-attr=feature-flag-variant-rollout-percentage-input]').click().type(`4.5`).should('have.value', 4)
+    })
+
+    it('Sets URL properly when switching between tabs', () => {
+        cy.get('[data-attr=top-bar-name]').should('contain', 'Feature flags')
+        cy.get('[data-attr=feature-flags-tab-navigation]').contains('History').click()
+        cy.url().should('include', `tab=history`)
+
+        cy.get('[data-attr=feature-flags-tab-navigation]').contains('Overview').click()
+        cy.url().should('include', `tab=overview`)
     })
 
     it('Renders flags in FlagSelector', () => {

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -436,6 +436,7 @@ export function FeatureFlags(): JSX.Element {
                         content: <ActivityLog scope={ActivityScope.FEATURE_FLAG} />,
                     },
                 ]}
+                data-attr="feature-flags-tab-navigation"
             />
         </div>
     )

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
@@ -242,6 +242,10 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
             // Initialize filters with the URL params if none are set
             const isInitializingFilters =
                 objectsEqual(DEFAULT_FILTERS, values.filters) && !objectsEqual(DEFAULT_FILTERS, pageFiltersFromUrl)
+            /**
+             * Pagination search param in the URL is modified directly by the LemonTable component,
+             * so let's update filter state if it changes
+             */
             const isChangingPage = page !== undefined && page !== values.filters.page
             if (isInitializingFilters || isChangingPage) {
                 actions.setFeatureFlagsFilters({ ...DEFAULT_FILTERS, ...pageFiltersFromUrl })

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
@@ -231,15 +231,12 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
                 order,
             }
 
-            if (active !== undefined) {
-                pageFiltersFromUrl.active = String(active)
-            }
+            pageFiltersFromUrl.active = active ? String(active) : undefined
+            pageFiltersFromUrl.page = page ? parseInt(page) : 1
 
-            if (page !== undefined) {
-                pageFiltersFromUrl.page = parseInt(page)
+            if (!objectsEqual(pageFiltersFromUrl, values.filters)) {
+                actions.setFeatureFlagsFilters({ ...DEFAULT_FILTERS, ...pageFiltersFromUrl, ...values.filters })
             }
-
-            actions.setFeatureFlagsFilters({ ...DEFAULT_FILTERS, ...pageFiltersFromUrl })
         },
     })),
     events(({ actions }) => ({

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
@@ -231,11 +231,20 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
                 order,
             }
 
-            pageFiltersFromUrl.active = active ? String(active) : undefined
-            pageFiltersFromUrl.page = page ? parseInt(page) : 1
+            if (active !== undefined) {
+                pageFiltersFromUrl.active = String(active)
+            }
 
-            if (!objectsEqual(pageFiltersFromUrl, values.filters)) {
-                actions.setFeatureFlagsFilters({ ...DEFAULT_FILTERS, ...pageFiltersFromUrl, ...values.filters })
+            if (page !== undefined) {
+                pageFiltersFromUrl.page = parseInt(page)
+            }
+
+            // Initialize filters with the URL params if none are set
+            const isInitializingFilters =
+                objectsEqual(DEFAULT_FILTERS, values.filters) && !objectsEqual(DEFAULT_FILTERS, pageFiltersFromUrl)
+            const isChangingPage = page !== undefined && page !== values.filters.page
+            if (isInitializingFilters || isChangingPage) {
+                actions.setFeatureFlagsFilters({ ...DEFAULT_FILTERS, ...pageFiltersFromUrl })
             }
         },
     })),


### PR DESCRIPTION
## Problem

Addresses https://posthog.sentry.io/issues/6064081660/?project=1899813

## Changes

Addresses a cycle between urlToAction <-> actionToUrl which causes the `Maximum call stack size exceeded` error we saw in Sentry

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->
Yes

## How did you test this code?

- Added cypress test
- (no sound in loom) https://www.loom.com/share/94a478c2f3dc4421aa163730e05c8e78
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
