### PR TITLE
feat: delete capture events in reverse proxy

### DIFF
--- a/posthog/api/proxy_record.py
+++ b/posthog/api/proxy_record.py
@@ -83,17 +83,20 @@ class ProxyRecordViewset(TeamAndOrgViewSetMixin, ModelViewSet):
             target_cname=record.target_cname,
         )
         workflow_id = f"proxy-create-{inputs.proxy_record_id}"
-        asyncio.run(
-            temporal.start_workflow(
-                "create-proxy",
-                inputs,
-                id=workflow_id,
-                task_queue=GENERAL_PURPOSE_TASK_QUEUE,
+        try:
+            asyncio.run(
+                temporal.start_workflow(
+                    "create-proxy",
+                    inputs,
+                    id=workflow_id,
+                    task_queue=GENERAL_PURPOSE_TASK_QUEUE,
+                )
             )
-        )
+            _capture_proxy_event(request, record, "created")
+        except Exception:
+            raise
 
         serializer = self.get_serializer(record)
-        _capture_proxy_event(request, record, "created")
         return Response(serializer.data)
 
     def destroy(self, request, *args, pk=None, **kwargs):
@@ -113,18 +116,20 @@ class ProxyRecordViewset(TeamAndOrgViewSetMixin, ModelViewSet):
                 domain=record.domain,
             )
             workflow_id = f"proxy-delete-{inputs.proxy_record_id}"
-            asyncio.run(
-                temporal.start_workflow(
-                    "delete-proxy",
-                    inputs,
-                    id=workflow_id,
-                    task_queue=GENERAL_PURPOSE_TASK_QUEUE,
+            try:
+                asyncio.run(
+                    temporal.start_workflow(
+                        "delete-proxy",
+                        inputs,
+                        id=workflow_id,
+                        task_queue=GENERAL_PURPOSE_TASK_QUEUE,
+                    )
                 )
-            )
-            record.status = ProxyRecord.Status.DELETING
-            record.save()
-
-            _capture_proxy_event(request, record, "deleted")
+                record.status = ProxyRecord.Status.DELETING
+                record.save()
+                _capture_proxy_event(request, record, "deleted")
+            except Exception:
+                raise
 
         return Response(
             {"success": True},


### PR DESCRIPTION
## Problem

Adding a capture event with a reverse proxy is deleted. 

Sorry for the small changes but I've been battling with testing these logs locally. Once I can verify them locally, I will push larger changes for the remaining team features.

## Changes

Verified managed reverse proxy's can be created and deleted in the frontend

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Cloud: yes

## How did you test this code?

Locally by adding and deleting managed reverse proxies
