### PR TITLE
chore: not capture-rs in debug

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -248,7 +248,7 @@ def get_decide(request: HttpRequest):
                 else False
             )
 
-            if str(team.id) not in (settings.NEW_ANALYTICS_CAPTURE_EXCLUDED_TEAM_IDS or []):
+            if not settings.DEBUG and str(team.id) not in (settings.NEW_ANALYTICS_CAPTURE_EXCLUDED_TEAM_IDS or []):
                 response["analytics"] = {"endpoint": settings.NEW_ANALYTICS_CAPTURE_ENDPOINT}
 
             if str(team.id) not in (settings.ELEMENT_CHAIN_AS_STRING_EXCLUDED_TEAMS or []):

--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -248,6 +248,8 @@ def get_decide(request: HttpRequest):
                 else False
             )
 
+            # this not settings.DEBUG check is a lazy workaround because
+            # NEW_ANALYTICS_CAPTURE_ENDPOINT doesn't currently work in DEBUG mode
             if not settings.DEBUG and str(team.id) not in (settings.NEW_ANALYTICS_CAPTURE_EXCLUDED_TEAM_IDS or []):
                 response["analytics"] = {"endpoint": settings.NEW_ANALYTICS_CAPTURE_ENDPOINT}
 


### PR DESCRIPTION
lazily, let's "fix" this before we _fix_ this

hitting `/i/v0/e` on localhost when dev'ing doesn't work

see https://posthog.slack.com/archives/C0113360FFV/p1733754903066699