### PR TITLE
fix: updating logic to show the view recording button in the feature flag page

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -396,7 +396,7 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                             </div>
                         </div>
                         <LemonDivider />
-                        <FeatureFlagRollout id={id} />
+                        <FeatureFlagRollout />
                         <LemonDivider />
                         <FeatureFlagReleaseConditions
                             id={`${featureFlag.id}`}
@@ -724,7 +724,7 @@ function variantConcatWithPunctuation(phrases: string[]): string {
     return `${phrases[0]} and ${phrases.length - 1} more sets`
 }
 
-function FeatureFlagRollout({ readOnly, id }: { readOnly?: boolean; id?: string }): JSX.Element {
+function FeatureFlagRollout({ readOnly }: { readOnly?: boolean }): JSX.Element {
     const {
         multivariateEnabled,
         variants,
@@ -989,7 +989,7 @@ function FeatureFlagRollout({ readOnly, id }: { readOnly?: boolean; id?: string 
                             </div>
                         )}
                     </div>
-                    {id !== 'new' && (
+                    {readOnly && (
                         <div>
                             <h3 className="l3">Recordings</h3>
                             <p>Watch recordings of people who have been exposed to the feature flag.</p>


### PR DESCRIPTION
## Problem

We only want to show the view recording button for the readOnly state of the page so I'm updating the logic to show the button.

This was the original PR that shows the button in the edit page as well: https://github.com/PostHog/posthog/pull/26407

## Changes

| Before | After |
|--------|-------|
| ![Edit Page](https://github.com/user-attachments/assets/b7a29f34-cbaa-4504-ac3a-56eb31ea5daf) | ![Updated Page](https://github.com/user-attachments/assets/2e0d30d7-5c59-4a4b-a0b2-20410d1a7fec) |



## Does this work well for both Cloud and self-hosted?

Cloud: Yes
Self-hosted: TBD

## How did you test this code?

Locally: http://localhost:8000/project/2/feature_flags/12
