### PR TITLE
fix: Complete done range using input on empty

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -544,7 +544,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                 await raise_on_produce_task_failure(produce_task)
                 await logger.adebug("Successfully consumed all record batches")
 
-                details.complete_done_ranges(inputs.data_interval_end)
+                details.complete_done_ranges(inputs.data_interval_start, inputs.data_interval_end)
                 heartbeater.set_from_heartbeat_details(details)
 
                 records_total = functools.reduce(operator.add, (task.result() for task in flush_tasks))

--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -32,6 +32,11 @@ from posthog.temporal.batch_exports.batch_exports import (
     start_batch_export_run,
     start_produce_batch_export_record_batches,
 )
+from posthog.temporal.batch_exports.heartbeat import (
+    BatchExportRangeHeartbeatDetails,
+    DateRange,
+    should_resume_from_activity_heartbeat,
+)
 from posthog.temporal.batch_exports.metrics import get_rows_exported_metric
 from posthog.temporal.batch_exports.postgres_batch_export import (
     Fields,
@@ -47,11 +52,6 @@ from posthog.temporal.batch_exports.utils import (
 from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import configure_temporal_worker_logger
-from posthog.temporal.batch_exports.heartbeat import (
-    BatchExportRangeHeartbeatDetails,
-    DateRange,
-    should_resume_from_activity_heartbeat,
-)
 
 
 def remove_escaped_whitespace_recursive(value):
@@ -389,7 +389,7 @@ async def insert_records_to_redshift(
                 heartbeat_details.track_done_range(last_date_range, data_interval_start)
                 heartbeater.set_from_heartbeat_details(heartbeat_details)
 
-    heartbeat_details.complete_done_ranges(data_interval_end)
+    heartbeat_details.complete_done_ranges(data_interval_start, data_interval_end)
     heartbeater.set_from_heartbeat_details(heartbeat_details)
 
     return total_rows_exported


### PR DESCRIPTION
## Problem

Let's not error if `done_ranges` is empty and instead take `data_interval_start` as the value. I think this error is caused by the flush failing, as otherwise any call to flush would track at least one done range (and we have already checked that there is at least one event in the queue).

The new work over at #26575 better handles exceptions when consuming events, I think we may not be handling them correctly here.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Complete a heartbeat range using `data_interval_start` if the stored `done_ranges` are empty.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
