### PR TITLE
fix: Disallow boolean comparison of `ast.Expr`

### DIFF
--- a/posthog/hogql/base.py
+++ b/posthog/hogql/base.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import dataclass, field
 
-from typing import TYPE_CHECKING, Literal, Optional, TypeVar
+from typing import TYPE_CHECKING, Literal, Never, Optional, TypeVar
 
 from posthog.hogql.constants import ConstantDataType
 from posthog.hogql.errors import NotImplementedError
@@ -71,6 +71,9 @@ class Type(AST):
 @dataclass(kw_only=True)
 class Expr(AST):
     type: Optional[Type] = field(default=None)
+
+    def __bool__(self) -> Never:
+        raise TypeError('unsupported boolean comparison (use "is None" instead)')
 
 
 @dataclass(kw_only=True)

--- a/posthog/hogql/compiler/bytecode.py
+++ b/posthog/hogql/compiler/bytecode.py
@@ -422,7 +422,7 @@ class BytecodeCompiler(Visitor):
         return response
 
     def visit_return_statement(self, node: ast.ReturnStatement):
-        if node.expr:
+        if node.expr is not None:
             response = self.visit(node.expr)
         else:
             response = [Operation.NULL]
@@ -671,7 +671,7 @@ class BytecodeCompiler(Visitor):
 
     def visit_variable_declaration(self, node: ast.VariableDeclaration):
         self._declare_local(node.name)
-        if node.expr:
+        if node.expr is not None:
             return self.visit(node.expr)
         return [Operation.NULL]
 

--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -280,7 +280,7 @@ multiIf(
             "gad_source": wrap_with_null_if_empty(source_exprs.gad_source),
         },
     )
-    if custom_rule_expr:
+    if custom_rule_expr is not None:
         return ast.Call(
             name="coalesce",
             args=[custom_rule_expr, builtin_rules],

--- a/posthog/hogql/database/schema/persons.py
+++ b/posthog/hogql/database/schema/persons.py
@@ -65,7 +65,7 @@ def select_from_persons_table(
 
     # For now, only do this optimization for directly querying the persons table (without joins or as part of a subquery) to avoid knock-on effects to insight queries
     if (
-        node.select_from
+        node.select_from is not None
         and node.select_from.type
         and hasattr(node.select_from.type, "table")
         and node.select_from.type.table

--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -78,7 +78,7 @@ class WhereClauseExtractor(CloningVisitor):
         if not select_query.where and not select_query.prewhere:
             return None
 
-        if select_query.select_from and select_query.select_from.next_join:
+        if select_query.select_from is not None and select_query.select_from.next_join is not None:
             self.is_join = True
 
         # visit the where clause
@@ -112,7 +112,7 @@ class WhereClauseExtractor(CloningVisitor):
         # extract timestamps from the main query into e.g. the sessions subquery
         if self.capture_timestamp_comparisons:
             result = self.handle_timestamp_comparison(node, is_left_constant, is_right_constant)
-            if result:
+            if result is not None:
                 return result
 
         # if it's a join, and if the comparison is negative, we don't want to filter down as the outer join might end up doing other comparisons that clash

--- a/posthog/hogql/visitor.py
+++ b/posthog/hogql/visitor.py
@@ -321,11 +321,11 @@ class TraversingVisitor(Visitor[None]):
         self.visit(node.expr)
 
     def visit_return_statement(self, node: ast.ReturnStatement):
-        if node.expr:
+        if node.expr is not None:
             self.visit(node.expr)
 
     def visit_throw_statement(self, node: ast.ThrowStatement):
-        if node.expr:
+        if node.expr is not None:
             self.visit(node.expr)
 
     def visit_try_catch_statement(self, node: ast.TryCatchStatement):
@@ -341,7 +341,7 @@ class TraversingVisitor(Visitor[None]):
         raise NotImplementedError("Abstract 'visit_declaration' not implemented")
 
     def visit_variable_declaration(self, node: ast.VariableDeclaration):
-        if node.expr:
+        if node.expr is not None:
             self.visit(node.expr)
 
     def visit_variable_assignment(self, node: ast.VariableAssignment):


### PR DESCRIPTION
Let's see what happens

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
