### PR TITLE
fix(settings): Fix back button and side panel when opening settings

### DIFF
--- a/frontend/src/scenes/settings/Settings.tsx
+++ b/frontend/src/scenes/settings/Settings.tsx
@@ -10,6 +10,7 @@ import { IconChevronRight, IconLink } from 'lib/lemon-ui/icons'
 import { capitalizeFirstLetter, inStorybookTestRunner } from 'lib/utils'
 import React from 'react'
 import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
 
 import { settingsLogic } from './settingsLogic'
 import { SettingsLogicProps } from './types'
@@ -56,7 +57,16 @@ export function Settings({
                                 {levels.map((level) => (
                                     <li key={level} className="space-y-px">
                                         <LemonButton
-                                            onClick={() => selectLevel(level)}
+                                            to={urls.settings(level)}
+                                            onClick={
+                                                // Outside of /settings, we want to select the level without navigating
+                                                props.logicKey === 'settingsScene'
+                                                    ? (e) => {
+                                                          selectLevel(level)
+                                                          e.preventDefault()
+                                                      }
+                                                    : undefined
+                                            }
                                             size="small"
                                             fullWidth
                                             active={selectedLevel === level && !selectedSectionId}
@@ -70,7 +80,16 @@ export function Settings({
                                                 .map((section) => (
                                                     <li key={section.id} className="pl-4">
                                                         <LemonButton
-                                                            onClick={() => selectSection(section.id, section.level)}
+                                                            to={urls.settings(section.id)}
+                                                            onClick={
+                                                                // Outside of /settings, we want to select the level without navigating
+                                                                props.logicKey === 'settingsScene'
+                                                                    ? (e) => {
+                                                                          selectSection(section.id, section.level)
+                                                                          e.preventDefault()
+                                                                      }
+                                                                    : undefined
+                                                            }
                                                             size="small"
                                                             fullWidth
                                                             active={selectedSectionId === section.id}
@@ -116,7 +135,7 @@ export function Settings({
 }
 
 function SettingsRenderer(props: SettingsLogicProps): JSX.Element {
-    const { settings } = useValues(settingsLogic(props))
+    const { settings, selectedLevel, selectedSectionId } = useValues(settingsLogic(props))
     const { selectSetting } = useActions(settingsLogic(props))
 
     return (
@@ -126,7 +145,20 @@ function SettingsRenderer(props: SettingsLogicProps): JSX.Element {
                     <div key={x.id} className="relative">
                         <h2 id={x.id} className="flex gap-2 items-center">
                             {x.title}
-                            <LemonButton icon={<IconLink />} size="small" onClick={() => selectSetting?.(x.id)} />
+                            <LemonButton
+                                icon={<IconLink />}
+                                size="small"
+                                to={urls.settings(selectedSectionId ?? selectedLevel, x.id)}
+                                onClick={
+                                    // Outside of /settings, we want to select the level without navigating
+                                    props.logicKey === 'settingsScene'
+                                        ? (e) => {
+                                              selectSetting(x.id)
+                                              e.preventDefault()
+                                          }
+                                        : undefined
+                                }
+                            />
                         </h2>
                         {x.description && <p>{x.description}</p>}
 

--- a/frontend/src/scenes/settings/SettingsScene.stories.tsx
+++ b/frontend/src/scenes/settings/SettingsScene.stories.tsx
@@ -46,7 +46,7 @@ export const SettingsProject: StoryFn = () => {
     return <App />
 }
 SettingsProject.parameters = {
-    testOptions: { waitForSelector: '.Settings__sections button' },
+    testOptions: { waitForSelector: '.Settings__sections a' },
 }
 
 export const SettingsProjectWithReplayFeatures: StoryFn = () => {
@@ -61,7 +61,7 @@ export const SettingsProjectWithReplayFeatures: StoryFn = () => {
     return <App />
 }
 SettingsProjectWithReplayFeatures.parameters = {
-    testOptions: { waitForSelector: '.Settings__sections button' },
+    testOptions: { waitForSelector: '.Settings__sections a' },
 }
 
 export const SettingsUser: StoryFn = () => {
@@ -71,7 +71,7 @@ export const SettingsUser: StoryFn = () => {
     return <App />
 }
 SettingsUser.parameters = {
-    testOptions: { waitForSelector: '.Settings__sections button' },
+    testOptions: { waitForSelector: '.Settings__sections a' },
 }
 
 export const SettingsOrganization: StoryFn = () => {
@@ -81,7 +81,7 @@ export const SettingsOrganization: StoryFn = () => {
     return <App />
 }
 SettingsOrganization.parameters = {
-    testOptions: { waitForSelector: '.Settings__sections button' },
+    testOptions: { waitForSelector: '.Settings__sections a' },
 }
 
 export const SettingsWebVitals: StoryFn = () => {
@@ -91,7 +91,7 @@ export const SettingsWebVitals: StoryFn = () => {
     return <App />
 }
 SettingsOrganization.parameters = {
-    testOptions: { waitForSelector: '.Settings__sections button' },
+    testOptions: { waitForSelector: '.Settings__sections a' },
 }
 
 function TimeSensitiveSettings(props: {
@@ -133,40 +133,40 @@ export const SettingsSessionTimeoutAllOptions: StoryFn = () => {
     return <TimeSensitiveSettings has_password saml_available />
 }
 SettingsSessionTimeoutAllOptions.parameters = {
-    testOptions: { waitForSelector: '.Settings__sections button' },
+    testOptions: { waitForSelector: '.Settings__sections a' },
 }
 
 export const SettingsSessionTimeoutPasswordOnly: StoryFn = () => {
     return <TimeSensitiveSettings has_password />
 }
 SettingsSessionTimeoutPasswordOnly.parameters = {
-    testOptions: { waitForSelector: '.Settings__sections button' },
+    testOptions: { waitForSelector: '.Settings__sections a' },
 }
 
 export const SettingsSessionTimeoutSsoOnly: StoryFn = () => {
     return <TimeSensitiveSettings />
 }
 SettingsSessionTimeoutSsoOnly.parameters = {
-    testOptions: { waitForSelector: '.Settings__sections button' },
+    testOptions: { waitForSelector: '.Settings__sections a' },
 }
 
 export const SettingsSessionTimeoutSsoEnforcedGithub: StoryFn = () => {
     return <TimeSensitiveSettings sso_enforcement="github" />
 }
 SettingsSessionTimeoutSsoEnforcedGithub.parameters = {
-    testOptions: { waitForSelector: '.Settings__sections button' },
+    testOptions: { waitForSelector: '.Settings__sections a' },
 }
 
 export const SettingsSessionTimeoutSsoEnforcedGoogle: StoryFn = () => {
     return <TimeSensitiveSettings sso_enforcement="google-oauth2" />
 }
 SettingsSessionTimeoutSsoEnforcedGoogle.parameters = {
-    testOptions: { waitForSelector: '.Settings__sections button' },
+    testOptions: { waitForSelector: '.Settings__sections a' },
 }
 
 export const SettingsSessionTimeoutSsoEnforcedSaml: StoryFn = () => {
     return <TimeSensitiveSettings sso_enforcement="saml" />
 }
 SettingsSessionTimeoutSsoEnforcedSaml.parameters = {
-    testOptions: { waitForSelector: '.Settings__sections button' },
+    testOptions: { waitForSelector: '.Settings__sections a' },
 }

--- a/frontend/src/scenes/settings/settingsSceneLogic.ts
+++ b/frontend/src/scenes/settings/settingsSceneLogic.ts
@@ -51,6 +51,7 @@ export const settingsSceneLogic = kea<settingsSceneLogicType>([
 
             // As of middle of September 2024, `details` and `danger-zone` are the only sections present
             // at both Environment and Project levels. Others we want to redirect based on the feature flag.
+            // This is just for URLs, since analogous logic for _rendering_ settings is already in settingsLogic.
             if (!section.endsWith('-details') && !section.endsWith('-danger-zone')) {
                 if (values.featureFlags[FEATURE_FLAGS.ENVIRONMENTS]) {
                     section = section.replace(/^project/, 'environment')

--- a/frontend/src/scenes/settings/settingsSceneLogic.ts
+++ b/frontend/src/scenes/settings/settingsSceneLogic.ts
@@ -73,16 +73,20 @@ export const settingsSceneLogic = kea<settingsSceneLogicType>([
     })),
 
     actionToUrl(({ values }) => ({
+        // Replacing history item instead of pushing, so that the environments<>project redirect doesn't affect history
         selectLevel({ level }) {
-            return [urls.settings(level), router.values.searchParams, router.values.hashParams]
+            return [urls.settings(level), router.values.searchParams, router.values.hashParams, { replace: true }]
         },
         selectSection({ section }) {
-            return [urls.settings(section), router.values.searchParams, router.values.hashParams]
+            return [urls.settings(section), router.values.searchParams, router.values.hashParams, { replace: true }]
         },
         selectSetting({ setting }) {
-            const url = urls.settings(values.selectedSectionId ?? values.selectedLevel, setting)
-
-            return [url]
+            return [
+                urls.settings(values.selectedSectionId ?? values.selectedLevel, setting),
+                undefined,
+                undefined,
+                { replace: true },
+            ]
         },
     })),
 ])


### PR DESCRIPTION
## Problem

1. [Quoting](https://posthog.slack.com/archives/C0113360FFV/p1733364108488629) @rafaeelaudibert:

    > redirecting from `project-` to `environment-` [is] not replacing the URL, it's simply adding a new entry, so you need to click the back arrow twice

2. [Quoting](https://posthog.slack.com/archives/C03PB072FMJ/p1733322460520979?thread_ts=1733319606.584529&cid=C03PB072FMJ) @annikaschmid:
    > The project settings button is not working anymore ["Configure" in session replay]

Both apply only behind the `environments` feature flag.

## Changes

1. The cause of redundant history items was an awkward interaction between `urlToAction` and `actionToUrl` in `settingsSceneLogic`:
    `urlToAction` called `selectLevel`/`selectSection` with the redirected path, which caused those actions' `actionToUrl` handlers to create new history items.
   Now `selectLevel`/`selectSection` _replace_ the current history item, and we no longer use them in the settings scene. 
    The settings scene uses URLs instead, which is overall better ergonomics (e.g. you can now use "Open in new tab" in settings).

2. The redirect only applied in `settingsSceneLogic`, but we also now have analogous logic for side panel settings in the lower-level `settingsLogic`.


## How did you test this code?

Clicked around in this case.