### PR TITLE
ci: Use POSTHOG_BOT_GITHUB_TOKEN to allow opening PRs

### DIFF
--- a/.github/workflows/browserslist-update.yml
+++ b/.github/workflows/browserslist-update.yml
@@ -34,7 +34,7 @@ jobs:
             - name: Update Browserslist database and create PR if applies
               uses: c2corg/browserslist-update-action@v2
               with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  github_token: ${{ secrets.POSTHOG_BOT_GITHUB_TOKEN }} # This token has permission to open PRs
                   commit_message: 'build: update Browserslist db'
                   title: 'build: update Browserslist db'
                   labels: 'dependencies, automerge'


### PR DESCRIPTION
The base token cannot create PRs, so let's use our PH bot token instead

See https://github.com/PostHog/posthog/actions/runs/12189444620/job/34004593259
See discussion in https://posthog.slack.com/archives/C0113360FFV/p1733489991978849