### PR TITLE
feat(web-analytics): Display data relevant to currently selected conversion goal

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -240,6 +240,7 @@ export const FEATURE_FLAGS = {
     REPLAY_LIST_RECORDINGS_AS_QUERY: 'replay-list-recordings-as-query', // owner: @pauldambra #team-replay
     BILLING_SKIP_FORECASTING: 'billing-skip-forecasting', // owner: @zach
     WEB_ANALYTICS_PERIOD_COMPARISON: 'web-analytics-period-comparison', // owner: @rafaeelaudibert #team-web-analytics
+    WEB_ANALYTICS_CONVERSION_GOAL_FILTERS: 'web-analytics-conversion-goal-filters', // owner: @rafaeelaudibert #team-web-analytics
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -12666,6 +12666,17 @@
                     "$ref": "#/definitions/CompareFilter",
                     "description": "Compare to date range"
                 },
+                "conversionGoal": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/WebAnalyticsConversionGoal"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Whether we should be comparing against a specific conversion goal"
+                },
                 "dateRange": {
                     "$ref": "#/definitions/InsightDateRange",
                     "description": "Date range for the query"

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -910,6 +910,8 @@ export interface TrendsQuery extends InsightsQueryBase<TrendsQueryResponse> {
     breakdownFilter?: BreakdownFilter
     /** Compare to date range */
     compareFilter?: CompareFilter
+    /**  Whether we should be comparing against a specific conversion goal */
+    conversionGoal?: WebAnalyticsConversionGoal | null
 }
 
 export type AssistantArrayPropertyFilterOperator = PropertyOperator.Exact | PropertyOperator.IsNot

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsRecordings.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsRecordings.tsx
@@ -16,6 +16,7 @@ export function WebAnalyticsRecordingsTile({ tile }: { tile: ReplayTile }): JSX.
     const { layout } = tile
     const { replayFilters, webAnalyticsFilters } = useValues(webAnalyticsLogic)
     const { currentTeam } = useValues(teamLogic)
+
     const sessionRecordingsListLogicInstance = sessionRecordingsPlaylistLogic({
         logicKey: 'webAnalytics',
         filters: replayFilters,

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -321,6 +321,11 @@ export const webAnalyticsDataTableQueryContext: QueryContext = {
             render: VariationCell(),
             align: 'right',
         },
+        unique_conversions: {
+            title: <span className="pr-5">Unique Conversions</span>,
+            render: VariationCell(),
+            align: 'right',
+        },
         conversion_rate: {
             title: <span className="pr-5">Conversion Rate</span>,
             render: VariationCell({ isPercentage: true }),

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -1187,62 +1187,64 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                               ],
                           }
                         : null,
-                    {
-                        kind: 'query',
-                        tileId: TileId.RETENTION,
-                        title: 'Retention',
-                        layout: {
-                            colSpanClassName: 'md:col-span-2',
-                        },
-                        query: {
-                            kind: NodeKind.InsightVizNode,
-                            source: {
-                                kind: NodeKind.RetentionQuery,
-                                properties: webAnalyticsFilters,
-                                dateRange,
-                                filterTestAccounts,
-                                retentionFilter: {
-                                    retentionType: RETENTION_FIRST_TIME,
-                                    retentionReference: 'total',
-                                    totalIntervals: isGreaterThanMd ? 8 : 5,
-                                    period: RetentionPeriod.Week,
-                                },
-                            },
-                            vizSpecificOptions: {
-                                [InsightType.RETENTION]: {
-                                    hideLineGraph: true,
-                                    hideSizeColumn: !isGreaterThanMd,
-                                    useSmallLayout: !isGreaterThanMd,
-                                },
-                            },
-                            embedded: true,
-                        },
-                        insightProps: createInsightProps(TileId.RETENTION),
-                        canOpenInsight: false,
-                        canOpenModal: true,
-                        docs: {
-                            url: 'https://posthog.com/docs/web-analytics/dashboard#retention',
-                            title: 'Retention',
-                            description: (
-                                <>
-                                    <div>
-                                        <p>
-                                            Retention creates a cohort of unique users who performed any event for the
-                                            first time in the last week. It then tracks the percentage of users who
-                                            return to perform any event in the following weeks.
-                                        </p>
-                                        <p>
-                                            You want the numbers numbers to be the highest possible, suggesting that
-                                            people that come to your page continue coming to your page - and performing
-                                            an actions. Also, the further down the table the higher the numbers should
-                                            be (or at least as high), which would indicate that you're either increasing
-                                            or keeping your retention at the same level.
-                                        </p>
-                                    </div>
-                                </>
-                            ),
-                        },
-                    },
+                    !conversionGoal
+                        ? {
+                              kind: 'query',
+                              tileId: TileId.RETENTION,
+                              title: 'Retention',
+                              layout: {
+                                  colSpanClassName: 'md:col-span-2',
+                              },
+                              query: {
+                                  kind: NodeKind.InsightVizNode,
+                                  source: {
+                                      kind: NodeKind.RetentionQuery,
+                                      properties: webAnalyticsFilters,
+                                      dateRange,
+                                      filterTestAccounts,
+                                      retentionFilter: {
+                                          retentionType: RETENTION_FIRST_TIME,
+                                          retentionReference: 'total',
+                                          totalIntervals: isGreaterThanMd ? 8 : 5,
+                                          period: RetentionPeriod.Week,
+                                      },
+                                  },
+                                  vizSpecificOptions: {
+                                      [InsightType.RETENTION]: {
+                                          hideLineGraph: true,
+                                          hideSizeColumn: !isGreaterThanMd,
+                                          useSmallLayout: !isGreaterThanMd,
+                                      },
+                                  },
+                                  embedded: true,
+                              },
+                              insightProps: createInsightProps(TileId.RETENTION),
+                              canOpenInsight: false,
+                              canOpenModal: true,
+                              docs: {
+                                  url: 'https://posthog.com/docs/web-analytics/dashboard#retention',
+                                  title: 'Retention',
+                                  description: (
+                                      <>
+                                          <div>
+                                              <p>
+                                                  Retention creates a cohort of unique users who performed any event for
+                                                  the first time in the last week. It then tracks the percentage of
+                                                  users who return to perform any event in the following weeks.
+                                              </p>
+                                              <p>
+                                                  You want the numbers numbers to be the highest possible, suggesting
+                                                  that people that come to your page continue coming to your page - and
+                                                  performing an actions. Also, the further down the table the higher the
+                                                  numbers should be (or at least as high), which would indicate that
+                                                  you're either increasing or keeping your retention at the same level.
+                                              </p>
+                                          </div>
+                                      </>
+                                  ),
+                              },
+                          }
+                        : null,
                     // Hiding if conversionGoal is set already because values aren't representative
                     !conversionGoal && featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_CONVERSION_GOALS]
                         ? {
@@ -1290,7 +1292,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                               },
                           }
                         : null,
-                    featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_REPLAY]
+                    !conversionGoal && featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_REPLAY]
                         ? {
                               kind: 'replay',
                               tileId: TileId.REPLAY,
@@ -1305,8 +1307,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                               },
                           }
                         : null,
-                    // TODO: What to do with this one if conversion goal is set? Hide it? Disable it?
-                    featureFlags[FEATURE_FLAGS.ERROR_TRACKING]
+                    !conversionGoal && featureFlags[FEATURE_FLAGS.ERROR_TRACKING]
                         ? {
                               kind: 'error_tracking',
                               tileId: TileId.ERROR_TRACKING,

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -790,14 +790,21 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                                         accessed in your application, regardless of when they were
                                                         accessed through the lifetime of a user session.
                                                     </p>
-                                                    <p>
-                                                        The{' '}
-                                                        <Link to="https://posthog.com/docs/web-analytics/dashboard#bounce-rate">
-                                                            bounce rate
-                                                        </Link>{' '}
-                                                        indicates the percentage of users who left your page immediately
-                                                        after visiting without capturing any event.
-                                                    </p>
+                                                    {conversionGoal ? (
+                                                        <p>
+                                                            The conversion rate is the percentage of users who completed
+                                                            the conversion goal in this specific path.
+                                                        </p>
+                                                    ) : (
+                                                        <p>
+                                                            The{' '}
+                                                            <Link to="https://posthog.com/docs/web-analytics/dashboard#bounce-rate">
+                                                                bounce rate
+                                                            </Link>{' '}
+                                                            indicates the percentage of users who left your page
+                                                            immediately after visiting without capturing any event.
+                                                        </p>
+                                                    )}
                                                 </div>
                                             ),
                                         },
@@ -821,8 +828,17 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                             title: 'Entry Path',
                                             description: (
                                                 <div>
-                                                    Entry paths are the paths a user session started, i.e. the first
-                                                    path they saw when they opened your website.
+                                                    <p>
+                                                        Entry paths are the paths a user session started, i.e. the first
+                                                        path they saw when they opened your website.
+                                                    </p>
+                                                    {conversionGoal && (
+                                                        <p>
+                                                            The conversion rate is the percentage of users who completed
+                                                            the conversion goal after the first path in their session
+                                                            being this path.
+                                                        </p>
+                                                    )}
                                                 </div>
                                             ),
                                         },

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -1298,7 +1298,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                               kind: 'replay',
                               tileId: TileId.REPLAY,
                               layout: {
-                                  colSpanClassName: 'md:col-span-1',
+                                  colSpanClassName: conversionGoal ? 'md:col-span-full' : 'md:col-span-1',
                               },
                               docs: {
                                   url: 'https://posthog.com/docs/session-replay',

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -622,6 +622,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             compareFilter: compareFilter || { compare: false },
                             filterTestAccounts,
+                            conversionGoal,
                             properties: webAnalyticsFilters,
                         },
                         hidePersonsModal: true,
@@ -662,6 +663,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 compareFilter,
                                 limit: 10,
                                 filterTestAccounts,
+                                conversionGoal,
                                 ...(source || {}),
                             },
                             embedded: false,
@@ -862,6 +864,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                                   sampling,
                                                   limit: 10,
                                                   filterTestAccounts,
+                                                  conversionGoal,
                                                   stripQueryParams: shouldStripQueryParams,
                                               },
                                               embedded: false,
@@ -1136,6 +1139,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                               trendsFilter: {
                                                   display: ChartDisplayType.WorldMap,
                                               },
+                                              conversionGoal,
                                               filterTestAccounts,
                                               properties: webAnalyticsFilters,
                                           },
@@ -1239,7 +1243,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             ),
                         },
                     },
-                    featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_CONVERSION_GOALS]
+                    // Hiding if conversionGoal is set already because values aren't representative
+                    !conversionGoal && featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_CONVERSION_GOALS]
                         ? {
                               kind: 'query',
                               tileId: TileId.GOALS,
@@ -1300,6 +1305,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                               },
                           }
                         : null,
+                    // TODO: What to do with this one if conversion goal is set? Hide it? Disable it?
                     featureFlags[FEATURE_FLAGS.ERROR_TRACKING]
                         ? {
                               kind: 'error_tracking',

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -623,7 +623,9 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             },
                             compareFilter: compareFilter || { compare: false },
                             filterTestAccounts,
-                            conversionGoal,
+                            conversionGoal: featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_CONVERSION_GOAL_FILTERS]
+                                ? conversionGoal
+                                : undefined,
                             properties: webAnalyticsFilters,
                         },
                         hidePersonsModal: true,
@@ -664,7 +666,9 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 compareFilter,
                                 limit: 10,
                                 filterTestAccounts,
-                                conversionGoal,
+                                conversionGoal: featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_CONVERSION_GOAL_FILTERS]
+                                    ? conversionGoal
+                                    : undefined,
                                 ...(source || {}),
                             },
                             embedded: false,
@@ -865,7 +869,11 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                                   sampling,
                                                   limit: 10,
                                                   filterTestAccounts,
-                                                  conversionGoal,
+                                                  conversionGoal: featureFlags[
+                                                      FEATURE_FLAGS.WEB_ANALYTICS_CONVERSION_GOAL_FILTERS
+                                                  ]
+                                                      ? conversionGoal
+                                                      : undefined,
                                                   stripQueryParams: shouldStripQueryParams,
                                               },
                                               embedded: false,
@@ -1140,7 +1148,11 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                               trendsFilter: {
                                                   display: ChartDisplayType.WorldMap,
                                               },
-                                              conversionGoal,
+                                              conversionGoal: featureFlags[
+                                                  FEATURE_FLAGS.WEB_ANALYTICS_CONVERSION_GOAL_FILTERS
+                                              ]
+                                                  ? conversionGoal
+                                                  : undefined,
                                               filterTestAccounts,
                                               properties: webAnalyticsFilters,
                                           },
@@ -1441,15 +1453,16 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             },
         ],
         replayFilters: [
-            (s) => [s.webAnalyticsFilters, s.dateFilter, s.shouldFilterTestAccounts, s.conversionGoal],
+            (s) => [s.webAnalyticsFilters, s.dateFilter, s.shouldFilterTestAccounts, s.conversionGoal, s.featureFlags],
             (
                 webAnalyticsFilters: WebAnalyticsPropertyFilters,
                 dateFilter,
                 shouldFilterTestAccounts,
-                conversionGoal
+                conversionGoal,
+                featureFlags
             ): RecordingUniversalFilters => {
                 const filters: UniversalFiltersGroupValue[] = [...webAnalyticsFilters]
-                if (conversionGoal) {
+                if (conversionGoal && featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_CONVERSION_GOAL_FILTERS]) {
                     if ('actionId' in conversionGoal) {
                         filters.push({
                             id: conversionGoal.actionId,

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -1450,11 +1450,19 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             ): RecordingUniversalFilters => {
                 const filters: UniversalFiltersGroupValue[] = [...webAnalyticsFilters]
                 if (conversionGoal) {
-                    const actionId = (conversionGoal as ActionConversionGoal).actionId
-                    const customEventName = (conversionGoal as CustomEventConversionGoal).customEventName
-                    const id = actionId || customEventName
-
-                    filters.push({ id, name: String(id), type: customEventName ? 'events' : 'actions' })
+                    if ('actionId' in conversionGoal) {
+                        filters.push({
+                            id: conversionGoal.actionId,
+                            name: String(conversionGoal.actionId),
+                            type: 'actions',
+                        })
+                    } else if ('customEventName' in conversionGoal) {
+                        filters.push({
+                            id: conversionGoal.customEventName,
+                            name: conversionGoal.customEventName,
+                            type: 'events',
+                        })
+                    }
                 }
 
                 return {

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -48,7 +48,9 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner):
 
     def to_query(self) -> ast.SelectQuery:
         if self.query.breakdownBy == WebStatsBreakdown.PAGE:
-            if self.query.includeScrollDepth and self.query.includeBounceRate:
+            if self.query.conversionGoal:
+                return self.to_main_query(self._counts_breakdown_value())
+            elif self.query.includeScrollDepth and self.query.includeBounceRate:
                 return self.to_path_scroll_bounce_query()
             elif self.query.includeBounceRate:
                 return self.to_path_bounce_query()

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -32,8 +32,6 @@ from posthog.schema import (
 BREAKDOWN_NULL_DISPLAY = "(none)"
 
 
-# TODO: Extend `conversion_goal` support to queries besides `to_main_query`
-# TODO: Add test cases for conversion goal, both action, and event-based ones
 class WebStatsTableQueryRunner(WebAnalyticsQueryRunner):
     query: WebStatsTableQuery
     response: WebStatsTableQueryResponse

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -371,7 +371,13 @@ GROUP BY session_id, breakdown_value
         assert isinstance(query, ast.SelectQuery)
 
         if include_session_properties:
-            query.where.args.append(self._session_properties())  # query.where is an `ast.Call`
+            # Append session properties to the where clause if it exists
+            #
+            # We know `query.where` is an `ast.Call` because it's a `WHERE` clause
+            # and `ast.Call` is the only kind of expression that `query.where` can be
+            # but we need to convince mypy
+            if query.where is not None and isinstance(query.where, ast.Call):
+                query.where.args.append(self._session_properties())
 
         if self.conversion_count_expr and self.conversion_person_id_expr:
             query.select.append(ast.Alias(alias="conversion_count", expr=self.conversion_count_expr))

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -526,6 +526,23 @@ GROUP BY session_id, breakdown_value
                 else response.columns
             )
 
+        # Add last conversion rate column
+        if self.query.conversionGoal is not None:
+            for result in results_mapped:
+                unique_visitors = result[1]
+                unique_conversions = result[-1]
+
+                # Keep them in the same tuple format we already have
+                result.append(
+                    (
+                        unique_conversions[0] / unique_visitors[0] if unique_visitors[0] != 0 else None,
+                        unique_conversions[1] / unique_visitors[1] if unique_visitors[1] != 0 else None,
+                    )
+                )
+
+            # Guarantee new column exists
+            columns.append("context.columns.conversion_rate")
+
         return WebStatsTableQueryResponse(
             columns=columns,
             results=results_mapped,

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -3,7 +3,7 @@ from typing import Optional
 from freezegun import freeze_time
 
 from posthog.hogql_queries.web_analytics.stats_table import WebStatsTableQueryRunner
-from posthog.models import Cohort
+from posthog.models import Action, Cohort, Element
 from posthog.models.utils import uuid7
 from posthog.schema import (
     DateRange,
@@ -13,6 +13,8 @@ from posthog.schema import (
     PropertyOperator,
     SessionTableVersion,
     HogQLQueryModifiers,
+    CustomEventConversionGoal,
+    ActionConversionGoal,
 )
 from posthog.test.base import (
     APIBaseTest,
@@ -38,13 +40,27 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
                         },
                     )
                 )
-            for timestamp, session_id, pathname in timestamps:
+            for timestamp, session_id, *extra in timestamps:
+                url = None
+                elements = None
+                if event == "$pageview":
+                    url = extra[0] if extra else None
+                elif event == "$autocapture":
+                    elements = extra[0] if extra else None
+                properties = extra[1] if extra and len(extra) > 1 else {}
+
                 _create_event(
                     team=self.team,
                     event=event,
                     distinct_id=id,
                     timestamp=timestamp,
-                    properties={"$session_id": session_id, "$pathname": pathname},
+                    properties={
+                        "$session_id": session_id,
+                        "$pathname": url,
+                        "$current_url": url,
+                        **properties,
+                    },
+                    elements=elements,
                 )
         return person_result
 
@@ -107,6 +123,8 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
         include_bounce_rate=False,
         include_scroll_depth=False,
         properties=None,
+        action: Optional[Action] = None,
+        custom_event: Optional[str] = None,
         session_table_version: SessionTableVersion = SessionTableVersion.V2,
         filter_test_accounts: Optional[bool] = False,
     ):
@@ -119,6 +137,11 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
             doPathCleaning=bool(path_cleaning_filters),
             includeBounceRate=include_bounce_rate,
             includeScrollDepth=include_scroll_depth,
+            conversionGoal=ActionConversionGoal(actionId=action.id)
+            if action
+            else CustomEventConversionGoal(customEventName=custom_event)
+            if custom_event
+            else None,
             filterTestAccounts=filter_test_accounts,
         )
         self.team.path_cleaning_filters = path_cleaning_filters or []
@@ -1255,3 +1278,216 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         # Don't crash, treat all of them null
         assert results == []
+
+    def test_conversion_goal_no_conversions(self):
+        s1 = str(uuid7("2023-12-01"))
+        self._create_events(
+            [
+                ("p1", [("2023-12-01", s1, "https://www.example.com/foo")]),
+            ]
+        )
+
+        action = Action.objects.create(
+            team=self.team,
+            name="Visited Bar",
+            steps_json=[{"event": "$pageview", "url": "https://www.example.com/bar", "url_matching": "regex"}],
+        )
+
+        response = self._run_web_stats_table_query(
+            "2023-12-01", "2023-12-03", breakdown_by=WebStatsBreakdown.PAGE, action=action
+        )
+
+        assert [["https://www.example.com/foo", (1, 0), (0, 0), (0, 0), (0, None)]] == response.results
+        assert [
+            "context.columns.breakdown_value",
+            "context.columns.visitors",
+            "context.columns.total_conversions",
+            "context.columns.unique_conversions",
+            "context.columns.conversion_rate",
+        ] == response.columns
+
+    def test_conversion_goal_one_pageview_conversion(self):
+        s1 = str(uuid7("2023-12-01"))
+        self._create_events(
+            [
+                ("p1", [("2023-12-01", s1, "https://www.example.com/foo")]),
+            ]
+        )
+
+        action = Action.objects.create(
+            team=self.team,
+            name="Visited Foo",
+            steps_json=[
+                {
+                    "event": "$pageview",
+                    "url": "https://www.example.com/foo",
+                    "url_matching": "regex",
+                }
+            ],
+        )
+
+        response = self._run_web_stats_table_query(
+            "2023-12-01", "2023-12-03", breakdown_by=WebStatsBreakdown.PAGE, action=action
+        )
+
+        response = self._run_web_stats_table_query(
+            "2023-12-01", "2023-12-03", breakdown_by=WebStatsBreakdown.PAGE, action=action
+        )
+
+        assert [["https://www.example.com/foo", (1, 0), (1, 0), (1, 0), (1, None)]] == response.results
+        assert [
+            "context.columns.breakdown_value",
+            "context.columns.visitors",
+            "context.columns.total_conversions",
+            "context.columns.unique_conversions",
+            "context.columns.conversion_rate",
+        ] == response.columns
+
+    def test_conversion_goal_one_custom_event_conversion(self):
+        s1 = str(uuid7("2023-12-01"))
+        self._create_events(
+            [
+                ("p1", [("2023-12-01", s1, "https://www.example.com/foo")]),
+            ],
+            event="custom_event",
+        )
+
+        response = self._run_web_stats_table_query(
+            "2023-12-01", "2023-12-03", breakdown_by=WebStatsBreakdown.PAGE, custom_event="custom_event"
+        )
+
+        # TODO: It's returning empty, I don't know why
+        assert [["https://www.example.com/foo", (1, 0), (0, 0), (0, 0), (0, None)]] == response.results
+        assert [
+            "context.columns.breakdown_value",
+            "context.columns.visitors",
+            "context.columns.total_conversions",
+            "context.columns.unique_conversions",
+            "context.columns.conversion_rate",
+        ] == response.columns
+
+    def test_conversion_goal_one_custom_action_conversion(self):
+        s1 = str(uuid7("2023-12-01"))
+        self._create_events(
+            [
+                ("p1", [("2023-12-01", s1)]),
+            ],
+            event="custom_event",
+        )
+
+        action = Action.objects.create(
+            team=self.team,
+            name="Did Custom Event",
+            steps_json=[
+                {
+                    "event": "custom_event",
+                }
+            ],
+        )
+
+        response = self._run_web_stats_table_query(
+            "2023-12-01", "2023-12-03", breakdown_by=WebStatsBreakdown.PAGE, action=action
+        )
+
+        # TODO: It's returning empty for some reason, check why
+        assert [["https://www.example.com/foo", (1, 0), (0, 0), (0, 0), (0, None)]] == response.results
+        assert [
+            "context.columns.breakdown_value",
+            "context.columns.visitors",
+            "context.columns.total_conversions",
+            "context.columns.unique_conversions",
+            "context.columns.conversion_rate",
+        ] == response.columns
+
+    def test_conversion_goal_one_autocapture_conversion(self):
+        s1 = str(uuid7("2023-12-01"))
+        self._create_events(
+            [
+                ("p1", [("2023-12-01", s1, [Element(nth_of_type=1, nth_child=0, tag_name="button", text="Pay $10")])]),
+            ],
+            event="$autocapture",
+        )
+
+        action = Action.objects.create(
+            team=self.team,
+            name="Paid $10",
+            steps_json=[
+                {
+                    "event": "$autocapture",
+                    "tag_name": "button",
+                    "text": "Pay $10",
+                }
+            ],
+        )
+
+        response = self._run_web_stats_table_query(
+            "2023-12-01", "2023-12-03", breakdown_by=WebStatsBreakdown.PAGE, action=action
+        )
+
+        # TODO: It's returning empty I don't know why, fix this
+        assert [["https://www.example.com/foo", (1, 0), (0, 0), (0, 0), (0, None)]] == response.results
+        assert [
+            "context.columns.breakdown_value",
+            "context.columns.visitors",
+            "context.columns.total_conversions",
+            "context.columns.unique_conversions",
+            "context.columns.conversion_rate",
+        ] == response.columns
+
+    def test_conversion_rate(self):
+        s1 = str(uuid7("2023-12-01"))
+        s2 = str(uuid7("2023-12-01"))
+        s3 = str(uuid7("2023-12-01"))
+
+        self._create_events(
+            [
+                (
+                    "p1",
+                    [
+                        ("2023-12-01", s1, "https://www.example.com/foo"),
+                        ("2023-12-01", s1, "https://www.example.com/foo"),
+                    ],
+                ),
+                (
+                    "p2",
+                    [
+                        ("2023-12-01", s2, "https://www.example.com/foo"),
+                        ("2023-12-01", s2, "https://www.example.com/bar"),
+                    ],
+                ),
+                ("p3", [("2023-12-01", s3, "https://www.example.com/bar")]),
+            ]
+        )
+
+        action = Action.objects.create(
+            team=self.team,
+            name="Visited Foo",
+            steps_json=[
+                {
+                    "event": "$pageview",
+                    "url": "https://www.example.com/foo",
+                    "url_matching": "regex",
+                }
+            ],
+        )
+
+        response = self._run_web_stats_table_query(
+            "2023-12-01", "2023-12-03", breakdown_by=WebStatsBreakdown.PAGE, action=action
+        )
+
+        # TODO: Check if conversion rate is accurate here, or if it should be a rational number
+        assert [
+            ["https://www.example.com/foo", (2, 0), (3, 0), (2, 0), (1, None)],
+            ["https://www.example.com/bar", (2, 0), (0, 0), (0, 0), (0, None)],
+        ] == response.results
+        assert [
+            "context.columns.breakdown_value",
+            "context.columns.visitors",
+            "context.columns.total_conversions",
+            "context.columns.unique_conversions",
+            "context.columns.conversion_rate",
+        ] == response.columns
+
+        # TODO: Guarantee this matches above
+        # conversion_rate = results[3]
+        # self.assertAlmostEqual(conversion_rate.value, 100 * 2 / 3)

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -1353,11 +1353,13 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         response = self._run_web_stats_table_query(
-            "2023-12-01", "2023-12-03", breakdown_by=WebStatsBreakdown.PAGE, custom_event="custom_event"
+            "2023-12-01",
+            "2023-12-03",
+            breakdown_by=WebStatsBreakdown.INITIAL_UTM_SOURCE,  # Allow the breakdown value to be non-null
+            custom_event="custom_event",
         )
 
-        # TODO: It's returning empty, I don't know why
-        assert [["https://www.example.com/foo", (1, 0), (0, 0), (0, 0), (0, None)]] == response.results
+        assert [[None, (1, 0), (1, 0), (1, 0), (1, None)]] == response.results
         assert [
             "context.columns.breakdown_value",
             "context.columns.visitors",
@@ -1386,11 +1388,13 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         response = self._run_web_stats_table_query(
-            "2023-12-01", "2023-12-03", breakdown_by=WebStatsBreakdown.PAGE, action=action
+            "2023-12-01",
+            "2023-12-03",
+            breakdown_by=WebStatsBreakdown.INITIAL_UTM_SOURCE,  # Allow the breakdown value to be non-null
+            action=action,
         )
 
-        # TODO: It's returning empty for some reason, check why
-        assert [["https://www.example.com/foo", (1, 0), (0, 0), (0, 0), (0, None)]] == response.results
+        assert [[None, (1, 0), (1, 0), (1, 0), (1, None)]] == response.results
         assert [
             "context.columns.breakdown_value",
             "context.columns.visitors",
@@ -1421,11 +1425,13 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         response = self._run_web_stats_table_query(
-            "2023-12-01", "2023-12-03", breakdown_by=WebStatsBreakdown.PAGE, action=action
+            "2023-12-01",
+            "2023-12-03",
+            breakdown_by=WebStatsBreakdown.INITIAL_UTM_SOURCE,  # Allow the breakdown value to be non-null
+            action=action,
         )
 
-        # TODO: It's returning empty I don't know why, fix this
-        assert [["https://www.example.com/foo", (1, 0), (0, 0), (0, 0), (0, None)]] == response.results
+        assert [[None, (1, 0), (1, 0), (1, 0), (1, None)]] == response.results
         assert [
             "context.columns.breakdown_value",
             "context.columns.visitors",

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -1475,7 +1475,6 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
             "2023-12-01", "2023-12-03", breakdown_by=WebStatsBreakdown.PAGE, action=action
         )
 
-        # TODO: Check if conversion rate is accurate here, or if it should be a rational number
         assert [
             ["https://www.example.com/foo", (2, 0), (3, 0), (2, 0), (1, None)],
             ["https://www.example.com/bar", (2, 0), (0, 0), (0, 0), (0, None)],
@@ -1487,7 +1486,3 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
             "context.columns.unique_conversions",
             "context.columns.conversion_rate",
         ] == response.columns
-
-        # TODO: Guarantee this matches above
-        # conversion_rate = results[3]
-        # self.assertAlmostEqual(conversion_rate.value, 100 * 2 / 3)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5823,6 +5823,9 @@ class TrendsQuery(BaseModel):
     aggregation_group_type_index: Optional[int] = Field(default=None, description="Groups aggregation")
     breakdownFilter: Optional[BreakdownFilter] = Field(default=None, description="Breakdown of the events and actions")
     compareFilter: Optional[CompareFilter] = Field(default=None, description="Compare to date range")
+    conversionGoal: Optional[Union[ActionConversionGoal, CustomEventConversionGoal]] = Field(
+        default=None, description="Whether we should be comparing against a specific conversion goal"
+    )
     dateRange: Optional[InsightDateRange] = Field(default=None, description="Date range for the query")
     filterTestAccounts: Optional[bool] = Field(
         default=False, description="Exclude internal and test users by applying the respective filters"


### PR DESCRIPTION
Customers can select a conversion goal at the top of the web analytics panel. We were, however, not respecting that conversion goal when rendering most of the panels in the web analytics screen.

Now, we properly respect that in the backend + hide the non-relevant parts of the UI, i.e. the ones that can't have their conversion rate computed.

## Screenshots

![image](https://github.com/user-attachments/assets/fdb48908-2b23-45a2-af10-b2615ca9fd60)


## Tests

UI locally + new unit tests