### PR TITLE
feat: adding capture events for when a reverse proxy is deleted

### DIFF
--- a/posthog/api/proxy_record.py
+++ b/posthog/api/proxy_record.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import posthoganalytics
 from django.conf import settings
 from rest_framework import serializers, status
 from rest_framework.viewsets import ModelViewSet
@@ -76,6 +77,16 @@ class ProxyRecordViewset(TeamAndOrgViewSetMixin, ModelViewSet):
         )
 
         serializer = self.get_serializer(record)
+        posthoganalytics.capture(
+            request.user.distinct_id,
+            "proxy record created",
+            properties={
+                "organization_id": record.organization_id,
+                "proxy_record_id": record.id,
+                "domain": record.domain,
+                "target_cname": record.target_cname,
+            },
+        )
         return Response(serializer.data)
 
     def destroy(self, request, *args, pk=None, **kwargs):

--- a/posthog/api/proxy_record.py
+++ b/posthog/api/proxy_record.py
@@ -120,6 +120,18 @@ class ProxyRecordViewset(TeamAndOrgViewSetMixin, ModelViewSet):
             record.status = ProxyRecord.Status.DELETING
             record.save()
 
+        organization = Organization.objects.get(id=record.organization_id)
+        posthoganalytics.capture(
+            request.user.distinct_id,
+            "managed reverse proxy deleted",
+            properties={
+                "proxy_record_id": record.id,
+                "domain": record.domain,
+                "target_cname": record.target_cname,
+            },
+            groups=groups(organization),
+        )
+
         return Response(
             {"success": True},
             status=status.HTTP_200_OK,


### PR DESCRIPTION
## Problem

Capture an event when a reverse proxy is deleted:

![image](https://github.com/user-attachments/assets/9f5133df-5bd2-411e-ba0c-35f5f352cc5c)


## Changes

Just added capture events for delete. I abstracted the function so it can be re-used within the file to help make the file more readable. I might want to abstract this function more broadly so it can be reused across all API requests since we will be capturing events for other features

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Cloud: yes

## How did you test this code?

Verified I can create and delete the proxy.
