### PR TITLE
fix: undefined event in canvas plugin

### DIFF
--- a/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
+++ b/frontend/src/scenes/session-recordings/player/rrweb/canvas/canvas-plugin.ts
@@ -16,12 +16,12 @@ function isCanvasMutation(e: eventWithTime): e is CanvasEventWithTime {
 }
 
 function quickFindClosestCanvasEventIndex(
-    events: CanvasEventWithTime[],
-    target: CanvasEventWithTime,
+    events: CanvasEventWithTime[] | undefined,
+    target: CanvasEventWithTime | undefined,
     start: number,
     end: number
 ): number {
-    if (!target) {
+    if (!target || !events || !events.length) {
         return -1
     }
 
@@ -29,9 +29,19 @@ function quickFindClosestCanvasEventIndex(
         return end
     }
 
+    if (start < 0 || end > events.length - 1) {
+        return -1
+    }
+
     const mid = Math.floor((start + end) / 2)
 
-    return target.timestamp <= events[mid].timestamp
+    // in production, we do sometimes see this be undefined
+    const middleEvent = events[mid]
+    if (!middleEvent) {
+        return -1
+    }
+
+    return target.timestamp <= middleEvent.timestamp
         ? quickFindClosestCanvasEventIndex(events, target, start, mid - 1)
         : quickFindClosestCanvasEventIndex(events, target, mid + 1, end)
 }


### PR DESCRIPTION
see https://posthog.sentry.io/issues/5558795783/?project=1899813&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20sdk.name%3Asentry.javascript.react&referrer=issue-stream&statsPeriod=24h&stream_index=4&utc=true

We see ~1000 a month where we get `Cannot read properties of undefined (reading 'timestamp')` on `return target.timestamp <= events[mid].timestamp`

Since we check if target is undefined in this method it must be `events[mid]` 

Let's just add some defensive programming