### PR TITLE
feat: Fix token check for remote config

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -67,6 +67,7 @@ export function loadPostHogJS(): void {
                     capture_copied_text: true,
                 },
                 person_profiles: 'always',
+                __preview_remote_config: true,
 
                 // Helper to capture events for assertions in Cypress
                 _onCapture: (window as any)._cypress_posthog_captures

--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -67,7 +67,6 @@ export function loadPostHogJS(): void {
                     capture_copied_text: true,
                 },
                 person_profiles: 'always',
-                __preview_remote_config: true,
 
                 // Helper to capture events for assertions in Cypress
                 _onCapture: (window as any)._cypress_posthog_captures

--- a/posthog/api/remote_config.py
+++ b/posthog/api/remote_config.py
@@ -14,7 +14,7 @@ class BaseRemoteConfigAPIView(APIView):
     permission_classes = []
 
     def check_token(self, token: str):
-        # Simple check rather than involving a whole serializer
+        # Most tokens are phc_xxx but there are some older ones that are random strings including underscores and dashes
         if len(token) > 200 or not re.match(r"^[a-zA-Z0-9_-]+$", token):
             raise ValidationError("Invalid token")
         return token

--- a/posthog/api/remote_config.py
+++ b/posthog/api/remote_config.py
@@ -15,7 +15,7 @@ class BaseRemoteConfigAPIView(APIView):
 
     def check_token(self, token: str):
         # Simple check rather than involving a whole serializer
-        if len(token) > 200 or not re.match(r"^[a-zA-Z0-9_]+$", token):
+        if len(token) > 200 or not re.match(r"^[a-zA-Z0-9_-]+$", token):
             raise ValidationError("Invalid token")
         return token
 

--- a/posthog/api/test/test_remote_config.py
+++ b/posthog/api/test/test_remote_config.py
@@ -24,9 +24,12 @@ class TestRemoteConfig(APIBaseTest, QueryMatchingTest):
             assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_invalid_tokens(self):
-        response = self.client.get("/array/§$%$&----/config")
+        response = self.client.get("/array/§$%$&/config")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["detail"] == "Invalid token"
+
+        response = self.client.get("/array/I-am_technically_v4lid/config")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_valid_config(self):
         with self.assertNumQueries(2):


### PR DESCRIPTION
## Problem

Turns on the remote config preview for our team

## Changes

* Also fixes a token check (some older tokens have that format

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
