### PR TITLE
chore(data-warehouse): Show table name example when adding a source prefix

### DIFF
--- a/frontend/src/scenes/data-warehouse/external/forms/SourceForm.tsx
+++ b/frontend/src/scenes/data-warehouse/external/forms/SourceForm.tsx
@@ -141,7 +141,24 @@ export function SourceFormComponent({ sourceConfig, showPrefix = true, jobInputs
             </Group>
             {showPrefix && (
                 <LemonField name="prefix" label="Table Prefix (optional)">
-                    <LemonInput className="ph-ignore-input" data-attr="prefix" placeholder="internal_" />
+                    {({ value, onChange }) => (
+                        <>
+                            <LemonInput
+                                className="ph-ignore-input"
+                                data-attr="prefix"
+                                placeholder="internal_"
+                                value={value}
+                                onChange={onChange}
+                            />
+                            <p>
+                                Example table name:{' '}
+                                <strong>
+                                    {value}
+                                    {sourceConfig.name.toLowerCase()}_table_name
+                                </strong>
+                            </p>
+                        </>
+                    )}
                 </LemonField>
             )}
         </div>


### PR DESCRIPTION
## Problem
- A bunch of users create a source with a bad prefix, delete it, and then recreate it because they're unsure on how the prefix us added to the table names

## Changes
- Show an example table name with the prefix prepended when adding the source prefix

https://github.com/user-attachments/assets/c3cc67d5-f91c-4d19-9cc7-6a9a367ce883
