### PR TITLE
feat(cdp): auto load slack channels

### DIFF
--- a/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
+++ b/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
@@ -1,7 +1,7 @@
 import { LemonBanner, LemonButton, LemonInputSelect, LemonInputSelectOption, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { IconSlackExternal } from 'lib/lemon-ui/icons'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import { IntegrationType, SlackChannelType } from '~/types'
 
@@ -52,6 +52,12 @@ export function SlackChannelPicker({ onChange, value, integration, disabled }: S
 
         return value
     }, [value, slackChannels])
+
+    useEffect(() => {
+        if (!disabled) {
+            loadSlackChannels()
+        }
+    }, [loadSlackChannels, disabled])
 
     return (
         <>

--- a/frontend/src/lib/integrations/slackIntegrationLogic.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, connect, kea, key, path, props, selectors } from 'kea'
+import { actions, connect, kea, key, path, props, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
@@ -44,8 +44,5 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
                 }
             },
         ],
-    }),
-    afterMount(({ actions }) => {
-        actions.loadSlackChannels()
     }),
 ])

--- a/frontend/src/lib/integrations/slackIntegrationLogic.ts
+++ b/frontend/src/lib/integrations/slackIntegrationLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, key, path, props, selectors } from 'kea'
+import { actions, afterMount, connect, kea, key, path, props, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
@@ -44,5 +44,8 @@ export const slackIntegrationLogic = kea<slackIntegrationLogicType>([
                 }
             },
         ],
+    }),
+    afterMount(({ actions }) => {
+        actions.loadSlackChannels()
     }),
 ])


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

![2024-12-05 at 09 53 25](https://github.com/user-attachments/assets/34b53ebe-43e5-436a-ada8-031855b89b19)

- We'll automatically load available slack channels.

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
