### PR TITLE
fix: test for ast.Constant(value=None) in web_overview query

### DIFF
--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -159,7 +159,7 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner):
             op=ast.CompareOperationOp.Eq, left=ast.Field(chain=["event"]), right=ast.Constant(value="$pageview")
         )
 
-        if self.conversion_goal_expr:
+        if self.conversion_goal_expr and self.conversion_goal_expr != ast.Constant(value=None):
             return ast.Call(name="or", args=[pageview_expr, self.conversion_goal_expr])
         else:
             return pageview_expr


### PR DESCRIPTION
## Problem

We are building a nasty query that breaks CH performance
https://posthog.slack.com/archives/C076R4753Q8/p1732733051007839?thread_ts=1732724606.064399&cid=C076R4753Q8

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
