### PR TITLE
feat(cdp): default to mock HTTP requests disabled

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
@@ -390,7 +390,7 @@ export function HogFunctionInputWithSchema({ schema }: HogFunctionInputWithSchem
                                     {supportsTemplating && (
                                         <LemonButton
                                             size="xsmall"
-                                            to="https://posthog.com/docs/cdp/destinations#input-formatting"
+                                            to="https://posthog.com/docs/cdp/destinations/customizing-destinations#customizing-payload"
                                             sideIcon={<IconInfo />}
                                             noPadding
                                             className=" opacity-0 group-hover:opacity-100 p-1 transition-opacity"

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
@@ -129,7 +129,7 @@ export function HogFunctionTest(props: HogFunctionTestLogicProps): JSX.Element {
                                                         }
                                                     >
                                                         <span className="flex gap-2">
-                                                            Mock out async functions
+                                                            Mock out HTTP requests
                                                             <IconInfo className="text-lg" />
                                                         </span>
                                                     </Tooltip>

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
@@ -77,7 +77,7 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
     forms(({ props, actions, values }) => ({
         testInvocation: {
             defaults: {
-                mock_async_functions: true,
+                mock_async_functions: false,
             } as HogFunctionTestInvocationForm,
             alwaysShowErrors: true,
             errors: ({ globals }) => {

--- a/posthog/cdp/templates/slack/template_slack.py
+++ b/posthog/cdp/templates/slack/template_slack.py
@@ -24,7 +24,7 @@ let res := fetch('https://slack.com/api/chat.postMessage', {
   }
 });
 
-if (res.status != 200 or not res.body.ok) {
+if (res.status != 200 or res.body.ok == false) {
   throw Error(f'Failed to post message to Slack: {res.status}: {res.body}');
 }
 """.strip(),


### PR DESCRIPTION
## Changes

- updated `Supports templating` link
- renamed mock toggle to `Mock out HTTP requests` and set the default to `false`

Haven't added a big warning since sending a real request seems what most people expect and Segment's custom function testing menu doesn't have any warnings as well, but happy to revisit this point.
![2024-12-04 at 09 34 27@2x](https://github.com/user-attachments/assets/a2414af8-166e-4199-8af4-e07934423008)

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
