### PR TITLE
chore: use inserted_at as partition and sorting key for events_recent

### DIFF
--- a/posthog/clickhouse/migrations/0091_events_recent_inserted_at.py
+++ b/posthog/clickhouse/migrations/0091_events_recent_inserted_at.py
@@ -1,0 +1,12 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.event.sql import (
+    EVENTS_RECENT_DATA_TABLE,
+)
+
+from posthog.settings import CLICKHOUSE_CLUSTER
+
+
+operations = [
+    run_sql_with_exceptions(f"DROP TABLE IF EXISTS {EVENTS_RECENT_DATA_TABLE()} ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    run_sql_with_exceptions(EVENTS_RECENT_DATA_TABLE()),
+]

--- a/posthog/clickhouse/migrations/0091_events_recent_inserted_at.py
+++ b/posthog/clickhouse/migrations/0091_events_recent_inserted_at.py
@@ -8,6 +8,8 @@ from posthog.settings import CLICKHOUSE_CLUSTER
 
 
 operations = [
-    run_sql_with_exceptions(f"DROP TABLE IF EXISTS {EVENTS_RECENT_DATA_TABLE()} ON CLUSTER '{CLICKHOUSE_CLUSTER}' SYNC"),
+    run_sql_with_exceptions(
+        f"DROP TABLE IF EXISTS {EVENTS_RECENT_DATA_TABLE()} ON CLUSTER '{CLICKHOUSE_CLUSTER}' SYNC"
+    ),
     run_sql_with_exceptions(EVENTS_RECENT_TABLE_SQL()),
 ]

--- a/posthog/clickhouse/migrations/0091_events_recent_inserted_at.py
+++ b/posthog/clickhouse/migrations/0091_events_recent_inserted_at.py
@@ -1,6 +1,7 @@
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
 from posthog.models.event.sql import (
     EVENTS_RECENT_DATA_TABLE,
+    EVENTS_RECENT_TABLE_SQL,
 )
 
 from posthog.settings import CLICKHOUSE_CLUSTER
@@ -8,5 +9,5 @@ from posthog.settings import CLICKHOUSE_CLUSTER
 
 operations = [
     run_sql_with_exceptions(f"DROP TABLE IF EXISTS {EVENTS_RECENT_DATA_TABLE()} ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
-    run_sql_with_exceptions(EVENTS_RECENT_DATA_TABLE()),
+    run_sql_with_exceptions(EVENTS_RECENT_TABLE_SQL()),
 ]

--- a/posthog/clickhouse/migrations/0091_events_recent_inserted_at.py
+++ b/posthog/clickhouse/migrations/0091_events_recent_inserted_at.py
@@ -8,6 +8,6 @@ from posthog.settings import CLICKHOUSE_CLUSTER
 
 
 operations = [
-    run_sql_with_exceptions(f"DROP TABLE IF EXISTS {EVENTS_RECENT_DATA_TABLE()} ON CLUSTER '{CLICKHOUSE_CLUSTER}'"),
+    run_sql_with_exceptions(f"DROP TABLE IF EXISTS {EVENTS_RECENT_DATA_TABLE()} ON CLUSTER '{CLICKHOUSE_CLUSTER}' SYNC"),
     run_sql_with_exceptions(EVENTS_RECENT_TABLE_SQL()),
 ]

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -243,9 +243,9 @@ FROM {database}.kafka_events_recent_json
 
 EVENTS_RECENT_TABLE_SQL = lambda: (
     EVENTS_TABLE_BASE_SQL
-    + """PARTITION BY toStartOfHour(_timestamp)
-ORDER BY (team_id, toStartOfHour(_timestamp), event, cityHash64(distinct_id), cityHash64(uuid))
-TTL _timestamp + INTERVAL 7 DAY
+    + """PARTITION BY toStartOfHour(inserted_at)
+ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid))
+TTL inserted_at + INTERVAL 7 DAY
 {storage_policy}
 """
 ).format(

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -28,6 +28,7 @@ DROP_EVENTS_TABLE_SQL = lambda: f"DROP TABLE IF EXISTS {EVENTS_DATA_TABLE()} ON 
 DROP_DISTRIBUTED_EVENTS_TABLE_SQL = f"DROP TABLE IF EXISTS events ON CLUSTER '{settings.CLICKHOUSE_CLUSTER}'"
 
 INSERTED_AT_COLUMN = ", inserted_at Nullable(DateTime64(6, 'UTC')) DEFAULT NOW64()"
+INSERTED_AT_NOT_NULLABLE_COLUMN = ", inserted_at DateTime64(6, 'UTC') DEFAULT NOW64()"
 
 EVENTS_TABLE_BASE_SQL = """
 CREATE TABLE IF NOT EXISTS {table_name} ON CLUSTER '{cluster}'
@@ -245,14 +246,14 @@ EVENTS_RECENT_TABLE_SQL = lambda: (
     EVENTS_TABLE_BASE_SQL
     + """PARTITION BY toStartOfHour(inserted_at)
 ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid))
-TTL inserted_at + INTERVAL 7 DAY
+TTL toDateTime(inserted_at) + INTERVAL 7 DAY
 {storage_policy}
 """
 ).format(
     table_name=EVENTS_RECENT_DATA_TABLE(),
     cluster=settings.CLICKHOUSE_CLUSTER,
     engine=ReplacingMergeTree(EVENTS_RECENT_DATA_TABLE(), ver="_timestamp"),
-    extra_fields=KAFKA_COLUMNS_WITH_PARTITION + INSERTED_AT_COLUMN + f", {KAFKA_TIMESTAMP_MS_COLUMN}",
+    extra_fields=KAFKA_COLUMNS_WITH_PARTITION + INSERTED_AT_NOT_NULLABLE_COLUMN + f", {KAFKA_TIMESTAMP_MS_COLUMN}",
     materialized_columns="",
     indexes="",
     storage_policy=STORAGE_POLICY(),


### PR DESCRIPTION
## Problem

Batch exports actually use `inserted_at` instead of `_timestamp` for those exports with high frequency (5 minutes).

## Changes

Recreate the events_recent table to use `inserted_at`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
