### PR TITLE
refactor: Backfill materialized columns by column reference instead of property

### DIFF
--- a/ee/clickhouse/materialized_columns/analyze.py
+++ b/ee/clickhouse/materialized_columns/analyze.py
@@ -165,7 +165,7 @@ LIMIT 100 -- Make sure we don't add 100s of columns in one run
 
 
 def materialize_properties_task(
-    columns_to_materialize: Optional[list[Suggestion]] = None,
+    properties_to_materialize: Optional[list[Suggestion]] = None,
     time_to_analyze_hours: int = MATERIALIZE_COLUMNS_ANALYSIS_PERIOD_HOURS,
     maximum: int = MATERIALIZE_COLUMNS_MAX_AT_ONCE,
     min_query_time: int = MATERIALIZE_COLUMNS_MINIMUM_QUERY_TIME,
@@ -178,18 +178,18 @@ def materialize_properties_task(
     Creates materialized columns for event and person properties based off of slow queries
     """
 
-    if columns_to_materialize is None:
-        columns_to_materialize = _analyze(time_to_analyze_hours, min_query_time, team_id_to_analyze)
+    if properties_to_materialize is None:
+        properties_to_materialize = _analyze(time_to_analyze_hours, min_query_time, team_id_to_analyze)
 
-    columns_by_table: dict[TableWithProperties, list[tuple[TableColumn, PropertyName]]] = defaultdict(list)
-    for table, table_column, property_name in columns_to_materialize:
-        columns_by_table[table].append((table_column, property_name))
+    properties_by_table: dict[TableWithProperties, list[tuple[TableColumn, PropertyName]]] = defaultdict(list)
+    for table, table_column, property_name in properties_to_materialize:
+        properties_by_table[table].append((table_column, property_name))
 
     result: list[Suggestion] = []
-    for table, columns in columns_by_table.items():
-        existing_materialized_columns = get_materialized_columns(table)
-        for table_column, property_name in columns:
-            if (property_name, table_column) not in existing_materialized_columns:
+    for table, properties in properties_by_table.items():
+        existing_materialized_properties = get_materialized_columns(table).keys()
+        for table_column, property_name in properties:
+            if (property_name, table_column) not in existing_materialized_properties:
                 result.append((table, table_column, property_name))
 
     if len(result) > 0:

--- a/ee/clickhouse/materialized_columns/columns.py
+++ b/ee/clickhouse/materialized_columns/columns.py
@@ -242,10 +242,10 @@ def materialize(
     table_column: TableColumn = DEFAULT_TABLE_COLUMN,
     create_minmax_index=not TEST,
     is_nullable: bool = False,
-) -> ColumnName | None:
-    if (property, table_column) in get_materialized_columns(table):
+) -> MaterializedColumn:
+    if existing_column := get_materialized_columns(table).get((property, table_column)):
         if TEST:
-            return None
+            return existing_column
 
         raise ValueError(f"Property already materialized. table={table}, property={property}, column={table_column}")
 
@@ -283,7 +283,7 @@ def materialize(
             ).execute
         ).result()
 
-    return column.name
+    return column
 
 
 @dataclass
@@ -444,7 +444,7 @@ class BackfillColumnTask:
 
 def backfill_materialized_columns(
     table: TableWithProperties,
-    properties: list[tuple[PropertyName, TableColumn]],
+    columns: Iterable[MaterializedColumn],
     backfill_period: timedelta,
     test_settings=None,
 ) -> None:
@@ -453,25 +453,14 @@ def backfill_materialized_columns(
 
     This will require reading and writing a lot of data on clickhouse disk.
     """
-
-    if len(properties) == 0:
-        return
-
     cluster = get_cluster()
     table_info = tables[table]
-
-    # TODO: this will eventually need to handle duplicates
-    materialized_columns = {
-        (column.details.property_name, column.details.table_column): column
-        for column in MaterializedColumn.get_all(table)
-    }
-    columns = [materialized_columns[property] for property in properties]
 
     table_info.map_data_nodes(
         cluster,
         BackfillColumnTask(
             table_info.data_table,
-            columns,
+            [*columns],
             backfill_period if table == "events" else None,  # XXX
             test_settings,
         ).execute,

--- a/ee/management/commands/materialize_columns.py
+++ b/ee/management/commands/materialize_columns.py
@@ -87,7 +87,7 @@ class Command(BaseCommand):
             logger.info(f"Materializing column. table={options['property_table']}, property_name={options['property']}")
 
             materialize_properties_task(
-                columns_to_materialize=[
+                properties_to_materialize=[
                     (
                         options["property_table"],
                         options["table_column"],


### PR DESCRIPTION
## Problem

Some properties will have multiple columns associated with them during the transition period when rematerializing columns as nullable, so simply providing a property source column and property name will no longer be specific enough to identify a particular column that needs to be backfilled.

More context available in #26651.

## Changes

- Make `backfill_materialized_columns` take `Iterable[MaterializedColumn]` instead of `list[tuple[PropertyName, TableColumn]]` and update all relevant call sites.
- Also updated `materialize` to return a `MaterializedColumn` instead of `ColumnName | None` to get rid of some annoying workarounds to appease the type checker.

## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

Updated tests.