### PR TITLE
fix: alert on breakdowns, fail earlier when no results

### DIFF
--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -154,7 +154,7 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 results_to_evaluate.append(selected_series_result)
 
             if not results_to_evaluate:
-                raise RuntimeError(f"No results returned for insight")
+                raise RuntimeError(f"No results found for insight with alert id = {alert.id}")
 
             # if we don't have breakdown, we'll have to evaluate just one result
             # and increase will be the evaluated value of that result

--- a/posthog/tasks/alerts/trends.py
+++ b/posthog/tasks/alerts/trends.py
@@ -153,9 +153,13 @@ def check_trends_alert(alert: AlertConfiguration, insight: Insight, query: Trend
                 selected_series_result = _pick_series_result(config, calculation_result)
                 results_to_evaluate.append(selected_series_result)
 
+            if not results_to_evaluate:
+                raise RuntimeError(f"No results returned for insight")
+
             # if we don't have breakdown, we'll have to evaluate just one result
             # and increase will be the evaluated value of that result
             increase = None
+            breaches = []
 
             for result in results_to_evaluate:
                 prev_interval_value = _pick_interval_value_from_trend_result(query, result, -1)


### PR DESCRIPTION
## Problem
Due to insight config issues on user side, sometimes you don't get results back. For breakdowns we want to classify these issues on Sentry as 'no results returned' so as not to generate a new category.

## Changes
Check for results and fail earlier if needed
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Locally + covered by existing tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
