### PR TITLE
fix(data-warehouse): Fix custom series colors in chart tooltips

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -348,7 +348,9 @@ export const LineGraph = (): JSX.Element => {
                                             },
                                         ]}
                                         uppercaseHeader={false}
-                                        rowRibbonColor={(_datum, index) => getSeriesColor(index)}
+                                        rowRibbonColor={(_datum, index) =>
+                                            ySeriesData[index]?.settings?.display?.color ?? getSeriesColor(index)
+                                        }
                                         showHeader
                                     />
                                 </div>


### PR DESCRIPTION
## Problem

Fixes #26233 

## Changes

- Use series custom color for chart tooltips if set


## Does this work well for both Cloud and self-hosted?

Should do

## How did you test this code?

Manual testing
