### PR TITLE
feat: add groups to event filters

### DIFF
--- a/frontend/src/queries/nodes/EventsNode/EventPropertyFilters.tsx
+++ b/frontend/src/queries/nodes/EventsNode/EventPropertyFilters.tsx
@@ -1,7 +1,9 @@
+import { useValues } from 'kea'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { useState } from 'react'
 
+import { groupsModel } from '~/models/groupsModel'
 import { EventsNode, EventsQuery, HogQLQuery, SessionAttributionExplorerQuery } from '~/queries/schema'
 import { isHogQLQuery, isSessionAttributionExplorerQuery } from '~/queries/utils'
 import { AnyPropertyFilter } from '~/types'
@@ -21,6 +23,7 @@ export function EventPropertyFilters<
         isHogQLQuery(query) || isSessionAttributionExplorerQuery(query) ? query.filters?.properties : query.properties
     const eventNames =
         isHogQLQuery(query) || isSessionAttributionExplorerQuery(query) ? [] : query.event ? [query.event] : []
+    const { groupsTaxonomicTypes } = useValues(groupsModel)
 
     return !properties || Array.isArray(properties) ? (
         <PropertyFilters
@@ -30,6 +33,7 @@ export function EventPropertyFilters<
                     TaxonomicFilterGroupType.EventProperties,
                     TaxonomicFilterGroupType.PersonProperties,
                     TaxonomicFilterGroupType.EventFeatureFlags,
+                    ...groupsTaxonomicTypes,
                     TaxonomicFilterGroupType.Cohorts,
                     TaxonomicFilterGroupType.Elements,
                     TaxonomicFilterGroupType.HogQLExpression,


### PR DESCRIPTION
## Problem
Event page doesn't let you filter events on groups, other than by using hog ql

<img width="1216" alt="image" src="https://github.com/user-attachments/assets/6de0c67d-398b-4157-bf91-76cc2cda0a4b">


## Changes
Add it

## How did you test this code?
Locally