### PR TITLE
chore(flags): add retries to is_postgres_connected_check for flag matching paths

### DIFF
--- a/posthog/database_healthcheck.py
+++ b/posthog/database_healthcheck.py
@@ -55,7 +55,9 @@ class DatabaseHealthcheck:
                     cursor.execute("SELECT 1")
                 return True
             except Exception:
-                logger.exception("failed to connect to postgres attempt %s of 3", i + 1)
+                logger.exception(
+                    f"failed to connect to postgres {DATABASE_FOR_FLAG_MATCHING} node attempt {i + 1} of 3"
+                )
                 time.sleep(0.3)
 
         logger.exception("postgres_connection_failure")


### PR DESCRIPTION
## Problem

We're still trying to root cause the recent spike in `healthcheck_failed` flag evaluation errors (conversation here https://posthog.slack.com/archives/C0185UNBSJZ/p1733369640212279), but for the short term this change will require 3 straight `SELECT 1` failures before determining PG to be down when during flag matching 🩹 

We see in Loki logs that this healthcheck is often failing with `django.db.utils.OperationalError: consuming input failed: query_wait_timeout server closed the connection unexpectedly This probably means the server terminated abnormally before or while processing the request.`, especially when the decide request is interacting with the PG writer.

We've also identified some over-reporting of `healthcheck_failed` when write paths fail, but short-circuiting other requests would only use read replicas. This will be addressed in a follow up PR

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->
Yes

## How did you test this code?

Hitting decide locally works as expected and with `"errorsWhileComputingFlags": false,`

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
