### PR TITLE
fix(flags): prevent error when CohortCriteriaGroupFilter has undefined values

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/cohortFilterUtils.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/cohortFilterUtils.ts
@@ -10,7 +10,7 @@ function isCohortCriteriaGroupFilter(
 
 const hasBehavioralFilter = (cohort: CohortType, allCohorts: CohortType[]): boolean => {
     const checkCriteriaGroup = (group: CohortCriteriaGroupFilter): boolean => {
-        return group.values.some((value) => {
+        return group.values?.some((value) => {
             if (isCohortCriteriaGroupFilter(value)) {
                 return checkCriteriaGroup(value)
             }


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/pull/25529, addresses error seen in sentry: https://posthog.sentry.io/issues/6073424921/?notification_uuid=8b502254-c66c-409e-a8af-9c899eea79c4&project=1899813&referrer=assigned_activity-email

I'm unclear on if groups.values is ever _expected_ to be undefined, but we should at least handle gracefully if this occurs. The TS types aren't expecting the data to be in this state, but they might be too optimistic.

This appears to be the cause of https://posthoghelp.zendesk.com/agent/tickets/20808 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/23213)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- Of course there should be no functional change for expected data, so existing tests should be sufficient

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
