### PR TITLE
fix(data-warehouse): Allow the choice of SSL for mysql connections

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -254,6 +254,23 @@ export const SOURCE_DETAILS: Record<ExternalDataSourceType, SourceConfig> = {
                 placeholder: 'public',
             },
             {
+                type: 'select',
+                name: 'use_ssl',
+                label: 'Use SSL?',
+                defaultValue: '1',
+                required: true,
+                options: [
+                    {
+                        value: '1',
+                        label: 'Yes',
+                    },
+                    {
+                        value: '0',
+                        label: 'No',
+                    },
+                ],
+            },
+            {
                 name: 'ssh-tunnel',
                 label: 'Use SSH tunnel?',
                 type: 'switch-group',

--- a/posthog/temporal/data_imports/pipelines/sql_database/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/sql_database/__init__.py
@@ -48,6 +48,7 @@ def sql_source_for_type(
     sslmode: str,
     schema: str,
     table_names: list[str],
+    using_ssl: Optional[bool] = True,
     team_id: Optional[int] = None,
     incremental_field: Optional[str] = None,
     incremental_field_type: Optional[IncrementalFieldType] = None,
@@ -72,11 +73,16 @@ def sql_source_for_type(
             f"postgresql://{user}:{password}@{host}:{port}/{database}?sslmode={sslmode}"
         )
     elif source_type == ExternalDataSource.Type.MYSQL:
-        # We have to get DEBUG in temporal workers cos we're not loading Django in the same way as the app
-        is_debug = get_from_env("DEBUG", False, type_cast=str_to_bool)
-        ssl_ca = "/etc/ssl/cert.pem" if is_debug else "/etc/ssl/certs/ca-certificates.crt"
+        query_params = ""
+
+        if using_ssl:
+            # We have to get DEBUG in temporal workers cos we're not loading Django in the same way as the app
+            is_debug = get_from_env("DEBUG", False, type_cast=str_to_bool)
+            ssl_ca = "/etc/ssl/cert.pem" if is_debug else "/etc/ssl/certs/ca-certificates.crt"
+            query_params = f"ssl_ca={ssl_ca}&ssl_verify_cert=false"
+
         credentials = ConnectionStringCredentials(
-            f"mysql+pymysql://{user}:{password}@{host}:{port}/{database}?ssl_ca={ssl_ca}&ssl_verify_cert=false"
+            f"mysql+pymysql://{user}:{password}@{host}:{port}/{database}?{query_params}"
         )
 
         # PlanetScale needs this to be set

--- a/posthog/temporal/data_imports/pipelines/sql_database_v2/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/sql_database_v2/__init__.py
@@ -64,6 +64,7 @@ def sql_source_for_type(
     sslmode: str,
     schema: str,
     table_names: list[str],
+    using_ssl: Optional[bool] = True,
     team_id: Optional[int] = None,
     incremental_field: Optional[str] = None,
     incremental_field_type: Optional[IncrementalFieldType] = None,
@@ -88,11 +89,16 @@ def sql_source_for_type(
             f"postgresql://{user}:{password}@{host}:{port}/{database}?sslmode={sslmode}"
         )
     elif source_type == ExternalDataSource.Type.MYSQL:
-        # We have to get DEBUG in temporal workers cos we're not loading Django in the same way as the app
-        is_debug = get_from_env("DEBUG", False, type_cast=str_to_bool)
-        ssl_ca = "/etc/ssl/cert.pem" if is_debug else "/etc/ssl/certs/ca-certificates.crt"
+        query_params = ""
+
+        if using_ssl:
+            # We have to get DEBUG in temporal workers cos we're not loading Django in the same way as the app
+            is_debug = get_from_env("DEBUG", False, type_cast=str_to_bool)
+            ssl_ca = "/etc/ssl/cert.pem" if is_debug else "/etc/ssl/certs/ca-certificates.crt"
+            query_params = f"ssl_ca={ssl_ca}&ssl_verify_cert=false"
+
         credentials = ConnectionStringCredentials(
-            f"mysql+pymysql://{user}:{password}@{host}:{port}/{database}?ssl_ca={ssl_ca}&ssl_verify_cert=false"
+            f"mysql+pymysql://{user}:{password}@{host}:{port}/{database}?{query_params}"
         )
 
         # PlanetScale needs this to be set

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -144,6 +144,8 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
             ssh_tunnel_auth_type_passphrase = model.pipeline.job_inputs.get("ssh_tunnel_auth_type_passphrase")
             ssh_tunnel_auth_type_private_key = model.pipeline.job_inputs.get("ssh_tunnel_auth_type_private_key")
 
+            using_ssl = str(model.pipeline.job_inputs.get("using_ssl", True)) == "True"
+
             ssh_tunnel = SSHTunnel(
                 enabled=using_ssh_tunnel,
                 host=ssh_tunnel_host,
@@ -177,6 +179,7 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                         if schema.is_incremental
                         else None,
                         team_id=inputs.team_id,
+                        using_ssl=using_ssl,
                     )
 
                     return _run(
@@ -203,6 +206,7 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                 if schema.is_incremental
                 else None,
                 team_id=inputs.team_id,
+                using_ssl=using_ssl,
             )
 
             return _run(

--- a/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
+++ b/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
@@ -55,6 +55,8 @@ def sync_new_schemas_activity(inputs: SyncNewSchemasActivityInputs) -> None:
         ssh_tunnel_auth_type_passphrase = source.job_inputs.get("ssh_tunnel_auth_type_passphrase")
         ssh_tunnel_auth_type_private_key = source.job_inputs.get("ssh_tunnel_auth_type_private_key")
 
+        using_ssl = str(source.job_inputs.get("using_ssl", True)) == "True"
+
         ssh_tunnel = SSHTunnel(
             enabled=using_ssh_tunnel,
             host=ssh_tunnel_host,
@@ -67,7 +69,15 @@ def sync_new_schemas_activity(inputs: SyncNewSchemasActivityInputs) -> None:
         )
 
         sql_schemas = get_sql_schemas_for_source_type(
-            ExternalDataSource.Type(source.source_type), host, port, database, user, password, db_schema, ssh_tunnel
+            ExternalDataSource.Type(source.source_type),
+            host,
+            port,
+            database,
+            user,
+            password,
+            db_schema,
+            ssh_tunnel,
+            using_ssl,
         )
 
         schemas_to_sync = list(sql_schemas.keys())

--- a/posthog/temporal/tests/batch_exports/test_import_data.py
+++ b/posthog/temporal/tests/batch_exports/test_import_data.py
@@ -87,6 +87,7 @@ def test_postgres_source_without_ssh_tunnel(activity_environment, team, **kwargs
             incremental_field=None,
             incremental_field_type=None,
             team_id=team.id,
+            using_ssl=True,
         )
 
 
@@ -127,6 +128,7 @@ def test_postgres_source_with_ssh_tunnel_disabled(activity_environment, team, **
             incremental_field=None,
             incremental_field_type=None,
             team_id=team.id,
+            using_ssl=True,
         )
 
 
@@ -185,4 +187,5 @@ def test_postgres_source_with_ssh_tunnel_enabled(activity_environment, team, **k
             incremental_field=None,
             incremental_field_type=None,
             team_id=team.id,
+            using_ssl=True,
         )

--- a/posthog/warehouse/api/external_data_schema.py
+++ b/posthog/warehouse/api/external_data_schema.py
@@ -303,6 +303,8 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.
             ssh_tunnel_auth_type_passphrase = source.job_inputs.get("ssh_tunnel_auth_type_passphrase")
             ssh_tunnel_auth_type_private_key = source.job_inputs.get("ssh_tunnel_auth_type_private_key")
 
+            using_ssl = str(source.job_inputs.get("using_ssl", True)) == "True"
+
             ssh_tunnel = SSHTunnel(
                 enabled=using_ssh_tunnel,
                 host=ssh_tunnel_host,
@@ -323,6 +325,7 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.
                 password=password,
                 schema=pg_schema,
                 ssh_tunnel=ssh_tunnel,
+                using_ssl=using_ssl,
             )
 
             columns = db_schemas.get(instance.name, [])

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -47,7 +47,7 @@ from posthog.temporal.data_imports.pipelines.vitally import (
 from posthog.temporal.data_imports.pipelines.zendesk import (
     validate_credentials as validate_zendesk_credentials,
 )
-from posthog.utils import get_instance_region
+from posthog.utils import get_instance_region, str_to_bool
 from posthog.warehouse.api.external_data_schema import (
     ExternalDataSchemaSerializer,
     SimpleExternalDataSchemaSerializer,
@@ -571,6 +571,10 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         ssh_tunnel_auth_type_passphrase = ssh_tunnel_auth_type_obj.get("passphrase", None)
         ssh_tunnel_auth_type_private_key = ssh_tunnel_auth_type_obj.get("private_key", None)
 
+        use_ssl_obj = payload.get("use_ssl", {})
+        using_ssl_str = use_ssl_obj.get("enabled", "0")
+        using_ssl = str_to_bool(using_ssl_str)
+
         if not self._validate_database_host(host, self.team_id, using_ssh_tunnel):
             raise InternalPostgresError()
 
@@ -596,6 +600,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 "ssh_tunnel_auth_type_password": ssh_tunnel_auth_type_password,
                 "ssh_tunnel_auth_type_passphrase": ssh_tunnel_auth_type_passphrase,
                 "ssh_tunnel_auth_type_private_key": ssh_tunnel_auth_type_private_key,
+                "using_ssl": using_ssl,
             },
             prefix=prefix,
         )

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -572,7 +572,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         ssh_tunnel_auth_type_private_key = ssh_tunnel_auth_type_obj.get("private_key", None)
 
         use_ssl_obj = payload.get("use_ssl", {})
-        using_ssl_str = use_ssl_obj.get("enabled", "0")
+        using_ssl_str = use_ssl_obj.get("enabled", "1")
         using_ssl = str_to_bool(using_ssl_str)
 
         if not self._validate_database_host(host, self.team_id, using_ssh_tunnel):
@@ -625,6 +625,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             password,
             schema,
             ssh_tunnel,
+            using_ssl,
         )
 
         return new_source_model, list(schemas.keys())
@@ -927,6 +928,10 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             ssh_tunnel_auth_type_passphrase = ssh_tunnel_auth_type_obj.get("passphrase", None)
             ssh_tunnel_auth_type_private_key = ssh_tunnel_auth_type_obj.get("private_key", None)
 
+            use_ssl_obj = request.data.get("use_ssl", {})
+            using_ssl_str = use_ssl_obj.get("enabled", "1")
+            using_ssl = str_to_bool(using_ssl_str)
+
             ssh_tunnel = SSHTunnel(
                 enabled=using_ssh_tunnel,
                 host=ssh_tunnel_host,
@@ -984,6 +989,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     password,
                     schema,
                     ssh_tunnel,
+                    using_ssl,
                 )
                 if len(result.keys()) == 0:
                     return Response(

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -300,9 +300,15 @@ def get_mysql_schemas(
     user: str,
     password: str,
     schema: str,
+    using_ssl: bool,
     ssh_tunnel: SSHTunnel,
 ) -> dict[str, list[tuple[str, str]]]:
     def get_schemas(mysql_host: str, mysql_port: int):
+        ssl_ca: str | None = None
+
+        if using_ssl:
+            ssl_ca = "/etc/ssl/cert.pem" if settings.DEBUG else "/etc/ssl/certs/ca-certificates.crt"
+
         connection = pymysql.connect(
             host=mysql_host,
             port=mysql_port,
@@ -310,7 +316,7 @@ def get_mysql_schemas(
             user=user,
             password=password,
             connect_timeout=5,
-            ssl_ca="/etc/ssl/cert.pem" if settings.DEBUG else "/etc/ssl/certs/ca-certificates.crt",
+            ssl_ca=ssl_ca,
         )
 
         with connection.cursor() as cursor:
@@ -403,11 +409,12 @@ def get_sql_schemas_for_source_type(
     password: str,
     schema: str,
     ssh_tunnel: SSHTunnel,
+    using_ssl: bool = True,
 ) -> dict[str, list[tuple[str, str]]]:
     if source_type == ExternalDataSource.Type.POSTGRES:
         schemas = get_postgres_schemas(host, port, database, user, password, schema, ssh_tunnel)
     elif source_type == ExternalDataSource.Type.MYSQL:
-        schemas = get_mysql_schemas(host, port, database, user, password, schema, ssh_tunnel)
+        schemas = get_mysql_schemas(host, port, database, user, password, schema, using_ssl, ssh_tunnel)
     elif source_type == ExternalDataSource.Type.MSSQL:
         schemas = get_mssql_schemas(host, port, database, user, password, schema, ssh_tunnel)
     else:


### PR DESCRIPTION
## Problem
- Adding in mandatory SSL support for mysql connections caused syncs to break for a customer ([see ticket](https://posthoghelp.zendesk.com/agent/tickets/20515))

## Changes
- Updated the UI to let users choose whether they want to use SSL for the connection
- Defaults to `true` everywhere to mimic existing behavior 

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Stepped through locally