### PR TITLE
fix: static files served with different vary headers

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -251,6 +251,19 @@ STATICFILES_DIRS = [
 ]
 STATICFILES_STORAGE = "whitenoise.storage.ManifestStaticFilesStorage"
 
+
+def add_vary_headers(headers, _path, _url):
+    """
+    we might serve static content on multiple domains, so we need to vary on Origin
+    as well as accept-encoding to avoid caching issues
+    see: https://github.com/evansd/whitenoise/blob/b3d250fd17da0e280d58b6dc4935c4573ebe8b55/docs/django.rst?plain=1#L392-L422
+    which says: The function should not return anything; changes should be made by modifying the headers dictionary directly.
+    """
+    headers["Vary"] = "Origin, Accept-Encoding"
+
+
+WHITENOISE_STATIC_HEADERS = add_vary_headers
+
 AUTH_USER_MODEL = "posthog.User"
 
 LOGIN_URL = "/login"


### PR DESCRIPTION
when using internal-t posthog route (which i think is just PostHog and managed reverse proxy)

going backwards and forwards between us.posthog.com and posthog.com I get a CORS error

<img width="1010" alt="Screenshot 2024-11-28 at 23 10 20" src="https://github.com/user-attachments/assets/5e8f26d9-7463-479d-9d2c-4ab644b6dcf3">

<img width="578" alt="Screenshot 2024-11-28 at 22 31 08" src="https://github.com/user-attachments/assets/689bbe53-37ec-484b-9ff2-debb8f9125a7">

I believe that because 

* we're sending `vary: accept-encoding` 
* the browser is caching the static file on one domain, 
* then re-using it on the next 
* __and reusing the header_ `access-control-allow-origin: https://posthog.com`  
* the browser re-uses the cached response and headers which makes it invalid

the default headers from whitenoise are https://github.com/evansd/whitenoise/blob/b3d250fd17da0e280d58b6dc4935c4573ebe8b55/src/whitenoise/responders.py#L170 `vary: accept-encoding` so it's probably whitenoise adding the vary headers for us (i guess it could be contour or envoy but that feels like it's whitenoise)

NB the real fix here IMO is to send `access-control-allow-origin: *` but the `CorsPostCsrfMiddleware` middleware that I think would add the domain specific `access-control-allow-origin` header in django shouldn't run on these static file requests 

I don't think it is since it would add the `vary: origin` header, so I think the access-control-allow-origin is being added somewhere else in the stack

I don't know where in the stack, so for the time being we can try and add the vary by origin header. this means folk will download the assets more often than they strictly need to but that's better than current

I haven't tested this since whitenoise doesn't serve static assets in DEBUG