### PR TITLE
feat: allow filtering of members list by email

### DIFF
--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -1,6 +1,6 @@
 from typing import cast
 
-from django.db.models import Model, Prefetch, QuerySet, F
+from django.db.models import F, Model, Prefetch, QuerySet
 from django.shortcuts import get_object_or_404
 from django.views import View
 from django_otp.plugins.otp_totp.models import TOTPDevice
@@ -124,14 +124,17 @@ class OrganizationMemberViewSet(
         if self.action == "list":
             params = self.request.GET.dict()
 
+            if "email" in params:
+                queryset = queryset.filter(user__email=params["email"])
+
             if "updated_after" in params:
                 queryset = queryset.filter(updated_at__gt=params["updated_after"])
 
-        order = self.request.GET.get("order", None)
-        if order:
-            queryset = queryset.order_by(order)
-        else:
-            queryset = queryset.order_by("-joined_at")
+            order = self.request.GET.get("order", None)
+            if order:
+                queryset = queryset.order_by(order)
+            else:
+                queryset = queryset.order_by("-joined_at")
 
         return queryset
 


### PR DESCRIPTION
## Problem

A customer wants to invite people to private projects via the API, but needs an easier way to get org member info. Right now we can [list all members](https://posthog.com/docs/api/members), but if there are many members in an org it's annoying to have to page through results if you just need a single member. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Takes an `email` param that filters the results to just members who match the param.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added a test

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
