### PR TITLE
fix: Revert sing in comparison in batch exports wait

### DIFF
--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -1165,7 +1165,7 @@ async def wait_for_delta_past_data_interval_end(
     target = data_interval_end.astimezone(dt.UTC)
     now = dt.datetime.now(dt.UTC)
 
-    while target + delta < now:
+    while target + delta > now:
         remaining = (target + delta) - now
         # Sleep between 1-10 seconds, there shouldn't ever be the need to wait too long.
         await asyncio.sleep(min(max(remaining.total_seconds(), 1), 10))


### PR DESCRIPTION
## Problem

We want to wait when we haven't crossed `data_interval_end + delta` not the other way around.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
