### PR TITLE
feat: single hog function run per exception issue

### DIFF
--- a/frontend/src/scenes/error-tracking/ErrorTrackingConfigurationScene.tsx
+++ b/frontend/src/scenes/error-tracking/ErrorTrackingConfigurationScene.tsx
@@ -5,17 +5,63 @@ import { stackFrameLogic } from 'lib/components/Errors/stackFrameLogic'
 import { ErrorTrackingSymbolSet } from 'lib/components/Errors/types'
 import { JSONViewer } from 'lib/components/JSONViewer'
 import { useEffect, useState } from 'react'
+import { LinkedHogFunctions } from 'scenes/pipeline/hogfunctions/list/LinkedHogFunctions'
 import { SceneExport } from 'scenes/sceneTypes'
 
+import {
+    errorTrackingConfigurationSceneLogic,
+    ErrorTrackingConfigurationTab,
+} from './errorTrackingConfigurationSceneLogic'
 import { errorTrackingSymbolSetLogic } from './errorTrackingSymbolSetLogic'
 import { SymbolSetUploadModal } from './SymbolSetUploadModal'
 
 export const scene: SceneExport = {
     component: ErrorTrackingConfigurationScene,
-    logic: errorTrackingSymbolSetLogic,
+    logic: errorTrackingConfigurationSceneLogic,
 }
 
 export function ErrorTrackingConfigurationScene(): JSX.Element {
+    const { activeTab } = useValues(errorTrackingConfigurationSceneLogic)
+    const { setActiveTab } = useActions(errorTrackingConfigurationSceneLogic)
+
+    return (
+        <LemonTabs
+            activeKey={activeTab}
+            tabs={[
+                {
+                    key: ErrorTrackingConfigurationTab.ALERTS,
+                    label: 'Alerts',
+                    content: <Alerts />,
+                },
+                {
+                    key: ErrorTrackingConfigurationTab.SYMBOL_SETS,
+                    label: 'Symbol sets',
+                    content: <SymbolSets />,
+                },
+            ]}
+            onChange={setActiveTab}
+        />
+    )
+}
+
+const Alerts = (): JSX.Element => {
+    return (
+        <LinkedHogFunctions
+            type="destination"
+            subTemplateId="exception"
+            filters={{
+                events: [
+                    {
+                        id: `$exception`,
+                        type: 'events',
+                    },
+                ],
+            }}
+        />
+    )
+}
+
+const SymbolSets = (): JSX.Element => {
     const { missingSymbolSets, validSymbolSets } = useValues(errorTrackingSymbolSetLogic)
 
     return (

--- a/frontend/src/scenes/error-tracking/errorTrackingConfigurationSceneLogic.tsx
+++ b/frontend/src/scenes/error-tracking/errorTrackingConfigurationSceneLogic.tsx
@@ -1,0 +1,25 @@
+import { actions, kea, path, reducers } from 'kea'
+
+import type { errorTrackingConfigurationSceneLogicType } from './errorTrackingConfigurationSceneLogicType'
+
+export enum ErrorTrackingConfigurationTab {
+    ALERTS = 'alerts',
+    SYMBOL_SETS = 'symbol_sets',
+}
+
+export const errorTrackingConfigurationSceneLogic = kea<errorTrackingConfigurationSceneLogicType>([
+    path(['scenes', 'error-tracking', 'errorTrackingConfigurationSceneLogic']),
+
+    actions({
+        setActiveTab: (tab: ErrorTrackingConfigurationTab) => ({ tab }),
+    }),
+
+    reducers({
+        activeTab: [
+            ErrorTrackingConfigurationTab.ALERTS as ErrorTrackingConfigurationTab,
+            {
+                setActiveTab: (_, { tab }) => tab,
+            },
+        ],
+    }),
+])

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -122,6 +122,7 @@ const templateToConfiguration = (
         description: subTemplate?.name ?? template.description,
         inputs_schema: template.inputs_schema,
         filters: subTemplate?.filters ?? template.filters,
+        masking: subTemplate?.masking ?? template.masking,
         hog: template.hog,
         icon_url: template.icon_url,
         inputs,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4610,7 +4610,7 @@ export type HogFunctionType = {
 }
 
 export type HogFunctionTemplateStatus = 'alpha' | 'beta' | 'stable' | 'free' | 'deprecated'
-export type HogFunctionSubTemplateIdType = 'early_access_feature_enrollment' | 'survey_response'
+export type HogFunctionSubTemplateIdType = 'early_access_feature_enrollment' | 'survey_response' | 'exception'
 
 export type HogFunctionConfigurationType = Omit<
     HogFunctionType,

--- a/posthog/cdp/templates/hog_function_template.py
+++ b/posthog/cdp/templates/hog_function_template.py
@@ -8,7 +8,7 @@ else:
     PluginConfig = None
 
 
-SubTemplateId = Literal["early_access_feature_enrollment", "survey_response"]
+SubTemplateId = Literal["early_access_feature_enrollment", "survey_response", "exception"]
 
 SUB_TEMPLATE_ID: tuple[SubTemplateId, ...] = get_args(SubTemplateId)
 
@@ -73,5 +73,11 @@ SUB_TEMPLATE_COMMON: dict[SubTemplateId, HogFunctionSubTemplate] = {
         id="early_access_feature_enrollment",
         name="Early Access Feature Enrollment",
         filters={"events": [{"id": "$feature_enrollment_update", "type": "events"}]},
+    ),
+    "exception": HogFunctionSubTemplate(
+        id="exception",
+        name="Error or Exception",
+        filters={"events": [{"id": "$exception", "type": "events"}]},
+        masking={"ttl": -1, "hash": "{event.properties.$exception_issue_id}"},
     ),
 }

--- a/posthog/cdp/templates/slack/template_slack.py
+++ b/posthog/cdp/templates/slack/template_slack.py
@@ -168,5 +168,46 @@ if (res.status != 200 or not res.body.ok) {
                 ],
             },
         ),
+        HogFunctionSubTemplate(
+            id="exception",
+            name="Post to Slack on Exception",
+            description="Posts a message to Slack when an error or exception occurs",
+            filters=SUB_TEMPLATE_COMMON["exception"].filters,
+            masking=SUB_TEMPLATE_COMMON["exception"].masking,
+            inputs={
+                "text": "*:exclamation: <{project.url}/error_tracking/{event.properties.$exception_issue_id}>*",
+                "blocks": [
+                    {
+                        "text": {
+                            "text": "*:exclamation: <{project.url}/error_tracking/{event.properties.$exception_issue_id}>*",
+                            "type": "mrkdwn",
+                        },
+                        "type": "section",
+                    },
+                    {
+                        "text": {
+                            "text": "```{event.properties.$exception_type}: {event.properties.$exception_message}```",
+                            "type": "mrkdwn",
+                        },
+                        "type": "section",
+                    },
+                    {
+                        "type": "actions",
+                        "elements": [
+                            {
+                                "url": "{project.url}/error_tracking/{event.properties.$exception_issue_id}",
+                                "text": {"text": "View Error", "type": "plain_text"},
+                                "type": "button",
+                            },
+                            {
+                                "url": "{person.url}",
+                                "text": {"text": "View Person", "type": "plain_text"},
+                                "type": "button",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ),
     ],
 )

--- a/posthog/cdp/templates/slack/template_slack.py
+++ b/posthog/cdp/templates/slack/template_slack.py
@@ -170,8 +170,8 @@ if (res.status != 200 or not res.body.ok) {
         ),
         HogFunctionSubTemplate(
             id="exception",
-            name="Post to Slack on Exception",
-            description="Posts a message to Slack when an error or exception occurs",
+            name="Post to Slack on new issue",
+            description="Posts a message to Slack when a new error or exception occurs",
             filters=SUB_TEMPLATE_COMMON["exception"].filters,
             masking=SUB_TEMPLATE_COMMON["exception"].masking,
             inputs={

--- a/posthog/cdp/templates/webhook/template_webhook.py
+++ b/posthog/cdp/templates/webhook/template_webhook.py
@@ -100,5 +100,11 @@ if (inputs.debug) {
             name="HTTP Webhook on survey response",
             filters=SUB_TEMPLATE_COMMON["survey_response"].filters,
         ),
+        HogFunctionSubTemplate(
+            id="exception",
+            name="HTTP Webhook on Exception",
+            filters=SUB_TEMPLATE_COMMON["exception"].filters,
+            masking=SUB_TEMPLATE_COMMON["exception"].masking,
+        ),
     ],
 )

--- a/posthog/cdp/templates/webhook/template_webhook.py
+++ b/posthog/cdp/templates/webhook/template_webhook.py
@@ -102,7 +102,7 @@ if (inputs.debug) {
         ),
         HogFunctionSubTemplate(
             id="exception",
-            name="HTTP Webhook on Exception",
+            name="HTTP Webhook on new issue",
             filters=SUB_TEMPLATE_COMMON["exception"].filters,
             masking=SUB_TEMPLATE_COMMON["exception"].masking,
         ),


### PR DESCRIPTION
## Problem

Support single instance alerting for error tracking

## Changes

Based on the original changes made in https://github.com/PostHog/posthog/pull/24601

- Adds a new "Run once per unique property value" configuration setting to hog functions
- Includes associated taxonomic property filter

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
