### PR TITLE
feat(web-analytics): Turn timezones into UTC offsets instead of timezone names

### DIFF
--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -19,6 +19,23 @@ import { DataTableNode, InsightVizNode, NodeKind, QuerySchema, WebStatsBreakdown
 import { QueryContext, QueryContextColumnComponent, QueryContextColumnTitleComponent } from '~/queries/types'
 import { ChartDisplayType, GraphPointPayload, InsightLogicProps, ProductKey, PropertyFilterType } from '~/types'
 
+const toUtcOffsetFormat = (value: number): string => {
+    if (value === 0) {
+        return 'UTC'
+    }
+
+    const integerPart = Math.floor(value)
+    const sign = integerPart > 0 ? '+' : '-'
+
+    // India has half-hour offsets, and Australia has 45-minute offsets, why?
+    const decimalPart = value - integerPart
+    const decimalPartAsMinutes = decimalPart * 60
+    const formattedMinutes = decimalPartAsMinutes > 0 ? `:${decimalPartAsMinutes}` : ''
+
+    // E.g. UTC-3, UTC, UTC+5:30, UTC+11:45
+    return `UTC${sign}${integerPart}${formattedMinutes}`
+}
+
 const PercentageCell: QueryContextColumnComponent = ({ value }) => {
     if (typeof value === 'number') {
         return <span>{`${(value * 100).toFixed(1)}%`}</span>
@@ -119,6 +136,11 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
                         {countryCodeToFlag(countryCode)} {countryCodeToName[countryCode] || countryCode} - {cityName}
                     </>
                 )
+            }
+            break
+        case WebStatsBreakdown.Timezone:
+            if (typeof value === 'number') {
+                return toUtcOffsetFormat(value)
             }
             break
     }

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -140,7 +140,7 @@ const BreakdownValueCell: QueryContextColumnComponent = (props) => {
             break
         case WebStatsBreakdown.Timezone:
             if (typeof value === 'number') {
-                return toUtcOffsetFormat(value)
+                return <>{toUtcOffsetFormat(value)}</>
             }
             break
     }

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -421,13 +421,15 @@ HOGQL_CLICKHOUSE_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "toString": HogQLFunctionMeta(
         "toString",
         1,
-        1,
+        2,
         signatures=[
             ((IntegerType(),), StringType()),
             ((StringType(),), StringType()),
             ((FloatType(),), StringType()),
             ((DateType(),), StringType()),
+            ((DateType(), StringType()), StringType()),
             ((DateTimeType(),), StringType()),
+            ((DateTimeType(), StringType()), StringType()),
         ],
     ),
     "toJSONString": HogQLFunctionMeta("toJSONString", 1, 1),

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -508,7 +508,7 @@ ORDER BY "context.columns.visitors" DESC,
                 # Get the difference between the UNIX timestamp at UTC and the UNIX timestamp at the event's timezone
                 # Value is in milliseconds, turn it to hours, works even for fractional timezone offsets (I'm looking at you, Australia)
                 return parse_expr(
-                    "if(isNull(properties.$timezone), NULL, (toUnixTimestamp64Milli(parseDateTimeBestEffort(assumeNotNull(toString(timestamp, properties.$timezone)))) - toUnixTimestamp64Milli(timestamp)) / 3600000)"
+                    "if(or(isNull(properties.$timezone), empty(properties.$timezone)), NULL, (toUnixTimestamp64Milli(parseDateTimeBestEffort(assumeNotNull(toString(timestamp, properties.$timezone)))) - toUnixTimestamp64Milli(timestamp)) / 3600000)"
                 )
             case _:
                 raise NotImplementedError("Breakdown not implemented")

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -1006,50 +1006,67 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert results == [["/path1", 1, 1]]
 
     def test_timezone_filter(self):
-        d1, s1 = "d1", str(uuid7("2024-07-30"))
-        d2, s2 = "d2", str(uuid7("2024-07-30"))
+        date = "2024-07-30"
 
-        _create_person(
-            team_id=self.team.pk,
-            distinct_ids=[d1],
-            properties={"name": d1, "email": "test@example.com"},
-        )
+        for idx, (distinct_id, session_id) in enumerate(
+            [
+                ("UTC", str(uuid7(date))),
+                ("Asia/Calcutta", str(uuid7(date))),
+                ("America/New_York", str(uuid7(date))),
+                ("America/Sao_Paulo", str(uuid7(date))),
+            ]
+        ):
+            _create_person(
+                team_id=self.team.pk,
+                distinct_ids=[distinct_id],
+                properties={"name": session_id, "email": f"{distinct_id}@example.com"},
+            )
 
-        _create_event(
-            team=self.team,
-            event="$pageview",
-            distinct_id=d1,
-            timestamp="2024-07-30",
-            properties={"$session_id": s1, "$pathname": "/path1", "$timezone": "America/New_York"},
-        )
-
-        _create_person(
-            team_id=self.team.pk,
-            distinct_ids=[d2],
-            properties={"name": d2, "email": "d2@hedgebox.net"},
-        )
-        _create_event(
-            team=self.team,
-            event="$pageview",
-            distinct_id=d2,
-            timestamp="2024-07-30",
-            properties={"$session_id": s2, "$pathname": "/path2", "$timezone": "America/Brasilia"},
-        )
-        _create_event(
-            team=self.team,
-            event="$pageview",
-            distinct_id=d2,
-            timestamp="2024-07-30",
-            properties={"$session_id": s2, "$pathname": "/path3", "$timezone": "America/Brasilia"},
-        )
-
-        flush_persons_and_events()
+            for i in range(idx + 1):
+                _create_event(
+                    team=self.team,
+                    event="$pageview",
+                    distinct_id=distinct_id,
+                    timestamp=date,
+                    properties={"$session_id": session_id, "$pathname": f"/path{i}", "$timezone": distinct_id},
+                )
 
         results = self._run_web_stats_table_query(
             "all",
             None,
             breakdown_by=WebStatsBreakdown.TIMEZONE,
-            filter_test_accounts=True,
         ).results
 
-        assert results == [["America/Brasilia", 1.0, 2.0], ["America/New_York", 1.0, 1.0]]
+        # Brasilia UTC-3, New York UTC-4, Calcutta UTC+5:30, UTC
+        assert results == [[-3.0, 1.0, 4.0], [-4.0, 1.0, 3.0], [5.5, 1.0, 2.0], [0.0, 1.0, 1.0]]
+
+    def test_timezone_filter_with_invalid_timezone(self):
+        date = "2024-07-30"
+
+        for idx, (distinct_id, session_id) in enumerate(
+            [
+                ("UTC", str(uuid7(date))),
+                ("Timezone_not_exists", str(uuid7(date))),
+            ]
+        ):
+            _create_person(
+                team_id=self.team.pk,
+                distinct_ids=[distinct_id],
+                properties={"name": session_id, "email": f"{distinct_id}@example.com"},
+            )
+
+            for i in range(idx + 1):
+                _create_event(
+                    team=self.team,
+                    event="$pageview",
+                    distinct_id=distinct_id,
+                    timestamp=date,
+                    properties={"$session_id": session_id, "$pathname": f"/path{i}", "$timezone": distinct_id},
+                )
+
+        with self.assertRaisesRegex(Exception, "Cannot load time zone"):
+            self._run_web_stats_table_query(
+                "all",
+                None,
+                breakdown_by=WebStatsBreakdown.TIMEZONE,
+            )


### PR DESCRIPTION
Timezone names on their own aren't that useful because they're basically a harder-to-use version of displaying events by city/region. Displaying them by offsets, however, can prove to be valuable. We're doing some magic to calculate the offset instead of simply using something like `timezoneOffset` because `toString` is one of the only functions in Clickhouse that allows us to use a dynamic timezone versus a hardcoded one. This might have some performance implications, we'll figure it out soon :). To workaround that, we're converting to a string, then parsing that back to a date, and getting the unix timestamp. Comparing the UNIX timestamp in a specific timezone versus the value at UTC allows us to get the offset at that day.

See #26376

## Changes

<img width="1190" alt="image" src="https://github.com/user-attachments/assets/07962b33-bafc-4d67-8773-d9a79fc6dce2">

## Does this work well for both Cloud and self-hosted?

Yep

## How did you test this code?

Comprehensive unit test + manual UI testing
