### PR TITLE
fix(experiments HogQL): fix funnels filter in prepare_query

### DIFF
--- a/posthog/hogql_queries/experiments/experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_funnels_query_runner.py
@@ -17,6 +17,7 @@ from posthog.schema import (
     ExperimentSignificanceCode,
     ExperimentVariantFunnelsBaseStats,
     FunnelLayout,
+    FunnelsFilter,
     FunnelsQuery,
     FunnelsQueryResponse,
     InsightDateRange,
@@ -114,6 +115,8 @@ class ExperimentFunnelsQueryRunner(QueryRunner):
         )
 
         # Set the layout to vertical
+        if prepared_funnels_query.funnelsFilter is None:
+            prepared_funnels_query.funnelsFilter = FunnelsFilter()
         prepared_funnels_query.funnelsFilter.layout = FunnelLayout.VERTICAL
 
         return prepared_funnels_query

--- a/posthog/hogql_queries/experiments/experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_funnels_query_runner.py
@@ -16,7 +16,7 @@ from posthog.schema import (
     ExperimentFunnelsQueryResponse,
     ExperimentSignificanceCode,
     ExperimentVariantFunnelsBaseStats,
-    FunnelsFilter,
+    FunnelLayout,
     FunnelsQuery,
     FunnelsQueryResponse,
     InsightDateRange,
@@ -113,9 +113,8 @@ class ExperimentFunnelsQueryRunner(QueryRunner):
             breakdown_type="event",
         )
 
-        prepared_funnels_query.funnelsFilter = FunnelsFilter(
-            funnelVizType="steps",
-        )
+        # Set the layout to vertical
+        prepared_funnels_query.funnelsFilter.layout = FunnelLayout.VERTICAL
 
         return prepared_funnels_query
 


### PR DESCRIPTION
## Problem
We make modifications to the raw experiment funnel query in the experiment query runner.

In the goal preview, we use a horizontal funnel visualization, but for the results, we use a vertical one. I needed to update this in the final funnel query.

Instead of updating the layout property in the existing filter, I mistakenly overwrote the entire filter. Additionally, I set the wrong property `steps` instead of `layout`. This deceived me because the visualization appeared correct, but it was due to the funnel filter being reset to its default values, not because I used the `steps` property correctly.

## Changes
- Update the layout property in the existing filter without overwriting the entire filter.
- Correctly set the `layout` property instead of `steps`

This ensures the original funnel filter is preserved which fixes the discrepancy in the experiment results.

## How did you test this code?
Verified locally that the visual is showing correctly and that the funnelsFilter is preserved.

Will write some tests for this in a follow up, but want to merge this quickly now.