### PR TITLE
fix(web-analytics): Use None, not Constant(value=None)

### DIFF
--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -98,7 +98,7 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner):
         return property_to_expr(properties, team=self.team, scope="event")
 
     @cached_property
-    def conversion_goal_expr(self) -> ast.Expr:
+    def conversion_goal_expr(self) -> Optional[ast.Expr]:
         if isinstance(self.query.conversionGoal, ActionConversionGoal):
             action = Action.objects.get(pk=self.query.conversionGoal.actionId, team__project_id=self.team.project_id)
             return action_to_expr(action)
@@ -109,10 +109,10 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner):
                 right=ast.Constant(value=self.query.conversionGoal.customEventName),
             )
         else:
-            return ast.Constant(value=None)
+            return None
 
     @cached_property
-    def conversion_person_id_expr(self) -> ast.Expr:
+    def conversion_person_id_expr(self) -> Optional[ast.Expr]:
         if self.conversion_goal_expr:
             return ast.Call(
                 name="any",
@@ -128,7 +128,7 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner):
                 ],
             )
         else:
-            return ast.Constant(value=None)
+            return None
 
     @cached_property
     def pageview_count_expression(self) -> ast.Expr:
@@ -147,11 +147,11 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner):
             return ast.Call(name="count", args=[])
 
     @cached_property
-    def conversion_count_expr(self) -> ast.Expr:
+    def conversion_count_expr(self) -> Optional[ast.Expr]:
         if self.conversion_goal_expr:
             return ast.Call(name="countIf", args=[self.conversion_goal_expr])
         else:
-            return ast.Constant(value=None)
+            return None
 
     @cached_property
     def event_type_expr(self) -> ast.Expr:

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -196,13 +196,12 @@ HAVING and(
                 "date_range_end": end,
                 "event_properties": self.event_properties(),
                 "session_properties": self.session_properties(),
-                "conversion_person_id_expr": self.conversion_person_id_expr,
                 "event_type_expr": self.event_type_expr,
             },
         )
         assert isinstance(parsed_select, ast.SelectQuery)
 
-        if self.query.conversionGoal:
+        if self.conversion_count_expr and self.conversion_person_id_expr:
             parsed_select.select.append(ast.Alias(alias="conversion_count", expr=self.conversion_count_expr))
             parsed_select.select.append(ast.Alias(alias="conversion_person_id", expr=self.conversion_person_id_expr))
         else:


### PR DESCRIPTION
## Problem

If there was another bug, this pattern could lead to us adding NULLs to our queries, rather than throwing an error while constructing a query. The former could silently result in long-running queries which would have a negative impact on the entire clickhouse cluster, whereas the latter would only affect this query and be easily caught in tests.

This other bug happened, see https://posthog.slack.com/archives/C076R4753Q8/p1732724606064399, and was fixed, but let's get rid of this pattern regardless

## Changes

Change this web analytics query to use a python None to show the absence of a conversion goal expression, rather than a hogql NULL

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Existing tests pass
