### PR TITLE
feat(data-warehouse): Added support for using a different dataset for temp tables in bigquery

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SourceForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SourceForm.tsx
@@ -19,6 +19,7 @@ const sourceFieldToElement = (field: SourceFieldConfig, sourceConfig: SourceConf
             <LemonField key={field.name} name={[field.name, 'enabled']} label={field.label}>
                 {({ value, onChange }) => (
                     <>
+                        {!!field.caption && <p>{field.caption}</p>}
                         <LemonSwitch
                             checked={value === undefined || value === null ? lastValue?.['enabled'] : value}
                             onChange={onChange}

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -625,6 +625,23 @@ export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
                 required: true,
                 placeholder: '',
             },
+            {
+                type: 'switch-group',
+                name: 'temporary-dataset',
+                label: 'Use a different dataset for the temporary tables?',
+                caption:
+                    "We have to create and delete temporary tables when querying your data, this is a requirement of querying large BigQuery tables. We can use a different dataset if you'd like to limit the permissions available to the service account provided.",
+                default: false,
+                fields: [
+                    {
+                        type: 'text',
+                        name: 'temporary_dataset_id',
+                        label: 'Dataset ID for temporary tables',
+                        required: true,
+                        placeholder: '',
+                    },
+                ],
+            },
         ],
         caption: '',
     },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4455,6 +4455,7 @@ export interface SourceFieldSwitchGroupConfig {
     label: string
     default: string | number | boolean
     fields: SourceFieldConfig[]
+    caption?: string
 }
 
 export interface SourceFieldFileUploadConfig {

--- a/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
@@ -94,5 +94,5 @@ def validate_credentials(dataset_id: str, key_file: dict[str, str]) -> bool:
         try:
             bq.get_dataset(bq.dataset(dataset_id), retry=bigquery.DEFAULT_RETRY.with_timeout(5))
             return True
-        except:
+        except Exception:
             return False

--- a/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/bigquery/__init__.py
@@ -94,5 +94,5 @@ def validate_credentials(dataset_id: str, key_file: dict[str, str]) -> bool:
         try:
             bq.get_dataset(bq.dataset(dataset_id), retry=bigquery.DEFAULT_RETRY.with_timeout(5))
             return True
-        except Exception:
+        except:
             return False

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -351,7 +351,14 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
             client_email = model.pipeline.job_inputs.get("client_email")
             token_uri = model.pipeline.job_inputs.get("token_uri")
 
-            destination_table = f"{project_id}.{dataset_id}.__posthog_import_{inputs.run_id}_{str(datetime.now().timestamp()).replace('.', '')}"
+            temporary_dataset_id = model.pipeline.job_inputs.get("temporary_dataset_id")
+            using_temporary_dataset = (
+                model.pipeline.job_inputs.get("using_temporary_dataset", False) and temporary_dataset_id is not None
+            )
+
+            destination_table_dataset_id = temporary_dataset_id if using_temporary_dataset else dataset_id
+            destination_table = f"{project_id}.{destination_table_dataset_id}.__posthog_import_{inputs.run_id}_{str(datetime.now().timestamp()).replace('.', '')}"
+
             try:
                 source = bigquery_source(
                     dataset_id=dataset_id,

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -677,6 +677,10 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         client_email = key_file.get("client_email")
         token_uri = key_file.get("token_uri")
 
+        temporary_dataset = request.data.get("temporary-dataset", {})
+        using_temporary_dataset = temporary_dataset.get("enabled", False)
+        temporary_dataset_id = temporary_dataset.get("temporary_dataset_id", None)
+
         new_source_model = ExternalDataSource.objects.create(
             source_id=str(uuid.uuid4()),
             connection_id=str(uuid.uuid4()),
@@ -691,6 +695,8 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 "private_key_id": private_key_id,
                 "client_email": client_email,
                 "token_uri": token_uri,
+                "using_temporary_dataset": using_temporary_dataset,
+                "temporary_dataset_id": temporary_dataset_id,
             },
             prefix=prefix,
         )


### PR DESCRIPTION
## Changes
- Added support for using a different dataset for temp tables in bigquery
- This is useful for customers who may only wanna give us table create/delete permissions in a dataset away from their core data
