### PR TITLE
fix(data-warehouse): Pass dashboard id into variables props

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
@@ -5,6 +5,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getVariablesFromQuery, haveVariablesOrFiltersChanged } from 'scenes/insights/utils/queryUtils'
 
 import { DataVisualizationNode, HogQLVariable } from '~/queries/schema'
+import { DashboardType } from '~/types'
 
 import { dataVisualizationLogic } from '../../dataVisualizationLogic'
 import { Variable, VariableType } from '../../types'
@@ -15,6 +16,8 @@ export interface VariablesLogicProps {
     key: string
     /** Disable any changes to the query */
     readOnly: boolean
+    /** Dashboard ID for the current dashboard if we're viewing one */
+    dashboardId?: DashboardType['id']
 }
 
 const convertValueToCorrectType = (value: string, type: VariableType): number | string | boolean => {
@@ -37,7 +40,7 @@ export const variablesLogic = kea<variablesLogicType>([
         actions: [dataVisualizationLogic, ['setQuery', 'loadData'], variableDataLogic, ['getVariables']],
         values: [
             dataVisualizationLogic,
-            ['query', 'dashboardId'],
+            ['query'],
             variableDataLogic,
             ['variables', 'variablesLoading'],
             featureFlagLogic,
@@ -124,7 +127,7 @@ export const variablesLogic = kea<variablesLogicType>([
             },
         ],
         showVariablesBar: [
-            (state) => [state.dashboardId],
+            () => [(_, props) => props.dashboardId],
             (dashboardId) => {
                 return !dashboardId
             },

--- a/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/DataVisualization.tsx
@@ -112,7 +112,11 @@ export function DataTableVisualization({
                 <BindLogic logic={displayLogic} props={{ key: dataVisualizationLogicProps.key }}>
                     <BindLogic
                         logic={variablesLogic}
-                        props={{ key: dataVisualizationLogicProps.key, readOnly: readOnly ?? false }}
+                        props={{
+                            key: dataVisualizationLogicProps.key,
+                            readOnly: readOnly ?? false,
+                            dashboardId: insightProps.dashboardId,
+                        }}
                     >
                         <BindLogic logic={variableModalLogic} props={{ key: dataVisualizationLogicProps.key }}>
                             <InternalDataTableVisualization


### PR DESCRIPTION
## Problem
- The variables bar was showing up on insights on dashboards - [slack report](https://posthog.slack.com/archives/C019RAX2XBN/p1733222737269089)
- When we `connect` from one kea logic to another, unless if you pass through _all_ props, the props of the version of logic you connect to will be empty from a previously bound version (although the kea state will be shared via the `key()`)

## Changes
- Instead of accessing the `dashboardId` prop of dataViz logic from variables logic, pass it into variables logic directly

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested locally 