### PR TITLE
feat: Add `CompareFilter` to Web Analytics frontend

### DIFF
--- a/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
+++ b/frontend/src/lib/components/CompareFilter/CompareFilter.tsx
@@ -8,7 +8,7 @@ import { CompareFilter as CompareFilterType } from '~/queries/schema'
 type CompareFilterProps = {
     compareFilter?: CompareFilterType | null
     updateCompareFilter: (compareFilter: CompareFilterType) => void
-    disabled: boolean
+    disabled?: boolean
 }
 
 export function CompareFilter({

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -239,6 +239,7 @@ export const FEATURE_FLAGS = {
     REPLAY_HOGQL_FILTERS: 'replay-hogql-filters', // owner: @pauldambra #team-replay
     REPLAY_LIST_RECORDINGS_AS_QUERY: 'replay-list-recordings-as-query', // owner: @pauldambra #team-replay
     BILLING_SKIP_FORECASTING: 'billing-skip-forecasting', // owner: @zach
+    WEB_ANALYTICS_PERIOD_COMPARISON: 'web-analytics-period-comparison', // owner: @rafaeelaudibert #team-web-analytics
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -13110,8 +13110,15 @@
         "WebOverviewQuery": {
             "additionalProperties": false,
             "properties": {
-                "compare": {
-                    "type": "boolean"
+                "compareFilter": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/CompareFilter"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "conversionGoal": {
                     "anyOf": [
@@ -13241,6 +13248,16 @@
             "properties": {
                 "breakdownBy": {
                     "$ref": "#/definitions/WebStatsBreakdown"
+                },
+                "compareFilter": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/CompareFilter"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "conversionGoal": {
                     "anyOf": [

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1798,7 +1798,7 @@ interface WebAnalyticsQueryBase<R extends Record<string, any>> extends DataNode<
 
 export interface WebOverviewQuery extends WebAnalyticsQueryBase<WebOverviewQueryResponse> {
     kind: NodeKind.WebOverviewQuery
-    compare?: boolean
+    compareFilter?: CompareFilter | null
     includeLCPScore?: boolean
 }
 
@@ -1850,6 +1850,7 @@ export enum WebStatsBreakdown {
 export interface WebStatsTableQuery extends WebAnalyticsQueryBase<WebStatsTableQueryResponse> {
     kind: NodeKind.WebStatsTableQuery
     breakdownBy: WebStatsBreakdown
+    compareFilter?: CompareFilter | null
     includeScrollDepth?: boolean // automatically sets includeBounceRate to true
     includeBounceRate?: boolean
     doPathCleaning?: boolean

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -1,6 +1,7 @@
 import { IconExpand45, IconInfo, IconOpenSidebar, IconX } from '@posthog/icons'
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
+import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { VersionCheckerBanner } from 'lib/components/VersionChecker/VersionCheckerBanner'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -38,8 +39,9 @@ const Filters = (): JSX.Element => {
     const {
         webAnalyticsFilters,
         dateFilter: { dateTo, dateFrom },
+        compareFilter,
     } = useValues(webAnalyticsLogic)
-    const { setWebAnalyticsFilters, setDates } = useActions(webAnalyticsLogic)
+    const { setWebAnalyticsFilters, setDates, setCompareFilter } = useActions(webAnalyticsLogic)
     const { mobileLayout } = useValues(navigationLogic)
     const { conversionGoal } = useValues(webAnalyticsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -53,6 +55,10 @@ const Filters = (): JSX.Element => {
         >
             <div className="flex flex-row flex-wrap gap-2">
                 <DateFilter dateFrom={dateFrom} dateTo={dateTo} onChange={setDates} />
+                {featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_PERIOD_COMPARISON] ? (
+                    <CompareFilter compareFilter={compareFilter} updateCompareFilter={setCompareFilter} />
+                ) : null}
+
                 <WebPropertyFilters
                     setWebAnalyticsFilters={setWebAnalyticsFilters}
                     webAnalyticsFilters={webAnalyticsFilters}

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -16,7 +16,7 @@ import {
     ActionConversionGoal,
     ActionsNode,
     AnyEntityNode,
-    CompareFilter as CompareFilterType,
+    CompareFilter,
     CustomEventConversionGoal,
     EventsNode,
     NodeKind,
@@ -280,7 +280,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             return { tileId, tabId }
         },
         setConversionGoalWarning: (warning: ConversionGoalWarning | null) => ({ warning }),
-        setCompareFilter: (compareFilter: CompareFilterType | null) => ({ compareFilter }),
+        setCompareFilter: (compareFilter: CompareFilter | null) => ({ compareFilter }),
     }),
     reducers({
         webAnalyticsFilters: [
@@ -474,7 +474,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             },
         ],
         compareFilter: [
-            { compare: true } as CompareFilterType | null,
+            { compare: true } as CompareFilter | null,
             persistConfig,
             {
                 setCompareFilter: (_, { compareFilter }) => compareFilter,
@@ -620,7 +620,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 display: ChartDisplayType.ActionsLineGraph,
                                 ...trendsFilter,
                             },
-                            compareFilter,
+                            compareFilter: compareFilter || { compare: false },
                             filterTestAccounts,
                             properties: webAnalyticsFilters,
                         },

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -16,6 +16,7 @@ import {
     ActionConversionGoal,
     ActionsNode,
     AnyEntityNode,
+    CompareFilter as CompareFilterType,
     CustomEventConversionGoal,
     EventsNode,
     NodeKind,
@@ -279,6 +280,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             return { tileId, tabId }
         },
         setConversionGoalWarning: (warning: ConversionGoalWarning | null) => ({ warning }),
+        setCompareFilter: (compareFilter: CompareFilterType | null) => ({ compareFilter }),
     }),
     reducers({
         webAnalyticsFilters: [
@@ -471,6 +473,13 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 setConversionGoalWarning: (_, { warning }) => warning,
             },
         ],
+        compareFilter: [
+            { compare: true } as CompareFilterType | null,
+            persistConfig,
+            {
+                setCompareFilter: (_, { compareFilter }) => compareFilter,
+            },
+        ],
     }),
     selectors(({ actions, values }) => ({
         graphsTab: [(s) => [s._graphsTab], (graphsTab: string | null) => graphsTab || GraphsTab.UNIQUE_USERS],
@@ -505,11 +514,12 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             }),
         ],
         filters: [
-            (s) => [s.webAnalyticsFilters, s.replayFilters, s.dateFilter, () => values.conversionGoal],
-            (webAnalyticsFilters, replayFilters, dateFilter, conversionGoal) => ({
+            (s) => [s.webAnalyticsFilters, s.replayFilters, s.dateFilter, s.compareFilter, () => values.conversionGoal],
+            (webAnalyticsFilters, replayFilters, dateFilter, compareFilter, conversionGoal) => ({
                 webAnalyticsFilters,
                 replayFilters,
                 dateFilter,
+                compareFilter,
                 conversionGoal,
             }),
         ],
@@ -518,7 +528,13 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             (
                 { graphsTab, sourceTab, deviceTab, pathTab, geographyTab, shouldShowGeographyTile },
                 { isPathCleaningEnabled, filterTestAccounts, shouldStripQueryParams },
-                { webAnalyticsFilters, replayFilters, dateFilter: { dateFrom, dateTo, interval }, conversionGoal },
+                {
+                    webAnalyticsFilters,
+                    replayFilters,
+                    dateFilter: { dateFrom, dateTo, interval },
+                    conversionGoal,
+                    compareFilter,
+                },
                 featureFlags,
                 isGreaterThanMd
             ): WebDashboardTile[] => {
@@ -526,7 +542,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     date_from: dateFrom,
                     date_to: dateTo,
                 }
-                const compare = !!dateRange.date_from && dateRange.date_from !== 'all'
+
                 const sampling = {
                     enabled: false,
                     forceSamplingRate: { numerator: 1, denominator: 10 },
@@ -604,9 +620,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 display: ChartDisplayType.ActionsLineGraph,
                                 ...trendsFilter,
                             },
-                            compareFilter: {
-                                compare,
-                            },
+                            compareFilter,
                             filterTestAccounts,
                             properties: webAnalyticsFilters,
                         },
@@ -645,6 +659,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 breakdownBy: breakdownBy,
                                 dateRange,
                                 sampling,
+                                compareFilter,
                                 limit: 10,
                                 filterTestAccounts,
                                 ...(source || {}),
@@ -671,7 +686,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                             properties: webAnalyticsFilters,
                             dateRange,
                             sampling,
-                            compare,
+                            compareFilter,
                             filterTestAccounts,
                             conversionGoal,
                             includeLCPScore: featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_LCP_SCORE] ? true : undefined,
@@ -1591,6 +1606,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 _graphsTab,
                 isPathCleaningEnabled,
                 shouldFilterTestAccounts,
+                compareFilter,
             } = values
 
             const urlParams = new URLSearchParams()
@@ -1630,6 +1646,9 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             if (shouldFilterTestAccounts != null) {
                 urlParams.set('filter_test_accounts', shouldFilterTestAccounts.toString())
             }
+            if (compareFilter) {
+                urlParams.set('compare_filter', JSON.stringify(compareFilter))
+            }
             return `/web?${urlParams.toString()}`
         }
 
@@ -1644,6 +1663,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             setGraphsTab: stateToUrl,
             setPathTab: stateToUrl,
             setGeographyTab: stateToUrl,
+            setCompareFilter: stateToUrl,
         }
     }),
 
@@ -1664,6 +1684,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 geography_tab,
                 path_cleaning,
                 filter_test_accounts,
+                compare_filter,
             }
         ) => {
             const parsedFilters = isWebAnalyticsPropertyFilters(filters) ? filters : undefined
@@ -1709,6 +1730,9 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             }
             if (filter_test_accounts && filter_test_accounts !== values.shouldFilterTestAccounts) {
                 actions.setShouldFilterTestAccounts([true, 'true', 1, '1'].includes(filter_test_accounts))
+            }
+            if (compare_filter && !objectsEqual(compare_filter, values.compareFilter)) {
+                actions.setCompareFilter(compare_filter)
             }
         },
     })),

--- a/posthog/hogql_queries/web_analytics/test/test_web_overview.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_overview.py
@@ -9,6 +9,7 @@ from posthog.hogql_queries.web_analytics.web_overview import WebOverviewQueryRun
 from posthog.models import Action, Element
 from posthog.models.utils import uuid7
 from posthog.schema import (
+    CompareFilter,
     WebOverviewQuery,
     DateRange,
     SessionTableVersion,
@@ -83,7 +84,7 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         query = WebOverviewQuery(
             dateRange=DateRange(date_from=date_from, date_to=date_to),
             properties=[],
-            compare=compare,
+            compareFilter=CompareFilter(compare=compare) if compare else None,
             modifiers=modifiers,
             filterTestAccounts=filter_test_accounts,
             conversionGoal=ActionConversionGoal(actionId=action.id)

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -192,7 +192,7 @@ HAVING and(
 )
         """,
             placeholders={
-                "date_range_start": start if self.query.compare else mid,
+                "date_range_start": start if self.query.compareFilter and self.query.compareFilter.compare else mid,
                 "date_range_end": end,
                 "event_properties": self.event_properties(),
                 "session_properties": self.session_properties(),
@@ -236,13 +236,13 @@ HAVING and(
         end = self.query_date_range.date_to_as_hogql()
 
         def current_period_aggregate(function_name, column_name, alias, params=None):
-            if not self.query.compare:
+            if not self.query.compareFilter or not self.query.compareFilter.compare:
                 return ast.Call(name=function_name, params=params, args=[ast.Field(chain=[column_name])])
 
             return self.period_aggregate(function_name, column_name, mid, end, alias=alias, params=params)
 
         def previous_period_aggregate(function_name, column_name, alias, params=None):
-            if not self.query.compare:
+            if not self.query.compareFilter or not self.query.compareFilter.compare:
                 return ast.Alias(alias=alias, expr=ast.Constant(value=None))
 
             return self.period_aggregate(function_name, column_name, start, mid, alias=alias, params=params)

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5432,7 +5432,7 @@ class WebOverviewQuery(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    compare: Optional[bool] = None
+    compareFilter: Optional[CompareFilter] = None
     conversionGoal: Optional[Union[ActionConversionGoal, CustomEventConversionGoal]] = None
     dateRange: Optional[DateRange] = None
     filterTestAccounts: Optional[bool] = None
@@ -5452,6 +5452,7 @@ class WebStatsTableQuery(BaseModel):
         extra="forbid",
     )
     breakdownBy: WebStatsBreakdown
+    compareFilter: Optional[CompareFilter] = None
     conversionGoal: Optional[Union[ActionConversionGoal, CustomEventConversionGoal]] = None
     dateRange: Optional[DateRange] = None
     doPathCleaning: Optional[bool] = None


### PR DESCRIPTION
## Problem

On Web Analytics we always compare the data against the previous period. We want that to change by using the `CompareFilter` component we already have for Product Analytics.

## Changes

Add the filter to the frontend AND update the schema to send the new structure to the backend: `CompareFilter` object vs `compare` boolean

This filter isn't working yet, so the filter is hidden behind a FF. We've set the state such that the default behavior will be the same as it was previously.

A follow-up PR will update our `WebOverview` and `StatsTable` queries in the backend to use the values coming from the frontend.

![image](https://github.com/user-attachments/assets/f95e0965-ee57-47f3-9340-d3bdd25cc4a7)


## How did you test this code?

It's hidden behind FF, so it doesn't really work. It doesn't crash in my local setup tho :)
