### PR TITLE
fix(trends): handle compare against option in exports

### DIFF
--- a/posthog/tasks/exports/csv_exporter.py
+++ b/posthog/tasks/exports/csv_exporter.py
@@ -172,15 +172,26 @@ def _convert_response_to_csv_data(data: Any) -> Generator[Any, None, None]:
         elif isinstance(first_result.get("data"), list):
             # TRENDS LIKE
             for index, item in enumerate(results):
-                line = {"series": item.get("label", f"Series #{index + 1}")}
+                label = item.get("label", f"Series #{index + 1}")
+                compare_label = item.get("compare_label", "")
+                series_name = f"{label} - {compare_label}" if compare_label else label
+                line = {"series": series_name}
+
+                # take labels from current results, when comparing against previous
+                if item.get("compare_label") == "previous":
+                    label_item = results[index - 1]
+                else:
+                    label_item = item
+
                 action = item.get("action")
+
                 if isinstance(action, dict) and action.get("custom_name"):
                     line["custom name"] = action.get("custom_name")
                 if item.get("aggregated_value"):
                     line["total count"] = item.get("aggregated_value")
                 else:
                     for index, data in enumerate(item["data"]):
-                        line[item["labels"][index]] = data
+                        line[label_item["labels"][index]] = data
 
                 yield line
 

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -744,6 +744,6 @@ class TestCSVExporter(APIBaseTest):
 
         with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_EXPORTS_FOLDER="Test-Exports"):
             csv_exporter.export_tabular(exported_asset)
-            content = object_storage.read(exported_asset.content_location)
+            content = object_storage.read(exported_asset.content_location)  # type: ignore
             lines = (content or "").strip().split("\r\n")
             self.assertEqual(lines, ["series,22-Mar-2024", "$pageview - current,1", "$pageview - previous,2"])

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -10,9 +10,7 @@ from boto3 import resource
 from botocore.client import Config
 from dateutil.relativedelta import relativedelta
 from django.test import override_settings
-from django.utils import timezone
 from django.utils.timezone import now
-import pytz
 from requests.exceptions import HTTPError
 
 from posthog.models import ExportedAsset

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -112,6 +112,11 @@ class TestCSVExporter(APIBaseTest):
         asset.save()
         return asset
 
+    def _split_to_dict(self, url: str) -> dict[str, Any]:
+        first_split_parts = url.split("?")
+        assert len(first_split_parts) == 2
+        return {bits[0]: bits[1] for bits in [param.split("=") for param in first_split_parts[1].split("&")]}
+
     def teardown_method(self, method):
         s3 = resource(
             "s3",
@@ -633,11 +638,6 @@ class TestCSVExporter(APIBaseTest):
                 self.assertEqual(lines[0], "error")
                 self.assertEqual(lines[1], "No data available or unable to format for export.")
 
-    def _split_to_dict(self, url: str) -> dict[str, Any]:
-        first_split_parts = url.split("?")
-        assert len(first_split_parts) == 2
-        return {bits[0]: bits[1] for bits in [param.split("=") for param in first_split_parts[1].split("&")]}
-
     @patch("posthog.hogql.constants.MAX_SELECT_RETURNED_ROWS", 10)
     @patch("posthog.models.exported_asset.UUIDT")
     def test_csv_exporter_trends_query_with_none_action(
@@ -701,55 +701,64 @@ class TestCSVExporter(APIBaseTest):
                 ["series,22-Mar-2024", "Formula ((B/A)*100),100.0"],
             )
 
-    def test_csv_exporter_trends_query_with_compare_previous_option(self) -> None:
-        self.team.timezone = "US/Pacific"  # GMT -8
-        self.team.save()
+    def test_csv_exporter_trends_query_with_compare_previous_option(
+        self,
+    ) -> None:
+        # self.team.timezone = "US/Pacific"  # GMT -8
+        # self.team.save()
 
-        with timezone.override(pytz.timezone("US/Pacific")):
-            _create_person(distinct_ids=[f"user_1"], team=self.team)
-            events_by_person = {
-                "user_1": [
-                    {
-                        "event": "$pageview",
-                        "timestamp": datetime(2024, 3, 21, 13, 46),
-                    },
-                    {
-                        "event": "$pageview",
-                        "timestamp": datetime(2024, 3, 21, 13, 46),
-                    },
-                    {
-                        "event": "$pageview",
-                        "timestamp": datetime(2024, 3, 22, 13, 47),
-                    },
-                ],
-            }
-            journeys_for(events_by_person, self.team)
-            flush_persons_and_events()
-
-            exported_asset = ExportedAsset(
-                team=self.team,
-                export_format=ExportedAsset.ExportFormat.CSV,
-                export_context={
-                    "source": {
-                        "kind": "TrendsQuery",
-                        "dateRange": {"date_to": "2024-03-22", "date_from": "2024-03-22"},
-                        "series": [
-                            {
-                                "kind": "EventsNode",
-                                "event": "$pageview",
-                                "name": "$pageview",
-                                "math": "total",
-                            },
-                        ],
-                        "interval": "day",
-                        "compareFilter": {"compare": True},
-                    }
+        # with timezone.override(pytz.timezone("US/Pacific")):
+        _create_person(distinct_ids=[f"user_1"], team=self.team)
+        events_by_person = {
+            "user_1": [
+                {
+                    "event": "$pageview",
+                    "timestamp": datetime(2023, 3, 21, 13, 46),
                 },
-            )
-            exported_asset.save()
+                {
+                    "event": "$pageview",
+                    "timestamp": datetime(2023, 3, 21, 13, 46),
+                },
+                {
+                    "event": "$pageview",
+                    "timestamp": datetime(2023, 3, 22, 13, 47),
+                },
+            ],
+        }
+        journeys_for(events_by_person, self.team)
+        flush_persons_and_events()
 
-            with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_EXPORTS_FOLDER="Test-Exports"):
-                csv_exporter.export_tabular(exported_asset)
-                content = object_storage.read(exported_asset.content_location)  # type: ignore
-                lines = (content or "").strip().split("\r\n")
-                self.assertEqual(lines, ["series,22-Mar-2024", "$pageview - current,1", "$pageview - previous,2"])
+        exported_asset = ExportedAsset(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.CSV,
+            export_context={
+                "source": {
+                    "kind": "TrendsQuery",
+                    "dateRange": {"date_to": "2023-03-22", "date_from": "2023-03-22"},
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "event": "$pageview",
+                            "name": "$pageview",
+                            "math": "total",
+                        },
+                    ],
+                    "interval": "day",
+                    "compareFilter": {"compare": True},
+                }
+            },
+        )
+        # mocked_uuidt.return_value = "a-guid-xxxx"
+        # mocked_object_storage_write.side_effect = ObjectStorageError("mock write failed")
+        exported_asset.save()
+
+        with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_EXPORTS_FOLDER="Test-Exports"):
+            csv_exporter.export_tabular(exported_asset)
+            content = object_storage.read(exported_asset.content_location)  # type: ignore
+            # self.assertEqual(
+            #     exported_asset.content,
+            #     b"series,22-Mar-2024\\r\\n$pageview - current,1\\r\\n$pageview - previous,2\\r\\n",
+            # )
+            # # content = str(exported_asset.content)
+            lines = (content or "").strip().split("\r\n")
+            self.assertEqual(lines, ["series,22-Mar-2023", "$pageview - current,1", "$pageview - previous,2"])

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -698,3 +698,52 @@ class TestCSVExporter(APIBaseTest):
                 lines,
                 ["series,22-Mar-2024", "Formula ((B/A)*100),100.0"],
             )
+
+    def test_csv_exporter_trends_query_with_compare_previous_option(self) -> None:
+        _create_person(distinct_ids=[f"user_1"], team=self.team)
+        events_by_person = {
+            "user_1": [
+                {
+                    "event": "$pageview",
+                    "timestamp": datetime(2024, 3, 21, 13, 46),
+                },
+                {
+                    "event": "$pageview",
+                    "timestamp": datetime(2024, 3, 21, 13, 46),
+                },
+                {
+                    "event": "$pageview",
+                    "timestamp": datetime(2024, 3, 22, 13, 47),
+                },
+            ],
+        }
+        journeys_for(events_by_person, self.team)
+        flush_persons_and_events()
+
+        exported_asset = ExportedAsset(
+            team=self.team,
+            export_format=ExportedAsset.ExportFormat.CSV,
+            export_context={
+                "source": {
+                    "kind": "TrendsQuery",
+                    "dateRange": {"date_to": "2024-03-22", "date_from": "2024-03-22"},
+                    "series": [
+                        {
+                            "kind": "EventsNode",
+                            "event": "$pageview",
+                            "name": "$pageview",
+                            "math": "total",
+                        },
+                    ],
+                    "interval": "day",
+                    "compareFilter": {"compare": True},
+                }
+            },
+        )
+        exported_asset.save()
+
+        with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_EXPORTS_FOLDER="Test-Exports"):
+            csv_exporter.export_tabular(exported_asset)
+            content = object_storage.read(exported_asset.content_location)
+            lines = (content or "").strip().split("\r\n")
+            self.assertEqual(lines, ["series,22-Mar-2024", "$pageview - current,1", "$pageview - previous,2"])

--- a/posthog/tasks/exports/test/test_csv_exporter.py
+++ b/posthog/tasks/exports/test/test_csv_exporter.py
@@ -704,10 +704,6 @@ class TestCSVExporter(APIBaseTest):
     def test_csv_exporter_trends_query_with_compare_previous_option(
         self,
     ) -> None:
-        # self.team.timezone = "US/Pacific"  # GMT -8
-        # self.team.save()
-
-        # with timezone.override(pytz.timezone("US/Pacific")):
         _create_person(distinct_ids=[f"user_1"], team=self.team)
         events_by_person = {
             "user_1": [
@@ -748,17 +744,10 @@ class TestCSVExporter(APIBaseTest):
                 }
             },
         )
-        # mocked_uuidt.return_value = "a-guid-xxxx"
-        # mocked_object_storage_write.side_effect = ObjectStorageError("mock write failed")
         exported_asset.save()
 
         with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_EXPORTS_FOLDER="Test-Exports"):
             csv_exporter.export_tabular(exported_asset)
             content = object_storage.read(exported_asset.content_location)  # type: ignore
-            # self.assertEqual(
-            #     exported_asset.content,
-            #     b"series,22-Mar-2024\\r\\n$pageview - current,1\\r\\n$pageview - previous,2\\r\\n",
-            # )
-            # # content = str(exported_asset.content)
             lines = (content or "").strip().split("\r\n")
             self.assertEqual(lines, ["series,22-Mar-2023", "$pageview - current,1", "$pageview - previous,2"])


### PR DESCRIPTION
## Problem

Exporting trend insights with compare option enabled didn't produce the expected results. See also https://posthoghelp.zendesk.com/agent/tickets/21027. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/23590)

## Changes

This adds special casing for the compare option

## How did you test this code?

Added a test and tried an insight locally