### PR TITLE
feat(organization-invites): handle duplicate invites

### DIFF
--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -59,7 +59,7 @@ class OrganizationInviteManager:
     def _get_invites_for_user_org(
         organization_id: UUID | str, target_email: str, include_expired: bool = False
     ) -> QuerySet:
-        filters = {
+        filters: dict[str, Any] = {
             "organization_id": organization_id,
             "target_email": target_email,
         }

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -2,6 +2,7 @@ import random
 from unittest.mock import ANY, patch
 
 from django.core import mail
+from freezegun import freeze_time
 from rest_framework import status
 
 from ee.models.explicit_team_membership import ExplicitTeamMembership
@@ -156,18 +157,18 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         # Assert invite email is not sent
         self.assertEqual(len(mail.outbox), 0)
 
-    def test_can_create_invites_for_the_same_email_multiple_times(self):
+    def test_create_invites_for_the_same_email_multiple_times_deletes_older_invites(self):
         email = "x@posthog.com"
         count = OrganizationInvite.objects.count()
 
-        for _ in range(0, 2):
+        for _ in range(0, 3):
             response = self.client.post("/api/organizations/@current/invites/", {"target_email": email})
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
             obj = OrganizationInvite.objects.get(id=response.json()["id"])
             self.assertEqual(obj.target_email, email)
             self.assertEqual(obj.created_by, self.user)
 
-        self.assertEqual(OrganizationInvite.objects.count(), count + 2)
+        self.assertEqual(OrganizationInvite.objects.count(), count + 1)
 
     def test_can_specify_membership_level_in_invite(self):
         email = "x@posthog.com"
@@ -508,3 +509,148 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         self.assertEqual(response.content, b"")  # Empty response
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(OrganizationInvite.objects.exists())
+
+    # Combine pending invites
+
+    def test_combine_pending_invites_combines_levels_and_project_access(self):
+        email = "x@posthog.com"
+        private_team_1 = Team.objects.create(organization=self.organization, name="Private Team 1", access_control=True)
+        private_team_2 = Team.objects.create(organization=self.organization, name="Private Team 2", access_control=True)
+
+        ExplicitTeamMembership.objects.create(
+            team=private_team_1,
+            parent_membership=self.organization_membership,
+            level=ExplicitTeamMembership.Level.ADMIN,
+        )
+        ExplicitTeamMembership.objects.create(
+            team=private_team_2,
+            parent_membership=self.organization_membership,
+            level=ExplicitTeamMembership.Level.ADMIN,
+        )
+
+        # Create first invite with member access to team 1
+        first_invite = self.client.post(
+            "/api/organizations/@current/invites/",
+            {
+                "target_email": email,
+                "level": OrganizationMembership.Level.MEMBER,
+                "private_project_access": [{"id": private_team_1.id, "level": ExplicitTeamMembership.Level.MEMBER}],
+            },
+        ).json()
+
+        # Create second invite with admin access to team 2
+        second_invite = self.client.post(
+            "/api/organizations/@current/invites/",
+            {
+                "target_email": email,
+                "level": OrganizationMembership.Level.ADMIN,
+                "private_project_access": [{"id": private_team_2.id, "level": ExplicitTeamMembership.Level.ADMIN}],
+            },
+        ).json()
+
+        # Create third invite combining previous invites
+        response = self.client.post(
+            "/api/organizations/@current/invites/",
+            {
+                "target_email": email,
+                "level": OrganizationMembership.Level.MEMBER,
+                "private_project_access": [{"id": private_team_1.id, "level": ExplicitTeamMembership.Level.ADMIN}],
+                "combine_pending_invites": True,
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        combined_invite = response.json()
+
+        # Check that previous invites are deleted
+        self.assertFalse(OrganizationInvite.objects.filter(id=first_invite["id"]).exists())
+        self.assertFalse(OrganizationInvite.objects.filter(id=second_invite["id"]).exists())
+
+        # Check that the new invite has the highest level (ADMIN)
+        self.assertEqual(combined_invite["level"], OrganizationMembership.Level.ADMIN)
+
+        # Check that private project access is combined with highest levels
+        expected_access = [
+            {"id": private_team_1.id, "level": ExplicitTeamMembership.Level.ADMIN},
+            {"id": private_team_2.id, "level": ExplicitTeamMembership.Level.ADMIN},
+        ]
+        self.assertEqual(len(combined_invite["private_project_access"]), 2)
+        for access in expected_access:
+            self.assertIn(access, combined_invite["private_project_access"])
+
+    def test_combine_pending_invites_with_no_existing_invites(self):
+        email = "x@posthog.com"
+        response = self.client.post(
+            "/api/organizations/@current/invites/",
+            {
+                "target_email": email,
+                "level": OrganizationMembership.Level.MEMBER,
+                "combine_pending_invites": True,
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        invite = response.json()
+        self.assertEqual(invite["level"], OrganizationMembership.Level.MEMBER)
+        self.assertEqual(invite["target_email"], email)
+        self.assertEqual(invite["private_project_access"], [])
+
+    @freeze_time("2024-01-10")
+    def test_combine_pending_invites_with_expired_invites(self):
+        email = "xyz@posthog.com"
+
+        # Create an expired invite
+        with freeze_time("2023-01-05"):
+            OrganizationInvite.objects.create(
+                organization=self.organization,
+                target_email=email,
+                level=OrganizationMembership.Level.ADMIN,
+            )
+
+        response = self.client.post(
+            "/api/organizations/@current/invites/",
+            {
+                "target_email": email,
+                "level": OrganizationMembership.Level.MEMBER,
+                "combine_pending_invites": True,
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        invite = response.json()
+
+        # Check that the new invite uses its own level, not the expired invite's level
+        self.assertEqual(invite["level"], OrganizationMembership.Level.MEMBER)
+        self.assertEqual(invite["target_email"], email)
+        self.assertEqual(invite["private_project_access"], [])
+
+    def test_combine_pending_invites_false_expires_existing_invites(self):
+        email = "x@posthog.com"
+
+        # Create first invite
+        first_invite = self.client.post(
+            "/api/organizations/@current/invites/",
+            {
+                "target_email": email,
+                "level": OrganizationMembership.Level.ADMIN,
+            },
+        ).json()
+
+        # Create second invite with combine_pending_invites=False
+        response = self.client.post(
+            "/api/organizations/@current/invites/",
+            {
+                "target_email": email,
+                "level": OrganizationMembership.Level.MEMBER,
+                "combine_pending_invites": False,
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        new_invite = response.json()
+
+        # Check that previous invite is deleted
+        self.assertFalse(OrganizationInvite.objects.filter(id=first_invite["id"]).exists())
+
+        # Check that new invite uses its own level
+        self.assertEqual(new_invite["level"], OrganizationMembership.Level.MEMBER)


### PR DESCRIPTION
## Problem

If someone is using the API to create invites, it's possible to create multiple invites for the same user. This is _fine_ but not ideal, esp if someone is using the `private_project_access` field on the invites to specify projects someone should get access to when they join.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

When creating an invite, the `combine_pending_invites` field can be optionally applied. 
- If True, non-expired pending invoices are combined, getting the highest access level specified on any invite and using those for the resulting invite. Old invites are deleted.
- If False (default), just delete the old invite and create a new one with the current invite info being supplied via the request.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Should!

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added a few tests.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
