### PR TITLE
fix: malformed where on exception events

### DIFF
--- a/frontend/src/scenes/error-tracking/queries.ts
+++ b/frontend/src/scenes/error-tracking/queries.ts
@@ -157,7 +157,7 @@ export const errorTrackingIssueEventsQuery = ({
 
     // TODO: fix this where clause. It does not take into account the events
     // associated with issues that have been merged into this primary issue
-    const where = [`eq(${issueId}, properties.$exception_issue_id)`]
+    const where = [`'${issueId}' == properties.$exception_issue_id`]
 
     const query: EventsQuery = {
         kind: NodeKind.EventsQuery,


### PR DESCRIPTION
## Problem

Noticed a malformed where clause introduced in https://github.com/PostHog/posthog/pull/26488

## Changes

Fix the query

## How did you test this code?

Confirmed in local query debugger that things now work