### PR TITLE
feat(experiments): Filter 'View recordings' to 1st funnel step

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
@@ -323,6 +323,13 @@ export function SummaryTable(): JSX.Element {
                                 ],
                             },
                         ]
+                        if (experiment.filters.insight === InsightType.FUNNELS) {
+                            if (experiment.filters?.events?.[0]) {
+                                filters.push(experiment.filters.events[0])
+                            } else if (experiment.filters?.actions?.[0]) {
+                                filters.push(experiment.filters.actions[0])
+                            }
+                        }
                         const filterGroup: Partial<RecordingUniversalFilters> = {
                             filter_group: {
                                 type: FilterLogicalOperator.And,


### PR DESCRIPTION
## Changes

Adds the first funnel step as a filter on 'View recordings' (when it's an event or an action). This more closely matches users' expected behavior.

See https://posthoghelp.zendesk.com/agent/tickets/21226 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/24073)

## How did you test this code?

I created a new experiment, populated some sample data, and verified 'View recordings' filtered to the first funnel step when I clicked on the button.