### PR TITLE
fix(cdp): add hubspot scope

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -166,10 +166,10 @@ class OauthIntegration:
                 token_info_config_fields=["hub_id", "hub_domain", "user", "user_id"],
                 client_id=settings.HUBSPOT_APP_CLIENT_ID,
                 client_secret=settings.HUBSPOT_APP_CLIENT_SECRET,
-                scope="tickets crm.objects.contacts.write sales-email-read crm.objects.companies.read crm.objects.deals.read crm.objects.contacts.read crm.objects.quotes.read",
+                scope="tickets crm.objects.contacts.write sales-email-read crm.objects.companies.read crm.objects.deals.read crm.objects.contacts.read crm.objects.quotes.read crm.objects.companies.write",
                 additional_authorize_params={
                     # NOTE: these scopes are only available on certain hubspot plans and as such are optional
-                    "optional_scope": "analytics.behavioral_events.send behavioral_events.event_definitions.read_write crm.objects.companies.write"
+                    "optional_scope": "analytics.behavioral_events.send behavioral_events.event_definitions.read_write"
                 },
                 id_path="hub_id",
                 name_path="hub_domain",

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -166,7 +166,7 @@ class OauthIntegration:
                 token_info_config_fields=["hub_id", "hub_domain", "user", "user_id"],
                 client_id=settings.HUBSPOT_APP_CLIENT_ID,
                 client_secret=settings.HUBSPOT_APP_CLIENT_SECRET,
-                scope="tickets crm.objects.contacts.write sales-email-read crm.objects.companies.read crm.objects.deals.read crm.objects.contacts.read crm.objects.quotes.read",
+                scope="tickets crm.objects.contacts.write crm.objects.companies.write sales-email-read crm.objects.companies.read crm.objects.deals.read crm.objects.contacts.read crm.objects.quotes.read",
                 additional_authorize_params={
                     # NOTE: these scopes are only available on certain hubspot plans and as such are optional
                     "optional_scope": "analytics.behavioral_events.send behavioral_events.event_definitions.read_write"

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -166,10 +166,10 @@ class OauthIntegration:
                 token_info_config_fields=["hub_id", "hub_domain", "user", "user_id"],
                 client_id=settings.HUBSPOT_APP_CLIENT_ID,
                 client_secret=settings.HUBSPOT_APP_CLIENT_SECRET,
-                scope="tickets crm.objects.contacts.write crm.objects.companies.write sales-email-read crm.objects.companies.read crm.objects.deals.read crm.objects.contacts.read crm.objects.quotes.read",
+                scope="tickets crm.objects.contacts.write sales-email-read crm.objects.companies.read crm.objects.deals.read crm.objects.contacts.read crm.objects.quotes.read",
                 additional_authorize_params={
                     # NOTE: these scopes are only available on certain hubspot plans and as such are optional
-                    "optional_scope": "analytics.behavioral_events.send behavioral_events.event_definitions.read_write"
+                    "optional_scope": "analytics.behavioral_events.send behavioral_events.event_definitions.read_write crm.objects.companies.write"
                 },
                 id_path="hub_id",
                 name_path="hub_domain",


### PR DESCRIPTION
## Problem

A user reported that our HubSpot integration is lacking the `crm.objects.companies.write` scope, and thus they're not allowed to update company records.

## Changes

Adds to the scope array.

## How did you test this code?

[Sanity checking in Slack](https://posthog.slack.com/archives/C06GG249PR6/p1732626685449679)