### PR TITLE
fix: timeout pushed with debug value

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,5 @@
 .eslintrc.js
 jest.config.ts
+node_modules
+rust
+livestream

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ const globals = {
 }
 
 module.exports = {
-    ignorePatterns: ['node_modules', 'plugin-server'],
+    ignorePatterns: ['node_modules', 'plugin-server', 'rust', 'livestream'],
     env,
     settings: {
         react: {

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ pyrightconfig.json
 .temporal-worker-settings
 temp_test_run_data.json
 .temp-deepeval-cache.json
+.eslintcache

--- a/frontend/src/scenes/session-recordings/player/PlayerUpNext.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerUpNext.tsx
@@ -50,9 +50,13 @@ export function PlayerUpNext({ playlistLogic }: PlayerUpNextProps): JSX.Element 
         if (endReached && nextSessionRecording?.id) {
             setAnimate(true)
             setPlayNextAnimationInterrupted(false)
-            timeoutRef.current = setTimeout(() => {
-                goToRecording(true)
-            }, 3000) // NOTE: Keep in sync with SCSS
+            timeoutRef.current = setTimeout(
+                () => {
+                    goToRecording(true)
+                },
+                // NOTE: Keep in sync with SCSS
+                3000
+            )
         }
 
         return () => clearTimeout(timeoutRef.current)

--- a/frontend/src/scenes/session-recordings/player/PlayerUpNext.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerUpNext.tsx
@@ -52,7 +52,7 @@ export function PlayerUpNext({ playlistLogic }: PlayerUpNextProps): JSX.Element 
             setPlayNextAnimationInterrupted(false)
             timeoutRef.current = setTimeout(() => {
                 goToRecording(true)
-            }, 30000) // NOTE: Keep in sync with SCSS
+            }, 3000) // NOTE: Keep in sync with SCSS
         }
 
         return () => clearTimeout(timeoutRef.current)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "prettier": "prettier --write \"./**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}\"",
         "prettier:check": "prettier --check \"frontend/**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}\"",
         "typescript:check": "tsc --noEmit && echo \"No errors reported by tsc.\"",
-        "lint:js": "eslint frontend/src cypress",
+        "lint:js": "eslint --cache frontend/src cypress",
         "lint:css": "stylelint \"frontend/**/*.{css,scss}\"",
         "format:backend": "ruff .",
         "format:frontend": "pnpm lint:js --fix && pnpm lint:css --fix && pnpm prettier",
@@ -349,7 +349,7 @@
             "prettier --write"
         ],
         "frontend/src/**/*.{js,jsx,mjs,ts,tsx}": [
-            "eslint -c .eslintrc.js --fix",
+            "eslint --cache -c .eslintrc.js --fix",
             "prettier --write"
         ],
         "frontend/*.mjs": [


### PR DESCRIPTION
fixes an error where i left a debug value in the upnext button
and makes eslint 89x faster by using a cache file

before

`eslint --debug --cache frontend/src cypress  89.20s user 6.07s system 145% cpu 1:05.57 total`

after

`eslint --debug --cache frontend/src cypress  1.14s user 0.26s system 68% cpu 2.035 total`

