### PR TITLE
chore: Add fastpriorityqueue to concurrencyController so it scales better

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
         "expr-eval": "^2.0.2",
         "express": "^4.17.1",
         "fast-deep-equal": "^3.1.3",
+        "fastpriorityqueue": "^0.7.5",
         "fflate": "^0.7.4",
         "fs-extra": "^10.0.0",
         "fuse.js": "^6.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ dependencies:
   fast-deep-equal:
     specifier: ^3.1.3
     version: 3.1.3
+  fastpriorityqueue:
+    specifier: ^0.7.5
+    version: 0.7.5
   fflate:
     specifier: ^0.7.4
     version: 0.7.4
@@ -12766,6 +12769,10 @@ packages:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
     dev: true
+
+  /fastpriorityqueue@0.7.5:
+    resolution: {integrity: sha512-3Pa0n9gwy8yIbEsT3m2j/E9DXgWvvjfiZjjqcJ+AdNKTAlVMIuFYrYG5Y3RHEM8O6cwv9hOpOWY/NaMfywoQVA==}
+    dev: false
 
   /fastq@1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}


### PR DESCRIPTION
## Problem

The ConcurrencyController relies on sorting a list, rather than a proper priority queue. In practice, this didn't matter, as usually there were < 20 items in the queue. I want to use this class for thousands of elements, and so this change is needed to scale better

## Changes

Use a priority queue instead of a list

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Existing tests still pass
