### PR TITLE
fix: Use UTC timezone during conversion

### DIFF
--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -541,7 +541,7 @@ ORDER BY "context.columns.visitors" DESC,
                 # Get the difference between the UNIX timestamp at UTC and the UNIX timestamp at the event's timezone
                 # Value is in milliseconds, turn it to hours, works even for fractional timezone offsets (I'm looking at you, Australia)
                 return parse_expr(
-                    "if(or(isNull(properties.$timezone), empty(properties.$timezone), properties.$timezone == 'Etc/Unknown'), NULL, (toUnixTimestamp64Milli(parseDateTimeBestEffort(assumeNotNull(toString(timestamp, properties.$timezone)))) - toUnixTimestamp64Milli(timestamp)) / 3600000)"
+                    "if(or(isNull(properties.$timezone), empty(properties.$timezone), properties.$timezone == 'Etc/Unknown'), NULL, (toUnixTimestamp64Milli(parseDateTimeBestEffort(assumeNotNull(toString(timestamp, properties.$timezone)))) - toUnixTimestamp64Milli(parseDateTimeBestEffort(assumeNotNull(toString(timestamp, 'UTC'))))) / 3600000)"
                 )
             case _:
                 raise NotImplementedError("Breakdown not implemented")


### PR DESCRIPTION
HogQL is doing some internal magic and treating timestamps as if they are in the project's timezone versus UTC, so let's make it explicit

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual queries in prod showed me that we need to force the values to be in UTC because HogQL implicits make them behave as if they were in the project's timezone.

I didn't notice this problem locally because both my local and my test setup projects use UTC (as one always should), so it was always incorrect 