### PR TITLE
fix(retention): fix retention actors with dashboard overrides

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -6973,8 +6973,15 @@
             "additionalProperties": false,
             "properties": {
                 "aggregation_group_type_index": {
-                    "description": "Groups aggregation",
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Groups aggregation"
                 },
                 "breakdownFilter": {
                     "$ref": "#/definitions/BreakdownFilter",
@@ -8063,8 +8070,15 @@
             "description": "Base class for insight query nodes. Should not be used directly.",
             "properties": {
                 "aggregation_group_type_index": {
-                    "description": "Groups aggregation",
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Groups aggregation"
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
@@ -8113,8 +8127,15 @@
             "description": "Base class for insight query nodes. Should not be used directly.",
             "properties": {
                 "aggregation_group_type_index": {
-                    "description": "Groups aggregation",
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Groups aggregation"
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
@@ -8163,8 +8184,15 @@
             "description": "Base class for insight query nodes. Should not be used directly.",
             "properties": {
                 "aggregation_group_type_index": {
-                    "description": "Groups aggregation",
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Groups aggregation"
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
@@ -8213,8 +8241,15 @@
             "description": "Base class for insight query nodes. Should not be used directly.",
             "properties": {
                 "aggregation_group_type_index": {
-                    "description": "Groups aggregation",
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Groups aggregation"
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
@@ -8263,8 +8298,15 @@
             "description": "Base class for insight query nodes. Should not be used directly.",
             "properties": {
                 "aggregation_group_type_index": {
-                    "description": "Groups aggregation",
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Groups aggregation"
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
@@ -8366,8 +8408,15 @@
             "additionalProperties": false,
             "properties": {
                 "aggregation_group_type_index": {
-                    "description": "Groups aggregation",
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Groups aggregation"
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
@@ -8769,8 +8818,15 @@
             "additionalProperties": false,
             "properties": {
                 "aggregation_group_type_index": {
-                    "description": "Groups aggregation",
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Groups aggregation"
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
@@ -11614,8 +11670,15 @@
             "additionalProperties": false,
             "properties": {
                 "aggregation_group_type_index": {
-                    "description": "Groups aggregation",
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Groups aggregation"
                 },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
@@ -12811,8 +12874,15 @@
             "additionalProperties": false,
             "properties": {
                 "aggregation_group_type_index": {
-                    "description": "Groups aggregation",
-                    "type": "integer"
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Groups aggregation"
                 },
                 "breakdownFilter": {
                     "$ref": "#/definitions/BreakdownFilter",

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -829,7 +829,7 @@ export interface InsightsQueryBase<R extends AnalyticsQueryResponseBase<any>> ex
     /**
      * Groups aggregation
      */
-    aggregation_group_type_index?: integer
+    aggregation_group_type_index?: integer | null
     /** Sampling rate */
     samplingFactor?: number | null
     /** Modifiers used when performing the query */

--- a/frontend/src/scenes/insights/EditorFilters/FunnelsAdvanced.tsx
+++ b/frontend/src/scenes/insights/EditorFilters/FunnelsAdvanced.tsx
@@ -73,7 +73,7 @@ function StepOrderInfo(): JSX.Element {
 
 type ExclusionStepsInfoProps = {
     aggregationTargetLabel: Noun
-    aggregation_group_type_index?: number
+    aggregation_group_type_index?: number | null
 }
 
 function ExclusionStepsInfo({

--- a/frontend/src/scenes/insights/filters/AggregationSelect.tsx
+++ b/frontend/src/scenes/insights/filters/AggregationSelect.tsx
@@ -10,8 +10,8 @@ import { FunnelsQuery } from '~/queries/schema'
 import { isFunnelsQuery, isInsightQueryNode, isStickinessQuery } from '~/queries/utils'
 import { InsightLogicProps } from '~/types'
 
-export function getHogQLValue(groupIndex?: number, aggregationQuery?: string): string {
-    if (groupIndex !== undefined) {
+export function getHogQLValue(groupIndex?: number | null, aggregationQuery?: string): string {
+    if (groupIndex != undefined) {
         return `$group_${groupIndex}`
     } else if (aggregationQuery) {
         return aggregationQuery

--- a/frontend/src/scenes/retention/queries.ts
+++ b/frontend/src/scenes/retention/queries.ts
@@ -4,7 +4,7 @@ import { performQuery } from '~/queries/query'
 import { ActorsQuery, NodeKind, RetentionQuery } from '~/queries/schema'
 
 export function retentionToActorsQuery(query: RetentionQuery, selectedInterval: number, offset = 0): ActorsQuery {
-    const group = query.aggregation_group_type_index !== undefined
+    const group = query.aggregation_group_type_index != null
     const selectActor = group ? 'group' : 'person'
     const totalIntervals = (query.retentionFilter.totalIntervals || 11) - selectedInterval
     const periodName = query.retentionFilter.period?.toLowerCase() ?? 'day'

--- a/frontend/src/scenes/trends/trendsDataLogic.ts
+++ b/frontend/src/scenes/trends/trendsDataLogic.ts
@@ -199,7 +199,7 @@ export const trendsDataLogic = kea<trendsDataLogicType>([
             (s) => [s.series, s.querySource, s.isLifecycle],
             (series, querySource, isLifecycle): 'people' | 'none' | number => {
                 // Find the commonly shared aggregation group index if there is one.
-                let firstAggregationGroupTypeIndex: 'people' | 'none' | number | undefined
+                let firstAggregationGroupTypeIndex: 'people' | 'none' | number | undefined | null
                 if (isLifecycle) {
                     firstAggregationGroupTypeIndex = (querySource as LifecycleQuery)?.aggregation_group_type_index
                 } else {


### PR DESCRIPTION
## Problem

Opening the actors modal for a retention insight with dashboard overrides results in the error `Unable to resolve field: group`. Related customer issue here: https://posthoghelp.zendesk.com/agent/tickets/20849 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/23577)

## Changes

Dashboard overrides serialize the insight query backend side, where `aggregation_group_type` get set to `null`.  Kind of the same thing as mentioned [here](https://github.com/PostHog/posthog/pull/26085) happens, where javascript treats nulls differently from undefined. Adapting the condition fixes it.

## How did you test this code?

Adding `aggregation_group_type: null` to a retention insight locally.