### PR TITLE
feat(experiments): add mgmt cmd to generate experiment data

### DIFF
--- a/posthog/management/commands/generate_experiment_data.py
+++ b/posthog/management/commands/generate_experiment_data.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timedelta
+import logging
+import random
+import secrets
+import uuid
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from posthoganalytics.client import Client
+
+
+logging.getLogger("kafka").setLevel(logging.ERROR)  # Hide kafka-python's logspam
+
+
+class Command(BaseCommand):
+    help = "Generate experiment data"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--experiment-id", type=str, help="Experiment ID")
+        parser.add_argument("--seed", type=str, help="Simulation seed for deterministic output")
+
+    def handle(self, *args, **options):
+        # Make sure this runs in development environment only
+        if not settings.DEBUG:
+            raise ValueError("This command should only be run in development! DEBUG must be True.")
+
+        experiment_id = options.get("experiment_id")
+        seed = options.get("seed") or secrets.token_hex(16)
+
+        if not experiment_id:
+            raise ValueError("Experiment ID is required")
+
+        # Create a new Posthog Client
+        posthog_client = Client(api_key=settings.POSTHOG_API_KEY)
+
+        experiment_config = {
+            "experiment_id": experiment_id,
+            "seed": seed,
+            "number_of_users": 1000,
+            "start_timestamp": datetime.now() - timedelta(days=7),
+            "end_timestamp": datetime.now(),
+            "variants": {
+                "control": {
+                    "weight": 0.5,
+                    "actions": [
+                        {"event": "$pageview", "probability": 0.75},
+                    ],
+                },
+                "test": {
+                    "weight": 0.5,
+                    "actions": [
+                        {"event": "$pageview", "probability": 1},
+                    ],
+                },
+            },
+        }
+
+        for _ in range(experiment_config["number_of_users"]):
+            variant = random.choices(
+                list(experiment_config["variants"].keys()),
+                weights=[v["weight"] for v in experiment_config["variants"].values()],
+            )[0]
+            distinct_id = uuid.uuid4()
+            random_timestamp = random.uniform(
+                experiment_config["start_timestamp"], experiment_config["end_timestamp"] - timedelta(hours=1)
+            )
+            posthog_client.capture(
+                distinct_id=distinct_id,
+                event="$feature_flag_called",
+                timestamp=random_timestamp,
+                properties={
+                    "feature_flag": experiment_config["experiment_id"],
+                    f"feature/{experiment_config['experiment_id']}": variant,
+                },
+            )
+
+            for action in experiment_config["variants"][variant]["actions"]:
+                if random.random() < action["probability"]:
+                    posthog_client.capture(
+                        distinct_id=distinct_id,
+                        event=action["event"],
+                        timestamp=random_timestamp + timedelta(minutes=1),
+                    )

--- a/posthog/management/commands/generate_experiment_data.py
+++ b/posthog/management/commands/generate_experiment_data.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 import logging
 import random
 import secrets
+import time
 import uuid
 
 from django.conf import settings
@@ -25,15 +26,18 @@ class Command(BaseCommand):
             raise ValueError("This command should only be run in development! DEBUG must be True.")
 
         experiment_id = options.get("experiment_id")
+
+        # TODO: actually implement a seed
         seed = options.get("seed") or secrets.token_hex(16)
 
         if not experiment_id:
             raise ValueError("Experiment ID is required")
 
+        # TODO: this can be a config file taken as an argument
         experiment_config = {
             "experiment_id": experiment_id,
             "seed": seed,
-            "number_of_users": 10,
+            "number_of_users": 1000,
             "start_timestamp": datetime.now() - timedelta(days=7),
             "end_timestamp": datetime.now(),
             "variants": {
@@ -52,31 +56,39 @@ class Command(BaseCommand):
             },
         }
 
+        variants = list(experiment_config["variants"].keys())
+        variant_counts = {variant: 0 for variant in variants}
         for _ in range(experiment_config["number_of_users"]):
             variant = random.choices(
-                list(experiment_config["variants"].keys()),
+                variants,
                 weights=[v["weight"] for v in experiment_config["variants"].values()],
             )[0]
+            variant_counts[variant] += 1
             distinct_id = uuid.uuid4()
             random_timestamp = random.uniform(
                 experiment_config["start_timestamp"], experiment_config["end_timestamp"] - timedelta(hours=1)
             )
-            print(f"Generating data for user {distinct_id} at {random_timestamp} with variant {variant}")
             posthoganalytics.capture(
                 distinct_id=distinct_id,
                 event="$feature_flag_called",
                 timestamp=random_timestamp,
                 properties={
-                    "feature_flag": experiment_config["experiment_id"],
-                    f"feature/{experiment_config['experiment_id']}": variant,
+                    "$feature_flag": experiment_config["experiment_id"],
+                    f"$feature/{experiment_config['experiment_id']}": variant,
                 },
             )
 
             for action in experiment_config["variants"][variant]["actions"]:
                 if random.random() < action["probability"]:
-                    print(f"Generating data for user {distinct_id} at {random_timestamp + timedelta(minutes=1)} with event {action['event']}")
                     posthoganalytics.capture(
                         distinct_id=distinct_id,
                         event=action["event"],
                         timestamp=random_timestamp + timedelta(minutes=1),
                     )
+
+        logging.info(f"Generated data for {experiment_config['experiment_id']} with seed {seed}")
+        logging.info(f"Variant counts: {variant_counts}")
+
+        # TODO: need to figure out how to wait for the data to be flushed. shutdown() doesn't work as expected.
+        time.sleep(10)
+        posthoganalytics.shutdown()

--- a/posthog/management/commands/generate_experiment_data.py
+++ b/posthog/management/commands/generate_experiment_data.py
@@ -123,6 +123,9 @@ class Command(BaseCommand):
                             distinct_id=distinct_id,
                             event=action.event,
                             timestamp=random_timestamp + timedelta(minutes=1),
+                            properties={
+                                f"$feature/{experiment_id}": variant,
+                            },
                         )
 
         # TODO: need to figure out how to wait for the data to be flushed. shutdown() doesn't work as expected.

--- a/posthog/management/commands/generate_experiment_data.py
+++ b/posthog/management/commands/generate_experiment_data.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 import logging
 import random
 import time
-from typing import Literal
 import uuid
 import json
 
@@ -77,7 +76,7 @@ def get_default_trend_experiment_config() -> ExperimentConfig:
     )
 
 
-def get_default_config(type: Literal["funnel", "trend"]) -> ExperimentConfig:
+def get_default_config(type) -> ExperimentConfig:
     match type:
         case "funnel":
             return get_default_funnel_experiment_config()

--- a/posthog/management/commands/generate_experiment_data.py
+++ b/posthog/management/commands/generate_experiment_data.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 import logging
 import random
 import time
+from typing import Literal
 import uuid
 import json
 
@@ -29,22 +30,56 @@ class ExperimentConfig(BaseModel):
     variants: dict[str, VariantConfig]
 
 
-def get_default_experiment_config() -> ExperimentConfig:
+def get_default_funnel_experiment_config() -> ExperimentConfig:
     return ExperimentConfig(
-        number_of_users=1000,
+        number_of_users=2000,
         start_timestamp=datetime.now() - timedelta(days=7),
         end_timestamp=datetime.now(),
         variants={
             "control": VariantConfig(
                 weight=0.5,
-                actions=[ActionConfig(event="$pageview", count=1, probability=0.75)],
+                actions=[
+                    ActionConfig(event="signup started", count=1, probability=1),
+                    ActionConfig(event="signup completed", count=1, probability=0.25),
+                ],
             ),
             "test": VariantConfig(
                 weight=0.5,
-                actions=[ActionConfig(event="$pageview", count=1, probability=1)],
+                actions=[
+                    ActionConfig(event="signup started", count=1, probability=1),
+                    ActionConfig(event="signup completed", count=1, probability=0.35),
+                ],
             ),
         },
     )
+
+
+def get_default_trends_experiment_config() -> ExperimentConfig:
+    return ExperimentConfig(
+        number_of_users=2000,
+        start_timestamp=datetime.now() - timedelta(days=7),
+        end_timestamp=datetime.now(),
+        variants={
+            "control": VariantConfig(
+                weight=0.5,
+                actions=[ActionConfig(event="$pageview", count=5, probability=0.25)],
+            ),
+            "test": VariantConfig(
+                weight=0.5,
+                actions=[ActionConfig(event="$pageview", count=5, probability=0.35)],
+            ),
+        },
+    )
+
+
+def get_default_config(type: Literal["funnel", "trends"]) -> ExperimentConfig:
+    match type:
+        case "funnel":
+            return get_default_funnel_experiment_config()
+        case "trends":
+            return get_default_trends_experiment_config()
+        case _:
+            raise ValueError(f"Invalid experiment type: {type}")
 
 
 class Command(BaseCommand):
@@ -53,41 +88,56 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         group = parser.add_mutually_exclusive_group(required=False)
         group.add_argument(
-            "--init-config", type=str, help="Initialize a new experiment configuration file at the specified path"
+            "--init-config",
+            type=str,
+            help="Initialize a new experiment configuration file at the specified path. Does not generate data.",
+        )
+        group.add_argument(
+            "--type",
+            type=str,
+            choices=["trends", "funnel"],
+            default="trends",
+            help="Type of experiment data to generate or configuration to initialize.",
         )
 
         experiment_group = parser.add_argument_group("experiment arguments")
         experiment_group.add_argument("--experiment-id", type=str, help="Experiment ID (feature flag name)")
         experiment_group.add_argument("--config", type=str, help="Path to experiment config file")
-        experiment_group.add_argument(
-            "--seed", type=str, required=False, help="Simulation seed for deterministic output"
-        )
 
     def handle(self, *args, **options):
         # Make sure this runs in development environment only
         if not settings.DEBUG:
             raise ValueError("This command should only be run in development! DEBUG must be True.")
 
-        if config_path := options.get("init_config"):
-            with open(config_path, "w") as f:
-                f.write(get_default_experiment_config().model_dump_json(indent=2))
-            logging.info(f"Created example configuration file at: {config_path}")
+        experiment_type = options.get("type")
+
+        if init_config_path := options.get("init_config"):
+            with open(init_config_path, "w") as f:
+                f.write(get_default_config(experiment_type).model_dump_json(indent=2))
+            logging.info(f"Created example {experiment_type} configuration file at: {init_config_path}")
             return
 
         experiment_id = options.get("experiment_id")
         config_path = options.get("config")
 
-        if not experiment_id or not config_path:
-            raise ValueError("Both --experiment-id and --config are required when not using --init-config")
+        # Validate required arguments
+        if not experiment_id:
+            raise ValueError("--experiment-id is missing!")
 
-        with open(config_path) as config_file:
-            config_data = json.load(config_file)
+        if config_path is None and experiment_type is None:
+            raise ValueError("--config <path-to-file> or --type trends|funnel is missing!")
 
-        try:
-            # Use the ExperimentConfig model to parse and validate the JSON data
-            experiment_config = ExperimentConfig(**config_data)
-        except ValidationError as e:
-            raise ValueError(f"Invalid configuration: {e}")
+        if config_path:
+            with open(config_path) as config_file:
+                config_data = json.load(config_file)
+
+            try:
+                # Use the ExperimentConfig model to parse and validate the JSON data
+                experiment_config = ExperimentConfig(**config_data)
+            except ValidationError as e:
+                raise ValueError(f"Invalid configuration: {e}")
+        else:
+            experiment_config = get_default_config(experiment_type)
 
         variants = list(experiment_config.variants.keys())
         variant_counts = {variant: 0 for variant in variants}

--- a/posthog/management/commands/generate_experiment_data.py
+++ b/posthog/management/commands/generate_experiment_data.py
@@ -99,11 +99,12 @@ class Command(BaseCommand):
             )[0]
             variant_counts[variant] += 1
             distinct_id = str(uuid.uuid4())
-            random_timestamp = random.uniform(
-                experiment_config.start_timestamp.timestamp(),
-                experiment_config.end_timestamp.timestamp() - 3600,
+            random_timestamp = datetime.fromtimestamp(
+                random.uniform(
+                    experiment_config.start_timestamp.timestamp(),
+                    experiment_config.end_timestamp.timestamp() - 3600,
+                )
             )
-            random_timestamp = datetime.fromtimestamp(random_timestamp)
 
             posthoganalytics.capture(
                 distinct_id=distinct_id,

--- a/posthog/management/commands/generate_experiment_data.py
+++ b/posthog/management/commands/generate_experiment_data.py
@@ -1,94 +1,132 @@
 from datetime import datetime, timedelta
 import logging
 import random
-import secrets
 import time
 import uuid
+import json
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 import posthoganalytics
+from pydantic import BaseModel, ValidationError
 
 
-logging.getLogger("kafka").setLevel(logging.ERROR)  # Hide kafka-python's logspam
+class ActionConfig(BaseModel):
+    event: str
+    count: int
+    probability: float
+
+
+class VariantConfig(BaseModel):
+    weight: float
+    actions: list[ActionConfig]
+
+
+class ExperimentConfig(BaseModel):
+    number_of_users: int
+    start_timestamp: datetime
+    end_timestamp: datetime
+    variants: dict[str, VariantConfig]
+
+
+def get_default_experiment_config() -> ExperimentConfig:
+    return ExperimentConfig(
+        number_of_users=1000,
+        start_timestamp=datetime.now() - timedelta(days=7),
+        end_timestamp=datetime.now(),
+        variants={
+            "control": VariantConfig(
+                weight=0.5,
+                actions=[ActionConfig(event="$pageview", count=1, probability=0.75)],
+            ),
+            "test": VariantConfig(
+                weight=0.5,
+                actions=[ActionConfig(event="$pageview", count=1, probability=1)],
+            ),
+        },
+    )
 
 
 class Command(BaseCommand):
-    help = "Generate experiment data"
+    help = "Generate experiment test data"
 
     def add_arguments(self, parser):
-        parser.add_argument("--experiment-id", type=str, help="Experiment ID")
-        parser.add_argument("--seed", type=str, help="Simulation seed for deterministic output")
+        group = parser.add_mutually_exclusive_group(required=False)
+        group.add_argument(
+            "--init-config", type=str, help="Initialize a new experiment configuration file at the specified path"
+        )
+
+        experiment_group = parser.add_argument_group("experiment arguments")
+        experiment_group.add_argument("--experiment-id", type=str, help="Experiment ID (feature flag name)")
+        experiment_group.add_argument("--config", type=str, help="Path to experiment config file")
+        experiment_group.add_argument(
+            "--seed", type=str, required=False, help="Simulation seed for deterministic output"
+        )
 
     def handle(self, *args, **options):
         # Make sure this runs in development environment only
         if not settings.DEBUG:
             raise ValueError("This command should only be run in development! DEBUG must be True.")
 
+        if config_path := options.get("init_config"):
+            with open(config_path, "w") as f:
+                f.write(get_default_experiment_config().model_dump_json(indent=2))
+            logging.info(f"Created example configuration file at: {config_path}")
+            return
+
         experiment_id = options.get("experiment_id")
+        config_path = options.get("config")
 
-        # TODO: actually implement a seed
-        seed = options.get("seed") or secrets.token_hex(16)
+        if not experiment_id or not config_path:
+            raise ValueError("Both --experiment-id and --config are required when not using --init-config")
 
-        if not experiment_id:
-            raise ValueError("Experiment ID is required")
+        with open(config_path) as config_file:
+            config_data = json.load(config_file)
 
-        # TODO: this can be a config file taken as an argument
-        experiment_config = {
-            "experiment_id": experiment_id,
-            "seed": seed,
-            "number_of_users": 1000,
-            "start_timestamp": datetime.now() - timedelta(days=7),
-            "end_timestamp": datetime.now(),
-            "variants": {
-                "control": {
-                    "weight": 0.5,
-                    "actions": [
-                        {"event": "$pageview", "probability": 0.75},
-                    ],
-                },
-                "test": {
-                    "weight": 0.5,
-                    "actions": [
-                        {"event": "$pageview", "probability": 1},
-                    ],
-                },
-            },
-        }
+        try:
+            # Use the ExperimentConfig model to parse and validate the JSON data
+            experiment_config = ExperimentConfig(**config_data)
+        except ValidationError as e:
+            raise ValueError(f"Invalid configuration: {e}")
 
-        variants = list(experiment_config["variants"].keys())
+        variants = list(experiment_config.variants.keys())
         variant_counts = {variant: 0 for variant in variants}
-        for _ in range(experiment_config["number_of_users"]):
+
+        for _ in range(experiment_config.number_of_users):
             variant = random.choices(
                 variants,
-                weights=[v["weight"] for v in experiment_config["variants"].values()],
+                weights=[v.weight for v in experiment_config.variants.values()],
             )[0]
             variant_counts[variant] += 1
-            distinct_id = uuid.uuid4()
+            distinct_id = str(uuid.uuid4())
             random_timestamp = random.uniform(
-                experiment_config["start_timestamp"], experiment_config["end_timestamp"] - timedelta(hours=1)
+                experiment_config.start_timestamp.timestamp(),
+                experiment_config.end_timestamp.timestamp() - 3600,
             )
+            random_timestamp = datetime.fromtimestamp(random_timestamp)
+
             posthoganalytics.capture(
                 distinct_id=distinct_id,
                 event="$feature_flag_called",
                 timestamp=random_timestamp,
                 properties={
-                    "$feature_flag": experiment_config["experiment_id"],
-                    f"$feature/{experiment_config['experiment_id']}": variant,
+                    "$feature_flag": experiment_id,
+                    f"$feature/{experiment_id}": variant,
                 },
             )
 
-            for action in experiment_config["variants"][variant]["actions"]:
-                if random.random() < action["probability"]:
-                    posthoganalytics.capture(
-                        distinct_id=distinct_id,
-                        event=action["event"],
-                        timestamp=random_timestamp + timedelta(minutes=1),
-                    )
-
-        logging.info(f"Generated data for {experiment_config['experiment_id']} with seed {seed}")
-        logging.info(f"Variant counts: {variant_counts}")
+            for action in experiment_config.variants[variant].actions:
+                for _ in range(action.count):
+                    if random.random() < action.probability:
+                        posthoganalytics.capture(
+                            distinct_id=distinct_id,
+                            event=action.event,
+                            timestamp=random_timestamp + timedelta(minutes=1),
+                        )
 
         # TODO: need to figure out how to wait for the data to be flushed. shutdown() doesn't work as expected.
-        time.sleep(10)
+        time.sleep(2)
         posthoganalytics.shutdown()
+
+        logging.info(f"Generated data for {experiment_id}")
+        logging.info(f"Variant counts: {variant_counts}")

--- a/posthog/management/commands/generate_experiment_data.py
+++ b/posthog/management/commands/generate_experiment_data.py
@@ -163,8 +163,8 @@ class Command(BaseCommand):
                 event="$feature_flag_called",
                 timestamp=random_timestamp,
                 properties={
+                    "$feature_flag_response": variant,
                     "$feature_flag": experiment_id,
-                    f"$feature/{experiment_id}": variant,
                 },
             )
 


### PR DESCRIPTION
## Problem

make it easy to generate data with known statistics.

It can be further improved, but it's already very useful so I would like to merge this to master as I use it a lot already.
Then we can iterate from there.

## Changes

added mgmt cmd that generates events, so now you can do
```
 ./manage.py generate_experiment_data --type funnel --experiment-id funnel-test-1
 ./manage.py generate_experiment_data --type trends --experiment-id trends-test-1
```
to generate with the default configs.

Or you can do

```
./manage.py generate_experiment_data --type funnel --init-config funnel-conf.json
./manage.py generate_experiment_data --config exp-conf.json --experiment-id funnel-test
```

the json conf file can easily be edited to suite your test purpose.

the default currently looks like this:
```
{
  "number_of_users": 1000,
  "start_timestamp": "2024-12-03T07:04:51.286943",
  "end_timestamp": "2024-12-10T07:04:51.286949",
  "variants": {
    "control": {
      "weight": 0.5,
      "actions": [
        {
          "event": "$pageview",
          "count": 1,
          "probability": 0.75
        }
      ]
    },
    "test": {
      "weight": 0.5,
      "actions": [
        {
          "event": "$pageview",
          "count": 1,
          "probability": 1.0
        }
      ]
    }
  }
}
```


## How did you test this code?
* ran the cmd and tested with this query in clickhouse
```
SELECT 
	properties_group_feature_flags['$feature/test-1'] as variant,
	event,
	count(*)
FROM events
WHERE mapContains(properties_group_feature_flags, '$feature/test-1)
GROUP BY all;
```
* used product analytics to visualize the funnel and verified that the numbers added up
* verified by looking at experiment results
<img width="1222" alt="Screenshot 2024-12-18 at 11 27 05" src="https://github.com/user-attachments/assets/8b0a1a8c-271c-4412-909b-d17559723060" />

