### PR TITLE
chore(environments): Update filtering of feature flags/surveys

### DIFF
--- a/posthog/api/early_access_feature.py
+++ b/posthog/api/early_access_feature.py
@@ -270,9 +270,9 @@ def early_access_features(request: Request):
         )
 
     early_access_features = MinimalEarlyAccessFeatureSerializer(
-        EarlyAccessFeature.objects.filter(team_id=team.id, stage=EarlyAccessFeature.Stage.BETA).select_related(
-            "feature_flag"
-        ),
+        EarlyAccessFeature.objects.filter(
+            team__project_id=team.project_id, stage=EarlyAccessFeature.Stage.BETA
+        ).select_related("feature_flag"),
         many=True,
     ).data
 

--- a/posthog/api/organization_feature_flag.py
+++ b/posthog/api/organization_feature_flag.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.response import Response
 from posthog.api.utils import action
 from rest_framework import (
@@ -82,9 +81,8 @@ class OrganizationFeatureFlagView(
 
         for target_project_id in target_project_ids:
             # Target project does not exist
-            try:
-                target_team = Team.objects.filter(project_id=target_project_id).first()
-            except ObjectDoesNotExist:
+            target_team = Team.objects.filter(project_id=target_project_id).first()
+            if target_team is None:
                 failed_projects.append(
                     {
                         "project_id": target_project_id,

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -291,7 +291,7 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
 
         if (
             self.context["request"].method == "POST"
-            and Survey.objects.filter(name=data.get("name"), team_id=self.context["team_id"]).exists()
+            and Survey.objects.filter(name=data.get("name"), team__project_id=self.context["project_id"]).exists()
         ):
             raise serializers.ValidationError("There is already a survey with this name.", code="unique")
 
@@ -300,7 +300,7 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
         if (
             existing_survey
             and existing_survey.name != data.get("name")
-            and Survey.objects.filter(name=data.get("name"), team_id=self.context["team_id"])
+            and Survey.objects.filter(name=data.get("name"), team__project_id=self.context["project_id"])
             .exclude(id=existing_survey.id)
             .exists()
         ):
@@ -686,9 +686,9 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     @action(methods=["GET"], detail=False, required_scopes=["survey:read"])
     def responses_count(self, request: request.Request, **kwargs):
-        earliest_survey_start_date = Survey.objects.filter(team_id=self.team_id).aggregate(Min("start_date"))[
-            "start_date__min"
-        ]
+        earliest_survey_start_date = Survey.objects.filter(team__project_id=self.project_id).aggregate(
+            Min("start_date")
+        )["start_date__min"]
         data = sync_execute(
             f"""
             SELECT JSONExtractString(properties, '$survey_id') as survey_id, count()
@@ -721,7 +721,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         item_id = kwargs["pk"]
 
-        if not Survey.objects.filter(id=item_id, team_id=self.team_id).exists():
+        if not Survey.objects.filter(id=item_id, team__project_id=self.project_id).exists():
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         activity_page = load_activity(
@@ -742,7 +742,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         survey_id = kwargs["pk"]
 
-        if not Survey.objects.filter(id=survey_id, team_id=self.team_id).exists():
+        if not Survey.objects.filter(id=survey_id, team__project_id=self.project_id).exists():
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         survey = self.get_object()
@@ -880,7 +880,7 @@ def surveys(request: Request):
         )
 
     surveys = SurveyAPISerializer(
-        Survey.objects.filter(team_id=team.id)
+        Survey.objects.filter(team__project_id=team.project_id)
         .exclude(archived=True)
         .select_related("linked_flag", "targeting_flag", "internal_targeting_flag")
         .prefetch_related("actions"),

--- a/posthog/api/test/__snapshots__/test_early_access_feature.ambr
+++ b/posthog/api/test/__snapshots__/test_early_access_feature.ambr
@@ -222,9 +222,10 @@
          "posthog_featureflag"."usage_dashboard_id",
          "posthog_featureflag"."has_enriched_analytics"
   FROM "posthog_earlyaccessfeature"
+  INNER JOIN "posthog_team" ON ("posthog_earlyaccessfeature"."team_id" = "posthog_team"."id")
   LEFT OUTER JOIN "posthog_featureflag" ON ("posthog_earlyaccessfeature"."feature_flag_id" = "posthog_featureflag"."id")
   WHERE ("posthog_earlyaccessfeature"."stage" = 'beta'
-         AND "posthog_earlyaccessfeature"."team_id" = 99999)
+         AND "posthog_team"."project_id" = 99999)
   '''
 # ---
 # name: TestPreviewList.test_early_access_features.2

--- a/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/posthog/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -925,8 +925,9 @@
          "posthog_featureflag"."usage_dashboard_id",
          "posthog_featureflag"."has_enriched_analytics"
   FROM "posthog_featureflag"
+  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
   WHERE ("posthog_featureflag"."key" = 'copied-flag-key'
-         AND "posthog_featureflag"."team_id" = 99999)
+         AND "posthog_team"."project_id" = 99999)
   LIMIT 21
   '''
 # ---
@@ -1673,8 +1674,9 @@
          "posthog_team"."external_data_workspace_id",
          "posthog_team"."external_data_workspace_last_synced_at"
   FROM "posthog_team"
-  WHERE "posthog_team"."id" = 99999
-  LIMIT 21
+  WHERE "posthog_team"."project_id" = 99999
+  ORDER BY "posthog_team"."id" ASC
+  LIMIT 1
   '''
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.50
@@ -1880,9 +1882,10 @@
          "posthog_featureflag"."usage_dashboard_id",
          "posthog_featureflag"."has_enriched_analytics"
   FROM "posthog_featureflag"
+  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
   WHERE (NOT "posthog_featureflag"."deleted"
          AND "posthog_featureflag"."key" = 'copied-flag-key'
-         AND "posthog_featureflag"."team_id" = 99999)
+         AND "posthog_team"."project_id" = 99999)
   ORDER BY "posthog_featureflag"."id" ASC
   LIMIT 1
   '''
@@ -2234,9 +2237,10 @@
          "posthog_featureflag"."usage_dashboard_id",
          "posthog_featureflag"."has_enriched_analytics"
   FROM "posthog_featureflag"
+  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
   WHERE ("posthog_featureflag"."deleted"
          AND "posthog_featureflag"."key" = 'copied-flag-key'
-         AND "posthog_featureflag"."team_id" = 99999)
+         AND "posthog_team"."project_id" = 99999)
   '''
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.9

--- a/posthog/api/test/__snapshots__/test_survey.ambr
+++ b/posthog/api/test/__snapshots__/test_survey.ambr
@@ -27,10 +27,11 @@
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_survey"
+  INNER JOIN "posthog_team" ON ("posthog_survey"."team_id" = "posthog_team"."id")
   WHERE (NOT "posthog_survey"."archived"
          AND "posthog_survey"."end_date" IS NULL
          AND "posthog_survey"."start_date" IS NOT NULL
-         AND "posthog_survey"."team_id" = 99999
+         AND "posthog_team"."project_id" = 99999
          AND NOT ("posthog_survey"."type" = 'api'))
   '''
 # ---
@@ -247,10 +248,11 @@
   '''
   SELECT COUNT(*) AS "__count"
   FROM "posthog_survey"
+  INNER JOIN "posthog_team" ON ("posthog_survey"."team_id" = "posthog_team"."id")
   WHERE (NOT "posthog_survey"."archived"
          AND "posthog_survey"."end_date" IS NULL
          AND "posthog_survey"."start_date" IS NOT NULL
-         AND "posthog_survey"."team_id" = 99999
+         AND "posthog_team"."project_id" = 99999
          AND NOT ("posthog_survey"."type" = 'api'))
   '''
 # ---
@@ -395,21 +397,6 @@
          "posthog_featureflag"."ensure_experience_continuity",
          "posthog_featureflag"."usage_dashboard_id",
          "posthog_featureflag"."has_enriched_analytics",
-         T4."id",
-         T4."key",
-         T4."name",
-         T4."filters",
-         T4."rollout_percentage",
-         T4."team_id",
-         T4."created_by_id",
-         T4."created_at",
-         T4."deleted",
-         T4."active",
-         T4."rollback_conditions",
-         T4."performed_rollback",
-         T4."ensure_experience_continuity",
-         T4."usage_dashboard_id",
-         T4."has_enriched_analytics",
          T5."id",
          T5."key",
          T5."name",
@@ -424,12 +411,28 @@
          T5."performed_rollback",
          T5."ensure_experience_continuity",
          T5."usage_dashboard_id",
-         T5."has_enriched_analytics"
+         T5."has_enriched_analytics",
+         T6."id",
+         T6."key",
+         T6."name",
+         T6."filters",
+         T6."rollout_percentage",
+         T6."team_id",
+         T6."created_by_id",
+         T6."created_at",
+         T6."deleted",
+         T6."active",
+         T6."rollback_conditions",
+         T6."performed_rollback",
+         T6."ensure_experience_continuity",
+         T6."usage_dashboard_id",
+         T6."has_enriched_analytics"
   FROM "posthog_survey"
+  INNER JOIN "posthog_team" ON ("posthog_survey"."team_id" = "posthog_team"."id")
   LEFT OUTER JOIN "posthog_featureflag" ON ("posthog_survey"."linked_flag_id" = "posthog_featureflag"."id")
-  LEFT OUTER JOIN "posthog_featureflag" T4 ON ("posthog_survey"."targeting_flag_id" = T4."id")
-  LEFT OUTER JOIN "posthog_featureflag" T5 ON ("posthog_survey"."internal_targeting_flag_id" = T5."id")
-  WHERE ("posthog_survey"."team_id" = 99999
+  LEFT OUTER JOIN "posthog_featureflag" T5 ON ("posthog_survey"."targeting_flag_id" = T5."id")
+  LEFT OUTER JOIN "posthog_featureflag" T6 ON ("posthog_survey"."internal_targeting_flag_id" = T6."id")
+  WHERE ("posthog_team"."project_id" = 99999
          AND NOT ("posthog_survey"."archived"))
   '''
 # ---

--- a/posthog/management/commands/sync_feature_flags.py
+++ b/posthog/management/commands/sync_feature_flags.py
@@ -2,7 +2,7 @@ from typing import cast
 
 from django.core.management.base import BaseCommand
 
-from posthog.models import FeatureFlag, Team, User
+from posthog.models import FeatureFlag, Project, User
 
 INACTIVE_FLAGS = [
     "cloud-announcement",
@@ -12,7 +12,7 @@ INACTIVE_FLAGS = [
 
 
 class Command(BaseCommand):
-    help = "Add and enable all feature flags in frontend/src/lib/constants.tsx for all teams"
+    help = "Add and enable all feature flags in frontend/src/lib/constants.tsx for all projects"
 
     def handle(self, *args, **options):
         flags: dict[str, str] = {}
@@ -37,23 +37,27 @@ class Command(BaseCommand):
                     parsing_flags = True
 
         first_user = cast(User, User.objects.first())
-        for team in Team.objects.all():
-            existing_flags = FeatureFlag.objects.filter(team=team).values_list("key", flat=True)
-            deleted_flags = FeatureFlag.objects.filter(team=team, deleted=True).values_list("key", flat=True)
+        for project in Project.objects.all():
+            existing_flags = FeatureFlag.objects.filter(team__project_id=project.id).values_list("key", flat=True)
+            deleted_flags = FeatureFlag.objects.filter(team__project_id=project.id, deleted=True).values_list(
+                "key", flat=True
+            )
             for flag in flags.keys():
                 flag_type = flags[flag]
                 is_enabled = flag not in INACTIVE_FLAGS
 
                 if flag in deleted_flags:
-                    ff = FeatureFlag.objects.filter(team=team, key=flag)[0]
+                    ff = FeatureFlag.objects.filter(team__project_id=project.id, key=flag)[0]
                     ff.deleted = False
                     ff.active = is_enabled
                     ff.save()
-                    print(f"Undeleted feature flag '{flag} for team {team.id} {' - ' + team.name if team.name else ''}")
+                    print(
+                        f"Undeleted feature flag '{flag} for project {project.id} {' - ' + project.name if project.name else ''}"
+                    )
                 elif flag not in existing_flags:
                     if flag_type == "multivariate":
                         FeatureFlag.objects.create(
-                            team=team,
+                            team=project.teams.first(),
                             rollout_percentage=100,
                             name=flag,
                             key=flag,
@@ -79,11 +83,13 @@ class Command(BaseCommand):
                         )
                     else:
                         FeatureFlag.objects.create(
-                            team=team,
+                            team=project.teams.first(),
                             rollout_percentage=100,
                             name=flag,
                             key=flag,
                             created_by=first_user,
                             active=is_enabled,
                         )
-                    print(f"Created feature flag '{flag} for team {team.id} {' - ' + team.name if team.name else ''}")
+                    print(
+                        f"Created feature flag '{flag} for project {project.id} {' - ' + project.name if project.name else ''}"
+                    )

--- a/posthog/models/feature_flag/flag_analytics.py
+++ b/posthog/models/feature_flag/flag_analytics.py
@@ -139,9 +139,10 @@ def find_flags_with_enriched_analytics(begin: datetime, end: datetime):
     for row in result:
         team_id = row[0]
         flag_key = row[1]
+        team = Team.objects.only("project_id").get(id=team_id)
 
         try:
-            flag = FeatureFlag.objects.get(team_id=team_id, key=flag_key)
+            flag = FeatureFlag.objects.get(team__project_id=team.project_id, key=flag_key)
             if not flag.has_enriched_analytics:
                 flag.has_enriched_analytics = True
                 flag.save()

--- a/posthog/models/feedback/survey.py
+++ b/posthog/models/feedback/survey.py
@@ -292,7 +292,7 @@ def update_survey_iterations(sender, instance, *args, **kwargs):
 def update_surveys_opt_in(sender, instance, **kwargs):
     active_surveys_count = (
         Survey.objects.filter(
-            team_id=instance.team_id,
+            team__project_id=instance.team.project_id,
             start_date__isnull=False,
             end_date__isnull=True,
             archived=False,


### PR DESCRIPTION
## Problem

Feature flags, experiments, early access features, and surveys are now project-level – filtered on `project_id=` – but in many places we were still filtering on `team_id=`.

## Changes

Used this regex to find every instance of those resources being queried on `team_id`:

`(FeatureFlag|Experiment|EarlyAccessFeature|Survey).+.(filter|get)\((.*\n){0,3}?.*team(_id)?=`

Replaced `team=`/`team_id=` with `team__project_id=` in every instance.

## How did you test this code?

Expecting existing tests to pass. Let me know where new ones are key.