### PR TITLE
fix: Flush individually valid files in BigQuery

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -648,12 +648,12 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
                     schema=record_batch_schema,
                     writer_format=WriterFormat.PARQUET,
                     max_bytes=settings.BATCH_EXPORT_BIGQUERY_UPLOAD_CHUNK_SIZE_BYTES,
-                    non_retryable_error_types=NON_RETRYABLE_ERROR_TYPES,
                     json_columns=(),
                     bigquery_client=bq_client,
                     bigquery_table=bigquery_stage_table,
                     table_schema=stage_schema,
                     writer_file_kwargs={"compression": "zstd"},
+                    multiple_files=True,
                 )
 
                 merge_key = (

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -712,7 +712,6 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
                 max_bytes=settings.BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES,
                 s3_upload=s3_upload,
                 writer_file_kwargs={"compression": inputs.compression},
-                non_retryable_error_types=NON_RETRYABLE_ERROR_TYPES,
             )
 
             await s3_upload.complete()

--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -227,12 +227,19 @@ class Consumer:
         max_bytes: int,
         schema: pa.Schema,
         json_columns: collections.abc.Sequence[str],
+        multiple_files: bool = False,
         **kwargs,
     ) -> int:
         """Start consuming record batches from queue.
 
         Record batches will be written to a temporary file defined by `writer_format`
         and the file will be flushed upon reaching at least `max_bytes`.
+
+        Callers can control whether a new file is created for each flush or whether we
+        continue flushing to the same file by setting `multiple_files`. File data is
+        reset regardless, so this is not meant to impact total file size, but rather
+        to control whether we are exporting a single large file in multiple parts, or
+        multiple files that must each individually be valid.
 
         Returns:
             Total number of records in all consumed record batches.
@@ -243,34 +250,60 @@ class Consumer:
         writer = get_batch_export_writer(writer_format, self.flush, schema=schema, max_bytes=max_bytes, **kwargs)
 
         record_batches_count = 0
+        records_count = 0
+        record_batch_generator = self.generate_record_batches_from_queue(queue, producer_task)
 
         await self.logger.adebug("Starting record batch writing loop")
-        async with writer.open_temporary_file():
-            while True:
-                try:
-                    record_batch = queue.get_nowait()
-                    record_batches_count += 1
-                except asyncio.QueueEmpty:
-                    if producer_task.done():
-                        await self.logger.adebug(
-                            "Empty queue with no more events being produced, closing writer loop and flushing"
-                        )
-                        self.flush_start_event.set()
-                        # Exit context manager to trigger final flush
-                        break
-                    else:
-                        await asyncio.sleep(0)
-                        continue
 
-                record_batch = cast_record_batch_json_columns(record_batch, json_columns=json_columns)
-                await writer.write_record_batch(record_batch, flush=True)
+        writer._batch_export_file = writer.create_temporary_file()
 
-        for _ in range(record_batches_count):
-            queue.task_done()
+        while True:
+            try:
+                record_batch = await anext(record_batch_generator)
+            except StopAsyncIteration:
+                break
 
-        await self.logger.adebug("Consumed %s records", writer.records_total)
+            record_batches_count += 1
+            record_batch = cast_record_batch_json_columns(record_batch, json_columns=json_columns)
+
+            await writer.write_record_batch(record_batch, flush=False)
+
+            if writer.should_flush():
+                records_count += writer.records_since_last_flush
+
+                if multiple_files:
+                    await writer.close_temporary_file()
+                    writer._batch_export_file = writer.create_temporary_file()
+                else:
+                    await writer.flush()
+
+                for _ in range(record_batches_count):
+                    queue.task_done()
+                record_batches_count = 0
+
+        if writer.should_flush():
+            records_count += writer.records_since_last_flush
+            await writer.close_temporary_file()
+
+        await self.logger.adebug("Consumed %s records", records_count)
         self.heartbeater.set_from_heartbeat_details(self.heartbeat_details)
-        return writer.records_total
+        return records_count
+
+    async def generate_record_batches_from_queue(self, queue, producer_task):
+        while True:
+            try:
+                record_batch = queue.get_nowait()
+            except asyncio.QueueEmpty:
+                if producer_task.done():
+                    await self.logger.adebug(
+                        "Empty queue with no more events being produced, closing writer loop and flushing"
+                    )
+                    break
+                else:
+                    await asyncio.sleep(0)
+                    continue
+
+            yield record_batch
 
 
 class RecordBatchConsumerRetryableExceptionGroup(ExceptionGroup):
@@ -300,7 +333,7 @@ async def run_consumer_loop(
     max_bytes: int,
     json_columns: collections.abc.Sequence[str] = ("properties", "person_properties", "set", "set_once"),
     writer_file_kwargs: collections.abc.Mapping[str, typing.Any] | None = None,
-    non_retryable_error_types: collections.abc.Sequence[str] = (),
+    multiple_files: bool = False,
     **kwargs,
 ) -> int:
     """Run record batch consumers in a loop.
@@ -348,6 +381,7 @@ async def run_consumer_loop(
             max_bytes=max_bytes,
             schema=schema,
             json_columns=json_columns,
+            multiple_files=multiple_files,
             **writer_file_kwargs or {},
         ),
         name=f"record_batch_consumer_{consumer_number}",

--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -281,6 +281,7 @@ class Consumer:
                     queue.task_done()
                 record_batches_count = 0
 
+        records_count += writer.records_since_last_flush
         await writer.close_temporary_file()
 
         await self.logger.adebug("Consumed %s records", records_count)

--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -281,15 +281,18 @@ class Consumer:
                     queue.task_done()
                 record_batches_count = 0
 
-        if writer.should_flush():
-            records_count += writer.records_since_last_flush
-            await writer.close_temporary_file()
+        await writer.close_temporary_file()
 
         await self.logger.adebug("Consumed %s records", records_count)
         self.heartbeater.set_from_heartbeat_details(self.heartbeat_details)
         return records_count
 
-    async def generate_record_batches_from_queue(self, queue, producer_task):
+    async def generate_record_batches_from_queue(
+        self,
+        queue: RecordBatchQueue,
+        producer_task: asyncio.Task,
+    ):
+        """Yield record batches from provided `queue` until `producer_task` is done."""
         while True:
             try:
                 record_batch = queue.get_nowait()

--- a/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
@@ -10,6 +10,7 @@ import warnings
 import pyarrow as pa
 import pytest
 import pytest_asyncio
+from django.test import override_settings
 from freezegun.api import freeze_time
 from google.cloud import bigquery
 from temporalio import activity
@@ -361,7 +362,7 @@ async def test_insert_into_bigquery_activity_inserts_data_into_bigquery_table(
         **bigquery_config,
     )
 
-    with freeze_time(TEST_TIME) as frozen_time:
+    with freeze_time(TEST_TIME) as frozen_time, override_settings(BATCH_EXPORT_BIGQUERY_UPLOAD_CHUNK_SIZE_BYTES=1):
         await activity_environment.run(insert_into_bigquery_activity, insert_inputs)
 
         ingested_timestamp = frozen_time().replace(tzinfo=dt.UTC)


### PR DESCRIPTION
## Problem

There is a problem with the recently merged #26761: Each time we flush, BigQuery expect us to be loading a single valid Parquet file, not a part of a larger Parquet file. So, each time we flush, we must flush a valid Parquet file, that is, including the footer bytes written on closing the file. So, this PR changes our spmc main loop to support a `multiple_files` parameter`: When set, we will close the underlying writer and open a new one, thus forcing the footer bytes to be written before flushing.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Adds support for `multiple_files` in spmc consumer loop.
* Updates tests to catch this error by forcing multiple small parquet files to be uploaded.
  * Test fails when ran on `master` branch, but passes on this branch.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
