### PR TITLE
fix(web-analytics): fix bug with etc/unknown timezone

### DIFF
--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -508,7 +508,7 @@ ORDER BY "context.columns.visitors" DESC,
                 # Get the difference between the UNIX timestamp at UTC and the UNIX timestamp at the event's timezone
                 # Value is in milliseconds, turn it to hours, works even for fractional timezone offsets (I'm looking at you, Australia)
                 return parse_expr(
-                    "if(or(isNull(properties.$timezone), empty(properties.$timezone)), NULL, (toUnixTimestamp64Milli(parseDateTimeBestEffort(assumeNotNull(toString(timestamp, properties.$timezone)))) - toUnixTimestamp64Milli(timestamp)) / 3600000)"
+                    "if(or(isNull(properties.$timezone), empty(properties.$timezone), properties.$timezone == 'Etc/Unknown'), NULL, (toUnixTimestamp64Milli(parseDateTimeBestEffort(assumeNotNull(toString(timestamp, properties.$timezone)))) - toUnixTimestamp64Milli(timestamp)) / 3600000)"
                 )
             case _:
                 raise NotImplementedError("Breakdown not implemented")

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -1137,6 +1137,15 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
             properties={"$session_id": sid, "$pathname": f"/path1", "$timezone": ""},
         )
 
+        # Key exists, it's set to the invalid 'Etc/Unknown' timezone
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id=did,
+            timestamp=f"2019-02-17 00:00:00",
+            properties={"$session_id": sid, "$pathname": f"/path1", "$timezone": "Etc/Unknown"},
+        )
+
         results = self._run_web_stats_table_query(
             "all",
             None,


### PR DESCRIPTION
## Problem

Fix bug with etc/unknown timezone

<img width="886" alt="image" src="https://github.com/user-attachments/assets/afe387a4-f976-448e-858a-159015294a0f">

See https://github.com/PostHog/posthog/issues/26376#issuecomment-2503538931

## Changes

Just treat it as an empty string

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unit test was updated