### PR TITLE
feat(web-analytics): Add warning when conversion goal is a custom action with no session id

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -232,6 +232,7 @@ export const FEATURE_FLAGS = {
     SELF_SERVE_CREDIT_OVERRIDE: 'self-serve-credit-override', // owner: @zach
     EXPERIMENTS_MIGRATION_DISABLE_UI: 'experiments-migration-disable-ui', // owner: @jurajmajerik #team-experiments
     CUSTOM_CSS_THEMES: 'custom-css-themes', // owner: @daibhin
+    WEB_ANALYTICS_WARN_CUSTOM_EVENT_NO_SESSION: 'web-analytics-warn-custom-event-no-session', // owner: @robbie-c #team-web-analytics
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
@@ -1,10 +1,34 @@
 import { useValues } from 'kea'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { Link } from 'lib/lemon-ui/Link'
-import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
+import { ConversionGoalWarning, webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 
 export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
-    const { statusCheck } = useValues(webAnalyticsLogic)
+    const { statusCheck, conversionGoalWarning } = useValues(webAnalyticsLogic)
+    const isFlagConversionGoalWarningsSet = useFeatureFlag('WEB_ANALYTICS_WARN_CUSTOM_EVENT_NO_SESSION')
+
+    if (conversionGoalWarning && isFlagConversionGoalWarningsSet) {
+        switch (conversionGoalWarning) {
+            case ConversionGoalWarning.CustomEventWithNoSessionId:
+                return (
+                    <LemonBanner type="warning" className="mt-2">
+                        <p>
+                            A custom event has been set as a conversion goal, but it has been seen with no{' '}
+                            <pre>$session_id</pre>. This means that some queries will not be able to include these
+                            events.
+                        </p>
+                        <p>
+                            To fix this, please see{' '}
+                            <Link to="https://posthog.com/docs/data/sessions#custom-session-ids">
+                                documentation for custom session IDs
+                            </Link>
+                            .
+                        </p>
+                    </LemonBanner>
+                )
+        }
+    }
 
     // No need to show loading or error states for this warning
     if (!statusCheck) {

--- a/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
@@ -15,7 +15,7 @@ export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
                     <LemonBanner type="warning" className="mt-2">
                         <p>
                             A custom event has been set as a conversion goal, but it has been seen with no{' '}
-                            <pre>$session_id</pre>. This means that some queries will not be able to include these
+                            <code>$session_id</code>. This means that some queries will not be able to include these
                             events.
                         </p>
                         <p>


### PR DESCRIPTION
## Problem

Events with no session ids don't work in web analytics, and with conversion goals, sometimes people set custom events that are only seen from their server SDK. If they haven't set up session IDs, these will fail.

Mitigates https://github.com/PostHog/posthog/issues/26428

## Changes

Add a warning if one of these events is chosen as the session id
![Uploading Screenshot 2024-11-27 at 10.09.28.png…]()


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Created a server side event on my local dev set up for testing
