### PR TITLE
fix(bigquery): Check for query permissions

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -466,9 +466,10 @@ class S3Consumer(Consumer):
         heartbeater: Heartbeater,
         heartbeat_details: S3HeartbeatDetails,
         data_interval_start: dt.datetime | str | None,
+        writer_format: WriterFormat,
         s3_upload: S3MultiPartUpload,
     ):
-        super().__init__(heartbeater, heartbeat_details, data_interval_start)
+        super().__init__(heartbeater, heartbeat_details, data_interval_start, writer_format)
         self.heartbeat_details: S3HeartbeatDetails = heartbeat_details
         self.s3_upload = s3_upload
 

--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -175,11 +175,13 @@ class Consumer:
         heartbeater: Heartbeater,
         heartbeat_details: BatchExportRangeHeartbeatDetails,
         data_interval_start: dt.datetime | str | None,
+        writer_format: WriterFormat,
     ):
         self.flush_start_event = asyncio.Event()
         self.heartbeater = heartbeater
         self.heartbeat_details = heartbeat_details
         self.data_interval_start = data_interval_start
+        self.writer_format = writer_format
         self.logger = logger
 
     @property
@@ -223,7 +225,6 @@ class Consumer:
         self,
         queue: RecordBatchQueue,
         producer_task: asyncio.Task,
-        writer_format: WriterFormat,
         max_bytes: int,
         schema: pa.Schema,
         json_columns: collections.abc.Sequence[str],
@@ -247,7 +248,7 @@ class Consumer:
         await logger.adebug("Starting record batch consumer")
 
         schema = cast_record_batch_schema_json_columns(schema, json_columns=json_columns)
-        writer = get_batch_export_writer(writer_format, self.flush, schema=schema, max_bytes=max_bytes, **kwargs)
+        writer = get_batch_export_writer(self.writer_format, self.flush, schema=schema, max_bytes=max_bytes, **kwargs)
 
         record_batches_count = 0
         records_count = 0
@@ -370,12 +371,11 @@ async def run_consumer_loop(
 
     await logger.adebug("Starting record batch consumer loop")
 
-    consumer = consumer_cls(heartbeater, heartbeat_details, data_interval_start, **kwargs)
+    consumer = consumer_cls(heartbeater, heartbeat_details, data_interval_start, writer_format, **kwargs)
     consumer_task = asyncio.create_task(
         consumer.start(
             queue=queue,
             producer_task=producer_task,
-            writer_format=writer_format,
             max_bytes=max_bytes,
             schema=schema,
             json_columns=json_columns,

--- a/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
@@ -4,6 +4,7 @@ import json
 import operator
 import os
 import typing
+import unittest.mock
 import uuid
 import warnings
 
@@ -367,6 +368,81 @@ async def test_insert_into_bigquery_activity_inserts_data_into_bigquery_table(
 
         ingested_timestamp = frozen_time().replace(tzinfo=dt.UTC)
 
+        await assert_clickhouse_records_in_bigquery(
+            bigquery_client=bigquery_client,
+            clickhouse_client=clickhouse_client,
+            table_id=f"test_insert_activity_table_{ateam.pk}",
+            dataset_id=bigquery_dataset.dataset_id,
+            team_id=ateam.pk,
+            date_ranges=[(data_interval_start, data_interval_end)],
+            exclude_events=exclude_events,
+            include_events=None,
+            batch_export_model=model,
+            use_json_type=use_json_type,
+            min_ingested_timestamp=ingested_timestamp,
+            sort_key="person_id"
+            if batch_export_model is not None and batch_export_model.name == "persons"
+            else "event",
+        )
+
+
+@pytest.mark.parametrize("use_json_type", [True], indirect=True)
+@pytest.mark.parametrize("model", TEST_MODELS)
+async def test_insert_into_bigquery_activity_inserts_data_into_bigquery_table_without_query_permissions(
+    clickhouse_client,
+    activity_environment,
+    bigquery_client,
+    bigquery_config,
+    exclude_events,
+    bigquery_dataset,
+    use_json_type,
+    model: BatchExportModel | BatchExportSchema | None,
+    generate_test_data,
+    data_interval_start,
+    data_interval_end,
+    ateam,
+):
+    """Test that the `insert_into_bigquery_activity` function inserts data into a BigQuery table.
+
+    For this test we mock the `acheck_for_query_permissions_on_table` method to assert the
+    behavior of the activity function when lacking query permissions in BigQuery.
+    """
+    if isinstance(model, BatchExportModel) and model.name == "persons":
+        pytest.skip("Unnecessary test case as person batch export requires query permissions")
+
+    batch_export_schema: BatchExportSchema | None = None
+    batch_export_model: BatchExportModel | None = None
+    if isinstance(model, BatchExportModel):
+        batch_export_model = model
+    elif model is not None:
+        batch_export_schema = model
+
+    insert_inputs = BigQueryInsertInputs(
+        team_id=ateam.pk,
+        table_id=f"test_insert_activity_table_{ateam.pk}",
+        dataset_id=bigquery_dataset.dataset_id,
+        data_interval_start=data_interval_start.isoformat(),
+        data_interval_end=data_interval_end.isoformat(),
+        exclude_events=exclude_events,
+        use_json_type=use_json_type,
+        batch_export_schema=batch_export_schema,
+        batch_export_model=batch_export_model,
+        **bigquery_config,
+    )
+
+    with (
+        freeze_time(TEST_TIME) as frozen_time,
+        override_settings(BATCH_EXPORT_BIGQUERY_UPLOAD_CHUNK_SIZE_BYTES=1),
+        unittest.mock.patch(
+            "posthog.temporal.batch_exports.bigquery_batch_export.BigQueryClient.acheck_for_query_permissions_on_table",
+            return_value=False,
+        ) as mocked_check,
+    ):
+        await activity_environment.run(insert_into_bigquery_activity, insert_inputs)
+
+        ingested_timestamp = frozen_time().replace(tzinfo=dt.UTC)
+
+        mocked_check.assert_called_once()
         await assert_clickhouse_records_in_bigquery(
             bigquery_client=bigquery_client,
             clickhouse_client=clickhouse_client,


### PR DESCRIPTION
## Problem

Users may have granted us permission to run jobs but not to query their tables.

In case we are missing query permissions, we should default to not using a stage table and instead attempt to use JSONL to load to the main table at once. Of course, this would mean higher risk of hitting BigQuery quotas, and other problems, but at least not immediate failure.
 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Implement a method to check for query permissions.
* Check for query permissions and go directly to main table if they are missing.
* Adds a unit test that mocks the call to `acheck_query_for_query_permissions_on_table` to assert behavior when permissions are missing.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Ran bigquery tests, ran new test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
