### PR TITLE
revert: add check for current team in personal api key (#26390)

### DIFF
--- a/posthog/api/test/test_authentication.py
+++ b/posthog/api/test/test_authentication.py
@@ -832,36 +832,6 @@ class TestPersonalAPIKeyAuthentication(APIBaseTest):
             model_key = PersonalAPIKey.objects.get(secure_value=hash_key_value(personal_api_key))
             self.assertEqual(str(model_key.last_used_at), "2021-08-25 21:09:14+00:00")
 
-    def test_personal_api_key_not_associated_with_project_or_organization(self):
-        self.client.logout()
-
-        user = User.objects.create_user(email="testuser@example.com", first_name="Test", password="password")
-
-        personal_api_key = generate_random_token_personal()
-        PersonalAPIKey.objects.create(
-            label="X",
-            user=user,
-            last_used_at="2021-08-25T21:09:14",
-            secure_value=hash_key_value(personal_api_key),
-        )
-
-        with freeze_time("2021-08-24T21:14:14.252"):
-            response = self.client.get(
-                f"/api/projects/{self.team.pk}/feature_flags/",
-                HTTP_AUTHORIZATION=f"Bearer {personal_api_key}",
-            )
-
-            self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-            self.assertEqual(
-                response.json(),
-                {
-                    "type": "authentication_error",
-                    "code": "authentication_failed",
-                    "detail": "Personal API key is not associated with a project or organization.",
-                    "attr": None,
-                },
-            )
-
 
 class TestTimeSensitivePermissions(APIBaseTest):
     def test_after_timeout_modifications_require_reauthentication(self):

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -3784,7 +3784,6 @@ class TestDecideUsesReadReplica(TransactionTestCase):
             email=f"test-{random.randint(1, 100000)}@posthog.com",
             password="password",
             first_name="first_name",
-            current_team_id=team.id,
         )
         OrganizationMembership.objects.db_manager(dbname).create(
             user=user,

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -153,14 +153,11 @@ class PersonalAPIKeyAuthentication(authentication.BaseAuthentication):
         now = timezone.now()
         key_last_used_at = personal_api_key_object.last_used_at
         # Only updating last_used_at if the hour's changed
-        # This is to avoid excessive UPDATE queries, while still presenting accurate (down to the hour) info in the UI
+        # This is to avooid excessive UPDATE queries, while still presenting accurate (down to the hour) info in the UI
         if key_last_used_at is None or (now - key_last_used_at > timedelta(hours=1)):
             personal_api_key_object.last_used_at = now
             personal_api_key_object.save(update_fields=["last_used_at"])
         assert personal_api_key_object.user is not None
-
-        if not personal_api_key_object.user.current_team_id:
-            raise AuthenticationFailed(detail="Personal API key is not associated with a project or organization.")
 
         # :KLUDGE: CHMiddleware does not receive the correct user when authenticating by api key.
         tag_queries(


### PR DESCRIPTION
This reverts commit 77b2f9dd13d32d52abab2dd860373f771575002d.

We've received a few customer notes about how this change effects API usage in unintended ways, so we are reverting, and we will look into a better solution for this. 