### PR TITLE
fix(cdp): add form validation for input schema

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
@@ -200,10 +200,15 @@ type HogFunctionInputSchemaControlsProps = {
 
 function HogFunctionInputSchemaControls({ value, onChange, onDone }: HogFunctionInputSchemaControlsProps): JSX.Element {
     const _onChange = (data: Partial<HogFunctionInputSchemaType> | null): void => {
+        if (data?.key?.length === 0) {
+            setLocalVariableError('Input variable name cannot be empty')
+            return
+        }
         onChange(data ? { ...value, ...data } : null)
     }
 
     const [localVariableValue, setLocalVariableValue] = useState(value.key)
+    const [localVariableError, setLocalVariableError] = useState<string | null>(null)
 
     return (
         <div className="flex flex-col gap-2">
@@ -248,7 +253,7 @@ function HogFunctionInputSchemaControls({ value, onChange, onDone }: HogFunction
                         placeholder="Display label"
                     />
                 </LemonField.Pure>
-                <LemonField.Pure label="Input variable name">
+                <LemonField.Pure label="Input variable name" error={localVariableError}>
                     <LemonInput
                         size="small"
                         value={localVariableValue}

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -56,7 +56,7 @@ class InputsSchemaItemSerializer(serializers.Serializer):
         choices=["string", "boolean", "dictionary", "choice", "json", "integration", "integration_field", "email"]
     )
     key = serializers.CharField()
-    label = serializers.CharField(required=False)  # type: ignore
+    label = serializers.CharField(required=False, allow_blank=True)  # type: ignore
     choices = serializers.ListField(child=serializers.DictField(), required=False)
     required = serializers.BooleanField(default=False)  # type: ignore
     default = serializers.JSONField(required=False)


### PR DESCRIPTION
## Problem

You get errors when `Display label` or `Input variable name` is empty. 

## Changes

- Allow the `Display label` to be an empty string. We can fall back to using the `key` as a label instead.
- Throw an error when the `key` is empty.

![2024-12-06 at 10 00 54](https://github.com/user-attachments/assets/1e795070-8e6d-4bcb-927d-a651844970d9)

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
