### PR TITLE
fix(data-warehouse): Have better popup text when saving an insight from the data warehouse…

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -408,9 +408,15 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                 query: values.query,
                 saved: true,
             })
-            lemonToast.info(
-                `You're now working on a copy of ${values.insight.name || values.insight.derived_name || name}`
-            )
+
+            if (router.values.location.pathname.includes(urls.dataWarehouse())) {
+                lemonToast.info(`You're now viewing ${values.insight.name || values.insight.derived_name || name}`)
+            } else {
+                lemonToast.info(
+                    `You're now working on a copy of ${values.insight.name || values.insight.derived_name || name}`
+                )
+            }
+
             persist && actions.setInsight(insight, { fromPersistentApi: true, overrideQuery: true })
             savedInsightsLogic.findMounted()?.actions.loadInsights() // Load insights afresh
 


### PR DESCRIPTION
## Problem
- [slack thread](https://posthog.slack.com/archives/C019RAX2XBN/p1733227627084079)
- The popup when you save an insight doesn't quite make sense right now:

![image](https://github.com/user-attachments/assets/db53e59b-9d64-4766-8acf-e27c54ca1b5c)


## Changes
- Update the copy