### PR TITLE
fix: Actions in surveys serializer

### DIFF
--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -808,6 +808,7 @@ class SurveyAPIActionSerializer(serializers.ModelSerializer):
         model = Action
         fields = [
             "id",
+            "name",
             "steps",
         ]
         read_only_fields = fields

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -19,7 +19,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from ee.surveys.summaries.summarize_surveys import summarize_survey_responses
-from posthog.api.action import ActionSerializer
+from posthog.api.action import ActionSerializer, ActionStepJSONSerializer
 from posthog.api.feature_flag import (
     BEHAVIOURAL_COHORT_FOUND_ERROR_CODE,
     FeatureFlagSerializer,
@@ -801,6 +801,18 @@ class SurveyConfigSerializer(serializers.ModelSerializer):
         fields = ["survey_config"]
 
 
+class SurveyAPIActionSerializer(serializers.ModelSerializer):
+    steps = ActionStepJSONSerializer(many=True, required=False)
+
+    class Meta:
+        model = Action
+        fields = [
+            "id",
+            "steps",
+        ]
+        read_only_fields = fields
+
+
 class SurveyAPISerializer(serializers.ModelSerializer):
     """
     Serializer for the exposed /api/surveys endpoint, to be used in posthog-js and for headless APIs.
@@ -844,7 +856,7 @@ class SurveyAPISerializer(serializers.ModelSerializer):
             if survey.conditions is None:
                 survey.conditions = {}
 
-            survey.conditions["actions"] = {"values": ActionSerializer(actions, many=True).data}
+            survey.conditions["actions"] = {"values": SurveyAPIActionSerializer(actions, many=True).data}
         return survey.conditions
 
 

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -2782,6 +2782,7 @@ class TestSurveysAPIList(BaseTest, QueryMatchingTest):
                                 "values": [
                                     {
                                         "id": action.id,
+                                        "name": "user subscribed",
                                         "steps": [
                                             {
                                                 "event": "$pageview",

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -2782,10 +2782,6 @@ class TestSurveysAPIList(BaseTest, QueryMatchingTest):
                                 "values": [
                                     {
                                         "id": action.id,
-                                        "name": "user subscribed",
-                                        "description": "",
-                                        "post_to_slack": False,
-                                        "slack_message_format": "",
                                         "steps": [
                                             {
                                                 "event": "$pageview",
@@ -2800,17 +2796,6 @@ class TestSurveysAPIList(BaseTest, QueryMatchingTest):
                                                 "url_matching": "contains",
                                             }
                                         ],
-                                        "created_at": ANY,
-                                        "created_by": None,
-                                        "deleted": False,
-                                        "is_calculating": False,
-                                        "creation_context": None,
-                                        "last_calculated_at": ANY,
-                                        "team_id": self.team.id,
-                                        "is_action": True,
-                                        "bytecode_error": None,
-                                        "pinned_at": None,
-                                        "tags": [],
                                     }
                                 ]
                             }


### PR DESCRIPTION
## Problem

Too much info in the payload. Reduced to what it really needs

## Changes

* as on tin

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
