### PR TITLE
fix: comparing object instance equality is bad m'kay

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -20,7 +20,7 @@ import { subscriptions } from 'kea-subscriptions'
 import { delay } from 'kea-test-utils'
 import { now } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { clamp, downloadFile } from 'lib/utils'
+import { clamp, downloadFile, objectsEqual } from 'lib/utils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { wrapConsole } from 'lib/utils/wrapConsole'
 import posthog from 'posthog-js'
@@ -860,7 +860,7 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
             // Check if we're seeking to a new segment
             const segment = values.segmentForTimestamp(timestamp)
 
-            if (segment && segment !== values.currentSegment) {
+            if (segment && !objectsEqual(segment, values.currentSegment)) {
                 actions.setCurrentSegment(segment)
             }
 


### PR DESCRIPTION
see: https://posthoghelp.zendesk.com/agent/tickets/21731 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/23912)

we're comparing instance equality and hitting an infinite recursion setting the segment over and over when it has the same values but isn't the same instance
