### PR TITLE
fix: blur toolbar event handler matches js lib approach

### DIFF
--- a/frontend/src/toolbar/bar/toolbarLogic.ts
+++ b/frontend/src/toolbar/bar/toolbarLogic.ts
@@ -9,7 +9,7 @@ import { elementsLogic } from '~/toolbar/elements/elementsLogic'
 import { heatmapLogic } from '~/toolbar/elements/heatmapLogic'
 import { experimentsTabLogic } from '~/toolbar/experiments/experimentsTabLogic'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
-import { inBounds, TOOLBAR_ID } from '~/toolbar/utils'
+import { inBounds, TOOLBAR_CONTAINER_CLASS, TOOLBAR_ID } from '~/toolbar/utils'
 
 import type { toolbarLogicType } from './toolbarLogicType'
 
@@ -431,8 +431,9 @@ export const toolbarLogic = kea<toolbarLogicType>([
     })),
     afterMount(({ actions, values, cache }) => {
         cache.clickListener = (e: MouseEvent): void => {
-            const shouldBeBlurred = (e.target as HTMLElement)?.id !== TOOLBAR_ID
-            if (shouldBeBlurred && !values.isBlurred) {
+            const target = e.target as HTMLElement
+            const clickIsInToolbar = target?.id === TOOLBAR_ID || !!target.closest?.('.' + TOOLBAR_CONTAINER_CLASS)
+            if (!clickIsInToolbar && !values.isBlurred) {
                 actions.setIsBlurred(true)
             }
         }

--- a/frontend/src/toolbar/utils.ts
+++ b/frontend/src/toolbar/utils.ts
@@ -10,6 +10,7 @@ import { ActionStepType } from '~/types'
 import { ActionStepPropertyKey } from './actions/ActionStep'
 
 export const TOOLBAR_ID = '__POSTHOG_TOOLBAR__'
+export const TOOLBAR_CONTAINER_CLASS = 'toolbar-global-fade-container'
 export const LOCALSTORAGE_KEY = '_postHogToolbarParams'
 
 export function getSafeText(el: HTMLElement): string {


### PR DESCRIPTION
for https://posthoghelp.zendesk.com/agent/tickets/20804 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/22794)

in that ticket, and only in local dev, when they interact with the toolbar its menus close

there's no way to investigate this, since it's in local dev, so we have to probe instead. this makes the "is in toolbar" detection more like that used by the heatmap for no other reason than it's something to try 🙈 