### PR TITLE
feat: pass through billing query params 

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -62,7 +62,10 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         plan_keys = request.query_params.get("plan_keys", None)
         billing_manager = self.get_billing_manager()
-        response = billing_manager.get_billing(org, plan_keys)
+        query = {}
+        if "include_forecasting" in request.query_params:
+            query["include_forecasting"] = request.query_params.get("include_forecasting")
+        response = billing_manager.get_billing(org, plan_keys, query)
 
         return Response(response)
 

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -963,7 +963,7 @@ class TestActivateBillingAPI(APILicensedTest):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_deactivate_products.assert_called_once_with(self.organization, "product_1")
-        mock_get_billing.assert_called_once_with(self.organization, None)
+        mock_get_billing.assert_called_once_with(self.organization, None, {})
 
     def test_deactivate_failure(self):
         url = "/api/billing/deactivate"

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -841,7 +841,7 @@ class TestBillingAPI(APILicensedTest):
         assert self.organization.customer_trust_scores == {"recordings": 0, "events": 15, "rows_synced": 0}
 
     @patch("ee.api.billing.requests.get")
-    def test_billing_with_forecasting(self, mock_get):
+    def test_billing_with_supported_params(self, mock_get):
         """Test that the include_forecasting param is passed through to the billing service."""
 
         def mock_implementation(url: str, headers: Any = None, params: Any = None) -> MagicMock:
@@ -851,7 +851,9 @@ class TestBillingAPI(APILicensedTest):
             if "api/billing/portal" in url:
                 mock.json.return_value = {"url": "https://billing.stripe.com/p/session/test_1234"}
             elif "api/billing" in url:
-                mock.json.return_value = {"customer": {}}
+                mock.json.return_value = create_billing_response(
+                    customer=create_billing_customer(has_active_subscription=True)
+                )
 
             return mock
 

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -840,6 +840,35 @@ class TestBillingAPI(APILicensedTest):
 
         assert self.organization.customer_trust_scores == {"recordings": 0, "events": 15, "rows_synced": 0}
 
+    @patch("ee.api.billing.requests.get")
+    def test_billing_with_forecasting(self, mock_get):
+        """Test that the include_forecasting param is passed through to the billing service."""
+
+        def mock_implementation(url: str, headers: Any = None, params: Any = None) -> MagicMock:
+            mock = MagicMock()
+            mock.status_code = 200
+
+            if "api/billing/portal" in url:
+                mock.json.return_value = {"url": "https://billing.stripe.com/p/session/test_1234"}
+            elif "api/billing" in url:
+                mock.json.return_value = {"customer": {}}
+
+            return mock
+
+        mock_get.side_effect = mock_implementation
+
+        response = self.client.get("/api/billing/?include_forecasting=true")
+        assert response.status_code == 200
+
+        # Verify the billing service was called with the correct query param
+        billing_calls = [
+            call
+            for call in mock_get.call_args_list
+            if "api/billing" in call[0][0] and "api/billing/portal" not in call[0][0]
+        ]
+        assert len(billing_calls) == 1
+        assert billing_calls[0].kwargs["params"] == {"include_forecasting": "true"}
+
 
 class TestPortalBillingAPI(APILicensedTest):
     @patch("ee.api.billing.requests.get")

--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -74,9 +74,14 @@ class BillingManager:
         self.license = license or get_cached_instance_license()
         self.user = user
 
-    def get_billing(self, organization: Optional[Organization], plan_keys: Optional[str]) -> dict[str, Any]:
+    def get_billing(
+        self,
+        organization: Optional[Organization],
+        plan_keys: Optional[str],
+        query_params: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
         if organization and self.license and self.license.is_v2_license:
-            billing_service_response = self._get_billing(organization)
+            billing_service_response = self._get_billing(organization, query_params)
 
             # Ensure the license and org are updated with the latest info
             if billing_service_response.get("license"):
@@ -225,7 +230,7 @@ class BillingManager:
 
         return self.license
 
-    def _get_billing(self, organization: Organization) -> BillingStatus:
+    def _get_billing(self, organization: Organization, query_params: Optional[dict[str, Any]] = None) -> BillingStatus:
         """
         Retrieves billing info and updates local models if necessary
         """
@@ -235,6 +240,7 @@ class BillingManager:
         res = requests.get(
             f"{BILLING_SERVICE_URL}/api/billing",
             headers=self.get_auth_headers(organization),
+            params=query_params,
         )
         handle_billing_service_error(res)
 


### PR DESCRIPTION
## Changes

We support `include_forecasting` in billing now so we should add pass through support.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

## How did you test this code?

Added a test
