### PR TITLE
fix: Apply setting to choose replicas with <60s of delay

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -687,7 +687,7 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
             start_at=batch_export.start_at,
             end_at=batch_export.end_at,
             intervals=[ScheduleIntervalSpec(every=batch_export.interval_time_delta)],
-            jitter=(batch_export.interval_time_delta / 6),
+            jitter=min(dt.timedelta(seconds=60), (batch_export.interval_time_delta / 6)),
             time_zone_name=batch_export.team.timezone,
         ),
         state=state,

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -687,7 +687,7 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
             start_at=batch_export.start_at,
             end_at=batch_export.end_at,
             intervals=[ScheduleIntervalSpec(every=batch_export.interval_time_delta)],
-            jitter=min(dt.timedelta(seconds=60), (batch_export.interval_time_delta / 6)),
+            jitter=max(dt.timedelta(seconds=60), (batch_export.interval_time_delta / 6)),
             time_zone_name=batch_export.team.timezone,
         ),
         state=state,

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -1105,3 +1105,16 @@ async def execute_batch_export_insert_activity(
                 non_retryable_error_types=["NotNullViolation", "IntegrityError"],
             ),
         )
+
+
+async def wait_for_delta_past_data_interval_end(
+    data_interval_end: dt.datetime, delta: dt.timedelta = dt.timedelta(seconds=60)
+) -> None:
+    """Wait for some time after `data_interval_end` before querying ClickHouse."""
+    target = data_interval_end.astimezone(dt.UTC)
+    now = dt.datetime.now(dt.UTC)
+
+    while target + delta < now:
+        remaining = (target + delta) - now
+        # Sleep between 1-10 seconds, there shouldn't ever be the need to wait too long.
+        await asyncio.sleep(min(max(remaining.total_seconds(), 1), 10))

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -105,7 +105,8 @@ FROM
 FORMAT ArrowStream
 SETTINGS
     -- This is half of configured MAX_MEMORY_USAGE for batch exports.
-    max_bytes_before_external_sort=50000000000
+    max_bytes_before_external_sort=50000000000,
+    max_replica_delay_for_distributed_queries=60
 """
 )
 
@@ -124,7 +125,8 @@ FROM
 FORMAT ArrowStream
 SETTINGS
     -- This is half of configured MAX_MEMORY_USAGE for batch exports.
-    max_bytes_before_external_sort=50000000000
+    max_bytes_before_external_sort=50000000000,
+    max_replica_delay_for_distributed_queries=60
 """
 )
 


### PR DESCRIPTION
## Problem

Batch exports queries can select replicas with up to 5 minutes of delay (default). This affects 5 minute batch exports that can see events missed due to this delay as they run quickly.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Wait until 1 minute has passed in S3 5 minute batch exports. 
* Bump minimum jitter to 60 seconds.
* Add `max_replica_delay_for_distributed_queries=60` to queries.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
