### PR TITLE
chore(experiments): Show notice when web experiments disabled

### DIFF
--- a/frontend/src/toolbar/experiments/ExperimentsToolbarMenu.tsx
+++ b/frontend/src/toolbar/experiments/ExperimentsToolbarMenu.tsx
@@ -1,4 +1,5 @@
 import { IconPlus } from '@posthog/icons'
+import { LemonBanner } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -29,6 +30,21 @@ const ExperimentsListToolbarMenu = (): JSX.Element => {
     return (
         <ToolbarMenu>
             <ToolbarMenu.Header>
+                {window.parent.posthog.config.disable_web_experiments && (
+                    <div className="p-2">
+                        <LemonBanner type="warning">
+                            Web experiments are disabled in your PostHog web snippet configuration. To run experiments,
+                            add <code>disable_web_experiments: false</code> to your configuration.{' '}
+                            <Link
+                                target="_blank"
+                                targetBlankIcon
+                                to="https://posthog.com/docs/experiments/no-code-web-experiments"
+                            >
+                                Learn more
+                            </Link>
+                        </LemonBanner>
+                    </div>
+                )}
                 <LemonInput
                     autoFocus
                     fullWidth


### PR DESCRIPTION
## Changes

Shows a notice in the toolbar when web experiments are disabled:

![CleanShot 2024-11-27 at 14 00 03@2x](https://github.com/user-attachments/assets/639d79a5-4f07-4e9c-b771-c2923d4347e1)

They're disabled in posthog.js by default during the beta period.

From https://posthoghelp.zendesk.com/agent/tickets/20914 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/23581)

## How did you test this code?

I verified the notice appears when `disable_web_experiments: true`, and doesn't appear when `disable_web_experiments: false`.