### PR TITLE
fix: Don't use port returned by `system.clusters` in `ClickhouseCluster`

### DIFF
--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -126,7 +126,7 @@ def get_materialized_columns(
 def get_cluster() -> ClickhouseCluster:
     extra_hosts = []
     for host_config in map(copy, CLICKHOUSE_PER_TEAM_SETTINGS.values()):
-        extra_hosts.append(ConnectionInfo(host_config.pop("host"), host_config.pop("port", None)))
+        extra_hosts.append(ConnectionInfo(host_config.pop("host")))
         assert len(host_config) == 0, f"unexpected values: {host_config!r}"
     return ClickhouseCluster(default_client(), extra_hosts=extra_hosts)
 

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -52,10 +52,9 @@ class FuturesMap(dict[K, Future[V]]):
 
 class ConnectionInfo(NamedTuple):
     address: str
-    port: int
 
     def make_pool(self) -> ChPool:
-        return make_ch_pool(host=self.address, port=self.port)
+        return make_ch_pool(host=self.address)
 
 
 class HostInfo(NamedTuple):
@@ -70,10 +69,10 @@ T = TypeVar("T")
 class ClickhouseCluster:
     def __init__(self, bootstrap_client: Client, extra_hosts: Sequence[ConnectionInfo] | None = None) -> None:
         self.__hosts = [
-            HostInfo(ConnectionInfo(host_address, port), shard_num, replica_num)
-            for (host_address, port, shard_num, replica_num) in bootstrap_client.execute(
+            HostInfo(ConnectionInfo(host_address), shard_num, replica_num)
+            for (host_address, shard_num, replica_num) in bootstrap_client.execute(
                 """
-                SELECT host_address, port, shard_num, replica_num
+                SELECT host_address, shard_num, replica_num
                 FROM system.clusters
                 WHERE name = %(name)s
                 ORDER BY shard_num, replica_num

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -54,6 +54,9 @@ class ConnectionInfo(NamedTuple):
     address: str
     port: int
 
+    def make_pool(self) -> ChPool:
+        return make_ch_pool(host=self.address, port=self.port)
+
 
 class HostInfo(NamedTuple):
     connection_info: ConnectionInfo
@@ -87,7 +90,7 @@ class ClickhouseCluster:
     def __get_task_function(self, host: HostInfo, fn: Callable[[Client], T]) -> Callable[[], T]:
         pool = self.__pools.get(host)
         if pool is None:
-            pool = self.__pools[host] = make_ch_pool(host=host.connection_info.address, port=host.connection_info.port)
+            pool = self.__pools[host] = host.connection_info.make_pool()
 
         def task():
             with pool.get_client() as client:


### PR DESCRIPTION
## Problem

Using the port provided by `system.clusters` (typically 9000) can cause connection errors as it's not necessarily the interface that we want the client to use when connecting.

## Changes

Don't use the returned port and use the port from settings instead.

This assumes the entire cluster is configured the same, which … seems like a reasonable assumption? Right? _Right?_

## Does this work well for both Cloud and self-hosted?

N/A - `ClickhouseCluster` is only used in cloud right now for materialized column management.

## How did you test this code?

Made sure dropping the port from the call to `make_ch_pool` worked as expected in a shell on toolbox:

```
>>> with make_ch_pool(host=…).get_client() as c:
...   c.execute('select 1')
... 
[(1,)]
```

Otherwise covered by existing tests that ensure connections can be established in general.