### PR TITLE
chore: Send S3 batch exports to async queue

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -648,7 +648,7 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
     destination_config = {k: v for k, v in batch_export.destination.config.items() if k in destination_config_fields}
     task_queue = (
         BATCH_EXPORTS_TASK_QUEUE
-        if batch_export.destination.type in ("BigQuery", "Redshift")
+        if batch_export.destination.type in ("BigQuery", "Redshift", "S3")
         else SYNC_BATCH_EXPORTS_TASK_QUEUE
     )
 

--- a/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
+++ b/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
@@ -549,7 +549,7 @@ async def failing_s3_batch_export(ateam, temporal_client):
 
 @pytest.mark.django_db(transaction=True)
 async def test_backfill_batch_export_workflow_is_cancelled_on_repeated_failures(
-    temporal_worker, failing_s3_batch_export, temporal_client, ateam, clickhouse_client
+    temporal_worker, temporal_worker_batch_exports, failing_s3_batch_export, temporal_client, ateam, clickhouse_client
 ):
     """Test BackfillBatchExportWorkflow will be cancelled on repeated failures."""
     start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC)

--- a/posthog/temporal/tests/conftest.py
+++ b/posthog/temporal/tests/conftest.py
@@ -145,6 +145,24 @@ async def temporal_worker(temporal_client, workflows, activities):
     await asyncio.wait([worker_run])
 
 
+@pytest_asyncio.fixture
+async def temporal_worker_batch_exports(temporal_client, workflows, activities):
+    worker = temporalio.worker.Worker(
+        temporal_client,
+        task_queue="batch-exports-task-queue",
+        workflows=workflows,
+        activities=activities,
+        workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+    )
+
+    worker_run = asyncio.create_task(worker.run())
+
+    yield worker
+
+    worker_run.cancel()
+    await asyncio.wait([worker_run])
+
+
 @pytest.fixture(scope="session")
 def event_loop():
     try:


### PR DESCRIPTION
## Problem

S3 batch exports are now fully async, so they can be moved over to async queue.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* On calling `sync_batch_export`, update queue to async queue for S3 batch exports.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
