### PR TITLE
feat: Added daily background sync of configs

### DIFF
--- a/posthog/tasks/remote_config.py
+++ b/posthog/tasks/remote_config.py
@@ -22,3 +22,12 @@ def update_team_remote_config(team_id: int) -> None:
         remote_config = RemoteConfig(team=team)
 
     remote_config.sync()
+
+
+@shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)
+def sync_all_remote_configs() -> None:
+    # Meant to ensure we have all configs in sync in case something failed
+
+    # Only select the id from the team queryset
+    for team_id in Team.objects.values_list("id", flat=True):
+        update_team_remote_config.delay(team_id)

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -57,6 +57,8 @@ from posthog.tasks.tasks import (
 )
 from posthog.utils import get_crontab
 
+from posthog.tasks.remote_config import sync_all_remote_configs
+
 
 def add_periodic_task_with_expiry(
     sender: Celery,
@@ -349,4 +351,12 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         60,
         refresh_integrations.s(),
         name="refresh integrations",
+    )
+
+    add_periodic_task_with_expiry(
+        sender,
+        # once a day
+        crontab(hour="0", minute=str(randrange(0, 40))),
+        sync_all_remote_configs.s(),
+        name="sync all remote configs",
     )

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -353,9 +353,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         name="refresh integrations",
     )
 
-    add_periodic_task_with_expiry(
-        sender,
-        # once a day
+    sender.add_periodic_task(
         crontab(hour="0", minute=str(randrange(0, 40))),
         sync_all_remote_configs.s(),
         name="sync all remote configs",

--- a/posthog/tasks/test/test_remote_config.py
+++ b/posthog/tasks/test/test_remote_config.py
@@ -20,7 +20,7 @@ class TestRemoteConfig(BaseTest):
         configs = RemoteConfig.objects.all()
         assert len(configs) == 1
 
-        last_synced_at = RemoteConfig.objects.last().synced_at
+        last_synced_at = RemoteConfig.objects.get(team=self.team).synced_at
 
         sync_all_remote_configs()
 

--- a/posthog/tasks/test/test_remote_config.py
+++ b/posthog/tasks/test/test_remote_config.py
@@ -5,7 +5,7 @@ from posthog.test.base import BaseTest
 
 
 class TestRemoteConfig(BaseTest):
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         project, team = Project.objects.create_with_team(
             initiating_user=self.user,
@@ -14,7 +14,7 @@ class TestRemoteConfig(BaseTest):
         )
         self.other_team = team
 
-    def test_sync_task_syncs_all_remote_configs(self):
+    def test_sync_task_syncs_all_remote_configs(self) -> None:
         # Delete one teams config
         RemoteConfig.objects.get(team=self.other_team).delete()
         configs = RemoteConfig.objects.all()

--- a/posthog/tasks/test/test_remote_config.py
+++ b/posthog/tasks/test/test_remote_config.py
@@ -1,0 +1,31 @@
+from posthog.models.project import Project
+from posthog.models.remote_config import RemoteConfig
+from posthog.tasks.remote_config import sync_all_remote_configs
+from posthog.test.base import BaseTest
+
+
+class TestRemoteConfig(BaseTest):
+    def setUp(self):
+        super().setUp()
+        project, team = Project.objects.create_with_team(
+            initiating_user=self.user,
+            organization=self.organization,
+            name="Test project",
+        )
+        self.other_team = team
+
+    def test_sync_task_syncs_all_remote_configs(self):
+        # Delete one teams config
+        RemoteConfig.objects.get(team=self.other_team).delete()
+        configs = RemoteConfig.objects.all()
+        assert len(configs) == 1
+
+        last_synced_at = RemoteConfig.objects.last().synced_at
+
+        sync_all_remote_configs()
+
+        configs = RemoteConfig.objects.all()
+        assert len(configs) == 2
+
+        assert RemoteConfig.objects.get(team=self.other_team).synced_at > last_synced_at  # type: ignore
+        assert RemoteConfig.objects.get(team=self.team).synced_at > last_synced_at  # type: ignore


### PR DESCRIPTION
## Problem

The configs are synced automatically. As with any system, something could go wrong here so as an absolute backup, we have a daily sync that takes care of ensuring the RemoteConfig exists and is in sync

## Changes

* does that

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
