### PR TITLE
fix(tests): create Kafka tables in Django tests

### DIFF
--- a/ee/hogai/eval/conftest.py
+++ b/ee/hogai/eval/conftest.py
@@ -4,7 +4,7 @@ from posthog.conftest import create_clickhouse_tables
 from posthog.test.base import run_clickhouse_statement_in_parallel
 
 
-@pytest.fixture(scope="package", autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def setup_kafka_tables(django_db_setup):
     from posthog.clickhouse.client import sync_execute
     from posthog.clickhouse.schema import (

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -14,7 +14,6 @@ def create_clickhouse_tables(num_tables: int):
         CREATE_DATA_QUERIES,
         CREATE_DICTIONARY_QUERIES,
         CREATE_DISTRIBUTED_TABLE_QUERIES,
-        CREATE_KAFKA_TABLE_QUERIES,
         CREATE_MERGETREE_TABLE_QUERIES,
         CREATE_MV_TABLE_QUERIES,
         CREATE_VIEW_QUERIES,
@@ -24,7 +23,6 @@ def create_clickhouse_tables(num_tables: int):
     total_tables = (
         len(CREATE_MERGETREE_TABLE_QUERIES)
         + len(CREATE_DISTRIBUTED_TABLE_QUERIES)
-        + len(CREATE_KAFKA_TABLE_QUERIES)
         + len(CREATE_MV_TABLE_QUERIES)
         + len(CREATE_VIEW_QUERIES)
         + len(CREATE_DICTIONARY_QUERIES)
@@ -34,9 +32,7 @@ def create_clickhouse_tables(num_tables: int):
     if num_tables == total_tables:
         return
 
-    table_queries = list(
-        map(build_query, CREATE_MERGETREE_TABLE_QUERIES + CREATE_DISTRIBUTED_TABLE_QUERIES + CREATE_KAFKA_TABLE_QUERIES)
-    )
+    table_queries = list(map(build_query, CREATE_MERGETREE_TABLE_QUERIES + CREATE_DISTRIBUTED_TABLE_QUERIES))
     run_clickhouse_statement_in_parallel(table_queries)
 
     mv_queries = list(map(build_query, CREATE_MV_TABLE_QUERIES))
@@ -66,7 +62,7 @@ def reset_clickhouse_tables():
     from posthog.models.channel_type.sql import TRUNCATE_CHANNEL_DEFINITION_TABLE_SQL
     from posthog.models.cohort.sql import TRUNCATE_COHORTPEOPLE_TABLE_SQL
     from posthog.models.error_tracking.sql import TRUNCATE_ERROR_TRACKING_ISSUE_FINGERPRINT_OVERRIDES_TABLE_SQL
-    from posthog.models.event.sql import TRUNCATE_EVENTS_RECENT_TABLE_SQL, TRUNCATE_EVENTS_TABLE_SQL
+    from posthog.models.event.sql import TRUNCATE_EVENTS_TABLE_SQL, TRUNCATE_EVENTS_RECENT_TABLE_SQL
     from posthog.models.group.sql import TRUNCATE_GROUPS_TABLE_SQL
     from posthog.models.performance.sql import TRUNCATE_PERFORMANCE_EVENTS_TABLE_SQL
     from posthog.models.person.sql import (

--- a/posthog/conftest.py
+++ b/posthog/conftest.py
@@ -14,6 +14,7 @@ def create_clickhouse_tables(num_tables: int):
         CREATE_DATA_QUERIES,
         CREATE_DICTIONARY_QUERIES,
         CREATE_DISTRIBUTED_TABLE_QUERIES,
+        CREATE_KAFKA_TABLE_QUERIES,
         CREATE_MERGETREE_TABLE_QUERIES,
         CREATE_MV_TABLE_QUERIES,
         CREATE_VIEW_QUERIES,
@@ -23,6 +24,7 @@ def create_clickhouse_tables(num_tables: int):
     total_tables = (
         len(CREATE_MERGETREE_TABLE_QUERIES)
         + len(CREATE_DISTRIBUTED_TABLE_QUERIES)
+        + len(CREATE_KAFKA_TABLE_QUERIES)
         + len(CREATE_MV_TABLE_QUERIES)
         + len(CREATE_VIEW_QUERIES)
         + len(CREATE_DICTIONARY_QUERIES)
@@ -32,7 +34,9 @@ def create_clickhouse_tables(num_tables: int):
     if num_tables == total_tables:
         return
 
-    table_queries = list(map(build_query, CREATE_MERGETREE_TABLE_QUERIES + CREATE_DISTRIBUTED_TABLE_QUERIES))
+    table_queries = list(
+        map(build_query, CREATE_MERGETREE_TABLE_QUERIES + CREATE_DISTRIBUTED_TABLE_QUERIES + CREATE_KAFKA_TABLE_QUERIES)
+    )
     run_clickhouse_statement_in_parallel(table_queries)
 
     mv_queries = list(map(build_query, CREATE_MV_TABLE_QUERIES))
@@ -62,7 +66,7 @@ def reset_clickhouse_tables():
     from posthog.models.channel_type.sql import TRUNCATE_CHANNEL_DEFINITION_TABLE_SQL
     from posthog.models.cohort.sql import TRUNCATE_COHORTPEOPLE_TABLE_SQL
     from posthog.models.error_tracking.sql import TRUNCATE_ERROR_TRACKING_ISSUE_FINGERPRINT_OVERRIDES_TABLE_SQL
-    from posthog.models.event.sql import TRUNCATE_EVENTS_TABLE_SQL, TRUNCATE_EVENTS_RECENT_TABLE_SQL
+    from posthog.models.event.sql import TRUNCATE_EVENTS_RECENT_TABLE_SQL, TRUNCATE_EVENTS_TABLE_SQL
     from posthog.models.group.sql import TRUNCATE_GROUPS_TABLE_SQL
     from posthog.models.performance.sql import TRUNCATE_PERFORMANCE_EVENTS_TABLE_SQL
     from posthog.models.person.sql import (


### PR DESCRIPTION
## Problem

Clickhouse tables, depending on the Kafka tables, are created before Kafka tables, which blocks further test execution of the evaluation tests. 

## Changes

Re-create Clickhouse tables after Kafka tables have been created.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing
