### PR TITLE
fix(alerts): pass correct filters for aggregate trends

### DIFF
--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -100,7 +100,7 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         anomalies_descriptions = self.get_breach_description(mock_send_notifications_for_breaches, call_index=0)
         assert len(anomalies_descriptions) == 1
         assert (
-            "The insight value ($pageview) for previous day (1) is more than upper threshold (0.0)"
+            "The insight value ($pageview) for previous interval (1) is more than upper threshold (0.0)"
             in anomalies_descriptions[0]
         )
 
@@ -130,7 +130,7 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
 
         assert mock_send_notifications_for_breaches.call_count == 1
         anomalies = self.get_breach_description(mock_send_notifications_for_breaches, call_index=0)
-        assert "The insight value ($pageview) for previous day (0) is less than lower threshold (1.0)" in anomalies
+        assert "The insight value ($pageview) for previous interval (0) is less than lower threshold (1.0)" in anomalies
 
     def test_alert_triggers_but_does_not_send_notification_during_firing(
         self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
@@ -318,7 +318,7 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
 
         assert mock_send_notifications_for_breaches.call_count == 1
         anomalies = self.get_breach_description(mock_send_notifications_for_breaches, call_index=0)
-        assert "The insight value ($pageview) for previous day (0) is less than lower threshold (1.0)" in anomalies
+        assert "The insight value ($pageview) for previous interval (0) is less than lower threshold (1.0)" in anomalies
 
     @patch("posthog.tasks.alerts.utils.EmailMessage")
     def test_send_emails(

--- a/posthog/tasks/alerts/test/test_trends_absolute_alerts.py
+++ b/posthog/tasks/alerts/test/test_trends_absolute_alerts.py
@@ -88,6 +88,34 @@ class TestTimeSeriesTrendsAbsoluteAlerts(APIBaseTest, ClickhouseDestroyTablesMix
 
         return insight
 
+    def create_aggregate_trend_insight(self, breakdown: Optional[BreakdownFilter] = None) -> dict[str, Any]:
+        query_dict = TrendsQuery(
+            series=[
+                EventsNode(
+                    event="signed_up",
+                    math=BaseMathType.TOTAL,
+                ),
+                EventsNode(
+                    event="$pageview",
+                    name="Pageview",
+                    math=BaseMathType.TOTAL,
+                ),
+            ],
+            breakdownFilter=breakdown,
+            trendsFilter=TrendsFilter(display=ChartDisplayType.ACTIONS_PIE),
+            interval=IntervalType.WEEK,
+            dateRange=InsightDateRange(date_from="-8w"),
+        ).model_dump()
+
+        insight = self.dashboard_api.create_insight(
+            data={
+                "name": "insight",
+                "query": query_dict,
+            }
+        )[1]
+
+        return insight
+
     def test_alert_lower_threshold_breached(self, mock_send_breaches: MagicMock, mock_send_errors: MagicMock) -> None:
         insight = self.create_time_series_trend_insight()
         alert = self.create_alert(insight, series_index=0, lower=1)
@@ -295,3 +323,87 @@ class TestTimeSeriesTrendsAbsoluteAlerts(APIBaseTest, ClickhouseDestroyTablesMix
         assert alert_check.error is None
 
         mock_send_breaches.assert_not_called()
+
+    def test_aggregate_trend_high_threshold_breached(
+        self, mock_send_breaches: MagicMock, mock_send_errors: MagicMock
+    ) -> None:
+        insight = self.create_aggregate_trend_insight()
+        alert = self.create_alert(insight, series_index=0, upper=1)
+
+        with freeze_time(FROZEN_TIME - dateutil.relativedelta.relativedelta(weeks=4)):
+            _create_event(
+                team=self.team,
+                event="signed_up",
+                distinct_id="3",
+                properties={"$browser": "Firefox"},
+            )
+            _create_event(
+                team=self.team,
+                event="signed_up",
+                distinct_id="1",
+                properties={"$browser": "Chrome"},
+            )
+            _create_event(
+                team=self.team,
+                event="signed_up",
+                distinct_id="2",
+                properties={"$browser": "Chrome"},
+            )
+            flush_persons_and_events()
+
+        check_alert(alert["id"])
+
+        updated_alert = AlertConfiguration.objects.get(pk=alert["id"])
+        assert updated_alert.state == AlertState.FIRING
+        assert updated_alert.next_check_at == FROZEN_TIME + dateutil.relativedelta.relativedelta(days=1)
+
+        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
+        assert alert_check.calculated_value == 3
+        assert alert_check.state == AlertState.FIRING
+        assert alert_check.error is None
+
+        mock_send_breaches.assert_called_once_with(
+            ANY, ["The insight value (signed_up) for previous interval (3) is more than upper threshold (1.0)"]
+        )
+
+    def test_aggregate_trend_with_breakdown_high_threshold_breached(
+        self, mock_send_breaches: MagicMock, mock_send_errors: MagicMock
+    ) -> None:
+        insight = self.create_aggregate_trend_insight(BreakdownFilter(breakdowns=[Breakdown(property="$browser")]))
+        alert = self.create_alert(insight, series_index=0, upper=1)
+
+        with freeze_time(FROZEN_TIME - dateutil.relativedelta.relativedelta(weeks=4)):
+            _create_event(
+                team=self.team,
+                event="signed_up",
+                distinct_id="3",
+                properties={"$browser": "Firefox"},
+            )
+            _create_event(
+                team=self.team,
+                event="signed_up",
+                distinct_id="1",
+                properties={"$browser": "Chrome"},
+            )
+            _create_event(
+                team=self.team,
+                event="signed_up",
+                distinct_id="2",
+                properties={"$browser": "Chrome"},
+            )
+            flush_persons_and_events()
+
+        check_alert(alert["id"])
+
+        updated_alert = AlertConfiguration.objects.get(pk=alert["id"])
+        assert updated_alert.state == AlertState.FIRING
+        assert updated_alert.next_check_at == FROZEN_TIME + dateutil.relativedelta.relativedelta(days=1)
+
+        alert_check = AlertCheck.objects.filter(alert_configuration=alert["id"]).latest("created_at")
+        assert alert_check.calculated_value == 2
+        assert alert_check.state == AlertState.FIRING
+        assert alert_check.error is None
+
+        mock_send_breaches.assert_called_once_with(
+            ANY, ["The insight value (signed_up - Chrome) for previous interval (2) is more than upper threshold (1.0)"]
+        )

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -125,7 +125,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
 
                 return AlertEvaluationResult(value=prev_interval_value, breaches=breaches)
         case AlertConditionType.RELATIVE_INCREASE:
-            if is_non_time_series(query):
+            if is_non_time_series:
                 raise ValueError(f"Relative alerts not supported for non time series trends")
 
             # to measure relative increase, we can't alert until current interval has completed
@@ -193,7 +193,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
             return AlertEvaluationResult(value=(increase if not has_breakdown else None), breaches=breaches)
 
         case AlertConditionType.RELATIVE_DECREASE:
-            if is_non_time_series(query):
+            if is_non_time_series:
                 raise ValueError(f"Relative alerts not supported for non time series trends")
 
             # to measure relative decrease, we can't alert until current interval has completed


### PR DESCRIPTION
## Problem
After recent changes, aggregate trends alerts (pie chart...) were only checking for last week/month instead of full date range (eg. last 8 weeks) while evaluating alerts 

## Changes
Reset to checking full date range, this ensures the insight value user sees in the alert email/alert modal matches that when they open the insight.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Added tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
