### PR TITLE
chore(editor-3000): init all models for autocomplete

### DIFF
--- a/frontend/src/lib/monaco/CodeEditor.tsx
+++ b/frontend/src/lib/monaco/CodeEditor.tsx
@@ -35,6 +35,10 @@ export interface CodeEditorProps extends Omit<EditorProps, 'loading' | 'theme'> 
 }
 let codeEditorIndex = 0
 
+export function initModel(model: editor.ITextModel, builtCodeEditorLogic: BuiltLogic<codeEditorLogicType>): void {
+    ;(model as any).codeEditorLogic = builtCodeEditorLogic
+}
+
 function initEditor(
     monaco: Monaco,
     editor: importedEditor.IStandaloneCodeEditor,
@@ -44,7 +48,9 @@ function initEditor(
 ): void {
     // This gives autocomplete access to the specific editor
     const model = editor.getModel()
-    ;(model as any).codeEditorLogic = builtCodeEditorLogic
+    if (model) {
+        initModel(model, builtCodeEditorLogic)
+    }
 
     if (editorProps?.language === 'hog') {
         initHogLanguage(monaco)

--- a/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryWindow.tsx
@@ -134,6 +134,7 @@ function InternalQueryWindow({ setQuery, query }: InternalQueryWindowProps): JSX
                 sourceQuery={query.source}
                 promptError={null}
                 codeEditorProps={{
+                    queryKey: codeEditorKey,
                     onChange: (v) => {
                         setQueryInput(v ?? '')
                     },


### PR DESCRIPTION
## Problem

- models that go to editor weren't being init with logic

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- init with logic

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
