### PR TITLE
fix: make the ALTER TABLE MODIFY QUERY run ON CLUSTER

### DIFF
--- a/posthog/clickhouse/migrations/0088_noop.py
+++ b/posthog/clickhouse/migrations/0088_noop.py
@@ -1,0 +1,1 @@
+operations = []

--- a/posthog/clickhouse/migrations/0088_noop.py
+++ b/posthog/clickhouse/migrations/0088_noop.py
@@ -1,1 +1,4 @@
-operations = []
+from infi.clickhouse_orm import RunPython
+
+
+operations: list[RunPython] = []

--- a/posthog/clickhouse/migrations/0088_noop.py
+++ b/posthog/clickhouse/migrations/0088_noop.py
@@ -1,4 +1,0 @@
-from infi.clickhouse_orm import RunPython
-
-
-operations: list[RunPython] = []

--- a/posthog/clickhouse/migrations/0090_nullable_uuid_type_session_on_cluster.py
+++ b/posthog/clickhouse/migrations/0090_nullable_uuid_type_session_on_cluster.py
@@ -1,0 +1,6 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.raw_sessions.sql import RAW_SESSION_TABLE_UPDATE_SQL
+
+operations = [
+    run_sql_with_exceptions(RAW_SESSION_TABLE_UPDATE_SQL),
+]

--- a/posthog/models/raw_sessions/sql.py
+++ b/posthog/models/raw_sessions/sql.py
@@ -409,10 +409,12 @@ AS
 
 RAW_SESSION_TABLE_UPDATE_SQL = (
     lambda: """
-ALTER TABLE {table_name} MODIFY QUERY
+ALTER TABLE {table_name} ON CLUSTER '{cluster}'
+MODIFY QUERY
 {select_sql}
 """.format(
         table_name=f"{TABLE_BASE_NAME}_mv",
+        cluster=settings.CLICKHOUSE_CLUSTER,
         select_sql=RAW_SESSION_TABLE_MV_SELECT_SQL(),
     )
 )


### PR DESCRIPTION
## Problem

The migration did not run on the entire cluster - this will make the ALTER run cluster wide

## Changes

`ON CLUSTER`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
