### PR TITLE
fix: changed how we import dompurify in survey/utils, was causing error

### DIFF
--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -1,7 +1,7 @@
-import { sanitize } from 'dompurify'
+import DOMPurify from 'dompurify'
 
 const sanitizeConfig = { ADD_ATTR: ['target'] }
 
 export function sanitizeHTML(html: string): string {
-    return sanitize(html, sanitizeConfig)
+    return DOMPurify.sanitize(html, sanitizeConfig)
 }


### PR DESCRIPTION
## Problem

For some reason unknown to me destructuring the import of `dompurify` was causing an import error when running `build:esbuild`

**Env**:
Node: v18.20.5
pnpm: 8.10.5
Chip: Apple M4 Pro

The error:

```bash
No matching export in node_modules/.pnpm/dompurify@3.2.3/node_modules/dompurify/dist/purify.es.mjs for import sanitize
```


## Changes
Replace `dompurify` from this: 
```js
import { sanitize } from 'dompurify'
...
sanitize(html)
```
to this:
```js
import DOMPurify from 'dompurify'
...
DOMPurify.sanitize(html)
```

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?

Running tests
