### PR TITLE
perf: Only drop columns and indexes associated with materialized columns if they exist

### DIFF
--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -339,15 +339,17 @@ class DropColumnTask:
         if self.try_drop_index:
             # XXX: copy/pasted from create task
             index_name = f"minmax_{self.column_name}"
+            drop_index_action = f"DROP INDEX IF EXISTS {index_name}"
             if check_index_exists(client, self.table, index_name):
-                actions.append(f"DROP INDEX IF EXISTS {index_name}")
+                actions.append(drop_index_action)
             else:
-                logger.info("Skipping DROP INDEX for %r, nothing to do...", self)
+                logger.info("Skipping %r, nothing to do...", drop_index_action)
 
+        drop_column_action = f"DROP COLUMN IF EXISTS {self.column_name}"
         if check_column_exists(client, self.table, self.column_name):
-            actions.append(f"DROP COLUMN IF EXISTS {self.column_name}")
+            actions.append(drop_column_action)
         else:
-            logger.info("Skipping DROP COLUMN for %r, nothing to do...", self)
+            logger.info("Skipping %r, nothing to do...", drop_column_action)
 
         if actions:
             client.execute(

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -295,7 +295,11 @@ def update_column_is_disabled(table: TablesWithMaterializedColumns, column_name:
 
 def check_index_exists(client: Client, table: str, index: str) -> bool:
     match client.execute(
-        "SELECT count() FROM system.data_skipping_indices WHERE table = %(table)s AND name = %(name)s",
+        """
+        SELECT count()
+        FROM system.data_skipping_indices
+        WHERE database = currentDatabase() AND table = %(table)s AND name = %(name)s
+        """,
         {"table": table, "name": index},
     ):
         case [(1,)]:
@@ -308,7 +312,11 @@ def check_index_exists(client: Client, table: str, index: str) -> bool:
 
 def check_column_exists(client: Client, table: str, column: str) -> bool:
     match client.execute(
-        "SELECT count() FROM system.columns WHERE table = %(table)s AND name = %(name)s",
+        """
+        SELECT count()
+        FROM system.columns
+        WHERE database = currentDatabase() AND table = %(table)s AND name = %(name)s
+        """,
         {"table": table, "name": column},
     ):
         case [(1,)]:

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -298,37 +298,29 @@ def update_column_is_disabled(table: TablesWithMaterializedColumns, column_name:
 
 
 def check_index_exists(client: Client, table: str, index: str) -> bool:
-    match client.execute(
+    [(count,)] = client.execute(
         """
         SELECT count()
         FROM system.data_skipping_indices
         WHERE database = currentDatabase() AND table = %(table)s AND name = %(name)s
         """,
         {"table": table, "name": index},
-    ):
-        case [(1,)]:
-            return True
-        case [(0,)]:
-            return False
-        case _:
-            raise Exception("received unexpected response")
+    )
+    assert 1 >= count >= 0
+    return bool(count)
 
 
 def check_column_exists(client: Client, table: str, column: str) -> bool:
-    match client.execute(
+    [(count,)] = client.execute(
         """
         SELECT count()
         FROM system.columns
         WHERE database = currentDatabase() AND table = %(table)s AND name = %(name)s
         """,
         {"table": table, "name": column},
-    ):
-        case [(1,)]:
-            return True
-        case [(0,)]:
-            return False
-        case _:
-            raise Exception("received unexpected response")
+    )
+    assert 1 >= count >= 0
+    return bool(count)
 
 
 @dataclass

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -165,6 +165,10 @@ tables: dict[str, TableInfo | ShardedTableInfo] = {
 }
 
 
+def get_minmax_index_name(column: str) -> str:
+    return f"minmax_{column}"
+
+
 @dataclass
 class CreateColumnOnDataNodesTask:
     table: str
@@ -186,7 +190,7 @@ class CreateColumnOnDataNodesTask:
             parameters["comment"] = self.column.details.as_column_comment()
 
         if self.create_minmax_index:
-            index_name = f"minmax_{self.column.name}"
+            index_name = get_minmax_index_name(self.column.name)
             actions.append(f"ADD INDEX IF NOT EXISTS {index_name} {self.column.name} TYPE minmax GRANULARITY 1")
 
         client.execute(
@@ -337,8 +341,7 @@ class DropColumnTask:
         actions = []
 
         if self.try_drop_index:
-            # XXX: copy/pasted from create task
-            index_name = f"minmax_{self.column_name}"
+            index_name = get_minmax_index_name(self.column_name)
             drop_index_action = f"DROP INDEX IF EXISTS {index_name}"
             if check_index_exists(client, self.table, index_name):
                 actions.append(drop_index_action)

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -339,7 +339,7 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
             MaterializedColumn.get(table, destination_column)
 
     def _get_latest_mutation_id(self, table: str) -> str:
-        match sync_execute(
+        [(mutation_id,)] = sync_execute(
             """
             SELECT max(mutation_id)
             FROM system.mutations
@@ -348,9 +348,8 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
                 AND table = %(table)s
             """,
             {"table": table},
-        ):
-            case [(mutation_id,)]:
-                return mutation_id
+        )
+        return mutation_id
 
     def _get_mutations_since_id(self, table: str, id: str) -> Iterable[str]:
         return [

--- a/ee/clickhouse/materialized_columns/test/test_columns.py
+++ b/ee/clickhouse/materialized_columns/test/test_columns.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from time import sleep
+from collections.abc import Iterable
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -336,3 +337,71 @@ class TestMaterializedColumns(ClickhouseTestMixin, BaseTest):
         assert key not in get_materialized_columns(table, exclude_disabled_columns=True)
         with self.assertRaises(ValueError):
             MaterializedColumn.get(table, destination_column)
+
+    def _get_latest_mutation_id(self, table: str) -> str:
+        match sync_execute(
+            """
+            SELECT max(mutation_id)
+            FROM system.mutations
+            WHERE
+                database = currentDatabase()
+                AND table = %(table)s
+            """,
+            {"table": table},
+        ):
+            case [(mutation_id,)]:
+                return mutation_id
+
+    def _get_mutations_since_id(self, table: str, id: str) -> Iterable[str]:
+        return [
+            command
+            for (command,) in sync_execute(
+                """
+                SELECT command
+                FROM system.mutations
+                WHERE
+                    database = currentDatabase()
+                    AND table = %(table)s
+                    AND mutation_id > %(mutation_id)s
+                ORDER BY mutation_id
+                """,
+                {"table": table, "mutation_id": id},
+            )
+        ]
+
+    def test_drop_optimized_no_index(self):
+        table: TablesWithMaterializedColumns = (
+            "person"  # little bit easier than events because no shard awareness needed
+        )
+        property: PropertyName = "myprop"
+        source_column: TableColumn = "properties"
+
+        destination_column = materialize(table, property, table_column=source_column, create_minmax_index=False)
+        assert destination_column is not None
+
+        latest_mutation_id_before_drop = self._get_latest_mutation_id(table)
+
+        drop_column(table, destination_column)
+
+        mutations_ran = self._get_mutations_since_id(table, latest_mutation_id_before_drop)
+        assert not any("DROP INDEX" in mutation for mutation in mutations_ran)
+
+    def test_drop_optimized_no_column(self):
+        table: TablesWithMaterializedColumns = (
+            "person"  # little bit easier than events because no shard awareness needed
+        )
+        property: PropertyName = "myprop"
+        source_column: TableColumn = "properties"
+
+        # create the materialized column
+        destination_column = materialize(table, property, table_column=source_column, create_minmax_index=False)
+        assert destination_column is not None
+
+        sync_execute(f"ALTER TABLE {table} DROP COLUMN {destination_column}", settings={"alter_sync": 1})
+
+        latest_mutation_id_before_drop = self._get_latest_mutation_id(table)
+
+        drop_column(table, destination_column)
+
+        mutations_ran = self._get_mutations_since_id(table, latest_mutation_id_before_drop)
+        assert not any("DROP COLUMN" in mutation for mutation in mutations_ran)


### PR DESCRIPTION
## Problem

`DROP` actions still create mutations, even if those actions don't have anything to drop and these inconsequential mutations are slow to execute. This makes retrying a task unnecessarily slow if after a partial failure or timeout occurs.

Reducing the number of materialized columns we manage is part of #26651.

## Changes

Only drop columns and indexes if they actually exist, otherwise skip these steps.

Since these tasks are run via `ClickhouseCluster` on specific hosts/shards, this should be resilient to partial failures on a per-shard basis.

## Does this work well for both Cloud and self-hosted?

N/A, Cloud only

## How did you test this code?

Added tests to ensure optimization works as expected, otherwise covered by existing lifecycle tests.