### PR TITLE
chore(batch-exports): Add batch export monitoring workflow

### DIFF
--- a/posthog/batch_exports/models.py
+++ b/posthog/batch_exports/models.py
@@ -106,6 +106,13 @@ class BatchExportRun(UUIDModel):
     records_total_count = models.IntegerField(
         null=True, help_text="The total count of records that should be exported in this BatchExportRun."
     )
+    expected_records_count = models.IntegerField(
+        null=True,
+        help_text=(
+            "The total count of records that we expect to be exported in this BatchExportRun. "
+            "This is updated automatically post-batch export by a monitoring job."
+        ),
+    )
 
     @property
     def workflow_id(self) -> str:

--- a/posthog/batch_exports/models.py
+++ b/posthog/batch_exports/models.py
@@ -106,13 +106,6 @@ class BatchExportRun(UUIDModel):
     records_total_count = models.IntegerField(
         null=True, help_text="The total count of records that should be exported in this BatchExportRun."
     )
-    expected_records_count = models.IntegerField(
-        null=True,
-        help_text=(
-            "The total count of records that we expect to be exported in this BatchExportRun. "
-            "This is updated automatically post-batch export by a monitoring job."
-        ),
-    )
 
     @property
     def workflow_id(self) -> str:

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -794,3 +794,13 @@ async def aupdate_batch_export_backfill_status(backfill_id: UUID, status: str) -
         raise ValueError(f"BatchExportBackfill with id {backfill_id} not found.")
 
     return await model.aget()
+
+
+async def aget_active_event_batch_exports(team_id: int) -> list[BatchExport]:
+    """Get active (non-paused, non-deleted) event batch exports for a given team."""
+    return [
+        model
+        async for model in BatchExport.objects.filter(
+            team_id=team_id, model="events", paused=False, deleted=False
+        ).prefetch_related("destination")
+    ]

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -796,16 +796,6 @@ async def aupdate_batch_export_backfill_status(backfill_id: UUID, status: str) -
     return await model.aget()
 
 
-async def aget_active_event_batch_exports(team_id: int) -> list[BatchExport]:
-    """Get active (non-paused, non-deleted) event batch exports for a given team."""
-    return [
-        model
-        async for model in BatchExport.objects.filter(
-            team_id=team_id, model="events", paused=False, deleted=False
-        ).prefetch_related("destination")
-    ]
-
-
 async def aupdate_expected_records_count(
     batch_export_id: UUID, interval_start: dt.datetime, interval_end: dt.datetime, count: int
 ) -> int:

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -808,15 +808,15 @@ async def aget_active_event_batch_exports(team_id: int) -> list[BatchExport]:
 
 async def aupdate_expected_records_count(
     batch_export_id: UUID, interval_start: dt.datetime, interval_end: dt.datetime, count: int
-):
+) -> int:
     """Update the expected records count for a set of batch export runs.
 
     Typically, there is one batch export run per batch export interval, however
     there could be multiple if data has been backfilled.
     """
-    # TODO - handle cases where it doesnt exist
-    await BatchExportRun.objects.filter(
+    rows_updated = await BatchExportRun.objects.filter(
         batch_export_id=batch_export_id,
         data_interval_start=interval_start,
         data_interval_end=interval_end,
     ).aupdate(expected_records_count=count)
+    return rows_updated

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -804,3 +804,19 @@ async def aget_active_event_batch_exports(team_id: int) -> list[BatchExport]:
             team_id=team_id, model="events", paused=False, deleted=False
         ).prefetch_related("destination")
     ]
+
+
+async def aupdate_expected_records_count(
+    batch_export_id: UUID, interval_start: dt.datetime, interval_end: dt.datetime, count: int
+):
+    """Update the expected records count for a set of batch export runs.
+
+    Typically, there is one batch export run per batch export interval, however
+    there could be multiple if data has been backfilled.
+    """
+    # TODO - handle cases where it doesnt exist
+    await BatchExportRun.objects.filter(
+        batch_export_id=batch_export_id,
+        data_interval_start=interval_start,
+        data_interval_end=interval_end,
+    ).aupdate(expected_records_count=count)

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -796,7 +796,7 @@ async def aupdate_batch_export_backfill_status(backfill_id: UUID, status: str) -
     return await model.aget()
 
 
-async def aupdate_expected_records_count(
+async def aupdate_records_total_count(
     batch_export_id: UUID, interval_start: dt.datetime, interval_end: dt.datetime, count: int
 ) -> int:
     """Update the expected records count for a set of batch export runs.
@@ -808,5 +808,5 @@ async def aupdate_expected_records_count(
         batch_export_id=batch_export_id,
         data_interval_start=interval_start,
         data_interval_end=interval_end,
-    ).aupdate(expected_records_count=count)
+    ).aupdate(records_total_count=count)
     return rows_updated

--- a/posthog/batch_exports/sql.py
+++ b/posthog/batch_exports/sql.py
@@ -318,3 +318,17 @@ CREATE OR REPLACE VIEW events_batch_export_backfill ON CLUSTER {settings.CLICKHO
     SETTINGS optimize_aggregation_in_order=1
 )
 """
+
+# TODO: is this the best query to use?
+EVENT_COUNT_FROM_UNBOUNDED_VIEW = """
+SELECT
+    count()
+FROM
+    events_batch_export_unbounded(
+        team_id={team_id},
+        interval_start={interval_start},
+        interval_end={interval_end},
+        include_events={include_events}::Array(String),
+        exclude_events={exclude_events}::Array(String)
+    ) AS events
+"""

--- a/posthog/temporal/batch_exports/__init__.py
+++ b/posthog/temporal/batch_exports/__init__.py
@@ -17,6 +17,12 @@ from posthog.temporal.batch_exports.http_batch_export import (
     HttpBatchExportWorkflow,
     insert_into_http_activity,
 )
+from posthog.temporal.batch_exports.monitoring import (
+    BatchExportMonitoringWorkflow,
+    get_batch_export,
+    get_event_counts,
+    update_batch_export_runs,
+)
 from posthog.temporal.batch_exports.noop import NoOpWorkflow, noop_activity
 from posthog.temporal.batch_exports.postgres_batch_export import (
     PostgresBatchExportWorkflow,
@@ -54,6 +60,7 @@ WORKFLOWS = [
     SnowflakeBatchExportWorkflow,
     HttpBatchExportWorkflow,
     SquashPersonOverridesWorkflow,
+    BatchExportMonitoringWorkflow,
 ]
 
 ACTIVITIES = [
@@ -76,4 +83,7 @@ ACTIVITIES = [
     update_batch_export_backfill_model_status,
     wait_for_mutation,
     wait_for_table,
+    get_batch_export,
+    get_event_counts,
+    update_batch_export_runs,
 ]

--- a/posthog/temporal/batch_exports/monitoring.py
+++ b/posthog/temporal/batch_exports/monitoring.py
@@ -1,0 +1,211 @@
+import datetime as dt
+import json
+from dataclasses import dataclass
+
+from django.db.models import Max, Sum
+from temporalio import activity, workflow
+from temporalio.common import RetryPolicy
+
+from posthog.batch_exports.models import BatchExportRun
+from posthog.batch_exports.service import aget_active_event_batch_exports
+from posthog.batch_exports.sql import EVENT_COUNT_FROM_UNBOUNDED_VIEW
+from posthog.temporal.batch_exports.base import PostHogWorkflow
+from posthog.temporal.common.clickhouse import get_client
+
+
+class NoActiveBatchExportsFoundError(Exception):
+    """Exception raised when no active events batch exports are found for a given team."""
+
+    def __init__(self, team_id: int):
+        super().__init__(f"No active events batch exports found for team {team_id}")
+
+
+@dataclass
+class BatchExportMonitoringInputs:
+    """Inputs for the BatchExportMonitoringWorkflow.
+
+    Attributes:
+        team_id: The team id to monitor batch exports for.
+    """
+
+    # TODO - make this a list of team ids or single?
+    team_id: int
+
+
+@dataclass
+class BatchExportDetails:
+    id: str
+    exclude_events: list[str]
+    include_events: list[str]
+
+
+@activity.defn
+async def get_batch_export(team_id: int) -> BatchExportDetails:
+    """Get the number of records completed for a given team."""
+    models = await aget_active_event_batch_exports(team_id)
+    if len(models) == 0:
+        raise NoActiveBatchExportsFoundError(team_id)
+    if len(models) > 1:
+        activity.logger.warning("More than one active events batch export found; using first one...")
+    model = models[0]
+    config = model.destination.config
+    return BatchExportDetails(
+        id=model.id, exclude_events=config.get("exclude_events", []), include_events=config.get("include_events", [])
+    )
+
+
+@dataclass
+class GetRecordsCompletedInputs:
+    batch_export_id: str
+    interval_start: str
+    interval_end: str
+
+
+@activity.defn
+async def get_records_completed(inputs: GetRecordsCompletedInputs) -> int:
+    """Get the number of records completed for the given batch export and interval.
+
+    There will typically be multiple batch export runs for a given batch export,
+    each with a different data interval, so we need to sum these. In addition, a
+    particular batch export run could have been re-run multiple times (eg
+    manually by the user), so we need to dedupe these (we choose to take the one
+    with the highest records_completed).
+    """
+
+    deduped_batch_export_runs = (
+        BatchExportRun.objects.filter(
+            batch_export_id=inputs.batch_export_id,
+            data_interval_start__gte=inputs.interval_start,
+            data_interval_start__lt=inputs.interval_end,
+        )
+        .values("data_interval_start")
+        .annotate(max_records_completed=Max("records_completed"))
+    )
+
+    result = await deduped_batch_export_runs.aaggregate(records_sum=Sum("max_records_completed"))
+    return result["records_sum"] or 0
+
+
+@dataclass
+class GetEventsCountInputs:
+    team_id: int
+    interval_start: str
+    interval_end: str
+    exclude_events: list[str]
+    include_events: list[str]
+
+
+@activity.defn
+async def get_events_count(inputs: GetEventsCountInputs) -> int:
+    """Get the total number of events for a given team and time interval."""
+
+    # TODO: is this the best query to use?
+    query = EVENT_COUNT_FROM_UNBOUNDED_VIEW
+    query_params = {
+        "team_id": inputs.team_id,
+        "interval_start": inputs.interval_start,
+        "interval_end": inputs.interval_end,
+        "include_events": inputs.include_events,
+        "exclude_events": inputs.exclude_events,
+    }
+    async with get_client() as client:
+        if not await client.is_alive():
+            raise ConnectionError("Cannot establish connection to ClickHouse")
+
+        response = await client.read_query(query, query_params)
+        line = response.decode("utf-8").splitlines()[0]
+        count_str = line.strip()
+        return int(count_str)
+
+
+@dataclass
+class CompareCountsInputs:
+    total_completed_records: int
+    total_events: int
+
+
+@activity.defn
+async def compare_counts(inputs: CompareCountsInputs) -> bool:
+    """Compare the number of events in ClickHouse with the reported number of exported events."""
+    # for now, return True if within 10% of each other
+    if inputs.total_events == 0:
+        return inputs.total_completed_records == 0
+    abs_diff = abs(inputs.total_completed_records - inputs.total_events)
+    return abs_diff / inputs.total_events < 0.1
+
+
+@workflow.defn(name="batch-export-monitoring")
+class BatchExportMonitoringWorkflow(PostHogWorkflow):
+    """Workflow to monitor batch exports.
+
+    We have had some issues with batch exports in the past, where some events
+    have been missing. The purpose of this workflow is to monitor the status of
+    batch exports for a given customer by reconciling the number of exported
+    events with the number of events in ClickHouse for a given interval.
+    """
+
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> BatchExportMonitoringInputs:
+        """Parse inputs from the management command CLI."""
+        loaded = json.loads(inputs[0])
+        return BatchExportMonitoringInputs(**loaded)
+
+    @workflow.run
+    async def run(self, inputs: BatchExportMonitoringInputs):
+        """Workflow implementation to monitor batch exports for a given team."""
+        # TODO - check if this is the right way to do logging since there seems to be a few different ways
+        workflow.logger.info("Starting batch exports monitoring workflow for team %s", inputs.team_id)
+
+        batch_export_details = await workflow.execute_activity(
+            get_batch_export,
+            inputs.team_id,
+            start_to_close_timeout=dt.timedelta(minutes=1),
+            retry_policy=RetryPolicy(
+                maximum_attempts=3,
+                initial_interval=dt.timedelta(seconds=20),
+                non_retryable_error_types=["NoActiveBatchExportsFoundError"],
+            ),
+            heartbeat_timeout=dt.timedelta(minutes=1),
+        )
+
+        # time interval to check is not the previous hour but the hour before that
+        # (just to ensure all recent batch exports have run successfully)
+        now = dt.datetime.now(tz=dt.UTC)
+        interval_end = now.replace(minute=0, second=0, microsecond=0) - dt.timedelta(hours=1)
+        interval_start = interval_end - dt.timedelta(hours=1)
+        interval_end_str = interval_end.strftime("%Y-%m-%d %H:%M:%S")
+        interval_start_str = interval_start.strftime("%Y-%m-%d %H:%M:%S")
+
+        total_completed_records = await workflow.execute_activity(
+            get_records_completed,
+            GetRecordsCompletedInputs(
+                batch_export_id=batch_export_details.id,
+                interval_start=interval_start_str,
+                interval_end=interval_end_str,
+            ),
+            start_to_close_timeout=dt.timedelta(hours=1),
+            retry_policy=RetryPolicy(maximum_attempts=3, initial_interval=dt.timedelta(seconds=20)),
+            heartbeat_timeout=dt.timedelta(minutes=1),
+        )
+
+        total_events = await workflow.execute_activity(
+            get_events_count,
+            GetEventsCountInputs(
+                team_id=inputs.team_id,
+                interval_start=interval_start_str,
+                interval_end=interval_end_str,
+                exclude_events=batch_export_details.exclude_events,
+                include_events=batch_export_details.include_events,
+            ),
+            start_to_close_timeout=dt.timedelta(hours=1),
+            retry_policy=RetryPolicy(maximum_attempts=3, initial_interval=dt.timedelta(seconds=20)),
+            heartbeat_timeout=dt.timedelta(minutes=1),
+        )
+
+        return await workflow.execute_activity(
+            compare_counts,
+            CompareCountsInputs(total_completed_records=total_completed_records, total_events=total_events),
+            start_to_close_timeout=dt.timedelta(minutes=1),
+            retry_policy=RetryPolicy(maximum_attempts=3, initial_interval=dt.timedelta(seconds=20)),
+            heartbeat_timeout=dt.timedelta(minutes=1),
+        )

--- a/posthog/temporal/batch_exports/monitoring.py
+++ b/posthog/temporal/batch_exports/monitoring.py
@@ -7,7 +7,7 @@ from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
 from posthog.batch_exports.models import BatchExport
-from posthog.batch_exports.service import aupdate_expected_records_count
+from posthog.batch_exports.service import aupdate_records_total_count
 from posthog.batch_exports.sql import EVENT_COUNT_BY_INTERVAL
 from posthog.temporal.batch_exports.base import PostHogWorkflow
 from posthog.temporal.common.clickhouse import get_client
@@ -147,7 +147,7 @@ async def update_batch_export_runs(inputs: UpdateBatchExportRunsInputs) -> int:
 
     total_rows_updated = 0
     for result in inputs.results:
-        total_rows_updated += await aupdate_expected_records_count(
+        total_rows_updated += await aupdate_records_total_count(
             batch_export_id=inputs.batch_export_id,
             interval_start=dt.datetime.strptime(result.interval_start, "%Y-%m-%d %H:%M:%S").replace(tzinfo=dt.UTC),
             interval_end=dt.datetime.strptime(result.interval_end, "%Y-%m-%d %H:%M:%S").replace(tzinfo=dt.UTC),

--- a/posthog/temporal/tests/batch_exports/conftest.py
+++ b/posthog/temporal/tests/batch_exports/conftest.py
@@ -152,8 +152,8 @@ async def create_clickhouse_tables_and_views(clickhouse_client, django_db_setup)
     from posthog.batch_exports.sql import (
         CREATE_EVENTS_BATCH_EXPORT_VIEW,
         CREATE_EVENTS_BATCH_EXPORT_VIEW_BACKFILL,
-        CREATE_EVENTS_BATCH_EXPORT_VIEW_UNBOUNDED,
         CREATE_EVENTS_BATCH_EXPORT_VIEW_RECENT,
+        CREATE_EVENTS_BATCH_EXPORT_VIEW_UNBOUNDED,
         CREATE_PERSONS_BATCH_EXPORT_VIEW,
         CREATE_PERSONS_BATCH_EXPORT_VIEW_BACKFILL,
     )
@@ -211,8 +211,12 @@ def data_interval_start(request, data_interval_end, interval):
 
 
 @pytest.fixture
-def data_interval_end(interval):
+def data_interval_end(request, interval):
     """Set a test data interval end."""
+    try:
+        return request.param
+    except AttributeError:
+        pass
     return dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.UTC)
 
 

--- a/posthog/temporal/tests/batch_exports/test_monitoring.py
+++ b/posthog/temporal/tests/batch_exports/test_monitoring.py
@@ -104,7 +104,7 @@ async def generate_batch_export_runs(
 
 async def test_monitoring_workflow_when_no_event_data(batch_export):
     workflow_id = str(uuid.uuid4())
-    inputs = BatchExportMonitoringInputs(team_id=batch_export.team_id)
+    inputs = BatchExportMonitoringInputs(batch_export_id=batch_export.id)
     async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
         async with Worker(
             activity_environment.client,
@@ -144,7 +144,11 @@ async def test_monitoring_workflow_when_no_event_data(batch_export):
     indirect=True,
 )
 async def test_monitoring_workflow(
-    batch_export, generate_test_data, data_interval_start, interval, generate_batch_export_runs
+    batch_export,
+    generate_test_data,
+    data_interval_start,
+    interval,
+    generate_batch_export_runs,
 ):
     """Test the monitoring workflow with a batch export that has data.
 
@@ -157,7 +161,7 @@ async def test_monitoring_workflow(
     completed.
     """
     workflow_id = str(uuid.uuid4())
-    inputs = BatchExportMonitoringInputs(team_id=batch_export.team_id)
+    inputs = BatchExportMonitoringInputs(batch_export_id=batch_export.id)
 
     with freeze_time(dt.datetime(2023, 4, 25, 15, 30, 0, tzinfo=dt.UTC)) as frozen_time:
         async with await WorkflowEnvironment.start_time_skipping() as activity_environment:

--- a/posthog/temporal/tests/batch_exports/test_monitoring.py
+++ b/posthog/temporal/tests/batch_exports/test_monitoring.py
@@ -1,0 +1,85 @@
+import datetime as dt
+import uuid
+
+import pytest
+import pytest_asyncio
+from temporalio.common import RetryPolicy
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from posthog import constants
+from posthog.temporal.batch_exports.monitoring import (
+    BatchExportMonitoringInputs,
+    BatchExportMonitoringWorkflow,
+    compare_counts,
+    get_batch_export,
+    get_events_count,
+    get_records_completed,
+)
+from posthog.temporal.tests.utils.models import (
+    acreate_batch_export,
+    adelete_batch_export,
+)
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
+
+TEST_TIME = dt.datetime.now(dt.UTC)
+
+
+@pytest_asyncio.fixture
+async def batch_export(ateam, temporal_client):
+    """Provide a batch export for tests, not intended to be used."""
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "a-bucket",
+            "region": "us-east-1",
+            "prefix": "a-key",
+            "aws_access_key_id": "object_storage_root_user",
+            "aws_secret_access_key": "object_storage_root_password",
+        },
+    }
+
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    batch_export = await acreate_batch_export(
+        team_id=ateam.pk,
+        name=batch_export_data["name"],  # type: ignore
+        destination_data=batch_export_data["destination"],  # type: ignore
+        interval=batch_export_data["interval"],  # type: ignore
+    )
+
+    yield batch_export
+
+    await adelete_batch_export(batch_export, temporal_client)
+
+
+async def test_monitoring_workflow(batch_export):
+    workflow_id = str(uuid.uuid4())
+    inputs = BatchExportMonitoringInputs(team_id=batch_export.team_id)
+    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+        async with Worker(
+            activity_environment.client,
+            # TODO - not sure if this is the right task queue
+            task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
+            workflows=[BatchExportMonitoringWorkflow],
+            activities=[
+                get_batch_export,
+                get_records_completed,
+                get_events_count,
+                compare_counts,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            await activity_environment.client.execute_workflow(
+                BatchExportMonitoringWorkflow.run,
+                inputs,
+                id=workflow_id,
+                task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
+                retry_policy=RetryPolicy(maximum_attempts=1),
+                execution_timeout=dt.timedelta(seconds=30),
+            )

--- a/posthog/temporal/tests/batch_exports/test_monitoring.py
+++ b/posthog/temporal/tests/batch_exports/test_monitoring.py
@@ -9,15 +9,18 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog import constants
+from posthog.batch_exports.models import BatchExportRun
 from posthog.temporal.batch_exports.monitoring import (
     BatchExportMonitoringInputs,
     BatchExportMonitoringWorkflow,
     get_batch_export,
     get_event_counts,
+    update_batch_export_runs,
 )
 from posthog.temporal.tests.utils.models import (
     acreate_batch_export,
     adelete_batch_export,
+    afetch_batch_export_runs,
 )
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
@@ -55,7 +58,78 @@ async def batch_export(ateam, temporal_client):
     await adelete_batch_export(batch_export, temporal_client)
 
 
-@freeze_time(dt.datetime(2023, 4, 25, 15, 30, 0, tzinfo=dt.UTC))
+@pytest_asyncio.fixture
+async def generate_batch_export_runs(
+    generate_test_data,
+    data_interval_start: dt.datetime,
+    data_interval_end: dt.datetime,
+    interval: str,
+    batch_export,
+):
+    # to keep things simple for now, we assume 5 min interval
+    if interval != "every 5 minutes":
+        raise NotImplementedError("Only 5 minute intervals are supported for now. Please update the test.")
+
+    events_created, _ = generate_test_data
+
+    batch_export_runs: list[BatchExportRun] = []
+    interval_start = data_interval_start
+    interval_end = interval_start + dt.timedelta(minutes=5)
+    while interval_end <= data_interval_end:
+        run = BatchExportRun(
+            batch_export_id=batch_export.id,
+            data_interval_start=interval_start,
+            data_interval_end=interval_end,
+            status="completed",
+            records_completed=len(
+                [
+                    e
+                    for e in events_created
+                    if interval_start
+                    <= dt.datetime.fromisoformat(e["inserted_at"]).replace(tzinfo=dt.UTC)
+                    < interval_end
+                ]
+            ),
+        )
+        await run.asave()
+        batch_export_runs.append(run)
+        interval_start = interval_end
+        interval_end += dt.timedelta(minutes=5)
+
+    yield
+
+    for run in batch_export_runs:
+        await run.adelete()
+
+
+async def test_monitoring_workflow_when_no_event_data(batch_export):
+    workflow_id = str(uuid.uuid4())
+    inputs = BatchExportMonitoringInputs(team_id=batch_export.team_id)
+    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+        async with Worker(
+            activity_environment.client,
+            # TODO - not sure if this is the right task queue
+            task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
+            workflows=[BatchExportMonitoringWorkflow],
+            activities=[
+                get_batch_export,
+                get_event_counts,
+                update_batch_export_runs,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            batch_export_runs_updated = await activity_environment.client.execute_workflow(
+                BatchExportMonitoringWorkflow.run,
+                inputs,
+                id=workflow_id,
+                task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
+                retry_policy=RetryPolicy(maximum_attempts=1),
+                execution_timeout=dt.timedelta(seconds=30),
+            )
+            assert batch_export_runs_updated == 0
+
+
+@freeze_time()
 @pytest.mark.parametrize(
     "data_interval_start",
     # This is hardcoded relative to the `data_interval_end` used in all or most tests, since that's also
@@ -69,30 +143,60 @@ async def batch_export(ateam, temporal_client):
     ["every 5 minutes"],
     indirect=True,
 )
-async def test_monitoring_workflow(batch_export, generate_test_data, data_interval_start, interval):
-    # now = dt.datetime.now(tz=dt.UTC)
-    # interval_end = now.replace(minute=0, second=0, microsecond=0) - dt.timedelta(hours=1)
-    # interval_start = interval_end - dt.timedelta(hours=1)
+async def test_monitoring_workflow(
+    batch_export, generate_test_data, data_interval_start, interval, generate_batch_export_runs
+):
+    """Test the monitoring workflow with a batch export that has data.
 
+    We generate 2 hours of data between 13:00 and 15:00, and then run the
+    monitoring workflow at 15:30.  The monitoring workflow should check the data
+    between 14:00 and 15:00, and update the batch export runs.
+
+    We generate some dummy batch export runs based on the event data we
+    generated and assert that the expected records count matches the records
+    completed.
+    """
     workflow_id = str(uuid.uuid4())
     inputs = BatchExportMonitoringInputs(team_id=batch_export.team_id)
-    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
-        async with Worker(
-            activity_environment.client,
-            # TODO - not sure if this is the right task queue
-            task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
-            workflows=[BatchExportMonitoringWorkflow],
-            activities=[
-                get_batch_export,
-                get_event_counts,
-            ],
-            workflow_runner=UnsandboxedWorkflowRunner(),
-        ):
-            await activity_environment.client.execute_workflow(
-                BatchExportMonitoringWorkflow.run,
-                inputs,
-                id=workflow_id,
+
+    with freeze_time(dt.datetime(2023, 4, 25, 15, 30, 0, tzinfo=dt.UTC)) as frozen_time:
+        async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+            async with Worker(
+                activity_environment.client,
+                # TODO - not sure if this is the right task queue
                 task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
-                retry_policy=RetryPolicy(maximum_attempts=1),
-                execution_timeout=dt.timedelta(seconds=30),
-            )
+                workflows=[BatchExportMonitoringWorkflow],
+                activities=[
+                    get_batch_export,
+                    get_event_counts,
+                    update_batch_export_runs,
+                ],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                await activity_environment.client.execute_workflow(
+                    BatchExportMonitoringWorkflow.run,
+                    inputs,
+                    id=workflow_id,
+                    task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                    execution_timeout=dt.timedelta(seconds=30),
+                )
+
+        # the monitoring workflow checks a single hour of data
+        check_interval_end = frozen_time().replace(minute=0, second=0, microsecond=0, tzinfo=dt.UTC) - dt.timedelta(
+            hours=1
+        )
+        check_interval_start = check_interval_end - dt.timedelta(hours=1)
+        batch_export_runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)
+        for run in batch_export_runs:
+            if run.data_interval_start is None:
+                continue
+            if run.data_interval_start >= check_interval_end or run.data_interval_end < check_interval_start:
+                # we shouldn't have updated this run
+                assert run.expected_records_count is None
+            elif run.records_completed == 0:
+                # TODO: in the actual monitoring activity it would be better to
+                # update the actual count to 0 rather than None
+                assert run.expected_records_count is None
+            else:
+                assert run.records_completed == run.expected_records_count

--- a/posthog/temporal/tests/batch_exports/test_monitoring.py
+++ b/posthog/temporal/tests/batch_exports/test_monitoring.py
@@ -197,10 +197,10 @@ async def test_monitoring_workflow(
                 continue
             if run.data_interval_start >= check_interval_end or run.data_interval_end < check_interval_start:
                 # we shouldn't have updated this run
-                assert run.expected_records_count is None
+                assert run.records_total_count is None
             elif run.records_completed == 0:
                 # TODO: in the actual monitoring activity it would be better to
                 # update the actual count to 0 rather than None
-                assert run.expected_records_count is None
+                assert run.records_total_count is None
             else:
-                assert run.records_completed == run.expected_records_count
+                assert run.records_completed == run.records_total_count


### PR DESCRIPTION
## Problem

In the past we've had some issues with events missing from certain batch exports and lack any reliable monitoring for this.

## Changes

Add a new workflow in Temporal for monitoring the events exported by a given team's batch export.

This workflow is quite specific at the moment, in that it just checks 5 min batch exports (since these are the only ones using the `recent_events` table). It checks for a previous hour's worth of events (based on `inserted_at`) and stores the event count in the `batch_export_runs` table, so we can later reconcile this against `records_completed`.

I have left a few TODOs in the code for things I'm unsure about.

## Does this work well for both Cloud and self-hosted?

it doesn't have an impact

## How did you test this code?

Added tests
