### PR TITLE
chore: add mprocs as an alternative to bin/start

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -1,0 +1,18 @@
+procs:
+    celery-worker:
+        shell: 'source ./bin/celery-queues.env && python manage.py run_autoreload_celery --type=worker'
+
+    celery-beat:
+        shell: 'source ./bin/celery-queues.env && python manage.py run_autoreload_celery --type=beat'
+
+    plugin-server:
+        shell: './bin/plugin-server'
+
+    backend:
+        shell: 'python3 manage.py runserver'
+
+    frontend:
+        shell: 'export DEBUG=0 && pnpm install && pnpm start'
+
+    temporal-worker:
+        shell: 'python3 manage.py start_temporal_worker'

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -15,4 +15,10 @@ procs:
         shell: 'export DEBUG=0 && pnpm install && pnpm start'
 
     temporal-worker:
-        shell: 'python3 manage.py start_temporal_worker'
+        # added a sleep to give the docker stuff time to start
+        shell: 'sleep 10 && python3 manage.py start_temporal_worker'
+
+    docker-compose:
+        shell: 'docker compose -f docker-compose.dev.yml up'
+        stop:
+            send-keys: ['<C-c>']

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -9,10 +9,10 @@ procs:
         shell: './bin/plugin-server'
 
     backend:
-        shell: 'python3 manage.py runserver'
+        shell: './bin/start-backend'
 
     frontend:
-        shell: 'export DEBUG=0 && pnpm install && pnpm start'
+        shell: './bin/start-frontend'
 
     temporal-worker:
         # added a sleep to give the docker stuff time to start

--- a/bin/start-mprocs
+++ b/bin/start-mprocs
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export DEBUG=${DEBUG:-1}
+export SKIP_SERVICE_VERSION_REQUIREMENTS=${SKIP_SERVICE_VERSION_REQUIREMENTS:-1}
+export BILLING_SERVICE_URL=${BILLING_SERVICE_URL:-https://billing.dev.posthog.dev}
+export HOG_HOOK_URL=${HOG_HOOK_URL:-http://localhost:3300/hoghook}
+
+exec mprocs --config bin/mprocs.yaml

--- a/bin/start-mprocs
+++ b/bin/start-mprocs
@@ -5,4 +5,6 @@ export SKIP_SERVICE_VERSION_REQUIREMENTS=${SKIP_SERVICE_VERSION_REQUIREMENTS:-1}
 export BILLING_SERVICE_URL=${BILLING_SERVICE_URL:-https://billing.dev.posthog.dev}
 export HOG_HOOK_URL=${HOG_HOOK_URL:-http://localhost:3300/hoghook}
 
+[ ! -f ./share/GeoLite2-City.mmdb ] && ( curl -L "https://mmdbcdn.posthog.net/" --http1.1 | brotli --decompress --output=./share/GeoLite2-City.mmdb )
+
 exec mprocs --config bin/mprocs.yaml

--- a/bin/start-mprocs
+++ b/bin/start-mprocs
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export DEBUG=${DEBUG:-1}
 export SKIP_SERVICE_VERSION_REQUIREMENTS=${SKIP_SERVICE_VERSION_REQUIREMENTS:-1}
 export BILLING_SERVICE_URL=${BILLING_SERVICE_URL:-https://billing.dev.posthog.dev}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
Separate dev processes. Make it easy to see logs separately and restart stuff separately.

[mprocs](https://github.com/pvolok/mprocs) is a nice tool for this. You can install it with `brew install mprocs`

With these changes, you can run `./bin/start-mprocs` and get this

<img width="1594" alt="Screenshot 2024-12-06 at 14 02 53" src="https://github.com/user-attachments/assets/7d8b7327-c99c-4dbf-964f-d9a9127b3876">

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
Add mprocs.yaml and a wrapper script to run mprocs with default env vars.
Just added stuff, nothing existing has been changed.
