### PR TITLE
fix: Do not merge heartbeat ranges

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_heartbeat.py
+++ b/posthog/temporal/tests/batch_exports/test_heartbeat.py
@@ -53,52 +53,7 @@ def test_insert_done_range(initial_done_ranges, done_range, expected_index):
     """
     heartbeat_details = BatchExportRangeHeartbeatDetails()
     heartbeat_details.done_ranges.extend(initial_done_ranges)
-    heartbeat_details.insert_done_range(done_range, merge=False)
+    heartbeat_details.insert_done_range(done_range)
 
     assert len(heartbeat_details.done_ranges) == len(initial_done_ranges) + 1
     assert heartbeat_details.done_ranges.index(done_range) == expected_index
-
-
-@pytest.mark.parametrize(
-    "initial_done_ranges,expected_done_ranges",
-    [
-        # Case 1: Disconnected ranges are not merged.
-        (
-            [
-                (dt.datetime.fromtimestamp(0), dt.datetime.fromtimestamp(5)),
-                (dt.datetime.fromtimestamp(6), dt.datetime.fromtimestamp(10)),
-            ],
-            [
-                (dt.datetime.fromtimestamp(0), dt.datetime.fromtimestamp(5)),
-                (dt.datetime.fromtimestamp(6), dt.datetime.fromtimestamp(10)),
-            ],
-        ),
-        # Case 2: Connected ranges are merged.
-        (
-            [
-                (dt.datetime.fromtimestamp(0), dt.datetime.fromtimestamp(5)),
-                (dt.datetime.fromtimestamp(5), dt.datetime.fromtimestamp(10)),
-            ],
-            [(dt.datetime.fromtimestamp(0), dt.datetime.fromtimestamp(10))],
-        ),
-        # Case 3: Connected ranges are merged, but disconnected are not.
-        (
-            [
-                (dt.datetime.fromtimestamp(0), dt.datetime.fromtimestamp(5)),
-                (dt.datetime.fromtimestamp(5), dt.datetime.fromtimestamp(10)),
-                (dt.datetime.fromtimestamp(11), dt.datetime.fromtimestamp(12)),
-            ],
-            [
-                (dt.datetime.fromtimestamp(0), dt.datetime.fromtimestamp(10)),
-                (dt.datetime.fromtimestamp(11), dt.datetime.fromtimestamp(12)),
-            ],
-        ),
-    ],
-)
-def test_merge_done_ranges(initial_done_ranges, expected_done_ranges):
-    """Test `BatchExportRangeHeartbeatDetails` merges done ranges."""
-    heartbeat_details = BatchExportRangeHeartbeatDetails()
-    heartbeat_details.done_ranges.extend(initial_done_ranges)
-    heartbeat_details.merge_done_ranges()
-
-    assert heartbeat_details.done_ranges == expected_done_ranges


### PR DESCRIPTION
## Problem

Merging heartbeat ranges in batch exports has currently two problems:
* If there are multiple ranges to merge, the function will fail as we pop indexes in a loop thus modifying the index we should pop in future loop iterations.
* We do not have enough information to marge two date ranges: There could be events with the same inserted_at still missing.

Until we update the queue to keep track of a record batch index that we can use to merge ranges together, let's just not merge.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
