### PR TITLE
fix: Function with name 'aggregate_funnel_array' does not exist. …

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -49,6 +49,8 @@ services:
             - ./posthog/docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
             - ./posthog/docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
             - ./posthog/docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml
+            - ./posthog/docker/clickhouse/user_defined_function.xml:/etc/clickhouse-server/user_defined_function.xml
+            - ./posthog/posthog/user_scripts/:/var/lib/clickhouse/user_scripts/
             - clickhouse-data:/var/lib/clickhouse
     zookeeper:
         extends:


### PR DESCRIPTION

## Problem
error messages in Dashboards
Function with name 'aggregate_funnel_array' does not exist. In scope SELECT arraySort(t
## Changes
 this pr add volume with  functions to container Cliackhouse
## Does this work well for both Cloud and self-hosted?
no, only selfhost hobby setup

## How did you test this code?
on my hobby setup
