### PR TITLE
feat(cdp): add custom data to meta ads

### DIFF
--- a/posthog/cdp/templates/meta_ads/template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/template_meta_ads.py
@@ -15,16 +15,22 @@ let body := {
             'event_name': inputs.eventName,
             'event_time': inputs.eventTime,
             'action_source': inputs.actionSource,
-            'user_data': {}
+            'user_data': {},
+            'custom_data': {}
         }
     ],
     'access_token': inputs.accessToken
 }
 
 for (let key, value in inputs.userData) {
-    // e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 is an empty string hashed
-    if (not empty(value) and value != 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855') {
+    if (not empty(value)) {
         body.data.1.user_data[key] := value
+    }
+}
+
+for (let key, value in inputs.customData) {
+    if (not empty(value)) {
+        body.data.1.custom_data[key] := value
     }
 }
 
@@ -127,10 +133,19 @@ if (res.status >= 400) {
             "label": "User data",
             "description": "A map that contains customer information data. See this page for options: https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/customer-information-parameters",
             "default": {
-                "em": "{sha256Hex(person.properties.email ?? '')}",
-                "fn": "{sha256Hex(person.properties.first_name ?? '')}",
-                "ln": "{sha256Hex(person.properties.last_name ?? '')}",
+                "em": "{sha256Hex(person.properties.email)}",
+                "fn": "{sha256Hex(person.properties.first_name)}",
+                "ln": "{sha256Hex(person.properties.last_name)}",
             },
+            "secret": False,
+            "required": True,
+        },
+        {
+            "key": "customData",
+            "type": "dictionary",
+            "label": "Custom data",
+            "description": "A map that contains custom data. See this page for options: https://developers.facebook.com/docs/marketing-api/conversions-api/parameters/custom-data",
+            "default": {"currency": "USD", "price": "{event.properties.price}"},
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
@@ -17,7 +17,11 @@ class TestTemplateMetaAds(BaseHogFunctionTemplateTest):
             "actionSource": "website",
             "userData": {
                 "em": "3edfaed7454eedb3c72bad566901af8bfbed1181816dde6db91dfff0f0cffa98",
-                "fn": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "fn": None,
+            },
+            "customData": {
+                "currency": "USD",
+                "price": "15",
             },
         }
         inputs.update(kwargs)
@@ -30,6 +34,10 @@ class TestTemplateMetaAds(BaseHogFunctionTemplateTest):
             (
                 "https://graph.facebook.com/v21.0/123451234512345/events",
                 {
+                    "method": "POST",
+                    "headers": {
+                        "Content-Type": "application/json",
+                    },
                     "body": {
                         "access_token": "accessToken12345",
                         "data": [
@@ -38,12 +46,9 @@ class TestTemplateMetaAds(BaseHogFunctionTemplateTest):
                                 "event_time": "1728812163",
                                 "action_source": "website",
                                 "user_data": {"em": "3edfaed7454eedb3c72bad566901af8bfbed1181816dde6db91dfff0f0cffa98"},
+                                "custom_data": {"currency": "USD", "price": "15"},
                             }
                         ],
-                    },
-                    "method": "POST",
-                    "headers": {
-                        "Content-Type": "application/json",
                     },
                 },
             )


### PR DESCRIPTION
## Changes

- adds the option to add custom data
- removes the `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 is an empty string hashed` workaround ([context](https://github.com/PostHog/posthog/pull/26311))

## How did you test this code?

updated tests