### PR TITLE
fix: Run only one consumer in loop

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -1685,7 +1685,7 @@ async def test_s3_export_workflow_with_request_timeouts(
     assert run.records_completed is None
     assert (
         run.latest_error
-        == "RecordBatchConsumerRetryableExceptionGroup: At least one unhandled retryable errors in a RecordBatch consumer TaskGroup (1 sub-exception)"
+        == "IntermittentUploadPartTimeoutError: An intermittent `RequestTimeout` was raised while attempting to upload part 1"
     )
 
     run = runs[1]

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -403,18 +403,10 @@ async def test_insert_into_s3_activity_puts_splitted_parquet_data_into_s3(
     model: BatchExportModel | BatchExportSchema | None,
     ateam,
 ):
-    """Test that the insert_into_s3_activity function ends up with data into S3.
+    """Test that the insert_into_s3_activity function exports uncorrupted parquet data.
 
-    We use the generate_test_events_in_clickhouse function to generate several sets
-    of events. Some of these sets are expected to be exported, and others not. Expected
-    events are those that:
-    * Are created for the team_id of the batch export.
-    * Are created in the date range of the batch export.
-    * Are not duplicates of other events that are in the same batch.
-    * Do not have an event name contained in the batch export's exclude_events.
-
-    Once we have these events, we pass them to the assert_clickhouse_records_in_s3 function to check
-    that they appear in the expected S3 bucket and key.
+    More specifically, we are interested in what happens when there is the need to split
+    up a parquet file into multiple parts, so we generate a lot of data for this test.
     """
     prefix = str(uuid.uuid4())
 


### PR DESCRIPTION
## Problem

Writing a parquet file with multiple `ParquetWriter` instances can cause it to corrupt. I am not fully certain why, I think it has to do with whatever the `close()` method is doing, as it does write some bytes. Maybe it's the schema and other parquet metadata. In theory it should be possible to copy this metadata around, but it will require some refactoring.

Anyways, in the meantime, let's run a single consumer as that takes care of the issue (see new test, now passing).

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Update `run_consumer_loop` to only start one consumer.
* Add a test that checks for corrupted parquet files.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
