### PR TITLE
feat: Added manual remoteconfig sync command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -107,6 +107,30 @@
             }
         },
         {
+            "name": "Celery Beat",
+            "consoleName": "Celery Beat",
+            "type": "debugpy",
+            "justMyCode": true,
+            "autoReload": {
+                "enable": true,
+                "include": ["posthog/**/*.py"]
+            },
+            "request": "launch",
+            "program": "${workspaceFolder}/manage.py",
+            "args": ["run_autoreload_celery", "--type=beat"],
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "SKIP_ASYNC_MIGRATIONS_SETUP": "1",
+                "DEBUG": "1",
+                "BILLING_SERVICE_URL": "https://billing.dev.posthog.dev",
+                "SKIP_SERVICE_VERSION_REQUIREMENTS": "1"
+            },
+            "presentation": {
+                "group": "main"
+            }
+        },
+        {
             "name": "Plugin Server",
             "command": "npm run start:dev",
             "request": "launch",
@@ -212,7 +236,14 @@
     "compounds": [
         {
             "name": "PostHog",
-            "configurations": ["Backend", "Celery Threaded Pool", "Frontend", "Plugin Server", "Temporal Worker"],
+            "configurations": [
+                "Backend",
+                "Celery Threaded Pool",
+                "Celery Beat",
+                "Frontend",
+                "Plugin Server",
+                "Temporal Worker"
+            ],
             "stopAll": true,
             "presentation": {
                 "order": 1,

--- a/posthog/management/commands/sync_remote_configs.py
+++ b/posthog/management/commands/sync_remote_configs.py
@@ -1,0 +1,12 @@
+from django.core.management.base import BaseCommand
+
+from posthog.tasks.remote_config import sync_all_remote_configs
+
+
+class Command(BaseCommand):
+    help = "Sync all RemoteConfigs"
+
+    def handle(self, *args, **options):
+        print("Syncing RemoteConfigs for all teams...")  # noqa: T201
+        sync_all_remote_configs()
+        print("All syncs scheduled")  # noqa: T201


### PR DESCRIPTION
## Problem

Would be handy to have right now and maybe in the future

## Changes

* Also adds missing celery beat from launch.json (couldnt figure out why my tasks weren't running)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
