### PR TITLE
fix: Execute cohort calculations on team's specific node where possible

### DIFF
--- a/posthog/models/cohort/util.py
+++ b/posthog/models/cohort/util.py
@@ -376,6 +376,7 @@ def recalculate_cohortpeople(
             "receive_timeout": 600,
             "optimize_on_insert": 0,
         },
+        team_id=cohort.team_id,
         workload=Workload.OFFLINE,
     )
 


### PR DESCRIPTION
## Problem

we aren't executing cohort calculations on team's private nodes, which should be quicker
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
