### PR TITLE
feat: unlimited alerts for paid plans

### DIFF
--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -260,22 +260,22 @@ class AlertSerializer(serializers.ModelSerializer):
             None,
         )
 
+        existing_alerts_count = AlertConfiguration.objects.filter(team_id=self.context["team_id"]).count()
+
         if has_alerts_feature:
             # If allowed_alerts_count is None then the user is allowed unlimited alerts
             if allowed_alerts_count is not None:
                 # Check current count against allowed limit
-                existing_alerts_count = AlertConfiguration.objects.filter(team_id=self.context["team_id"]).count()
                 if existing_alerts_count >= allowed_alerts_count:
                     raise ValidationError(
-                        {
-                            "alert": [
-                                f"Your team has reached the limit of {allowed_alerts_count} enabled alerts on your plan."
-                            ]
-                        }
+                        {"alert": [f"Your team has reached the limit of {allowed_alerts_count} alerts on your plan."]}
                     )
         else:
-            # If the org doesn't have alerts feature, they can't create alerts
-            raise ValidationError({"alert": [f"Your plan doesn't allow creating alerts"]})
+            # If the org doesn't have alerts feature, limit to that on free tier
+            if existing_alerts_count >= AlertConfiguration.ALERTS_ALLOWED_ON_FREE_TIER:
+                raise ValidationError(
+                    {"alert": [f"Your plan is limited to {AlertConfiguration.ALERTS_ALLOWED_ON_FREE_TIER} alerts"]}
+                )
 
         return attrs
 

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -249,7 +249,7 @@ class AlertSerializer(serializers.ModelSerializer):
 
         user_org = self.context["request"].user.organization
 
-        has_alerts_feature = user_org.is_feature_available(AvailableFeature.ORGANIZATIONS_PROJECTS)
+        has_alerts_feature = user_org.is_feature_available(AvailableFeature.ALERTS)
 
         allowed_alerts_count = next(
             (

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -247,6 +247,10 @@ class AlertSerializer(serializers.ModelSerializer):
         if attrs.get("insight") and attrs["insight"].team.id != self.context["team_id"]:
             raise ValidationError({"insight": ["This insight does not belong to your team."]})
 
+        # only validate alert count when creating a new alert
+        if self.context["request"].method != "POST":
+            return attrs
+
         user_org = self.context["request"].user.organization
 
         has_alerts_feature = user_org.is_feature_available(AvailableFeature.ALERTS)

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -18,6 +18,7 @@ from posthog.api.insight import InsightBasicSerializer
 
 from posthog.utils import relative_date_parse
 from zoneinfo import ZoneInfo
+from posthog.constants import AvailableFeature
 
 
 class ThresholdSerializer(serializers.ModelSerializer):
@@ -246,15 +247,37 @@ class AlertSerializer(serializers.ModelSerializer):
         if attrs.get("insight") and attrs["insight"].team.id != self.context["team_id"]:
             raise ValidationError({"insight": ["This insight does not belong to your team."]})
 
-        if attrs.get("enabled") is not False and (
-            AlertConfiguration.objects.filter(team_id=self.context["team_id"], enabled=True).count()
-            >= AlertConfiguration.ALERTS_PER_TEAM
-        ):
-            raise ValidationError(
-                {"alert": [f"Your team has reached the limit of {AlertConfiguration.ALERTS_PER_TEAM} enabled alerts."]}
-            )
+        user_org = self.context["request"].user.organization
 
-        return attrs
+        has_alerts_feature = user_org.is_feature_available(AvailableFeature.ORGANIZATIONS_PROJECTS)
+
+        allowed_alerts_count = next(
+            (
+                feature.get("limit")
+                for feature in user_org.available_product_features or []
+                if feature.get("key") == AvailableFeature.ALERTS
+            ),
+            None,
+        )
+
+        if has_alerts_feature:
+            # If allowed_alerts_count is None then the user is allowed unlimited alerts
+            if allowed_alerts_count is None:
+                return attrs
+
+            # Check current count against allowed limit
+            existing_alerts_count = AlertConfiguration.objects.filter(team_id=self.context["team_id"]).count()
+            if existing_alerts_count >= allowed_alerts_count:
+                raise ValidationError(
+                    {
+                        "alert": [
+                            f"Your team has reached the limit of {allowed_alerts_count} enabled alerts on your plan."
+                        ]
+                    }
+                )
+        else:
+            # If the org doesn't have alerts feature, they can't create alerts
+            raise ValidationError({"alert": [f"Your plan doesn't allow creating alerts"]})
 
 
 class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):

--- a/posthog/api/alert.py
+++ b/posthog/api/alert.py
@@ -262,22 +262,22 @@ class AlertSerializer(serializers.ModelSerializer):
 
         if has_alerts_feature:
             # If allowed_alerts_count is None then the user is allowed unlimited alerts
-            if allowed_alerts_count is None:
-                return attrs
-
-            # Check current count against allowed limit
-            existing_alerts_count = AlertConfiguration.objects.filter(team_id=self.context["team_id"]).count()
-            if existing_alerts_count >= allowed_alerts_count:
-                raise ValidationError(
-                    {
-                        "alert": [
-                            f"Your team has reached the limit of {allowed_alerts_count} enabled alerts on your plan."
-                        ]
-                    }
-                )
+            if allowed_alerts_count is not None:
+                # Check current count against allowed limit
+                existing_alerts_count = AlertConfiguration.objects.filter(team_id=self.context["team_id"]).count()
+                if existing_alerts_count >= allowed_alerts_count:
+                    raise ValidationError(
+                        {
+                            "alert": [
+                                f"Your team has reached the limit of {allowed_alerts_count} enabled alerts on your plan."
+                            ]
+                        }
+                    )
         else:
             # If the org doesn't have alerts feature, they can't create alerts
             raise ValidationError({"alert": [f"Your plan doesn't allow creating alerts"]})
+
+        return attrs
 
 
 class AlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):

--- a/posthog/api/test/test_alert.py
+++ b/posthog/api/test/test_alert.py
@@ -130,7 +130,7 @@ class TestAlert(APIBaseTest, QueryMatchingTest):
         assert len(list_for_another_insight.json()["results"]) == 0
 
     def test_alert_limit(self) -> None:
-        with mock.patch("posthog.api.alert.AlertConfiguration.ALERTS_PER_TEAM") as alert_limit:
+        with mock.patch("posthog.api.alert.AlertConfiguration.ALERTS_ALLOWED_ON_FREE_TIER") as alert_limit:
             alert_limit.__get__ = mock.Mock(return_value=1)
 
             creation_request = {

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -68,6 +68,8 @@ class Threshold(CreatedMetaFields, UUIDModel):
 
 
 class AlertConfiguration(CreatedMetaFields, UUIDModel):
+    ALERTS_ALLOWED_ON_FREE_TIER = 2
+
     team = models.ForeignKey("Team", on_delete=models.CASCADE)
     insight = models.ForeignKey("posthog.Insight", on_delete=models.CASCADE)
 

--- a/posthog/models/alert.py
+++ b/posthog/models/alert.py
@@ -68,8 +68,6 @@ class Threshold(CreatedMetaFields, UUIDModel):
 
 
 class AlertConfiguration(CreatedMetaFields, UUIDModel):
-    ALERTS_PER_TEAM = 5
-
     team = models.ForeignKey("Team", on_delete=models.CASCADE)
     insight = models.ForeignKey("posthog.Insight", on_delete=models.CASCADE)
 


### PR DESCRIPTION
## Problem
Want to limit to 2 alerts for free plan and unlimited for paid plans
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
Use organisation 'feature' to check for how many alerts are allowed
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
