### PR TITLE
feat: load issue pages quicker

### DIFF
--- a/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
+++ b/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
@@ -19,6 +19,7 @@ import { InsightLogicProps } from '~/types'
 import { AssigneeSelect } from './AssigneeSelect'
 import { errorTrackingDataNodeLogic } from './errorTrackingDataNodeLogic'
 import ErrorTrackingFilters from './ErrorTrackingFilters'
+import { errorTrackingIssueSceneLogic } from './errorTrackingIssueSceneLogic'
 import { errorTrackingLogic } from './errorTrackingLogic'
 import { errorTrackingSceneLogic } from './errorTrackingSceneLogic'
 
@@ -147,6 +148,11 @@ const CustomGroupTitleColumn: QueryContextColumnComponent = (props) => {
                 }
                 className="flex-1"
                 to={urls.errorTrackingIssue(record.id)}
+                onClick={() => {
+                    const issueLogic = errorTrackingIssueSceneLogic({ id: record.id })
+                    issueLogic.mount()
+                    issueLogic.actions.setIssue(record)
+                }}
             />
         </div>
     )

--- a/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
+++ b/frontend/src/scenes/error-tracking/errorTrackingIssueSceneLogic.ts
@@ -46,6 +46,7 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
     actions({
         setTab: (tab: IssueTab) => ({ tab }),
         setActiveEventUUID: (uuid: ErrorTrackingEvent['uuid']) => ({ uuid }),
+        setIssue: (issue: ErrorTrackingIssue) => ({ issue }),
         updateIssue: (issue: Partial<Pick<ErrorTrackingIssue, 'assignee' | 'status'>>) => ({ issue }),
     }),
 
@@ -89,6 +90,7 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                     const response = await api.errorTracking.updateIssue(props.id, issue)
                     return { ...values.issue, ...response }
                 },
+                setIssue: ({ issue }) => issue,
             },
         ],
         events: [


### PR DESCRIPTION
## Problem

We currently refetch issues when visiting the scene (despite having the data loaded from the index page)

## Changes

- Use the data from the index page when available
- Leaves the issue to refresh in the background
- (Events still need to be loaded async)