### PR TITLE
chore: make raw_sessions CH 24.8 compatible

### DIFF
--- a/posthog/clickhouse/migrations/0089_nullable_uuid_type_sessions.py
+++ b/posthog/clickhouse/migrations/0089_nullable_uuid_type_sessions.py
@@ -1,0 +1,6 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.raw_sessions.sql import RAW_SESSION_TABLE_UPDATE_SQL
+
+operations = [
+    run_sql_with_exceptions(RAW_SESSION_TABLE_UPDATE_SQL),
+]

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -1905,17 +1905,17 @@
   
       -- count
       sumIf(1, event='$pageview') as pageview_count,
-      uniqState(if(event='$pageview', uuid, NULL)) as pageview_uniq,
+      uniqState(CAST(if(event='$pageview', uuid, NULL) AS Nullable(UUID))) as pageview_uniq,
       sumIf(1, event='$autocapture') as autocapture_count,
-      uniqState(if(event='$autocapture', uuid, NULL)) as autocapture_uniq,
+      uniqState(CAST(if(event='$autocapture', uuid, NULL) AS Nullable(UUID))) as autocapture_uniq,
       sumIf(1, event='$screen') as screen_count,
-      uniqState(if(event='$screen', uuid, NULL)) as screen_uniq,
+      uniqState(CAST(if(event='$screen', uuid, NULL) AS Nullable(UUID))) as screen_uniq,
   
       -- replay
       false as maybe_has_session_replay,
   
       -- perf
-      uniqUpToState(1)(if(event='$pageview' OR event='$screen' OR event='$autocapture', uuid, NULL)) as page_screen_autocapture_uniq_up_to,
+      uniqUpToState(1)(CAST(if(event='$pageview' OR event='$screen' OR event='$autocapture', uuid, NULL) AS Nullable(UUID))) as page_screen_autocapture_uniq_up_to,
   
       -- web vitals
       argMinState(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$web_vitals_LCP_value'), ''), 'null'), '^"|"$', ''), 'Float64'), timestamp) as vitals_lcp

--- a/posthog/models/raw_sessions/sql.py
+++ b/posthog/models/raw_sessions/sql.py
@@ -331,17 +331,17 @@ SELECT
 
     -- count
     sumIf(1, event='$pageview') as pageview_count,
-    uniqState(if(event='$pageview', uuid, NULL)) as pageview_uniq,
+    uniqState(CAST(if(event='$pageview', uuid, NULL) AS Nullable(UUID))) as pageview_uniq,
     sumIf(1, event='$autocapture') as autocapture_count,
-    uniqState(if(event='$autocapture', uuid, NULL)) as autocapture_uniq,
+    uniqState(CAST(if(event='$autocapture', uuid, NULL) AS Nullable(UUID))) as autocapture_uniq,
     sumIf(1, event='$screen') as screen_count,
-    uniqState(if(event='$screen', uuid, NULL)) as screen_uniq,
+    uniqState(CAST(if(event='$screen', uuid, NULL) AS Nullable(UUID))) as screen_uniq,
 
     -- replay
     false as maybe_has_session_replay,
 
     -- perf
-    uniqUpToState(1)(if(event='$pageview' OR event='$screen' OR event='$autocapture', uuid, NULL)) as page_screen_autocapture_uniq_up_to,
+    uniqUpToState(1)(CAST(if(event='$pageview' OR event='$screen' OR event='$autocapture', uuid, NULL) AS Nullable(UUID))) as page_screen_autocapture_uniq_up_to,
 
     -- web vitals
     argMinState({vitals_lcp}, timestamp) as vitals_lcp


### PR DESCRIPTION
## Problem

Making `raw_sessions` table compatible with CH 24.8

Prerequisite for CH 24.8 upgrade PR https://github.com/PostHog/posthog/pull/25189

## Changes

Cast columns to correct types

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
