### PR TITLE
fix(err): support fingerprint passthrough

### DIFF
--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -49,6 +49,8 @@ pub struct Exception {
 pub struct RawErrProps {
     #[serde(rename = "$exception_list")]
     pub exception_list: Vec<Exception>,
+    #[serde(rename = "$exception_fingerprint")]
+    pub fingerprint: Option<String>, // Clients can send us fingerprints, which we'll use if present
     #[serde(flatten)]
     // A catch-all for all the properties we don't "care" about, so when we send back to kafka we don't lose any info
     pub other: HashMap<String, Value>,
@@ -57,6 +59,7 @@ pub struct RawErrProps {
 pub struct FingerprintedErrProps {
     pub exception_list: Vec<Exception>,
     pub fingerprint: String,
+    pub proposed_fingerprint: String, // We suggest a fingerprint, based on hashes, but let users override client-side
     pub other: HashMap<String, Value>,
 }
 
@@ -67,6 +70,8 @@ pub struct OutputErrProps {
     pub exception_list: Vec<Exception>,
     #[serde(rename = "$exception_fingerprint")]
     pub fingerprint: String,
+    #[serde(rename = "$exception_proposed_fingerprint")]
+    pub proposed_fingerprint: String,
     #[serde(rename = "$exception_issue_id")]
     pub issue_id: Uuid,
     #[serde(flatten)]
@@ -119,7 +124,8 @@ impl RawErrProps {
     pub fn to_fingerprinted(self, fingerprint: String) -> FingerprintedErrProps {
         FingerprintedErrProps {
             exception_list: self.exception_list,
-            fingerprint,
+            fingerprint: self.fingerprint.unwrap_or(fingerprint.clone()),
+            proposed_fingerprint: fingerprint,
             other: self.other,
         }
     }
@@ -131,6 +137,7 @@ impl FingerprintedErrProps {
             exception_list: self.exception_list,
             fingerprint: self.fingerprint,
             issue_id,
+            proposed_fingerprint: self.proposed_fingerprint,
             other: self.other,
         }
     }

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -49,7 +49,10 @@ pub struct Exception {
 pub struct RawErrProps {
     #[serde(rename = "$exception_list")]
     pub exception_list: Vec<Exception>,
-    #[serde(rename = "$exception_fingerprint")]
+    #[serde(
+        rename = "$exception_fingerprint",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub fingerprint: Option<String>, // Clients can send us fingerprints, which we'll use if present
     #[serde(flatten)]
     // A catch-all for all the properties we don't "care" about, so when we send back to kafka we don't lose any info

--- a/rust/cymbal/tests/static/python_err_props.json
+++ b/rust/cymbal/tests/static/python_err_props.json
@@ -733,6 +733,5 @@
     "$ip": "185.140.230.43",
     "$lib_version__minor": 6,
     "$lib": "posthog-python",
-    "$lib_version__major": 3,
-    "$exception_fingerprint": ["ConnectionRefusedError", "[Errno 111] Connection refused", "_new_conn"]
+    "$lib_version__major": 3
 }


### PR DESCRIPTION
We want clients to be able to set an `$exception_fingerprint`, and for cymbal to not override that. This PR does that, and also adds a `$proposed_exception_fingerprint`, which might let us show users what issue an exception _would_ have been in, had they not set the id in the client.