### PR TITLE
fix: usage of `a deprecated Node.js version` in CI

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -30,12 +30,12 @@ jobs:
 
         steps:
             - name: Check out
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   fetch-depth: 2
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v2
+              uses: docker/setup-buildx-action@v3
 
             - name: Set up QEMU
               uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Fixes #26366

## Problem

[`.github/workflows/container-images-cd.yml` uses `actions` that `use a deprecated Node.js version`](https://github.com/PostHog/posthog/actions/runs/11982083759).

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

I updated `.github/workflows/container-images-cd.yml` so that it no longer uses actions that `use a deprecated Node.js version`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
I ran the updated workflow on a fork of this repository.