### PR TITLE
fix(insights): Only allow duplicating insight if user has edit permissions

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -201,26 +201,30 @@ export function InsightMeta({
                             Move to
                         </LemonButtonWithDropdown>
                     )}
-                    <LemonDivider />
                     {editable && (
-                        <LemonButton to={urls.insightEdit(short_id)} fullWidth>
-                            Edit
-                        </LemonButton>
+                        <>
+                            <LemonDivider />
+                            <LemonButton to={urls.insightEdit(short_id)} fullWidth>
+                                Edit
+                            </LemonButton>
+
+                            <LemonButton onClick={rename} fullWidth>
+                                Rename
+                            </LemonButton>
+
+                            <LemonButton
+                                onClick={duplicate}
+                                fullWidth
+                                data-attr={
+                                    dashboardId
+                                        ? 'duplicate-insight-from-dashboard'
+                                        : 'duplicate-insight-from-card-list-view'
+                                }
+                            >
+                                Duplicate
+                            </LemonButton>
+                        </>
                     )}
-                    {editable && (
-                        <LemonButton onClick={rename} fullWidth>
-                            Rename
-                        </LemonButton>
-                    )}
-                    <LemonButton
-                        onClick={duplicate}
-                        fullWidth
-                        data-attr={
-                            dashboardId ? 'duplicate-insight-from-dashboard' : 'duplicate-insight-from-card-list-view'
-                        }
-                    >
-                        Duplicate
-                    </LemonButton>
                     {exportContext ? (
                         <>
                             <LemonDivider />


### PR DESCRIPTION
## Problem

Fixes #24432 to remove `Duplicate` option from insights when the user doesn't have edit permissions to the dashboard.

## Changes

Moves the entire Edit/Rename/Duplicate set of action buttons behind a conditional for the dashboard privileges. 

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unable to completely test since permissions require Team access.  And wasn't able to find a home for tests similar to this fix.

Was able to simulate a false value for `editable` and the 3 options were removed from the UI correctly.
