### PR TITLE
fix(product-assistant): trim redundant queries in the schema generator

### DIFF
--- a/ee/hogai/schema_generator/nodes.py
+++ b/ee/hogai/schema_generator/nodes.py
@@ -144,7 +144,10 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
         human_messages, visualization_messages = filter_visualization_conversation(messages)
         first_ai_message = True
 
-        for human_message, ai_message in itertools.zip_longest(human_messages, visualization_messages):
+        for idx, (human_message, ai_message) in enumerate(
+            itertools.zip_longest(human_messages, visualization_messages)
+        ):
+            # Plans go first
             if ai_message:
                 conversation.append(
                     HumanMessagePromptTemplate.from_template(
@@ -161,6 +164,7 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
                     ).format(plan=generated_plan)
                 )
 
+            # Then questions
             if human_message:
                 conversation.append(
                     HumanMessagePromptTemplate.from_template(QUESTION_PROMPT, template_format="mustache").format(
@@ -168,7 +172,8 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
                     )
                 )
 
-            if ai_message:
+            # Then schemas, but include only last generated schema because it doesn't need more context.
+            if ai_message and idx + 1 == len(visualization_messages):
                 conversation.append(
                     LangchainAssistantMessage(content=ai_message.answer.model_dump_json() if ai_message.answer else "")
                 )

--- a/ee/hogai/taxonomy_agent/test/test_nodes.py
+++ b/ee/hogai/taxonomy_agent/test/test_nodes.py
@@ -17,6 +17,7 @@ from posthog.schema import (
     AssistantTrendsQuery,
     FailureMessage,
     HumanMessage,
+    RouterMessage,
     VisualizationMessage,
 )
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person
@@ -114,6 +115,36 @@ class TestTaxonomyAgentPlannerNode(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(history[0].type, "human")
         self.assertIn("Text", history[0].content)
         self.assertNotIn("{{question}}", history[0].content)
+
+    def test_agent_reconstructs_typical_conversation(self):
+        node = self._get_node()
+        history = node._construct_messages(
+            {
+                "messages": [
+                    HumanMessage(content="Question 1"),
+                    RouterMessage(content="trends"),
+                    VisualizationMessage(answer=AssistantTrendsQuery(series=[]), plan="Plan 1"),
+                    AssistantMessage(content="Summary 1"),
+                    HumanMessage(content="Question 2"),
+                    RouterMessage(content="funnel"),
+                    VisualizationMessage(answer=AssistantTrendsQuery(series=[]), plan="Plan 2"),
+                    AssistantMessage(content="Summary 2"),
+                    HumanMessage(content="Question 3"),
+                    RouterMessage(content="funnel"),
+                ]
+            }
+        )
+        self.assertEqual(len(history), 5)
+        self.assertEqual(history[0].type, "human")
+        self.assertIn("Question 1", history[0].content)
+        self.assertEqual(history[1].type, "ai")
+        self.assertEqual(history[1].content, "Plan 1")
+        self.assertEqual(history[2].type, "human")
+        self.assertIn("Question 2", history[2].content)
+        self.assertEqual(history[3].type, "ai")
+        self.assertEqual(history[3].content, "Plan 2")
+        self.assertEqual(history[4].type, "human")
+        self.assertIn("Question 3", history[4].content)
 
     def test_agent_filters_out_low_count_events(self):
         _create_person(distinct_ids=["test"], team=self.team)

--- a/ee/hogai/test/test_utils.py
+++ b/ee/hogai/test/test_utils.py
@@ -1,7 +1,14 @@
 from langchain_core.messages import HumanMessage as LangchainHumanMessage
 
 from ee.hogai.utils import filter_visualization_conversation, merge_human_messages
-from posthog.schema import AssistantTrendsQuery, FailureMessage, HumanMessage, VisualizationMessage
+from posthog.schema import (
+    AssistantMessage,
+    AssistantTrendsQuery,
+    FailureMessage,
+    HumanMessage,
+    RouterMessage,
+    VisualizationMessage,
+)
 from posthog.test.base import BaseTest
 
 
@@ -36,4 +43,30 @@ class TestTrendsUtils(BaseTest):
         )
         self.assertEqual(
             visualization_messages, [VisualizationMessage(answer=AssistantTrendsQuery(series=[]), plan="plan")]
+        )
+
+    def test_filters_typical_conversation(self):
+        human_messages, visualization_messages = filter_visualization_conversation(
+            [
+                HumanMessage(content="Question 1"),
+                RouterMessage(content="trends"),
+                VisualizationMessage(answer=AssistantTrendsQuery(series=[]), plan="Plan 1"),
+                AssistantMessage(content="Summary 1"),
+                HumanMessage(content="Question 2"),
+                RouterMessage(content="funnel"),
+                VisualizationMessage(answer=AssistantTrendsQuery(series=[]), plan="Plan 2"),
+                AssistantMessage(content="Summary 2"),
+            ]
+        )
+        self.assertEqual(len(human_messages), 2)
+        self.assertEqual(len(visualization_messages), 2)
+        self.assertEqual(
+            human_messages, [LangchainHumanMessage(content="Question 1"), LangchainHumanMessage(content="Question 2")]
+        )
+        self.assertEqual(
+            visualization_messages,
+            [
+                VisualizationMessage(answer=AssistantTrendsQuery(series=[]), plan="Plan 1"),
+                VisualizationMessage(answer=AssistantTrendsQuery(series=[]), plan="Plan 2"),
+            ],
         )


### PR DESCRIPTION
## Problem

When a conversation has more than two messages, we output all previously generated schemas. In practice, it doesn't make sense because it doesn't provide any context but rather pollutes if previous steps have weirdness (excessive breakdowns or filters).

## Changes

- Append only the last schema to the schema generator step.
- Add tests checking that the message history is correctly constructed.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Unit tests, manual testing.