### PR TITLE
chore(flags): Include `project_id` in Rust `Team`

### DIFF
--- a/rust/feature-flags/src/team/team_models.rs
+++ b/rust/feature-flags/src/team/team_models.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 // TODO: Add integration tests across repos to ensure this doesn't happen.
 pub const TEAM_TOKEN_CACHE_PREFIX: &str = "posthog:1:team_token:";
 
-#[derive(Clone, Debug, Deserialize, Serialize,sqlx::FromRow)]
+#[derive(Clone, Debug, Deserialize, Serialize, sqlx::FromRow)]
 pub struct Team {
     pub id: i32,
     pub name: String,

--- a/rust/feature-flags/src/team/team_models.rs
+++ b/rust/feature-flags/src/team/team_models.rs
@@ -4,11 +4,17 @@ use serde::{Deserialize, Serialize};
 // TODO: Add integration tests across repos to ensure this doesn't happen.
 pub const TEAM_TOKEN_CACHE_PREFIX: &str = "posthog:1:team_token:";
 
-#[derive(Clone, Debug, Deserialize, Serialize, sqlx::FromRow)]
+#[derive(Clone, Debug, Deserialize, Serialize,sqlx::FromRow)]
 pub struct Team {
     pub id: i32,
     pub name: String,
     pub api_token: String,
+    /// Project ID. This field is not present in Redis cache before Dec 2025, but this is not a problem at all,
+    /// because we know all Teams created before Dec 2025 have `project_id` = `id`. To handle this case gracefully,
+    /// we use 0 as a fallback value in deserialization here, and handle this in `Team::from_redis`.
+    /// Thanks to this default-base approach, we avoid invalidating the whole cache needlessly.
+    #[serde(default)]
+    pub project_id: i64,
     // TODO: the following fields are used for the `/decide` response,
     // but they're not used for flags and they don't live in redis.
     // At some point I'll need to differentiate between teams in Redis and teams

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -21,10 +21,14 @@ impl Team {
             .await?;
 
         // TODO: Consider an LRU cache for teams as well, with small TTL to skip redis/pg lookups
-        let team: Team = serde_json::from_str(&serialized_team).map_err(|e| {
+        let mut team: Team = serde_json::from_str(&serialized_team).map_err(|e| {
             tracing::error!("failed to parse data to team: {}", e);
             FlagError::RedisDataParsingError
         })?;
+        if team.project_id == 0 {
+            // If `project_id` is 0, this means the payload is from before December 2025, which we correct for here
+            team.project_id = team.id as i64;
+        }
 
         Ok(team)
     }
@@ -59,7 +63,7 @@ impl Team {
     ) -> Result<Team, FlagError> {
         let mut conn = client.get_connection().await?;
 
-        let query = "SELECT id, name, api_token FROM posthog_team WHERE api_token = $1";
+        let query = "SELECT id, name, api_token, project_id FROM posthog_team WHERE api_token = $1";
         let row = sqlx::query_as::<_, Team>(query)
             .bind(&token)
             .fetch_one(&mut *conn)
@@ -95,6 +99,7 @@ mod tests {
             .unwrap();
         assert_eq!(team_from_redis.api_token, target_token);
         assert_eq!(team_from_redis.id, team.id);
+        assert_eq!(team_from_redis.project_id, team.project_id);
     }
 
     #[tokio::test]
@@ -120,10 +125,11 @@ mod tests {
     #[tokio::test]
     async fn test_corrupted_data_in_redis_is_handled() {
         // TODO: Extend this test with fallback to pg
-        let id = rand::thread_rng().gen_range(0..10_000_000);
+        let id = rand::thread_rng().gen_range(1..10_000_000);
         let token = random_string("phc_", 12);
         let team = Team {
             id,
+            project_id: i64::from(id) - 1,
             name: "team".to_string(),
             api_token: token,
         };
@@ -151,6 +157,31 @@ mod tests {
             Err(other) => panic!("Expected DataParsingError, got {:?}", other),
             Ok(_) => panic!("Expected DataParsingError"),
         };
+    }
+
+    #[tokio::test]
+    async fn test_fetch_team_from_before_project_id_from_redis() {
+        let client = setup_redis_client(None);
+        let target_token = "phc_123456789012".to_string();
+        // A payload form before December 2025, it's missing `project_id`
+        let serialized_team = format!(
+            "{{\"id\":343,\"name\":\"team\",\"api_token\":\"{}\"}}",
+            target_token
+        );
+        client
+            .set(
+                format!("{}{}", TEAM_TOKEN_CACHE_PREFIX, target_token),
+                serialized_team,
+            )
+            .await.expect("Failed to write data to redis");
+
+        let team_from_redis = Team::from_redis(client.clone(), target_token.clone())
+            .await
+            .expect("Failed to fetch team from redis");
+
+        assert_eq!(team_from_redis.api_token, target_token);
+        assert_eq!(team_from_redis.id, 343);
+        assert_eq!(team_from_redis.project_id, 343); // Same as `id`
     }
 
     #[tokio::test]

--- a/rust/feature-flags/src/team/team_operations.rs
+++ b/rust/feature-flags/src/team/team_operations.rs
@@ -173,7 +173,8 @@ mod tests {
                 format!("{}{}", TEAM_TOKEN_CACHE_PREFIX, target_token),
                 serialized_team,
             )
-            .await.expect("Failed to write data to redis");
+            .await
+            .expect("Failed to write data to redis");
 
         let team_from_redis = Team::from_redis(client.clone(), target_token.clone())
             .await

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -33,7 +33,7 @@ pub async fn insert_new_team_in_redis(
     let token = random_string("phc_", 12);
     let team = Team {
         id,
-        project_id: i64::from(id)-1,
+        project_id: i64::from(id) - 1,
         name: "team".to_string(),
         api_token: token,
     };

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -29,10 +29,11 @@ pub fn random_string(prefix: &str, length: usize) -> String {
 pub async fn insert_new_team_in_redis(
     client: Arc<dyn RedisClientTrait + Send + Sync>,
 ) -> Result<Team, Error> {
-    let id = rand::thread_rng().gen_range(0..10_000_000);
+    let id = rand::thread_rng().gen_range(1..10_000_000);
     let token = random_string("phc_", 12);
     let team = Team {
         id,
+        project_id: i64::from(id)-1,
         name: "team".to_string(),
         api_token: token,
     };
@@ -206,6 +207,7 @@ pub async fn insert_new_team_in_pg(
     let token = random_string("phc_", 12);
     let team = Team {
         id,
+        project_id: id as i64,
         name: "team".to_string(),
         api_token: token,
     };
@@ -228,8 +230,8 @@ pub async fn insert_new_team_in_pg(
     let res = sqlx::query(
         r#"INSERT INTO posthog_team 
         (id, uuid, organization_id, project_id, api_token, name, created_at, updated_at, app_urls, anonymize_ips, completed_snippet_onboarding, ingested_event, session_recording_opt_in, is_demo, access_control, test_account_filters, timezone, data_attributes, plugins_opt_in, opt_out_capture, event_names, event_names_with_usage, event_properties, event_properties_with_usage, event_properties_numerical) VALUES
-        ($1, $5, $2::uuid, $1, $3, $4, '2024-06-17 14:40:51.332036+00:00', '2024-06-17', '{}', false, false, false, false, false, false, '{}', 'UTC', '["data-attr"]', false, false, '[]', '[]', '[]', '[]', '[]')"#
-    ).bind(team.id).bind(ORG_ID).bind(&team.api_token).bind(&team.name).bind(uuid).execute(&mut *conn).await?;
+        ($1, $2, $3::uuid, $4, $5, $6, '2024-06-17 14:40:51.332036+00:00', '2024-06-17', '{}', false, false, false, false, false, false, '{}', 'UTC', '["data-attr"]', false, false, '[]', '[]', '[]', '[]', '[]')"#
+    ).bind(team.id).bind(uuid).bind(ORG_ID).bind(team.project_id).bind(&team.api_token).bind(&team.name).execute(&mut *conn).await?;
     assert_eq!(res.rows_affected(), 1);
 
     // Insert group type mappings
@@ -246,11 +248,12 @@ pub async fn insert_new_team_in_pg(
             r#"INSERT INTO posthog_grouptypemapping
             (group_type, group_type_index, name_singular, name_plural, team_id, project_id)
             VALUES
-            ($1, $2, NULL, NULL, $3, $3)"#,
+            ($1, $2, NULL, NULL, $3, $4)"#,
         )
         .bind(group_type)
         .bind(group_type_index)
         .bind(team.id)
+        .bind(team.project_id)
         .execute(&mut *conn)
         .await?;
         assert_eq!(res.rows_affected(), 1);


### PR DESCRIPTION
## Problem

The `GroupTypeMapping` model is now project-specific (via `posthog_grouptypemapping.project_id`) and no longer team-specific (via `.team_id`). But `rust/feature-flags/` didn't know about this.

## Changes

`rust/feature-flags/` now knows. :) Added `project_id` to the team struct, with graceful handling for existing Redis cache entries that don't have this field. This means everything  works with no needless cache invalidation.

## How did you test this code?

Added a Team fetching test case and adjusted a few existing ones.