### PR TITLE
fix: hit 2fa setup endpoint when the logic is mounted

### DIFF
--- a/frontend/src/scenes/authentication/twoFactorLogic.ts
+++ b/frontend/src/scenes/authentication/twoFactorLogic.ts
@@ -37,6 +37,7 @@ export const twoFactorLogic = kea<twoFactorLogicType>([
         toggleTwoFactorSetupModal: (open: boolean) => ({ open }),
         toggleDisable2FAModal: (open: boolean) => ({ open }),
         toggleBackupCodesModal: (open: boolean) => ({ open }),
+        startSetup: true,
     }),
     reducers({
         isTwoFactorSetupModalOpen: [
@@ -158,9 +159,13 @@ export const twoFactorLogic = kea<twoFactorLogicType>([
                 actions.resetToken()
             }
         },
+        startSetup: async () => {
+            await api.get('api/users/@me/two_factor_start_setup/')
+        },
     })),
 
     afterMount(({ actions }) => {
+        actions.startSetup()
         actions.loadStatus()
     }),
 ])


### PR DESCRIPTION
## Problem

For the force 2fa modal, we never hit the API endpoint to get the 2fa setup initiated because the modal was forced open - but the only time that endpoint was called was when we _triggered_ it to be open (not forced it initially)

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

When we mount the 2fa logic, hit the endpoint to make sure we're ready to set up.

IDK if this is the best fix - we might end up hitting the endpoint way more than necessary. But, I think that will be okay for now to let people use this.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

I works locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
