### PR TITLE
fix(experiments): Allow editing variant rollout percentage

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -64,7 +64,12 @@ export function DistributionModal({ experimentId }: { experimentId: Experiment['
                     <LemonButton
                         onClick={() => {
                             saveSidebarExperimentFeatureFlag(featureFlag)
-                            updateExperiment({ holdout_id: experiment.holdout_id })
+                            updateExperiment({
+                                holdout_id: experiment.holdout_id,
+                                parameters: {
+                                    feature_flag_variants: featureFlag?.filters?.multivariate?.variants ?? [],
+                                },
+                            })
                             closeDistributionModal()
                         }}
                         type="primary"


### PR DESCRIPTION
## Changes

Fixes the ability to edit the variant rollout percentage in the Distribution modal, see https://posthoghelp.zendesk.com/agent/tickets/21687 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/24203)

The bug exists because there's a race condition between `saveSidebarExperimentFeatureFlag()` and `updateExperiment()`. `saveSidebarExperimentFeatureFlag()` saves the variant rollout percentage values, but then `updateExperiment()` can accidentally overwrite it:

https://github.com/PostHog/posthog/blob/97bfd30de792eebeb59192c5e7188fdfafffaeac/ee/clickhouse/views/experiments.py#L449-L457

I think there's no harm in continuing to call `saveSidebarExperimentFeatureFlag()`. By including `parameters.feature_flag_variants` on the request, the update method will make sure the variant data is stored too:

https://github.com/PostHog/posthog/blob/97bfd30de792eebeb59192c5e7188fdfafffaeac/ee/clickhouse/views/experiments.py#L432-L446

I think this is a "least worst" fix, independent of some refactoring.

**Before**

https://github.com/user-attachments/assets/666410c7-6d4d-450c-a5cd-17f1e29161e0

**After**

https://github.com/user-attachments/assets/52d46c74-b5a7-4842-9cb9-92aad725c389

## How did you test this code?

I saved variant rollout percentages and verified they were applied as expected to the experiment.