### PR TITLE
fix(environments): Update API calls for using `currentProjectId`

### DIFF
--- a/frontend/src/layout/navigation-3000/sidebars/featureFlags.tsx
+++ b/frontend/src/layout/navigation-3000/sidebars/featureFlags.tsx
@@ -7,9 +7,9 @@ import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
 import { groupFilters } from 'scenes/feature-flags/FeatureFlags'
 import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
+import { projectLogic } from 'scenes/projectLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
-import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -35,8 +35,8 @@ export const featureFlagsSidebarLogic = kea<featureFlagsSidebarLogicType>([
         values: [
             featureFlagsLogic,
             ['featureFlags', 'featureFlagsLoading'],
-            teamLogic,
-            ['currentTeamId'],
+            projectLogic,
+            ['currentProjectId'],
             sceneLogic,
             ['activeScene', 'sceneParams'],
             groupsModel,
@@ -46,8 +46,8 @@ export const featureFlagsSidebarLogic = kea<featureFlagsSidebarLogicType>([
     }),
     selectors(({ actions }) => ({
         contents: [
-            (s) => [s.relevantFeatureFlags, s.featureFlagsLoading, s.currentTeamId, s.aggregationLabel],
-            (relevantFeatureFlags, featureFlagsLoading, currentTeamId, aggregationLabel) => [
+            (s) => [s.relevantFeatureFlags, s.featureFlagsLoading, s.currentProjectId, s.aggregationLabel],
+            (relevantFeatureFlags, featureFlagsLoading, currentProjectId, aggregationLabel) => [
                 {
                     key: 'feature-flags',
                     noun: 'feature flag',
@@ -147,7 +147,7 @@ export const featureFlagsSidebarLogic = kea<featureFlagsSidebarLogicType>([
                                             label: 'Delete feature flag',
                                             onClick: () => {
                                                 void deleteWithUndo({
-                                                    endpoint: `projects/${currentTeamId}/feature_flags`,
+                                                    endpoint: `projects/${currentProjectId}/feature_flags`,
                                                     object: { name: featureFlag.key, id: featureFlag.id },
                                                     callback: () => {
                                                         actions.loadFeatureFlags()

--- a/frontend/src/layout/navigation-3000/sidebars/insights.ts
+++ b/frontend/src/layout/navigation-3000/sidebars/insights.ts
@@ -2,10 +2,10 @@ import { afterMount, connect, kea, listeners, path, reducers, selectors } from '
 import { subscriptions } from 'kea-subscriptions'
 import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { insightsApi } from 'scenes/insights/utils/api'
+import { projectLogic } from 'scenes/projectLogic'
 import { INSIGHTS_PER_PAGE, savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
-import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
@@ -46,8 +46,8 @@ export const insightsSidebarLogic = kea<insightsSidebarLogicType>([
     })),
     selectors(({ actions, values, cache }) => ({
         contents: [
-            (s) => [s.insights, s.infiniteInsights, s.insightsLoading, teamLogic.selectors.currentTeamId],
-            (insights, infiniteInsights, insightsLoading, currentTeamId) => [
+            (s) => [s.insights, s.infiniteInsights, s.insightsLoading, projectLogic.selectors.currentProjectId],
+            (insights, infiniteInsights, insightsLoading, currentProjectId) => [
                 {
                     key: 'insights',
                     noun: 'insight',
@@ -92,7 +92,7 @@ export const insightsSidebarLogic = kea<insightsSidebarLogicType>([
                                             onClick: () => {
                                                 void deleteInsightWithUndo({
                                                     object: insight,
-                                                    endpoint: `projects/${currentTeamId}/insights`,
+                                                    endpoint: `projects/${currentProjectId}/insights`,
                                                     callback: actions.loadInsights,
                                                 })
                                             },

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
@@ -8,7 +8,7 @@ import { dayjs } from 'lib/dayjs'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { toParams } from 'lib/utils'
 import posthog from 'posthog-js'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 
 import { ActivityFilters, activityForSceneLogic } from './activityForSceneLogic'
 import type { sidePanelActivityLogicType } from './sidePanelActivityLogicType'
@@ -34,7 +34,7 @@ export enum SidePanelActivityTab {
 export const sidePanelActivityLogic = kea<sidePanelActivityLogicType>([
     path(['scenes', 'navigation', 'sidepanel', 'sidePanelActivityLogic']),
     connect({
-        values: [activityForSceneLogic, ['sceneActivityFilters']],
+        values: [activityForSceneLogic, ['sceneActivityFilters'], projectLogic, ['currentProjectId']],
     }),
     actions({
         togglePolling: (pageIsVisible: boolean) => ({ pageIsVisible }),
@@ -104,7 +104,7 @@ export const sidePanelActivityLogic = kea<sidePanelActivityLogicType>([
                     }
 
                     await api.create(
-                        `api/projects/${teamLogic.values.currentTeamId}/activity_log/bookmark_activity_notification`,
+                        `api/projects/${values.currentProjectId}/activity_log/bookmark_activity_notification`,
                         {
                             bookmark: latestNotification.created_at.toISOString(),
                         }
@@ -123,7 +123,7 @@ export const sidePanelActivityLogic = kea<sidePanelActivityLogicType>([
 
                     try {
                         const response = await api.get<ChangesResponse>(
-                            `api/projects/${teamLogic.values.currentTeamId}/activity_log/important_changes?` +
+                            `api/projects/${values.currentProjectId}/activity_log/important_changes?` +
                                 toParams({ unread: onlyUnread })
                         )
 

--- a/frontend/src/models/groupPropertiesModel.ts
+++ b/frontend/src/models/groupPropertiesModel.ts
@@ -2,7 +2,7 @@ import { connect, events, kea, path, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 
 import { GroupTypeProperties, PersonProperty } from '~/types'
 
@@ -11,7 +11,7 @@ import type { groupPropertiesModelType } from './groupPropertiesModelType'
 export const groupPropertiesModel = kea<groupPropertiesModelType>([
     path(['models', 'groupPropertiesModel']),
     connect({
-        values: [teamLogic, ['currentTeamId'], groupsAccessLogic, ['groupsEnabled']],
+        values: [projectLogic, ['currentProjectId'], groupsAccessLogic, ['groupsEnabled']],
     }),
     loaders(({ values }) => ({
         allGroupProperties: [
@@ -19,7 +19,7 @@ export const groupPropertiesModel = kea<groupPropertiesModelType>([
             {
                 loadAllGroupProperties: async () => {
                     if (values.groupsEnabled) {
-                        return await api.get(`api/projects/${values.currentTeamId}/groups/property_definitions`)
+                        return await api.get(`api/projects/${values.currentProjectId}/groups/property_definitions`)
                     }
                     return {}
                 },

--- a/frontend/src/models/groupsModel.ts
+++ b/frontend/src/models/groupsModel.ts
@@ -4,7 +4,7 @@ import { subscriptions } from 'kea-subscriptions'
 import api from 'lib/api'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 
 import { GroupType, GroupTypeIndex } from '~/types'
 
@@ -18,19 +18,19 @@ export interface Noun {
 export const groupsModel = kea<groupsModelType>([
     path(['models', 'groupsModel']),
     connect({
-        values: [teamLogic, ['currentTeamId'], groupsAccessLogic, ['groupsEnabled', 'groupsAccessStatus']],
+        values: [projectLogic, ['currentProjectId'], groupsAccessLogic, ['groupsEnabled', 'groupsAccessStatus']],
     }),
     loaders(({ values }) => ({
         groupTypesRaw: [
             [] as Array<GroupType>,
             {
                 loadAllGroupTypes: async () => {
-                    return await api.get(`api/projects/${values.currentTeamId}/groups_types`)
+                    return await api.get(`api/projects/${values.currentProjectId}/groups_types`)
                 },
                 updateGroupTypesMetadata: async (payload: Array<GroupType>) => {
                     if (values.groupsEnabled) {
                         return await api.update(
-                            `/api/projects/${teamLogic.values.currentTeamId}/groups_types/update_metadata`,
+                            `/api/projects/${values.currentProjectId}/groups_types/update_metadata`,
                             payload
                         )
                     }

--- a/frontend/src/models/notebooksModel.ts
+++ b/frontend/src/models/notebooksModel.ts
@@ -9,7 +9,7 @@ import type { notebookLogicType } from 'scenes/notebooks/Notebook/notebookLogicT
 import { defaultNotebookContent, EditorFocusPosition, JSONContent } from 'scenes/notebooks/Notebook/utils'
 import { notebookPanelLogic } from 'scenes/notebooks/NotebookPanel/notebookPanelLogic'
 import { LOCAL_NOTEBOOK_TEMPLATES } from 'scenes/notebooks/NotebookTemplates/notebookTemplates'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 import { urls } from 'scenes/urls'
 
 import { InsightVizNode, Node } from '~/queries/schema'
@@ -75,7 +75,7 @@ export const notebooksModel = kea<notebooksModelType>([
         createNotebookFromDashboard: (dashboard: DashboardType<QueryBasedInsightModel>) => ({ dashboard }),
     }),
     connect({
-        values: [teamLogic, ['currentTeamId']],
+        values: [projectLogic, ['currentProjectId']],
     }),
 
     reducers({
@@ -105,7 +105,7 @@ export const notebooksModel = kea<notebooksModelType>([
 
                 deleteNotebook: async ({ shortId, title }) => {
                     await deleteWithUndo({
-                        endpoint: `projects/${values.currentTeamId}/notebooks`,
+                        endpoint: `projects/${values.currentProjectId}/notebooks`,
                         object: { name: title || shortId, id: shortId },
                     })
 

--- a/frontend/src/scenes/data-management/database/DatabaseTable.tsx
+++ b/frontend/src/scenes/data-management/database/DatabaseTable.tsx
@@ -9,7 +9,7 @@ import { useCallback } from 'react'
 import { dataWarehouseJoinsLogic } from 'scenes/data-warehouse/external/dataWarehouseJoinsLogic'
 import { dataWarehouseSceneLogic } from 'scenes/data-warehouse/settings/dataWarehouseSceneLogic'
 import { viewLinkLogic } from 'scenes/data-warehouse/viewLinkLogic'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 import { urls } from 'scenes/urls'
 
 import { DatabaseSchemaTable, DatabaseSerializedFieldType } from '~/queries/schema'
@@ -46,7 +46,7 @@ const isNonEditableSchemaType = (schemaType: unknown): schemaType is NonEditable
     return typeof schemaType === 'string' && nonEditableSchemaTypes.includes(schemaType as NonEditableSchemaTypes)
 }
 const JoinsMoreMenu = ({ tableName, fieldName }: { tableName: string; fieldName: string }): JSX.Element => {
-    const { currentTeamId } = useValues(teamLogic)
+    const { currentProjectId } = useValues(projectLogic)
     const { toggleEditJoinModal } = useActions(viewLinkLogic)
     const { joins, joinsLoading } = useValues(dataWarehouseJoinsLogic)
     const { loadJoins } = useActions(dataWarehouseJoinsLogic)
@@ -68,7 +68,7 @@ const JoinsMoreMenu = ({ tableName, fieldName }: { tableName: string; fieldName:
                         fullWidth
                         onClick={() => {
                             void deleteWithUndo({
-                                endpoint: `projects/${currentTeamId}/warehouse_view_link`,
+                                endpoint: `projects/${currentProjectId}/warehouse_view_link`,
                                 object: {
                                     id: join.id,
                                     name: `${join.field_name} on ${join.source_table_name}`,

--- a/frontend/src/scenes/data-management/ingestion-warnings/ingestionWarningsLogic.ts
+++ b/frontend/src/scenes/data-management/ingestion-warnings/ingestionWarningsLogic.ts
@@ -3,6 +3,7 @@ import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { dayjs, dayjsUtcToTimezone } from 'lib/dayjs'
 import { range } from 'lib/utils'
+import { projectLogic } from 'scenes/projectLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -31,7 +32,7 @@ export const ingestionWarningsLogic = kea<ingestionWarningsLogicType>([
     path(['scenes', 'data-management', 'ingestion-warnings', 'ingestionWarningsLogic']),
 
     connect({
-        values: [teamLogic, ['currentTeamId', 'timezone']],
+        values: [teamLogic, ['timezone'], projectLogic, ['currentProjectId']],
     }),
 
     loaders(({ values }) => ({
@@ -39,7 +40,7 @@ export const ingestionWarningsLogic = kea<ingestionWarningsLogicType>([
             [] as IngestionWarningSummary[],
             {
                 loadData: async () => {
-                    const { results } = await api.get(`api/projects/${values.currentTeamId}/ingestion_warnings`)
+                    const { results } = await api.get(`api/projects/${values.currentProjectId}/ingestion_warnings`)
                     return results
                 },
             },

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -17,9 +17,9 @@ import { validateFeatureFlagKey } from 'scenes/feature-flags/featureFlagLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { cleanFilters, getDefaultEvent } from 'scenes/insights/utils/cleanFilters'
+import { projectLogic } from 'scenes/projectLogic'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
-import { teamLogic } from 'scenes/teamLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import { urls } from 'scenes/urls'
 
@@ -125,8 +125,8 @@ export const experimentLogic = kea<experimentLogicType>([
     path((key) => ['scenes', 'experiment', 'experimentLogic', key]),
     connect(() => ({
         values: [
-            teamLogic,
-            ['currentTeamId'],
+            projectLogic,
+            ['currentProjectId'],
             groupsModel,
             ['aggregationLabel', 'groupTypes', 'showGroupsOptions'],
             sceneLogic,
@@ -496,7 +496,7 @@ export const experimentLogic = kea<experimentLogicType>([
             try {
                 if (isUpdate) {
                     response = await api.update(
-                        `api/projects/${values.currentTeamId}/experiments/${values.experimentId}`,
+                        `api/projects/${values.currentProjectId}/experiments/${values.experimentId}`,
                         {
                             ...values.experiment,
                             parameters: {
@@ -524,7 +524,7 @@ export const experimentLogic = kea<experimentLogicType>([
                         return
                     }
                 } else {
-                    response = await api.create(`api/projects/${values.currentTeamId}/experiments`, {
+                    response = await api.create(`api/projects/${values.currentProjectId}/experiments`, {
                         ...values.experiment,
                         parameters: {
                             ...values.experiment?.parameters,
@@ -712,9 +712,9 @@ export const experimentLogic = kea<experimentLogicType>([
             }
 
             if (experimentEntitiesChanged) {
-                const url = `/api/projects/${values.currentTeamId}/experiments/requires_flag_implementation?${toParams(
-                    experiment.filters || {}
-                )}`
+                const url = `/api/projects/${
+                    values.currentProjectId
+                }/experiments/requires_flag_implementation?${toParams(experiment.filters || {})}`
                 await breakpoint(100)
 
                 try {
@@ -758,7 +758,7 @@ export const experimentLogic = kea<experimentLogicType>([
                     ...values.experiment.parameters,
                     variant_screenshot_media_ids: variantPreviewMediaIds,
                 }
-                await api.update(`api/projects/${values.currentTeamId}/experiments/${values.experimentId}`, {
+                await api.update(`api/projects/${values.currentProjectId}/experiments/${values.experimentId}`, {
                     parameters: updatedParameters,
                 })
                 actions.setExperiment({
@@ -775,7 +775,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 if (props.experimentId && props.experimentId !== 'new') {
                     try {
                         const response = await api.get(
-                            `api/projects/${values.currentTeamId}/experiments/${props.experimentId}`
+                            `api/projects/${values.currentProjectId}/experiments/${props.experimentId}`
                         )
                         return response as Experiment
                     } catch (error: any) {
@@ -790,7 +790,7 @@ export const experimentLogic = kea<experimentLogicType>([
             },
             updateExperiment: async (update: Partial<Experiment>) => {
                 const response: Experiment = await api.update(
-                    `api/projects/${values.currentTeamId}/experiments/${values.experimentId}`,
+                    `api/projects/${values.currentProjectId}/experiments/${values.experimentId}`,
                     update
                 )
                 return response
@@ -830,7 +830,7 @@ export const experimentLogic = kea<experimentLogicType>([
 
                         const refreshParam = refresh ? '?refresh=true' : ''
                         const response: ExperimentResults = await api.get(
-                            `api/projects/${values.currentTeamId}/experiments/${values.experimentId}/results${refreshParam}`
+                            `api/projects/${values.currentProjectId}/experiments/${values.experimentId}/results${refreshParam}`
                         )
                         return {
                             ...response.result,
@@ -876,7 +876,7 @@ export const experimentLogic = kea<experimentLogicType>([
                                         experiment_id: values.experimentId,
                                     }
                                     const response: ExperimentResults = await api.create(
-                                        `api/projects/${values.currentTeamId}/query`,
+                                        `api/projects/${values.currentProjectId}/query`,
                                         { query: queryWithExperimentId, refresh: 'lazy_async' }
                                     )
 
@@ -898,7 +898,7 @@ export const experimentLogic = kea<experimentLogicType>([
                         (values.experiment?.secondary_metrics || []).map(async (_, index) => {
                             try {
                                 const secResults = await api.get(
-                                    `api/projects/${values.currentTeamId}/experiments/${values.experimentId}/secondary_results?id=${index}${refreshParam}`
+                                    `api/projects/${values.currentProjectId}/experiments/${values.experimentId}/secondary_results?id=${index}${refreshParam}`
                                 )
                                 // :TRICKY: Maintain backwards compatibility for cached responses, remove after cache period has expired
                                 if (secResults && secResults.result && !secResults.result.hasOwnProperty('result')) {
@@ -945,7 +945,7 @@ export const experimentLogic = kea<experimentLogicType>([
                     const newFilters = transformFiltersForWinningVariant(currentFlagFilters, selectedVariantKey)
 
                     await api.update(
-                        `api/projects/${values.currentTeamId}/feature_flags/${values.experiment.feature_flag?.id}`,
+                        `api/projects/${values.currentProjectId}/feature_flags/${values.experiment.feature_flag?.id}`,
                         { filters: newFilters }
                     )
 

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -6,7 +6,7 @@ import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic, FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { Experiment, ExperimentsTabs, ProgressStatus } from '~/types'
@@ -37,8 +37,8 @@ export const experimentsLogic = kea<experimentsLogicType>([
     path(['scenes', 'experiments', 'experimentsLogic']),
     connect({
         values: [
-            teamLogic,
-            ['currentTeamId'],
+            projectLogic,
+            ['currentProjectId'],
             userLogic,
             ['user', 'hasAvailableFeature'],
             featureFlagLogic,
@@ -76,16 +76,16 @@ export const experimentsLogic = kea<experimentsLogicType>([
             [] as Experiment[],
             {
                 loadExperiments: async () => {
-                    const response = await api.get(`api/projects/${values.currentTeamId}/experiments?limit=1000`)
+                    const response = await api.get(`api/projects/${values.currentProjectId}/experiments?limit=1000`)
                     return response.results as Experiment[]
                 },
                 deleteExperiment: async (id: number) => {
-                    await api.delete(`api/projects/${values.currentTeamId}/experiments/${id}`)
+                    await api.delete(`api/projects/${values.currentProjectId}/experiments/${id}`)
                     lemonToast.info('Experiment removed')
                     return values.experiments.filter((experiment) => experiment.id !== id)
                 },
                 archiveExperiment: async (id: number) => {
-                    await api.update(`api/projects/${values.currentTeamId}/experiments/${id}`, { archived: true })
+                    await api.update(`api/projects/${values.currentProjectId}/experiments/${id}`, { archived: true })
                     lemonToast.info('Experiment archived')
                     return values.experiments.filter((experiment) => experiment.id !== id)
                 },

--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsLogic.ts
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsLogic.ts
@@ -4,6 +4,7 @@ import api from 'lib/api'
 import { isEmptyProperty } from 'lib/components/PropertyFilters/utils'
 import { TaxonomicFilterGroupType, TaxonomicFilterProps } from 'lib/components/TaxonomicFilter/types'
 import { objectsEqual, range } from 'lib/utils'
+import { projectLogic } from 'scenes/projectLogic'
 
 import { groupsModel } from '~/models/groupsModel'
 import {
@@ -16,7 +17,6 @@ import {
     UserBlastRadiusType,
 } from '~/types'
 
-import { teamLogic } from '../teamLogic'
 import type { featureFlagReleaseConditionsLogicType } from './FeatureFlagReleaseConditionsLogicType'
 
 // TODO: Type onChange errors properly
@@ -33,7 +33,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
     props({} as FeatureFlagReleaseConditionsLogicProps),
     key(({ id }) => id ?? 'unknown'),
     connect({
-        values: [teamLogic, ['currentTeamId'], groupsModel, ['groupTypes', 'aggregationLabel']],
+        values: [projectLogic, ['currentProjectId'], groupsModel, ['groupTypes', 'aggregationLabel']],
     }),
     actions({
         setFilters: (filters: FeatureFlagFilters) => ({ filters }),
@@ -156,10 +156,13 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
             }
 
             await breakpoint(1000) // in ms
-            const response = await api.create(`api/projects/${values.currentTeamId}/feature_flags/user_blast_radius`, {
-                condition: { properties: newProperties },
-                group_type_index: values.filters?.aggregation_group_type_index ?? null,
-            })
+            const response = await api.create(
+                `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
+                {
+                    condition: { properties: newProperties },
+                    group_type_index: values.filters?.aggregation_group_type_index ?? null,
+                }
+            )
             actions.setAffectedUsers(index, response.users_affected)
             actions.setTotalUsers(response.total_users)
         },
@@ -189,7 +192,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                 } else if (properties.length === 0) {
                     // Request total users for empty condition sets
                     const responsePromise = api.create(
-                        `api/projects/${values.currentTeamId}/feature_flags/user_blast_radius`,
+                        `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
                         {
                             condition: { properties: [] },
                             group_type_index: values.filters?.aggregation_group_type_index ?? null,
@@ -199,7 +202,7 @@ export const featureFlagReleaseConditionsLogic = kea<featureFlagReleaseCondition
                     usersAffected.push(responsePromise)
                 } else {
                     const responsePromise = api.create(
-                        `api/projects/${values.currentTeamId}/feature_flags/user_blast_radius`,
+                        `api/projects/${values.currentProjectId}/feature_flags/user_blast_radius`,
                         {
                             condition,
                             group_type_index: values.filters?.aggregation_group_type_index ?? null,

--- a/frontend/src/scenes/feature-flags/FeatureFlags.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlags.tsx
@@ -20,6 +20,7 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import stringWithWBR from 'lib/utils/stringWithWBR'
+import { projectLogic } from 'scenes/projectLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -36,7 +37,6 @@ import {
     FeatureFlagType,
 } from '~/types'
 
-import { teamLogic } from '../teamLogic'
 import { featureFlagsLogic, FeatureFlagsTab, FLAGS_PER_PAGE } from './featureFlagsLogic'
 
 export const scene: SceneExport = {
@@ -53,7 +53,7 @@ export function OverViewTab({
     searchPlaceholder?: string
     nouns?: [string, string]
 }): JSX.Element {
-    const { currentTeamId } = useValues(teamLogic)
+    const { currentProjectId } = useValues(projectLogic)
     const { aggregationLabel } = useValues(groupsModel)
 
     const flagLogic = featureFlagsLogic({ flagPrefix })
@@ -240,7 +240,7 @@ export function OverViewTab({
                                         status="danger"
                                         onClick={() => {
                                             void deleteWithUndo({
-                                                endpoint: `projects/${currentTeamId}/feature_flags`,
+                                                endpoint: `projects/${currentProjectId}/feature_flags`,
                                                 object: { name: featureFlag.key, id: featureFlag.id },
                                                 callback: loadFeatureFlags,
                                             })

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -584,13 +584,16 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                 try {
                     let savedFlag: FeatureFlagType
                     if (!updatedFlag.id) {
-                        savedFlag = await api.create(`api/projects/${values.currentTeamId}/feature_flags`, preparedFlag)
+                        savedFlag = await api.create(
+                            `api/projects/${values.currentProjectId}/feature_flags`,
+                            preparedFlag
+                        )
                         if (values.roleBasedAccessEnabled && savedFlag.id) {
                             featureFlagPermissionsLogic({ flagId: null })?.actions.addAssociatedRoles(savedFlag.id)
                         }
                     } else {
                         savedFlag = await api.update(
-                            `api/projects/${values.currentTeamId}/feature_flags/${updatedFlag.id}`,
+                            `api/projects/${values.currentProjectId}/feature_flags/${updatedFlag.id}`,
                             preparedFlag
                         )
                     }

--- a/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagsLogic.ts
@@ -4,12 +4,12 @@ import { loaders } from 'kea-loaders'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 import api from 'lib/api'
 import { objectsEqual, toParams } from 'lib/utils'
+import { projectLogic } from 'scenes/projectLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { Breadcrumb, FeatureFlagType } from '~/types'
 
-import { teamLogic } from '../teamLogic'
 import type { featureFlagsLogicType } from './featureFlagsLogicType'
 
 export const FLAGS_PER_PAGE = 100
@@ -60,7 +60,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
     props({} as FlagLogicProps),
     path(['scenes', 'feature-flags', 'featureFlagsLogic']),
     connect({
-        values: [teamLogic, ['currentTeamId']],
+        values: [projectLogic, ['currentProjectId']],
     }),
     actions({
         updateFlag: (flag: FeatureFlagType) => ({ flag }),
@@ -75,7 +75,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
             {
                 loadFeatureFlags: async () => {
                     const response = await api.get(
-                        `api/projects/${values.currentTeamId}/feature_flags/?${toParams(values.paramsFromFilters)}`
+                        `api/projects/${values.currentProjectId}/feature_flags/?${toParams(values.paramsFromFilters)}`
                     )
 
                     return {
@@ -85,7 +85,7 @@ export const featureFlagsLogic = kea<featureFlagsLogicType>([
                 },
                 updateFeatureFlag: async ({ id, payload }: { id: number; payload: Partial<FeatureFlagType> }) => {
                     const response = await api.update(
-                        `api/projects/${values.currentTeamId}/feature_flags/${id}`,
+                        `api/projects/${values.currentProjectId}/feature_flags/${id}`,
                         payload
                     )
                     const updatedFlags = [...values.featureFlags.results].map((flag) =>

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -7,8 +7,8 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { toParams } from 'lib/utils'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
+import { projectLogic } from 'scenes/projectLogic'
 import { Scene } from 'scenes/sceneTypes'
-import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -50,8 +50,8 @@ export const groupLogic = kea<groupLogicType>([
     path((key) => ['scenes', 'groups', 'groupLogic', key]),
     connect({
         values: [
-            teamLogic,
-            ['currentTeamId'],
+            projectLogic,
+            ['currentProjectId'],
             groupsModel,
             ['groupTypes', 'aggregationLabel'],
             featureFlagLogic,
@@ -68,7 +68,7 @@ export const groupLogic = kea<groupLogicType>([
             {
                 loadGroup: async () => {
                     const params = { group_type_index: props.groupTypeIndex, group_key: props.groupKey }
-                    const url = `api/projects/${values.currentTeamId}/groups/find?${toParams(params)}`
+                    const url = `api/projects/${values.currentProjectId}/groups/find?${toParams(params)}`
                     return await api.get(url)
                 },
             },

--- a/frontend/src/scenes/groups/groupsListLogic.ts
+++ b/frontend/src/scenes/groups/groupsListLogic.ts
@@ -2,7 +2,7 @@ import { actions, afterMount, connect, kea, key, listeners, path, props, reducer
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { groupsAccessLogic } from 'lib/introductions/groupsAccessLogic'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 
 import { groupsModel, Noun } from '~/models/groupsModel'
 import { Group } from '~/types'
@@ -25,8 +25,8 @@ export const groupsListLogic = kea<groupsListLogicType>([
     path(['groups', 'groupsListLogic']),
     connect({
         values: [
-            teamLogic,
-            ['currentTeamId'],
+            projectLogic,
+            ['currentProjectId'],
             groupsModel,
             ['groupTypes', 'aggregationLabel'],
             groupsAccessLogic,
@@ -49,7 +49,7 @@ export const groupsListLogic = kea<groupsListLogicType>([
                     }
                     url =
                         url ||
-                        `api/projects/${values.currentTeamId}/groups/?group_type_index=${props.groupTypeIndex}${
+                        `api/projects/${values.currentProjectId}/groups/?group_type_index=${props.groupTypeIndex}${
                             values.search ? '&search=' + encodeURIComponent(values.search) : ''
                         }`
                     return await api.get(url)

--- a/frontend/src/scenes/groups/relatedGroupsLogic.ts
+++ b/frontend/src/scenes/groups/relatedGroupsLogic.ts
@@ -2,7 +2,7 @@ import { actions, connect, events, kea, key, path, props } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { toParams } from 'lib/utils'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 
 import { ActorType } from '~/types'
 
@@ -17,7 +17,7 @@ export const relatedGroupsLogic = kea<relatedGroupsLogicType>([
     ),
     key((props) => `${props.groupTypeIndex ?? 'person'}-${props.id}`),
     path(['scenes', 'groups', 'relatedGroupsLogic']),
-    connect({ values: [teamLogic, ['currentTeamId']] }),
+    connect({ values: [projectLogic, ['currentProjectId']] }),
     actions(() => ({
         loadRelatedActors: true,
     })),
@@ -26,7 +26,7 @@ export const relatedGroupsLogic = kea<relatedGroupsLogicType>([
             [] as ActorType[],
             {
                 loadRelatedActors: async () => {
-                    const url = `api/projects/${values.currentTeamId}/groups/related?${toParams({
+                    const url = `api/projects/${values.currentProjectId}/groups/related?${toParams({
                         group_type_index: props.groupTypeIndex,
                         id: props.id,
                     })}`

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -31,8 +31,8 @@ import { InsightSaveButton } from 'scenes/insights/InsightSaveButton'
 import { insightSceneLogic } from 'scenes/insights/insightSceneLogic'
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { projectLogic } from 'scenes/projectLogic'
 import { savedInsightsLogic } from 'scenes/saved-insights/savedInsightsLogic'
-import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
@@ -83,7 +83,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     const { tags } = useValues(tagsModel)
     const { user } = useValues(userLogic)
     const { preflight } = useValues(preflightLogic)
-    const { currentTeamId } = useValues(teamLogic)
+    const { currentProjectId } = useValues(projectLogic)
     const { push } = useActions(router)
 
     const [addToDashboardModalOpen, setAddToDashboardModalOpenModal] = useState<boolean>(false)
@@ -316,7 +316,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                 onClick={() =>
                                                     void deleteInsightWithUndo({
                                                         object: insight as QueryBasedInsightModel,
-                                                        endpoint: `projects/${currentTeamId}/insights`,
+                                                        endpoint: `projects/${currentProjectId}/insights`,
                                                         callback: () => {
                                                             loadInsights()
                                                             push(urls.savedInsights())

--- a/frontend/src/scenes/messaging/functionsTableLogic.tsx
+++ b/frontend/src/scenes/messaging/functionsTableLogic.tsx
@@ -3,7 +3,7 @@ import { actions, afterMount, connect, kea, key, path, props, reducers, selector
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 
 import { HogFunctionType, HogFunctionTypeType } from '~/types'
 
@@ -23,7 +23,7 @@ export const functionsTableLogic = kea<functionsTableLogicType>([
     props({} as FunctionsTableLogicProps),
     key((props: FunctionsTableLogicProps) => props.type ?? 'destination'),
     connect({
-        values: [teamLogic, ['currentTeamId']],
+        values: [projectLogic, ['currentProjectId']],
     }),
     actions({
         deleteHogFunction: (hogFunction: HogFunctionType) => ({ hogFunction }),
@@ -52,7 +52,7 @@ export const functionsTableLogic = kea<functionsTableLogicType>([
                 },
                 deleteHogFunction: async ({ hogFunction }) => {
                     await deleteWithUndo({
-                        endpoint: `projects/${teamLogic.values.currentTeamId}/hog_functions`,
+                        endpoint: `projects/${values.currentProjectId}/hog_functions`,
                         object: {
                             id: hogFunction.id,
                             name: hogFunction.name,

--- a/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
+++ b/frontend/src/scenes/persons/relatedFeatureFlagsLogic.ts
@@ -4,7 +4,7 @@ import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { toParams } from 'lib/utils'
 import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 
 import { FeatureFlagReleaseType, FeatureFlagType } from '~/types'
 
@@ -36,7 +36,7 @@ export interface RelatedFlagsFilters {
 
 export const relatedFeatureFlagsLogic = kea<relatedFeatureFlagsLogicType>([
     path(['scenes', 'persons', 'relatedFeatureFlagsLogic']),
-    connect({ values: [teamLogic, ['currentTeamId'], featureFlagsLogic, ['featureFlags']] }),
+    connect({ values: [projectLogic, ['currentProjectId'], featureFlagsLogic, ['featureFlags']] }),
     props(
         {} as {
             distinctId: string
@@ -56,7 +56,7 @@ export const relatedFeatureFlagsLogic = kea<relatedFeatureFlagsLogicType>([
             {
                 loadRelatedFeatureFlags: async () => {
                     const response = await api.get(
-                        `api/projects/${values.currentTeamId}/feature_flags/evaluation_reasons?${toParams({
+                        `api/projects/${values.currentProjectId}/feature_flags/evaluation_reasons?${toParams({
                             distinct_id: props.distinctId,
                             ...(props.groups ? { groups: props.groups } : {}),
                         })}`

--- a/frontend/src/scenes/pipeline/destinations/destinationsLogic.tsx
+++ b/frontend/src/scenes/pipeline/destinations/destinationsLogic.tsx
@@ -6,6 +6,7 @@ import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { projectLogic } from 'scenes/projectLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 
@@ -38,8 +39,8 @@ export const pipelineDestinationsLogic = kea<pipelineDestinationsLogicType>([
     path(['scenes', 'pipeline', 'destinationsLogic']),
     connect({
         values: [
-            teamLogic,
-            ['currentTeamId'],
+            projectLogic,
+            ['currentProjectId'],
             userLogic,
             ['user', 'hasAvailableFeature'],
             pipelineAccessLogic,
@@ -76,7 +77,7 @@ export const pipelineDestinationsLogic = kea<pipelineDestinationsLogicType>([
                 loadPluginConfigs: async () => {
                     const pluginConfigs: Record<number, PluginConfigTypeNew> = {}
                     const results = await api.loadPaginatedResults<PluginConfigTypeNew>(
-                        `api/projects/${values.currentTeamId}/pipeline_destination_configs`
+                        `api/projects/${values.currentProjectId}/pipeline_destination_configs`
                     )
 
                     for (const pluginConfig of results) {
@@ -133,7 +134,7 @@ export const pipelineDestinationsLogic = kea<pipelineDestinationsLogicType>([
             {
                 loadBatchExports: async () => {
                     const results = await api.loadPaginatedResults<BatchExportConfiguration>(
-                        `api/projects/${values.currentTeamId}/batch_exports`
+                        `api/projects/${values.currentProjectId}/batch_exports`
                     )
                     return Object.fromEntries(results.map((batchExport) => [batchExport.id, batchExport]))
                 },
@@ -175,7 +176,7 @@ export const pipelineDestinationsLogic = kea<pipelineDestinationsLogicType>([
                     }
 
                     await deleteWithUndo({
-                        endpoint: `projects/${teamLogic.values.currentTeamId}/hog_functions`,
+                        endpoint: `projects/${values.currentProjectId}/hog_functions`,
                         object: {
                             id: destination.hog_function.id,
                             name: destination.name,

--- a/frontend/src/scenes/pipeline/frontendAppsLogic.tsx
+++ b/frontend/src/scenes/pipeline/frontendAppsLogic.tsx
@@ -1,7 +1,7 @@
 import { actions, afterMount, connect, kea, path, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { PipelineStage, PluginConfigTypeNew, PluginConfigWithPluginInfoNew, PluginType } from '~/types'
@@ -13,7 +13,7 @@ import { capturePluginEvent, checkPermissions, loadPluginsFromUrl } from './util
 export const frontendAppsLogic = kea<frontendAppsLogicType>([
     path(['scenes', 'pipeline', 'frontendAppsLogic']),
     connect({
-        values: [teamLogic, ['currentTeamId'], userLogic, ['user']],
+        values: [projectLogic, ['currentProjectId'], userLogic, ['user']],
     }),
     actions({
         loadPluginConfigs: true,
@@ -33,7 +33,7 @@ export const frontendAppsLogic = kea<frontendAppsLogicType>([
             {
                 loadPluginConfigs: async () => {
                     const res: PluginConfigTypeNew[] = await api.loadPaginatedResults(
-                        `api/projects/${values.currentTeamId}/pipeline_frontend_apps_configs`
+                        `api/projects/${values.currentProjectId}/pipeline_frontend_apps_configs`
                     )
 
                     return Object.fromEntries(res.map((pluginConfig) => [pluginConfig.id, pluginConfig]))

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -12,6 +12,7 @@ import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import posthog from 'posthog-js'
 import { asDisplay } from 'scenes/persons/person-utils'
 import { hogFunctionNewUrl, hogFunctionUrl } from 'scenes/pipeline/hogfunctions/urls'
+import { projectLogic } from 'scenes/projectLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 
@@ -169,7 +170,14 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
         return id ?? templateId ?? 'new'
     }),
     connect({
-        values: [teamLogic, ['currentTeam'], groupsModel, ['groupTypes'], userLogic, ['hasAvailableFeature']],
+        values: [
+            projectLogic,
+            ['currentProjectId', 'currentProject'],
+            groupsModel,
+            ['groupTypes'],
+            userLogic,
+            ['hasAvailableFeature'],
+        ],
     }),
     path((id) => ['scenes', 'pipeline', 'hogFunctionConfigurationLogic', id]),
     actions({
@@ -525,8 +533,8 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             },
         ],
         exampleInvocationGlobals: [
-            (s) => [s.configuration, s.currentTeam, s.groupTypes],
-            (configuration, currentTeam, groupTypes): HogFunctionInvocationGlobals => {
+            (s) => [s.configuration, s.currentProject, s.groupTypes],
+            (configuration, currentProject, groupTypes): HogFunctionInvocationGlobals => {
                 const currentUrl = window.location.href.split('#')[0]
                 const eventId = uuid()
                 const personId = uuid()
@@ -541,7 +549,7 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                             $current_url: currentUrl,
                             $browser: 'Chrome',
                         },
-                        url: `${window.location.origin}/project/${currentTeam?.id}/events/`,
+                        url: `${window.location.origin}/project/${currentProject?.id}/events/`,
                     },
                     person: {
                         id: personId,
@@ -553,9 +561,9 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                     },
                     groups: {},
                     project: {
-                        id: currentTeam?.id || 0,
-                        name: currentTeam?.name || '',
-                        url: `${window.location.origin}/project/${currentTeam?.id}`,
+                        id: currentProject?.id || 0,
+                        name: currentProject?.name || '',
+                        url: `${window.location.origin}/project/${currentProject?.id}`,
                     },
                     source: {
                         name: configuration?.name ?? 'Unnamed',
@@ -891,7 +899,7 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             }
             const { id, name, type } = values.hogFunction
             await deleteWithUndo({
-                endpoint: `projects/${teamLogic.values.currentTeamId}/hog_functions`,
+                endpoint: `projects/${values.currentProjectId}/hog_functions`,
                 object: {
                     id,
                     name,

--- a/frontend/src/scenes/pipeline/hogfunctions/list/hogFunctionListLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/list/hogFunctionListLogic.tsx
@@ -8,7 +8,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectsEqual } from 'lib/utils'
 import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
 import { pipelineAccessLogic } from 'scenes/pipeline/pipelineAccessLogic'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { HogFunctionType, HogFunctionTypeType } from '~/types'
@@ -37,8 +37,8 @@ export const hogFunctionListLogic = kea<hogFunctionListLogicType>([
     path((id) => ['scenes', 'pipeline', 'hogFunctionListLogic', id]),
     connect({
         values: [
-            teamLogic,
-            ['currentTeamId'],
+            projectLogic,
+            ['currentProjectId'],
             userLogic,
             ['user', 'hasAvailableFeature'],
             pipelineAccessLogic,
@@ -83,7 +83,7 @@ export const hogFunctionListLogic = kea<hogFunctionListLogicType>([
                 },
                 deleteHogFunction: async ({ hogFunction }) => {
                     await deleteWithUndo({
-                        endpoint: `projects/${teamLogic.values.currentTeamId}/hog_functions`,
+                        endpoint: `projects/${values.currentProjectId}/hog_functions`,
                         object: {
                             id: hogFunction.id,
                             name: hogFunction.name,

--- a/frontend/src/scenes/pipeline/importAppsLogic.tsx
+++ b/frontend/src/scenes/pipeline/importAppsLogic.tsx
@@ -1,7 +1,7 @@
 import { actions, afterMount, connect, kea, path, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { PipelineStage, PluginConfigTypeNew, PluginConfigWithPluginInfoNew, PluginType } from '~/types'
@@ -13,7 +13,7 @@ import { capturePluginEvent, checkPermissions, loadPluginsFromUrl } from './util
 export const importAppsLogic = kea<importAppsLogicType>([
     path(['scenes', 'pipeline', 'importAppsLogic']),
     connect({
-        values: [teamLogic, ['currentTeamId'], userLogic, ['user']],
+        values: [projectLogic, ['currentProjectId'], userLogic, ['user']],
     }),
     actions({
         loadPluginConfigs: true,
@@ -33,7 +33,7 @@ export const importAppsLogic = kea<importAppsLogicType>([
             {
                 loadPluginConfigs: async () => {
                     const res: PluginConfigTypeNew[] = await api.loadPaginatedResults(
-                        `api/projects/${values.currentTeamId}/pipeline_import_apps_configs`
+                        `api/projects/${values.currentProjectId}/pipeline_import_apps_configs`
                     )
 
                     return Object.fromEntries(res.map((pluginConfig) => [pluginConfig.id, pluginConfig]))

--- a/frontend/src/scenes/pipeline/pipelineNodeMetricsLogic.tsx
+++ b/frontend/src/scenes/pipeline/pipelineNodeMetricsLogic.tsx
@@ -2,7 +2,7 @@ import { actions, afterMount, connect, kea, key, listeners, path, props, reducer
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { toParams } from 'lib/utils'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 
 import type { pipelineNodeMetricsLogicType } from './pipelineNodeMetricsLogicType'
 
@@ -52,7 +52,7 @@ export const pipelineNodeMetricsLogic = kea<pipelineNodeMetricsLogicType>([
     key(({ id }: PipelineNodeMetricsProps) => id),
     path((id) => ['scenes', 'pipeline', 'appMetricsLogic', id]),
     connect({
-        values: [teamLogic, ['currentTeamId']],
+        values: [projectLogic, ['currentProjectId']],
     }),
     actions({
         setDateRange: (from: string | null, to: string | null) => ({ from, to }),
@@ -67,9 +67,7 @@ export const pipelineNodeMetricsLogic = kea<pipelineNodeMetricsLogicType>([
             {
                 loadMetrics: async () => {
                     const params = toParams({ date_from: values.dateRange.from, date_to: values.dateRange.to })
-                    return await api.get(
-                        `api/projects/${teamLogic.values.currentTeamId}/app_metrics/${props.id}?${params}`
-                    )
+                    return await api.get(`api/projects/${values.currentProjectId}/app_metrics/${props.id}?${params}`)
                 },
             },
         ],
@@ -79,7 +77,7 @@ export const pipelineNodeMetricsLogic = kea<pipelineNodeMetricsLogicType>([
                 openErrorDetailsModal: async ({ errorType }) => {
                     const params = toParams({ error_type: errorType })
                     const { result } = await api.get(
-                        `api/projects/${teamLogic.values.currentTeamId}/app_metrics/${props.id}/error_details?${params}`
+                        `api/projects/${values.currentProjectId}/app_metrics/${props.id}/error_details?${params}`
                     )
                     return result
                 },

--- a/frontend/src/scenes/pipeline/transformationsLogic.tsx
+++ b/frontend/src/scenes/pipeline/transformationsLogic.tsx
@@ -1,7 +1,7 @@
 import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
-import { teamLogic } from 'scenes/teamLogic'
+import { projectLogic } from 'scenes/projectLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { PipelineStage, PluginConfigTypeNew, PluginConfigWithPluginInfoNew, PluginType } from '~/types'
@@ -13,7 +13,7 @@ import { capturePluginEvent, checkPermissions, loadPluginsFromUrl } from './util
 export const pipelineTransformationsLogic = kea<pipelineTransformationsLogicType>([
     path(['scenes', 'pipeline', 'transformationsLogic']),
     connect({
-        values: [teamLogic, ['currentTeamId'], userLogic, ['user']],
+        values: [projectLogic, ['currentProjectId'], userLogic, ['user']],
     }),
     actions({
         loadPluginConfigs: true,
@@ -47,7 +47,7 @@ export const pipelineTransformationsLogic = kea<pipelineTransformationsLogicType
             {
                 loadPluginConfigs: async () => {
                     const res = await api.loadPaginatedResults<PluginConfigTypeNew>(
-                        `api/projects/${values.currentTeamId}/pipeline_transformation_configs`
+                        `api/projects/${values.currentProjectId}/pipeline_transformation_configs`
                     )
 
                     return Object.fromEntries(res.map((pluginConfig) => [pluginConfig.id, pluginConfig]))

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -47,6 +47,7 @@ import { deleteInsightWithUndo } from 'lib/utils/deleteWithUndo'
 import { SavedInsightsEmptyState } from 'scenes/insights/EmptyStates'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
 import { organizationLogic } from 'scenes/organizationLogic'
+import { projectLogic } from 'scenes/projectLogic'
 import { overlayForNewInsightMenu } from 'scenes/saved-insights/newInsightsMenu'
 import { SavedInsightsFilters } from 'scenes/saved-insights/SavedInsightsFilters'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -56,7 +57,6 @@ import { NodeKind } from '~/queries/schema'
 import { isNodeWithSource } from '~/queries/utils'
 import { ActivityScope, InsightType, LayoutView, QueryBasedInsightModel, SavedInsightsTabs } from '~/types'
 
-import { teamLogic } from '../teamLogic'
 import { INSIGHTS_PER_PAGE, savedInsightsLogic } from './savedInsightsLogic'
 
 interface NewInsightButtonProps {
@@ -431,7 +431,7 @@ export function NewInsightButton({ dataAttr }: NewInsightButtonProps): JSX.Eleme
 function SavedInsightsGrid(): JSX.Element {
     const { loadInsights, renameInsight, duplicateInsight } = useActions(savedInsightsLogic)
     const { insights, insightsLoading, pagination } = useValues(savedInsightsLogic)
-    const { currentTeamId } = useValues(teamLogic)
+    const { currentProjectId } = useValues(projectLogic)
 
     const paginationState = usePagination(insights?.results || [], pagination)
 
@@ -448,7 +448,7 @@ function SavedInsightsGrid(): JSX.Element {
                             deleteWithUndo={async () =>
                                 await deleteInsightWithUndo({
                                     object: insight,
-                                    endpoint: `projects/${currentTeamId}/insights`,
+                                    endpoint: `projects/${currentProjectId}/insights`,
                                     callback: loadInsights,
                                 })
                             }
@@ -476,7 +476,7 @@ export function SavedInsights(): JSX.Element {
     const { insights, count, insightsLoading, filters, sorting, pagination, alertModalId } =
         useValues(savedInsightsLogic)
     const { hasTagging } = useValues(organizationLogic)
-    const { currentTeamId } = useValues(teamLogic)
+    const { currentProjectId } = useValues(projectLogic)
     const summarizeInsight = useSummarizeInsight()
 
     const { tab, layoutView, page } = filters
@@ -594,7 +594,7 @@ export function SavedInsights(): JSX.Element {
                                     onClick={() =>
                                         void deleteInsightWithUndo({
                                             object: insight,
-                                            endpoint: `projects/${currentTeamId}/insights`,
+                                            endpoint: `projects/${currentProjectId}/insights`,
                                             callback: loadInsights,
                                         })
                                     }

--- a/frontend/src/stories/How to build a form.stories.mdx
+++ b/frontend/src/stories/How to build a form.stories.mdx
@@ -24,7 +24,7 @@ export const featureFlagLogic = kea<featureFlagLogicType<FeatureFlagLogicProps>>
         featureFlag: [
             { ...NEW_FLAG } as FeatureFlagModel,
             {
-                loadFeatureFlag: () => api.get(`api/projects/${values.currentTeamId}/feature_flags/${props.id}`),
+                loadFeatureFlag: () => api.get(`api/projects/${values.currentProjectId}/feature_flags/${props.id}`),
             },
         ],
     }),
@@ -44,8 +44,8 @@ export const featureFlagLogic = kea<featureFlagLogicType<FeatureFlagLogicProps>>
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 const { created_at, id, ...flag } = featureFlag
                 const newFeatureFlag = updatedFlag.id
-                    ? await api.update(`api/projects/${values.currentTeamId}/feature_flags/${updatedFlag.id}`, flag)
-                    : await api.create(`api/projects/${values.currentTeamId}/feature_flags`, flag)
+                    ? await api.update(`api/projects/${values.currentProjectId}/feature_flags/${updatedFlag.id}`, flag)
+                    : await api.create(`api/projects/${values.currentProjectId}/feature_flags`, flag)
                 breakpoint()
                 actions.setFeatureFlagValues(newFeatureFlag)
                 lemonToast.success('Feature flag saved')


### PR DESCRIPTION
## Problem

Current users of environments (i.e. us) have been seeing this:

![image](https://github.com/user-attachments/assets/1e817aff-6a75-4331-9c51-67c10c5277b0)

This was because we were calling endpoints like this: `projects/${currentTeamId}/...` rather than like so: `projects/${currentProjectId}/...`

## Changes

Updated all the relevant API calls to the `projects/${currentProjectId}/...` form (I _think_ I haven't missed any, though it's possible).