### PR TITLE
feat: adding capture for 2fa enforcements at org level

### DIFF
--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -5,6 +5,8 @@ from django.db.models import Model, QuerySet
 from django.shortcuts import get_object_or_404
 from rest_framework import exceptions, permissions, serializers, viewsets
 from rest_framework.request import Request
+from rest_framework.response import Response
+import posthoganalytics
 
 from posthog import settings
 from posthog.api.routing import TeamAndOrgViewSetMixin
@@ -12,7 +14,7 @@ from posthog.api.shared import ProjectBasicSerializer, TeamBasicSerializer
 from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.cloud_utils import is_cloud
 from posthog.constants import INTERNAL_BOT_EMAIL_SUFFIX, AvailableFeature
-from posthog.event_usage import report_organization_deleted
+from posthog.event_usage import report_organization_deleted, groups
 from posthog.models import Organization, User
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
@@ -240,3 +242,23 @@ class OrganizationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             **super().get_serializer_context(),
             "user_permissions": UserPermissions(cast(User, self.request.user)),
         }
+
+    def update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        if "enforce_2fa" in request.data:
+            enforce_2fa_value = request.data["enforce_2fa"]
+            organization = self.get_object()
+
+            # Add capture event for 2FA enforcement change
+            posthoganalytics.capture(
+                request.user.distinct_id,
+                "organization 2fa enforcement toggled",
+                properties={
+                    "enabled": enforce_2fa_value,
+                    "organization_id": str(organization.id),
+                    "organization_name": organization.name,
+                    "user_role": request.user.organization_memberships.get(organization=organization).level,
+                },
+                groups=groups(organization),
+            )
+
+        return super().update(request, *args, **kwargs)

--- a/posthog/api/organization.py
+++ b/posthog/api/organization.py
@@ -247,16 +247,17 @@ class OrganizationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if "enforce_2fa" in request.data:
             enforce_2fa_value = request.data["enforce_2fa"]
             organization = self.get_object()
+            user = cast(User, request.user)
 
             # Add capture event for 2FA enforcement change
             posthoganalytics.capture(
-                request.user.distinct_id,
+                str(user.distinct_id),
                 "organization 2fa enforcement toggled",
                 properties={
                     "enabled": enforce_2fa_value,
                     "organization_id": str(organization.id),
                     "organization_name": organization.name,
-                    "user_role": request.user.organization_memberships.get(organization=organization).level,
+                    "user_role": user.organization_memberships.get(organization=organization).level,
                 },
                 groups=groups(organization),
             )


### PR DESCRIPTION
## Problem

We want to capture when the user toggle 2fa for everyone in the org

## Changes

No UX changes, just capturing logs in the backend

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Cloud: Yes

## How did you test this code?

Tested locally and added tests:

```
env) surbhijhavar@Surbhis-MacBook-Pro posthog % pytest /Users/surbhijhavar/posthog/posthog/api/test/test_organization.py
=============================================== test session starts ================================================
platform darwin -- Python 3.11.10, pytest-8.0.2, pluggy-1.5.0
django: settings: posthog.settings (from ini)
rootdir: /Users/surbhijhavar/posthog
configfile: pytest.ini
plugins: inline-snapshot-0.12.1, icdiff-0.6, flaky-3.7.0, cov-4.1.0, asyncio-0.21.1, mock-3.11.1, Faker-17.5.0, split-0.9.0, django-4.5.2, env-0.8.2, anyio-4.6.2.post1, xdist-3.6.1, syrupy-4.6.4
asyncio: mode=Mode.STRICT
collected 15 items                                                                                                 

posthog/api/test/test_organization.py ...............                                                        [100%]
================================================= inline snapshot ==================================================

============================== 15 passed in 3.46s ==============================
```

Toggle on/off and ensured the log is captured:
![image](https://github.com/user-attachments/assets/70c5e391-d28b-4668-8a4a-5fa5071d1029)

