### PR TITLE
feat(hogql): Allow breakdowns for lazy-joined tables

### DIFF
--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -888,7 +888,16 @@ class TrendsQueryRunner(QueryRunner):
             if not table_or_view:
                 raise ValueError(f"Table {series.table_name} not found")
 
-            field_type = dict(table_or_view.columns)[self.query.breakdownFilter.breakdown]["clickhouse"]
+            breakdown_key = (
+                self.query.breakdownFilter.breakdown[0]
+                if isinstance(self.query.breakdownFilter.breakdown, list)
+                else self.query.breakdownFilter.breakdown
+            )
+
+            if breakdown_key not in dict(table_or_view.columns):
+                return False
+
+            field_type = dict(table_or_view.columns)[breakdown_key]["clickhouse"]
 
             if field_type.startswith("Nullable("):
                 field_type = field_type.replace("Nullable(", "")[:-1]

--- a/posthog/hogql_queries/insights/trends/utils.py
+++ b/posthog/hogql_queries/insights/trends/utils.py
@@ -26,7 +26,7 @@ def get_properties_chain(
         raise Exception("group_type_index missing from params")
 
     if breakdown_type == "data_warehouse":
-        return [breakdown_field]
+        return [*breakdown_field.split(".")]
 
     if breakdown_type == "data_warehouse_person_property":
         return ["person", *breakdown_field.split(".")]


### PR DESCRIPTION
## Changes

Allows breakdowns for lazy-joined tables by splitting `breakdown_field` by `.` to support nested references.

From https://github.com/PostHog/posthog/pull/26247

## How did you test this code?

Tests should pass.