### PR TITLE
fix(data-warehouse): A handful of fixes for bigquery sources

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime, date
 from typing import Any, Literal, Optional
 from collections.abc import Iterator, Sequence
 import uuid
@@ -6,8 +7,13 @@ import uuid
 import dlt
 from django.conf import settings
 from django.db.models import Prefetch
+import dlt.common
+import dlt.common.libs
+import dlt.common.libs.pyarrow
 from dlt.pipeline.exceptions import PipelineStepFailed
 from deltalake import DeltaTable
+import pendulum
+import pyarrow
 
 from posthog.settings.base_variables import TEST
 from structlog.typing import FilteringBoundLogger
@@ -153,10 +159,21 @@ class DataImportPipelineSync:
             for i in range(0, len(lst), n):
                 yield lst[i : i + n]
 
+        def from_arrow_scalar(arrow_value: pyarrow.Scalar) -> Any:
+            """Converts arrow scalar into Python type. Currently adds "UTC" to naive date times and converts all others to UTC"""
+            row_value = arrow_value.as_py()
+
+            if isinstance(row_value, date) and not isinstance(row_value, datetime):
+                return row_value
+            elif isinstance(row_value, datetime):
+                row_value = pendulum.instance(row_value).in_tz("UTC")
+            return row_value
+
         # Monkey patch to fix large memory consumption until https://github.com/dlt-hub/dlt/pull/2031 gets merged in
         FilesystemDestinationClientConfiguration.delta_jobs_per_write = 1
         FilesystemClient.create_table_chain_completed_followup_jobs = create_table_chain_completed_followup_jobs  # type: ignore
         FilesystemClient._iter_chunks = _iter_chunks  # type: ignore
+        dlt.common.libs.pyarrow.from_arrow_scalar = from_arrow_scalar
 
         dlt.config["data_writer.file_max_items"] = 500_000
         dlt.config["data_writer.file_max_bytes"] = 500_000_000  # 500 MB

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -10,7 +10,7 @@ from temporalio import activity
 
 from posthog.models.integration import Integration
 from posthog.temporal.common.heartbeat_sync import HeartbeaterSync
-from posthog.temporal.data_imports.pipelines.bigquery import delete_table
+from posthog.temporal.data_imports.pipelines.bigquery import delete_all_temp_destination_tables, delete_table
 
 from posthog.temporal.data_imports.pipelines.pipeline_sync import DataImportPipelineSync, PipelineInputs
 from posthog.temporal.data_imports.util import is_posthog_team
@@ -360,8 +360,20 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                 model.pipeline.job_inputs.get("using_temporary_dataset", False) and temporary_dataset_id is not None
             )
 
+            destination_table_prefix = "__posthog_import_"
             destination_table_dataset_id = temporary_dataset_id if using_temporary_dataset else dataset_id
-            destination_table = f"{project_id}.{destination_table_dataset_id}.__posthog_import_{inputs.run_id}_{str(datetime.now().timestamp()).replace('.', '')}"
+            destination_table = f"{project_id}.{destination_table_dataset_id}.{destination_table_prefix}{inputs.run_id}_{str(datetime.now().timestamp()).replace('.', '')}"
+
+            delete_all_temp_destination_tables(
+                dataset_id=dataset_id,
+                table_prefix=destination_table_prefix,
+                project_id=project_id,
+                private_key=private_key,
+                private_key_id=private_key_id,
+                client_email=client_email,
+                token_uri=token_uri,
+                logger=logger,
+            )
 
             try:
                 source = bigquery_source(


### PR DESCRIPTION
## Changes
- Ensure all posthog created temp tables are deleted in the customers bigquery account
- Monkeypatch DLT some more to not error out when using a `date` type for incremental fields
- Check bigquery credentials using the `list table` bq command instead of getting the dataset
