### PR TITLE
fix(err): discard old frame results

### DIFF
--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -75,6 +75,14 @@ pub struct Config {
     #[envconfig(default = "600")]
     pub frame_cache_ttl_seconds: u64,
 
+    // When we resolve a frame, we put it in PG, so other instance of cymbal can
+    // use it, or so we can re-use it after a restart. This is the TTL for that,
+    // after this many minutes we'll discard saved resolution results and re-resolve
+    // TODO - 5 minutes is too short for production use, it's only twice as long as
+    // our in-memory caching. We should do something like 1 hour once we release
+    #[envconfig(default = "10")]
+    pub frame_result_ttl_minutes: u32,
+
     // Maximum number of lines of pre and post context to get per frame
     #[envconfig(default = "15")]
     pub context_line_count: usize,

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -75,11 +75,11 @@ pub struct Config {
     #[envconfig(default = "600")]
     pub frame_cache_ttl_seconds: u64,
 
-    // When we resolve a frame, we put it in PG, so other instance of cymbal can
+    // When we resolve a frame, we put it in PG, so other instances of cymbal can
     // use it, or so we can re-use it after a restart. This is the TTL for that,
     // after this many minutes we'll discard saved resolution results and re-resolve
-    // TODO - 5 minutes is too short for production use, it's only twice as long as
-    // our in-memory caching. We should do something like 1 hour once we release
+    // TODO - 10 minutes is too short for production use, it's only twice as long as
+    // our in-memory caching. We should do at least an hour once we release
     #[envconfig(default = "10")]
     pub frame_result_ttl_minutes: u32,
 

--- a/rust/cymbal/src/frames/resolver.rs
+++ b/rust/cymbal/src/frames/resolver.rs
@@ -13,6 +13,7 @@ use super::{records::ErrorTrackingStackFrame, Frame, RawFrame};
 
 pub struct Resolver {
     cache: Cache<String, ErrorTrackingStackFrame>,
+    result_ttl: chrono::Duration,
 }
 
 impl Resolver {
@@ -21,7 +22,9 @@ impl Resolver {
             .time_to_live(Duration::from_secs(config.frame_cache_ttl_seconds))
             .build();
 
-        Self { cache }
+        let result_ttl = chrono::Duration::minutes(config.frame_result_ttl_minutes as i64);
+
+        Self { cache, result_ttl }
     }
 
     pub async fn resolve(
@@ -36,7 +39,7 @@ impl Resolver {
         }
 
         if let Some(result) =
-            ErrorTrackingStackFrame::load(pool, team_id, &frame.frame_id()).await?
+            ErrorTrackingStackFrame::load(pool, team_id, &frame.frame_id(), self.result_ttl).await?
         {
             self.cache.insert(frame.frame_id(), result.clone());
             return Ok(result.contents);
@@ -237,10 +240,11 @@ mod test {
 
         // get the frame
         let frame_id = frame.frame_id();
-        let frame = ErrorTrackingStackFrame::load(&pool, 0, &frame_id)
-            .await
-            .unwrap()
-            .unwrap();
+        let frame =
+            ErrorTrackingStackFrame::load(&pool, 0, &frame_id, chrono::Duration::minutes(30))
+                .await
+                .unwrap()
+                .unwrap();
 
         assert_eq!(frame.symbol_set_id.unwrap(), set.id);
 


### PR DESCRIPTION
Older frames/released packages should benefit from improved processing as it's deployed, without having to manually delete the old results