### PR TITLE
fix(product-assistant): fallback "All Events" to $pageview

### DIFF
--- a/ee/hogai/taxonomy_agent/test/test_toolkit.py
+++ b/ee/hogai/taxonomy_agent/test/test_toolkit.py
@@ -271,3 +271,29 @@ class TestTaxonomyAgentToolkit(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(prop, "$geoip_city_name")
         self.assertEqual(type, "String")
         self.assertIsNotNone(description)
+
+    def test_retrieve_event_properties_handles_all_events(self):
+        self._create_taxonomy()
+        _create_event(
+            event="$pageview",
+            distinct_id="person1",
+            properties={
+                "$browser": "Firefox",
+            },
+            team=self.team,
+        )
+        toolkit = DummyToolkit(self.team)
+        self.assertIn("$browser", toolkit.retrieve_event_properties("All Events"))
+
+    def test_retrieve_event_property_values_handles_all_events(self):
+        self._create_taxonomy()
+        _create_event(
+            event="$pageview",
+            distinct_id="person1",
+            properties={
+                "$browser": "Firefox",
+            },
+            team=self.team,
+        )
+        toolkit = DummyToolkit(self.team)
+        self.assertIn('"Firefox"', toolkit.retrieve_event_property_values("All Events", "$browser"))

--- a/ee/hogai/taxonomy_agent/toolkit.py
+++ b/ee/hogai/taxonomy_agent/toolkit.py
@@ -259,11 +259,17 @@ class TaxonomyAgentToolkit(ABC):
 
         return self._generate_properties_xml(props)
 
+    def _normalize_event_name(self, event_name: str) -> str:
+        # It's safe to replace "All Events" with "$pageview".
+        if event_name.lower() == "all events":
+            return "$pageview"
+        return event_name
+
     def retrieve_event_properties(self, event_name: str) -> str:
         """
         Retrieve properties for an event.
         """
-        runner = EventTaxonomyQueryRunner(EventTaxonomyQuery(event=event_name), self._team)
+        runner = EventTaxonomyQueryRunner(EventTaxonomyQuery(event=self._normalize_event_name(event_name)), self._team)
         response = runner.run(ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS)
 
         if not isinstance(response, CachedEventTaxonomyQueryResponse):
@@ -325,7 +331,7 @@ class TaxonomyAgentToolkit(ABC):
         except PropertyDefinition.DoesNotExist:
             return f"The property {property_name} does not exist in the taxonomy."
 
-        runner = EventTaxonomyQueryRunner(EventTaxonomyQuery(event=event_name), self._team)
+        runner = EventTaxonomyQueryRunner(EventTaxonomyQuery(event=self._normalize_event_name(event_name)), self._team)
         response = runner.run(ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS)
 
         if not isinstance(response, CachedEventTaxonomyQueryResponse):


### PR DESCRIPTION
## Problem

The taxonomy agent is aware about "All Events" special case, but the toolkit doesn't output any properties.

## Changes

- Add a fallback to $pageview when "All Events" is used.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Unit tests
