### PR TITLE
chore(environments): Calculate cohorts for each environment

### DIFF
--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -487,7 +487,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
             name="cohort1",
         )
 
-        results = get_person_ids_by_cohort_id(self.team_id, cohort.id)
+        results = get_person_ids_by_cohort_id(self.team.pk, cohort.id)
         self.assertEqual(len(results), 2)
         self.assertIn(str(user1.uuid), results)
         self.assertIn(str(user3.uuid), results)
@@ -503,7 +503,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         cohort = Cohort.objects.create(team=self.team, groups=[], is_static=True)
         cohort.insert_users_by_list(["1", "123"])
         cohort = Cohort.objects.get()
-        results = get_person_ids_by_cohort_id(self.team_id, cohort.id)
+        results = get_person_ids_by_cohort_id(self.team.pk, cohort.id)
         self.assertEqual(len(results), 2)
         self.assertEqual(cohort.is_calculating, False)
 
@@ -518,12 +518,12 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
 
         #  If we accidentally call calculate_people it shouldn't erase people
         cohort.calculate_people_ch(pending_version=0)
-        results = get_person_ids_by_cohort_id(self.team_id, cohort.id)
+        results = get_person_ids_by_cohort_id(self.team.pk, cohort.id)
         self.assertEqual(len(results), 3)
 
         # if we add people again, don't increase the number of people in cohort
         cohort.insert_users_by_list(["123"])
-        results = get_person_ids_by_cohort_id(self.team_id, cohort.id)
+        results = get_person_ids_by_cohort_id(self.team.pk, cohort.id)
         self.assertEqual(len(results), 3)
 
     @snapshot_clickhouse_insert_cohortpeople_queries
@@ -854,7 +854,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         cohort.calculate_people_ch(pending_version=0)
 
         with self.settings(USE_PRECALCULATED_CH_COHORT_PEOPLE=True):
-            sql, _ = format_filter_query(cohort, 0, HogQLContext(team_id=self.team.pk), team=self.team)
+            sql, _ = format_filter_query(cohort, 0, HogQLContext(team_id=self.team.pk))
             self.assertQueryMatchesSnapshot(sql)
 
     def test_cohortpeople_with_valid_other_cohort_filter(self):

--- a/ee/clickhouse/models/test/test_cohort.py
+++ b/ee/clickhouse/models/test/test_cohort.py
@@ -854,7 +854,7 @@ class TestCohort(ClickhouseTestMixin, BaseTest):
         cohort.calculate_people_ch(pending_version=0)
 
         with self.settings(USE_PRECALCULATED_CH_COHORT_PEOPLE=True):
-            sql, _ = format_filter_query(cohort, 0, HogQLContext(team_id=self.team.pk))
+            sql, _ = format_filter_query(cohort, 0, HogQLContext(team_id=self.team.pk), team=self.team)
             self.assertQueryMatchesSnapshot(sql)
 
     def test_cohortpeople_with_valid_other_cohort_filter(self):

--- a/ee/clickhouse/queries/funnels/test/test_funnel_correlations_persons.py
+++ b/ee/clickhouse/queries/funnels/test/test_funnel_correlations_persons.py
@@ -251,6 +251,7 @@ class TestClickhouseFunnelCorrelationsActors(ClickhouseTestMixin, APIBaseTest):
                 "funnel_correlation_person_entity": "{'id': 'positively_related', 'type': 'events'}",
                 "funnel_correlation_person_converted": "TrUe",
             },
+            self.team.pk,
         )
 
         insert_cohort_from_insight_filter(cohort_id, params)

--- a/ee/clickhouse/views/test/test_clickhouse_path_person.py
+++ b/ee/clickhouse/views/test/test_clickhouse_path_person.py
@@ -97,6 +97,7 @@ class TestPathPerson(ClickhouseTestMixin, APIBaseTest):
                 "date_from": "2021-05-01",
                 "date_to": "2021-05-10",
             },
+            self.team.pk,
         )
 
         insert_cohort_from_insight_filter(cohort_id, params)

--- a/ee/tasks/test/test_calculate_cohort.py
+++ b/ee/tasks/test/test_calculate_cohort.py
@@ -45,6 +45,7 @@ class TestClickhouseCalculateCohort(ClickhouseTestMixin, calculate_cohort_test_f
                 "stickiness_days": "1",
                 "label": "$pageview",
             },
+            self.team.pk,
         )
 
         insert_cohort_from_insight_filter(
@@ -118,6 +119,7 @@ class TestClickhouseCalculateCohort(ClickhouseTestMixin, calculate_cohort_test_f
                 "date_to": "2021-01-01",
                 "label": "$pageview",
             },
+            self.team.pk,
         )
         insert_cohort_from_insight_filter(
             cohort_id,
@@ -228,6 +230,7 @@ class TestClickhouseCalculateCohort(ClickhouseTestMixin, calculate_cohort_test_f
                 "interval": "day",
                 "properties": '[{"key": "$domain", "value": "app.posthog.com", "operator": "icontains", "type": "event"}]',
             },
+            self.team.pk,
         )
         insert_cohort_from_insight_filter(
             cohort_id,
@@ -357,6 +360,7 @@ class TestClickhouseCalculateCohort(ClickhouseTestMixin, calculate_cohort_test_f
                 "date_to": "2021-01-07",
                 "funnel_step": "1",
             },
+            self.team.pk,
         )
 
         insert_cohort_from_insight_filter(cohort_id, params)
@@ -445,6 +449,7 @@ class TestClickhouseCalculateCohort(ClickhouseTestMixin, calculate_cohort_test_f
                 "entity_order": "0",
                 "lifecycle_type": "returning",
             },
+            self.team.pk,
         )
 
         insert_cohort_from_insight_filter(
@@ -507,6 +512,7 @@ class TestClickhouseCalculateCohort(ClickhouseTestMixin, calculate_cohort_test_f
                 "entity_order": "0",
                 "lifecycle_type": "dormant",
             },
+            self.team.pk,
         )
         self.assertEqual(_insert_cohort_from_insight_filter.call_count, 2)
 

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -238,9 +238,7 @@ class CohortSerializer(serializers.ModelSerializer):
 
         is_deletion_change = deleted_state is not None and cohort.deleted != deleted_state
         if is_deletion_change:
-            relevant_team_ids = (
-                Team.objects.order_by("id").filter(project_id=cohort.team.project_id).values_list("id", flat=True)
-            )
+            relevant_team_ids = Team.objects.filter(project_id=cohort.team.project_id).values_list("id", flat=True)
             cohort.deleted = deleted_state
             if deleted_state:
                 # De-attach from experiments

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -530,7 +530,7 @@ def insert_cohort_people_into_pg(cohort: Cohort, *, team_id: int):
 
 
 def insert_cohort_query_actors_into_ch(cohort: Cohort, *, team: Team):
-    context = HogQLContext(enable_select_queries=True, team=team)
+    context = HogQLContext(enable_select_queries=True, team_id=team.id)
     query = print_cohort_hogql_query(cohort, context, team=team)
     insert_actors_into_cohort_by_query(cohort, query, {}, context, team_id=team.id)
 

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -14,6 +14,7 @@ from posthog.models.feature_flag.flag_matching import (
 )
 from posthog.models.person.person import PersonDistinctId
 from posthog.models.property.property import Property, PropertyGroup
+from posthog.models.team.team import Team
 from posthog.queries.base import property_group_to_Q
 from posthog.metrics import LABEL_TEAM_ID
 from posthog.renderers import SafeJSONRenderer
@@ -208,7 +209,7 @@ class CohortSerializer(serializers.ModelSerializer):
                             )
 
                     if prop.type == "cohort":
-                        nested_cohort = Cohort.objects.get(pk=prop.value, team_id=self.context["team_id"])
+                        nested_cohort = Cohort.objects.get(pk=prop.value, team__project_id=self.context["project_id"])
                         dependent_cohorts = get_dependent_cohorts(nested_cohort)
                         for dependent_cohort in [nested_cohort, *dependent_cohorts]:
                             if (
@@ -480,7 +481,7 @@ class LegacyCohortViewSet(CohortViewSet):
 
 def will_create_loops(cohort: Cohort) -> bool:
     # Loops can only be formed when trying to update a Cohort, not when creating one
-    team_id = cohort.team_id
+    project_id = cohort.team.project_id
 
     # We can model this as a directed graph, where each node is a Cohort and each edge is a reference to another Cohort
     # There's a loop only if there's a cycle in the directed graph. The "directed" bit is important.
@@ -501,7 +502,7 @@ def will_create_loops(cohort: Cohort) -> bool:
                     return True
                 elif property.value not in seen_cohorts:
                     try:
-                        nested_cohort = Cohort.objects.get(pk=property.value, team_id=team_id)
+                        nested_cohort = Cohort.objects.get(pk=property.value, team__project_id=project_id)
                     except Cohort.DoesNotExist:
                         raise ValidationError("Invalid Cohort ID in filter")
 
@@ -623,15 +624,16 @@ def insert_actors_into_cohort_by_query(cohort: Cohort, query: str, params: dict[
 
 def get_cohort_actors_for_feature_flag(cohort_id: int, flag: str, team_id: int, batchsize: int = 1_000):
     # :TODO: Find a way to incorporate this into the same code path as feature flag evaluation
+    team: Team = Team.objects.get(pk=team_id)
     try:
-        feature_flag = FeatureFlag.objects.get(team_id=team_id, key=flag)
+        feature_flag = FeatureFlag.objects.get(team__project_id=team.project_id, key=flag)
     except FeatureFlag.DoesNotExist:
         return []
 
     if not feature_flag.active or feature_flag.deleted or feature_flag.aggregation_group_type_index is not None:
         return []
 
-    cohort = Cohort.objects.get(pk=cohort_id, team_id=team_id)
+    cohort = Cohort.objects.get(pk=cohort_id, team__project_id=team.project_id)
     matcher_cache = FlagsMatcherCache(team_id)
     uuids_to_add_to_cohort = []
     cohorts_cache: dict[int, CohortOrEmpty] = {}
@@ -640,7 +642,9 @@ def get_cohort_actors_for_feature_flag(cohort_id: int, flag: str, team_id: int, 
         # TODO: Consider disabling flags with cohorts for creating static cohorts
         # because this is currently a lot more inefficient for flag matching,
         # as we're required to go to the database for each person.
-        cohorts_cache = {cohort.pk: cohort for cohort in Cohort.objects.filter(team_id=team_id, deleted=False)}
+        cohorts_cache = {
+            cohort.pk: cohort for cohort in Cohort.objects.filter(team__project_id=team.project_id, deleted=False)
+        }
 
     default_person_properties = {}
     for condition in feature_flag.conditions:

--- a/posthog/api/test/__snapshots__/test_cohort.ambr
+++ b/posthog/api/test/__snapshots__/test_cohort.ambr
@@ -98,11 +98,14 @@
 # name: TestCohort.test_async_deletion_of_cohort.3
   '''
   /* user_id:0 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
-  SELECT count()
+  SELECT team_id,
+         count() AS stale_people_count
   FROM cohortpeople
-  WHERE team_id = 99999
+  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
     AND cohort_id = 99999
     AND version < 1
+  GROUP BY team_id
+  HAVING stale_people_count > 0
   '''
 # ---
 # name: TestCohort.test_async_deletion_of_cohort.4
@@ -163,11 +166,14 @@
 # name: TestCohort.test_async_deletion_of_cohort.7
   '''
   /* user_id:0 celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
-  SELECT count()
+  SELECT team_id,
+         count() AS stale_people_count
   FROM cohortpeople
-  WHERE team_id = 99999
+  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
     AND cohort_id = 99999
     AND version < 2
+  GROUP BY team_id
+  HAVING stale_people_count > 0
   '''
 # ---
 # name: TestCohort.test_async_deletion_of_cohort.8

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -1934,12 +1934,12 @@
   LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_accesscontrol"."organization_member_id" = "posthog_organizationmembership"."id")
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."resource" = 'project'
-          AND "ee_accesscontrol"."resource_id" = '22'
+          AND "ee_accesscontrol"."resource_id" = '313'
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
          OR ("posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."resource" = 'project'
-             AND "ee_accesscontrol"."resource_id" = '22'
+             AND "ee_accesscontrol"."resource_id" = '313'
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999)
          OR ("ee_accesscontrol"."organization_member_id" IS NULL
@@ -1954,12 +1954,12 @@
              AND "ee_accesscontrol"."team_id" = 99999)
          OR ("ee_accesscontrol"."organization_member_id" IS NULL
              AND "ee_accesscontrol"."resource" = 'feature_flag'
-             AND "ee_accesscontrol"."resource_id" = '35'
+             AND "ee_accesscontrol"."resource_id" = '130'
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999)
          OR ("posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."resource" = 'feature_flag'
-             AND "ee_accesscontrol"."resource_id" = '35'
+             AND "ee_accesscontrol"."resource_id" = '130'
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''

--- a/posthog/api/test/__snapshots__/test_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_feature_flag.ambr
@@ -337,111 +337,6 @@
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_iterator
   '''
-  SELECT "posthog_featureflag"."id",
-         "posthog_featureflag"."key",
-         "posthog_featureflag"."name",
-         "posthog_featureflag"."filters",
-         "posthog_featureflag"."rollout_percentage",
-         "posthog_featureflag"."team_id",
-         "posthog_featureflag"."created_by_id",
-         "posthog_featureflag"."created_at",
-         "posthog_featureflag"."deleted",
-         "posthog_featureflag"."active",
-         "posthog_featureflag"."rollback_conditions",
-         "posthog_featureflag"."performed_rollback",
-         "posthog_featureflag"."ensure_experience_continuity",
-         "posthog_featureflag"."usage_dashboard_id",
-         "posthog_featureflag"."has_enriched_analytics"
-  FROM "posthog_featureflag"
-  WHERE ("posthog_featureflag"."key" = 'some-feature2'
-         AND "posthog_featureflag"."team_id" = 99999)
-  LIMIT 21
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_iterator.1
-  '''
-  SELECT "posthog_cohort"."id",
-         "posthog_cohort"."name",
-         "posthog_cohort"."description",
-         "posthog_cohort"."team_id",
-         "posthog_cohort"."deleted",
-         "posthog_cohort"."filters",
-         "posthog_cohort"."query",
-         "posthog_cohort"."version",
-         "posthog_cohort"."pending_version",
-         "posthog_cohort"."count",
-         "posthog_cohort"."created_by_id",
-         "posthog_cohort"."created_at",
-         "posthog_cohort"."is_calculating",
-         "posthog_cohort"."last_calculation",
-         "posthog_cohort"."errors_calculating",
-         "posthog_cohort"."last_error_at",
-         "posthog_cohort"."is_static",
-         "posthog_cohort"."groups"
-  FROM "posthog_cohort"
-  WHERE ("posthog_cohort"."id" = 99999
-         AND "posthog_cohort"."team_id" = 99999)
-  LIMIT 21
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_iterator.2
-  '''
-  SELECT "posthog_person"."id",
-         "posthog_person"."created_at",
-         "posthog_person"."properties_last_updated_at",
-         "posthog_person"."properties_last_operation",
-         "posthog_person"."team_id",
-         "posthog_person"."properties",
-         "posthog_person"."is_user_id",
-         "posthog_person"."is_identified",
-         "posthog_person"."uuid",
-         "posthog_person"."version"
-  FROM "posthog_person"
-  WHERE ("posthog_person"."team_id" = 99999
-         AND ("posthog_person"."properties" -> 'key') = '"value"'::jsonb
-         AND "posthog_person"."properties" ? 'key'
-         AND NOT (("posthog_person"."properties" -> 'key') = 'null'::jsonb))
-  ORDER BY "posthog_person"."id" ASC
-  LIMIT 2
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_iterator.3
-  '''
-  SELECT "posthog_persondistinctid"."id",
-         "posthog_persondistinctid"."team_id",
-         "posthog_persondistinctid"."person_id",
-         "posthog_persondistinctid"."distinct_id",
-         "posthog_persondistinctid"."version"
-  FROM "posthog_persondistinctid"
-  WHERE ("posthog_persondistinctid"."id" IN
-           (SELECT U0."id"
-            FROM "posthog_persondistinctid" U0
-            WHERE U0."person_id" = ("posthog_persondistinctid"."person_id")
-            LIMIT 3)
-         AND "posthog_persondistinctid"."person_id" IN (1,
-                                                        2,
-                                                        3,
-                                                        4,
-                                                        5 /* ... */))
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_iterator.4
-  '''
-  SELECT "posthog_person"."uuid"
-  FROM "posthog_person"
-  WHERE ("posthog_person"."team_id" = 99999
-         AND "posthog_person"."uuid" IN ('00000000000040008000000000000000'::uuid,
-                                         '00000000000040008000000000000001'::uuid)
-         AND NOT (EXISTS
-                    (SELECT 1 AS "a"
-                     FROM "posthog_cohortpeople" U1
-                     WHERE (U1."cohort_id" = 99999
-                            AND U1."person_id" = ("posthog_person"."id"))
-                     LIMIT 1)))
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_iterator.5
-  '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
          "posthog_team"."organization_id",
@@ -496,18 +391,118 @@
          "posthog_team"."modifiers",
          "posthog_team"."correlation_config",
          "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
          "posthog_team"."external_data_workspace_id",
          "posthog_team"."external_data_workspace_last_synced_at"
   FROM "posthog_team"
   WHERE "posthog_team"."id" = 99999
   LIMIT 21
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_iterator.1
+  '''
+  SELECT "posthog_featureflag"."id",
+         "posthog_featureflag"."key",
+         "posthog_featureflag"."name",
+         "posthog_featureflag"."filters",
+         "posthog_featureflag"."rollout_percentage",
+         "posthog_featureflag"."team_id",
+         "posthog_featureflag"."created_by_id",
+         "posthog_featureflag"."created_at",
+         "posthog_featureflag"."deleted",
+         "posthog_featureflag"."active",
+         "posthog_featureflag"."rollback_conditions",
+         "posthog_featureflag"."performed_rollback",
+         "posthog_featureflag"."ensure_experience_continuity",
+         "posthog_featureflag"."usage_dashboard_id",
+         "posthog_featureflag"."has_enriched_analytics"
+  FROM "posthog_featureflag"
+  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
+  WHERE ("posthog_featureflag"."key" = 'some-feature2'
+         AND "posthog_team"."project_id" = 99999)
+  LIMIT 21
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_iterator.2
+  '''
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."query",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."last_error_at",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE ("posthog_cohort"."id" = 99999
+         AND "posthog_team"."project_id" = 99999)
+  LIMIT 21
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_iterator.3
+  '''
+  SELECT "posthog_person"."id",
+         "posthog_person"."created_at",
+         "posthog_person"."properties_last_updated_at",
+         "posthog_person"."properties_last_operation",
+         "posthog_person"."team_id",
+         "posthog_person"."properties",
+         "posthog_person"."is_user_id",
+         "posthog_person"."is_identified",
+         "posthog_person"."uuid",
+         "posthog_person"."version"
+  FROM "posthog_person"
+  WHERE ("posthog_person"."team_id" = 99999
+         AND ("posthog_person"."properties" -> 'key') = '"value"'::jsonb
+         AND "posthog_person"."properties" ? 'key'
+         AND NOT (("posthog_person"."properties" -> 'key') = 'null'::jsonb))
+  ORDER BY "posthog_person"."id" ASC
+  LIMIT 2
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_iterator.4
+  '''
+  SELECT "posthog_persondistinctid"."id",
+         "posthog_persondistinctid"."team_id",
+         "posthog_persondistinctid"."person_id",
+         "posthog_persondistinctid"."distinct_id",
+         "posthog_persondistinctid"."version"
+  FROM "posthog_persondistinctid"
+  WHERE ("posthog_persondistinctid"."id" IN
+           (SELECT U0."id"
+            FROM "posthog_persondistinctid" U0
+            WHERE U0."person_id" = ("posthog_persondistinctid"."person_id")
+            LIMIT 3)
+         AND "posthog_persondistinctid"."person_id" IN (1,
+                                                        2,
+                                                        3,
+                                                        4,
+                                                        5 /* ... */))
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_iterator.5
+  '''
+  SELECT "posthog_person"."uuid"
+  FROM "posthog_person"
+  WHERE ("posthog_person"."team_id" = 99999
+         AND "posthog_person"."uuid" IN ('00000000000040008000000000000000'::uuid,
+                                         '00000000000040008000000000000001'::uuid)
+         AND NOT (EXISTS
+                    (SELECT 1 AS "a"
+                     FROM "posthog_cohortpeople" U1
+                     WHERE (U1."cohort_id" = 99999
+                            AND U1."person_id" = ("posthog_person"."id"))
+                     LIMIT 1)))
   '''
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_iterator.6
@@ -590,72 +585,6 @@
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too
   '''
-  SELECT "posthog_featureflag"."id",
-         "posthog_featureflag"."key",
-         "posthog_featureflag"."name",
-         "posthog_featureflag"."filters",
-         "posthog_featureflag"."rollout_percentage",
-         "posthog_featureflag"."team_id",
-         "posthog_featureflag"."created_by_id",
-         "posthog_featureflag"."created_at",
-         "posthog_featureflag"."deleted",
-         "posthog_featureflag"."active",
-         "posthog_featureflag"."rollback_conditions",
-         "posthog_featureflag"."performed_rollback",
-         "posthog_featureflag"."ensure_experience_continuity",
-         "posthog_featureflag"."usage_dashboard_id",
-         "posthog_featureflag"."has_enriched_analytics"
-  FROM "posthog_featureflag"
-  WHERE ("posthog_featureflag"."key" = 'some-feature-new'
-         AND "posthog_featureflag"."team_id" = 99999)
-  LIMIT 21
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.1
-  '''
-  SELECT "posthog_cohort"."id",
-         "posthog_cohort"."name",
-         "posthog_cohort"."description",
-         "posthog_cohort"."team_id",
-         "posthog_cohort"."deleted",
-         "posthog_cohort"."filters",
-         "posthog_cohort"."query",
-         "posthog_cohort"."version",
-         "posthog_cohort"."pending_version",
-         "posthog_cohort"."count",
-         "posthog_cohort"."created_by_id",
-         "posthog_cohort"."created_at",
-         "posthog_cohort"."is_calculating",
-         "posthog_cohort"."last_calculation",
-         "posthog_cohort"."errors_calculating",
-         "posthog_cohort"."last_error_at",
-         "posthog_cohort"."is_static",
-         "posthog_cohort"."groups"
-  FROM "posthog_cohort"
-  WHERE ("posthog_cohort"."id" = 99999
-         AND "posthog_cohort"."team_id" = 99999)
-  LIMIT 21
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.10
-  '''
-  SELECT "posthog_person"."uuid"
-  FROM "posthog_person"
-  WHERE ("posthog_person"."team_id" = 99999
-         AND "posthog_person"."uuid" IN ('00000000000040008000000000000000'::uuid,
-                                         '00000000000040008000000000000001'::uuid,
-                                         '00000000000040008000000000000002'::uuid,
-                                         '00000000000040008000000000000003'::uuid)
-         AND NOT (EXISTS
-                    (SELECT 1 AS "a"
-                     FROM "posthog_cohortpeople" U1
-                     WHERE (U1."cohort_id" = 99999
-                            AND U1."person_id" = ("posthog_person"."id"))
-                     LIMIT 1)))
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.11
-  '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
          "posthog_team"."organization_id",
@@ -710,18 +639,92 @@
          "posthog_team"."modifiers",
          "posthog_team"."correlation_config",
          "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
          "posthog_team"."external_data_workspace_id",
          "posthog_team"."external_data_workspace_last_synced_at"
   FROM "posthog_team"
   WHERE "posthog_team"."id" = 99999
   LIMIT 21
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.1
+  '''
+  SELECT "posthog_featureflag"."id",
+         "posthog_featureflag"."key",
+         "posthog_featureflag"."name",
+         "posthog_featureflag"."filters",
+         "posthog_featureflag"."rollout_percentage",
+         "posthog_featureflag"."team_id",
+         "posthog_featureflag"."created_by_id",
+         "posthog_featureflag"."created_at",
+         "posthog_featureflag"."deleted",
+         "posthog_featureflag"."active",
+         "posthog_featureflag"."rollback_conditions",
+         "posthog_featureflag"."performed_rollback",
+         "posthog_featureflag"."ensure_experience_continuity",
+         "posthog_featureflag"."usage_dashboard_id",
+         "posthog_featureflag"."has_enriched_analytics"
+  FROM "posthog_featureflag"
+  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
+  WHERE ("posthog_featureflag"."key" = 'some-feature-new'
+         AND "posthog_team"."project_id" = 99999)
+  LIMIT 21
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.10
+  '''
+  SELECT "posthog_person"."id",
+         "posthog_person"."created_at",
+         "posthog_person"."properties_last_updated_at",
+         "posthog_person"."properties_last_operation",
+         "posthog_person"."team_id",
+         "posthog_person"."properties",
+         "posthog_person"."is_user_id",
+         "posthog_person"."is_identified",
+         "posthog_person"."uuid",
+         "posthog_person"."version"
+  FROM "posthog_person"
+  WHERE ("posthog_person"."team_id" = 99999
+         AND ((("posthog_person"."properties" -> 'group') = '"none"'::jsonb
+               AND "posthog_person"."properties" ? 'group'
+               AND NOT (("posthog_person"."properties" -> 'group') = 'null'::jsonb))
+              OR (("posthog_person"."properties" -> 'group2') IN ('1'::jsonb,
+                                                                  '2'::jsonb,
+                                                                  '3'::jsonb)
+                  AND "posthog_person"."properties" ? 'group2'
+                  AND NOT (("posthog_person"."properties" -> 'group2') = 'null'::jsonb))
+              OR EXISTS
+                (SELECT 1 AS "a"
+                 FROM "posthog_cohortpeople" U0
+                 WHERE (U0."cohort_id" = 99999
+                        AND U0."cohort_id" = 99999
+                        AND U0."person_id" = ("posthog_person"."id"))
+                 LIMIT 1)
+              OR (("posthog_person"."properties" -> 'does-not-exist') = '"none"'::jsonb
+                  AND "posthog_person"."properties" ? 'does-not-exist'
+                  AND NOT (("posthog_person"."properties" -> 'does-not-exist') = 'null'::jsonb))
+              OR (("posthog_person"."properties" -> 'key') = '"value"'::jsonb
+                  AND "posthog_person"."properties" ? 'key'
+                  AND NOT (("posthog_person"."properties" -> 'key') = 'null'::jsonb))))
+  ORDER BY "posthog_person"."id" ASC
+  LIMIT 1000
+  OFFSET 1000
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.11
+  '''
+  SELECT "posthog_person"."uuid"
+  FROM "posthog_person"
+  WHERE ("posthog_person"."team_id" = 99999
+         AND "posthog_person"."uuid" IN ('00000000000040008000000000000000'::uuid,
+                                         '00000000000040008000000000000001'::uuid,
+                                         '00000000000040008000000000000002'::uuid,
+                                         '00000000000040008000000000000003'::uuid)
+         AND NOT (EXISTS
+                    (SELECT 1 AS "a"
+                     FROM "posthog_cohortpeople" U1
+                     WHERE (U1."cohort_id" = 99999
+                            AND U1."person_id" = ("posthog_person"."id"))
+                     LIMIT 1)))
   '''
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.2
@@ -745,11 +748,39 @@
          "posthog_cohort"."is_static",
          "posthog_cohort"."groups"
   FROM "posthog_cohort"
-  WHERE (NOT "posthog_cohort"."deleted"
-         AND "posthog_cohort"."team_id" = 99999)
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE ("posthog_cohort"."id" = 99999
+         AND "posthog_team"."project_id" = 99999)
+  LIMIT 21
   '''
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.3
+  '''
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."query",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."last_error_at",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE (NOT "posthog_cohort"."deleted"
+         AND "posthog_team"."project_id" = 99999)
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.4
   '''
   SELECT "posthog_person"."id",
          "posthog_person"."created_at",
@@ -788,7 +819,7 @@
   LIMIT 1000
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.4
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.5
   '''
   SELECT "posthog_persondistinctid"."id",
          "posthog_persondistinctid"."team_id",
@@ -808,7 +839,7 @@
                                                         5 /* ... */))
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.5
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.6
   '''
   SELECT ("posthog_person"."id" IS NULL
           OR "posthog_person"."id" IS NULL
@@ -827,7 +858,7 @@
          AND "posthog_person"."team_id" = 99999)
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.6
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.7
   '''
   SELECT ("posthog_person"."id" IS NOT NULL
           OR "posthog_person"."id" IS NULL
@@ -846,7 +877,7 @@
          AND "posthog_person"."team_id" = 99999)
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.7
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.8
   '''
   SELECT ("posthog_person"."id" IS NULL
           OR "posthog_person"."id" IS NOT NULL
@@ -865,7 +896,7 @@
          AND "posthog_person"."team_id" = 99999)
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.8
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.9
   '''
   SELECT ("posthog_person"."id" IS NULL
           OR "posthog_person"."id" IS NULL
@@ -884,47 +915,70 @@
          AND "posthog_person"."team_id" = 99999)
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_cohort_flag_adds_cohort_props_as_default_too.9
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment
   '''
-  SELECT "posthog_person"."id",
-         "posthog_person"."created_at",
-         "posthog_person"."properties_last_updated_at",
-         "posthog_person"."properties_last_operation",
-         "posthog_person"."team_id",
-         "posthog_person"."properties",
-         "posthog_person"."is_user_id",
-         "posthog_person"."is_identified",
-         "posthog_person"."uuid",
-         "posthog_person"."version"
-  FROM "posthog_person"
-  WHERE ("posthog_person"."team_id" = 99999
-         AND ((("posthog_person"."properties" -> 'group') = '"none"'::jsonb
-               AND "posthog_person"."properties" ? 'group'
-               AND NOT (("posthog_person"."properties" -> 'group') = 'null'::jsonb))
-              OR (("posthog_person"."properties" -> 'group2') IN ('1'::jsonb,
-                                                                  '2'::jsonb,
-                                                                  '3'::jsonb)
-                  AND "posthog_person"."properties" ? 'group2'
-                  AND NOT (("posthog_person"."properties" -> 'group2') = 'null'::jsonb))
-              OR EXISTS
-                (SELECT 1 AS "a"
-                 FROM "posthog_cohortpeople" U0
-                 WHERE (U0."cohort_id" = 99999
-                        AND U0."cohort_id" = 99999
-                        AND U0."person_id" = ("posthog_person"."id"))
-                 LIMIT 1)
-              OR (("posthog_person"."properties" -> 'does-not-exist') = '"none"'::jsonb
-                  AND "posthog_person"."properties" ? 'does-not-exist'
-                  AND NOT (("posthog_person"."properties" -> 'does-not-exist') = 'null'::jsonb))
-              OR (("posthog_person"."properties" -> 'key') = '"value"'::jsonb
-                  AND "posthog_person"."properties" ? 'key'
-                  AND NOT (("posthog_person"."properties" -> 'key') = 'null'::jsonb))))
-  ORDER BY "posthog_person"."id" ASC
-  LIMIT 1000
-  OFFSET 1000
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.1
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -942,38 +996,32 @@
          "posthog_featureflag"."usage_dashboard_id",
          "posthog_featureflag"."has_enriched_analytics"
   FROM "posthog_featureflag"
+  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
   WHERE ("posthog_featureflag"."key" = 'some-feature2'
-         AND "posthog_featureflag"."team_id" = 99999)
-  LIMIT 21
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.1
-  '''
-  SELECT "posthog_cohort"."id",
-         "posthog_cohort"."name",
-         "posthog_cohort"."description",
-         "posthog_cohort"."team_id",
-         "posthog_cohort"."deleted",
-         "posthog_cohort"."filters",
-         "posthog_cohort"."query",
-         "posthog_cohort"."version",
-         "posthog_cohort"."pending_version",
-         "posthog_cohort"."count",
-         "posthog_cohort"."created_by_id",
-         "posthog_cohort"."created_at",
-         "posthog_cohort"."is_calculating",
-         "posthog_cohort"."last_calculation",
-         "posthog_cohort"."errors_calculating",
-         "posthog_cohort"."last_error_at",
-         "posthog_cohort"."is_static",
-         "posthog_cohort"."groups"
-  FROM "posthog_cohort"
-  WHERE ("posthog_cohort"."id" = 99999
-         AND "posthog_cohort"."team_id" = 99999)
+         AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.10
+  '''
+  SELECT "posthog_person"."id",
+         "posthog_person"."created_at",
+         "posthog_person"."properties_last_updated_at",
+         "posthog_person"."properties_last_operation",
+         "posthog_person"."team_id",
+         "posthog_person"."properties",
+         "posthog_person"."is_user_id",
+         "posthog_person"."is_identified",
+         "posthog_person"."uuid",
+         "posthog_person"."version"
+  FROM "posthog_person"
+  WHERE ("posthog_person"."team_id" = 99999
+         AND ("posthog_person"."properties" -> 'key') IS NOT NULL)
+  ORDER BY "posthog_person"."id" ASC
+  LIMIT 1000
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.11
   '''
   SELECT "posthog_persondistinctid"."id",
          "posthog_persondistinctid"."team_id",
@@ -993,7 +1041,7 @@
                                                         5 /* ... */))
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.11
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.12
   '''
   SELECT "posthog_person"."id",
          "posthog_person"."created_at",
@@ -1013,7 +1061,7 @@
   OFFSET 1000
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.12
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.13
   '''
   SELECT "posthog_person"."uuid"
   FROM "posthog_person"
@@ -1028,77 +1076,34 @@
                      LIMIT 1)))
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.13
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.2
   '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 99999
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."query",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."last_error_at",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE ("posthog_cohort"."id" = 99999
+         AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.2
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.3
   '''
   SELECT "posthog_person"."id",
          "posthog_person"."created_at",
@@ -1119,7 +1124,7 @@
   LIMIT 1000
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.3
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.4
   '''
   SELECT "posthog_persondistinctid"."id",
          "posthog_persondistinctid"."team_id",
@@ -1139,7 +1144,7 @@
                                                         5 /* ... */))
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.4
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.5
   '''
   SELECT "posthog_person"."id",
          "posthog_person"."created_at",
@@ -1161,7 +1166,7 @@
   OFFSET 1000
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.5
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.6
   '''
   SELECT "posthog_person"."uuid"
   FROM "posthog_person"
@@ -1175,7 +1180,7 @@
                      LIMIT 1)))
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.6
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.7
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -1231,13 +1236,6 @@
          "posthog_team"."modifiers",
          "posthog_team"."correlation_config",
          "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
          "posthog_team"."external_data_workspace_id",
          "posthog_team"."external_data_workspace_last_synced_at"
   FROM "posthog_team"
@@ -1245,7 +1243,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.7
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.8
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -1263,57 +1261,103 @@
          "posthog_featureflag"."usage_dashboard_id",
          "posthog_featureflag"."has_enriched_analytics"
   FROM "posthog_featureflag"
+  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
   WHERE ("posthog_featureflag"."key" = 'some-feature-new'
-         AND "posthog_featureflag"."team_id" = 99999)
-  LIMIT 21
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.8
-  '''
-  SELECT "posthog_cohort"."id",
-         "posthog_cohort"."name",
-         "posthog_cohort"."description",
-         "posthog_cohort"."team_id",
-         "posthog_cohort"."deleted",
-         "posthog_cohort"."filters",
-         "posthog_cohort"."query",
-         "posthog_cohort"."version",
-         "posthog_cohort"."pending_version",
-         "posthog_cohort"."count",
-         "posthog_cohort"."created_by_id",
-         "posthog_cohort"."created_at",
-         "posthog_cohort"."is_calculating",
-         "posthog_cohort"."last_calculation",
-         "posthog_cohort"."errors_calculating",
-         "posthog_cohort"."last_error_at",
-         "posthog_cohort"."is_static",
-         "posthog_cohort"."groups"
-  FROM "posthog_cohort"
-  WHERE ("posthog_cohort"."id" = 99999
-         AND "posthog_cohort"."team_id" = 99999)
+         AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_default_person_properties_adjustment.9
   '''
-  SELECT "posthog_person"."id",
-         "posthog_person"."created_at",
-         "posthog_person"."properties_last_updated_at",
-         "posthog_person"."properties_last_operation",
-         "posthog_person"."team_id",
-         "posthog_person"."properties",
-         "posthog_person"."is_user_id",
-         "posthog_person"."is_identified",
-         "posthog_person"."uuid",
-         "posthog_person"."version"
-  FROM "posthog_person"
-  WHERE ("posthog_person"."team_id" = 99999
-         AND ("posthog_person"."properties" -> 'key') IS NOT NULL)
-  ORDER BY "posthog_person"."id" ASC
-  LIMIT 1000
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."query",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."last_error_at",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE ("posthog_cohort"."id" = 99999
+         AND "posthog_team"."project_id" = 99999)
+  LIMIT 21
   '''
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag
+  '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.1
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -1331,12 +1375,13 @@
          "posthog_featureflag"."usage_dashboard_id",
          "posthog_featureflag"."has_enriched_analytics"
   FROM "posthog_featureflag"
+  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
   WHERE ("posthog_featureflag"."key" = 'some-feature2'
-         AND "posthog_featureflag"."team_id" = 99999)
+         AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.1
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.2
   '''
   SELECT "posthog_cohort"."id",
          "posthog_cohort"."name",
@@ -1357,12 +1402,13 @@
          "posthog_cohort"."is_static",
          "posthog_cohort"."groups"
   FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
   WHERE ("posthog_cohort"."id" = 99999
-         AND "posthog_cohort"."team_id" = 99999)
+         AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.2
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.3
   '''
   SELECT "posthog_person"."id",
          "posthog_person"."created_at",
@@ -1383,7 +1429,7 @@
   LIMIT 1000
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.3
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.4
   '''
   SELECT "posthog_persondistinctid"."id",
          "posthog_persondistinctid"."team_id",
@@ -1401,20 +1447,6 @@
                                                         3,
                                                         4,
                                                         5 /* ... */))
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.4
-  '''
-  SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key",
-         "posthog_featureflaghashkeyoverride"."hash_key",
-         "posthog_featureflaghashkeyoverride"."person_id"
-  FROM "posthog_featureflaghashkeyoverride"
-  WHERE ("posthog_featureflaghashkeyoverride"."person_id" IN (1,
-                                                              2,
-                                                              3,
-                                                              4,
-                                                              5 /* ... */)
-         AND "posthog_featureflaghashkeyoverride"."team_id" = 99999)
   '''
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.5
@@ -1447,6 +1479,20 @@
 # ---
 # name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.7
   '''
+  SELECT "posthog_featureflaghashkeyoverride"."feature_flag_key",
+         "posthog_featureflaghashkeyoverride"."hash_key",
+         "posthog_featureflaghashkeyoverride"."person_id"
+  FROM "posthog_featureflaghashkeyoverride"
+  WHERE ("posthog_featureflaghashkeyoverride"."person_id" IN (1,
+                                                              2,
+                                                              3,
+                                                              4,
+                                                              5 /* ... */)
+         AND "posthog_featureflaghashkeyoverride"."team_id" = 99999)
+  '''
+# ---
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.8
+  '''
   SELECT "posthog_person"."id",
          "posthog_person"."created_at",
          "posthog_person"."properties_last_updated_at",
@@ -1467,7 +1513,7 @@
   OFFSET 1000
   '''
 # ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.8
+# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.9
   '''
   SELECT "posthog_person"."uuid"
   FROM "posthog_person"
@@ -1479,76 +1525,6 @@
                      WHERE (U1."cohort_id" = 99999
                             AND U1."person_id" = ("posthog_person"."id"))
                      LIMIT 1)))
-  '''
-# ---
-# name: TestCohortGenerationForFeatureFlag.test_creating_static_cohort_with_experience_continuity_flag.9
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 99999
-  LIMIT 21
   '''
 # ---
 # name: TestFeatureFlag.test_cant_create_flag_with_data_that_fails_to_query
@@ -1669,6 +1645,33 @@
 # ---
 # name: TestFeatureFlag.test_creating_static_cohort.10
   '''
+  SELECT "posthog_cohort"."id",
+         "posthog_cohort"."name",
+         "posthog_cohort"."description",
+         "posthog_cohort"."team_id",
+         "posthog_cohort"."deleted",
+         "posthog_cohort"."filters",
+         "posthog_cohort"."query",
+         "posthog_cohort"."version",
+         "posthog_cohort"."pending_version",
+         "posthog_cohort"."count",
+         "posthog_cohort"."created_by_id",
+         "posthog_cohort"."created_at",
+         "posthog_cohort"."is_calculating",
+         "posthog_cohort"."last_calculation",
+         "posthog_cohort"."errors_calculating",
+         "posthog_cohort"."last_error_at",
+         "posthog_cohort"."is_static",
+         "posthog_cohort"."groups"
+  FROM "posthog_cohort"
+  INNER JOIN "posthog_team" ON ("posthog_cohort"."team_id" = "posthog_team"."id")
+  WHERE ("posthog_cohort"."id" = 99999
+         AND "posthog_team"."project_id" = 99999)
+  LIMIT 21
+  '''
+# ---
+# name: TestFeatureFlag.test_creating_static_cohort.11
+  '''
   SELECT "posthog_person"."id",
          "posthog_person"."created_at",
          "posthog_person"."properties_last_updated_at",
@@ -1688,7 +1691,7 @@
   LIMIT 10000
   '''
 # ---
-# name: TestFeatureFlag.test_creating_static_cohort.11
+# name: TestFeatureFlag.test_creating_static_cohort.12
   '''
   SELECT "posthog_persondistinctid"."id",
          "posthog_persondistinctid"."team_id",
@@ -1708,7 +1711,7 @@
                                                         5 /* ... */))
   '''
 # ---
-# name: TestFeatureFlag.test_creating_static_cohort.12
+# name: TestFeatureFlag.test_creating_static_cohort.13
   '''
   SELECT "posthog_person"."id",
          "posthog_person"."created_at",
@@ -1730,7 +1733,7 @@
   OFFSET 10000
   '''
 # ---
-# name: TestFeatureFlag.test_creating_static_cohort.13
+# name: TestFeatureFlag.test_creating_static_cohort.14
   '''
   SELECT "posthog_person"."uuid"
   FROM "posthog_person"
@@ -1742,76 +1745,6 @@
                      WHERE (U1."cohort_id" = 99999
                             AND U1."person_id" = ("posthog_person"."id"))
                      LIMIT 1)))
-  '''
-# ---
-# name: TestFeatureFlag.test_creating_static_cohort.14
-  '''
-  SELECT "posthog_team"."id",
-         "posthog_team"."uuid",
-         "posthog_team"."organization_id",
-         "posthog_team"."project_id",
-         "posthog_team"."api_token",
-         "posthog_team"."app_urls",
-         "posthog_team"."name",
-         "posthog_team"."slack_incoming_webhook",
-         "posthog_team"."created_at",
-         "posthog_team"."updated_at",
-         "posthog_team"."anonymize_ips",
-         "posthog_team"."completed_snippet_onboarding",
-         "posthog_team"."has_completed_onboarding_for",
-         "posthog_team"."ingested_event",
-         "posthog_team"."autocapture_opt_out",
-         "posthog_team"."autocapture_web_vitals_opt_in",
-         "posthog_team"."autocapture_web_vitals_allowed_metrics",
-         "posthog_team"."autocapture_exceptions_opt_in",
-         "posthog_team"."autocapture_exceptions_errors_to_ignore",
-         "posthog_team"."person_processing_opt_out",
-         "posthog_team"."session_recording_opt_in",
-         "posthog_team"."session_recording_sample_rate",
-         "posthog_team"."session_recording_minimum_duration_milliseconds",
-         "posthog_team"."session_recording_linked_flag",
-         "posthog_team"."session_recording_network_payload_capture_config",
-         "posthog_team"."session_recording_url_trigger_config",
-         "posthog_team"."session_recording_url_blocklist_config",
-         "posthog_team"."session_recording_event_trigger_config",
-         "posthog_team"."session_replay_config",
-         "posthog_team"."survey_config",
-         "posthog_team"."capture_console_log_opt_in",
-         "posthog_team"."capture_performance_opt_in",
-         "posthog_team"."capture_dead_clicks",
-         "posthog_team"."surveys_opt_in",
-         "posthog_team"."heatmaps_opt_in",
-         "posthog_team"."session_recording_version",
-         "posthog_team"."signup_token",
-         "posthog_team"."is_demo",
-         "posthog_team"."access_control",
-         "posthog_team"."week_start_day",
-         "posthog_team"."inject_web_apps",
-         "posthog_team"."test_account_filters",
-         "posthog_team"."test_account_filters_default_checked",
-         "posthog_team"."path_cleaning_filters",
-         "posthog_team"."timezone",
-         "posthog_team"."data_attributes",
-         "posthog_team"."person_display_name_properties",
-         "posthog_team"."live_events_columns",
-         "posthog_team"."recording_domains",
-         "posthog_team"."primary_dashboard_id",
-         "posthog_team"."extra_settings",
-         "posthog_team"."modifiers",
-         "posthog_team"."correlation_config",
-         "posthog_team"."session_recording_retention_period_days",
-         "posthog_team"."plugins_opt_in",
-         "posthog_team"."opt_out_capture",
-         "posthog_team"."event_names",
-         "posthog_team"."event_names_with_usage",
-         "posthog_team"."event_properties",
-         "posthog_team"."event_properties_with_usage",
-         "posthog_team"."event_properties_numerical",
-         "posthog_team"."external_data_workspace_id",
-         "posthog_team"."external_data_workspace_last_synced_at"
-  FROM "posthog_team"
-  WHERE "posthog_team"."id" = 99999
-  LIMIT 21
   '''
 # ---
 # name: TestFeatureFlag.test_creating_static_cohort.15
@@ -2001,12 +1934,12 @@
   LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_accesscontrol"."organization_member_id" = "posthog_organizationmembership"."id")
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."resource" = 'project'
-          AND "ee_accesscontrol"."resource_id" = '313'
+          AND "ee_accesscontrol"."resource_id" = '22'
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
          OR ("posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."resource" = 'project'
-             AND "ee_accesscontrol"."resource_id" = '313'
+             AND "ee_accesscontrol"."resource_id" = '22'
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999)
          OR ("ee_accesscontrol"."organization_member_id" IS NULL
@@ -2021,12 +1954,12 @@
              AND "ee_accesscontrol"."team_id" = 99999)
          OR ("ee_accesscontrol"."organization_member_id" IS NULL
              AND "ee_accesscontrol"."resource" = 'feature_flag'
-             AND "ee_accesscontrol"."resource_id" = '130'
+             AND "ee_accesscontrol"."resource_id" = '35'
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999)
          OR ("posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."resource" = 'feature_flag'
-             AND "ee_accesscontrol"."resource_id" = '130'
+             AND "ee_accesscontrol"."resource_id" = '35'
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -2142,6 +2075,69 @@
 # ---
 # name: TestFeatureFlag.test_creating_static_cohort.8
   '''
+  SELECT "posthog_team"."id",
+         "posthog_team"."uuid",
+         "posthog_team"."organization_id",
+         "posthog_team"."project_id",
+         "posthog_team"."api_token",
+         "posthog_team"."app_urls",
+         "posthog_team"."name",
+         "posthog_team"."slack_incoming_webhook",
+         "posthog_team"."created_at",
+         "posthog_team"."updated_at",
+         "posthog_team"."anonymize_ips",
+         "posthog_team"."completed_snippet_onboarding",
+         "posthog_team"."has_completed_onboarding_for",
+         "posthog_team"."ingested_event",
+         "posthog_team"."autocapture_opt_out",
+         "posthog_team"."autocapture_web_vitals_opt_in",
+         "posthog_team"."autocapture_web_vitals_allowed_metrics",
+         "posthog_team"."autocapture_exceptions_opt_in",
+         "posthog_team"."autocapture_exceptions_errors_to_ignore",
+         "posthog_team"."person_processing_opt_out",
+         "posthog_team"."session_recording_opt_in",
+         "posthog_team"."session_recording_sample_rate",
+         "posthog_team"."session_recording_minimum_duration_milliseconds",
+         "posthog_team"."session_recording_linked_flag",
+         "posthog_team"."session_recording_network_payload_capture_config",
+         "posthog_team"."session_recording_url_trigger_config",
+         "posthog_team"."session_recording_url_blocklist_config",
+         "posthog_team"."session_recording_event_trigger_config",
+         "posthog_team"."session_replay_config",
+         "posthog_team"."survey_config",
+         "posthog_team"."capture_console_log_opt_in",
+         "posthog_team"."capture_performance_opt_in",
+         "posthog_team"."capture_dead_clicks",
+         "posthog_team"."surveys_opt_in",
+         "posthog_team"."heatmaps_opt_in",
+         "posthog_team"."session_recording_version",
+         "posthog_team"."signup_token",
+         "posthog_team"."is_demo",
+         "posthog_team"."access_control",
+         "posthog_team"."week_start_day",
+         "posthog_team"."inject_web_apps",
+         "posthog_team"."test_account_filters",
+         "posthog_team"."test_account_filters_default_checked",
+         "posthog_team"."path_cleaning_filters",
+         "posthog_team"."timezone",
+         "posthog_team"."data_attributes",
+         "posthog_team"."person_display_name_properties",
+         "posthog_team"."live_events_columns",
+         "posthog_team"."recording_domains",
+         "posthog_team"."primary_dashboard_id",
+         "posthog_team"."extra_settings",
+         "posthog_team"."modifiers",
+         "posthog_team"."correlation_config",
+         "posthog_team"."session_recording_retention_period_days",
+         "posthog_team"."external_data_workspace_id",
+         "posthog_team"."external_data_workspace_last_synced_at"
+  FROM "posthog_team"
+  WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestFeatureFlag.test_creating_static_cohort.9
+  '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
          "posthog_featureflag"."name",
@@ -2158,34 +2154,9 @@
          "posthog_featureflag"."usage_dashboard_id",
          "posthog_featureflag"."has_enriched_analytics"
   FROM "posthog_featureflag"
+  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
   WHERE ("posthog_featureflag"."key" = 'some-feature'
-         AND "posthog_featureflag"."team_id" = 99999)
-  LIMIT 21
-  '''
-# ---
-# name: TestFeatureFlag.test_creating_static_cohort.9
-  '''
-  SELECT "posthog_cohort"."id",
-         "posthog_cohort"."name",
-         "posthog_cohort"."description",
-         "posthog_cohort"."team_id",
-         "posthog_cohort"."deleted",
-         "posthog_cohort"."filters",
-         "posthog_cohort"."query",
-         "posthog_cohort"."version",
-         "posthog_cohort"."pending_version",
-         "posthog_cohort"."count",
-         "posthog_cohort"."created_by_id",
-         "posthog_cohort"."created_at",
-         "posthog_cohort"."is_calculating",
-         "posthog_cohort"."last_calculation",
-         "posthog_cohort"."errors_calculating",
-         "posthog_cohort"."last_error_at",
-         "posthog_cohort"."is_static",
-         "posthog_cohort"."groups"
-  FROM "posthog_cohort"
-  WHERE ("posthog_cohort"."id" = 99999
-         AND "posthog_cohort"."team_id" = 99999)
+         AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
 # ---

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -1111,7 +1111,7 @@ email@example.org,
         self.assertEqual(1, _calc("select 1 from events"))
 
         # raises on all other cases
-        response = self.client.post(
+        query_post_response = self.client.post(
             f"/api/projects/{self.team.id}/cohorts",
             data={
                 "name": "cohort A",
@@ -1122,7 +1122,15 @@ email@example.org,
                 },
             },
         )
-        self.assertEqual(response.status_code, 500, response.content)
+        query_get_response = self.client.get(
+            f"/api/projects/{self.team.id}/cohorts/{query_post_response.json()['id']}/"
+        )
+
+        self.assertEqual(query_post_response.status_code, 201)
+        self.assertEqual(query_get_response.status_code, 200)
+        self.assertEqual(
+            query_get_response.json()["errors_calculating"], 1
+        )  # Should be because selecting from groups is not allowed
 
     @patch("posthog.api.cohort.report_user_action")
     def test_cohort_with_is_set_filter_missing_value(self, patch_capture):

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1259,7 +1259,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
                 format="json",
             ).json()
 
-        with self.assertNumQueries(FuzzyInt(7, 8)):
+        with self.assertNumQueries(FuzzyInt(8, 9)):
             response = self.client.get(f"/api/projects/{self.team.id}/feature_flags/my_flags")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -2229,7 +2229,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         self.client.logout()
 
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(18):
             # 1. SAVEPOINT
             # 2. SELECT "posthog_personalapikey"."id",
             # 3. RELEASE SAVEPOINT
@@ -2242,10 +2242,12 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             # 10. SELECT "posthog_organizationmembership"."id",
             # 11. SELECT "posthog_cohort"."id"  -- all cohorts
             # 12. SELECT "posthog_featureflag"."id", "posthog_featureflag"."key", -- all flags
-            # 13. SELECT "posthog_cohort". id = 99999
-            # 14. SELECT "posthog_cohort". id = deleted cohort
-            # 15. SELECT "posthog_cohort". id = cohort from other team
-            # 16. SELECT "posthog_grouptypemapping"."id", -- group type mapping
+            # 13. SELECT "posthog_team"."id", "posthog_team"."uuid",
+            # 14. SELECT "posthog_cohort". id = 99999
+            # 15. SELECT "posthog_team"."id", "posthog_team"."uuid",
+            # 16. SELECT "posthog_cohort". id = deleted cohort
+            # 17. SELECT "posthog_cohort". id = cohort from other team
+            # 18. SELECT "posthog_grouptypemapping"."id", -- group type mapping
 
             response = self.client.get(
                 f"/api/feature_flag/local_evaluation?token={self.team.api_token}&send_cohorts",
@@ -4230,7 +4232,7 @@ class TestCohortGenerationForFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             name="some cohort",
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             get_cohort_actors_for_feature_flag(cohort.pk, "some-feature", self.team.pk)
 
         cohort.refresh_from_db()
@@ -4268,7 +4270,7 @@ class TestCohortGenerationForFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             name="some cohort",
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             get_cohort_actors_for_feature_flag(cohort.pk, "some-feature2", self.team.pk)
 
         cohort.refresh_from_db()
@@ -4307,7 +4309,7 @@ class TestCohortGenerationForFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             name="some cohort",
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             get_cohort_actors_for_feature_flag(cohort.pk, "some-feature3", self.team.pk)
 
         cohort.refresh_from_db()
@@ -4339,7 +4341,7 @@ class TestCohortGenerationForFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             name="some cohort",
         )
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             get_cohort_actors_for_feature_flag(cohort.pk, "some-feature2", self.team.pk)
 
         cohort.refresh_from_db()
@@ -4357,7 +4359,7 @@ class TestCohortGenerationForFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             name="some cohort",
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             get_cohort_actors_for_feature_flag(cohort.pk, "some-feature2", self.team.pk)
 
         cohort.refresh_from_db()

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -42,11 +42,14 @@
 # name: TestTrends.test_action_filtering_with_cohort.4
   '''
   /* celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
-  SELECT count()
+  SELECT team_id,
+         count() AS stale_people_count
   FROM cohortpeople
-  WHERE team_id = 99999
+  WHERE team_id IN [434]
     AND cohort_id = 99999
     AND version < 2
+  GROUP BY team_id
+  HAVING stale_people_count > 0
   '''
 # ---
 # name: TestTrends.test_action_filtering_with_cohort.5
@@ -138,11 +141,14 @@
 # name: TestTrends.test_action_filtering_with_cohort_poe_v2.4
   '''
   /* celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
-  SELECT count()
+  SELECT team_id,
+         count() AS stale_people_count
   FROM cohortpeople
-  WHERE team_id = 99999
+  WHERE team_id IN [435]
     AND cohort_id = 99999
     AND version < 2
+  GROUP BY team_id
+  HAVING stale_people_count > 0
   '''
 # ---
 # name: TestTrends.test_action_filtering_with_cohort_poe_v2.5

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -45,7 +45,7 @@
   SELECT team_id,
          count() AS stale_people_count
   FROM cohortpeople
-  WHERE team_id IN [434]
+  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
     AND cohort_id = 99999
     AND version < 2
   GROUP BY team_id
@@ -144,7 +144,7 @@
   SELECT team_id,
          count() AS stale_people_count
   FROM cohortpeople
-  WHERE team_id IN [435]
+  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
     AND cohort_id = 99999
     AND version < 2
   GROUP BY team_id

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -219,7 +219,10 @@ class TrendsQueryRunner(QueryRunner):
                 for value in self.query.breakdownFilter.breakdown:
                     if value != "all" and str(value) != "0":
                         res_breakdown.append(
-                            BreakdownItem(label=Cohort.objects.get(pk=int(value), team=self.team).name, value=value)
+                            BreakdownItem(
+                                label=Cohort.objects.get(pk=int(value), team__project_id=self.team.project_id).name,
+                                value=value,
+                            )
                         )
                     else:
                         res_breakdown.append(BreakdownItem(label="all users", value="all"))

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -289,7 +289,7 @@ class Cohort(models.Model):
                 insert_static_cohort(
                     list(persons_query.values_list("uuid", flat=True)),
                     self.pk,
-                    team_id,
+                    team_id=team_id,
                 )
                 sql, params = persons_query.distinct("pk").only("pk").query.sql_with_params()
                 query = UPDATE_QUERY.format(
@@ -343,7 +343,7 @@ class Cohort(models.Model):
                     insert_static_cohort(
                         list(persons_query.values_list("uuid", flat=True)),
                         self.pk,
-                        team_id,
+                        team_id=team_id,
                     )
                 sql, params = persons_query.distinct("pk").only("pk").query.sql_with_params()
                 query = UPDATE_QUERY.format(

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -250,11 +250,16 @@ class Cohort(models.Model):
 
         clear_stale_cohort.delay(self.pk, before_version=pending_version)
 
-    def insert_users_by_list(self, items: list[str]) -> None:
+    def insert_users_by_list(self, items: list[str], *, team_id: Optional[int] = None) -> None:
         """
-        Items is a list of distinct_ids
-        """
+        Insert a list of users identified by their distinct ID into the cohort, for the given team.
 
+        Args:
+            items: List of distinct IDs of users to be inserted into the cohort.
+            team_id: ID of the team for which to insert the users. Defaults to `self.team`, because of a lot of existing usage in tests.
+        """
+        if team_id is None:
+            team_id = self.team_id
         batchsize = 1000
         from posthog.models.cohort.util import (
             insert_static_cohort,
@@ -272,10 +277,10 @@ class Cohort(models.Model):
             for i in range(0, len(items), batchsize):
                 batch = items[i : i + batchsize]
                 persons_query = (
-                    Person.objects.filter(team_id=self.team_id)
+                    Person.objects.filter(team_id=team_id)
                     .filter(
                         Q(
-                            persondistinctid__team_id=self.team_id,
+                            persondistinctid__team_id=team_id,
                             persondistinctid__distinct_id__in=batch,
                         )
                     )
@@ -284,7 +289,7 @@ class Cohort(models.Model):
                 insert_static_cohort(
                     list(persons_query.values_list("uuid", flat=True)),
                     self.pk,
-                    self.team,
+                    team_id,
                 )
                 sql, params = persons_query.distinct("pk").only("pk").query.sql_with_params()
                 query = UPDATE_QUERY.format(
@@ -297,7 +302,7 @@ class Cohort(models.Model):
                 )
                 cursor.execute(query, params)
 
-            count = get_static_cohort_size(self)
+            count = get_static_cohort_size(self, team_id=team_id)
             self.count = count
 
             self.is_calculating = False
@@ -313,7 +318,18 @@ class Cohort(models.Model):
             self.save()
             capture_exception(err)
 
-    def insert_users_list_by_uuid(self, items: list[str], insert_in_clickhouse: bool = False, batchsize=1000) -> None:
+    def insert_users_list_by_uuid(
+        self, items: list[str], insert_in_clickhouse: bool = False, batchsize=1000, *, team_id: int
+    ) -> None:
+        """
+        Insert a list of users identified by their UUID into the cohort, for the given team.
+
+        Args:
+            items: List of user UUIDs to be inserted into the cohort.
+            insert_in_clickhouse: Whether the data should also be inserted into ClickHouse.
+            batchsize: Number of UUIDs to process in each batch.
+            team_id: The ID of the team to which the cohort belongs.
+        """
         from posthog.models.cohort.util import get_static_cohort_size, insert_static_cohort
 
         try:
@@ -321,13 +337,13 @@ class Cohort(models.Model):
             for i in range(0, len(items), batchsize):
                 batch = items[i : i + batchsize]
                 persons_query = (
-                    Person.objects.filter(team_id=self.team_id).filter(uuid__in=batch).exclude(cohort__id=self.id)
+                    Person.objects.filter(team_id=team_id).filter(uuid__in=batch).exclude(cohort__id=self.id)
                 )
                 if insert_in_clickhouse:
                     insert_static_cohort(
                         list(persons_query.values_list("uuid", flat=True)),
                         self.pk,
-                        self.team,
+                        team_id,
                     )
                 sql, params = persons_query.distinct("pk").only("pk").query.sql_with_params()
                 query = UPDATE_QUERY.format(
@@ -340,7 +356,7 @@ class Cohort(models.Model):
                 )
                 cursor.execute(query, params)
 
-            count = get_static_cohort_size(self)
+            count = get_static_cohort_size(self, team_id=team_id)
             self.count = count
 
             self.is_calculating = False
@@ -356,12 +372,6 @@ class Cohort(models.Model):
 
             self.save()
             capture_exception(err)
-
-    def _clickhouse_persons_query(self, batch_size=10000, offset=0):
-        from posthog.models.cohort.util import get_person_ids_by_cohort_id
-
-        uuids = get_person_ids_by_cohort_id(team=self.team, cohort_id=self.pk, limit=batch_size, offset=offset)
-        return Person.objects.filter(uuid__in=uuids, team=self.team)
 
     __repr__ = sane_repr("id", "name", "last_calculation")
 

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -302,7 +302,7 @@ class Cohort(models.Model):
                 )
                 cursor.execute(query, params)
 
-            count = get_static_cohort_size(self, team_id=team_id)
+            count = get_static_cohort_size(cohort_id=self.id, team_id=team_id)
             self.count = count
 
             self.is_calculating = False
@@ -356,7 +356,7 @@ class Cohort(models.Model):
                 )
                 cursor.execute(query, params)
 
-            count = get_static_cohort_size(self, team_id=team_id)
+            count = get_static_cohort_size(cohort_id=self.id, team_id=team_id)
             self.count = count
 
             self.is_calculating = False

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -302,7 +302,7 @@ class Cohort(models.Model):
                 )
                 cursor.execute(query, params)
 
-            count = get_static_cohort_size(cohort_id=self.id, team_id=team_id)
+            count = get_static_cohort_size(cohort_id=self.id, team_id=self.team_id)
             self.count = count
 
             self.is_calculating = False
@@ -356,7 +356,7 @@ class Cohort(models.Model):
                 )
                 cursor.execute(query, params)
 
-            count = get_static_cohort_size(cohort_id=self.id, team_id=team_id)
+            count = get_static_cohort_size(cohort_id=self.id, team_id=self.team_id)
             self.count = count
 
             self.is_calculating = False

--- a/posthog/models/cohort/sql.py
+++ b/posthog/models/cohort/sql.py
@@ -91,6 +91,8 @@ WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s
 """
 
 STALE_COHORTPEOPLE = f"""
-SELECT count() FROM cohortpeople
-WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s AND version < %(version)s
+SELECT team_id, count() AS stale_people_count FROM cohortpeople
+WHERE team_id IN %(team_ids)s AND cohort_id = %(cohort_id)s AND version < %(version)s
+GROUP BY team_id
+HAVING stale_people_count > 0
 """

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -247,17 +247,13 @@ def format_filter_query(
     hogql_context: HogQLContext,
     id_column: str = "distinct_id",
     custom_match_field="person_id",
-    *,
-    team: Team,
 ) -> tuple[str, dict[str, Any]]:
-    person_query, params = format_cohort_subquery(
-        cohort, index, hogql_context, custom_match_field=custom_match_field, team=team
-    )
+    person_query, params = format_cohort_subquery(cohort, index, hogql_context, custom_match_field=custom_match_field)
 
     person_id_query = CALCULATE_COHORT_PEOPLE_SQL.format(
         query=person_query,
         id_column=id_column,
-        GET_TEAM_PERSON_DISTINCT_IDS=get_team_distinct_ids_query(team.id),
+        GET_TEAM_PERSON_DISTINCT_IDS=get_team_distinct_ids_query(cohort.team_id),
     )
     return person_id_query, params
 
@@ -314,7 +310,7 @@ def recalculate_cohortpeople(
         count_for_team = _recalculate_cohortpeople_for_team(
             cohort, pending_version, team, initiating_user_id=initiating_user_id
         )
-        counts.append(count_for_team)
+        counts.append(cast(int, count_for_team))
     return counts[0]
 
 
@@ -322,7 +318,7 @@ def _recalculate_cohortpeople_for_team(
     cohort: Cohort, pending_version: int, team: Team, *, initiating_user_id: Optional[int]
 ) -> Optional[int]:
     hogql_context = HogQLContext(within_non_hogql_query=True, team=team)
-    cohort_query, cohort_params = format_person_query(cohort, 0, hogql_context, team=team)
+    cohort_query, cohort_params = format_person_query(cohort, 0, hogql_context)
 
     before_count = get_cohort_size(cohort, team_id=team.id)
 

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -370,7 +370,7 @@ def _recalculate_cohortpeople_for_team(
 
 def clear_stale_cohortpeople(cohort: Cohort, before_version: int) -> None:
     if cohort.version and cohort.version > 0:
-        relevant_team_ids = Team.objects.filter(project_id=cohort.team.project_id).values_list("pk", flat=True)
+        relevant_team_ids = list(Team.objects.filter(project_id=cohort.team.project_id).values_list("pk", flat=True))
         stale_count_result = sync_execute(
             STALE_COHORTPEOPLE,
             {

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -317,7 +317,7 @@ def recalculate_cohortpeople(
 def _recalculate_cohortpeople_for_team(
     cohort: Cohort, pending_version: int, team: Team, *, initiating_user_id: Optional[int]
 ) -> Optional[int]:
-    hogql_context = HogQLContext(within_non_hogql_query=True, team=team)
+    hogql_context = HogQLContext(within_non_hogql_query=True, team_id=team.id)
     cohort_query, cohort_params = format_person_query(cohort, 0, hogql_context)
 
     before_count = get_cohort_size(cohort, team_id=team.id)

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -303,15 +303,18 @@ def get_static_cohort_size(*, cohort_id: int, team_id: int) -> Optional[int]:
 def recalculate_cohortpeople(
     cohort: Cohort, pending_version: int, *, initiating_user_id: Optional[int]
 ) -> Optional[int]:
-    # All environments where the cohort is present
+    """
+    Recalculate cohort people for all environments of the project.
+    NOTE: Currently this only returns the count for the team where the cohort was created. Instead it should return for all teams.
+    """
     relevant_teams = Team.objects.order_by("id").filter(project_id=cohort.team.project_id)
-    counts: list[int] = []
+    count_by_team_id: dict[int, int] = {}
     for team in relevant_teams:
         count_for_team = _recalculate_cohortpeople_for_team(
             cohort, pending_version, team, initiating_user_id=initiating_user_id
         )
-        counts.append(cast(int, count_for_team))
-    return counts[0]
+        count_by_team_id[team.id] = count_for_team or 0
+    return count_by_team_id[cohort.team_id]
 
 
 def _recalculate_cohortpeople_for_team(

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -285,11 +285,11 @@ def insert_static_cohort(person_uuids: list[Optional[uuid.UUID]], cohort_id: int
     sync_execute(INSERT_PERSON_STATIC_COHORT, persons)
 
 
-def get_static_cohort_size(cohort: Cohort, *, team_id: int) -> Optional[int]:
+def get_static_cohort_size(*, cohort_id: int, team_id: int) -> Optional[int]:
     count_result = sync_execute(
         GET_STATIC_COHORT_SIZE_SQL,
         {
-            "cohort_id": cohort.pk,
+            "cohort_id": cohort_id,
             "team_id": team_id,
         },
     )

--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -395,24 +395,31 @@ def recalculate_cohortpeople(
 
 def clear_stale_cohortpeople(cohort: Cohort, before_version: int) -> None:
     if cohort.version and cohort.version > 0:
+        relevant_team_ids = Team.objects.filter(project_id=cohort.team.project_id).values_list("pk", flat=True)
         stale_count_result = sync_execute(
             STALE_COHORTPEOPLE,
             {
                 "cohort_id": cohort.pk,
-                "team_id": cohort.team_id,
+                "team_ids": relevant_team_ids,
                 "version": before_version,
             },
         )
 
-        if stale_count_result and len(stale_count_result) and len(stale_count_result[0]):
-            stale_count = stale_count_result[0][0]
-            if stale_count > 0:
-                # Don't do anything if it already exists
-                AsyncDeletion.objects.get_or_create(
-                    deletion_type=DeletionType.Cohort_stale,
-                    team_id=cohort.team.pk,
-                    key=f"{cohort.pk}_{before_version}",
-                )
+        team_ids_with_stale_cohortpeople = [row[0] for row in stale_count_result]
+        if team_ids_with_stale_cohortpeople:
+            AsyncDeletion.objects.bulk_create(
+                [
+                    AsyncDeletion(
+                        deletion_type=DeletionType.Cohort_stale,
+                        team_id=team_id,
+                        # Only appending `team_id` if it's not the same as the cohort's `team_id``, so that
+                        # the migration to environments does not accidentally cause duplicate `AsyncDeletion`s
+                        key=f"{cohort.pk}_{before_version}{('_'+team_id) if team_id != cohort.team_id else ''}",
+                    )
+                    for team_id in team_ids_with_stale_cohortpeople
+                ],
+                ignore_conflicts=True,
+            )
 
 
 def get_cohort_size(cohort: Cohort, override_version: Optional[int] = None) -> Optional[int]:

--- a/posthog/models/feature_flag/feature_flag.py
+++ b/posthog/models/feature_flag/feature_flag.py
@@ -187,7 +187,7 @@ class FeatureFlag(models.Model):
                                     return self.conditions
                             else:
                                 cohort = Cohort.objects.db_manager(using_database).get(
-                                    pk=cohort_id, team_id=self.team_id, deleted=False
+                                    pk=cohort_id, team__project_id=self.team.project_id, deleted=False
                                 )
                                 seen_cohorts_cache[cohort_id] = cohort
                         except Cohort.DoesNotExist:
@@ -291,7 +291,7 @@ class FeatureFlag(models.Model):
                                 continue
                         else:
                             cohort = Cohort.objects.db_manager(using_database).get(
-                                pk=cohort_id, team_id=self.team_id, deleted=False
+                                pk=cohort_id, team__project_id=self.team.project_id, deleted=False
                             )
                             seen_cohorts_cache[cohort_id] = cohort
 

--- a/posthog/models/feature_flag/user_blast_radius.py
+++ b/posthog/models/feature_flag/user_blast_radius.py
@@ -77,7 +77,7 @@ def get_user_blast_radius(
 
         if len(cohort_filters) == 1:
             try:
-                target_cohort = Cohort.objects.get(id=cohort_filters[0].value, team=team)
+                target_cohort = Cohort.objects.get(id=cohort_filters[0].value, team__project_id=team.project_id)
             except Cohort.DoesNotExist:
                 pass
             finally:

--- a/posthog/models/filters/mixins/simplify.py
+++ b/posthog/models/filters/mixins/simplify.py
@@ -108,7 +108,7 @@ class SimplifyFilterMixin:
             from posthog.models.cohort.util import simplified_cohort_filter_properties
 
             try:
-                cohort = Cohort.objects.get(pk=property.value, team_id=team.pk)
+                cohort = Cohort.objects.get(pk=property.value, team__project_id=team.project_id)
             except Cohort.DoesNotExist:
                 # :TODO: Handle non-existing resource in-query instead
                 return PropertyGroup(type=PropertyOperatorType.AND, values=[property])

--- a/posthog/models/test/test_async_deletion_model.py
+++ b/posthog/models/test/test_async_deletion_model.py
@@ -365,7 +365,7 @@ class TestAsyncDeletion(ClickhouseTestMixin, ClickhouseDestroyTablesMixin, BaseT
             group_key="org:5",
             properties={},
         )
-        insert_static_cohort([uuid4()], 0, self.teams[0])
+        insert_static_cohort([uuid4()], 0, team_id=self.teams[0].pk)
         self._insert_cohortpeople_row(self.teams[0], uuid4(), 3)
         create_plugin_log_entry(
             team_id=self.teams[0].pk,
@@ -403,7 +403,7 @@ class TestAsyncDeletion(ClickhouseTestMixin, ClickhouseDestroyTablesMixin, BaseT
             group_key="org:5",
             properties={},
         )
-        insert_static_cohort([uuid4()], 0, self.teams[1])
+        insert_static_cohort([uuid4()], 0, team_id=self.teams[1].pk)
         self._insert_cohortpeople_row(self.teams[1], uuid4(), 3)
         create_plugin_log_entry(
             team_id=self.teams[1].pk,

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -25,7 +25,7 @@
   SELECT team_id,
          count() AS stale_people_count
   FROM cohortpeople
-  WHERE team_id IN [392]
+  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
     AND cohort_id = 99999
     AND version < 2
   GROUP BY team_id
@@ -116,7 +116,7 @@
   SELECT team_id,
          count() AS stale_people_count
   FROM cohortpeople
-  WHERE team_id IN [393]
+  WHERE team_id IN [1, 2, 3, 4, 5 /* ... */]
     AND cohort_id = 99999
     AND version < 2
   GROUP BY team_id

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -22,11 +22,14 @@
 # name: TestTrends.test_action_filtering_with_cohort.2
   '''
   /* celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
-  SELECT count()
+  SELECT team_id,
+         count() AS stale_people_count
   FROM cohortpeople
-  WHERE team_id = 99999
+  WHERE team_id IN [392]
     AND cohort_id = 99999
     AND version < 2
+  GROUP BY team_id
+  HAVING stale_people_count > 0
   '''
 # ---
 # name: TestTrends.test_action_filtering_with_cohort.3
@@ -110,11 +113,14 @@
 # name: TestTrends.test_action_filtering_with_cohort_poe_v2.2
   '''
   /* celery:posthog.tasks.calculate_cohort.clear_stale_cohort */
-  SELECT count()
+  SELECT team_id,
+         count() AS stale_people_count
   FROM cohortpeople
-  WHERE team_id = 99999
+  WHERE team_id IN [393]
     AND cohort_id = 99999
     AND version < 2
+  GROUP BY team_id
+  HAVING stale_people_count > 0
   '''
 # ---
 # name: TestTrends.test_action_filtering_with_cohort_poe_v2.3

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -2,6 +2,7 @@ import time
 from typing import Any, Optional
 
 from django.conf import settings
+
 from posthog.models.team.team import Team
 import structlog
 from celery import shared_task
@@ -158,7 +159,7 @@ def insert_cohort_from_query(cohort_id: int, team_id: Optional[int] = None) -> N
     try:
         insert_cohort_query_actors_into_ch(cohort, team=team)
         insert_cohort_people_into_pg(cohort, team_id=team_id)
-        cohort.count = get_static_cohort_size(cohort_id=cohort.id, team_id=team_id)
+        cohort.count = get_static_cohort_size(cohort_id=cohort.id, team_id=cohort.team_id)
         cohort.errors_calculating = 0
         cohort.last_calculation = timezone.now()
     except:

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -1,20 +1,21 @@
 import time
 from typing import Any, Optional
 
+from django.conf import settings
 import structlog
 from celery import shared_task
 from dateutil.relativedelta import relativedelta
 from django.db.models import F, ExpressionWrapper, DurationField, Q
 from django.utils import timezone
 from prometheus_client import Gauge
-from sentry_sdk import set_tag
+from sentry_sdk import capture_exception, set_tag
 
 from datetime import timedelta
 
 from posthog.api.monitoring import Feature
 from posthog.models import Cohort
 from posthog.models.cohort import get_and_update_pending_version
-from posthog.models.cohort.util import clear_stale_cohortpeople
+from posthog.models.cohort.util import clear_stale_cohortpeople, get_static_cohort_size
 from posthog.models.user import User
 
 COHORT_RECALCULATIONS_BACKLOG_GAUGE = Gauge(
@@ -109,37 +110,58 @@ def calculate_cohort_ch(cohort_id: int, pending_version: int, initiating_user_id
 
 
 @shared_task(ignore_result=True, max_retries=1)
-def calculate_cohort_from_list(cohort_id: int, items: list[str]) -> None:
+def calculate_cohort_from_list(cohort_id: int, items: list[str], team_id: Optional[int] = None) -> None:
+    """
+    team_id is only optional for backwards compatibility with the old celery task signature.
+    All new tasks should pass team_id explicitly.
+    """
     start_time = time.time()
     cohort = Cohort.objects.get(pk=cohort_id)
 
-    cohort.insert_users_by_list(items)
+    cohort.insert_users_by_list(items, team_id=team_id or cohort.team_id)
     logger.warn("Calculating cohort {} from CSV took {:.2f} seconds".format(cohort.pk, (time.time() - start_time)))
 
 
 @shared_task(ignore_result=True, max_retries=1)
-def insert_cohort_from_insight_filter(cohort_id: int, filter_data: dict[str, Any]) -> None:
-    from posthog.api.cohort import (
-        insert_cohort_actors_into_ch,
-        insert_cohort_people_into_pg,
-    )
+def insert_cohort_from_insight_filter(
+    cohort_id: int, filter_data: dict[str, Any], team_id: Optional[int] = None
+) -> None:
+    """
+    team_id is only optional for backwards compatibility with the old celery task signature.
+    All new tasks should pass team_id explicitly.
+    """
+    from posthog.api.cohort import insert_cohort_actors_into_ch, insert_cohort_people_into_pg
 
     cohort = Cohort.objects.get(pk=cohort_id)
 
-    insert_cohort_actors_into_ch(cohort, filter_data)
-    insert_cohort_people_into_pg(cohort=cohort)
+    insert_cohort_actors_into_ch(cohort, filter_data, team_id=team_id or cohort.team_id)
+    insert_cohort_people_into_pg(cohort, team_id=team_id or cohort.team_id)
 
 
 @shared_task(ignore_result=True, max_retries=1)
-def insert_cohort_from_query(cohort_id: int) -> None:
-    from posthog.api.cohort import (
-        insert_cohort_people_into_pg,
-        insert_cohort_query_actors_into_ch,
-    )
+def insert_cohort_from_query(cohort_id: int, team_id: Optional[int] = None) -> None:
+    """
+    team_id is only optional for backwards compatibility with the old celery task signature.
+    All new tasks should pass team_id explicitly.
+    """
+    from posthog.api.cohort import insert_cohort_people_into_pg, insert_cohort_query_actors_into_ch
 
     cohort = Cohort.objects.get(pk=cohort_id)
-    insert_cohort_query_actors_into_ch(cohort)
-    insert_cohort_people_into_pg(cohort=cohort)
+    try:
+        insert_cohort_query_actors_into_ch(cohort, team_id=team_id or cohort.team_id)
+        insert_cohort_people_into_pg(cohort, team_id=team_id or cohort.team_id)
+        cohort.count = get_static_cohort_size(cohort, team_id=team_id)
+        cohort.errors_calculating = 0
+        cohort.last_calculation = timezone.now()
+    except:
+        cohort.errors_calculating = F("errors_calculating") + 1
+        cohort.last_error_at = timezone.now()
+        capture_exception()
+        if settings.DEBUG:
+            raise
+    finally:
+        cohort.is_calculating = False
+        cohort.save()
 
 
 @shared_task(ignore_result=True, max_retries=1)

--- a/posthog/tasks/calculate_cohort.py
+++ b/posthog/tasks/calculate_cohort.py
@@ -158,7 +158,7 @@ def insert_cohort_from_query(cohort_id: int, team_id: Optional[int] = None) -> N
     try:
         insert_cohort_query_actors_into_ch(cohort, team=team)
         insert_cohort_people_into_pg(cohort, team_id=team_id)
-        cohort.count = get_static_cohort_size(cohort, team_id=team_id)
+        cohort.count = get_static_cohort_size(cohort_id=cohort.id, team_id=team_id)
         cohort.errors_calculating = 0
         cohort.last_calculation = timezone.now()
     except:

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -121,6 +121,8 @@ def clean_varying_query_parts(query, replace_all_numbers):
 
     else:
         query = re.sub(r"(team|cohort)_id(\"?) = \d+", r"\1_id\2 = 99999", query)
+        query = re.sub(r"(team|cohort)_id(\"?) IN \(\d+(, ?\d+)*\)", r"\1_id\2 IN (1, 2, 3, 4, 5 /* ... */)", query)
+        query = re.sub(r"(team|cohort)_id(\"?) IN \[\d+(, ?\d+)*\]", r"\1_id\2 IN [1, 2, 3, 4, 5 /* ... */]", query)
         query = re.sub(r"\d+ as (team|cohort)_id(\"?)", r"99999 as \1_id\2", query)
     # feature flag conditions use primary keys as columns in queries, so replace those always
     query = re.sub(r"flag_\d+_condition", r"flag_X_condition", query)


### PR DESCRIPTION
## Problem

Appendix A of the [environments implementation plan](https://github.com/PostHog/posthog/issues/13418#issuecomment-2180883524).

## Changes

`recalculate_cohortpeople()` and `clear_stale_cohortpeople()` now insert and clear cohort people for every team the cohort is available in, instead of just the one the cohort was created in.

## How did you test this code?

Added a test case to `test_cohort.py`. Definitely let me know how to improve test coverage!