### PR TITLE
feat: Use Parquet in BigQuery batch export

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -338,9 +338,12 @@ class BigQueryClient(bigquery.Client):
                 values += ", "
                 field_names += ", "
 
-            update_clause += f"final.`{field.name}` = PARSE_JSON(stage.`{field.name}`)"
+            stage_field = (
+                f"PARSE_JSON(stage.`{field.name}`)" if field.name in fields_to_cast else f"stage.`{field.name}`"
+            )
+            update_clause += f"final.`{field.name}` = {stage_field}"
             field_names += f"`{field.name}`"
-            values += f"PARSE_JSON(stage.`{field.name}`)" if field.name in fields_to_cast else f"stage.`{field.name}`"
+            values += stage_field
 
         if not update_clause:
             raise ValueError("Empty update clause")

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -73,7 +73,7 @@ NON_RETRYABLE_ERROR_TYPES = [
 
 
 def get_bigquery_fields_from_record_schema(
-    record_schema: pa.Schema, known_json_columns: list[str]
+    record_schema: pa.Schema, known_json_columns: collections.abc.Sequence[str]
 ) -> list[bigquery.SchemaField]:
     """Generate a list of supported BigQuery fields from PyArrow schema.
 
@@ -239,6 +239,71 @@ class BigQueryClient(bigquery.Client):
             if delete is True:
                 await self.adelete_table(project_id, dataset_id, table_id, not_found_ok)
 
+    async def amerge_tables(
+        self,
+        final_table: bigquery.Table,
+        stage_table: bigquery.Table,
+        mutable: bool,
+        stage_fields_cast_to_json: collections.abc.Sequence[str] | None = None,
+        merge_key: collections.abc.Iterable[bigquery.SchemaField] | None = None,
+    ):
+        """Merge two tables in BigQuery.
+
+        When `mutable` is `False`, we will do a simple `INSERT INTO final FROM stage`,
+        whereas when `mutable` is `True` we will do the more complex `MERGE` query.
+        This is because inmutable tables do not need to concern themselves with
+        the conflict resolution options provided by `MERGE` as each row is unique.
+
+        Arguments:
+            final_table: The BigQuery table we are merging into.
+            stage_table: The BigQuery table we are merging from.
+            mutable: Whether the table is mutable and requires a merge, or not.
+            stage_fields_cast_to_json: Fields that must be cast to `JSON` from
+                `stage_table` when inserting them in `final_table`.
+            merge_key: If table is mutable, the merge key columns.
+        """
+        if mutable is False:
+            return await self.ainsert_into_from_stage_table(
+                final_table, stage_table, stage_fields_cast_to_json=stage_fields_cast_to_json
+            )
+        else:
+            if merge_key is None:
+                raise ValueError("Merge key must be defined when merging a mutable model")
+
+            return await self.amerge_person_tables(
+                final_table, stage_table, merge_key=merge_key, stage_fields_cast_to_json=stage_fields_cast_to_json
+            )
+
+    async def ainsert_into_from_stage_table(
+        self,
+        into_table: bigquery.Table,
+        stage_table: bigquery.Table,
+        stage_fields_cast_to_json: collections.abc.Sequence[str] | None = None,
+    ):
+        """Insert data from `stage_table` into `into_table`."""
+        job_config = bigquery.QueryJobConfig()
+        into_table_fields = ",".join(f"`{field.name}`" for field in into_table.schema)
+
+        if stage_fields_cast_to_json is not None:
+            fields_to_cast = set(stage_fields_cast_to_json)
+        else:
+            fields_to_cast = set()
+        stage_table_fields = ",".join(
+            f"PARSE_JSON(`{field.name}`)" if field.name in fields_to_cast else f"`{field.name}`"
+            for field in into_table.schema
+        )
+
+        query = f"""
+        INSERT INTO `{into_table.full_table_id.replace(":", ".", 1)}`
+          ({into_table_fields})
+        SELECT
+          {stage_table_fields}
+        FROM `{stage_table.full_table_id.replace(":", ".", 1)}`
+        """
+
+        query_job = self.query(query, job_config=job_config)
+        return await asyncio.to_thread(query_job.result)
+
     async def amerge_person_tables(
         self,
         final_table: bigquery.Table,
@@ -246,9 +311,15 @@ class BigQueryClient(bigquery.Client):
         merge_key: collections.abc.Iterable[bigquery.SchemaField],
         person_version_key: str = "person_version",
         person_distinct_id_version_key: str = "person_distinct_id_version",
+        stage_fields_cast_to_json: collections.abc.Sequence[str] | None = None,
     ):
         """Merge two identical person model tables in BigQuery."""
         job_config = bigquery.QueryJobConfig()
+
+        if stage_fields_cast_to_json is not None:
+            fields_to_cast = set(stage_fields_cast_to_json)
+        else:
+            fields_to_cast = set()
 
         merge_condition = "ON "
 
@@ -267,9 +338,9 @@ class BigQueryClient(bigquery.Client):
                 values += ", "
                 field_names += ", "
 
-            update_clause += f"final.`{field.name}` = stage.`{field.name}`"
+            update_clause += f"final.`{field.name}` = PARSE_JSON(stage.`{field.name}`)"
             field_names += f"`{field.name}`"
-            values += f"stage.`{field.name}`"
+            values += f"PARSE_JSON(stage.`{field.name}`)" if field.name in fields_to_cast else f"stage.`{field.name}`"
 
         if not update_clause:
             raise ValueError("Empty update clause")
@@ -302,7 +373,14 @@ class BigQueryClient(bigquery.Client):
             self.load_table_from_file, parquet_file, table, job_config=job_config, rewind=True
         )
         await logger.adebug("Waiting for BigQuery load job for Parquet file '%s'", parquet_file)
-        result = await asyncio.to_thread(load_job.result)
+
+        try:
+            result = await asyncio.to_thread(load_job.result)
+        except Forbidden as err:
+            if err.reason == "quotaExceeded":
+                raise BigQueryQuotaExceededError(err.message) from err
+            raise
+
         return result
 
     async def load_jsonl_file(self, jsonl_file, table, table_schema):
@@ -321,7 +399,6 @@ class BigQueryClient(bigquery.Client):
         load_job = await asyncio.to_thread(
             self.load_table_from_file, jsonl_file, table, job_config=job_config, rewind=True
         )
-
         await logger.adebug("Waiting for BigQuery load job for JSONL file '%s'", jsonl_file)
 
         try:
@@ -415,7 +492,7 @@ class BigQueryConsumer(Consumer):
             self.bigquery_table,
         )
 
-        await self.bigquery_client.load_jsonl_file(batch_export_file, self.bigquery_table, self.table_schema)
+        await self.bigquery_client.load_parquet_file(batch_export_file, self.bigquery_table, self.table_schema)
 
         await self.logger.adebug("Loaded %s to BigQuery table '%s'", records_since_last_flush, self.bigquery_table)
         self.rows_exported_counter.add(records_since_last_flush)
@@ -508,7 +585,6 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
             # between batches.
             [field.with_nullable(True) for field in record_batch_schema if field.name != "_inserted_at"]
         )
-
         if inputs.use_json_type is True:
             json_type = "JSON"
             json_columns = ["properties", "set", "set_once", "person_properties"]
@@ -534,15 +610,11 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
         else:
             schema = get_bigquery_fields_from_record_schema(record_batch_schema, known_json_columns=json_columns)
 
-        # TODO: Expose this as a configuration parameter
-        # Currently, only allow merging persons model, as it's required.
-        # Although all exports could potentially benefit from merging, merging can have an impact on cost,
-        # so users should decide whether to opt-in or not.
-        requires_merge = (
-            isinstance(inputs.batch_export_model, BatchExportModel) and inputs.batch_export_model.name == "persons"
-        )
+        stage_schema = [
+            bigquery.SchemaField(field.name, "STRING") if field.name in json_columns else field for field in schema
+        ]
         data_interval_end_str = dt.datetime.fromisoformat(inputs.data_interval_end).strftime("%Y-%m-%d_%H-%M-%S")
-        stage_table_name = f"stage_{inputs.table_id}_{data_interval_end_str}" if requires_merge else inputs.table_id
+        stage_table_name = f"stage_{inputs.table_id}_{data_interval_end_str}"
 
         with bigquery_client(inputs) as bq_client:
             async with (
@@ -557,9 +629,9 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                     project_id=inputs.project_id,
                     dataset_id=inputs.dataset_id,
                     table_id=stage_table_name,
-                    table_schema=schema,
-                    create=requires_merge,
-                    delete=requires_merge,
+                    table_schema=stage_schema,
+                    create=True,
+                    delete=True,
                 ) as bigquery_stage_table,
             ):
                 records_completed = await run_consumer_loop(
@@ -571,25 +643,27 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                     data_interval_end=data_interval_end,
                     data_interval_start=data_interval_start,
                     schema=record_batch_schema,
-                    writer_format=WriterFormat.JSONL,
+                    writer_format=WriterFormat.PARQUET,
                     max_bytes=settings.BATCH_EXPORT_BIGQUERY_UPLOAD_CHUNK_SIZE_BYTES,
                     non_retryable_error_types=NON_RETRYABLE_ERROR_TYPES,
-                    json_columns=json_columns,
+                    json_columns=(),
                     bigquery_client=bq_client,
-                    bigquery_table=bigquery_stage_table if requires_merge else bigquery_table,
-                    table_schema=schema,
+                    bigquery_table=bigquery_stage_table,
+                    table_schema=stage_schema,
+                    writer_file_kwargs={"compression": "zstd"},
                 )
 
-                if requires_merge:
-                    merge_key = (
-                        bigquery.SchemaField("team_id", "INT64"),
-                        bigquery.SchemaField("distinct_id", "STRING"),
-                    )
-                    await bq_client.amerge_person_tables(
-                        final_table=bigquery_table,
-                        stage_table=bigquery_stage_table,
-                        merge_key=merge_key,
-                    )
+                merge_key = (
+                    bigquery.SchemaField("team_id", "INT64"),
+                    bigquery.SchemaField("distinct_id", "STRING"),
+                )
+                await bq_client.amerge_tables(
+                    final_table=bigquery_table,
+                    stage_table=bigquery_stage_table,
+                    mutable=True if model_name == "persons" else False,
+                    merge_key=merge_key,
+                    stage_fields_cast_to_json=json_columns,
+                )
 
         return records_completed
 
@@ -671,4 +745,5 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
             interval=inputs.interval,
             non_retryable_error_types=NON_RETRYABLE_ERROR_TYPES,
             finish_inputs=finish_inputs,
+            maximum_retry_interval_seconds=240,
         )

--- a/posthog/temporal/batch_exports/temporary_file.py
+++ b/posthog/temporal/batch_exports/temporary_file.py
@@ -662,6 +662,7 @@ class ParquetBatchExportWriter(BatchExportWriter):
         flush_callable: FlushCallable,
         schema: pa.Schema,
         compression: str | None = "snappy",
+        compression_level: int | None = None,
     ):
         super().__init__(
             max_bytes=max_bytes,
@@ -670,6 +671,7 @@ class ParquetBatchExportWriter(BatchExportWriter):
         )
         self.schema = schema
         self.compression = compression
+        self.compression_level = compression_level
 
         self._parquet_writer: pq.ParquetWriter | None = None
 
@@ -680,6 +682,7 @@ class ParquetBatchExportWriter(BatchExportWriter):
                 self.batch_export_file,
                 schema=self.schema,
                 compression="none" if self.compression is None else self.compression,
+                compression_level=self.compression_level,
             )
         return self._parquet_writer
 


### PR DESCRIPTION
## Problem

Continuing from the problem seen in #26758.

We want to make it less likely we will hit any BigQuery quota limits. In order to do so, we have to reduce the overall number of load jobs. There are a few ways to do this, for example:
* Bump the flush max bytes limit, so more data is stored on disk before flushing. Thus, more data is flushed in one single load job.
* Switch to Parquet to allow using less space to send more data, thus reducing the number of load jobs.

Although the first option would be easier, it would put more pressure on our disk storage. So, this PR implements the second alternative. 

The problem with using Parquet format is that loading columns with `JSON` column type is not supported in BigQuery when using Parquet. So, we must first stage the data as `STRING` in a stage table, and cast it to `JSON` using `PARSE_JSON` when inserting it into the final table.

This solution is not free: Parquet (especially with compression) will use up more CPU, and the added merge could increase the overall runtime of the batch export. However, the tradeoff is a significant reduction in file size, which could in turn offset the increase in overall runtime caused by the merge. Larger batch exports will benefit the most from this change, whereas smaller batch exports will likely pay a performance cost due to the added merge.

From my tests with a few thousand rows, the same data in JSONL is taking up 0.36 MB, but using Parquet with zstd compression reduces the file size to 0.04 MB. So, we could fit roughly 9 times the amount of data in a Parquet zstd compressed file that we can in a JSONL file of the same size.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Support merging all models in BigQuery.
  * Immutable models can just `INSERT INTO` as rows are supposed to be unique.
  * Mutable models (currently only "persons") need to do a `MERGE` query. This could be abstracted to allow all models to be mutable, but left that for later.
* Switch BigQuery's flush implementation to use `load_parquet_file` instead of `load_jsonl_file`.
* Stage JSON columns as `STRING`, later convert to `JSON` when merging or inserting.
* Allow setting `compression_level` when writing a file, although currently not in use.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
