### PR TITLE
fix: case where symbol set is not available

### DIFF
--- a/posthog/api/error_tracking.py
+++ b/posthog/api/error_tracking.py
@@ -49,7 +49,7 @@ class ObjectStorageUnavailable(Exception):
 
 
 class ErrorTrackingStackFrameSerializer(serializers.ModelSerializer):
-    symbol_set_ref = serializers.CharField(source="symbol_set.ref")
+    symbol_set_ref = serializers.CharField(source="symbol_set.ref", default=None)
 
     class Meta:
         model = ErrorTrackingStackFrame


### PR DESCRIPTION
## Problem

Symbol sets can be `null`, so we need a default value for `symbol_set_ref`

## Changes

Set the default