### PR TITLE
fix: Make snowflake interface error non-retryable

### DIFF
--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -12,7 +12,7 @@ import pyarrow as pa
 import snowflake.connector
 from django.conf import settings
 from snowflake.connector.connection import SnowflakeConnection
-from snowflake.connector.errors import OperationalError
+from snowflake.connector.errors import OperationalError, InterfaceError
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
@@ -205,6 +205,9 @@ class SnowflakeClient:
                 ) from err
             else:
                 raise SnowflakeConnectionError(f"Could not connect to Snowflake - {err.errno}: {err.msg}") from err
+
+        except InterfaceError as err:
+            raise SnowflakeConnectionError(f"Could not connect to Snowflake - {err.errno}: {err.msg}") from err
 
         self._connection = connection
 


### PR DESCRIPTION
## Problem

Snowflake raises an `InterfaceError` when hitting 404 Not Found on the requests. This is usually due to a misconfiguration of the destination (e.g. incorrect account), as Snowflake builds up URLs from the destination configuration, so if anything leads to a non-existent URL we will see a 404.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Raise `SnowflakeConnectionError` on `InterfaceError` raised during connection.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
