### PR TITLE
fix(bigquery): Account for duplicates in table before merging

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -276,7 +276,17 @@ class BigQueryClient(bigquery.Client):
 
         merge_query = f"""
         MERGE `{final_table.full_table_id.replace(":", ".", 1)}` final
-        USING (SELECT DISTINCT * FROM `{stage_table.full_table_id.replace(":", ".", 1)}`) stage
+        USING (
+            SELECT * FROM
+            (
+              SELECT
+              *,
+              ROW_NUMBER() OVER (PARTITION BY {",".join(field.name for field in merge_key)}) row_num
+            FROM
+              `{stage_table.full_table_id.replace(":", ".", 1)}`
+            )
+            WHERE row_num = 1
+        ) stage
         {merge_condition}
 
         WHEN MATCHED AND (stage.`{person_version_key}` > final.`{person_version_key}` OR stage.`{person_distinct_id_version_key}` > final.`{person_distinct_id_version_key}`) THEN

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -276,7 +276,7 @@ class BigQueryClient(bigquery.Client):
 
         merge_query = f"""
         MERGE `{final_table.full_table_id.replace(":", ".", 1)}` final
-        USING `{stage_table.full_table_id.replace(":", ".", 1)}` stage
+        USING (SELECT DISTINCT * FROM `{stage_table.full_table_id.replace(":", ".", 1)}`) stage
         {merge_condition}
 
         WHEN MATCHED AND (stage.`{person_version_key}` > final.`{person_version_key}` OR stage.`{person_distinct_id_version_key}` > final.`{person_distinct_id_version_key}`) THEN


### PR DESCRIPTION
## Problem

Occasionally, batch exports will fail as it reports multiple rows matching when merging. Currently, we only merge on persons batch export. Given that we merge, it is unlikely that the final table has duplicate rows (unless the user has manually inputted them, which is rare). What is more likely is that we are retrying (for whatever reason) and adding more rows to the stage, thus then matching multiple rows when merging.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Select only unique rows when merging.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
