### PR TITLE
fix: use combinations in the breakdowns test for perf

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -52,10 +52,10 @@ from posthog.schema import (
     PersonPropertyFilter,
     PropertyMathType,
     PropertyOperator,
+    Series as InsightActorsQuerySeries,
     TrendsFilter,
     TrendsQuery,
 )
-from posthog.schema import Series as InsightActorsQuerySeries
 from posthog.settings import HOGQL_INCREASED_MAX_EXECUTION_TIME
 from posthog.test.base import (
     APIBaseTest,
@@ -3844,7 +3844,7 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             Breakdown(type="group", group_type_index=0, property="industry"),
         ]
 
-        for breakdown_filter in itertools.permutations(breakdowns, 2):
+        for breakdown_filter in itertools.combinations(breakdowns, 3):
             response = self._run_trends_query(
                 "2020-01-09",
                 "2020-01-20",

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -3580,7 +3580,7 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             Breakdown(property="$browser"),
             Breakdown(property="bool_field"),
         ]
-        for breakdown_filter in itertools.combinations(breakdowns, 3):
+        for breakdown_filter in itertools.combinations(breakdowns, 2):
             response = self._run_trends_query(
                 "2020-01-09",
                 "2020-01-20",


### PR DESCRIPTION
## Problem

Only combinations of elements matter in the test. The original test has 336 iterations, while with combinations this count is reduced to 56 still using three elements.

## Changes

Use combinations instead of permutations, as permutations are unnecessary.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

N/A