### PR TITLE
feat: add a posthog capture event when a proxy record is created

### DIFF
--- a/posthog/api/proxy_record.py
+++ b/posthog/api/proxy_record.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import posthoganalytics
 from django.conf import settings
 from rest_framework import serializers, status
 from rest_framework.viewsets import ModelViewSet
@@ -76,6 +77,16 @@ class ProxyRecordViewset(TeamAndOrgViewSetMixin, ModelViewSet):
         )
 
         serializer = self.get_serializer(record)
+        posthoganalytics.capture(
+            request.user.distinct_id,
+            "proxy record created",
+            properties={
+                "organization_id": record.organization_id,
+                "proxy_record_id": record.id,
+                "domain": record.domain,
+                "target_cname": record.target_cname,
+            },
+        )
         return Response(serializer.data)
 
     def destroy(self, request, *args, pk=None, **kwargs):


### PR DESCRIPTION
## Problem

I'm adding `managed reverse proxy created ` event on the backend. I'm assuming we use this in analytics downstream.

## Changes

Verified that a proxy was created successfully

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Cloud: Yes

## How did you test this code?

Tested locally on: http://localhost:8000/project/2/settings/organization-proxy
If there are other suggestions on how to verify if the logs are working correctly, please let me know. I might be missing stuff here.
