### PR TITLE
fix: authorized url suggestions UX

### DIFF
--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -9,6 +9,7 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
 import { LemonTag } from 'lib/lemon-ui/LemonTag/LemonTag'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
 import { ExperimentIdType } from '~/types'
 
@@ -157,9 +158,11 @@ export function AuthorizedUrlList({
                         ) : (
                             <div key={index} className={clsx('border rounded flex items-center p-2 pl-4 bg-bg-light')}>
                                 {keyedURL.type === 'suggestion' && (
-                                    <LemonTag type="highlight" className="mr-4 uppercase">
-                                        Suggestion
-                                    </LemonTag>
+                                    <Tooltip title={'Seen in ' + keyedURL.count + ' events in the last 3 days'}>
+                                        <LemonTag type="highlight" className="mr-4 uppercase cursor-pointer">
+                                            Suggestion
+                                        </LemonTag>
+                                    </Tooltip>
                                 )}
                                 <span title={keyedURL.url} className="flex-1 truncate">
                                     {keyedURL.url}

--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.test.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.test.ts
@@ -11,6 +11,7 @@ import {
     authorizedUrlListLogic,
     AuthorizedUrlListType,
     filterNotAuthorizedUrls,
+    SuggestedDomain,
     validateProposedUrl,
 } from './authorizedUrlListLogic'
 
@@ -167,13 +168,13 @@ describe('the authorized urls list logic', () => {
     })
 
     describe('filterNotAuthorizedUrls', () => {
-        const testUrls = [
-            'https://1.wildcard.com',
-            'https://2.wildcard.com',
-            'https://a.single.io',
-            'https://a.sub.b.multi-wildcard.com',
-            'https://a.not.b.multi-wildcard.com',
-            'https://not.valid.io',
+        const testUrls: SuggestedDomain[] = [
+            { url: 'https://1.wildcard.com', count: 1 },
+            { url: 'https://2.wildcard.com', count: 1 },
+            { url: 'https://a.single.io', count: 1 },
+            { url: 'https://a.sub.b.multi-wildcard.com', count: 1 },
+            { url: 'https://a.not.b.multi-wildcard.com', count: 1 },
+            { url: 'https://not.valid.io', count: 1 },
         ]
 
         it('suggests all if empty', () => {
@@ -182,18 +183,22 @@ describe('the authorized urls list logic', () => {
 
         it('allows specific domains', () => {
             expect(filterNotAuthorizedUrls(testUrls, ['https://a.single.io'])).toEqual([
-                'https://1.wildcard.com',
-                'https://2.wildcard.com',
-                'https://a.sub.b.multi-wildcard.com',
-                'https://a.not.b.multi-wildcard.com',
-                'https://not.valid.io',
+                { url: 'https://1.wildcard.com', count: 1 },
+                { url: 'https://2.wildcard.com', count: 1 },
+                { url: 'https://a.sub.b.multi-wildcard.com', count: 1 },
+                { url: 'https://a.not.b.multi-wildcard.com', count: 1 },
+                { url: 'https://not.valid.io', count: 1 },
             ])
         })
 
         it('filters wildcard domains', () => {
             expect(
                 filterNotAuthorizedUrls(testUrls, ['https://*.wildcard.com', 'https://*.sub.*.multi-wildcard.com'])
-            ).toEqual(['https://a.single.io', 'https://a.not.b.multi-wildcard.com', 'https://not.valid.io'])
+            ).toEqual([
+                { url: 'https://a.single.io', count: 1 },
+                { url: 'https://a.not.b.multi-wildcard.com', count: 1 },
+                { url: 'https://not.valid.io', count: 1 },
+            ])
         })
     })
 })

--- a/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
+++ b/frontend/src/lib/components/AuthorizedUrlList/authorizedUrlListLogic.ts
@@ -49,9 +49,9 @@ export function sanitizePossibleWildCardedURL(url: string): URL {
 }
 
 /**
- * Checks if the URL has a wildcard (*) in the port position eg http://localhost:*
+ * Checks if the URL has a wildcard (*) in the port position e.g. http://localhost:*
  */
-export function hasPortWildcard(input: string): boolean {
+export function hasPortWildcard(input: unknown): boolean {
     if (!input || typeof input !== 'string') {
         return false
     }
@@ -139,19 +139,27 @@ export const checkUrlIsAuthorized = (url: string | URL, authorizedUrls: string[]
     return false
 }
 
-export const filterNotAuthorizedUrls = (urls: string[], authorizedUrls: string[]): string[] => {
-    const suggestedDomains: string[] = []
+export interface SuggestedDomain {
+    url: string
+    count: number
+}
 
-    urls.forEach((url) => {
+export const filterNotAuthorizedUrls = (
+    suggestions: SuggestedDomain[],
+    authorizedUrls: string[]
+): SuggestedDomain[] => {
+    const suggestedDomains: SuggestedDomain[] = []
+
+    suggestions.forEach(({ url, count }) => {
         const parsedUrl = sanitizePossibleWildCardedURL(url)
         const urlWithoutPath = parsedUrl.protocol + '//' + parsedUrl.host
         // Have we already added this domain?
-        if (suggestedDomains.indexOf(urlWithoutPath) > -1) {
+        if (suggestedDomains.some((sd) => sd.url === urlWithoutPath)) {
             return
         }
 
         if (!checkUrlIsAuthorized(parsedUrl, authorizedUrls)) {
-            suggestedDomains.push(urlWithoutPath)
+            suggestedDomains.push({ url: urlWithoutPath, count })
         }
     })
 
@@ -164,6 +172,8 @@ export interface KeyedAppUrl {
     url: string
     type: 'authorized' | 'suggestion'
     originalIndex: number
+    // how many seen in the last three days
+    count?: number
 }
 
 export interface AuthorizedUrlListLogicProps {
@@ -200,7 +210,7 @@ export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
     })),
     loaders(({ values }) => ({
         suggestions: {
-            __default: [] as string[],
+            __default: [] as SuggestedDomain[],
             loadSuggestions: async () => {
                 const query: HogQLQuery = {
                     kind: NodeKind.HogQLQuery,
@@ -222,7 +232,7 @@ export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
                 }
 
                 const suggestedDomains = filterNotAuthorizedUrls(
-                    result.map(([url]) => url),
+                    result.map(([url, count]) => ({ url, count })),
                     values.authorizedUrls
                 )
 
@@ -282,7 +292,7 @@ export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
         suggestions: [
             [],
             {
-                addUrl: (state, { url }) => [...state].filter((item) => url !== item),
+                addUrl: (state, { url }) => [...state].filter((sd) => url !== sd.url),
             },
         ],
         searchTerm: [
@@ -365,10 +375,11 @@ export const authorizedUrlListLogic = kea<authorizedUrlListLogicType>([
                         originalIndex: index,
                     }))
                     .concat(
-                        suggestions.map((url, index) => ({
+                        suggestions.map(({ url, count }, index) => ({
                             url,
                             type: 'suggestion',
                             originalIndex: index,
+                            count,
                         }))
                     ) as KeyedAppUrl[]
 

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -167,7 +167,8 @@ function Warnings(): JSX.Element {
                     action={{
                         type: 'secondary',
                         icon: <IconGear />,
-                        onClick: () => openSettingsPanel({ sectionId: 'project-replay' }),
+                        onClick: () =>
+                            openSettingsPanel({ sectionId: 'project-replay', settingId: 'replay-authorized-domains' }),
                         children: 'Configure',
                     }}
                     dismissKey={`session-recordings-authorized-domains-warning/${suggestions.join(',')}`}


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/21119 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/22818)

* take someone to the right part of settings when they click in the unauthorized replay domains banner
* show how many times the suggestion has been seen in the last 3 days

![2024-11-26 11 34 25](https://github.com/user-attachments/assets/728e7937-7f6a-426d-8ca9-71b63b2a9101)
