### PR TITLE
fix: persisting browser url in heatmaps apge

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -11,7 +11,9 @@ import { ErrorBoundary } from './layout/ErrorBoundary'
 import { loadPostHogJS } from './loadPostHogJS'
 
 loadPostHogJS()
-initKea()
+initKea({
+    prefix: `team_${window.POSTHOG_APP_CONTEXT?.current_team?.id}_project_${window.POSTHOG_APP_CONTEXT?.current_team?.project_id}`,
+})
 
 // Expose `window.getReduxState()` to make snapshots to storybook easy
 if (typeof window !== 'undefined') {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -11,9 +11,7 @@ import { ErrorBoundary } from './layout/ErrorBoundary'
 import { loadPostHogJS } from './loadPostHogJS'
 
 loadPostHogJS()
-initKea({
-    prefix: `team_${window.POSTHOG_APP_CONTEXT?.current_team?.id}_project_${window.POSTHOG_APP_CONTEXT?.current_team?.project_id}`,
-})
+initKea()
 
 // Expose `window.getReduxState()` to make snapshots to storybook easy
 if (typeof window !== 'undefined') {

--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -61,10 +61,17 @@ export const loggerPlugin: () => KeaPlugin = () => ({
     },
 })
 
-export function initKea({ routerHistory, routerLocation, beforePlugins }: InitKeaProps = {}): void {
+export function initKea({
+    routerHistory,
+    routerLocation,
+    beforePlugins,
+    prefix,
+}: InitKeaProps & { prefix?: string } = {}): void {
     const plugins = [
         ...(beforePlugins || []),
-        localStoragePlugin,
+        localStoragePlugin({
+            prefix: prefix,
+        }),
         windowValuesPlugin({ window: window }),
         routerPlugin({
             history: routerHistory,

--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -61,17 +61,10 @@ export const loggerPlugin: () => KeaPlugin = () => ({
     },
 })
 
-export function initKea({
-    routerHistory,
-    routerLocation,
-    beforePlugins,
-    prefix,
-}: InitKeaProps & { prefix?: string } = {}): void {
+export function initKea({ routerHistory, routerLocation, beforePlugins }: InitKeaProps = {}): void {
     const plugins = [
         ...(beforePlugins || []),
-        localStoragePlugin({
-            prefix: prefix,
-        }),
+        localStoragePlugin(),
         windowValuesPlugin({ window: window }),
         routerPlugin({
             history: routerHistory,

--- a/frontend/src/scenes/heatmaps/heatmapsBrowserLogic.ts
+++ b/frontend/src/scenes/heatmaps/heatmapsBrowserLogic.ts
@@ -32,6 +32,9 @@ export interface IFrameBanner {
     message: string | JSX.Element
 }
 
+// team id is always available on window
+const teamId = window.POSTHOG_APP_CONTEXT?.current_team?.id
+
 export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
     path(['scenes', 'heatmaps', 'heatmapsBrowserLogic']),
     props({} as HeatmapsBrowserLogicProps),
@@ -172,7 +175,7 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
         ],
         browserUrl: [
             null as string | null,
-            { persist: true },
+            { persist: true, key: `${teamId}__` },
             {
                 setBrowserUrl: (_, { url }) => url,
             },

--- a/frontend/src/scenes/heatmaps/heatmapsBrowserLogic.ts
+++ b/frontend/src/scenes/heatmaps/heatmapsBrowserLogic.ts
@@ -17,7 +17,6 @@ import { LemonBannerProps } from 'lib/lemon-ui/LemonBanner'
 import { objectsEqual } from 'lib/utils'
 import posthog from 'posthog-js'
 import { RefObject } from 'react'
-import { teamLogic } from 'scenes/teamLogic'
 
 import { HogQLQuery, NodeKind } from '~/queries/schema'
 import { hogql } from '~/queries/utils'
@@ -44,8 +43,6 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
                 type: AuthorizedUrlListType.TOOLBAR_URLS,
             }),
             ['urlsKeyed', 'checkUrlIsAuthorized'],
-            teamLogic,
-            ['currentTeam'],
         ],
     }),
 
@@ -127,7 +124,7 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
         ],
     })),
 
-    reducers(({ values }) => ({
+    reducers({
         filterPanelCollapsed: [
             false as boolean,
             { persist: true },
@@ -175,7 +172,7 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
         ],
         browserUrl: [
             null as string | null,
-            { persist: true, prefix: `team_${values.currentTeam?.id}` },
+            { persist: true },
             {
                 setBrowserUrl: (_, { url }) => url,
             },
@@ -195,7 +192,7 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
                 setIframeBanner: (_, { banner }) => banner,
             },
         ],
-    })),
+    }),
 
     selectors({
         browserUrlSearchOptions: [

--- a/frontend/src/scenes/heatmaps/heatmapsBrowserLogic.ts
+++ b/frontend/src/scenes/heatmaps/heatmapsBrowserLogic.ts
@@ -175,7 +175,7 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
         ],
         browserUrl: [
             null as string | null,
-            { persist: true, key: `${teamId}__` },
+            { persist: true, prefix: `${teamId}__` },
             {
                 setBrowserUrl: (_, { url }) => url,
             },

--- a/frontend/src/scenes/heatmaps/heatmapsBrowserLogic.ts
+++ b/frontend/src/scenes/heatmaps/heatmapsBrowserLogic.ts
@@ -17,6 +17,7 @@ import { LemonBannerProps } from 'lib/lemon-ui/LemonBanner'
 import { objectsEqual } from 'lib/utils'
 import posthog from 'posthog-js'
 import { RefObject } from 'react'
+import { teamLogic } from 'scenes/teamLogic'
 
 import { HogQLQuery, NodeKind } from '~/queries/schema'
 import { hogql } from '~/queries/utils'
@@ -43,6 +44,8 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
                 type: AuthorizedUrlListType.TOOLBAR_URLS,
             }),
             ['urlsKeyed', 'checkUrlIsAuthorized'],
+            teamLogic,
+            ['currentTeam'],
         ],
     }),
 
@@ -124,7 +127,7 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
         ],
     })),
 
-    reducers({
+    reducers(({ values }) => ({
         filterPanelCollapsed: [
             false as boolean,
             { persist: true },
@@ -172,7 +175,7 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
         ],
         browserUrl: [
             null as string | null,
-            { persist: true },
+            { persist: true, prefix: `team_${values.currentTeam?.id}` },
             {
                 setBrowserUrl: (_, { url }) => url,
             },
@@ -192,7 +195,7 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
                 setIframeBanner: (_, { banner }) => banner,
             },
         ],
-    }),
+    })),
 
     selectors({
         browserUrlSearchOptions: [


### PR DESCRIPTION
We persist the browser url for the in-app heatmaps page. 
This is intended to be helpful

If you swap projects or log into another account entirely. The in-app heatmaps page uses the now incorrect browser url because the persistence is not team/project aware

have seen this feedback a few different times.

