### PR TITLE
chore: Bump batch exports start jitter

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -679,7 +679,7 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
             start_at=batch_export.start_at,
             end_at=batch_export.end_at,
             intervals=[ScheduleIntervalSpec(every=batch_export.interval_time_delta)],
-            jitter=(batch_export.interval_time_delta / 12),
+            jitter=(batch_export.interval_time_delta / 6),
             time_zone_name=batch_export.team.timezone,
         ),
         state=state,


### PR DESCRIPTION
## Problem

Batch exports are thunder herding a bit too much. Let's spread out the load by increasing start jitter to 1/6 of the interval. This means that:
* Hourly batch exports will start within 10 minutes of the hour mark.
* Daily batch exports will start within 2~ hours of midnight.
* 5 minute batch exports will start within 50 seconds of the 5 minute mark.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Increase jitter to 1/6 of the interval.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
