### PR TITLE
fix(hogql): Support parsing dw properties with nested values

### DIFF
--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -238,44 +238,6 @@ def _expr_to_compare_op(
         raise NotImplementedError(f"PropertyOperator {operator} not implemented")
 
 
-def _handle_property_values(
-    property: Property,
-    value: list,
-    team: Team,
-    scope: str,
-    field: ast.Expr,
-    operator: PropertyOperator,
-    is_json_field: bool,
-) -> ast.Expr:
-    if len(value) == 0:
-        return ast.Constant(value=1)
-    elif len(value) == 1:
-        return _expr_to_compare_op(
-            expr=field,
-            value=value[0],
-            operator=operator,
-            team=team,
-            property=property,
-            is_json_field=is_json_field,
-        )
-    else:
-        # Using an AND here instead of `in()` or `notIn()`, due to Clickhouses poor handling of `null` values
-        exprs = [
-            _expr_to_compare_op(
-                expr=field,
-                value=v,
-                operator=operator,
-                team=team,
-                property=property,
-                is_json_field=is_json_field,
-            )
-            for v in value
-        ]
-        if operator in (PropertyOperator.NOT_ICONTAINS, PropertyOperator.NOT_REGEX, PropertyOperator.IS_NOT):
-            return ast.And(exprs=exprs)
-        return ast.Or(exprs=exprs)
-
-
 def property_to_expr(
     property: (
         list
@@ -392,18 +354,38 @@ def property_to_expr(
             else:
                 raise QueryError("Data warehouse property filter value must be a string")
 
-            field = ast.Field(chain=[*chain, property_key])
+            # For data warehouse properties, we split the key on dots to get the table chain and property key
+            # e.g. "foobars.properties.$feature/flag" becomes chain=["foobars", "properties"] and property_key="$feature/flag"
+            # This allows us to properly reference nested fields in data warehouse tables while maintaining consistent
+            # property filtering behavior. The chain represents the path to traverse through nested table structures,
+            # while the property_key is the actual field name we want to filter on.
             if isinstance(value, list):
-                return _handle_property_values(
-                    property=property,
-                    value=value,
-                    team=team,
-                    scope=scope,
-                    field=field,
-                    operator=operator,
-                    is_json_field=False,
-                )
+                if len(value) == 0:
+                    return ast.Constant(value=1)
+                elif len(value) == 1:
+                    value = value[0]
+                else:
+                    field = ast.Field(chain=[*chain, property_key])
+                    exprs = [
+                        _expr_to_compare_op(
+                            expr=field,
+                            value=v,
+                            operator=operator,
+                            team=team,
+                            property=property,
+                            is_json_field=False,
+                        )
+                        for v in value
+                    ]
+                    if (
+                        operator == PropertyOperator.NOT_ICONTAINS
+                        or operator == PropertyOperator.NOT_REGEX
+                        or operator == PropertyOperator.IS_NOT
+                    ):
+                        return ast.And(exprs=exprs)
+                    return ast.Or(exprs=exprs)
 
+            field = ast.Field(chain=[*chain, property_key])
             return _expr_to_compare_op(
                 expr=field,
                 value=value,
@@ -438,15 +420,33 @@ def property_to_expr(
             expr = ast.Call(name="argMinMerge", args=[field])
 
         if isinstance(value, list):
-            return _handle_property_values(
-                property=property,
-                value=value,
-                team=team,
-                scope=scope,
-                field=expr,
-                operator=operator,
-                is_json_field=property.type != "session",
-            )
+            if len(value) == 0:
+                return ast.Constant(value=1)
+            elif len(value) == 1:
+                value = value[0]
+            else:
+                # Using an AND here instead of `in()` or `notIn()`, due to Clickhouses poor handling of `null` values
+                exprs = [
+                    property_to_expr(
+                        Property(
+                            type=property.type,
+                            key=property.key,
+                            operator=property.operator,
+                            group_type_index=property.group_type_index,
+                            value=v,
+                        ),
+                        team,
+                        scope,
+                    )
+                    for v in value
+                ]
+                if (
+                    operator == PropertyOperator.NOT_ICONTAINS
+                    or operator == PropertyOperator.NOT_REGEX
+                    or operator == PropertyOperator.IS_NOT
+                ):
+                    return ast.And(exprs=exprs)
+                return ast.Or(exprs=exprs)
 
         return _expr_to_compare_op(
             expr=expr,

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -346,6 +346,55 @@ def property_to_expr(
             chain = ["events", "properties"]
         elif property.type == "session" and scope == "replay_entity":
             chain = ["events", "session"]
+        elif property.type == "data_warehouse":
+            if isinstance(property.key, str):
+                split = property.key.split(".")
+                chain = split[:-1]
+                property_key = split[-1]
+            else:
+                raise QueryError("Data warehouse property filter value must be a string")
+
+            # For data warehouse properties, we split the key on dots to get the table chain and property key
+            # e.g. "foobars.properties.$feature/flag" becomes chain=["foobars", "properties"] and property_key="$feature/flag"
+            # This allows us to properly reference nested fields in data warehouse tables while maintaining consistent
+            # property filtering behavior. The chain represents the path to traverse through nested table structures,
+            # while the property_key is the actual field name we want to filter on.
+            if isinstance(value, list):
+                if len(value) == 0:
+                    return ast.Constant(value=1)
+                elif len(value) == 1:
+                    value = value[0]
+                else:
+                    field = ast.Field(chain=[*chain, property_key])
+                    exprs = [
+                        _expr_to_compare_op(
+                            expr=field,
+                            value=v,
+                            operator=operator,
+                            team=team,
+                            property=property,
+                            is_json_field=False,
+                        )
+                        for v in value
+                    ]
+                    if (
+                        operator == PropertyOperator.NOT_ICONTAINS
+                        or operator == PropertyOperator.NOT_REGEX
+                        or operator == PropertyOperator.IS_NOT
+                    ):
+                        return ast.And(exprs=exprs)
+                    return ast.Or(exprs=exprs)
+
+            field = ast.Field(chain=[*chain, property_key])
+            return _expr_to_compare_op(
+                expr=field,
+                value=value,
+                operator=operator,
+                team=team,
+                property=property,
+                is_json_field=False,
+            )
+
         elif property.type == "data_warehouse_person_property":
             if isinstance(property.key, str):
                 table, key = property.key.split(".")

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -812,17 +812,17 @@ class TestProperty(BaseTest):
         )
 
         self.assertIsInstance(expr, ast.Or)
-        self.assertEqual(len(expr.exprs), 2)
+        self.assertEqual(len(getattr(expr, 'exprs')), 2)
 
         # First expression
-        compare_op_1 = expr.exprs[0]
+        compare_op_1 = getattr(expr, 'exprs')[0]
         self.assertIsInstance(compare_op_1, ast.CompareOperation)
         self.assertIsInstance(compare_op_1.left, ast.Field)
         self.assertEqual(compare_op_1.left.chain, ["foobars", "properties", "$feature/test"])
         self.assertEqual(compare_op_1.right.value, "control")
 
         # Second expression
-        compare_op_2 = expr.exprs[1]
+        compare_op_2 = getattr(expr, 'exprs')[1]
         self.assertIsInstance(compare_op_2, ast.CompareOperation)
         self.assertIsInstance(compare_op_2.left, ast.Field)
         self.assertEqual(compare_op_2.left.chain, ["foobars", "properties", "$feature/test"])

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -812,17 +812,17 @@ class TestProperty(BaseTest):
         )
 
         self.assertIsInstance(expr, ast.Or)
-        self.assertEqual(len(getattr(expr, 'exprs')), 2)
+        self.assertEqual(len(expr.exprs), 2)
 
         # First expression
-        compare_op_1 = getattr(expr, 'exprs')[0]
+        compare_op_1 = expr.exprs[0]
         self.assertIsInstance(compare_op_1, ast.CompareOperation)
         self.assertIsInstance(compare_op_1.left, ast.Field)
         self.assertEqual(compare_op_1.left.chain, ["foobars", "properties", "$feature/test"])
         self.assertEqual(compare_op_1.right.value, "control")
 
         # Second expression
-        compare_op_2 = getattr(expr, 'exprs')[1]
+        compare_op_2 = expr.exprs[1]
         self.assertIsInstance(compare_op_2, ast.CompareOperation)
         self.assertIsInstance(compare_op_2.left, ast.Field)
         self.assertEqual(compare_op_2.left.chain, ["foobars", "properties", "$feature/test"])

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -785,3 +785,45 @@ class TestProperty(BaseTest):
             ),
             self._parse_expr("person.extended_properties.bool_prop = true"),
         )
+
+    def test_data_warehouse_property_with_list_values(self):
+        credential = DataWarehouseCredential.objects.create(
+            team=self.team, access_key="_accesskey", access_secret="_secret"
+        )
+        DataWarehouseTable.objects.create(
+            team=self.team,
+            name="foobars",
+            columns={
+                "event": {"hogql": "StringDatabaseField", "clickhouse": "String"},
+                "properties": {"hogql": "JSONField", "clickhouse": "String"},
+            },
+            credential=credential,
+            url_pattern="",
+        )
+
+        expr = property_to_expr(
+            Property(
+                type="data_warehouse",
+                key="foobars.properties.$feature/test",
+                value=["control", "test"],
+                operator="exact",
+            ),
+            self.team,
+        )
+
+        self.assertIsInstance(expr, ast.Or)
+        self.assertEqual(len(expr.exprs), 2)
+
+        # First expression
+        compare_op_1 = expr.exprs[0]
+        self.assertIsInstance(compare_op_1, ast.CompareOperation)
+        self.assertIsInstance(compare_op_1.left, ast.Field)
+        self.assertEqual(compare_op_1.left.chain, ["foobars", "properties", "$feature/test"])
+        self.assertEqual(compare_op_1.right.value, "control")
+
+        # Second expression
+        compare_op_2 = expr.exprs[1]
+        self.assertIsInstance(compare_op_2, ast.CompareOperation)
+        self.assertIsInstance(compare_op_2.left, ast.Field)
+        self.assertEqual(compare_op_2.left.chain, ["foobars", "properties", "$feature/test"])
+        self.assertEqual(compare_op_2.right.value, "test")

--- a/posthog/hogql/test/test_property.py
+++ b/posthog/hogql/test/test_property.py
@@ -801,7 +801,7 @@ class TestProperty(BaseTest):
             url_pattern="",
         )
 
-        expr = property_to_expr(
+        expr = self._property_to_expr(
             Property(
                 type="data_warehouse",
                 key="foobars.properties.$feature/test",


### PR DESCRIPTION
## Changes

Updates `property_to_expr()` to handle data warehouse properties with nested values, e.g.:

```python
 prepared_count_query.properties = [
    DataWarehousePropertyFilter(
        key=f"{column_name}.event",
        value="$feature_flag_called",
        operator=PropertyOperator.EXACT,
        type="data_warehouse",
    ),
    DataWarehousePropertyFilter(
        key=f"{column_name}.properties.{self.breakdown_key}",
        value=self.variants,
        operator=PropertyOperator.EXACT,
        type="data_warehouse",
    ),
]
```

Without the patch, the properties evaluate to:

```
sql(and(equals(events.event, '$feature_flag_called'), or(equals(`$feature/dw-trends-nov-14-v2`, 'control'), equals(`$feature/dw-trends-nov-14-v2`, 'test'))))
```

With the patch, the properties evaluate to:

```
sql(and(equals(events.event, '$feature_flag_called'), or(equals(events.properties.`$feature/dw-trends-nov-14-v2`, 'control'), equals(events.properties.`$feature/dw-trends-nov-14-v2`, 'test'))))
```

From https://github.com/PostHog/posthog/pull/26301

## How did you test this code?

Tests should pass

Also verified that https://github.com/PostHog/posthog/pull/26301 works as expected with this patch