### PR TITLE
chore(data-warehouse): Store incremental value in our DB

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -372,6 +372,10 @@ class DataImportPipelineSync:
             job_id=self.inputs.run_id, schema_id=str(self.inputs.schema_id), team_id=self.inputs.team_id
         )
 
+        if self._incremental:
+            self.logger.debug("Saving last incremental value...")
+            save_last_incremental_value(str(self.inputs.schema_id), str(self.inputs.team_id), self.source, self.logger)
+
         # Cleanup: delete local state from the file system
         pipeline.drop()
 
@@ -396,6 +400,28 @@ def update_last_synced_at_sync(job_id: str, schema_id: str, team_id: int) -> Non
     schema.last_synced_at = job.created_at
 
     schema.save()
+
+
+def save_last_incremental_value(schema_id: str, team_id: str, source: DltSource, logger: FilteringBoundLogger) -> None:
+    schema = ExternalDataSchema.objects.exclude(deleted=True).get(id=schema_id, team_id=team_id)
+
+    incremental_field = schema.sync_type_config.get("incremental_field")
+    resource = next(iter(source.resources.values()))
+
+    incremental: dict | None = resource.state.get("incremental")
+
+    if incremental is None:
+        return
+
+    incremental_object: dict | None = incremental.get(incremental_field)
+    if incremental_object is None:
+        return
+
+    last_value = incremental_object.get("last_value")
+
+    logger.debug(f"Updating incremental_field_last_value with {last_value}")
+
+    schema.update_incremental_field_last_value(last_value)
 
 
 def validate_schema_and_update_table_sync(

--- a/posthog/temporal/data_imports/pipelines/test/test_pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/test/test_pipeline_sync.py
@@ -134,6 +134,7 @@ class TestDataImportPipeline(APIBaseTest):
             ) as mock_validate_schema_and_update_table,
             patch("posthog.temporal.data_imports.pipelines.pipeline_sync.get_delta_tables"),
             patch("posthog.temporal.data_imports.pipelines.pipeline_sync.update_last_synced_at_sync"),
+            patch("posthog.temporal.data_imports.pipelines.pipeline_sync.save_last_incremental_value"),
             override_settings(
                 BUCKET_URL=f"s3://{BUCKET_NAME}",
                 AIRBYTE_BUCKET_KEY=settings.OBJECT_STORAGE_ACCESS_KEY_ID,

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -1,8 +1,9 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Any, Optional
 from django.db import models
 from django_deprecate_fields import deprecate_field
+import numpy
 import snowflake.connector
 from django.conf import settings
 from posthog.models.team import Team
@@ -70,6 +71,22 @@ class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
     def soft_delete(self):
         self.deleted = True
         self.deleted_at = datetime.now()
+        self.save()
+
+    def update_incremental_field_last_value(self, last_value: Any) -> None:
+        incremental_field_type = self.sync_type_config.get("incremental_field_type")
+
+        last_value_py = last_value.item() if isinstance(last_value, numpy.generic) else last_value
+
+        if (
+            incremental_field_type == IncrementalFieldType.Integer
+            or incremental_field_type == IncrementalFieldType.Numeric
+        ):
+            last_value_json = last_value_py
+        else:
+            last_value_json = str(last_value_py)
+
+        self.sync_type_config["incremental_field_last_value"] = last_value_json
         self.save()
 
 


### PR DESCRIPTION
## Problem
- In the new pipeline, we want to read the last incremental values from our DB instead of from S3

## Changes
- Code is pulled out of https://github.com/PostHog/posthog/pull/26341 ahead of the deployment
- Get the last incremental value from DLT and store it in the DB on the schema

## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
Tested locally