### PR TITLE
fix: validate managed reverse proxy domain

### DIFF
--- a/frontend/src/scenes/settings/environment/proxyLogic.ts
+++ b/frontend/src/scenes/settings/environment/proxyLogic.ts
@@ -83,6 +83,8 @@ export const proxyLogic = kea<proxyLogicType>([
                     ? 'Domains cannot include wildcards'
                     : !isDomain('http://' + domain)
                     ? 'Do not include the protocol e.g. https://'
+                    : !domain.match(/^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/)
+                    ? "Invalid domain. Please provide a lowercase RFC 1123 subdomain. It must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"
                     : undefined,
             }),
             submit: ({ domain }) => {


### PR DESCRIPTION
<img width="1094" alt="Screenshot 2024-12-04 at 21 26 26" src="https://github.com/user-attachments/assets/8a3f9b6c-70e2-42dd-8d29-cbb33358d128">

see https://posthoghelp.zendesk.com/agent/tickets/21538 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/23632)

we let people try to create invalid reverse proxies... let's not

i grabbed the rule from the temporal error message 