### PR TITLE
fix(flags): prevent kea logic loop and clean filters on tab switch

### DIFF
--- a/cypress/e2e/featureFlags.cy.ts
+++ b/cypress/e2e/featureFlags.cy.ts
@@ -17,10 +17,8 @@ describe('Feature Flags', () => {
     })
 
     it('Display product introduction when no feature flags exist', () => {
-        // ensure unique names to avoid clashes
         cy.get('[data-attr=top-bar-name]').should('contain', 'Feature flags')
-        cy.get('[data-attr=new-feature-flag]').click()
-        cy.contains('Create your first feature flag').should('exist')
+        cy.contains('Welcome to Feature flags!').should('exist')
     })
 
     it('Create feature flag', () => {
@@ -104,6 +102,7 @@ describe('Feature Flags', () => {
         cy.get('[data-attr=feature-flag-key]').focus().type(name).should('have.value', name)
         cy.get('[data-attr=rollout-percentage]').type('{selectall}50').should('have.value', '50')
         cy.get('[data-attr=save-feature-flag]').first().click()
+        cy.get('[data-attr=toast-close-button]').click()
 
         // after save there should be a delete button
         cy.get('[data-attr="more-button"]').click()
@@ -336,6 +335,9 @@ describe('Feature Flags', () => {
 
         cy.get('[data-attr=feature-flags-tab-navigation]').contains('Overview').click()
         cy.url().should('include', `tab=overview`)
+
+        cy.get('[data-attr=feature-flags-tab-navigation]').contains('History').click()
+        cy.url().should('include', `tab=history`)
     })
 
     it('Renders flags in FlagSelector', () => {

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
@@ -180,6 +180,10 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
             await breakpoint(300)
             actions.loadFeatureFlags()
         },
+        setActiveTab: () => {
+            // Don't carry over pagination from previous tab
+            actions.setFeatureFlagsFilters({ page: 1 }, true)
+        },
     })),
     actionToUrl(({ values }) => {
         const changeUrl = ():
@@ -218,9 +222,11 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
             if (!tabInURL) {
                 if (values.activeTab !== FeatureFlagsTab.OVERVIEW) {
                     actions.setActiveTab(FeatureFlagsTab.OVERVIEW)
+                    return
                 }
             } else if (tabInURL !== values.activeTab) {
                 actions.setActiveTab(tabInURL)
+                return
             }
 
             const { page, created_by_id, active, type, search, order } = searchParams
@@ -231,13 +237,8 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
                 order,
             }
 
-            if (active !== undefined) {
-                pageFiltersFromUrl.active = String(active)
-            }
-
-            if (page !== undefined) {
-                pageFiltersFromUrl.page = parseInt(page)
-            }
+            pageFiltersFromUrl.active = active ? String(active) : undefined
+            pageFiltersFromUrl.page = page ? parseInt(page) : undefined
 
             // Initialize filters with the URL params if none are set
             const isInitializingFilters =

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
@@ -222,11 +222,9 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
             if (!tabInURL) {
                 if (values.activeTab !== FeatureFlagsTab.OVERVIEW) {
                     actions.setActiveTab(FeatureFlagsTab.OVERVIEW)
-                    return
                 }
             } else if (tabInURL !== values.activeTab) {
                 actions.setActiveTab(tabInURL)
-                return
             }
 
             const { page, created_by_id, active, type, search, order } = searchParams
@@ -240,17 +238,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
             pageFiltersFromUrl.active = active ? String(active) : undefined
             pageFiltersFromUrl.page = page ? parseInt(page) : undefined
 
-            // Initialize filters with the URL params if none are set
-            const isInitializingFilters =
-                objectsEqual(DEFAULT_FILTERS, values.filters) && !objectsEqual(DEFAULT_FILTERS, pageFiltersFromUrl)
-            /**
-             * Pagination search param in the URL is modified directly by the LemonTable component,
-             * so let's update filter state if it changes
-             */
-            const isChangingPage = page !== undefined && page !== values.filters.page
-            if (isInitializingFilters || isChangingPage) {
-                actions.setFeatureFlagsFilters({ ...DEFAULT_FILTERS, ...pageFiltersFromUrl })
-            }
+            actions.setFeatureFlagsFilters({ ...DEFAULT_FILTERS, ...pageFiltersFromUrl })
         },
     })),
     events(({ actions }) => ({

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
@@ -235,8 +235,8 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
                 order,
             }
 
-            pageFiltersFromUrl.active = active ? String(active) : undefined
-            pageFiltersFromUrl.page = page ? parseInt(page) : undefined
+            pageFiltersFromUrl.active = active !== undefined ? String(active) : undefined
+            pageFiltersFromUrl.page = page !== undefined ? parseInt(page) : undefined
 
             actions.setFeatureFlagsFilters({ ...DEFAULT_FILTERS, ...pageFiltersFromUrl })
         },


### PR DESCRIPTION
## Problem

Issue resolved by https://github.com/PostHog/posthog/pull/26257 re-occurred, after investigating I found that a fresh navigation to the FF UI still exhibits the `Maximum call stack size exceeded` error here: 
https://posthog.sentry.io/issues/6063840317/?notification_uuid=65ceb7bd-8e81-49e2-bb7b-956fddd59861&project=1899813&referrer=regression_activity-email 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- Fixed issue where a fresh navigation to Feature flags can still have the maximum depth exceeded error
- Cleaned up `page` search param being carried over between tab switches

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

https://www.loom.com/share/b5e4c76aba3e4d63b0218e96d51da944

