### PR TITLE
chore(cymbal): auto deploy

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -142,10 +142,10 @@ jobs:
                       values:
                           image:
                               sha: '${{ needs.build.outputs.property-defs-rs_digest }}'
-                    # - release: cymbal - disabled until a charts in place, for now we just build
-                    #   values:
-                    #       image:
-                    #           sha: '${{ needs.build.outputs.cymbal_digest }}'
+                    - release: cymbal
+                      values:
+                          image:
+                              sha: '${{ needs.build.outputs.cymbal_digest }}'
                     - release: hoghooks
                       values:
                           api_image:


### PR DESCRIPTION
## Problem

New cymbal deployment doesn't auto-deploy.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Add it to matrix which is what updates and triggers our charts deployment.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
