### PR TITLE
feat: Added posthog-js debugger site app

### DIFF
--- a/posthog/cdp/templates/__init__.py
+++ b/posthog/cdp/templates/__init__.py
@@ -44,6 +44,7 @@ from ._siteapps.template_early_access_features import template as early_access_f
 from ._siteapps.template_hogdesk import template as hogdesk
 from ._siteapps.template_notification_bar import template as notification_bar
 from ._siteapps.template_pineapple_mode import template as pineapple_mode
+from ._siteapps.template_debug_posthog import template as debug_posthog
 from ._internal.template_broadcast import template_new_broadcast as _broadcast
 from ._internal.template_blank import blank_site_destination, blank_site_app
 
@@ -96,6 +97,7 @@ HOG_FUNCTION_TEMPLATES = [
     hogdesk,
     notification_bar,
     pineapple_mode,
+    debug_posthog,
 ]
 
 

--- a/posthog/cdp/templates/_siteapps/template_debug_posthog.py
+++ b/posthog/cdp/templates/_siteapps/template_debug_posthog.py
@@ -1,0 +1,45 @@
+from posthog.cdp.templates.hog_function_template import HogFunctionTemplate
+
+template: HogFunctionTemplate = HogFunctionTemplate(
+    status="client-side",
+    type="site_app",
+    id="template-debug-posthog-js",
+    name="PostHog JS debugger",
+    description="Enable extra debugging tools on your posthog-js",
+    icon_url="/static/hedgehog/builder-hog-01.png",
+    category=["Custom"],
+    hog="""
+export function onLoad({ inputs, posthog }) {
+    console.log("Enabling PostHog.js debugging", posthog)
+
+    if (inputs.enable_debugging) {
+        posthog.debug(true)
+    }
+
+    if (inputs.capture_config) {
+        posthog.capture("posthog-js debug", {
+            config: posthog.config
+        })
+    }
+}
+""".strip(),
+    inputs_schema=[
+        {
+            "key": "capture_config",
+            "type": "boolean",
+            "label": "Capture debug event on load",
+            "secret": False,
+            "default": False,
+            "required": False,
+            "description": "Whether to capture an event on load including the posthog config",
+        },
+        {
+            "key": "enable_debugging",
+            "type": "boolean",
+            "label": "Enable debugging",
+            "secret": False,
+            "default": False,
+            "required": False,
+        },
+    ],
+)


### PR DESCRIPTION
## Problem

We've often wanted this for ourselves to debug a users site better, especially when they install via npm or have some weirdness going on. Now we can use our own tools to help our users :o 

## Changes

* Adds a new posthog debugger template

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
