### PR TITLE
fix(experiments): add `flaky` decorator to statistical tests

### DIFF
--- a/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
@@ -16,6 +16,7 @@ from rest_framework.exceptions import ValidationError
 from posthog.constants import ExperimentNoResultsErrorKeys
 import json
 from posthog.test.test_journeys import journeys_for
+from flaky import flaky
 
 
 class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
@@ -128,6 +129,7 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertIn("control", result.credible_intervals)
         self.assertIn("test", result.credible_intervals)
 
+    @flaky(max_runs=10, min_passes=1)
     @freeze_time("2020-01-01T12:00:00Z")
     def test_query_runner_standard_flow(self):
         feature_flag = self.create_feature_flag()

--- a/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
@@ -29,6 +29,7 @@ import s3fs
 from pyarrow import parquet as pq
 import pyarrow as pa
 import json
+from flaky import flaky
 
 from boto3 import resource
 from botocore.config import Config
@@ -650,6 +651,7 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         prepared_count_query = query_runner.prepared_count_query
         self.assertEqual(prepared_count_query.series[0].math, "sum")
 
+    @flaky(max_runs=10, min_passes=1)
     @freeze_time("2020-01-01T12:00:00Z")
     def test_query_runner_standard_flow(self):
         feature_flag = self.create_feature_flag()


### PR DESCRIPTION
## Changes
Statistical calculations aren't fully deterministic, so assertions occasionally fail. Add a flaky decorator to tests that involve statistical results.

## How did you test this code?
Tests pass.