### PR TITLE
fix: Specify `multidict` version on requirements

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -23,7 +23,7 @@ Faker==17.5.0
 fakeredis[lua]==2.23.3
 freezegun==1.2.2
 inline-snapshot==0.12.*
-multidict==6.0.5
+multidict==6.0.5 # Not used by us directly, but code won't run on Ubuntu 24.04 unless we resolve this to 6.0.5
 packaging==24.1
 black~=23.9.1
 boto3-stubs[s3]

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -23,6 +23,7 @@ Faker==17.5.0
 fakeredis[lua]==2.23.3
 freezegun==1.2.2
 inline-snapshot==0.12.*
+multidict==6.0.5
 packaging==24.1
 black~=23.9.1
 boto3-stubs[s3]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -163,6 +163,10 @@ googleapis-common-protos==1.60.0
     # via
     #   -c requirements.txt
     #   opentelemetry-exporter-otlp-proto-grpc
+greenlet==3.1.1
+    # via
+    #   -c requirements.txt
+    #   sqlalchemy
 grpcio==1.63.2
     # via
     #   -c requirements.txt
@@ -275,9 +279,10 @@ marshmallow==3.23.1
     # via dataclasses-json
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.0.2
+multidict==6.0.5
     # via
     #   -c requirements.txt
+    #   -r requirements-dev.in
     #   aiohttp
     #   yarl
 multiprocess==0.70.16

--- a/requirements.in
+++ b/requirements.in
@@ -51,6 +51,7 @@ langfuse==2.52.1
 langgraph==0.2.34
 langsmith==0.1.132
 lzstring==1.0.4
+multidict==6.0.5
 natsort==8.4.0
 nanoid==2.0.0
 numpy==1.23.3

--- a/requirements.in
+++ b/requirements.in
@@ -51,7 +51,7 @@ langfuse==2.52.1
 langgraph==0.2.34
 langsmith==0.1.132
 lzstring==1.0.4
-multidict==6.0.5
+multidict==6.0.5 # Not used by us directly, but code won't run on Ubuntu 24.04 unless we resolve this to 6.0.5
 natsort==8.4.0
 nanoid==2.0.0
 numpy==1.23.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -267,6 +267,8 @@ googleapis-common-protos==1.60.0
     # via
     #   google-api-core
     #   grpcio-status
+greenlet==3.1.1
+    # via sqlalchemy
 grpcio==1.63.2
     # via
     #   -r requirements.in
@@ -389,8 +391,9 @@ more-itertools==9.0.0
     #   simple-salesforce
 msgpack==1.1.0
     # via langgraph-checkpoint
-multidict==6.0.2
+multidict==6.0.5
     # via
+    #   -r requirements.in
     #   aiohttp
     #   yarl
 nanoid==2.0.0


### PR DESCRIPTION
We can't install our dependencies on Ubuntu 24 because of a broken Ubuntu wheel. The problem was fixed in a later patch version, let's just move it there, there aren't any other relevant changes that would block this.