### PR TITLE
fix(product-assistant): filter out reasoning messages

### DIFF
--- a/ee/hogai/utils.py
+++ b/ee/hogai/utils.py
@@ -31,7 +31,7 @@ AssistantMessageUnion = Union[
 
 
 class Conversation(BaseModel):
-    messages: list[RootAssistantMessage] = Field(..., min_length=1, max_length=20)
+    messages: list[RootAssistantMessage] = Field(..., min_length=1, max_length=50)
     session_id: str
 
 

--- a/frontend/src/scenes/max/maxLogic.ts
+++ b/frontend/src/scenes/max/maxLogic.ts
@@ -4,7 +4,7 @@ import { createParser } from 'eventsource-parser'
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import api, { ApiError } from 'lib/api'
-import { isHumanMessage, isVisualizationMessage } from 'scenes/max/utils'
+import { isHumanMessage, isReasoningMessage, isVisualizationMessage } from 'scenes/max/utils'
 import { projectLogic } from 'scenes/projectLogic'
 
 import {
@@ -84,6 +84,7 @@ export const maxLogic = kea<maxLogicType>([
                     },
                     ...state.slice(index + 1),
                 ],
+                setThreadLoaded: (state) => state.filter((message) => !isReasoningMessage(message)),
             },
         ],
         threadLoading: [


### PR DESCRIPTION
## Problem

Reasoning messages are only useful in UI. A thread now reaches its maximum limit after a fourth message.

## Changes

- Bump max message count.
- Filter out reasoning messages when a thread finishes generating.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Manual testing