### PR TITLE
fix: only measure start from snapshot data

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -980,6 +980,10 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                 const eventStart = meta?.start_time ? dayjs(meta.start_time) : null
                 const snapshotStart = firstSnapshot ? dayjs(firstSnapshot.timestamp) : null
 
+                if (snapshotStart && eventStart) {
+                    return snapshotStart
+                }
+
                 return snapshotStart || eventStart
             },
         ],
@@ -992,7 +996,7 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
 
                 // whichever is latest
                 if (eventEnd && snapshotEnd) {
-                    return eventEnd.isAfter(snapshotEnd) ? eventEnd : snapshotEnd
+                    return snapshotEnd
                 }
                 return eventEnd || snapshotEnd
             },


### PR DESCRIPTION
follow-up to https://github.com/PostHog/posthog/pull/26718

we're getting the event timestamp before the snapshot timestamp and not updating. 

We only ever want to use the snapshot data start date so let's only do that