### PR TITLE
feat(query_log): add query_log table to hogql

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -59,6 +59,7 @@ from posthog.hogql.database.schema.persons import (
     RawPersonsTable,
     join_with_persons_table,
 )
+from posthog.hogql.database.schema.query_log import QueryLogTable, RawQueryLogTable
 from posthog.hogql.database.schema.session_replay_events import (
     RawSessionReplayEventsTable,
     SessionReplayEventsTable,
@@ -117,6 +118,7 @@ class Database(BaseModel):
     cohort_people: CohortPeople = CohortPeople()
     static_cohort_people: StaticCohortPeople = StaticCohortPeople()
     log_entries: LogEntriesTable = LogEntriesTable()
+    query_log: QueryLogTable = QueryLogTable()
     app_metrics: AppMetrics2Table = AppMetrics2Table()
     console_logs_log_entries: ReplayConsoleLogsLogEntriesTable = ReplayConsoleLogsLogEntriesTable()
     batch_export_log_entries: BatchExportLogEntriesTable = BatchExportLogEntriesTable()
@@ -133,6 +135,7 @@ class Database(BaseModel):
         RawErrorTrackingIssueFingerprintOverridesTable()
     )
     raw_sessions: Union[RawSessionsTableV1, RawSessionsTableV2] = RawSessionsTableV1()
+    raw_query_log: RawQueryLogTable = RawQueryLogTable()
 
     # system tables
     numbers: NumbersTable = NumbersTable()
@@ -150,6 +153,7 @@ class Database(BaseModel):
         "app_metrics",
         "sessions",
         "heatmaps",
+        "query_log",
     ]
 
     _warehouse_table_names: list[str] = []

--- a/posthog/hogql/database/schema/query_log.py
+++ b/posthog/hogql/database/schema/query_log.py
@@ -1,0 +1,81 @@
+from posthog.hogql import ast
+from posthog.hogql.database.models import (
+    IntegerDatabaseField,
+    StringDatabaseField,
+    DateTimeDatabaseField,
+    LazyTable,
+    FieldOrTable,
+    LazyTableToAdd,
+    FloatDatabaseField,
+    FunctionCallTable,
+)
+from posthog.hogql.parser import parse_expr
+
+QUERY_LOG_FIELDS: dict[str, FieldOrTable] = {
+    "query": StringDatabaseField(name="query"),
+    "query_start_time": DateTimeDatabaseField(name="event_time"),
+    "query_duration_ms": FloatDatabaseField(name="query_duration_ms"),
+    "log_comment": StringDatabaseField(name="log_comment"),
+    "created_by": IntegerDatabaseField(name="created_by"),
+    "exception": StringDatabaseField(name="exception"),
+    "cache_key": StringDatabaseField(name="cache_key"),
+    "type": StringDatabaseField(name="type"),
+    "query_type": StringDatabaseField(name="query_type"),
+    # "query_1": ExpressionField(name="query_1", ),
+}
+
+STRING_FIELDS = {
+    "cache_key": "cache_key",
+    "query_type": "query_type",
+    "query": ["query", "query"],
+}
+INT_FIELDS = {"created_by": "user_id"}
+
+
+def format_extract_args(keys):
+    if isinstance(keys, str):
+        return f"'{keys}'"
+    return ",".join([f'"{k}"' for k in keys])
+
+
+class QueryLogTable(LazyTable):
+    fields: dict[str, FieldOrTable] = QUERY_LOG_FIELDS
+
+    def to_printed_clickhouse(self, context):
+        return "query_log"
+
+    def to_printed_hogql(self):
+        return "query_log"
+
+    def lazy_select(self, table_to_add: LazyTableToAdd, context, node):
+        requested_fields = table_to_add.fields_accessed
+
+        raw_table_name = "raw_query_log"
+
+        def get_alias(name, chain):
+            if name in STRING_FIELDS:
+                keys = format_extract_args(STRING_FIELDS[name])
+                return ast.Alias(alias=name, expr=parse_expr(f"JSONExtractString(log_comment, {keys})"))
+            if name in INT_FIELDS:
+                keys = format_extract_args(INT_FIELDS[name])
+                return ast.Alias(alias=name, expr=parse_expr(f"JSONExtractInt(log_comment, {keys})"))
+            return ast.Alias(alias=name, expr=ast.Field(chain=[raw_table_name, *chain]))
+
+        fields: list[ast.Expr] = [get_alias(name, chain) for name, chain in requested_fields.items()]
+
+        return ast.SelectQuery(
+            select=fields,
+            select_from=ast.JoinExpr(table=ast.Field(chain=[raw_table_name])),
+        )
+
+
+class RawQueryLogTable(FunctionCallTable):
+    fields: dict[str, FieldOrTable] = QUERY_LOG_FIELDS
+
+    name: str = "raw_query_log"
+
+    def to_printed_clickhouse(self, context):
+        return "clusterAllReplicas(posthog, system.query_log)"
+
+    def to_printed_hogql(self, context):
+        return "query_log"

--- a/posthog/hogql/database/schema/query_log.py
+++ b/posthog/hogql/database/schema/query_log.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from posthog.hogql import ast
 from posthog.hogql.database.models import (
     IntegerDatabaseField,
@@ -46,13 +48,13 @@ INT_FIELDS = {"created_by": ["user_id"]}
 class QueryLogTable(LazyTable):
     fields: dict[str, FieldOrTable] = QUERY_LOG_FIELDS
 
-    def to_printed_clickhouse(self, context):
+    def to_printed_clickhouse(self, context) -> str:
         return "query_log"
 
-    def to_printed_hogql(self):
+    def to_printed_hogql(self) -> str:
         return "query_log"
 
-    def lazy_select(self, table_to_add: LazyTableToAdd, context, node):
+    def lazy_select(self, table_to_add: LazyTableToAdd, context, node) -> Any:
         requested_fields = table_to_add.fields_accessed
 
         raw_table_name = "raw_query_log"
@@ -121,8 +123,8 @@ class RawQueryLogTable(FunctionCallTable):
 
     name: str = "raw_query_log"
 
-    def to_printed_clickhouse(self, context):
+    def to_printed_clickhouse(self, context) -> str:
         return "clusterAllReplicas(posthog, system.query_log)"
 
-    def to_printed_hogql(self, context):
+    def to_printed_hogql(self, context) -> str:
         return "query_log"

--- a/posthog/hogql/database/schema/query_log.py
+++ b/posthog/hogql/database/schema/query_log.py
@@ -14,7 +14,7 @@ from posthog.hogql.database.models import (
 )
 
 QUERY_LOG_FIELDS: dict[str, FieldOrTable] = {
-    "query_id": StringDatabaseField(name="query_id"),  #
+    "query_id": StringDatabaseField(name="query_id"),
     "query": StringDatabaseField(name="query"),  #
     "query_start_time": DateTimeDatabaseField(name="event_time"),  #
     "query_duration_ms": FloatDatabaseField(name="query_duration_ms"),  #
@@ -25,18 +25,19 @@ QUERY_LOG_FIELDS: dict[str, FieldOrTable] = {
     "result_bytes": IntegerDatabaseField(name="result_bytes"),
     "memory_usage": IntegerDatabaseField(name="memory_usage"),
     "status": StringDatabaseField(name="type"),
-    "log_comment": StringDatabaseField(name="log_comment"),
     "kind": StringDatabaseField(name="kind"),
     "query_type": StringDatabaseField(name="query_type"),
     "is_personal_api_key_request": BooleanDatabaseField(name="is_personal_api_key_request"),
-    # below fields are used in condition and cannot be removed
+}
+
+RAW_QUERY_LOG_FIELDS: dict[str, FieldOrTable] = QUERY_LOG_FIELDS | {
+    # below fields are necessary to compute some of the resulting fields
     "type": StringDatabaseField(name="type"),
     "is_initial_query": BooleanDatabaseField(name="is_initial_query"),
-    # "query_1": ExpressionField(name="query_1", ),
+    "log_comment": StringDatabaseField(name="log_comment"),
 }
 
 STRING_FIELDS = {
-    "cache_key": ["cache_key"],
     "query_type": ["query_type"],
     "query_id": ["client_query_id"],
     "query": ["query", "query"],
@@ -119,7 +120,7 @@ class QueryLogTable(LazyTable):
 
 
 class RawQueryLogTable(FunctionCallTable):
-    fields: dict[str, FieldOrTable] = QUERY_LOG_FIELDS
+    fields: dict[str, FieldOrTable] = RAW_QUERY_LOG_FIELDS
 
     name: str = "raw_query_log"
 

--- a/posthog/hogql/database/schema/query_log.py
+++ b/posthog/hogql/database/schema/query_log.py
@@ -75,7 +75,7 @@ class QueryLogTable(LazyTable):
                 )
                 return ast.Alias(alias=name, expr=expr)
             if name == "is_personal_api_key_request":
-                expr = ast.CompareOperation(
+                cmp_expr = ast.CompareOperation(
                     op=ast.CompareOperationOp.Eq,
                     left=ast.Constant(value="personal_api_key"),
                     right=ast.Call(
@@ -83,7 +83,7 @@ class QueryLogTable(LazyTable):
                         args=[ast.Field(chain=["log_comment"]), ast.Constant(value="access_method")],
                     ),
                 )
-                return ast.Alias(alias=name, expr=expr)
+                return ast.Alias(alias=name, expr=cmp_expr)
             return ast.Alias(alias=name, expr=ast.Field(chain=[raw_table_name, *chain]))
 
         fields: list[ast.Expr] = [get_alias(name, chain) for name, chain in requested_fields.items()]
@@ -126,5 +126,5 @@ class RawQueryLogTable(FunctionCallTable):
     def to_printed_clickhouse(self, context) -> str:
         return "clusterAllReplicas(posthog, system.query_log)"
 
-    def to_printed_hogql(self, context) -> str:
+    def to_printed_hogql(self) -> str:
         return "query_log"

--- a/posthog/hogql/database/schema/test/test_table_query_log.py
+++ b/posthog/hogql/database/schema/test/test_table_query_log.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock, patch
+from posthog.clickhouse.client import sync_execute
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import create_hogql_database
+from posthog.hogql.query import execute_hogql_query
+from posthog.test.base import (
+    APIBaseTest,
+    ClickhouseTestMixin,
+)
+
+
+class TestPersonOptimization(ClickhouseTestMixin, APIBaseTest):
+    """
+    Mostly tests for the optimization of pre-filtering before aggregating. See https://github.com/PostHog/posthog/pull/25604
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.database = create_hogql_database(self.team.pk)
+        self.context = HogQLContext(database=self.database, team_id=self.team.pk, enable_select_queries=True)
+
+    @patch("posthog.hogql.query.sync_execute", wraps=sync_execute)
+    def test_dumb_query(self, mock_sync_execute: MagicMock):
+        response = execute_hogql_query("select query_start_time from query_log limit 10", self.team)
+
+        ch_query = f"""SELECT
+    query_log.query_start_time AS query_start_time
+FROM
+    (SELECT
+        toTimeZone(raw_query_log.event_time, %(hogql_val_0)s) AS query_start_time
+    FROM
+        clusterAllReplicas(posthog, system.query_log) AS raw_query_log
+    WHERE
+        and(ifNull(equals({self.team.pk}, JSONExtractInt(raw_query_log.log_comment, %(hogql_val_1)s)), 0), in(raw_query_log.type, [%(hogql_val_2)s, %(hogql_val_3)s, %(hogql_val_4)s]), raw_query_log.is_initial_query)) AS query_log
+LIMIT 10 SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, format_csv_allow_double_quotes=0, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0"""
+
+        from unittest.mock import ANY
+
+        mock_sync_execute.assert_called_once_with(
+            ch_query,
+            {
+                "hogql_val_0": "UTC",
+                "hogql_val_1": "user_id",
+                "hogql_val_2": "QueryFinish",
+                "hogql_val_3": "ExceptionBeforeStart",
+                "hogql_val_4": "ExceptionWhileProcessing",
+            },
+            with_column_types=True,
+            workload=ANY,
+            team_id=self.team.pk,
+            readonly=True,
+        )
+        assert response.results is not None

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -1707,6 +1707,16 @@
       },
       "query_log": {
           "fields": {
+              "query_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "query_id",
+                  "id": null,
+                  "name": "query_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
               "query": {
                   "chain": null,
                   "fields": null,
@@ -1737,16 +1747,6 @@
                   "table": null,
                   "type": "float"
               },
-              "log_comment": {
-                  "chain": null,
-                  "fields": null,
-                  "hogql_value": "log_comment",
-                  "id": null,
-                  "name": "log_comment",
-                  "schema_valid": true,
-                  "table": null,
-                  "type": "string"
-              },
               "created_by": {
                   "chain": null,
                   "fields": null,
@@ -1757,32 +1757,82 @@
                   "table": null,
                   "type": "integer"
               },
-              "exception": {
+              "read_rows": {
                   "chain": null,
                   "fields": null,
-                  "hogql_value": "exception",
+                  "hogql_value": "read_rows",
                   "id": null,
-                  "name": "exception",
+                  "name": "read_rows",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "read_bytes": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "read_bytes",
+                  "id": null,
+                  "name": "read_bytes",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "result_rows": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "result_rows",
+                  "id": null,
+                  "name": "result_rows",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "result_bytes": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "result_bytes",
+                  "id": null,
+                  "name": "result_bytes",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "memory_usage": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "memory_usage",
+                  "id": null,
+                  "name": "memory_usage",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "status": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "status",
+                  "id": null,
+                  "name": "status",
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
               },
-              "cache_key": {
+              "log_comment": {
                   "chain": null,
                   "fields": null,
-                  "hogql_value": "cache_key",
+                  "hogql_value": "log_comment",
                   "id": null,
-                  "name": "cache_key",
+                  "name": "log_comment",
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
               },
-              "type": {
+              "kind": {
                   "chain": null,
                   "fields": null,
-                  "hogql_value": "type",
+                  "hogql_value": "kind",
                   "id": null,
-                  "name": "type",
+                  "name": "kind",
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
@@ -1796,6 +1846,36 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
+              },
+              "is_personal_api_key_request": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "is_personal_api_key_request",
+                  "id": null,
+                  "name": "is_personal_api_key_request",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "boolean"
+              },
+              "type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "type",
+                  "id": null,
+                  "name": "type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "is_initial_query": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "is_initial_query",
+                  "id": null,
+                  "name": "is_initial_query",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "boolean"
               }
           },
           "id": "query_log",
@@ -3466,6 +3546,16 @@
       },
       "query_log": {
           "fields": {
+              "query_id": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "query_id",
+                  "id": null,
+                  "name": "query_id",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
               "query": {
                   "chain": null,
                   "fields": null,
@@ -3496,16 +3586,6 @@
                   "table": null,
                   "type": "float"
               },
-              "log_comment": {
-                  "chain": null,
-                  "fields": null,
-                  "hogql_value": "log_comment",
-                  "id": null,
-                  "name": "log_comment",
-                  "schema_valid": true,
-                  "table": null,
-                  "type": "string"
-              },
               "created_by": {
                   "chain": null,
                   "fields": null,
@@ -3516,32 +3596,82 @@
                   "table": null,
                   "type": "integer"
               },
-              "exception": {
+              "read_rows": {
                   "chain": null,
                   "fields": null,
-                  "hogql_value": "exception",
+                  "hogql_value": "read_rows",
                   "id": null,
-                  "name": "exception",
+                  "name": "read_rows",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "read_bytes": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "read_bytes",
+                  "id": null,
+                  "name": "read_bytes",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "result_rows": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "result_rows",
+                  "id": null,
+                  "name": "result_rows",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "result_bytes": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "result_bytes",
+                  "id": null,
+                  "name": "result_bytes",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "memory_usage": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "memory_usage",
+                  "id": null,
+                  "name": "memory_usage",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "status": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "status",
+                  "id": null,
+                  "name": "status",
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
               },
-              "cache_key": {
+              "log_comment": {
                   "chain": null,
                   "fields": null,
-                  "hogql_value": "cache_key",
+                  "hogql_value": "log_comment",
                   "id": null,
-                  "name": "cache_key",
+                  "name": "log_comment",
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
               },
-              "type": {
+              "kind": {
                   "chain": null,
                   "fields": null,
-                  "hogql_value": "type",
+                  "hogql_value": "kind",
                   "id": null,
-                  "name": "type",
+                  "name": "kind",
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
@@ -3555,6 +3685,36 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
+              },
+              "is_personal_api_key_request": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "is_personal_api_key_request",
+                  "id": null,
+                  "name": "is_personal_api_key_request",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "boolean"
+              },
+              "type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "type",
+                  "id": null,
+                  "name": "type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "is_initial_query": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "is_initial_query",
+                  "id": null,
+                  "name": "is_initial_query",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "boolean"
               }
           },
           "id": "query_log",

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -1704,6 +1704,103 @@
           "id": "heatmaps",
           "name": "heatmaps",
           "type": "posthog"
+      },
+      "query_log": {
+          "fields": {
+              "query": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "query",
+                  "id": null,
+                  "name": "query",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "query_start_time": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "query_start_time",
+                  "id": null,
+                  "name": "query_start_time",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "query_duration_ms": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "query_duration_ms",
+                  "id": null,
+                  "name": "query_duration_ms",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "float"
+              },
+              "log_comment": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "log_comment",
+                  "id": null,
+                  "name": "log_comment",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "created_by": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by",
+                  "id": null,
+                  "name": "created_by",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "exception": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "exception",
+                  "id": null,
+                  "name": "exception",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "cache_key": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "cache_key",
+                  "id": null,
+                  "name": "cache_key",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "type",
+                  "id": null,
+                  "name": "type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "query_type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "query_type",
+                  "id": null,
+                  "name": "query_type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              }
+          },
+          "id": "query_log",
+          "name": "query_log",
+          "type": "posthog"
       }
   }
   '''
@@ -3365,6 +3462,103 @@
           },
           "id": "heatmaps",
           "name": "heatmaps",
+          "type": "posthog"
+      },
+      "query_log": {
+          "fields": {
+              "query": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "query",
+                  "id": null,
+                  "name": "query",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "query_start_time": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "query_start_time",
+                  "id": null,
+                  "name": "query_start_time",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
+              },
+              "query_duration_ms": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "query_duration_ms",
+                  "id": null,
+                  "name": "query_duration_ms",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "float"
+              },
+              "log_comment": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "log_comment",
+                  "id": null,
+                  "name": "log_comment",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "created_by": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "created_by",
+                  "id": null,
+                  "name": "created_by",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "exception": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "exception",
+                  "id": null,
+                  "name": "exception",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "cache_key": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "cache_key",
+                  "id": null,
+                  "name": "cache_key",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "type",
+                  "id": null,
+                  "name": "type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "query_type": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "query_type",
+                  "id": null,
+                  "name": "query_type",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              }
+          },
+          "id": "query_log",
+          "name": "query_log",
           "type": "posthog"
       }
   }

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -1817,16 +1817,6 @@
                   "table": null,
                   "type": "string"
               },
-              "log_comment": {
-                  "chain": null,
-                  "fields": null,
-                  "hogql_value": "log_comment",
-                  "id": null,
-                  "name": "log_comment",
-                  "schema_valid": true,
-                  "table": null,
-                  "type": "string"
-              },
               "kind": {
                   "chain": null,
                   "fields": null,
@@ -1853,26 +1843,6 @@
                   "hogql_value": "is_personal_api_key_request",
                   "id": null,
                   "name": "is_personal_api_key_request",
-                  "schema_valid": true,
-                  "table": null,
-                  "type": "boolean"
-              },
-              "type": {
-                  "chain": null,
-                  "fields": null,
-                  "hogql_value": "type",
-                  "id": null,
-                  "name": "type",
-                  "schema_valid": true,
-                  "table": null,
-                  "type": "string"
-              },
-              "is_initial_query": {
-                  "chain": null,
-                  "fields": null,
-                  "hogql_value": "is_initial_query",
-                  "id": null,
-                  "name": "is_initial_query",
                   "schema_valid": true,
                   "table": null,
                   "type": "boolean"
@@ -3656,16 +3626,6 @@
                   "table": null,
                   "type": "string"
               },
-              "log_comment": {
-                  "chain": null,
-                  "fields": null,
-                  "hogql_value": "log_comment",
-                  "id": null,
-                  "name": "log_comment",
-                  "schema_valid": true,
-                  "table": null,
-                  "type": "string"
-              },
               "kind": {
                   "chain": null,
                   "fields": null,
@@ -3692,26 +3652,6 @@
                   "hogql_value": "is_personal_api_key_request",
                   "id": null,
                   "name": "is_personal_api_key_request",
-                  "schema_valid": true,
-                  "table": null,
-                  "type": "boolean"
-              },
-              "type": {
-                  "chain": null,
-                  "fields": null,
-                  "hogql_value": "type",
-                  "id": null,
-                  "name": "type",
-                  "schema_valid": true,
-                  "table": null,
-                  "type": "string"
-              },
-              "is_initial_query": {
-                  "chain": null,
-                  "fields": null,
-                  "hogql_value": "is_initial_query",
-                  "id": null,
-                  "name": "is_initial_query",
                   "schema_valid": true,
                   "table": null,
                   "type": "boolean"


### PR DESCRIPTION
## Problem

We want to expose query log to users and present them what's the cost of a query.

## Changes

 * Adds a query_log table to a HogQL. It allows users to see queries made by their user.
 
<img width="1203" alt="Zrzut ekranu 2024-12-11 o 15 50 49" src="https://github.com/user-attachments/assets/8eabadd9-d1e6-4fe4-9fe5-037854538002" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
* Added a unit test for querying table.
* tested on local environement in HogQL editor
