### PR TITLE
fix: Pass `github_token` to the `browserslist` action

### DIFF
--- a/.github/workflows/browserslist-update.yml
+++ b/.github/workflows/browserslist-update.yml
@@ -25,6 +25,7 @@ jobs:
             - name: Update Browserslist database and create PR if applies
               uses: c2corg/browserslist-update-action@v2
               with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
                   base_branch: master
                   commit_message: 'build: update Browserslist db'
                   title: 'build: update Browserslist db'


### PR DESCRIPTION
Their docs say this isn't a required argument and that it'd use `secrets.GITHUB_TOKEN` automatically, but it's actually a good thing they're wrong, I wouldn't want them to steal our tokens.