### PR TITLE
feat(experiments): Hide internal and test user filter for DW

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/PrimaryGoalTrends.tsx
+++ b/frontend/src/scenes/experiments/Metrics/PrimaryGoalTrends.tsx
@@ -24,6 +24,10 @@ export function PrimaryGoalTrends(): JSX.Element {
 
     const metricIdx = 0
     const currentMetric = experiment.metrics[metricIdx] as ExperimentTrendsQuery
+    // :FLAG: CLEAN UP AFTER MIGRATION
+    const isDataWarehouseMetric =
+        featureFlags[FEATURE_FLAGS.EXPERIMENTS_HOGQL] &&
+        currentMetric.count_query.series[0].kind === NodeKind.DataWarehouseNode
 
     return (
         <>
@@ -59,10 +63,18 @@ export function PrimaryGoalTrends(): JSX.Element {
                             MathAvailability.All
                         )
 
-                        setTrendsMetric({
-                            metricIdx,
-                            series,
-                        })
+                        if (series[0].kind === NodeKind.DataWarehouseNode) {
+                            setTrendsMetric({
+                                metricIdx,
+                                series,
+                                filterTestAccounts: false,
+                            })
+                        } else {
+                            setTrendsMetric({
+                                metricIdx,
+                                series,
+                            })
+                        }
                     } else {
                         if (actions?.length) {
                             setExperiment({
@@ -101,35 +113,37 @@ export function PrimaryGoalTrends(): JSX.Element {
                 showNumericalPropsOnly={true}
                 {...commonActionFilterProps}
             />
-            <div className="mt-4 space-y-4">
-                <TestAccountFilterSwitch
-                    checked={(() => {
-                        // :FLAG: CLEAN UP AFTER MIGRATION
-                        if (featureFlags[FEATURE_FLAGS.EXPERIMENTS_HOGQL]) {
-                            const val = currentMetric.count_query?.filterTestAccounts
-                            return hasFilters ? !!val : false
-                        }
-                        return hasFilters ? !!experiment.filters.filter_test_accounts : false
-                    })()}
-                    onChange={(checked: boolean) => {
-                        // :FLAG: CLEAN UP AFTER MIGRATION
-                        if (featureFlags[FEATURE_FLAGS.EXPERIMENTS_HOGQL]) {
-                            setTrendsMetric({
-                                metricIdx,
-                                filterTestAccounts: checked,
-                            })
-                        } else {
-                            setExperiment({
-                                filters: {
-                                    ...experiment.filters,
-                                    filter_test_accounts: checked,
-                                },
-                            })
-                        }
-                    }}
-                    fullWidth
-                />
-            </div>
+            {!isDataWarehouseMetric && (
+                <div className="mt-4 space-y-4">
+                    <TestAccountFilterSwitch
+                        checked={(() => {
+                            // :FLAG: CLEAN UP AFTER MIGRATION
+                            if (featureFlags[FEATURE_FLAGS.EXPERIMENTS_HOGQL]) {
+                                const val = currentMetric.count_query?.filterTestAccounts
+                                return hasFilters ? !!val : false
+                            }
+                            return hasFilters ? !!experiment.filters.filter_test_accounts : false
+                        })()}
+                        onChange={(checked: boolean) => {
+                            // :FLAG: CLEAN UP AFTER MIGRATION
+                            if (featureFlags[FEATURE_FLAGS.EXPERIMENTS_HOGQL]) {
+                                setTrendsMetric({
+                                    metricIdx,
+                                    filterTestAccounts: checked,
+                                })
+                            } else {
+                                setExperiment({
+                                    filters: {
+                                        ...experiment.filters,
+                                        filter_test_accounts: checked,
+                                    },
+                                })
+                            }
+                        }}
+                        fullWidth
+                    />
+                </div>
+            )}
             {isExperimentRunning && (
                 <LemonBanner type="info" className="mt-3 mb-3">
                     Preview insights are generated based on {EXPERIMENT_DEFAULT_DURATION} days of data. This can cause a


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/26332#issuecomment-2531811977
See https://posthog.slack.com/archives/C07PXH2GTGV/p1733847219869179

## Changes

Hides the "Filter out internal and test users" toggle for data warehouse goals. If the data warehouse is picked as a goal, then `filterTestAccounts` is also set to false.

![CleanShot 2024-12-10 at 15 21 14](https://github.com/user-attachments/assets/d4645653-c070-4c1c-b325-9d376f539d66)

## How did you test this code?

Manual testing