### PR TITLE
fix: Hide timezones behind FF

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -233,6 +233,7 @@ export const FEATURE_FLAGS = {
     EXPERIMENTS_MIGRATION_DISABLE_UI: 'experiments-migration-disable-ui', // owner: @jurajmajerik #team-experiments
     CUSTOM_CSS_THEMES: 'custom-css-themes', // owner: @daibhin
     WEB_ANALYTICS_WARN_CUSTOM_EVENT_NO_SESSION: 'web-analytics-warn-custom-event-no-session', // owner: @robbie-c #team-web-analytics
+    WEB_ANALYTICS_TIMEZONE_TAB: 'web-analytics-timezone-tab', // owner: @rafaeelaudibert #team-web-analytics
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -973,7 +973,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                       },
                                       insightProps: createInsightProps(TileId.GEOGRAPHY, GeographyTab.MAP),
                                       canOpenInsight: true,
-                                  },
+                                  } as TabsTileTab,
                                   createTableTab(
                                       TileId.GEOGRAPHY,
                                       GeographyTab.COUNTRIES,
@@ -1004,18 +1004,16 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                   ),
 
                                   // :BUG:, see #26475, hidden behind FF while we fix it
-                                  ...[
-                                      featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TIMEZONE_TAB]
-                                          ? createTableTab(
-                                                TileId.GEOGRAPHY,
-                                                GeographyTab.TIMEZONES,
-                                                'Timezones',
-                                                'Timezones',
-                                                WebStatsBreakdown.Timezone
-                                            )
-                                          : null,
-                                  ].filter((x) => x !== null),
-                              ],
+                                  featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TIMEZONE_TAB]
+                                      ? createTableTab(
+                                            TileId.GEOGRAPHY,
+                                            GeographyTab.TIMEZONES,
+                                            'Timezones',
+                                            'Timezones',
+                                            WebStatsBreakdown.Timezone
+                                        )
+                                      : null,
+                              ].filter(isNotNil),
                           }
                         : null,
                     {

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -997,18 +997,24 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                   ),
                                   createTableTab(
                                       TileId.GEOGRAPHY,
-                                      GeographyTab.TIMEZONES,
-                                      'Timezones',
-                                      'Timezones',
-                                      WebStatsBreakdown.Timezone
-                                  ),
-                                  createTableTab(
-                                      TileId.GEOGRAPHY,
                                       GeographyTab.LANGUAGES,
                                       'Languages',
                                       'Languages',
                                       WebStatsBreakdown.Language
                                   ),
+
+                                  // :BUG:, see #26475, hidden behind FF while we fix it
+                                  ...[
+                                      featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_TIMEZONE_TAB]
+                                          ? createTableTab(
+                                                TileId.GEOGRAPHY,
+                                                GeographyTab.TIMEZONES,
+                                                'Timezones',
+                                                'Timezones',
+                                                WebStatsBreakdown.Timezone
+                                            )
+                                          : null,
+                                  ].filter((x) => x !== null),
                               ],
                           }
                         : null,


### PR DESCRIPTION
We're seeing inconsistent values in production, let's hide it behind a FF for now

See #26475