### PR TITLE
feat: Add languages filter in the world map section

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -13363,7 +13363,8 @@
                 "DeviceType",
                 "Country",
                 "Region",
-                "City"
+                "City",
+                "Timezone"
             ],
             "type": "string"
         },

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1840,6 +1840,7 @@ export enum WebStatsBreakdown {
     Country = 'Country',
     Region = 'Region',
     City = 'City',
+    Timezone = 'Timezone',
 }
 export interface WebStatsTableQuery extends WebAnalyticsQueryBase<WebStatsTableQueryResponse> {
     kind: NodeKind.WebStatsTableQuery

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -259,7 +259,7 @@ export const WebTabs = ({
                     )}
                 </h2>
 
-                {tabs.length > 5 ? (
+                {tabs.length > 4 ? (
                     <LemonSelect
                         size="small"
                         disabled={false}

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -259,7 +259,7 @@ export const WebTabs = ({
                     )}
                 </h2>
 
-                {tabs.length > 4 ? (
+                {tabs.length > 5 ? (
                     <LemonSelect
                         size="small"
                         disabled={false}

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -72,6 +72,8 @@ const BreakdownValueTitle: QueryContextColumnTitleComponent = (props) => {
             return <>Region</>
         case WebStatsBreakdown.City:
             return <>City</>
+        case WebStatsBreakdown.Timezone:
+            return <>Timezone</>
         case WebStatsBreakdown.InitialUTMSourceMediumCampaign:
             return <>Source / Medium / Campaign</>
         default:
@@ -167,6 +169,8 @@ export const webStatsBreakdownToPropertyName = (
             return { key: '$geoip_subdivision_1_code', type: PropertyFilterType.Event }
         case WebStatsBreakdown.City:
             return { key: '$geoip_city_name', type: PropertyFilterType.Event }
+        case WebStatsBreakdown.Timezone:
+            return { key: '$timezone', type: PropertyFilterType.Event }
         case WebStatsBreakdown.InitialUTMSourceMediumCampaign:
             return undefined
         default:

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -185,6 +185,7 @@ export enum GeographyTab {
     COUNTRIES = 'COUNTRIES',
     REGIONS = 'REGIONS',
     CITIES = 'CITIES',
+    TIMEZONES = 'TIMEZONES',
 }
 
 export interface WebAnalyticsStatusCheck {
@@ -980,6 +981,13 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                       'Cities',
                                       'Cities',
                                       WebStatsBreakdown.City
+                                  ),
+                                  createTableTab(
+                                      TileId.GEOGRAPHY,
+                                      GeographyTab.TIMEZONES,
+                                      'Timezones',
+                                      'Timezones',
+                                      WebStatsBreakdown.Timezone
                                   ),
                               ],
                           }

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -499,6 +499,10 @@ ORDER BY "context.columns.visitors" DESC,
                 )
             case WebStatsBreakdown.CITY:
                 return parse_expr("tuple(properties.$geoip_country_code, properties.$geoip_city_name)")
+            case WebStatsBreakdown.TIMEZONE:
+                # Timezone offsets would be slightly more useful, but that's not easily achievable
+                # with Clickhouse, we might attempt to change this in the future
+                return ast.Field(chain=["properties", "$timezone"])
             case _:
                 raise NotImplementedError("Breakdown not implemented")
 

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -504,19 +504,15 @@ ORDER BY "context.columns.visitors" DESC,
 
     def where_breakdown(self):
         match self.query.breakdownBy:
-            case WebStatsBreakdown.REGION:
+            case WebStatsBreakdown.REGION | WebStatsBreakdown.CITY:
                 return parse_expr("tupleElement(breakdown_value, 2) IS NOT NULL")
-            case WebStatsBreakdown.CITY:
-                return parse_expr("tupleElement(breakdown_value, 2) IS NOT NULL")
-            case WebStatsBreakdown.INITIAL_UTM_SOURCE:
-                return parse_expr("TRUE")  # actually show null values
-            case WebStatsBreakdown.INITIAL_UTM_CAMPAIGN:
-                return parse_expr("TRUE")  # actually show null values
-            case WebStatsBreakdown.INITIAL_UTM_MEDIUM:
-                return parse_expr("TRUE")  # actually show null values
-            case WebStatsBreakdown.INITIAL_UTM_TERM:
-                return parse_expr("TRUE")  # actually show null values
-            case WebStatsBreakdown.INITIAL_UTM_CONTENT:
+            case (
+                WebStatsBreakdown.INITIAL_UTM_SOURCE
+                | WebStatsBreakdown.INITIAL_UTM_CAMPAIGN
+                | WebStatsBreakdown.INITIAL_UTM_MEDIUM
+                | WebStatsBreakdown.INITIAL_UTM_TERM
+                | WebStatsBreakdown.INITIAL_UTM_CONTENT
+            ):
                 return parse_expr("TRUE")  # actually show null values
             case WebStatsBreakdown.INITIAL_CHANNEL_TYPE:
                 return parse_expr(

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1723,6 +1723,7 @@ class WebStatsBreakdown(StrEnum):
     COUNTRY = "Country"
     REGION = "Region"
     CITY = "City"
+    TIMEZONE = "Timezone"
 
 
 class Scale(StrEnum):


### PR DESCRIPTION
## Problem

We want to increase the number of available breakdowns in our web analytics product. This is a good start, more is coming.

See #26376

## Changes

Add a new filter in the frontend that allows us to see views by timezone. I've also changed the button offset when changing to a dropdown because I thought a segment button made more sense here.

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/cd5b11bd-2e7e-4875-944e-e982948173b6">


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual by looking at the UI + automated tests (TBD)
