### PR TITLE
fix(admin): add separate group type mapping admin

### DIFF
--- a/posthog/admin/__init__.py
+++ b/posthog/admin/__init__.py
@@ -21,6 +21,7 @@ from posthog.admin.admins import (
     DataWarehouseTableAdmin,
     ProjectAdmin,
     HogFunctionAdmin,
+    GroupTypeMappingAdmin,
 )
 from posthog.models import (
     Organization,
@@ -43,6 +44,7 @@ from posthog.models import (
     Survey,
     DataWarehouseTable,
     HogFunction,
+    GroupTypeMapping,
 )
 
 admin.site.register(Organization, OrganizationAdmin)
@@ -53,6 +55,7 @@ admin.site.register(User, UserAdmin)
 admin.site.register(Dashboard, DashboardAdmin)
 admin.site.register(DashboardTemplate, DashboardTemplateAdmin)
 admin.site.register(Insight, InsightAdmin)
+admin.site.register(GroupTypeMapping, GroupTypeMappingAdmin)
 
 admin.site.register(Experiment, ExperimentAdmin)
 admin.site.register(FeatureFlag, FeatureFlagAdmin)

--- a/posthog/admin/admins/__init__.py
+++ b/posthog/admin/admins/__init__.py
@@ -5,6 +5,7 @@ from .dashboard_template_admin import DashboardTemplateAdmin
 from .data_warehouse_table_admin import DataWarehouseTableAdmin
 from .experiment_admin import ExperimentAdmin
 from .feature_flag_admin import FeatureFlagAdmin
+from .group_type_mapping_admin import GroupTypeMappingAdmin
 from .insight_admin import InsightAdmin
 from .instance_setting_admin import InstanceSettingAdmin
 from .organization_admin import OrganizationAdmin

--- a/posthog/admin/admins/group_type_mapping_admin.py
+++ b/posthog/admin/admins/group_type_mapping_admin.py
@@ -18,8 +18,6 @@ class GroupTypeMappingAdmin(admin.ModelAdmin):
 
     @admin.display(description="Team")
     def team_link(self, group_type_mapping: GroupTypeMapping):
-        if group_type_mapping.team is None:
-            return None
         return format_html(
             '<a href="/admin/posthog/team/{}/change/">{}</a>',
             group_type_mapping.team.pk,

--- a/posthog/admin/admins/group_type_mapping_admin.py
+++ b/posthog/admin/admins/group_type_mapping_admin.py
@@ -1,0 +1,27 @@
+from django.contrib import admin
+from django.utils.html import format_html
+
+from posthog.models.group_type_mapping import GroupTypeMapping
+
+
+class GroupTypeMappingAdmin(admin.ModelAdmin):
+    list_display = (
+        "group_type_index",
+        "group_type",
+        "name_singular",
+        "name_plural",
+        "team_link",
+    )
+    list_select_related = ("team", "team__organization")
+    search_fields = ("name_singular", "team__name", "team__organization__name")
+    readonly_fields = ("team", "project", "group_type", "group_type_index")
+
+    @admin.display(description="Team")
+    def team_link(self, group_type_mapping: GroupTypeMapping):
+        if group_type_mapping.team is None:
+            return None
+        return format_html(
+            '<a href="/admin/posthog/team/{}/change/">{}</a>',
+            group_type_mapping.team.pk,
+            group_type_mapping.team.name,
+        )

--- a/posthog/admin/inlines/group_type_mapping_inline.py
+++ b/posthog/admin/inlines/group_type_mapping_inline.py
@@ -11,3 +11,4 @@ class GroupTypeMappingInline(admin.TabularInline):
     classes = ("collapse",)
     max_num = 5
     min_num = 5
+    show_change_link = True


### PR DESCRIPTION
## Problem

Deleting the group type mapping can lead to a 400 Bad Request in some cases, see https://posthog.slack.com/archives/C02E3BKC78F/p1732717566916409 for context. 

Unfortunately the error doesn't show up in Sentry.

The way we currently delete group type mappings is going to the team,  selecting the deleted checkbox for the respective group type mapping and then saving the whole team. A lot of unrelated entities e.g. actions are serialized / deserialized during this process and I suspect an issue due to this or due to existing data that doesn't meet validation criteria any more.

In sum: I think this approach of saving a model with a lot of related models is fragile and a better approach would be to just delete the respective entry.

## Changes

This PR adds a separate admin for group type mappings, allowing us to delete them.

## How did you test this code?

Tried locally