### PR TITLE
refactor: Update materialized column management

### DIFF
--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -134,7 +134,7 @@ class TableInfo:
     data_table: str
 
     @property
-    def read_table(self):
+    def read_table(self) -> str:
         return self.data_table
 
     def map_data_nodes(self, cluster: ClickhouseCluster, fn: Callable[[Client], T]) -> FuturesMap[HostInfo, T]:
@@ -146,7 +146,7 @@ class ShardedTableInfo(TableInfo):
     dist_table: str
 
     @property
-    def read_table(self):
+    def read_table(self) -> str:
         return self.dist_table
 
     def map_data_nodes(self, cluster: ClickhouseCluster, fn: Callable[[Client], T]) -> FuturesMap[HostInfo, T]:
@@ -167,7 +167,7 @@ class CreateColumnOnDataNodesTask:
     create_minmax_index: bool
     add_column_comment: bool
 
-    def execute(self, client):
+    def execute(self, client: Client) -> None:
         actions = [
             f"""
             ADD COLUMN IF NOT EXISTS {self.column.name} VARCHAR
@@ -196,7 +196,7 @@ class CreateColumnOnQueryNodesTask:
     table: str
     column: MaterializedColumn
 
-    def execute(self, client):
+    def execute(self, client: Client) -> None:
         client.execute(
             f"""
             ALTER TABLE {self.table}
@@ -262,7 +262,7 @@ class UpdateColumnCommentTask:
     table: str
     column: MaterializedColumn
 
-    def execute(self, client):
+    def execute(self, client: Client) -> None:
         client.execute(
             f"ALTER TABLE {self.table} COMMENT COLUMN {self.column.name} %(comment)s",
             {"comment": self.column.details.as_column_comment()},
@@ -294,7 +294,7 @@ class DropColumnTask:
     column_name: str
     try_drop_index: bool
 
-    def execute(self, client):
+    def execute(self, client: Client) -> None:
         # XXX: copy/pasted from create task
         if self.try_drop_index:
             index_name = f"minmax_{self.column_name}"
@@ -339,7 +339,7 @@ class BackfillColumnTask:
     backfill_period: timedelta | None
     test_settings: dict[str, Any] | None
 
-    def execute(self, client):
+    def execute(self, client: Client) -> None:
         # Hack from https://github.com/ClickHouse/ClickHouse/issues/19785
         # Note that for this to work all inserts should list columns explicitly
         # Improve this if https://github.com/ClickHouse/ClickHouse/issues/27730 ever gets resolved

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -11,7 +11,7 @@ from clickhouse_driver import Client
 from django.utils.timezone import now
 
 from posthog.clickhouse.client.connection import default_client
-from posthog.clickhouse.cluster import ClickhouseCluster, ConnectionInfo, FuturesMap
+from posthog.clickhouse.cluster import ClickhouseCluster, ConnectionInfo, FuturesMap, HostInfo
 from posthog.clickhouse.kafka_engine import trim_quotes_expr
 from posthog.clickhouse.materialized_columns import ColumnName, TablesWithMaterializedColumns
 from posthog.client import sync_execute
@@ -21,7 +21,6 @@ from posthog.models.utils import generate_random_short_suffix
 from posthog.settings import CLICKHOUSE_DATABASE, CLICKHOUSE_PER_TEAM_SETTINGS, TEST
 
 T = TypeVar("T")
-K = TypeVar("K")
 
 DEFAULT_TABLE_COLUMN: Literal["properties"] = "properties"
 
@@ -145,7 +144,7 @@ class TableInfo(NamedTuple):
         else:
             return self.data_table
 
-    def map_data_nodes(self, cluster: ClickhouseCluster, fn: Callable[[Client], T]) -> FuturesMap[K, T]:
+    def map_data_nodes(self, cluster: ClickhouseCluster, fn: Callable[[Client], T]) -> FuturesMap[HostInfo, T]:
         if self.is_sharded:
             return cluster.map_one_host_per_shard(fn)
         else:

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -15,7 +15,9 @@ from posthog.clickhouse.cluster import ClickhouseCluster, ConnectionInfo, Future
 from posthog.clickhouse.kafka_engine import trim_quotes_expr
 from posthog.clickhouse.materialized_columns import ColumnName, TablesWithMaterializedColumns
 from posthog.client import sync_execute
+from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.models.instance_setting import get_instance_setting
+from posthog.models.person.sql import PERSONS_TABLE
 from posthog.models.property import PropertyName, TableColumn, TableWithProperties
 from posthog.models.utils import generate_random_short_suffix
 from posthog.settings import CLICKHOUSE_DATABASE, CLICKHOUSE_PER_TEAM_SETTINGS, TEST
@@ -154,8 +156,8 @@ class ShardedTableInfo(TableInfo):
 
 
 tables: dict[str, TableInfo | ShardedTableInfo] = {
-    "person": TableInfo("person"),
-    "events": ShardedTableInfo("sharded_events", "events"),
+    PERSONS_TABLE: TableInfo(PERSONS_TABLE),
+    "events": ShardedTableInfo(EVENTS_DATA_TABLE, "events"),
 }
 
 

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -156,7 +156,6 @@ class ShardedTableInfo(TableInfo):
 tables: dict[str, TableInfo | ShardedTableInfo] = {
     "person": TableInfo("person"),
     "events": ShardedTableInfo("sharded_events", "events"),
-    # TODO ...
 }
 
 

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -17,7 +17,7 @@ from posthog.client import sync_execute
 from posthog.models.instance_setting import get_instance_setting
 from posthog.models.property import PropertyName, TableColumn, TableWithProperties
 from posthog.models.utils import generate_random_short_suffix
-from posthog.settings import CLICKHOUSE_CLUSTER, CLICKHOUSE_DATABASE, CLICKHOUSE_PER_TEAM_SETTINGS, TEST
+from posthog.settings import CLICKHOUSE_DATABASE, CLICKHOUSE_PER_TEAM_SETTINGS, TEST
 
 DEFAULT_TABLE_COLUMN: Literal["properties"] = "properties"
 
@@ -116,10 +116,6 @@ def get_materialized_columns(
         for column in MaterializedColumn.get_all(table)
         if not (exclude_disabled_columns and column.details.is_disabled)
     }
-
-
-def get_on_cluster_clause_for_table(table: TableWithProperties) -> str:
-    return f"ON CLUSTER '{CLICKHOUSE_CLUSTER}'" if table == "events" else ""
 
 
 def get_cluster() -> ClickhouseCluster:

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -157,7 +157,7 @@ class ShardedTableInfo(TableInfo):
 
 tables: dict[str, TableInfo | ShardedTableInfo] = {
     PERSONS_TABLE: TableInfo(PERSONS_TABLE),
-    "events": ShardedTableInfo(EVENTS_DATA_TABLE, "events"),
+    "events": ShardedTableInfo(EVENTS_DATA_TABLE(), "events"),
 }
 
 

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -1,0 +1,71 @@
+from collections.abc import Callable, Mapping
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import NamedTuple, TypeVar
+
+from clickhouse_driver import Client
+from clickhouse_pool import ChPool
+from django.conf import settings
+
+from posthog.clickhouse.client.connection import make_ch_pool
+
+
+class HostInfo(NamedTuple):
+    shard_num: int
+    replica_num: int
+    host_address: str
+    port: int
+
+
+T = TypeVar("T")
+
+
+class ClickhouseCluster:
+    def __init__(self, bootstrap_client: Client, name: str = settings.CLICKHOUSE_CLUSTER) -> None:
+        self.name = name
+        self.hosts = [
+            HostInfo(shard_num, replica_num, host_address, port)
+            for (shard_num, replica_num, host_address, port) in bootstrap_client.execute(
+                """
+                SELECT shard_num, replica_num, host_address, port
+                FROM system.clusters
+                WHERE name = %(name)s
+                ORDER BY shard_num, replica_num
+                """,
+                {"name": name},
+            )
+        ]
+
+        self.__pools: dict[HostInfo, ChPool] = {}
+
+    def map_hosts(self, fn: Callable[[Client], T]) -> Mapping[HostInfo, Future[T]]:
+        def task(pool):
+            with pool.get_client() as client:
+                return fn(client)
+
+        with ThreadPoolExecutor() as executor:
+            results = {}
+            for host in self.hosts:
+                pool = self.__pools.get(host)
+                if pool is None:
+                    pool = self.__pools[pool] = make_ch_pool(host=host.host_address, port=host.port)
+                results[host] = executor.submit(task, pool)
+            return results
+
+    def map_shards(self, fn: Callable[[Client], T]) -> Mapping[int, Future[T]]:
+        def task(pool):
+            with pool.get_client() as client:
+                return fn(client)
+
+        shard_hosts: dict[int, HostInfo] = {}
+        for host in self.hosts:
+            if host.shard_num not in shard_hosts:
+                shard_hosts[host.shard_num] = host
+
+        with ThreadPoolExecutor() as executor:
+            results = {}
+            for shard_num, host in shard_hosts.items():
+                pool = self.__pools.get(host)
+                if pool is None:
+                    pool = self.__pools[pool] = make_ch_pool(host=host.host_address, port=host.port)
+                results[shard_num] = executor.submit(task, pool)
+            return results

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Sequence
-from concurrent.futures import ALL_COMPLETED, FIRST_EXCEPTION, Future, ThreadPoolExecutor, as_completed, wait
+from concurrent.futures import ALL_COMPLETED, FIRST_EXCEPTION, Future, ThreadPoolExecutor, as_completed
 from typing import NamedTuple, TypeVar
 
 from clickhouse_driver import Client
@@ -22,16 +22,6 @@ class FuturesMap(dict[K, Future[V]]):
 
         for f in as_completed(self.values()):
             yield reverse_map[f], f
-
-    def wait(self, *args, **kwargs) -> tuple[FuturesMap[K, V], FuturesMap[K, V]]:
-        reverse_map = {v: k for k, v in self.items()}
-        assert len(reverse_map) == len(self)
-
-        done_futures, not_done_futures = wait(self.values(), *args, **kwargs)
-        return (
-            FuturesMap({reverse_map[f]: f for f in done_futures}),
-            FuturesMap({reverse_map[f]: f for f in not_done_futures}),
-        )
 
     def result(
         self, timeout: float | int | None = None, return_when: FIRST_EXCEPTION | ALL_COMPLETED = ALL_COMPLETED

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -99,14 +99,14 @@ class ClickhouseCluster:
 
         return task
 
-    def map_hosts(self, fn: Callable[[Client], T]) -> FuturesMap[HostInfo, T]:
+    def map_all_hosts(self, fn: Callable[[Client], T]) -> FuturesMap[HostInfo, T]:
         """
         Execute the callable once for each host in the cluster.
         """
         with ThreadPoolExecutor() as executor:
             return FuturesMap({host: executor.submit(self.__get_task_function(host, fn)) for host in self.__hosts})
 
-    def map_shards(self, fn: Callable[[Client], T]) -> FuturesMap[HostInfo, T]:
+    def map_one_host_per_shard(self, fn: Callable[[Client], T]) -> FuturesMap[HostInfo, T]:
         """
         Execute the callable once for each shard in the cluster.
         """

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -88,7 +88,7 @@ class ClickhouseCluster:
             )
         self.__pools: dict[HostInfo, ChPool] = {}
 
-    def __get_task_function(self, host: HostInfo, fn: Callable[[Client], T]) -> Callable[[Client], T]:
+    def __get_task_function(self, host: HostInfo, fn: Callable[[Client], T]) -> Callable[[], T]:
         pool = self.__pools.get(host)
         if pool is None:
             pool = self.__pools[host] = make_ch_pool(host=host.connection_info.address, port=host.connection_info.port)

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -86,7 +86,7 @@ class ClickhouseCluster:
         with ThreadPoolExecutor() as executor:
             return FuturesMap({host: executor.submit(task, self.__get_pool(host)) for host in self.__hosts})
 
-    def map_shards(self, fn: Callable[[Client], T]) -> FuturesMap[int, T]:
+    def map_shards(self, fn: Callable[[Client], T]) -> FuturesMap[HostInfo, T]:
         """
         Execute the callable once for each shard in the cluster.
         """
@@ -101,6 +101,4 @@ class ClickhouseCluster:
                 shard_hosts[host.shard_num] = host
 
         with ThreadPoolExecutor() as executor:
-            return FuturesMap(
-                {shard_num: executor.submit(task, self.__get_pool(host)) for shard_num, host in shard_hosts.items()}
-            )
+            return FuturesMap({host: executor.submit(task, self.__get_pool(host)) for host in shard_hosts.values()})

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -20,8 +20,7 @@ T = TypeVar("T")
 
 
 class ClickhouseCluster:
-    def __init__(self, bootstrap_client: Client, name: str = settings.CLICKHOUSE_CLUSTER) -> None:
-        self.name = name
+    def __init__(self, bootstrap_client: Client) -> None:
         self.hosts = [
             HostInfo(shard_num, replica_num, host_address, port)
             for (shard_num, replica_num, host_address, port) in bootstrap_client.execute(
@@ -31,10 +30,9 @@ class ClickhouseCluster:
                 WHERE name = %(name)s
                 ORDER BY shard_num, replica_num
                 """,
-                {"name": name},
+                {"name": settings.CLICKHOUSE_CLUSTER},
             )
         ]
-
         self.__pools: dict[HostInfo, ChPool] = {}
 
     def __get_pool(self, host: HostInfo) -> ChPool:


### PR DESCRIPTION
## Problem

- Coordinator nodes currently are not updated using the management tools which can cause problems for high value customers if easily overlooked manual schema synchronization is not performed
- It can be challenging with the existing code to determine what tables are being altered on what hosts and why without understanding implicit expectations baked into the logic (see https://github.com/PostHog/posthog/pull/26068#discussion_r1839957449)
- Slow distributed DDL would be challenging to migrate as written to something that is more resilient to toolbox pod restarts (this doesn't fix the issue, but hopefully nudges in the right direction)
- Some distributed DDL (e.g. `DROP INDEX`) doesn't appear to actually be deduplicated when using `ON CLUSTER` and seems to need to be targeted more granularly at individual hosts to ensure efficient execution
- Many similar changes needed to be made anyway to support nullable materialized column types anyway without it being shotgun surgery (#26448, https://github.com/PostHog/posthog/compare/clickhouse-cluster...column-types in particular)

## Changes

- Adds a `ClickhouseCluster` class that can be used to direct work to either all hosts in the default cluster (including extra hosts, i.e. coordinators - this is the only functional part of this change) or to only one host per shard, with queries executed concurrently across the selected hosts
- Adds utilities for managing concurrent work with less boilerplate (`FuturesMap`)
- Refactors materialized management commands into chunks based on host responsibility (data node, query node, etc.)

## Does this work well for both Cloud and self-hosted?

N/A, `ee.*` only

## How did you test this code?

Covered by existing (but could use more)