### PR TITLE
fix(lemon): remove buggy delay from _onBlur for LemonInputSelect

### DIFF
--- a/cypress/e2e/surveys.cy.ts
+++ b/cypress/e2e/surveys.cy.ts
@@ -100,7 +100,7 @@ describe('Surveys', () => {
         cy.get('[data-attr=prop-val]').click({ force: true })
         cy.get('[data-attr=prop-val-0]').click({ force: true })
 
-        cy.get('[data-attr="rollout-percentage"]').type('100')
+        cy.get('[data-attr="rollout-percentage"]').focus().type('100')
 
         // save
         cy.get('[data-attr="save-survey"]').eq(0).click()

--- a/cypress/e2e/surveys.cy.ts
+++ b/cypress/e2e/surveys.cy.ts
@@ -100,7 +100,7 @@ describe('Surveys', () => {
         cy.get('[data-attr=prop-val]').click({ force: true })
         cy.get('[data-attr=prop-val-0]').click({ force: true })
 
-        cy.get('[data-attr="rollout-percentage"]').focus().type('100')
+        cy.get('[data-attr="rollout-percentage"]').click().type('100')
 
         // save
         cy.get('[data-attr="save-survey"]').eq(0).click()

--- a/cypress/e2e/surveys.cy.ts
+++ b/cypress/e2e/surveys.cy.ts
@@ -202,7 +202,7 @@ describe('Surveys', () => {
         cy.get('[data-attr="prop-filter-person_properties-0"]').click()
         cy.get('[data-attr=prop-val]').click({ force: true })
         cy.get('[data-attr=prop-val-0]').click({ force: true })
-        cy.get('[data-attr="rollout-percentage"]').type('100')
+        cy.get('[data-attr="rollout-percentage"]').click().type('100')
 
         cy.get('[data-attr=save-survey]').first().click()
 

--- a/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInputSelect/LemonInputSelect.tsx
@@ -249,22 +249,25 @@ export function LemonInputSelect({
     }
 
     const _onBlur = (): void => {
-        // We need to add a delay as a click could be in the popover or the input wrapper which refocuses
-        setTimeout(() => {
-            if (popoverFocusRef.current) {
-                popoverFocusRef.current = false
-                inputRef.current?.focus()
-                _onFocus()
-                return
-            }
-            if (allowCustomValues && inputValue.trim() && !values.includes(inputValue)) {
+        const hasSelectedAutofilledValue = selectedIndex > 0
+        const hasCustomValue =
+            !hasSelectedAutofilledValue && allowCustomValues && inputValue.trim() && !values.includes(inputValue)
+        if (popoverFocusRef.current) {
+            popoverFocusRef.current = false
+            inputRef.current?.focus()
+            _onFocus()
+            if (hasCustomValue) {
                 _onActionItem(inputValue.trim(), null)
-            } else {
-                setInputValue('')
             }
-            setShowPopover(false)
-            onBlur?.()
-        }, 100)
+            return
+        }
+        if (hasCustomValue) {
+            _onActionItem(inputValue.trim(), null)
+        } else {
+            setInputValue('')
+        }
+        setShowPopover(false)
+        onBlur?.()
     }
 
     const _onFocus = (): void => {


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Addresses issue described here: https://posthoghelp.zendesk.com/agent/tickets/20603 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/23966)

The problem: When clicking on an item from the popover which does not match the text input, the delayed `_onBlur` typically runs _after_ the `_onActionItem`, reverting the selection back as can be seen in the Loom
<img width="912" alt="Screenshot 2024-11-25 at 11 22 48 AM" src="https://github.com/user-attachments/assets/a9f49c47-056e-4059-9d90-caf4d6ecd2a5">

Note - currently with the delay, this is a race condition. However when we remove the delay, the click action runs the _onActionItem, and because the popover is present during the click, the `_onBlur` will then go into its early return condition `if (popoverFocusRef.current) {`, which closes the popover, focuses the text input, and does not try to set any state values, which feels like the exact desired behavior

Given the deleted comment, I also tested all sorts of clicks in or around the popover, opening other popovers, etc and I can not find any adverse effects of removing this delay, but I'm wondering if @benjackwhite has any thoughts here as he added the delay initially when creating this component!

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Remove the `setTimeout` wrapping `_onBlur` for LemonInputSelect

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

Yes

## How did you test this code?

https://www.loom.com/share/ec54ef15771749b98d5ae11354cbb496

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
