### PR TITLE
chore: use posthog single-shard cluster for distributed_events_recent

### DIFF
--- a/docker/clickhouse/config.xml
+++ b/docker/clickhouse/config.xml
@@ -712,6 +712,14 @@
                 </replica>
             </shard>
         </posthog>
+        <posthog_single_shard>
+            <shard>
+                <replica>
+                    <host>localhost</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </posthog_single_shard>
     </remote_servers>
 
     <!-- The list of hosts allowed to use in URL-related storage engines and table functions.

--- a/posthog/clickhouse/migrations/0087_events_recent_single_shard.py
+++ b/posthog/clickhouse/migrations/0087_events_recent_single_shard.py
@@ -1,8 +1,5 @@
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.models.event.sql import (
-    EVENTS_RECENT_TABLE_JSON_MV_SQL,
-    EVENTS_RECENT_TABLE_SQL,
-    KAFKA_EVENTS_RECENT_TABLE_JSON_SQL,
     DISTRIBUTED_EVENTS_RECENT_TABLE_SQL,
 )
 

--- a/posthog/clickhouse/migrations/0087_events_recent_single_shard.py
+++ b/posthog/clickhouse/migrations/0087_events_recent_single_shard.py
@@ -1,0 +1,15 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.event.sql import (
+    EVENTS_RECENT_TABLE_JSON_MV_SQL,
+    EVENTS_RECENT_TABLE_SQL,
+    KAFKA_EVENTS_RECENT_TABLE_JSON_SQL,
+    DISTRIBUTED_EVENTS_RECENT_TABLE_SQL,
+)
+
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+
+operations = [
+    run_sql_with_exceptions(f"DROP TABLE IF EXISTS distributed_events_recent ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    run_sql_with_exceptions(DISTRIBUTED_EVENTS_RECENT_TABLE_SQL()),
+]

--- a/posthog/clickhouse/table_engines.py
+++ b/posthog/clickhouse/table_engines.py
@@ -75,9 +75,10 @@ class AggregatingMergeTree(MergeTreeEngine):
 
 
 class Distributed:
-    def __init__(self, data_table: str, sharding_key: str):
+    def __init__(self, data_table: str, sharding_key: str, cluster: str = settings.CLICKHOUSE_CLUSTER):
         self.data_table = data_table
         self.sharding_key = sharding_key
+        self.cluster = cluster
 
     def __str__(self):
-        return f"Distributed('{settings.CLICKHOUSE_CLUSTER}', '{settings.CLICKHOUSE_DATABASE}', '{self.data_table}', {self.sharding_key})"
+        return f"Distributed('{self.cluster}', '{settings.CLICKHOUSE_DATABASE}', '{self.data_table}', {self.sharding_key})"

--- a/posthog/clickhouse/table_engines.py
+++ b/posthog/clickhouse/table_engines.py
@@ -81,4 +81,6 @@ class Distributed:
         self.cluster = cluster
 
     def __str__(self):
-        return f"Distributed('{self.cluster}', '{settings.CLICKHOUSE_DATABASE}', '{self.data_table}', {self.sharding_key})"
+        return (
+            f"Distributed('{self.cluster}', '{settings.CLICKHOUSE_DATABASE}', '{self.data_table}', {self.sharding_key})"
+        )

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -264,7 +264,7 @@ DISTRIBUTED_EVENTS_RECENT_TABLE_SQL = lambda: EVENTS_TABLE_BASE_SQL.format(
     engine=Distributed(
         data_table=EVENTS_RECENT_DATA_TABLE(),
         sharding_key="sipHash64(distinct_id)",
-        cluster=settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER
+        cluster=settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER,
     ),
     extra_fields=KAFKA_COLUMNS_WITH_PARTITION + INSERTED_AT_COLUMN + f", {KAFKA_TIMESTAMP_MS_COLUMN}",
     materialized_columns="",

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -261,7 +261,7 @@ TTL _timestamp + INTERVAL 7 DAY
 DISTRIBUTED_EVENTS_RECENT_TABLE_SQL = lambda: EVENTS_TABLE_BASE_SQL.format(
     table_name="distributed_events_recent",
     cluster=settings.CLICKHOUSE_CLUSTER,
-    engine=Distributed(data_table=EVENTS_RECENT_DATA_TABLE(), sharding_key="sipHash64(distinct_id)", cluster="posthog_single_shard"),
+    engine=Distributed(data_table=EVENTS_RECENT_DATA_TABLE(), sharding_key="sipHash64(distinct_id)", cluster=settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER),
     extra_fields=KAFKA_COLUMNS_WITH_PARTITION + INSERTED_AT_COLUMN + f", {KAFKA_TIMESTAMP_MS_COLUMN}",
     materialized_columns="",
     indexes="",

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -261,7 +261,7 @@ TTL _timestamp + INTERVAL 7 DAY
 DISTRIBUTED_EVENTS_RECENT_TABLE_SQL = lambda: EVENTS_TABLE_BASE_SQL.format(
     table_name="distributed_events_recent",
     cluster=settings.CLICKHOUSE_CLUSTER,
-    engine=Distributed(data_table=EVENTS_RECENT_DATA_TABLE(), sharding_key="sipHash64(distinct_id)"),
+    engine=Distributed(data_table=EVENTS_RECENT_DATA_TABLE(), sharding_key="sipHash64(distinct_id)", cluster="posthog_single_shard"),
     extra_fields=KAFKA_COLUMNS_WITH_PARTITION + INSERTED_AT_COLUMN + f", {KAFKA_TIMESTAMP_MS_COLUMN}",
     materialized_columns="",
     indexes="",

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -261,7 +261,11 @@ TTL _timestamp + INTERVAL 7 DAY
 DISTRIBUTED_EVENTS_RECENT_TABLE_SQL = lambda: EVENTS_TABLE_BASE_SQL.format(
     table_name="distributed_events_recent",
     cluster=settings.CLICKHOUSE_CLUSTER,
-    engine=Distributed(data_table=EVENTS_RECENT_DATA_TABLE(), sharding_key="sipHash64(distinct_id)", cluster=settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER),
+    engine=Distributed(
+        data_table=EVENTS_RECENT_DATA_TABLE(),
+        sharding_key="sipHash64(distinct_id)",
+        cluster=settings.CLICKHOUSE_SINGLE_SHARD_CLUSTER
+    ),
     extra_fields=KAFKA_COLUMNS_WITH_PARTITION + INSERTED_AT_COLUMN + f", {KAFKA_TIMESTAMP_MS_COLUMN}",
     materialized_columns="",
     indexes="",

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -154,6 +154,7 @@ CLICKHOUSE_CA: str | None = os.getenv("CLICKHOUSE_CA", None)
 CLICKHOUSE_SECURE: bool = get_from_env("CLICKHOUSE_SECURE", not TEST and not DEBUG, type_cast=str_to_bool)
 CLICKHOUSE_VERIFY: bool = get_from_env("CLICKHOUSE_VERIFY", True, type_cast=str_to_bool)
 CLICKHOUSE_ENABLE_STORAGE_POLICY: bool = get_from_env("CLICKHOUSE_ENABLE_STORAGE_POLICY", False, type_cast=str_to_bool)
+CLICKHOUSE_SINGLE_SHARD_CLUSTER: str = os.getenv("CLICKHOUSE_SINGLE_SHARD_CLUSTER", "posthog_single_shard")
 
 CLICKHOUSE_CONN_POOL_MIN: int = get_from_env("CLICKHOUSE_CONN_POOL_MIN", 20, type_cast=int)
 CLICKHOUSE_CONN_POOL_MAX: int = get_from_env("CLICKHOUSE_CONN_POOL_MAX", 1000, type_cast=int)


### PR DESCRIPTION
## Problem

The current table reads from the default cluster, which contains two (US) or eight (EU) shards. Since the `events_recent` table is not sharded, reading from `distributed_events_recent` duplicates results.

We want to use a distributed table to hit replicas with low lag (the setting needs to be configured yet).

## Changes
Use the `posthog_single_shard` cluster.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes! Updated the Docker ClickHouse config file so it creates a the new cluster.