### PR TITLE
fix: Fix timezone link in TZLabel component

### DIFF
--- a/frontend/src/lib/components/TZLabel/index.tsx
+++ b/frontend/src/lib/components/TZLabel/index.tsx
@@ -46,7 +46,11 @@ const TZLabelPopoverContent = React.memo(function TZLabelPopoverContent({
             <div className="flex justify-between items-center">
                 <h3 className="mb-0">Timezone conversion</h3>
                 <span>
-                    <LemonButton icon={<IconGear />} size="small" to={urls.settings('project', 'date-and-time')} />
+                    <LemonButton
+                        icon={<IconGear />}
+                        size="small"
+                        to={urls.settings('environment-product-analytics', 'date-and-time')}
+                    />
                 </span>
             </div>
 

--- a/frontend/src/scenes/annotations/AnnotationModal.tsx
+++ b/frontend/src/scenes/annotations/AnnotationModal.tsx
@@ -97,7 +97,10 @@ export function AnnotationModal({
                         label={
                             <span>
                                 Date and time (
-                                <Link to={urls.settings('project', 'date-and-time')} target="_blank">
+                                <Link
+                                    to={urls.settings('environment-product-analytics', 'date-and-time')}
+                                    target="_blank"
+                                >
                                     {shortTimeZone(timezone)}
                                 </Link>
                                 )


### PR DESCRIPTION
Timezone configuration changed places but we forgot to update the places where we were linking to it. It'd be nice if this was more typesafe.

~We already have some stuff in place to make this typesafe, but some `keyof` magic should be useful here, I might check if that's possible.~ Nope, would need to revamp the whole URL architecture, and it's not that bad, so I'll keep it

## Does this work well for both Cloud and self-hosted?

Yep

## How did you test this code?

Just clicked through the UI :)
