### PR TITLE
fix(experiments): hide "Participant Type" section if user don't use groups

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -6,6 +6,7 @@ import { useActions, useValues } from 'kea'
 import { Form, Group } from 'kea-forms'
 import { ExperimentVariantNumber } from 'lib/components/SeriesGlyph'
 import { MAX_EXPERIMENT_VARIANTS } from 'lib/constants'
+import { groupsAccessLogic, GroupsAccessStatus } from 'lib/introductions/groupsAccessLogic'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
@@ -20,6 +21,7 @@ const ExperimentFormFields = (): JSX.Element => {
     const { addExperimentGroup, removeExperimentGroup, setExperiment, createExperiment, setExperimentType } =
         useActions(experimentLogic)
     const { webExperimentsAvailable } = useValues(experimentsLogic)
+    const { groupsAccessStatus } = useValues(groupsAccessLogic)
 
     return (
         <div>
@@ -103,37 +105,40 @@ const ExperimentFormFields = (): JSX.Element => {
                         />
                     </div>
                 )}
-                <div>
-                    <h3 className="mt-10">Participant type</h3>
-                    <div className="text-xs text-muted">
-                        The type on which to aggregate metrics. You can change this at any time during the experiment.
-                    </div>
-                    <LemonDivider />
-                    <LemonRadio
-                        value={
-                            experiment.parameters.aggregation_group_type_index != undefined
-                                ? experiment.parameters.aggregation_group_type_index
-                                : -1
-                        }
-                        onChange={(rawGroupTypeIndex) => {
-                            const groupTypeIndex = rawGroupTypeIndex !== -1 ? rawGroupTypeIndex : undefined
+                {groupsAccessStatus === GroupsAccessStatus.AlreadyUsing && (
+                    <div>
+                        <h3 className="mt-10">Participant type</h3>
+                        <div className="text-xs text-muted">
+                            The type on which to aggregate metrics. You can change this at any time during the
+                            experiment.
+                        </div>
+                        <LemonDivider />
+                        <LemonRadio
+                            value={
+                                experiment.parameters.aggregation_group_type_index != undefined
+                                    ? experiment.parameters.aggregation_group_type_index
+                                    : -1
+                            }
+                            onChange={(rawGroupTypeIndex) => {
+                                const groupTypeIndex = rawGroupTypeIndex !== -1 ? rawGroupTypeIndex : undefined
 
-                            setExperiment({
-                                parameters: {
-                                    ...experiment.parameters,
-                                    aggregation_group_type_index: groupTypeIndex ?? undefined,
-                                },
-                            })
-                        }}
-                        options={[
-                            { value: -1, label: 'Persons' },
-                            ...Array.from(groupTypes.values()).map((groupType) => ({
-                                value: groupType.group_type_index,
-                                label: capitalizeFirstLetter(aggregationLabel(groupType.group_type_index).plural),
-                            })),
-                        ]}
-                    />
-                </div>
+                                setExperiment({
+                                    parameters: {
+                                        ...experiment.parameters,
+                                        aggregation_group_type_index: groupTypeIndex ?? undefined,
+                                    },
+                                })
+                            }}
+                            options={[
+                                { value: -1, label: 'Persons' },
+                                ...Array.from(groupTypes.values()).map((groupType) => ({
+                                    value: groupType.group_type_index,
+                                    label: capitalizeFirstLetter(aggregationLabel(groupType.group_type_index).plural),
+                                })),
+                            ]}
+                        />
+                    </div>
+                )}
                 <div className="mt-10">
                     <h3 className="mb-1">Variants</h3>
                     <div className="text-xs text-muted">Add up to 9 variants to test against your control.</div>


### PR DESCRIPTION
## Problem
We currently show the "Participant type" section in the experiments form, even if if the user dont use it.

## Changes
Use the existing logic `GroupsAccessStatus` and only show the section if the status is `AlreadyUsing` (i.e, has groups enabled and has created some groups).

When not "AlreadyUsing":
<img width="709" alt="Screenshot 2024-12-11 at 11 05 36" src="https://github.com/user-attachments/assets/d6841af4-9027-4fa8-baf3-4ec0aee19a35">

When "AlreadyUsing":
<img width="758" alt="Screenshot 2024-12-11 at 11 06 28" src="https://github.com/user-attachments/assets/d4fde52e-3e88-4501-a127-c791d3acf438">

## How did you test this code?
* created a new user without "group analytics" and "create new experiment"
* enabled the "group analytics" product feature and "create new experiment"