### PR TITLE
fix: replay auth url construction

### DIFF
--- a/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
+++ b/frontend/src/lib/components/AuthorizedUrlList/AuthorizedUrlList.tsx
@@ -186,7 +186,7 @@ export function AuthorizedUrlList({
                                                     type === AuthorizedUrlListType.TOOLBAR_URLS
                                                         ? launchUrl(keyedURL.url)
                                                         : // other urls are simply opened directly
-                                                          keyedURL.url + query
+                                                          `${keyedURL.url}${query ? query : ''}`
                                                 }
                                                 targetBlank
                                                 tooltip={


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/21456 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/23625)

user reports that authorized URL launch list is adding `undefined` onto URLs

and it is

well, not any more