### PR TITLE
feat: track size of promise set

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording/session-recordings-consumer.ts
@@ -71,6 +71,11 @@ const gaugeLagMilliseconds = new Gauge({
     labelNames: ['partition'],
 })
 
+const gaugePromisesInProgress = new Gauge({
+    name: 'recording_blob_ingestion_promises_in_progress',
+    help: 'A gauge of the number of promises in progress',
+})
+
 // NOTE: This gauge is important! It is used as our primary metric for scaling up / down
 const gaugeLag = new Gauge({
     name: 'recording_blob_ingestion_lag',
@@ -397,6 +402,8 @@ export class SessionRecordingIngester {
 
                 await this.reportPartitionMetrics()
 
+                gaugePromisesInProgress.set(this.promises.size)
+
                 await runInstrumentedFunction({
                     statsKey: `recordingingester.handleEachBatch.consumeBatch`,
                     func: async () => {
@@ -592,6 +599,7 @@ export class SessionRecordingIngester {
         void this.scheduleWork(this.realtimeManager.unsubscribe())
 
         const promiseResults = await Promise.allSettled(this.promises)
+        gaugePromisesInProgress.remove()
 
         if (this.sharedClusterProducerWrapper) {
             await this.sharedClusterProducerWrapper.disconnect()


### PR DESCRIPTION
adds a new gauge to the blob consumer
will remove it soon, just need to see that this set of tracked promises doesn't grow over time