### PR TITLE
feat: survey summary opt-in

### DIFF
--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -1,3 +1,4 @@
+import { offset } from '@floating-ui/react'
 import {
     IconInfo,
     IconSparkles,
@@ -5,8 +6,9 @@ import {
     IconThumbsDownFilled,
     IconThumbsUp,
     IconThumbsUpFilled,
+    IconX,
 } from '@posthog/icons'
-import { LemonButton, LemonTable, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, LemonTable, Popover, Spinner } from '@posthog/lemon-ui'
 import { BindLogic, useActions, useValues } from 'kea'
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -21,6 +23,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { LineGraph } from 'scenes/insights/views/LineGraph/LineGraph'
 import { PieChart } from 'scenes/insights/views/LineGraph/PieChart'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
+import { surveyDataProcessingLogic } from 'scenes/surveys/suveyDataProcessingLogic'
 
 import { GraphType } from '~/types'
 import { InsightLogicProps, SurveyQuestionType } from '~/types'
@@ -634,29 +637,76 @@ export function OpenTextViz({
 }
 
 function ResponseSummariesButton({ questionIndex }: { questionIndex: number | undefined }): JSX.Element {
+    const [popOverClosed, setPopOverClosed] = useState(false)
+
     const { summarize } = useActions(surveyLogic)
     const { responseSummary, responseSummaryLoading } = useValues(surveyLogic)
+    const { surveyDataProcessingAccepted, surveyDataProcessingRefused } = useValues(surveyDataProcessingLogic)
+    const { acceptSurveyDataProcessing, refuseSurveyDataProcessing } = useActions(surveyDataProcessingLogic)
 
+    const summarizeButton = (
+        <LemonButton
+            type="secondary"
+            data-attr="summarize-survey"
+            onClick={() => summarize({ questionIndex })}
+            disabledReason={
+                surveyDataProcessingRefused
+                    ? 'OpenAI processing refused'
+                    : responseSummaryLoading
+                    ? 'Let me think...'
+                    : responseSummary
+                    ? 'already summarized'
+                    : undefined
+            }
+            icon={<IconSparkles />}
+        >
+            {responseSummaryLoading ? (
+                <>
+                    Let me think...
+                    <Spinner />
+                </>
+            ) : (
+                <>Summarize responses</>
+            )}
+        </LemonButton>
+    )
     return (
         <FlaggedFeature flag={FEATURE_FLAGS.AI_SURVEY_RESPONSE_SUMMARY} match={true}>
-            <LemonButton
-                type="secondary"
-                data-attr="summarize-survey"
-                onClick={() => summarize({ questionIndex })}
-                disabledReason={
-                    responseSummaryLoading ? 'Let me think...' : responseSummary ? 'already summarized' : undefined
-                }
-                icon={<IconSparkles />}
-            >
-                {responseSummaryLoading ? (
-                    <>
-                        Let me think...
-                        <Spinner />
-                    </>
-                ) : (
-                    <>Summarize responses</>
-                )}
-            </LemonButton>
+            {surveyDataProcessingAccepted ? (
+                summarizeButton
+            ) : (
+                <Popover
+                    overlay={
+                        <div className="mx-1.5 my 0.5 flex flex-col gap-1">
+                            <div className="flex justify-end">
+                                <LemonButton size="small" icon={<IconX />} onClick={() => setPopOverClosed(true)} />
+                            </div>
+                            <div>
+                                <p className="font-medium text-pretty mb-1.5">
+                                    Uses OpenAI services to analyze your survey responses,
+                                    <br />
+                                    This <em>can</em> include personal data of your users,
+                                    <br />
+                                    if they include it in their responses.
+                                    <br />
+                                    <em>Your data won't be used for training models.</em>
+                                </p>
+                            </div>
+                            <LemonButton type="secondary" size="small" onClick={() => acceptSurveyDataProcessing()}>
+                                Got it, I accept OpenAI processing survey data
+                            </LemonButton>
+                            <LemonButton type="secondary" size="small" onClick={() => refuseSurveyDataProcessing()}>
+                                No thanks, I don't want OpenAI processing survey data
+                            </LemonButton>
+                        </div>
+                    }
+                    middleware={[offset(-12)]}
+                    showArrow
+                    visible={!popOverClosed && !surveyDataProcessingAccepted && !surveyDataProcessingRefused}
+                >
+                    {summarizeButton}
+                </Popover>
+            )}
         </FlaggedFeature>
     )
 }

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -736,7 +736,7 @@ function ResponseSummaryFeedback({ surveyId }: { surveyId: string }): JSX.Elemen
             return // Already rated
         }
         setRating(newRating)
-        posthog.capture('chat rating', {
+        posthog.capture('survey_resonse_rated', {
             survey_id: surveyId,
             answer_rating: rating,
         })

--- a/frontend/src/scenes/surveys/surveyViewViz.tsx
+++ b/frontend/src/scenes/surveys/surveyViewViz.tsx
@@ -655,7 +655,7 @@ function ResponseSummariesButton({ questionIndex }: { questionIndex: number | un
                     : responseSummaryLoading
                     ? 'Let me think...'
                     : responseSummary
-                    ? 'already summarized'
+                    ? 'Already summarized'
                     : undefined
             }
             icon={<IconSparkles />}

--- a/frontend/src/scenes/surveys/suveyDataProcessingLogic.ts
+++ b/frontend/src/scenes/surveys/suveyDataProcessingLogic.ts
@@ -1,4 +1,5 @@
-import { actions, kea, path, reducers } from 'kea'
+import { actions, kea, listeners, path, reducers } from 'kea'
+import posthog from 'posthog-js'
 
 import type { surveyDataProcessingLogicType } from './suveyDataProcessingLogicType'
 
@@ -25,5 +26,13 @@ export const surveyDataProcessingLogic = kea<surveyDataProcessingLogicType>([
                 refuseSurveyDataProcessing: () => true,
             },
         ],
+    }),
+    listeners({
+        acceptSurveyDataProcessing: () => {
+            posthog.capture('survey_data_processing_accepted')
+        },
+        refuseSurveyDataProcessing: () => {
+            posthog.capture('survey_data_processing_refused')
+        },
     }),
 ])

--- a/frontend/src/scenes/surveys/suveyDataProcessingLogic.ts
+++ b/frontend/src/scenes/surveys/suveyDataProcessingLogic.ts
@@ -1,0 +1,29 @@
+import { actions, kea, path, reducers } from 'kea'
+
+import type { surveyDataProcessingLogicType } from './suveyDataProcessingLogicType'
+
+export const surveyDataProcessingLogic = kea<surveyDataProcessingLogicType>([
+    path(['scenes', 'surveys', 'suveyDataProcessingLogic']),
+    actions({
+        acceptSurveyDataProcessing: true,
+        refuseSurveyDataProcessing: true,
+    }),
+    reducers({
+        surveyDataProcessingAccepted: [
+            false,
+            { persist: true },
+            {
+                acceptSurveyDataProcessing: () => true,
+                refuseSurveyDataProcessing: () => false,
+            },
+        ],
+        surveyDataProcessingRefused: [
+            false,
+            { persist: true },
+            {
+                acceptSurveyDataProcessing: () => false,
+                refuseSurveyDataProcessing: () => true,
+            },
+        ],
+    }),
+])


### PR DESCRIPTION
We added survey summarization in a hackathon

This adds a mechanism to capture consent for open ai processing of survey responses so that we can roll it out

(I just copied what Max AI is doing)

## accepting proccessing

![2024-12-04 06 07 15](https://github.com/user-attachments/assets/aba6fce4-c5b0-4ff4-b552-6a01961e4d47)

## ignoring/refusing

![2024-12-04 06 02 19](https://github.com/user-attachments/assets/26cca149-e060-4960-b9b5-93d3ec861d23)



