### PR TITLE
fix: change wording on person profile config tooltip

### DIFF
--- a/frontend/src/scenes/billing/BillingProductAddon.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddon.tsx
@@ -74,7 +74,7 @@ export const BillingProductAddon = ({ addon }: { addon: BillingProductV2AddonTyp
                             <h4 className="leading-5 mb-1 font-bold">{addon.name}</h4>
                             {addon.inclusion_only ? (
                                 <div className="flex gap-x-2">
-                                    <Tooltip title="Automatically included with your plan. Used based on your posthog-js config options.">
+                                    <Tooltip title="Automatically included with your plan. Used based on whether you capture person profiles with your events.">
                                         <LemonTag type="muted">Config option</LemonTag>
                                     </Tooltip>
                                 </div>


### PR DESCRIPTION
## Problem

It's not just set in `posthog-js`. I've also changed the docs to make this clearer https://github.com/PostHog/posthog.com/pull/9956

## Changes

Changed copy 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

No impact

## How did you test this code?

n/a