### PR TITLE
fix: Hubspot scopes

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -166,7 +166,11 @@ class OauthIntegration:
                 token_info_config_fields=["hub_id", "hub_domain", "user", "user_id"],
                 client_id=settings.HUBSPOT_APP_CLIENT_ID,
                 client_secret=settings.HUBSPOT_APP_CLIENT_SECRET,
-                scope="tickets crm.objects.contacts.write sales-email-read crm.objects.companies.read crm.objects.deals.read crm.objects.contacts.read crm.objects.quotes.read analytics.behavioral_events.send behavioral_events.event_definitions.read_write",
+                scope="tickets crm.objects.contacts.write sales-email-read crm.objects.companies.read crm.objects.deals.read crm.objects.contacts.read crm.objects.quotes.read",
+                additional_authorize_params={
+                    # NOTE: these scopes are only available on certain hubspot plans and as such are optional
+                    "optional_scope": "analytics.behavioral_events.send behavioral_events.event_definitions.read_write"
+                },
                 id_path="hub_id",
                 name_path="hub_domain",
             )


### PR DESCRIPTION
## Problem

The hubspot scopes were made as conditionally required but they are only available on certain plans so need to be set as optional scopes

## Changes

* Fixes it

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
