### PR TITLE
fix: log open ai survey summary response

### DIFF
--- a/ee/surveys/summaries/summarize_surveys.py
+++ b/ee/surveys/summaries/summarize_surveys.py
@@ -131,5 +131,7 @@ we're trying to identify what to work on
         if usage:
             TOKENS_IN_PROMPT_HISTOGRAM.observe(usage)
 
+    logger.info("survey_summary_response", result=result)
+
     content: str = result.choices[0].message.content or ""
     return {"content": content, "timings": timer.get_all_timings()}

--- a/ee/surveys/summaries/summarize_surveys.py
+++ b/ee/surveys/summaries/summarize_surveys.py
@@ -121,7 +121,7 @@ use bullet points to identify the themes, and highlights of quotes to bring them
 we're trying to identify what to work on
             use as concise and simple language as is possible.
             generate no text other than the summary.
-            the aim is to let people see themes in the responses received. return the text in github flavoured markdown format""",
+            the aim is to let people see themes in the responses received. return the text in markdown format without using any paragraph formatting""",
                 },
             ],
             user=f"{instance_region}/{user.pk}",


### PR DESCRIPTION
AI summaries of surveys sometimes have paragraphs in which looks weird

This asks that not to happen, and adds logging of responses 