### PR TITLE
fix(settings): Fix links to env settings without section

### DIFF
--- a/frontend/src/lib/hooks/useAnchor.ts
+++ b/frontend/src/lib/hooks/useAnchor.ts
@@ -2,20 +2,18 @@ import { useEffect } from 'react'
 
 export function useAnchor(hash: string): void {
     useEffect(() => {
-        if (hash && document.getElementById(hash.substr(1))) {
-            // Check if there is a hash and if an element with that id exists
-            const element = document.getElementById(hash.substr(1))
-
-            if (!element) {
-                return
-            }
-
-            element.classList.add('highlighted')
-
-            // allow time for layout and repainting
-            window.requestAnimationFrame(() => {
-                element.scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'smooth' })
-            })
+        if (hash && document.getElementById(hash.slice(1))) {
+            // Allow time for layout and repainting
+            // (setTimeout because requestAnimationFrame resulted in final scroll position being slightly off)
+            setTimeout(() => {
+                // Check if there is a hash and if an element with that id exists
+                const element = document.getElementById(hash.slice(1))
+                if (!element) {
+                    return
+                }
+                element.classList.add('highlighted')
+                element.scrollIntoView()
+            }, 1000 / 60)
         }
     }, [hash])
 }

--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -124,11 +124,7 @@ function SettingsRenderer(props: SettingsLogicProps): JSX.Element {
             {settings.length ? (
                 settings.map((x) => (
                     <div key={x.id} className="relative">
-                        <div
-                            id={x.id}
-                            className="absolute -mt-14" // Account for top bar when scrolling to anchor
-                        />
-                        <h2 className="flex gap-2 items-center">
+                        <h2 id={x.id} className="flex gap-2 items-center">
                             {x.title}
                             <LemonButton icon={<IconLink />} size="small" onClick={() => selectSetting?.(x.id)} />
                         </h2>

--- a/frontend/src/scenes/settings/settingsSceneLogic.test.ts
+++ b/frontend/src/scenes/settings/settingsSceneLogic.test.ts
@@ -1,5 +1,7 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { initKeaTests } from '~/test/init'
 
@@ -22,5 +24,75 @@ describe('settingsSceneLogic', () => {
         })
 
         expect(router.values.hashParams).toEqual({ 'person-display-name': true })
+    })
+
+    it('handles environment vs. project level based on feature flag', async () => {
+        // Test when environments feature flag is disabled
+        featureFlagLogic.actions.setFeatureFlags([], { [FEATURE_FLAGS.ENVIRONMENTS]: false })
+
+        router.actions.push('/settings/environment')
+        await expectLogic(logic).toMatchValues({
+            selectedLevel: 'project',
+            selectedSectionId: null,
+        })
+
+        router.actions.push('/settings/environment-autocapture')
+        await expectLogic(logic).toMatchValues({
+            selectedLevel: 'project',
+            selectedSectionId: 'project-autocapture',
+        })
+
+        router.actions.push('/settings/project')
+        await expectLogic(logic).toMatchValues({
+            selectedLevel: 'project',
+            selectedSectionId: null,
+        })
+
+        router.actions.push('/settings/project-autocapture')
+        await expectLogic(logic).toMatchValues({
+            selectedLevel: 'project',
+            selectedSectionId: 'project-autocapture',
+        })
+
+        // Test when environments feature flag is enabled
+        featureFlagLogic.actions.setFeatureFlags([], { [FEATURE_FLAGS.ENVIRONMENTS]: true })
+
+        router.actions.push('/settings/environment')
+        await expectLogic(logic).toMatchValues({
+            selectedLevel: 'environment',
+            selectedSectionId: null,
+        })
+
+        router.actions.push('/settings/environment-autocapture')
+        await expectLogic(logic).toMatchValues({
+            selectedLevel: 'environment',
+            selectedSectionId: 'environment-autocapture',
+        })
+
+        router.actions.push('/settings/project')
+        await expectLogic(logic).toMatchValues({
+            selectedLevel: 'environment',
+            selectedSectionId: null,
+        })
+
+        router.actions.push('/settings/project-autocapture')
+        await expectLogic(logic).toMatchValues({
+            selectedLevel: 'environment',
+            selectedSectionId: 'environment-autocapture',
+        })
+
+        // Test that details sections aren't affected by feature flag
+        router.actions.push('/settings/project-details')
+        await expectLogic(logic).toMatchValues({
+            selectedLevel: 'project',
+            selectedSectionId: 'project-details',
+        })
+
+        // Test that danger zone sections aren't affected by feature flag
+        router.actions.push('/settings/project-danger-zone')
+        await expectLogic(logic).toMatchValues({
+            selectedLevel: 'project',
+            selectedSectionId: 'project-danger-zone',
+        })
     })
 })

--- a/frontend/src/scenes/settings/settingsSceneLogic.ts
+++ b/frontend/src/scenes/settings/settingsSceneLogic.ts
@@ -48,6 +48,7 @@ export const settingsSceneLogic = kea<settingsSceneLogicType>([
             if (!section) {
                 return
             }
+
             // As of middle of September 2024, `details` and `danger-zone` are the only sections present
             // at both Environment and Project levels. Others we want to redirect based on the feature flag.
             if (!section.endsWith('-details') && !section.endsWith('-danger-zone')) {
@@ -57,8 +58,9 @@ export const settingsSceneLogic = kea<settingsSceneLogicType>([
                     section = section.replace(/^environment/, 'project')
                 }
             }
+
             if (SettingLevelIds.includes(section as SettingLevelId)) {
-                if (section !== values.selectedLevel) {
+                if (section !== values.selectedLevel || values.selectedSectionId) {
                     actions.selectLevel(section as SettingLevelId)
                 }
             } else if (section !== values.selectedSectionId) {

--- a/frontend/src/scenes/settings/settingsSceneLogic.ts
+++ b/frontend/src/scenes/settings/settingsSceneLogic.ts
@@ -52,9 +52,9 @@ export const settingsSceneLogic = kea<settingsSceneLogicType>([
             // at both Environment and Project levels. Others we want to redirect based on the feature flag.
             if (!section.endsWith('-details') && !section.endsWith('-danger-zone')) {
                 if (values.featureFlags[FEATURE_FLAGS.ENVIRONMENTS]) {
-                    section = section.replace('project-', 'environment-')
+                    section = section.replace(/^project/, 'environment')
                 } else {
-                    section = section.replace('environment-', 'project-')
+                    section = section.replace(/^environment/, 'project')
                 }
             }
             if (SettingLevelIds.includes(section as SettingLevelId)) {

--- a/frontend/src/styles/utilities-legacy.scss
+++ b/frontend/src/styles/utilities-legacy.scss
@@ -34,4 +34,5 @@
 .highlighted {
     border-radius: var(--radius);
     animation: highlight 2000ms ease-out;
+    scroll-margin-top: var(--breadcrumbs-height-full);
 }


### PR DESCRIPTION
## Problem

Links of form `urls.settings('project', '<foo>')` didn't scroll to setting `foo` with `environments` flag on. One such example here:
https://github.com/PostHog/posthog/blob/a8c6576467a4a6bb76d06d46f6c9e605461bb782/frontend/src/lib/components/TZLabel/index.tsx#L49

## Changes

This supersedes #26500.
We only adjusted links that started with `project-` and `environment-`, but not those which started with just `project` or `environment` (i.e. all project/environments, rather than a specific section). Now we also adjust `project`/`environment` based on the status of the `environments` flag.

## How did you test this code?

Added logic tests to `settingsSceneLogic.test.ts`.