### PR TITLE
feat: adding a posthog capture event when a billing proxy is created

### DIFF
--- a/frontend/src/scenes/settings/environment/proxyLogic.ts
+++ b/frontend/src/scenes/settings/environment/proxyLogic.ts
@@ -4,6 +4,7 @@ import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { isDomain } from 'lib/utils'
+import posthog from 'posthog-js'
 import { organizationLogic } from 'scenes/organizationLogic'
 
 import type { proxyLogicType } from './proxyLogicType'
@@ -68,7 +69,10 @@ export const proxyLogic = kea<proxyLogicType>([
     listeners(({ actions, values }) => ({
         collapseForm: () => actions.loadRecords(),
         deleteRecordFailure: () => actions.loadRecords(),
-        createRecordSuccess: () => actions.loadRecords(),
+        createRecordSuccess: () => {
+            actions.loadRecords()
+            posthog.capture('proxy_record_created')
+        },
         maybeRefreshRecords: () => {
             if (values.shouldRefreshRecords) {
                 actions.loadRecords()


### PR DESCRIPTION
## Problem

We want to add events when the features under the teams products are used. For example: managed_reverse_proxy, 2fa_enforcement etc.

in this PR, Im adding a capture event for only one feature `managed_reverse_proxy`. I will follow up the PR with adding events for the remaining features that include but are not limited to:

automatic_provisioning,
sso_enforcement,
2fa_enforcement,
priority_support etc.

## Changes
Event is fired when a managed reverse proxy is created.
![image](https://github.com/user-attachments/assets/ce1a0f0d-75a1-4c92-b77f-df0cf225ed5f)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Cloud: Yes
self-hosted: TBD

## How did you test this code?
Tested locally on: http://localhost:8000/project/2/settings/organization-proxy

Created a managed reverse proxy and verified that an event was fired in the console.


