### PR TITLE
feat: Add more fallback flags for missing languages

### DIFF
--- a/frontend/src/scenes/insights/views/WorldMap/countryCodes.ts
+++ b/frontend/src/scenes/insights/views/WorldMap/countryCodes.ts
@@ -54,9 +54,13 @@ export function countryCodeToFlag(countryCode: string): string {
  * This isn't needed often because the locales usually come in the nl-NL format (for dutch, for example)
  * but there are cases where we only see the first part in case the language isn't shared by more than
  * one country - such as the Netherlands.
+ *
+ * For most cases we can simply uppercase the language and that's the country code,
+ * but there are some exceptions listed inside `languageCodeToCountryCode`
  */
 export function languageCodeToFlag(languageCode: string): string {
-    return countryCodeToFlag(languageCodeToCountryCode[languageCode])
+    const countryCode = languageCodeToCountryCode[languageCode] ?? languageCode.toLocaleUpperCase()
+    return countryCodeToFlag(countryCode)
 }
 
 export const countryCodeToName: Record<string, string> = {
@@ -499,6 +503,9 @@ export const languageCodeToName: Record<string, string> = {
     za: 'Zhuang',
     zu: 'Zulu',
 
+    // Some browsers might use `zz` to imply an unknown locale
+    zz: 'Unknown',
+
     // Some browsers use one-long or three-long codes so we're adding here as fallback
     h: 'Croatian',
     chr: 'Cherokee',
@@ -510,7 +517,13 @@ export const languageCodeToName: Record<string, string> = {
 
 // This is only used as a fallback for some languages that don't usually
 // come in the locale-country format (such as nl-NL usually being presented simply as nl)
-// We'll fill this as we see fit based on the values seen in the wild
+// but that can't simply be translated to a country by capitalizing the locale
 const languageCodeToCountryCode: Record<string, string> = {
-    nl: 'NL',
+    ar: 'SA', // Arabic -> Saudi Arabia, tricky, there's no good representation for the "default Arab country"
+    af: 'ZA', // Afrikaans -> South Africa
+    ta: 'IN', // Tamil -> India
+    eu: 'ES', // Basque -> Spain, tricky, but there's no better flag than the Spanish one, we could move to custom SVGs if we wanted to solve this
+    cy: 'GB', // Welsh -> UK
+    ne: 'NP', // Nepali -> Nepal
+    zz: '', // Unknown Language -> No Emoji
 }

--- a/frontend/src/scenes/insights/views/WorldMap/countryCodes.ts
+++ b/frontend/src/scenes/insights/views/WorldMap/countryCodes.ts
@@ -56,11 +56,10 @@ export function countryCodeToFlag(countryCode: string): string {
  * one country - such as the Netherlands.
  *
  * For most cases we can simply uppercase the language and that's the country code,
- * but there are some exceptions listed inside `languageCodeToCountryCode`
+ * but there are some exceptions listed inside `languageCodeToEmojiFlag`
  */
 export function languageCodeToFlag(languageCode: string): string {
-    const countryCode = languageCodeToCountryCode[languageCode] ?? languageCode.toLocaleUpperCase()
-    return countryCodeToFlag(countryCode)
+    return languageCodeToEmojiFlag[languageCode] ?? countryCodeToFlag(languageCode.toLocaleUpperCase())
 }
 
 export const countryCodeToName: Record<string, string> = {
@@ -517,13 +516,13 @@ export const languageCodeToName: Record<string, string> = {
 
 // This is only used as a fallback for some languages that don't usually
 // come in the locale-country format (such as nl-NL usually being presented simply as nl)
-// but that can't simply be translated to a country by capitalizing the locale
-const languageCodeToCountryCode: Record<string, string> = {
-    ar: 'SA', // Arabic -> Saudi Arabia, tricky, there's no good representation for the "default Arab country"
-    af: 'ZA', // Afrikaans -> South Africa
-    ta: 'IN', // Tamil -> India
-    eu: 'ES', // Basque -> Spain, tricky, but there's no better flag than the Spanish one, we could move to custom SVGs if we wanted to solve this
-    cy: 'GB', // Welsh -> UK
-    ne: 'NP', // Nepali -> Nepal
-    zz: '', // Unknown Language -> No Emoji
+// but that can't simply be translated to a flag by capitalizing the locale
+const languageCodeToEmojiFlag: Record<string, string> = {
+    ar: '🇪🇬', // Arabic -> Egypt, tricky, there's no good representation for the "default Arab country", the Egyptian variant is the most commonly understood
+    af: '🇿🇦', // Afrikaans -> South Africa
+    ta: '🇮🇳', // Tamil -> India
+    eu: '🇪🇸', // Basque -> Spain, tricky, but there's no better flag than the Spanish one, we could move to custom SVGs if we wanted to solve this
+    cy: '🏴󠁧󠁢󠁷󠁬󠁳󠁿', // Welsh -> Wales
+    ne: '🇳🇵', // Nepali -> Nepal
+    zz: '🇺🇳', // Unknown Language -> UN flag?
 }


### PR DESCRIPTION
## Problem

Some languages come in a format where they don't contain their "country", so we need a way to fallback to a reasonable country. 

## Changes

We're now always falling back to using the locale as the country (so nl -> NL) but we also need some edge cases which we've added to `languageCodeToCountryCode`

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Visually, looked at our prod data to learn what are the broken languages