### PR TITLE
fix: send alert metrics to correct ph instance

### DIFF
--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -77,9 +77,9 @@ ALERT_COMPUTED_COUNTER = Counter(
 ANIRUDH_DISTINCT_ID = "wcPbDRs08GtNzrNIXfzHvYAkwUaekW7UrAo4y3coznT"
 
 
-def _capture_ph_event(ph_client: Posthog | None, *args) -> None:
+def _capture_ph_event(ph_client: Posthog | None, *args, **kwargs) -> None:
     if ph_client:
-        ph_client.capture(*args)
+        ph_client.capture(*args, **kwargs)
 
     return None
 

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -2,7 +2,7 @@ import time
 import traceback
 
 from datetime import datetime, timedelta, UTC
-from typing import cast
+from typing import Any, cast
 from dateutil.relativedelta import relativedelta
 
 from celery import shared_task
@@ -77,7 +77,7 @@ ALERT_COMPUTED_COUNTER = Counter(
 ANIRUDH_DISTINCT_ID = "wcPbDRs08GtNzrNIXfzHvYAkwUaekW7UrAo4y3coznT"
 
 
-def _capture_ph_event(ph_client: Posthog | None, *args, **kwargs) -> None:
+def _capture_ph_event(ph_client: Posthog | None, *args: Any, **kwargs: Any) -> None:
     if ph_client:
         ph_client.capture(*args, **kwargs)
 

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -146,7 +146,8 @@ def alerts_backlog_task() -> None:
 
     # sleeping 30s for prometheus to pick up the metrics sent during task
     time.sleep(30)
-    ph_client.shutdown()
+    if ph_client:
+        ph_client.shutdown()
 
 
 @shared_task(
@@ -311,7 +312,8 @@ def check_alert(alert_id: str) -> None:
         alert.is_calculating = False
         alert.save()
 
-        ph_client.shutdown()
+        if ph_client:
+            ph_client.shutdown()
 
 
 @transaction.atomic


### PR DESCRIPTION
## Problem
Send alert metrics to US/EU instance.

## Changes
Using the `get_ph_client` util
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
