### PR TITLE
fix(err): stackframes: skip empty list, get context per-event

### DIFF
--- a/frontend/src/lib/components/Errors/ErrorDisplay.tsx
+++ b/frontend/src/lib/components/Errors/ErrorDisplay.tsx
@@ -28,12 +28,7 @@ function StackTrace({
     showAllFrames: boolean
 }): JSX.Element | null {
     const { stackFrameRecords } = useValues(stackFrameLogic)
-    const { loadFromRawIds } = useActions(stackFrameLogic)
     const displayFrames = showAllFrames ? frames : frames.filter((f) => f.in_app)
-
-    useEffect(() => {
-        loadFromRawIds(frames.map(({ raw_id }) => raw_id))
-    }, [frames, loadFromRawIds])
 
     const panels = displayFrames.map(
         ({ raw_id, source, line, column, resolved_name, lang, resolved, resolve_failure }, index) => {
@@ -122,8 +117,19 @@ function FrameContextLine({
 }
 function ChainedStackTraces({ exceptionList }: { exceptionList: ErrorTrackingException[] }): JSX.Element {
     const hasAnyInApp = exceptionList.some(({ stacktrace }) => stacktrace?.frames?.some(({ in_app }) => in_app))
-
     const [showAllFrames, setShowAllFrames] = useState(!hasAnyInApp)
+    const { loadFromRawIds } = useActions(stackFrameLogic)
+
+    useEffect(() => {
+        const frames: ErrorTrackingStackFrame[] = exceptionList.flatMap((e) => {
+            const trace = e.stacktrace
+            if (trace?.type === 'resolved') {
+                return trace.frames
+            }
+            return []
+        })
+        loadFromRawIds(frames.map(({ raw_id }) => raw_id))
+    }, [exceptionList, showAllFrames, setShowAllFrames, loadFromRawIds])
 
     return (
         <>

--- a/frontend/src/lib/components/Errors/ErrorDisplay.tsx
+++ b/frontend/src/lib/components/Errors/ErrorDisplay.tsx
@@ -129,7 +129,7 @@ function ChainedStackTraces({ exceptionList }: { exceptionList: ErrorTrackingExc
             return []
         })
         loadFromRawIds(frames.map(({ raw_id }) => raw_id))
-    }, [exceptionList, showAllFrames, setShowAllFrames, loadFromRawIds])
+    }, [exceptionList, loadFromRawIds])
 
     return (
         <>

--- a/frontend/src/lib/components/Errors/stackFrameLogic.ts
+++ b/frontend/src/lib/components/Errors/stackFrameLogic.ts
@@ -29,6 +29,9 @@ export const stackFrameLogic = kea<stackFrameLogicType>([
                 loadFromRawIds: async ({ rawIds }) => {
                     const loadedRawIds = Object.keys(values.stackFrameRecords)
                     rawIds = rawIds.filter((rawId) => !loadedRawIds.includes(rawId))
+                    if (rawIds.length === 0) {
+                        return values.stackFrameRecords
+                    }
                     const { results } = await api.errorTracking.stackFrames(rawIds)
                     return mapStackFrameRecords(results, values.stackFrameRecords)
                 },

--- a/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
+++ b/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
@@ -167,18 +167,9 @@ const Header = (): JSX.Element => {
     return (
         <PageHeader
             buttons={
-                <>
-                    <LemonButton
-                        onClick={() => {
-                            throw Error('Oh my!')
-                        }}
-                    >
-                        Send an exception
-                    </LemonButton>
-                    <LemonButton to={urls.errorTrackingConfiguration()} type="secondary" icon={<IconGear />}>
-                        Configure
-                    </LemonButton>
-                </>
+                <LemonButton to={urls.errorTrackingConfiguration()} type="secondary" icon={<IconGear />}>
+                    Configure
+                </LemonButton>
             }
         />
     )

--- a/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
+++ b/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
@@ -167,9 +167,18 @@ const Header = (): JSX.Element => {
     return (
         <PageHeader
             buttons={
-                <LemonButton to={urls.errorTrackingConfiguration()} type="secondary" icon={<IconGear />}>
-                    Configure
-                </LemonButton>
+                <>
+                    <LemonButton
+                        onClick={() => {
+                            throw Error('Oh my!')
+                        }}
+                    >
+                        Send an exception
+                    </LemonButton>
+                    <LemonButton to={urls.errorTrackingConfiguration()} type="secondary" icon={<IconGear />}>
+                        Configure
+                    </LemonButton>
+                </>
             }
         />
     )

--- a/rust/cymbal/src/bin/run.sh
+++ b/rust/cymbal/src/bin/run.sh
@@ -3,5 +3,6 @@ export KAFKA_CONSUMER_TOPIC="exception_symbolification_events"
 export OBJECT_STORAGE_BUCKET="posthog"
 export OBJECT_STORAGE_ACCESS_KEY_ID="object_storage_root_user"
 export OBJECT_STORAGE_SECRET_ACCESS_KEY="object_storage_root_password"
+export ALLOW_INTERNAL_IPS="true"
 
-cargo run --bin cymbal
+RUST_LOG=info cargo run --bin cymbal


### PR DESCRIPTION
Noticed we were making API requests:
- When toggling the in-app toggle if there was more than one exception in the exception list, and one of those exceptions was all in-app frames
- Even if there were no new frames to fetch, which happens in the above case (two exceptions in a single event, one with only in-app frames) if two events are "open", and you toggle the toggle on one of them (the logic's loadFrames was getting called, the filter in it filtered out all the frame id's because the other open event mean all the necessary contexts were loaded, but we'd still make the HTTP request with an empty list and get nothing back)