### PR TITLE
feat(experiments): Always allow refreshing experiment results

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -493,44 +493,38 @@ export function PageHeaderCustom(): JSX.Element {
                     )}
                     {experiment && isExperimentRunning && (
                         <div className="flex flex-row gap-2">
-                            {!isExperimentStopped && !experiment.archived && (
-                                <>
-                                    <More
-                                        overlay={
-                                            <>
-                                                <LemonButton
-                                                    onClick={() =>
-                                                        exposureCohortId ? undefined : createExposureCohort()
-                                                    }
-                                                    fullWidth
-                                                    data-attr={`${
-                                                        exposureCohortId ? 'view' : 'create'
-                                                    }-exposure-cohort`}
-                                                    to={exposureCohortId ? urls.cohort(exposureCohortId) : undefined}
-                                                    targetBlank={!!exposureCohortId}
-                                                >
-                                                    {exposureCohortId ? 'View' : 'Create'} exposure cohort
-                                                </LemonButton>
-                                                <LemonButton
-                                                    onClick={() => loadExperimentResults(true)}
-                                                    fullWidth
-                                                    data-attr="refresh-experiment"
-                                                >
-                                                    Refresh experiment results
-                                                </LemonButton>
-                                                <LemonButton
-                                                    onClick={() => loadSecondaryMetricResults(true)}
-                                                    fullWidth
-                                                    data-attr="refresh-secondary-metrics"
-                                                >
-                                                    Refresh secondary metrics
-                                                </LemonButton>
-                                            </>
-                                        }
-                                    />
-                                    <LemonDivider vertical />
-                                </>
-                            )}
+                            <>
+                                <More
+                                    overlay={
+                                        <>
+                                            <LemonButton
+                                                onClick={() => (exposureCohortId ? undefined : createExposureCohort())}
+                                                fullWidth
+                                                data-attr={`${exposureCohortId ? 'view' : 'create'}-exposure-cohort`}
+                                                to={exposureCohortId ? urls.cohort(exposureCohortId) : undefined}
+                                                targetBlank={!!exposureCohortId}
+                                            >
+                                                {exposureCohortId ? 'View' : 'Create'} exposure cohort
+                                            </LemonButton>
+                                            <LemonButton
+                                                onClick={() => loadExperimentResults(true)}
+                                                fullWidth
+                                                data-attr="refresh-experiment"
+                                            >
+                                                Refresh experiment results
+                                            </LemonButton>
+                                            <LemonButton
+                                                onClick={() => loadSecondaryMetricResults(true)}
+                                                fullWidth
+                                                data-attr="refresh-secondary-metrics"
+                                            >
+                                                Refresh secondary metrics
+                                            </LemonButton>
+                                        </>
+                                    }
+                                />
+                                <LemonDivider vertical />
+                            </>
                             <ResetButton experimentId={experiment.id} />
                             {!experiment.end_date && (
                                 <LemonButton


### PR DESCRIPTION
## Changes

Restores the UI to refresh experiment results when an experiment is completed or archived:

![CleanShot 2024-12-10 at 10 25 19@2x](https://github.com/user-attachments/assets/ffe9aa80-2034-4a7c-99e2-71e2e7a4a497)

It looks like the conditional was originally added in https://github.com/PostHog/posthog/pull/21686/commits/8ff6f2a563fe2fa1cf53f645f66cf4dd0751d8fa (https://github.com/PostHog/posthog/pull/21686) but it's not super clear why.

I wanted to refresh the results for https://posthoghelp.zendesk.com/agent/tickets/21723, (moved to PostHog: https://us.posthog.com/project/2/support/tickets/24207) but it's a completed experiment so I don't have the UI for it.

## How did you test this code?

I verified that each of the buttons worked as expected when an experiment is completed.