### PR TITLE
fix(cdp): add event id to errors

### DIFF
--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -305,6 +305,8 @@ export class HogExecutor {
                       )
                     : invocation.hogFunction.bytecode)
 
+            const eventId = invocation?.globals?.event?.uuid || 'Unknown event'
+
             try {
                 let hogLogs = 0
                 execRes = execHog(invocationInput, {
@@ -354,7 +356,7 @@ export class HogExecutor {
                                 result.logs.push({
                                     level: 'warn',
                                     timestamp: DateTime.now(),
-                                    message: `Function exceeded maximum log entries. No more logs will be collected.`,
+                                    message: `Function exceeded maximum log entries. No more logs will be collected. Event: ${eventId}`,
                                 })
                             }
 
@@ -410,7 +412,7 @@ export class HogExecutor {
                 result.logs.push({
                     level: 'error',
                     timestamp: DateTime.now(),
-                    message: `Error executing function: ${e}`,
+                    message: `Error executing function on event ${eventId}: ${e}`,
                 })
                 throw e
             }
@@ -436,7 +438,7 @@ export class HogExecutor {
                     timestamp: DateTime.now(),
                     message: `Suspending function due to async function call '${execRes.asyncFunctionName}'. Payload: ${
                         calculateCost(execRes.state) + calculateCost(args)
-                    } bytes`,
+                    } bytes. Event: ${eventId}`,
                 })
 
                 if (execRes.asyncFunctionName) {

--- a/plugin-server/tests/cdp/cdp-api.test.ts
+++ b/plugin-server/tests/cdp/cdp-api.test.ts
@@ -174,7 +174,8 @@ describe('CDP API', () => {
                     },
                     {
                         level: 'debug',
-                        message: "Suspending function due to async function call 'fetch'. Payload: 2110 bytes",
+                        message:
+                            "Suspending function due to async function call 'fetch'. Payload: 2110 bytes. Event: b3a1fe86-b10c-43cc-acaf-d208977608d0",
                     },
                     {
                         level: 'info',
@@ -223,7 +224,8 @@ describe('CDP API', () => {
                     },
                     {
                         level: 'debug',
-                        message: "Suspending function due to async function call 'fetch'. Payload: 2110 bytes",
+                        message:
+                            "Suspending function due to async function call 'fetch'. Payload: 2110 bytes. Event: b3a1fe86-b10c-43cc-acaf-d208977608d0",
                     },
                     {
                         level: 'debug',

--- a/plugin-server/tests/cdp/cdp-processed-events-consumer.test.ts
+++ b/plugin-server/tests/cdp/cdp-processed-events-consumer.test.ts
@@ -172,7 +172,8 @@ describe('CDP Processed Events Consumer', () => {
                     {
                         topic: 'log_entries_test',
                         value: {
-                            message: "Suspending function due to async function call 'fetch'. Payload: 2035 bytes",
+                            message:
+                                "Suspending function due to async function call 'fetch'. Payload: 2035 bytes. Event: b3a1fe86-b10c-43cc-acaf-d208977608d0",
                             log_source_id: fnFetchNoFilters.id,
                         },
                     },

--- a/plugin-server/tests/cdp/hog-executor.test.ts
+++ b/plugin-server/tests/cdp/hog-executor.test.ts
@@ -612,7 +612,7 @@ describe('Hog Executor', () => {
                 'I AM FIBONACCI',
                 'Function exceeded maximum log entries. No more logs will be collected. Event: uuid',
                 expect.stringContaining(
-                    'Error executing function: HogVMException: Execution timed out after 0.1 seconds. Performed'
+                    'Error executing function on event uuid: HogVMException: Execution timed out after 0.1 seconds. Performed'
                 ),
             ])
         })

--- a/plugin-server/tests/cdp/hog-executor.test.ts
+++ b/plugin-server/tests/cdp/hog-executor.test.ts
@@ -112,7 +112,7 @@ describe('Hog Executor', () => {
                 {
                     timestamp: expect.any(DateTime),
                     level: 'debug',
-                    message: "Suspending function due to async function call 'fetch'. Payload: 1951 bytes",
+                    message: "Suspending function due to async function call 'fetch'. Payload: 1951 bytes. Event: uuid",
                 },
             ])
         })
@@ -193,7 +193,7 @@ describe('Hog Executor', () => {
             expect(logs.map((log) => log.message)).toMatchInlineSnapshot(`
                 Array [
                   "Executing function",
-                  "Suspending function due to async function call 'fetch'. Payload: 1951 bytes",
+                  "Suspending function due to async function call 'fetch'. Payload: 1951 bytes. Event: uuid",
                   "Resuming function",
                   "Fetch response:, {\\"status\\":200,\\"body\\":\\"success\\"}",
                   "Function completed in 100ms. Sync: 0ms. Mem: 812 bytes. Ops: 22. Event: 'http://localhost:8000/events/1'",
@@ -212,7 +212,7 @@ describe('Hog Executor', () => {
             expect(logs.map((log) => log.message)).toMatchInlineSnapshot(`
                 Array [
                   "Executing function",
-                  "Suspending function due to async function call 'fetch'. Payload: 1951 bytes",
+                  "Suspending function due to async function call 'fetch'. Payload: 1951 bytes. Event: uuid",
                   "Resuming function",
                   "Fetch response:, {\\"status\\":200,\\"body\\":{\\"foo\\":\\"bar\\"}}",
                   "Function completed in 100ms. Sync: 0ms. Mem: 812 bytes. Ops: 22. Event: 'http://localhost:8000/events/1'",
@@ -243,7 +243,7 @@ describe('Hog Executor', () => {
             expect(logs.map((log) => log.message)).toMatchInlineSnapshot(`
                 Array [
                   "Executing function",
-                  "Suspending function due to async function call 'fetch'. Payload: 1951 bytes",
+                  "Suspending function due to async function call 'fetch'. Payload: 1951 bytes. Event: uuid",
                   "Fetch failed after 1 attempts",
                   "Fetch failure of kind failurestatus with status 404 and message 404 Not Found",
                   "Resuming function",
@@ -562,7 +562,7 @@ describe('Hog Executor', () => {
             expect(result3.error).toEqual('Exceeded maximum number of async steps: 5')
             expect(result3.logs.map((log) => log.message)).toEqual([
                 'Resuming function',
-                'Error executing function: HogVMException: Exceeded maximum number of async steps: 5',
+                'Error executing function on event uuid: HogVMException: Exceeded maximum number of async steps: 5',
             ])
         })
     })
@@ -610,7 +610,7 @@ describe('Hog Executor', () => {
                 'I AM FIBONACCI',
                 'I AM FIBONACCI',
                 'I AM FIBONACCI',
-                'Function exceeded maximum log entries. No more logs will be collected.',
+                'Function exceeded maximum log entries. No more logs will be collected. Event: uuid',
                 expect.stringContaining(
                     'Error executing function: HogVMException: Execution timed out after 0.1 seconds. Performed'
                 ),


### PR DESCRIPTION
## Problem

When Hog functions fail, it's hard to replay them because we don't know what caused them to fail

## Changes

Add the event UUID into log messages.

## How did you test this code?

Changed the line, waited for CI, fixed the broken tests.