### PR TITLE
refactor(dashboards): remove remaining filters from dashboard templates

### DIFF
--- a/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
+++ b/ee/clickhouse/views/test/__snapshots__/test_clickhouse_experiments.ambr
@@ -1,18 +1,6 @@
 # serializer version: 1
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results.1
-  '''
   /* user_id:0 request:_snapshot_ */
   SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS value,
          count(*) as count
@@ -25,6 +13,85 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0
+  '''
+# ---
+# name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time,
+         prop
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner ,
+            prop
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time ,
+                               prop
+        FROM
+          (SELECT *,
+                  if(latest_0 <= latest_1
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
+                  if(isNotNull(latest_1)
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                  prop
+           FROM
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([['test'], ['control'], ['']], prop), prop, ['Other']) as prop
+              FROM
+                (SELECT *,
+                        if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
+                 FROM
+                   (SELECT e.timestamp as timestamp,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
+                           if(event = '$pageview', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = '$pageleave', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS prop_basic,
+                           prop_basic as prop,
+                           argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
+                    FROM events e
+                    LEFT OUTER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 99999
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 99999
+                              AND event IN ['$pageleave', '$pageview']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 99999
+                      AND event IN ['$pageleave', '$pageview']
+                      AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                      AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC')
+                      AND (step_0 = 1
+                           OR step_1 = 1) )))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps,
+              prop
+     HAVING steps = max(max_steps))
+  GROUP BY prop
   '''
 # ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results.2
@@ -108,18 +175,6 @@
 # ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_and_events_out_of_time_range_timezones
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_and_events_out_of_time_range_timezones.1
-  '''
   /* user_id:0 request:_snapshot_ */
   SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS value,
          count(*) as count
@@ -132,6 +187,85 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0
+  '''
+# ---
+# name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_and_events_out_of_time_range_timezones.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time,
+         prop
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner ,
+            prop
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time ,
+                               prop
+        FROM
+          (SELECT *,
+                  if(latest_0 <= latest_1
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
+                  if(isNotNull(latest_1)
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                  prop
+           FROM
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([['test'], ['control']], prop), prop, ['Other']) as prop
+              FROM
+                (SELECT *,
+                        if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
+                 FROM
+                   (SELECT e.timestamp as timestamp,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
+                           if(event = '$pageview', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = '$pageleave', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS prop_basic,
+                           prop_basic as prop,
+                           argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
+                    FROM events e
+                    LEFT OUTER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 99999
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 99999
+                              AND event IN ['$pageleave', '$pageview']
+                              AND toTimeZone(timestamp, 'Europe/Amsterdam') >= toDateTime('2020-01-01 14:20:21', 'Europe/Amsterdam')
+                              AND toTimeZone(timestamp, 'Europe/Amsterdam') <= toDateTime('2020-01-06 10:00:00', 'Europe/Amsterdam') )
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 99999
+                      AND event IN ['$pageleave', '$pageview']
+                      AND toTimeZone(timestamp, 'Europe/Amsterdam') >= toDateTime('2020-01-01 14:20:21', 'Europe/Amsterdam')
+                      AND toTimeZone(timestamp, 'Europe/Amsterdam') <= toDateTime('2020-01-06 10:00:00', 'Europe/Amsterdam')
+                      AND (step_0 = 1
+                           OR step_1 = 1) )))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps,
+              prop
+     HAVING steps = max(max_steps))
+  GROUP BY prop
   '''
 # ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_and_events_out_of_time_range_timezones.2
@@ -215,18 +349,6 @@
 # ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants.1
-  '''
   /* user_id:0 request:_snapshot_ */
   SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS value,
          count(*) as count
@@ -239,6 +361,85 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0
+  '''
+# ---
+# name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time,
+         prop
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner ,
+            prop
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time ,
+                               prop
+        FROM
+          (SELECT *,
+                  if(latest_0 <= latest_1
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
+                  if(isNotNull(latest_1)
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                  prop
+           FROM
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([[''], ['test_1'], ['test'], ['control'], ['unknown_3'], ['unknown_2'], ['unknown_1'], ['test_2']], prop), prop, ['Other']) as prop
+              FROM
+                (SELECT *,
+                        if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
+                 FROM
+                   (SELECT e.timestamp as timestamp,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
+                           if(event = '$pageview', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = '$pageleave', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS prop_basic,
+                           prop_basic as prop,
+                           argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
+                    FROM events e
+                    LEFT OUTER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 99999
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 99999
+                              AND event IN ['$pageleave', '$pageview']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 99999
+                      AND event IN ['$pageleave', '$pageview']
+                      AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                      AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC')
+                      AND (step_0 = 1
+                           OR step_1 = 1) )))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps,
+              prop
+     HAVING steps = max(max_steps))
+  GROUP BY prop
   '''
 # ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants.2
@@ -322,18 +523,6 @@
 # ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_with_hogql_aggregation
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_with_hogql_aggregation.1
-  '''
   /* user_id:0 request:_snapshot_ */
   SELECT array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS value,
          count(*) as count
@@ -346,6 +535,85 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0
+  '''
+# ---
+# name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_with_hogql_aggregation.1
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT countIf(steps = 1) step_1,
+         countIf(steps = 2) step_2,
+         avg(step_1_average_conversion_time_inner) step_1_average_conversion_time,
+         median(step_1_median_conversion_time_inner) step_1_median_conversion_time,
+         prop
+  FROM
+    (SELECT aggregation_target,
+            steps,
+            avg(step_1_conversion_time) step_1_average_conversion_time_inner,
+            median(step_1_conversion_time) step_1_median_conversion_time_inner ,
+            prop
+     FROM
+       (SELECT aggregation_target,
+               steps,
+               max(steps) over (PARTITION BY aggregation_target,
+                                             prop) as max_steps,
+                               step_1_conversion_time ,
+                               prop
+        FROM
+          (SELECT *,
+                  if(latest_0 <= latest_1
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, 2, 1) AS steps ,
+                  if(isNotNull(latest_1)
+                     AND latest_1 <= latest_0 + INTERVAL 14 DAY, dateDiff('second', toDateTime(latest_0), toDateTime(latest_1)), NULL) step_1_conversion_time,
+                  prop
+           FROM
+             (SELECT aggregation_target, timestamp, step_0,
+                                                    latest_0,
+                                                    step_1,
+                                                    min(latest_1) over (PARTITION by aggregation_target,
+                                                                                     prop
+                                                                        ORDER BY timestamp DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING) latest_1 ,
+                                                                       if(has([['test'], ['control'], ['']], prop), prop, ['Other']) as prop
+              FROM
+                (SELECT *,
+                        if(notEmpty(arrayFilter(x -> notEmpty(x), prop_vals)), prop_vals, ['']) as prop
+                 FROM
+                   (SELECT e.timestamp as timestamp,
+                           replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(properties, '$account_id'), ''), 'null'), '^"|"$', '') as aggregation_target,
+                           if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
+                           if(event = '$pageview', 1, 0) as step_0,
+                           if(step_0 = 1, timestamp, null) as latest_0,
+                           if(event = '$pageleave', 1, 0) as step_1,
+                           if(step_1 = 1, timestamp, null) as latest_1,
+                           array(replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '')) AS prop_basic,
+                           prop_basic as prop,
+                           argMinIf(prop, timestamp, notEmpty(arrayFilter(x -> notEmpty(x), prop))) over (PARTITION by aggregation_target) as prop_vals
+                    FROM events e
+                    LEFT OUTER JOIN
+                      (SELECT distinct_id,
+                              argMax(person_id, version) as person_id
+                       FROM person_distinct_id2
+                       WHERE team_id = 99999
+                         AND distinct_id IN
+                           (SELECT distinct_id
+                            FROM events
+                            WHERE team_id = 99999
+                              AND event IN ['$pageleave', '$pageview']
+                              AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
+                       GROUP BY distinct_id
+                       HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
+                    WHERE team_id = 99999
+                      AND event IN ['$pageleave', '$pageview']
+                      AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                      AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC')
+                      AND (step_0 = 1
+                           OR step_1 = 1) )))
+           WHERE step_0 = 1 ))
+     GROUP BY aggregation_target,
+              steps,
+              prop
+     HAVING steps = max(max_steps))
+  GROUP BY prop
   '''
 # ---
 # name: ClickhouseTestFunnelExperimentResults.test_experiment_flow_with_event_results_with_hogql_aggregation.2
@@ -429,18 +697,6 @@
 # ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results.1
-  '''
   /* user_id:0 request:_snapshot_ */
   SELECT replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '') AS value,
          count(*) as count
@@ -458,7 +714,7 @@
   OFFSET 0
   '''
 # ---
-# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results.2
+# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results.1
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT groupArray(day_start) as date,
@@ -506,7 +762,7 @@
   ORDER BY breakdown_value
   '''
 # ---
-# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results.3
+# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results.2
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT replaceRegexpAll(JSONExtractRaw(properties, '$feature_flag_response'), '^"|"$', '') AS value,
@@ -524,6 +780,70 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0
+  '''
+# ---
+# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results.3
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total,
+         breakdown_value
+  FROM
+    (SELECT SUM(total) as count,
+            day_start,
+            breakdown_value
+     FROM
+       (SELECT *
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  ticks.day_start as day_start,
+                  breakdown_value
+           FROM
+             (SELECT toStartOfDay(toDateTime('2020-01-06 00:00:00', 'UTC')) - toIntervalDay(number) as day_start
+              FROM numbers(6)
+              UNION ALL SELECT toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')) as day_start) as ticks
+           CROSS JOIN
+             (SELECT breakdown_value
+              FROM
+                (SELECT ['control', 'test'] as breakdown_value) ARRAY
+              JOIN breakdown_value) as sec
+           ORDER BY breakdown_value,
+                    day_start
+           UNION ALL SELECT count(DISTINCT person_id) as total,
+                            toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                            breakdown_value
+           FROM
+             (SELECT person_id,
+                     min(timestamp) as timestamp,
+                     breakdown_value
+              FROM
+                (SELECT pdi.person_id as person_id, timestamp, transform(ifNull(nullIf(replaceRegexpAll(JSONExtractRaw(properties, '$feature_flag_response'), '^"|"$', ''), ''), '$$_posthog_breakdown_null_$$'), (['control', 'test']), (['control', 'test']), '$$_posthog_breakdown_other_$$') as breakdown_value
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 99999
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
+                 WHERE e.team_id = 99999
+                   AND event = '$feature_flag_called'
+                   AND (((isNull(replaceRegexpAll(JSONExtractRaw(e.properties, 'exclude'), '^"|"$', ''))
+                          OR NOT JSONHas(e.properties, 'exclude')))
+                        AND ((has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag_response'), '^"|"$', '')))
+                             AND (has(['a-b-test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag'), '^"|"$', '')))))
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
+              GROUP BY person_id,
+                       breakdown_value) AS pdi
+           GROUP BY day_start,
+                    breakdown_value))
+     GROUP BY day_start,
+              breakdown_value
+     ORDER BY breakdown_value,
+              day_start)
+  GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '''
 # ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results.4
@@ -592,18 +912,6 @@
 # ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants.1
-  '''
   /* user_id:0 request:_snapshot_ */
   SELECT replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '') AS value,
          count(*) as count
@@ -619,7 +927,7 @@
   OFFSET 0
   '''
 # ---
-# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants.2
+# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants.1
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT groupArray(day_start) as date,
@@ -665,7 +973,7 @@
   ORDER BY breakdown_value
   '''
 # ---
-# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants.3
+# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants.2
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT replaceRegexpAll(JSONExtractRaw(properties, '$feature_flag_response'), '^"|"$', '') AS value,
@@ -683,6 +991,15 @@
   OFFSET 0
   '''
 # ---
+# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants.3
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT [now()] AS date,
+         [0] AS total,
+         '' AS breakdown_value
+  LIMIT 0
+  '''
+# ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_for_three_test_variants.4
   '''
   /* user_id:0 request:_snapshot_ */
@@ -693,18 +1010,6 @@
   '''
 # ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone
-  '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone.1
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '') AS value,
@@ -721,7 +1026,7 @@
   OFFSET 0
   '''
 # ---
-# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone.2
+# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone.1
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT groupArray(day_start) as date,
@@ -767,7 +1072,7 @@
   ORDER BY breakdown_value
   '''
 # ---
-# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone.3
+# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone.2
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT replaceRegexpAll(JSONExtractRaw(properties, '$feature_flag_response'), '^"|"$', '') AS value,
@@ -783,6 +1088,68 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0
+  '''
+# ---
+# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone.3
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total,
+         breakdown_value
+  FROM
+    (SELECT SUM(total) as count,
+            day_start,
+            breakdown_value
+     FROM
+       (SELECT *
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  ticks.day_start as day_start,
+                  breakdown_value
+           FROM
+             (SELECT toStartOfDay(toDateTime('2020-01-06 07:00:00', 'US/Pacific')) - toIntervalDay(number) as day_start
+              FROM numbers(6)
+              UNION ALL SELECT toStartOfDay(toDateTime('2020-01-01 02:10:00', 'US/Pacific')) as day_start) as ticks
+           CROSS JOIN
+             (SELECT breakdown_value
+              FROM
+                (SELECT ['control', 'test'] as breakdown_value) ARRAY
+              JOIN breakdown_value) as sec
+           ORDER BY breakdown_value,
+                    day_start
+           UNION ALL SELECT count(DISTINCT person_id) as total,
+                            toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'US/Pacific')) as day_start,
+                            breakdown_value
+           FROM
+             (SELECT person_id,
+                     min(timestamp) as timestamp,
+                     breakdown_value
+              FROM
+                (SELECT pdi.person_id as person_id, timestamp, transform(ifNull(nullIf(replaceRegexpAll(JSONExtractRaw(properties, '$feature_flag_response'), '^"|"$', ''), ''), '$$_posthog_breakdown_null_$$'), (['control', 'test']), (['control', 'test']), '$$_posthog_breakdown_other_$$') as breakdown_value
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 99999
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
+                 WHERE e.team_id = 99999
+                   AND event = '$feature_flag_called'
+                   AND ((has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag_response'), '^"|"$', '')))
+                        AND (has(['a-b-test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag'), '^"|"$', ''))))
+                   AND toTimeZone(timestamp, 'US/Pacific') >= toDateTime('2020-01-01 02:10:00', 'US/Pacific')
+                   AND toTimeZone(timestamp, 'US/Pacific') <= toDateTime('2020-01-06 07:00:00', 'US/Pacific') )
+              GROUP BY person_id,
+                       breakdown_value) AS pdi
+           GROUP BY day_start,
+                    breakdown_value))
+     GROUP BY day_start,
+              breakdown_value
+     ORDER BY breakdown_value,
+              day_start)
+  GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '''
 # ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_out_of_timerange_timezone.4
@@ -849,18 +1216,6 @@
 # ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter.1
-  '''
   /* user_id:0 request:_snapshot_ */
   SELECT replaceRegexpAll(JSONExtractRaw(properties, '$feature/a-b-test'), '^"|"$', '') AS value,
          count(*) as count
@@ -877,7 +1232,7 @@
   OFFSET 0
   '''
 # ---
-# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter.2
+# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter.1
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT groupArray(day_start) as date,
@@ -924,7 +1279,7 @@
   ORDER BY breakdown_value
   '''
 # ---
-# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter.3
+# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter.2
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT replaceRegexpAll(JSONExtractRaw(properties, '$feature_flag_response'), '^"|"$', '') AS value,
@@ -940,6 +1295,68 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0
+  '''
+# ---
+# name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter.3
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total,
+         breakdown_value
+  FROM
+    (SELECT SUM(total) as count,
+            day_start,
+            breakdown_value
+     FROM
+       (SELECT *
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  ticks.day_start as day_start,
+                  breakdown_value
+           FROM
+             (SELECT toStartOfDay(toDateTime('2020-01-06 00:00:00', 'UTC')) - toIntervalDay(number) as day_start
+              FROM numbers(6)
+              UNION ALL SELECT toStartOfDay(toDateTime('2020-01-01 00:00:00', 'UTC')) as day_start) as ticks
+           CROSS JOIN
+             (SELECT breakdown_value
+              FROM
+                (SELECT ['control', 'test'] as breakdown_value) ARRAY
+              JOIN breakdown_value) as sec
+           ORDER BY breakdown_value,
+                    day_start
+           UNION ALL SELECT count(DISTINCT person_id) as total,
+                            toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                            breakdown_value
+           FROM
+             (SELECT person_id,
+                     min(timestamp) as timestamp,
+                     breakdown_value
+              FROM
+                (SELECT pdi.person_id as person_id, timestamp, transform(ifNull(nullIf(replaceRegexpAll(JSONExtractRaw(properties, '$feature_flag_response'), '^"|"$', ''), ''), '$$_posthog_breakdown_null_$$'), (['control', 'test']), (['control', 'test']), '$$_posthog_breakdown_other_$$') as breakdown_value
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 99999
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
+                 WHERE e.team_id = 99999
+                   AND event = '$feature_flag_called'
+                   AND ((has(['control', 'test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag_response'), '^"|"$', '')))
+                        AND (has(['a-b-test'], replaceRegexpAll(JSONExtractRaw(e.properties, '$feature_flag'), '^"|"$', ''))))
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime('2020-01-01 00:00:00', 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-06 00:00:00', 'UTC') )
+              GROUP BY person_id,
+                       breakdown_value) AS pdi
+           GROUP BY day_start,
+                    breakdown_value))
+     GROUP BY day_start,
+              breakdown_value
+     ORDER BY breakdown_value,
+              day_start)
+  GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '''
 # ---
 # name: ClickhouseTestTrendExperimentResults.test_experiment_flow_with_event_results_with_hogql_filter.4

--- a/posthog/api/test/__snapshots__/test_event.ambr
+++ b/posthog/api/test/__snapshots__/test_event.ambr
@@ -1,18 +1,6 @@
 # serializer version: 1
 # name: TestEvents.test_event_property_values
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: TestEvents.test_event_property_values.1
-  '''
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
   FROM events
@@ -23,7 +11,7 @@
   LIMIT 10
   '''
 # ---
-# name: TestEvents.test_event_property_values.2
+# name: TestEvents.test_event_property_values.1
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
@@ -37,7 +25,7 @@
   LIMIT 10
   '''
 # ---
-# name: TestEvents.test_event_property_values.3
+# name: TestEvents.test_event_property_values.2
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
@@ -51,7 +39,7 @@
   LIMIT 10
   '''
 # ---
-# name: TestEvents.test_event_property_values.4
+# name: TestEvents.test_event_property_values.3
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
@@ -65,7 +53,7 @@
   LIMIT 10
   '''
 # ---
-# name: TestEvents.test_event_property_values.5
+# name: TestEvents.test_event_property_values.4
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
@@ -80,7 +68,7 @@
   LIMIT 10
   '''
 # ---
-# name: TestEvents.test_event_property_values.6
+# name: TestEvents.test_event_property_values.5
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
@@ -92,6 +80,21 @@
     AND (event = 'foo'
          OR event = 'random event')
     AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%6%'
+  order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
+  LIMIT 10
+  '''
+# ---
+# name: TestEvents.test_event_property_values.6
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT DISTINCT replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '')
+  FROM events
+  WHERE team_id = 99999
+    AND JSONHas(properties, 'random_prop')
+    AND timestamp >= '2020-01-13 00:00:00'
+    AND timestamp <= '2020-01-20 23:59:59'
+    AND (event = '404_i_dont_exist')
+    AND replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', '') ILIKE '%qw%'
   order by length(replaceRegexpAll(JSONExtractRaw(properties, 'random_prop'), '^"|"$', ''))
   LIMIT 10
   '''
@@ -113,18 +116,6 @@
 # ---
 # name: TestEvents.test_event_property_values_materialized
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: TestEvents.test_event_property_values_materialized.1
-  '''
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT "mat_random_prop"
   FROM events
@@ -135,7 +126,7 @@
   LIMIT 10
   '''
 # ---
-# name: TestEvents.test_event_property_values_materialized.2
+# name: TestEvents.test_event_property_values_materialized.1
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT "mat_random_prop"
@@ -149,7 +140,7 @@
   LIMIT 10
   '''
 # ---
-# name: TestEvents.test_event_property_values_materialized.3
+# name: TestEvents.test_event_property_values_materialized.2
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT "mat_random_prop"
@@ -163,7 +154,7 @@
   LIMIT 10
   '''
 # ---
-# name: TestEvents.test_event_property_values_materialized.4
+# name: TestEvents.test_event_property_values_materialized.3
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT "mat_random_prop"
@@ -177,7 +168,7 @@
   LIMIT 10
   '''
 # ---
-# name: TestEvents.test_event_property_values_materialized.5
+# name: TestEvents.test_event_property_values_materialized.4
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT "mat_random_prop"
@@ -192,7 +183,7 @@
   LIMIT 10
   '''
 # ---
-# name: TestEvents.test_event_property_values_materialized.6
+# name: TestEvents.test_event_property_values_materialized.5
   '''
   /* user_id:0 request:_snapshot_ */
   SELECT DISTINCT "mat_random_prop"
@@ -204,6 +195,21 @@
     AND (event = 'foo'
          OR event = 'random event')
     AND "mat_random_prop" ILIKE '%6%'
+  order by length("mat_random_prop")
+  LIMIT 10
+  '''
+# ---
+# name: TestEvents.test_event_property_values_materialized.6
+  '''
+  /* user_id:0 request:_snapshot_ */
+  SELECT DISTINCT "mat_random_prop"
+  FROM events
+  WHERE team_id = 99999
+    AND notEmpty("mat_random_prop")
+    AND timestamp >= '2020-01-13 00:00:00'
+    AND timestamp <= '2020-01-20 23:59:59'
+    AND (event = '404_i_dont_exist')
+    AND "mat_random_prop" ILIKE '%qw%'
   order by length("mat_random_prop")
   LIMIT 10
   '''

--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -1313,7 +1313,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
                     "effective_privilege_level": 37,
                     "effective_restriction_level": 21,
                     "favorited": False,
-                    "filters": {"filter_test_accounts": True},
+                    "filters": {},
                     "filters_hash": ANY,
                     "hasMore": None,
                     "id": ANY,

--- a/posthog/api/test/test_feature_flag.py
+++ b/posthog/api/test/test_feature_flag.py
@@ -1463,73 +1463,91 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertEqual(len(tiles), 2)
         self.assertEqual(tiles[0].insight.name, "Feature Flag Called Total Volume")
         self.assertEqual(
-            tiles[0].insight.filters,
+            tiles[0].insight.query,
             {
-                "events": [
-                    {
-                        "id": "$feature_flag_called",
-                        "name": "$feature_flag_called",
-                        "type": "events",
-                    }
-                ],
-                "display": "ActionsLineGraph",
-                "insight": "TRENDS",
-                "interval": "day",
-                "breakdown": "$feature_flag_response",
-                "date_from": "-30d",
-                "properties": {
-                    "type": "AND",
-                    "values": [
-                        {
-                            "type": "AND",
-                            "values": [
-                                {
-                                    "key": "$feature_flag",
-                                    "type": "event",
-                                    "value": "alpha-feature",
-                                }
-                            ],
-                        }
-                    ],
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "name": "$feature_flag_called", "event": "$feature_flag_called"}],
+                    "interval": "day",
+                    "dateRange": {"date_from": "-30d", "explicitDate": False},
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "key": "$feature_flag",
+                                        "type": "event",
+                                        "value": "alpha-feature",
+                                        "operator": "exact",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    "trendsFilter": {
+                        "display": "ActionsLineGraph",
+                        "showLegend": False,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": False,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": False,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": False,
+                    },
+                    "breakdownFilter": {"breakdown": "$feature_flag_response", "breakdown_type": "event"},
+                    "filterTestAccounts": False,
                 },
-                "breakdown_type": "event",
-                "filter_test_accounts": False,
             },
         )
         self.assertEqual(tiles[1].insight.name, "Feature Flag calls made by unique users per variant")
         self.assertEqual(
-            tiles[1].insight.filters,
+            tiles[1].insight.query,
             {
-                "events": [
-                    {
-                        "id": "$feature_flag_called",
-                        "math": "dau",
-                        "name": "$feature_flag_called",
-                        "type": "events",
-                    }
-                ],
-                "display": "ActionsTable",
-                "insight": "TRENDS",
-                "interval": "day",
-                "breakdown": "$feature_flag_response",
-                "date_from": "-30d",
-                "properties": {
-                    "type": "AND",
-                    "values": [
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
                         {
-                            "type": "AND",
-                            "values": [
-                                {
-                                    "key": "$feature_flag",
-                                    "type": "event",
-                                    "value": "alpha-feature",
-                                }
-                            ],
+                            "kind": "EventsNode",
+                            "math": "dau",
+                            "name": "$feature_flag_called",
+                            "event": "$feature_flag_called",
                         }
                     ],
+                    "interval": "day",
+                    "dateRange": {"date_from": "-30d", "explicitDate": False},
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "key": "$feature_flag",
+                                        "type": "event",
+                                        "value": "alpha-feature",
+                                        "operator": "exact",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    "trendsFilter": {
+                        "display": "ActionsTable",
+                        "showLegend": False,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": False,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": False,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": False,
+                    },
+                    "breakdownFilter": {"breakdown": "$feature_flag_response", "breakdown_type": "event"},
+                    "filterTestAccounts": False,
                 },
-                "breakdown_type": "event",
-                "filter_test_accounts": False,
             },
         )
 
@@ -1557,153 +1575,191 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         self.assertEqual(len(tiles), 4)
         self.assertEqual(tiles[0].insight.name, "Feature Flag Called Total Volume")
         self.assertEqual(
-            tiles[0].insight.filters,
+            tiles[0].insight.query,
             {
-                "events": [
-                    {
-                        "id": "$feature_flag_called",
-                        "name": "$feature_flag_called",
-                        "type": "events",
-                    }
-                ],
-                "display": "ActionsLineGraph",
-                "insight": "TRENDS",
-                "interval": "day",
-                "breakdown": "$feature_flag_response",
-                "date_from": "-30d",
-                "properties": {
-                    "type": "AND",
-                    "values": [
-                        {
-                            "type": "AND",
-                            "values": [
-                                {
-                                    "key": "$feature_flag",
-                                    "type": "event",
-                                    "value": "alpha-feature",
-                                }
-                            ],
-                        }
-                    ],
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [{"kind": "EventsNode", "name": "$feature_flag_called", "event": "$feature_flag_called"}],
+                    "interval": "day",
+                    "dateRange": {"date_from": "-30d", "explicitDate": False},
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "key": "$feature_flag",
+                                        "type": "event",
+                                        "value": "alpha-feature",
+                                        "operator": "exact",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    "trendsFilter": {
+                        "display": "ActionsLineGraph",
+                        "showLegend": False,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": False,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": False,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": False,
+                    },
+                    "breakdownFilter": {"breakdown": "$feature_flag_response", "breakdown_type": "event"},
+                    "filterTestAccounts": False,
                 },
-                "breakdown_type": "event",
-                "filter_test_accounts": False,
             },
         )
         self.assertEqual(tiles[1].insight.name, "Feature Flag calls made by unique users per variant")
         self.assertEqual(
-            tiles[1].insight.filters,
+            tiles[1].insight.query,
             {
-                "events": [
-                    {
-                        "id": "$feature_flag_called",
-                        "math": "dau",
-                        "name": "$feature_flag_called",
-                        "type": "events",
-                    }
-                ],
-                "display": "ActionsTable",
-                "insight": "TRENDS",
-                "interval": "day",
-                "breakdown": "$feature_flag_response",
-                "date_from": "-30d",
-                "properties": {
-                    "type": "AND",
-                    "values": [
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
                         {
-                            "type": "AND",
-                            "values": [
-                                {
-                                    "key": "$feature_flag",
-                                    "type": "event",
-                                    "value": "alpha-feature",
-                                }
-                            ],
+                            "kind": "EventsNode",
+                            "math": "dau",
+                            "name": "$feature_flag_called",
+                            "event": "$feature_flag_called",
                         }
                     ],
+                    "interval": "day",
+                    "dateRange": {"date_from": "-30d", "explicitDate": False},
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "key": "$feature_flag",
+                                        "type": "event",
+                                        "value": "alpha-feature",
+                                        "operator": "exact",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    "trendsFilter": {
+                        "display": "ActionsTable",
+                        "showLegend": False,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": False,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": False,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": False,
+                    },
+                    "breakdownFilter": {"breakdown": "$feature_flag_response", "breakdown_type": "event"},
+                    "filterTestAccounts": False,
                 },
-                "breakdown_type": "event",
-                "filter_test_accounts": False,
             },
         )
 
         # enriched insights
         self.assertEqual(tiles[2].insight.name, "Feature Interaction Total Volume")
         self.assertEqual(
-            tiles[2].insight.filters,
+            tiles[2].insight.query,
             {
-                "events": [
-                    {
-                        "id": "$feature_interaction",
-                        "name": "Feature Interaction - Total",
-                        "type": "events",
-                    },
-                    {
-                        "id": "$feature_interaction",
-                        "math": "dau",
-                        "name": "Feature Interaction - Unique users",
-                        "type": "events",
-                    },
-                ],
-                "display": "ActionsLineGraph",
-                "insight": "TRENDS",
-                "interval": "day",
-                "date_from": "-30d",
-                "properties": {
-                    "type": "AND",
-                    "values": [
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {"kind": "EventsNode", "name": "Feature Interaction - Total", "event": "$feature_interaction"},
                         {
-                            "type": "AND",
-                            "values": [
-                                {
-                                    "key": "feature_flag",
-                                    "type": "event",
-                                    "value": "alpha-feature",
-                                }
-                            ],
-                        }
+                            "kind": "EventsNode",
+                            "math": "dau",
+                            "name": "Feature Interaction - Unique users",
+                            "event": "$feature_interaction",
+                        },
                     ],
+                    "interval": "day",
+                    "dateRange": {"date_from": "-30d", "explicitDate": False},
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "key": "feature_flag",
+                                        "type": "event",
+                                        "value": "alpha-feature",
+                                        "operator": "exact",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    "trendsFilter": {
+                        "display": "ActionsLineGraph",
+                        "showLegend": False,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": False,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": False,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": False,
+                    },
+                    "breakdownFilter": {"breakdown_type": "event"},
+                    "filterTestAccounts": False,
                 },
-                "filter_test_accounts": False,
             },
         )
         self.assertEqual(tiles[3].insight.name, "Feature Viewed Total Volume")
         self.assertEqual(
-            tiles[3].insight.filters,
+            tiles[3].insight.query,
             {
-                "events": [
-                    {
-                        "id": "$feature_view",
-                        "name": "Feature View - Total",
-                        "type": "events",
-                    },
-                    {
-                        "id": "$feature_view",
-                        "math": "dau",
-                        "name": "Feature View - Unique users",
-                        "type": "events",
-                    },
-                ],
-                "display": "ActionsLineGraph",
-                "insight": "TRENDS",
-                "interval": "day",
-                "date_from": "-30d",
-                "properties": {
-                    "type": "AND",
-                    "values": [
+                "kind": "InsightVizNode",
+                "source": {
+                    "kind": "TrendsQuery",
+                    "series": [
+                        {"kind": "EventsNode", "name": "Feature View - Total", "event": "$feature_view"},
                         {
-                            "type": "AND",
-                            "values": [
-                                {
-                                    "key": "feature_flag",
-                                    "type": "event",
-                                    "value": "alpha-feature",
-                                }
-                            ],
-                        }
+                            "kind": "EventsNode",
+                            "math": "dau",
+                            "name": "Feature View - Unique users",
+                            "event": "$feature_view",
+                        },
                     ],
+                    "interval": "day",
+                    "dateRange": {"date_from": "-30d", "explicitDate": False},
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "key": "feature_flag",
+                                        "type": "event",
+                                        "value": "alpha-feature",
+                                        "operator": "exact",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    "trendsFilter": {
+                        "display": "ActionsLineGraph",
+                        "showLegend": False,
+                        "yAxisScaleType": "linear",
+                        "showValuesOnSeries": False,
+                        "smoothingIntervals": 1,
+                        "showPercentStackView": False,
+                        "aggregationAxisFormat": "numeric",
+                        "showAlertThresholdLines": False,
+                    },
+                    "breakdownFilter": {"breakdown_type": "event"},
+                    "filterTestAccounts": False,
                 },
-                "filter_test_accounts": False,
             },
         )
 

--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -36,19 +36,25 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         dashboard,
         name="Website Unique Users (Total)",
         description="Shows the number of unique users that use your app every day.",
-        filters={
-            "events": [
-                {
-                    "id": "$pageview",
-                    "math": "dau",
-                    "type": "events",
-                }
-            ],
+        query={
+            "breakdownFilter": {"breakdown_type": "event"},
+            "compareFilter": {"compare": True},
+            "dateRange": {"date_from": "-30d", "explicitDate": False},
+            "filterTestAccounts": False,
             "interval": "day",
-            "insight": "TRENDS",
-            "date_from": "-30d",
-            "display": "BoldNumber",
-            "compare": True,
+            "kind": "TrendsQuery",
+            "properties": [],
+            "series": [{"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"}],
+            "trendsFilter": {
+                "aggregationAxisFormat": "numeric",
+                "display": "BoldNumber",
+                "showAlertThresholdLines": False,
+                "showLegend": False,
+                "showPercentStackView": False,
+                "showValuesOnSeries": False,
+                "smoothingIntervals": 1,
+                "yAxisScaleType": "linear",
+            },
         },
         layouts={
             "sm": {"i": "21", "x": 0, "y": 0, "w": 6, "h": 5, "minW": 3, "minH": 5},
@@ -69,40 +75,35 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         dashboard,
         name="Organic SEO Unique Users (Total)",
         description="",
-        filters={
-            "events": [
-                {
-                    "id": "$pageview",
-                    "math": "dau",
-                    "type": "events",
-                }
-            ],
+        query={
+            "breakdownFilter": {"breakdown_type": "event"},
+            "compareFilter": {"compare": True},
+            "dateRange": {"date_from": "-30d", "explicitDate": False},
+            "filterTestAccounts": False,
             "interval": "day",
-            "insight": "TRENDS",
-            "date_from": "-30d",
-            "display": "BoldNumber",
-            "compare": True,
+            "kind": "TrendsQuery",
             "properties": {
                 "type": "AND",
                 "values": [
                     {
                         "type": "AND",
                         "values": [
-                            {
-                                "key": "$referring_domain",
-                                "type": "event",
-                                "value": "google",
-                                "operator": "icontains",
-                            },
-                            {
-                                "key": "utm_source",
-                                "type": "event",
-                                "value": "is_not_set",
-                                "operator": "is_not_set",
-                            },
+                            {"key": "$referring_domain", "operator": "icontains", "type": "event", "value": "google"},
+                            {"key": "utm_source", "operator": "is_not_set", "type": "event", "value": "is_not_set"},
                         ],
                     }
                 ],
+            },
+            "series": [{"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"}],
+            "trendsFilter": {
+                "aggregationAxisFormat": "numeric",
+                "display": "BoldNumber",
+                "showAlertThresholdLines": False,
+                "showLegend": False,
+                "showPercentStackView": False,
+                "showValuesOnSeries": False,
+                "smoothingIntervals": 1,
+                "yAxisScaleType": "linear",
             },
         },
         layouts={
@@ -125,18 +126,24 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         dashboard,
         name="Website Unique Users (Breakdown)",
         description="",
-        filters={
-            "events": [
-                {
-                    "id": "$pageview",
-                    "math": "dau",
-                    "type": "events",
-                }
-            ],
+        query={
+            "breakdownFilter": {"breakdown_type": "event"},
+            "dateRange": {"date_from": "-30d", "explicitDate": False},
+            "filterTestAccounts": False,
             "interval": "week",
-            "insight": "TRENDS",
-            "date_from": "-30d",
-            "display": "ActionsBar",
+            "kind": "TrendsQuery",
+            "properties": [],
+            "series": [{"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"}],
+            "trendsFilter": {
+                "aggregationAxisFormat": "numeric",
+                "display": "ActionsBar",
+                "showAlertThresholdLines": False,
+                "showLegend": False,
+                "showPercentStackView": False,
+                "showValuesOnSeries": False,
+                "smoothingIntervals": 1,
+                "yAxisScaleType": "linear",
+            },
         },
         layouts={
             "sm": {"i": "23", "x": 0, "y": 5, "w": 6, "h": 5, "minW": 3, "minH": 5},
@@ -157,32 +164,35 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         dashboard,
         name="Organic SEO Unique Users (Breakdown)",
         description="",
-        filters={
-            "events": [
+        query={
+            "breakdownFilter": {"breakdown_type": "event"},
+            "dateRange": {"date_from": "-30d", "explicitDate": False},
+            "filterTestAccounts": False,
+            "interval": "week",
+            "kind": "TrendsQuery",
+            "properties": [],
+            "series": [
                 {
-                    "id": "$pageview",
+                    "event": "$pageview",
+                    "kind": "EventsNode",
                     "math": "dau",
-                    "type": "events",
+                    "name": "$pageview",
                     "properties": [
-                        {
-                            "key": "$referring_domain",
-                            "type": "event",
-                            "value": "google",
-                            "operator": "icontains",
-                        },
-                        {
-                            "key": "utm_source",
-                            "type": "event",
-                            "value": "is_not_set",
-                            "operator": "is_not_set",
-                        },
+                        {"key": "$referring_domain", "operator": "icontains", "type": "event", "value": "google"},
+                        {"key": "utm_source", "operator": "is_not_set", "type": "event", "value": "is_not_set"},
                     ],
                 }
             ],
-            "interval": "week",
-            "insight": "TRENDS",
-            "date_from": "-30d",
-            "display": "ActionsBar",
+            "trendsFilter": {
+                "aggregationAxisFormat": "numeric",
+                "display": "ActionsBar",
+                "showAlertThresholdLines": False,
+                "showLegend": False,
+                "showPercentStackView": False,
+                "showValuesOnSeries": False,
+                "smoothingIntervals": 1,
+                "yAxisScaleType": "linear",
+            },
         },
         layouts={
             "sm": {"i": "24", "x": 6, "y": 5, "w": 6, "h": 5, "minW": 3, "minH": 5},
@@ -197,30 +207,28 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         dashboard,
         name="Sessions Per User",
         description="",
-        filters={
-            "events": [
-                {
-                    "id": "$pageview",
-                    "math": "dau",
-                    "name": "$pageview",
-                    "type": "events",
-                    "order": 0,
-                    "properties": [],
-                },
-                {
-                    "id": "$pageview",
-                    "math": "unique_session",
-                    "name": "$pageview",
-                    "type": "events",
-                    "order": 1,
-                    "properties": [],
-                },
-            ],
+        query={
+            "breakdownFilter": {"breakdown_type": "event"},
+            "dateRange": {"date_from": "-30d", "explicitDate": False},
+            "filterTestAccounts": False,
             "interval": "week",
-            "insight": "TRENDS",
-            "date_from": "-30d",
-            "display": "ActionsLineGraph",
-            "formula": "B/A",
+            "kind": "TrendsQuery",
+            "properties": [],
+            "series": [
+                {"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"},
+                {"event": "$pageview", "kind": "EventsNode", "math": "unique_session", "name": "$pageview"},
+            ],
+            "trendsFilter": {
+                "aggregationAxisFormat": "numeric",
+                "display": "ActionsLineGraph",
+                "formula": "B/A",
+                "showAlertThresholdLines": False,
+                "showLegend": False,
+                "showPercentStackView": False,
+                "showValuesOnSeries": False,
+                "smoothingIntervals": 1,
+                "yAxisScaleType": "linear",
+            },
         },
         layouts={
             "sm": {"i": "25", "x": 0, "y": 10, "w": 6, "h": 5, "minW": 3, "minH": 5},
@@ -241,30 +249,28 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         dashboard,
         name="Pages Per User",
         description="",
-        filters={
-            "events": [
-                {
-                    "id": "$pageview",
-                    "math": "total",
-                    "name": "$pageview",
-                    "type": "events",
-                    "order": 0,
-                    "properties": [],
-                },
-                {
-                    "id": "$pageview",
-                    "math": "dau",
-                    "name": "$pageview",
-                    "type": "events",
-                    "order": 1,
-                    "properties": [],
-                },
-            ],
+        query={
+            "breakdownFilter": {"breakdown_type": "event"},
+            "dateRange": {"date_from": "-30d", "explicitDate": False},
+            "filterTestAccounts": False,
             "interval": "week",
-            "insight": "TRENDS",
-            "date_from": "-30d",
-            "display": "ActionsLineGraph",
-            "formula": "A/B",
+            "kind": "TrendsQuery",
+            "properties": [],
+            "series": [
+                {"event": "$pageview", "kind": "EventsNode", "math": "total", "name": "$pageview"},
+                {"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"},
+            ],
+            "trendsFilter": {
+                "aggregationAxisFormat": "numeric",
+                "display": "ActionsLineGraph",
+                "formula": "A/B",
+                "showAlertThresholdLines": False,
+                "showLegend": False,
+                "showPercentStackView": False,
+                "showValuesOnSeries": False,
+                "smoothingIntervals": 1,
+                "yAxisScaleType": "linear",
+            },
         },
         layouts={
             "sm": {"i": "26", "x": 6, "y": 10, "w": 6, "h": 5, "minW": 3, "minH": 5},
@@ -287,37 +293,31 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         dashboard,
         name="Top Website Pages (Overall)",
         description="",
-        filters={
-            "events": [
-                {
-                    "id": "$pageview",
-                    "math": "unique_session",
-                    "name": "$pageview",
-                    "type": "events",
-                    "order": 0,
-                }
-            ],
+        query={
+            "breakdownFilter": {"breakdown": "$current_url", "breakdown_type": "event"},
+            "dateRange": {"date_from": "-30d", "explicitDate": False},
+            "filterTestAccounts": False,
             "interval": "day",
-            "insight": "TRENDS",
-            "date_from": "-30d",
-            "display": "ActionsBarValue",
-            "breakdown": "$current_url",
-            "breakdown_type": "event",
+            "kind": "TrendsQuery",
             "properties": {
                 "type": "AND",
                 "values": [
                     {
                         "type": "AND",
-                        "values": [
-                            {
-                                "key": "$current_url",
-                                "type": "event",
-                                "value": "?",
-                                "operator": "not_icontains",
-                            }
-                        ],
+                        "values": [{"key": "$current_url", "operator": "not_icontains", "type": "event", "value": "?"}],
                     }
                 ],
+            },
+            "series": [{"event": "$pageview", "kind": "EventsNode", "math": "unique_session", "name": "$pageview"}],
+            "trendsFilter": {
+                "aggregationAxisFormat": "numeric",
+                "display": "ActionsBarValue",
+                "showAlertThresholdLines": False,
+                "showLegend": False,
+                "showPercentStackView": False,
+                "showValuesOnSeries": False,
+                "smoothingIntervals": 1,
+                "yAxisScaleType": "linear",
             },
         },
         layouts={
@@ -339,43 +339,34 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         dashboard,
         name="Top Website Pages (via Google)",
         description="",
-        filters={
-            "events": [
-                {
-                    "id": "$pageview",
-                    "math": "unique_session",
-                    "name": "$pageview",
-                    "type": "events",
-                    "order": 0,
-                }
-            ],
+        query={
+            "breakdownFilter": {"breakdown": "$current_url", "breakdown_type": "event"},
+            "dateRange": {"date_from": "-30d", "explicitDate": False},
+            "filterTestAccounts": False,
             "interval": "day",
-            "insight": "TRENDS",
-            "date_from": "-30d",
-            "display": "ActionsBarValue",
-            "breakdown": "$current_url",
-            "breakdown_type": "event",
+            "kind": "TrendsQuery",
             "properties": {
                 "type": "AND",
                 "values": [
                     {
                         "type": "AND",
                         "values": [
-                            {
-                                "key": "$current_url",
-                                "type": "event",
-                                "value": "?",
-                                "operator": "not_icontains",
-                            },
-                            {
-                                "key": "$referring_domain",
-                                "type": "event",
-                                "value": "google",
-                                "operator": "icontains",
-                            },
+                            {"key": "$current_url", "operator": "not_icontains", "type": "event", "value": "?"},
+                            {"key": "$referring_domain", "operator": "icontains", "type": "event", "value": "google"},
                         ],
                     }
                 ],
+            },
+            "series": [{"event": "$pageview", "kind": "EventsNode", "math": "unique_session", "name": "$pageview"}],
+            "trendsFilter": {
+                "aggregationAxisFormat": "numeric",
+                "display": "ActionsBarValue",
+                "showAlertThresholdLines": False,
+                "showLegend": False,
+                "showPercentStackView": False,
+                "showValuesOnSeries": False,
+                "smoothingIntervals": 1,
+                "yAxisScaleType": "linear",
             },
         },
         layouts={
@@ -391,22 +382,24 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         dashboard,
         name="Website Users by Location",
         description="",
-        filters={
-            "events": [
-                {
-                    "id": "$pageview",
-                    "math": "dau",
-                    "name": "$pageview",
-                    "type": "events",
-                    "order": 0,
-                }
-            ],
+        query={
+            "breakdownFilter": {"breakdown": "$geoip_country_code", "breakdown_type": "person"},
+            "dateRange": {"date_from": "-30d", "explicitDate": False},
+            "filterTestAccounts": False,
             "interval": "day",
-            "insight": "TRENDS",
-            "date_from": "-30d",
-            "display": "WorldMap",
-            "breakdown": "$geoip_country_code",
-            "breakdown_type": "person",
+            "kind": "TrendsQuery",
+            "properties": [],
+            "series": [{"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"}],
+            "trendsFilter": {
+                "aggregationAxisFormat": "numeric",
+                "display": "WorldMap",
+                "showAlertThresholdLines": False,
+                "showLegend": False,
+                "showPercentStackView": False,
+                "showValuesOnSeries": False,
+                "smoothingIntervals": 1,
+                "yAxisScaleType": "linear",
+            },
         },
         layouts={
             "sm": {"i": "29", "x": 0, "y": 23, "w": 12, "h": 8, "minW": 3, "minH": 5},
@@ -492,10 +485,10 @@ def _create_tile_for_text(dashboard: Dashboard, body: str, layouts: dict, color:
 def _create_tile_for_insight(
     dashboard: Dashboard,
     name: str,
-    filters: dict,
     description: str,
     layouts: dict,
     color: Optional[str],
+    filters: Optional[dict] = None,
     query: Optional[dict] = None,
 ) -> None:
     filter_test_accounts = filters.get("filter_test_accounts", True)
@@ -503,7 +496,7 @@ def _create_tile_for_insight(
         team=dashboard.team,
         name=name,
         description=description,
-        filters={**filters, "filter_test_accounts": filter_test_accounts},
+        filters=None if filters is None else {**filters, "filter_test_accounts": filter_test_accounts},
         is_sample=True,
         query=query,
     )
@@ -546,36 +539,34 @@ def create_feature_flag_dashboard(feature_flag, dashboard: Dashboard) -> None:
         dashboard,
         name="Feature Flag Called Total Volume",
         description="Shows the number of total calls made on feature flag with key: " + feature_flag.key,
-        filters={
-            "events": [
-                {
-                    "id": "$feature_flag_called",
-                    "name": "$feature_flag_called",
-                    "type": "events",
-                }
-            ],
+        query={
+            "breakdownFilter": {"breakdown": "$feature_flag_response", "breakdown_type": "event"},
+            "dateRange": {"date_from": "-30d", "explicitDate": False},
+            "filterTestAccounts": False,
             "interval": "day",
-            "insight": "TRENDS",
-            "date_from": "-30d",
-            "display": "ActionsLineGraph",
+            "kind": "TrendsQuery",
             "properties": {
                 "type": "AND",
                 "values": [
                     {
                         "type": "AND",
                         "values": [
-                            {
-                                "key": "$feature_flag",
-                                "type": "event",
-                                "value": feature_flag.key,
-                            },
+                            {"key": "$feature_flag", "operator": "exact", "type": "event", "value": feature_flag.key}
                         ],
                     }
                 ],
             },
-            "breakdown": "$feature_flag_response",
-            "breakdown_type": "event",
-            "filter_test_accounts": False,
+            "series": [{"event": "$feature_flag_called", "kind": "EventsNode", "name": "$feature_flag_called"}],
+            "trendsFilter": {
+                "aggregationAxisFormat": "numeric",
+                "display": "ActionsLineGraph",
+                "showAlertThresholdLines": False,
+                "showLegend": False,
+                "showPercentStackView": False,
+                "showValuesOnSeries": False,
+                "smoothingIntervals": 1,
+                "yAxisScaleType": "linear",
+            },
         },
         layouts={
             "sm": {"i": "21", "x": 0, "y": 0, "w": 6, "h": 5, "minW": 3, "minH": 5},
@@ -597,37 +588,36 @@ def create_feature_flag_dashboard(feature_flag, dashboard: Dashboard) -> None:
         name="Feature Flag calls made by unique users per variant",
         description="Shows the number of unique user calls made on feature flag per variant with key: "
         + feature_flag.key,
-        filters={
-            "events": [
-                {
-                    "id": "$feature_flag_called",
-                    "name": "$feature_flag_called",
-                    "math": "dau",
-                    "type": "events",
-                }
-            ],
+        query={
+            "breakdownFilter": {"breakdown": "$feature_flag_response", "breakdown_type": "event"},
+            "dateRange": {"date_from": "-30d", "explicitDate": False},
+            "filterTestAccounts": False,
             "interval": "day",
-            "insight": "TRENDS",
-            "date_from": "-30d",
-            "display": "ActionsTable",
+            "kind": "TrendsQuery",
             "properties": {
                 "type": "AND",
                 "values": [
                     {
                         "type": "AND",
                         "values": [
-                            {
-                                "key": "$feature_flag",
-                                "type": "event",
-                                "value": feature_flag.key,
-                            },
+                            {"key": "$feature_flag", "operator": "exact", "type": "event", "value": feature_flag.key}
                         ],
                     }
                 ],
             },
-            "breakdown": "$feature_flag_response",
-            "breakdown_type": "event",
-            "filter_test_accounts": False,
+            "series": [
+                {"event": "$feature_flag_called", "kind": "EventsNode", "math": "dau", "name": "$feature_flag_called"}
+            ],
+            "trendsFilter": {
+                "aggregationAxisFormat": "numeric",
+                "display": "ActionsTable",
+                "showAlertThresholdLines": False,
+                "showLegend": False,
+                "showPercentStackView": False,
+                "showValuesOnSeries": False,
+                "smoothingIntervals": 1,
+                "yAxisScaleType": "linear",
+            },
         },
         layouts={
             "sm": {"i": "22", "x": 6, "y": 0, "w": 6, "h": 5, "minW": 3, "minH": 5},
@@ -651,40 +641,37 @@ def add_enriched_insights_to_feature_flag_dashboard(feature_flag, dashboard: Das
         dashboard,
         name=f"{ENRICHED_DASHBOARD_INSIGHT_IDENTIFIER} Total Volume",
         description="Shows the total number of times this feature was viewed and interacted with",
-        filters={
-            "events": [
-                {
-                    "id": "$feature_view",
-                    "name": "Feature View - Total",
-                    "type": "events",
-                },
-                {
-                    "id": "$feature_view",
-                    "name": "Feature View - Unique users",
-                    "type": "events",
-                    "math": "dau",
-                },
-            ],
+        query={
+            "breakdownFilter": {"breakdown_type": "event"},
+            "dateRange": {"date_from": "-30d", "explicitDate": False},
+            "filterTestAccounts": False,
             "interval": "day",
-            "insight": "TRENDS",
-            "date_from": "-30d",
-            "display": "ActionsLineGraph",
+            "kind": "TrendsQuery",
             "properties": {
                 "type": "AND",
                 "values": [
                     {
                         "type": "AND",
                         "values": [
-                            {
-                                "key": "feature_flag",
-                                "type": "event",
-                                "value": feature_flag.key,
-                            },
+                            {"key": "feature_flag", "operator": "exact", "type": "event", "value": feature_flag.key}
                         ],
                     }
                 ],
             },
-            "filter_test_accounts": False,
+            "series": [
+                {"event": "$feature_view", "kind": "EventsNode", "name": "Feature View - Total"},
+                {"event": "$feature_view", "kind": "EventsNode", "math": "dau", "name": "Feature View - Unique users"},
+            ],
+            "trendsFilter": {
+                "aggregationAxisFormat": "numeric",
+                "display": "ActionsLineGraph",
+                "showAlertThresholdLines": False,
+                "showLegend": False,
+                "showPercentStackView": False,
+                "showValuesOnSeries": False,
+                "smoothingIntervals": 1,
+                "yAxisScaleType": "linear",
+            },
         },
         layouts={},
         color=None,
@@ -694,40 +681,42 @@ def add_enriched_insights_to_feature_flag_dashboard(feature_flag, dashboard: Das
         dashboard,
         name="Feature Interaction Total Volume",
         description="Shows the total number of times this feature was viewed and interacted with",
-        filters={
-            "events": [
-                {
-                    "id": "$feature_interaction",
-                    "name": "Feature Interaction - Total",
-                    "type": "events",
-                },
-                {
-                    "id": "$feature_interaction",
-                    "name": "Feature Interaction - Unique users",
-                    "type": "events",
-                    "math": "dau",
-                },
-            ],
+        query={
+            "breakdownFilter": {"breakdown_type": "event"},
+            "dateRange": {"date_from": "-30d", "explicitDate": False},
+            "filterTestAccounts": False,
             "interval": "day",
-            "insight": "TRENDS",
-            "date_from": "-30d",
-            "display": "ActionsLineGraph",
+            "kind": "TrendsQuery",
             "properties": {
                 "type": "AND",
                 "values": [
                     {
                         "type": "AND",
                         "values": [
-                            {
-                                "key": "feature_flag",
-                                "type": "event",
-                                "value": feature_flag.key,
-                            },
+                            {"key": "feature_flag", "operator": "exact", "type": "event", "value": feature_flag.key}
                         ],
                     }
                 ],
             },
-            "filter_test_accounts": False,
+            "series": [
+                {"event": "$feature_interaction", "kind": "EventsNode", "name": "Feature Interaction - Total"},
+                {
+                    "event": "$feature_interaction",
+                    "kind": "EventsNode",
+                    "math": "dau",
+                    "name": "Feature Interaction - Unique users",
+                },
+            ],
+            "trendsFilter": {
+                "aggregationAxisFormat": "numeric",
+                "display": "ActionsLineGraph",
+                "showAlertThresholdLines": False,
+                "showLegend": False,
+                "showPercentStackView": False,
+                "showValuesOnSeries": False,
+                "smoothingIntervals": 1,
+                "yAxisScaleType": "linear",
+            },
         },
         layouts={},
         color=None,

--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -448,11 +448,9 @@ def create_from_template(dashboard: Dashboard, template: DashboardTemplate) -> N
     for template_tile in template.tiles:
         if template_tile["type"] == "insight":
             query = template_tile.get("query", None)
-            filters = template_tile.get("filters") if not query else {}
             _create_tile_for_insight(
                 dashboard,
                 name=template_tile.get("name"),
-                filters=filters,
                 query=query,
                 description=template_tile.get("description"),
                 color=template_tile.get("color"),
@@ -488,15 +486,12 @@ def _create_tile_for_insight(
     description: str,
     layouts: dict,
     color: Optional[str],
-    filters: Optional[dict] = None,
     query: Optional[dict] = None,
 ) -> None:
-    filter_test_accounts = filters.get("filter_test_accounts", True)
     insight = Insight.objects.create(
         team=dashboard.team,
         name=name,
         description=description,
-        filters=None if filters is None else {**filters, "filter_test_accounts": filter_test_accounts},
         is_sample=True,
         query=query,
     )

--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -37,23 +37,26 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Website Unique Users (Total)",
         description="Shows the number of unique users that use your app every day.",
         query={
-            "breakdownFilter": {"breakdown_type": "event"},
-            "compareFilter": {"compare": True},
-            "dateRange": {"date_from": "-30d", "explicitDate": False},
-            "filterTestAccounts": False,
-            "interval": "day",
-            "kind": "TrendsQuery",
-            "properties": [],
-            "series": [{"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"}],
-            "trendsFilter": {
-                "aggregationAxisFormat": "numeric",
-                "display": "BoldNumber",
-                "showAlertThresholdLines": False,
-                "showLegend": False,
-                "showPercentStackView": False,
-                "showValuesOnSeries": False,
-                "smoothingIntervals": 1,
-                "yAxisScaleType": "linear",
+            "kind": "InsightVizNode",
+            "source": {
+                "breakdownFilter": {"breakdown_type": "event"},
+                "compareFilter": {"compare": True},
+                "dateRange": {"date_from": "-30d", "explicitDate": False},
+                "filterTestAccounts": False,
+                "interval": "day",
+                "kind": "TrendsQuery",
+                "properties": [],
+                "series": [{"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"}],
+                "trendsFilter": {
+                    "aggregationAxisFormat": "numeric",
+                    "display": "BoldNumber",
+                    "showAlertThresholdLines": False,
+                    "showLegend": False,
+                    "showPercentStackView": False,
+                    "showValuesOnSeries": False,
+                    "smoothingIntervals": 1,
+                    "yAxisScaleType": "linear",
+                },
             },
         },
         layouts={
@@ -76,34 +79,42 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Organic SEO Unique Users (Total)",
         description="",
         query={
-            "breakdownFilter": {"breakdown_type": "event"},
-            "compareFilter": {"compare": True},
-            "dateRange": {"date_from": "-30d", "explicitDate": False},
-            "filterTestAccounts": False,
-            "interval": "day",
-            "kind": "TrendsQuery",
-            "properties": {
-                "type": "AND",
-                "values": [
-                    {
-                        "type": "AND",
-                        "values": [
-                            {"key": "$referring_domain", "operator": "icontains", "type": "event", "value": "google"},
-                            {"key": "utm_source", "operator": "is_not_set", "type": "event", "value": "is_not_set"},
-                        ],
-                    }
-                ],
-            },
-            "series": [{"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"}],
-            "trendsFilter": {
-                "aggregationAxisFormat": "numeric",
-                "display": "BoldNumber",
-                "showAlertThresholdLines": False,
-                "showLegend": False,
-                "showPercentStackView": False,
-                "showValuesOnSeries": False,
-                "smoothingIntervals": 1,
-                "yAxisScaleType": "linear",
+            "kind": "InsightVizNode",
+            "source": {
+                "breakdownFilter": {"breakdown_type": "event"},
+                "compareFilter": {"compare": True},
+                "dateRange": {"date_from": "-30d", "explicitDate": False},
+                "filterTestAccounts": False,
+                "interval": "day",
+                "kind": "TrendsQuery",
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "$referring_domain",
+                                    "operator": "icontains",
+                                    "type": "event",
+                                    "value": "google",
+                                },
+                                {"key": "utm_source", "operator": "is_not_set", "type": "event", "value": "is_not_set"},
+                            ],
+                        }
+                    ],
+                },
+                "series": [{"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"}],
+                "trendsFilter": {
+                    "aggregationAxisFormat": "numeric",
+                    "display": "BoldNumber",
+                    "showAlertThresholdLines": False,
+                    "showLegend": False,
+                    "showPercentStackView": False,
+                    "showValuesOnSeries": False,
+                    "smoothingIntervals": 1,
+                    "yAxisScaleType": "linear",
+                },
             },
         },
         layouts={
@@ -127,22 +138,25 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Website Unique Users (Breakdown)",
         description="",
         query={
-            "breakdownFilter": {"breakdown_type": "event"},
-            "dateRange": {"date_from": "-30d", "explicitDate": False},
-            "filterTestAccounts": False,
-            "interval": "week",
-            "kind": "TrendsQuery",
-            "properties": [],
-            "series": [{"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"}],
-            "trendsFilter": {
-                "aggregationAxisFormat": "numeric",
-                "display": "ActionsBar",
-                "showAlertThresholdLines": False,
-                "showLegend": False,
-                "showPercentStackView": False,
-                "showValuesOnSeries": False,
-                "smoothingIntervals": 1,
-                "yAxisScaleType": "linear",
+            "kind": "InsightVizNode",
+            "source": {
+                "breakdownFilter": {"breakdown_type": "event"},
+                "dateRange": {"date_from": "-30d", "explicitDate": False},
+                "filterTestAccounts": False,
+                "interval": "week",
+                "kind": "TrendsQuery",
+                "properties": [],
+                "series": [{"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"}],
+                "trendsFilter": {
+                    "aggregationAxisFormat": "numeric",
+                    "display": "ActionsBar",
+                    "showAlertThresholdLines": False,
+                    "showLegend": False,
+                    "showPercentStackView": False,
+                    "showValuesOnSeries": False,
+                    "smoothingIntervals": 1,
+                    "yAxisScaleType": "linear",
+                },
             },
         },
         layouts={
@@ -165,33 +179,36 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Organic SEO Unique Users (Breakdown)",
         description="",
         query={
-            "breakdownFilter": {"breakdown_type": "event"},
-            "dateRange": {"date_from": "-30d", "explicitDate": False},
-            "filterTestAccounts": False,
-            "interval": "week",
-            "kind": "TrendsQuery",
-            "properties": [],
-            "series": [
-                {
-                    "event": "$pageview",
-                    "kind": "EventsNode",
-                    "math": "dau",
-                    "name": "$pageview",
-                    "properties": [
-                        {"key": "$referring_domain", "operator": "icontains", "type": "event", "value": "google"},
-                        {"key": "utm_source", "operator": "is_not_set", "type": "event", "value": "is_not_set"},
-                    ],
-                }
-            ],
-            "trendsFilter": {
-                "aggregationAxisFormat": "numeric",
-                "display": "ActionsBar",
-                "showAlertThresholdLines": False,
-                "showLegend": False,
-                "showPercentStackView": False,
-                "showValuesOnSeries": False,
-                "smoothingIntervals": 1,
-                "yAxisScaleType": "linear",
+            "kind": "InsightVizNode",
+            "source": {
+                "breakdownFilter": {"breakdown_type": "event"},
+                "dateRange": {"date_from": "-30d", "explicitDate": False},
+                "filterTestAccounts": False,
+                "interval": "week",
+                "kind": "TrendsQuery",
+                "properties": [],
+                "series": [
+                    {
+                        "event": "$pageview",
+                        "kind": "EventsNode",
+                        "math": "dau",
+                        "name": "$pageview",
+                        "properties": [
+                            {"key": "$referring_domain", "operator": "icontains", "type": "event", "value": "google"},
+                            {"key": "utm_source", "operator": "is_not_set", "type": "event", "value": "is_not_set"},
+                        ],
+                    }
+                ],
+                "trendsFilter": {
+                    "aggregationAxisFormat": "numeric",
+                    "display": "ActionsBar",
+                    "showAlertThresholdLines": False,
+                    "showLegend": False,
+                    "showPercentStackView": False,
+                    "showValuesOnSeries": False,
+                    "smoothingIntervals": 1,
+                    "yAxisScaleType": "linear",
+                },
             },
         },
         layouts={
@@ -208,26 +225,29 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Sessions Per User",
         description="",
         query={
-            "breakdownFilter": {"breakdown_type": "event"},
-            "dateRange": {"date_from": "-30d", "explicitDate": False},
-            "filterTestAccounts": False,
-            "interval": "week",
-            "kind": "TrendsQuery",
-            "properties": [],
-            "series": [
-                {"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"},
-                {"event": "$pageview", "kind": "EventsNode", "math": "unique_session", "name": "$pageview"},
-            ],
-            "trendsFilter": {
-                "aggregationAxisFormat": "numeric",
-                "display": "ActionsLineGraph",
-                "formula": "B/A",
-                "showAlertThresholdLines": False,
-                "showLegend": False,
-                "showPercentStackView": False,
-                "showValuesOnSeries": False,
-                "smoothingIntervals": 1,
-                "yAxisScaleType": "linear",
+            "kind": "InsightVizNode",
+            "source": {
+                "breakdownFilter": {"breakdown_type": "event"},
+                "dateRange": {"date_from": "-30d", "explicitDate": False},
+                "filterTestAccounts": False,
+                "interval": "week",
+                "kind": "TrendsQuery",
+                "properties": [],
+                "series": [
+                    {"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"},
+                    {"event": "$pageview", "kind": "EventsNode", "math": "unique_session", "name": "$pageview"},
+                ],
+                "trendsFilter": {
+                    "aggregationAxisFormat": "numeric",
+                    "display": "ActionsLineGraph",
+                    "formula": "B/A",
+                    "showAlertThresholdLines": False,
+                    "showLegend": False,
+                    "showPercentStackView": False,
+                    "showValuesOnSeries": False,
+                    "smoothingIntervals": 1,
+                    "yAxisScaleType": "linear",
+                },
             },
         },
         layouts={
@@ -250,26 +270,29 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Pages Per User",
         description="",
         query={
-            "breakdownFilter": {"breakdown_type": "event"},
-            "dateRange": {"date_from": "-30d", "explicitDate": False},
-            "filterTestAccounts": False,
-            "interval": "week",
-            "kind": "TrendsQuery",
-            "properties": [],
-            "series": [
-                {"event": "$pageview", "kind": "EventsNode", "math": "total", "name": "$pageview"},
-                {"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"},
-            ],
-            "trendsFilter": {
-                "aggregationAxisFormat": "numeric",
-                "display": "ActionsLineGraph",
-                "formula": "A/B",
-                "showAlertThresholdLines": False,
-                "showLegend": False,
-                "showPercentStackView": False,
-                "showValuesOnSeries": False,
-                "smoothingIntervals": 1,
-                "yAxisScaleType": "linear",
+            "kind": "InsightVizNode",
+            "source": {
+                "breakdownFilter": {"breakdown_type": "event"},
+                "dateRange": {"date_from": "-30d", "explicitDate": False},
+                "filterTestAccounts": False,
+                "interval": "week",
+                "kind": "TrendsQuery",
+                "properties": [],
+                "series": [
+                    {"event": "$pageview", "kind": "EventsNode", "math": "total", "name": "$pageview"},
+                    {"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"},
+                ],
+                "trendsFilter": {
+                    "aggregationAxisFormat": "numeric",
+                    "display": "ActionsLineGraph",
+                    "formula": "A/B",
+                    "showAlertThresholdLines": False,
+                    "showLegend": False,
+                    "showPercentStackView": False,
+                    "showValuesOnSeries": False,
+                    "smoothingIntervals": 1,
+                    "yAxisScaleType": "linear",
+                },
             },
         },
         layouts={
@@ -294,30 +317,35 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Top Website Pages (Overall)",
         description="",
         query={
-            "breakdownFilter": {"breakdown": "$current_url", "breakdown_type": "event"},
-            "dateRange": {"date_from": "-30d", "explicitDate": False},
-            "filterTestAccounts": False,
-            "interval": "day",
-            "kind": "TrendsQuery",
-            "properties": {
-                "type": "AND",
-                "values": [
-                    {
-                        "type": "AND",
-                        "values": [{"key": "$current_url", "operator": "not_icontains", "type": "event", "value": "?"}],
-                    }
-                ],
-            },
-            "series": [{"event": "$pageview", "kind": "EventsNode", "math": "unique_session", "name": "$pageview"}],
-            "trendsFilter": {
-                "aggregationAxisFormat": "numeric",
-                "display": "ActionsBarValue",
-                "showAlertThresholdLines": False,
-                "showLegend": False,
-                "showPercentStackView": False,
-                "showValuesOnSeries": False,
-                "smoothingIntervals": 1,
-                "yAxisScaleType": "linear",
+            "kind": "InsightVizNode",
+            "source": {
+                "breakdownFilter": {"breakdown": "$current_url", "breakdown_type": "event"},
+                "dateRange": {"date_from": "-30d", "explicitDate": False},
+                "filterTestAccounts": False,
+                "interval": "day",
+                "kind": "TrendsQuery",
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {"key": "$current_url", "operator": "not_icontains", "type": "event", "value": "?"}
+                            ],
+                        }
+                    ],
+                },
+                "series": [{"event": "$pageview", "kind": "EventsNode", "math": "unique_session", "name": "$pageview"}],
+                "trendsFilter": {
+                    "aggregationAxisFormat": "numeric",
+                    "display": "ActionsBarValue",
+                    "showAlertThresholdLines": False,
+                    "showLegend": False,
+                    "showPercentStackView": False,
+                    "showValuesOnSeries": False,
+                    "smoothingIntervals": 1,
+                    "yAxisScaleType": "linear",
+                },
             },
         },
         layouts={
@@ -340,33 +368,41 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Top Website Pages (via Google)",
         description="",
         query={
-            "breakdownFilter": {"breakdown": "$current_url", "breakdown_type": "event"},
-            "dateRange": {"date_from": "-30d", "explicitDate": False},
-            "filterTestAccounts": False,
-            "interval": "day",
-            "kind": "TrendsQuery",
-            "properties": {
-                "type": "AND",
-                "values": [
-                    {
-                        "type": "AND",
-                        "values": [
-                            {"key": "$current_url", "operator": "not_icontains", "type": "event", "value": "?"},
-                            {"key": "$referring_domain", "operator": "icontains", "type": "event", "value": "google"},
-                        ],
-                    }
-                ],
-            },
-            "series": [{"event": "$pageview", "kind": "EventsNode", "math": "unique_session", "name": "$pageview"}],
-            "trendsFilter": {
-                "aggregationAxisFormat": "numeric",
-                "display": "ActionsBarValue",
-                "showAlertThresholdLines": False,
-                "showLegend": False,
-                "showPercentStackView": False,
-                "showValuesOnSeries": False,
-                "smoothingIntervals": 1,
-                "yAxisScaleType": "linear",
+            "kind": "InsightVizNode",
+            "source": {
+                "breakdownFilter": {"breakdown": "$current_url", "breakdown_type": "event"},
+                "dateRange": {"date_from": "-30d", "explicitDate": False},
+                "filterTestAccounts": False,
+                "interval": "day",
+                "kind": "TrendsQuery",
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {"key": "$current_url", "operator": "not_icontains", "type": "event", "value": "?"},
+                                {
+                                    "key": "$referring_domain",
+                                    "operator": "icontains",
+                                    "type": "event",
+                                    "value": "google",
+                                },
+                            ],
+                        }
+                    ],
+                },
+                "series": [{"event": "$pageview", "kind": "EventsNode", "math": "unique_session", "name": "$pageview"}],
+                "trendsFilter": {
+                    "aggregationAxisFormat": "numeric",
+                    "display": "ActionsBarValue",
+                    "showAlertThresholdLines": False,
+                    "showLegend": False,
+                    "showPercentStackView": False,
+                    "showValuesOnSeries": False,
+                    "smoothingIntervals": 1,
+                    "yAxisScaleType": "linear",
+                },
             },
         },
         layouts={
@@ -383,22 +419,25 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Website Users by Location",
         description="",
         query={
-            "breakdownFilter": {"breakdown": "$geoip_country_code", "breakdown_type": "person"},
-            "dateRange": {"date_from": "-30d", "explicitDate": False},
-            "filterTestAccounts": False,
-            "interval": "day",
-            "kind": "TrendsQuery",
-            "properties": [],
-            "series": [{"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"}],
-            "trendsFilter": {
-                "aggregationAxisFormat": "numeric",
-                "display": "WorldMap",
-                "showAlertThresholdLines": False,
-                "showLegend": False,
-                "showPercentStackView": False,
-                "showValuesOnSeries": False,
-                "smoothingIntervals": 1,
-                "yAxisScaleType": "linear",
+            "kind": "InsightVizNode",
+            "source": {
+                "breakdownFilter": {"breakdown": "$geoip_country_code", "breakdown_type": "person"},
+                "dateRange": {"date_from": "-30d", "explicitDate": False},
+                "filterTestAccounts": False,
+                "interval": "day",
+                "kind": "TrendsQuery",
+                "properties": [],
+                "series": [{"event": "$pageview", "kind": "EventsNode", "math": "dau", "name": "$pageview"}],
+                "trendsFilter": {
+                    "aggregationAxisFormat": "numeric",
+                    "display": "WorldMap",
+                    "showAlertThresholdLines": False,
+                    "showLegend": False,
+                    "showPercentStackView": False,
+                    "showValuesOnSeries": False,
+                    "smoothingIntervals": 1,
+                    "yAxisScaleType": "linear",
+                },
             },
         },
         layouts={
@@ -535,32 +574,40 @@ def create_feature_flag_dashboard(feature_flag, dashboard: Dashboard) -> None:
         name="Feature Flag Called Total Volume",
         description="Shows the number of total calls made on feature flag with key: " + feature_flag.key,
         query={
-            "breakdownFilter": {"breakdown": "$feature_flag_response", "breakdown_type": "event"},
-            "dateRange": {"date_from": "-30d", "explicitDate": False},
-            "filterTestAccounts": False,
-            "interval": "day",
-            "kind": "TrendsQuery",
-            "properties": {
-                "type": "AND",
-                "values": [
-                    {
-                        "type": "AND",
-                        "values": [
-                            {"key": "$feature_flag", "operator": "exact", "type": "event", "value": feature_flag.key}
-                        ],
-                    }
-                ],
-            },
-            "series": [{"event": "$feature_flag_called", "kind": "EventsNode", "name": "$feature_flag_called"}],
-            "trendsFilter": {
-                "aggregationAxisFormat": "numeric",
-                "display": "ActionsLineGraph",
-                "showAlertThresholdLines": False,
-                "showLegend": False,
-                "showPercentStackView": False,
-                "showValuesOnSeries": False,
-                "smoothingIntervals": 1,
-                "yAxisScaleType": "linear",
+            "kind": "InsightVizNode",
+            "source": {
+                "breakdownFilter": {"breakdown": "$feature_flag_response", "breakdown_type": "event"},
+                "dateRange": {"date_from": "-30d", "explicitDate": False},
+                "filterTestAccounts": False,
+                "interval": "day",
+                "kind": "TrendsQuery",
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "$feature_flag",
+                                    "operator": "exact",
+                                    "type": "event",
+                                    "value": feature_flag.key,
+                                }
+                            ],
+                        }
+                    ],
+                },
+                "series": [{"event": "$feature_flag_called", "kind": "EventsNode", "name": "$feature_flag_called"}],
+                "trendsFilter": {
+                    "aggregationAxisFormat": "numeric",
+                    "display": "ActionsLineGraph",
+                    "showAlertThresholdLines": False,
+                    "showLegend": False,
+                    "showPercentStackView": False,
+                    "showValuesOnSeries": False,
+                    "smoothingIntervals": 1,
+                    "yAxisScaleType": "linear",
+                },
             },
         },
         layouts={
@@ -584,34 +631,47 @@ def create_feature_flag_dashboard(feature_flag, dashboard: Dashboard) -> None:
         description="Shows the number of unique user calls made on feature flag per variant with key: "
         + feature_flag.key,
         query={
-            "breakdownFilter": {"breakdown": "$feature_flag_response", "breakdown_type": "event"},
-            "dateRange": {"date_from": "-30d", "explicitDate": False},
-            "filterTestAccounts": False,
-            "interval": "day",
-            "kind": "TrendsQuery",
-            "properties": {
-                "type": "AND",
-                "values": [
+            "kind": "InsightVizNode",
+            "source": {
+                "breakdownFilter": {"breakdown": "$feature_flag_response", "breakdown_type": "event"},
+                "dateRange": {"date_from": "-30d", "explicitDate": False},
+                "filterTestAccounts": False,
+                "interval": "day",
+                "kind": "TrendsQuery",
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "$feature_flag",
+                                    "operator": "exact",
+                                    "type": "event",
+                                    "value": feature_flag.key,
+                                }
+                            ],
+                        }
+                    ],
+                },
+                "series": [
                     {
-                        "type": "AND",
-                        "values": [
-                            {"key": "$feature_flag", "operator": "exact", "type": "event", "value": feature_flag.key}
-                        ],
+                        "event": "$feature_flag_called",
+                        "kind": "EventsNode",
+                        "math": "dau",
+                        "name": "$feature_flag_called",
                     }
                 ],
-            },
-            "series": [
-                {"event": "$feature_flag_called", "kind": "EventsNode", "math": "dau", "name": "$feature_flag_called"}
-            ],
-            "trendsFilter": {
-                "aggregationAxisFormat": "numeric",
-                "display": "ActionsTable",
-                "showAlertThresholdLines": False,
-                "showLegend": False,
-                "showPercentStackView": False,
-                "showValuesOnSeries": False,
-                "smoothingIntervals": 1,
-                "yAxisScaleType": "linear",
+                "trendsFilter": {
+                    "aggregationAxisFormat": "numeric",
+                    "display": "ActionsTable",
+                    "showAlertThresholdLines": False,
+                    "showLegend": False,
+                    "showPercentStackView": False,
+                    "showValuesOnSeries": False,
+                    "smoothingIntervals": 1,
+                    "yAxisScaleType": "linear",
+                },
             },
         },
         layouts={
@@ -637,35 +697,43 @@ def add_enriched_insights_to_feature_flag_dashboard(feature_flag, dashboard: Das
         name=f"{ENRICHED_DASHBOARD_INSIGHT_IDENTIFIER} Total Volume",
         description="Shows the total number of times this feature was viewed and interacted with",
         query={
-            "breakdownFilter": {"breakdown_type": "event"},
-            "dateRange": {"date_from": "-30d", "explicitDate": False},
-            "filterTestAccounts": False,
-            "interval": "day",
-            "kind": "TrendsQuery",
-            "properties": {
-                "type": "AND",
-                "values": [
+            "kind": "InsightVizNode",
+            "source": {
+                "breakdownFilter": {"breakdown_type": "event"},
+                "dateRange": {"date_from": "-30d", "explicitDate": False},
+                "filterTestAccounts": False,
+                "interval": "day",
+                "kind": "TrendsQuery",
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {"key": "feature_flag", "operator": "exact", "type": "event", "value": feature_flag.key}
+                            ],
+                        }
+                    ],
+                },
+                "series": [
+                    {"event": "$feature_view", "kind": "EventsNode", "name": "Feature View - Total"},
                     {
-                        "type": "AND",
-                        "values": [
-                            {"key": "feature_flag", "operator": "exact", "type": "event", "value": feature_flag.key}
-                        ],
-                    }
+                        "event": "$feature_view",
+                        "kind": "EventsNode",
+                        "math": "dau",
+                        "name": "Feature View - Unique users",
+                    },
                 ],
-            },
-            "series": [
-                {"event": "$feature_view", "kind": "EventsNode", "name": "Feature View - Total"},
-                {"event": "$feature_view", "kind": "EventsNode", "math": "dau", "name": "Feature View - Unique users"},
-            ],
-            "trendsFilter": {
-                "aggregationAxisFormat": "numeric",
-                "display": "ActionsLineGraph",
-                "showAlertThresholdLines": False,
-                "showLegend": False,
-                "showPercentStackView": False,
-                "showValuesOnSeries": False,
-                "smoothingIntervals": 1,
-                "yAxisScaleType": "linear",
+                "trendsFilter": {
+                    "aggregationAxisFormat": "numeric",
+                    "display": "ActionsLineGraph",
+                    "showAlertThresholdLines": False,
+                    "showLegend": False,
+                    "showPercentStackView": False,
+                    "showValuesOnSeries": False,
+                    "smoothingIntervals": 1,
+                    "yAxisScaleType": "linear",
+                },
             },
         },
         layouts={},
@@ -677,40 +745,43 @@ def add_enriched_insights_to_feature_flag_dashboard(feature_flag, dashboard: Das
         name="Feature Interaction Total Volume",
         description="Shows the total number of times this feature was viewed and interacted with",
         query={
-            "breakdownFilter": {"breakdown_type": "event"},
-            "dateRange": {"date_from": "-30d", "explicitDate": False},
-            "filterTestAccounts": False,
-            "interval": "day",
-            "kind": "TrendsQuery",
-            "properties": {
-                "type": "AND",
-                "values": [
-                    {
-                        "type": "AND",
-                        "values": [
-                            {"key": "feature_flag", "operator": "exact", "type": "event", "value": feature_flag.key}
-                        ],
-                    }
-                ],
-            },
-            "series": [
-                {"event": "$feature_interaction", "kind": "EventsNode", "name": "Feature Interaction - Total"},
-                {
-                    "event": "$feature_interaction",
-                    "kind": "EventsNode",
-                    "math": "dau",
-                    "name": "Feature Interaction - Unique users",
+            "kind": "InsightVizNode",
+            "source": {
+                "breakdownFilter": {"breakdown_type": "event"},
+                "dateRange": {"date_from": "-30d", "explicitDate": False},
+                "filterTestAccounts": False,
+                "interval": "day",
+                "kind": "TrendsQuery",
+                "properties": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {"key": "feature_flag", "operator": "exact", "type": "event", "value": feature_flag.key}
+                            ],
+                        }
+                    ],
                 },
-            ],
-            "trendsFilter": {
-                "aggregationAxisFormat": "numeric",
-                "display": "ActionsLineGraph",
-                "showAlertThresholdLines": False,
-                "showLegend": False,
-                "showPercentStackView": False,
-                "showValuesOnSeries": False,
-                "smoothingIntervals": 1,
-                "yAxisScaleType": "linear",
+                "series": [
+                    {"event": "$feature_interaction", "kind": "EventsNode", "name": "Feature Interaction - Total"},
+                    {
+                        "event": "$feature_interaction",
+                        "kind": "EventsNode",
+                        "math": "dau",
+                        "name": "Feature Interaction - Unique users",
+                    },
+                ],
+                "trendsFilter": {
+                    "aggregationAxisFormat": "numeric",
+                    "display": "ActionsLineGraph",
+                    "showAlertThresholdLines": False,
+                    "showLegend": False,
+                    "showPercentStackView": False,
+                    "showValuesOnSeries": False,
+                    "smoothingIntervals": 1,
+                    "yAxisScaleType": "linear",
+                },
             },
         },
         layouts={},

--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -4,22 +4,6 @@ from collections.abc import Callable
 import structlog
 
 from posthog.constants import (
-    BREAKDOWN,
-    BREAKDOWN_TYPE,
-    DATE_FROM,
-    DISPLAY,
-    FILTER_TEST_ACCOUNTS,
-    INSIGHT,
-    INSIGHT_TRENDS,
-    INTERVAL,
-    PROPERTIES,
-    TREND_FILTER_TYPE_EVENTS,
-    TRENDS_BAR_VALUE,
-    TRENDS_BOLD_NUMBER,
-    TRENDS_LINEAR,
-    TRENDS_TABLE,
-    TRENDS_WORLD_MAP,
-    UNIQUE_USERS,
     AvailableFeature,
     ENRICHED_DASHBOARD_INSIGHT_IDENTIFIER,
 )
@@ -37,7 +21,7 @@ logger = structlog.get_logger(__name__)
 
 
 def _create_website_dashboard(dashboard: Dashboard) -> None:
-    dashboard.filters = {DATE_FROM: "-30d"}
+    dashboard.filters = {"date_from": "-30d"}
     if dashboard.team.organization.is_feature_available(AvailableFeature.TAGGING):
         tag, _ = Tag.objects.get_or_create(
             name="marketing",
@@ -53,17 +37,17 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Website Unique Users (Total)",
         description="Shows the number of unique users that use your app every day.",
         filters={
-            TREND_FILTER_TYPE_EVENTS: [
+            "events": [
                 {
                     "id": "$pageview",
-                    "math": UNIQUE_USERS,
-                    "type": TREND_FILTER_TYPE_EVENTS,
+                    "math": "dau",
+                    "type": "events",
                 }
             ],
-            INTERVAL: "day",
-            INSIGHT: INSIGHT_TRENDS,
-            DATE_FROM: "-30d",
-            DISPLAY: TRENDS_BOLD_NUMBER,
+            "interval": "day",
+            "insight": "TRENDS",
+            "date_from": "-30d",
+            "display": "BoldNumber",
             "compare": True,
         },
         layouts={
@@ -86,19 +70,19 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Organic SEO Unique Users (Total)",
         description="",
         filters={
-            TREND_FILTER_TYPE_EVENTS: [
+            "events": [
                 {
                     "id": "$pageview",
-                    "math": UNIQUE_USERS,
-                    "type": TREND_FILTER_TYPE_EVENTS,
+                    "math": "dau",
+                    "type": "events",
                 }
             ],
-            INTERVAL: "day",
-            INSIGHT: INSIGHT_TRENDS,
-            DATE_FROM: "-30d",
-            DISPLAY: TRENDS_BOLD_NUMBER,
+            "interval": "day",
+            "insight": "TRENDS",
+            "date_from": "-30d",
+            "display": "BoldNumber",
             "compare": True,
-            PROPERTIES: {
+            "properties": {
                 "type": "AND",
                 "values": [
                     {
@@ -142,17 +126,17 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Website Unique Users (Breakdown)",
         description="",
         filters={
-            TREND_FILTER_TYPE_EVENTS: [
+            "events": [
                 {
                     "id": "$pageview",
-                    "math": UNIQUE_USERS,
-                    "type": TREND_FILTER_TYPE_EVENTS,
+                    "math": "dau",
+                    "type": "events",
                 }
             ],
-            INTERVAL: "week",
-            INSIGHT: INSIGHT_TRENDS,
-            DATE_FROM: "-30d",
-            DISPLAY: "ActionsBar",
+            "interval": "week",
+            "insight": "TRENDS",
+            "date_from": "-30d",
+            "display": "ActionsBar",
         },
         layouts={
             "sm": {"i": "23", "x": 0, "y": 5, "w": 6, "h": 5, "minW": 3, "minH": 5},
@@ -174,12 +158,12 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Organic SEO Unique Users (Breakdown)",
         description="",
         filters={
-            TREND_FILTER_TYPE_EVENTS: [
+            "events": [
                 {
                     "id": "$pageview",
-                    "math": UNIQUE_USERS,
-                    "type": TREND_FILTER_TYPE_EVENTS,
-                    PROPERTIES: [
+                    "math": "dau",
+                    "type": "events",
+                    "properties": [
                         {
                             "key": "$referring_domain",
                             "type": "event",
@@ -195,10 +179,10 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
                     ],
                 }
             ],
-            INTERVAL: "week",
-            INSIGHT: INSIGHT_TRENDS,
-            DATE_FROM: "-30d",
-            DISPLAY: "ActionsBar",
+            "interval": "week",
+            "insight": "TRENDS",
+            "date_from": "-30d",
+            "display": "ActionsBar",
         },
         layouts={
             "sm": {"i": "24", "x": 6, "y": 5, "w": 6, "h": 5, "minW": 3, "minH": 5},
@@ -214,28 +198,28 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Sessions Per User",
         description="",
         filters={
-            TREND_FILTER_TYPE_EVENTS: [
+            "events": [
                 {
                     "id": "$pageview",
-                    "math": UNIQUE_USERS,
+                    "math": "dau",
                     "name": "$pageview",
-                    "type": TREND_FILTER_TYPE_EVENTS,
+                    "type": "events",
                     "order": 0,
-                    PROPERTIES: [],
+                    "properties": [],
                 },
                 {
                     "id": "$pageview",
                     "math": "unique_session",
                     "name": "$pageview",
-                    "type": TREND_FILTER_TYPE_EVENTS,
+                    "type": "events",
                     "order": 1,
-                    PROPERTIES: [],
+                    "properties": [],
                 },
             ],
-            INTERVAL: "week",
-            INSIGHT: INSIGHT_TRENDS,
-            DATE_FROM: "-30d",
-            DISPLAY: "ActionsLineGraph",
+            "interval": "week",
+            "insight": "TRENDS",
+            "date_from": "-30d",
+            "display": "ActionsLineGraph",
             "formula": "B/A",
         },
         layouts={
@@ -258,28 +242,28 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Pages Per User",
         description="",
         filters={
-            TREND_FILTER_TYPE_EVENTS: [
+            "events": [
                 {
                     "id": "$pageview",
                     "math": "total",
                     "name": "$pageview",
-                    "type": TREND_FILTER_TYPE_EVENTS,
+                    "type": "events",
                     "order": 0,
-                    PROPERTIES: [],
+                    "properties": [],
                 },
                 {
                     "id": "$pageview",
-                    "math": UNIQUE_USERS,
+                    "math": "dau",
                     "name": "$pageview",
-                    "type": TREND_FILTER_TYPE_EVENTS,
+                    "type": "events",
                     "order": 1,
-                    PROPERTIES: [],
+                    "properties": [],
                 },
             ],
-            INTERVAL: "week",
-            INSIGHT: INSIGHT_TRENDS,
-            DATE_FROM: "-30d",
-            DISPLAY: "ActionsLineGraph",
+            "interval": "week",
+            "insight": "TRENDS",
+            "date_from": "-30d",
+            "display": "ActionsLineGraph",
             "formula": "A/B",
         },
         layouts={
@@ -304,22 +288,22 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Top Website Pages (Overall)",
         description="",
         filters={
-            TREND_FILTER_TYPE_EVENTS: [
+            "events": [
                 {
                     "id": "$pageview",
                     "math": "unique_session",
                     "name": "$pageview",
-                    "type": TREND_FILTER_TYPE_EVENTS,
+                    "type": "events",
                     "order": 0,
                 }
             ],
-            INTERVAL: "day",
-            INSIGHT: INSIGHT_TRENDS,
-            DATE_FROM: "-30d",
-            DISPLAY: TRENDS_BAR_VALUE,
-            BREAKDOWN: "$current_url",
-            BREAKDOWN_TYPE: "event",
-            PROPERTIES: {
+            "interval": "day",
+            "insight": "TRENDS",
+            "date_from": "-30d",
+            "display": "ActionsBarValue",
+            "breakdown": "$current_url",
+            "breakdown_type": "event",
+            "properties": {
                 "type": "AND",
                 "values": [
                     {
@@ -356,22 +340,22 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Top Website Pages (via Google)",
         description="",
         filters={
-            TREND_FILTER_TYPE_EVENTS: [
+            "events": [
                 {
                     "id": "$pageview",
                     "math": "unique_session",
                     "name": "$pageview",
-                    "type": TREND_FILTER_TYPE_EVENTS,
+                    "type": "events",
                     "order": 0,
                 }
             ],
-            INTERVAL: "day",
-            INSIGHT: INSIGHT_TRENDS,
-            DATE_FROM: "-30d",
-            DISPLAY: TRENDS_BAR_VALUE,
-            BREAKDOWN: "$current_url",
-            BREAKDOWN_TYPE: "event",
-            PROPERTIES: {
+            "interval": "day",
+            "insight": "TRENDS",
+            "date_from": "-30d",
+            "display": "ActionsBarValue",
+            "breakdown": "$current_url",
+            "breakdown_type": "event",
+            "properties": {
                 "type": "AND",
                 "values": [
                     {
@@ -408,21 +392,21 @@ def _create_website_dashboard(dashboard: Dashboard) -> None:
         name="Website Users by Location",
         description="",
         filters={
-            TREND_FILTER_TYPE_EVENTS: [
+            "events": [
                 {
                     "id": "$pageview",
-                    "math": UNIQUE_USERS,
+                    "math": "dau",
                     "name": "$pageview",
-                    "type": TREND_FILTER_TYPE_EVENTS,
+                    "type": "events",
                     "order": 0,
                 }
             ],
-            INTERVAL: "day",
-            INSIGHT: INSIGHT_TRENDS,
-            DATE_FROM: "-30d",
-            DISPLAY: TRENDS_WORLD_MAP,
-            BREAKDOWN: "$geoip_country_code",
-            BREAKDOWN_TYPE: "person",
+            "interval": "day",
+            "insight": "TRENDS",
+            "date_from": "-30d",
+            "display": "WorldMap",
+            "breakdown": "$geoip_country_code",
+            "breakdown_type": "person",
         },
         layouts={
             "sm": {"i": "29", "x": 0, "y": 23, "w": 12, "h": 8, "minW": 3, "minH": 5},
@@ -469,7 +453,7 @@ def create_from_template(dashboard: Dashboard, template: DashboardTemplate) -> N
     dashboard.save()
 
     for template_tile in template.tiles:
-        if template_tile["type"] == "INSIGHT":
+        if template_tile["type"] == "insight":
             query = template_tile.get("query", None)
             filters = template_tile.get("filters") if not query else {}
             _create_tile_for_insight(
@@ -547,7 +531,7 @@ def create_dashboard_from_template(template_key: str, dashboard: Dashboard) -> N
 
 
 def create_feature_flag_dashboard(feature_flag, dashboard: Dashboard) -> None:
-    dashboard.filters = {DATE_FROM: "-30d"}
+    dashboard.filters = {"date_from": "-30d"}
     if dashboard.team.organization.is_feature_available(AvailableFeature.TAGGING):
         tag, _ = Tag.objects.get_or_create(
             name="feature flags",
@@ -563,18 +547,18 @@ def create_feature_flag_dashboard(feature_flag, dashboard: Dashboard) -> None:
         name="Feature Flag Called Total Volume",
         description="Shows the number of total calls made on feature flag with key: " + feature_flag.key,
         filters={
-            TREND_FILTER_TYPE_EVENTS: [
+            "events": [
                 {
                     "id": "$feature_flag_called",
                     "name": "$feature_flag_called",
-                    "type": TREND_FILTER_TYPE_EVENTS,
+                    "type": "events",
                 }
             ],
-            INTERVAL: "day",
-            INSIGHT: INSIGHT_TRENDS,
-            DATE_FROM: "-30d",
-            DISPLAY: TRENDS_LINEAR,
-            PROPERTIES: {
+            "interval": "day",
+            "insight": "TRENDS",
+            "date_from": "-30d",
+            "display": "ActionsLineGraph",
+            "properties": {
                 "type": "AND",
                 "values": [
                     {
@@ -589,9 +573,9 @@ def create_feature_flag_dashboard(feature_flag, dashboard: Dashboard) -> None:
                     }
                 ],
             },
-            BREAKDOWN: "$feature_flag_response",
-            BREAKDOWN_TYPE: "event",
-            FILTER_TEST_ACCOUNTS: False,
+            "breakdown": "$feature_flag_response",
+            "breakdown_type": "event",
+            "filter_test_accounts": False,
         },
         layouts={
             "sm": {"i": "21", "x": 0, "y": 0, "w": 6, "h": 5, "minW": 3, "minH": 5},
@@ -614,19 +598,19 @@ def create_feature_flag_dashboard(feature_flag, dashboard: Dashboard) -> None:
         description="Shows the number of unique user calls made on feature flag per variant with key: "
         + feature_flag.key,
         filters={
-            TREND_FILTER_TYPE_EVENTS: [
+            "events": [
                 {
                     "id": "$feature_flag_called",
                     "name": "$feature_flag_called",
-                    "math": UNIQUE_USERS,
-                    "type": TREND_FILTER_TYPE_EVENTS,
+                    "math": "dau",
+                    "type": "events",
                 }
             ],
-            INTERVAL: "day",
-            INSIGHT: INSIGHT_TRENDS,
-            DATE_FROM: "-30d",
-            DISPLAY: TRENDS_TABLE,
-            PROPERTIES: {
+            "interval": "day",
+            "insight": "TRENDS",
+            "date_from": "-30d",
+            "display": "ActionsTable",
+            "properties": {
                 "type": "AND",
                 "values": [
                     {
@@ -641,9 +625,9 @@ def create_feature_flag_dashboard(feature_flag, dashboard: Dashboard) -> None:
                     }
                 ],
             },
-            BREAKDOWN: "$feature_flag_response",
-            BREAKDOWN_TYPE: "event",
-            FILTER_TEST_ACCOUNTS: False,
+            "breakdown": "$feature_flag_response",
+            "breakdown_type": "event",
+            "filter_test_accounts": False,
         },
         layouts={
             "sm": {"i": "22", "x": 6, "y": 0, "w": 6, "h": 5, "minW": 3, "minH": 5},
@@ -668,24 +652,24 @@ def add_enriched_insights_to_feature_flag_dashboard(feature_flag, dashboard: Das
         name=f"{ENRICHED_DASHBOARD_INSIGHT_IDENTIFIER} Total Volume",
         description="Shows the total number of times this feature was viewed and interacted with",
         filters={
-            TREND_FILTER_TYPE_EVENTS: [
+            "events": [
                 {
                     "id": "$feature_view",
                     "name": "Feature View - Total",
-                    "type": TREND_FILTER_TYPE_EVENTS,
+                    "type": "events",
                 },
                 {
                     "id": "$feature_view",
                     "name": "Feature View - Unique users",
-                    "type": TREND_FILTER_TYPE_EVENTS,
-                    "math": UNIQUE_USERS,
+                    "type": "events",
+                    "math": "dau",
                 },
             ],
-            INTERVAL: "day",
-            INSIGHT: INSIGHT_TRENDS,
-            DATE_FROM: "-30d",
-            DISPLAY: TRENDS_LINEAR,
-            PROPERTIES: {
+            "interval": "day",
+            "insight": "TRENDS",
+            "date_from": "-30d",
+            "display": "ActionsLineGraph",
+            "properties": {
                 "type": "AND",
                 "values": [
                     {
@@ -700,7 +684,7 @@ def add_enriched_insights_to_feature_flag_dashboard(feature_flag, dashboard: Das
                     }
                 ],
             },
-            FILTER_TEST_ACCOUNTS: False,
+            "filter_test_accounts": False,
         },
         layouts={},
         color=None,
@@ -711,24 +695,24 @@ def add_enriched_insights_to_feature_flag_dashboard(feature_flag, dashboard: Das
         name="Feature Interaction Total Volume",
         description="Shows the total number of times this feature was viewed and interacted with",
         filters={
-            TREND_FILTER_TYPE_EVENTS: [
+            "events": [
                 {
                     "id": "$feature_interaction",
                     "name": "Feature Interaction - Total",
-                    "type": TREND_FILTER_TYPE_EVENTS,
+                    "type": "events",
                 },
                 {
                     "id": "$feature_interaction",
                     "name": "Feature Interaction - Unique users",
-                    "type": TREND_FILTER_TYPE_EVENTS,
-                    "math": UNIQUE_USERS,
+                    "type": "events",
+                    "math": "dau",
                 },
             ],
-            INTERVAL: "day",
-            INSIGHT: INSIGHT_TRENDS,
-            DATE_FROM: "-30d",
-            DISPLAY: TRENDS_LINEAR,
-            PROPERTIES: {
+            "interval": "day",
+            "insight": "TRENDS",
+            "date_from": "-30d",
+            "display": "ActionsLineGraph",
+            "properties": {
                 "type": "AND",
                 "values": [
                     {
@@ -743,7 +727,7 @@ def add_enriched_insights_to_feature_flag_dashboard(feature_flag, dashboard: Das
                     }
                 ],
             },
-            FILTER_TEST_ACCOUNTS: False,
+            "filter_test_accounts": False,
         },
         layouts={},
         color=None,

--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -446,7 +446,7 @@ def create_from_template(dashboard: Dashboard, template: DashboardTemplate) -> N
     dashboard.save()
 
     for template_tile in template.tiles:
-        if template_tile["type"] == "insight":
+        if template_tile["type"] == "INSIGHT":
             query = template_tile.get("query", None)
             _create_tile_for_insight(
                 dashboard,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -847,14 +847,49 @@
 # ---
 # name: TestTrends.test_dau_with_breakdown_filtering_with_sampling
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
+  SELECT groupArray(1)(date)[1] AS date,
+                      arrayFold((acc, x) -> arrayMap(i -> plus(acc[i], x[i]), range(1, plus(length(date), 1))), groupArray(ifNull(total, 0)), arrayWithConstant(length(date), reinterpretAsFloat64(0))) AS total,
+                      if(ifNull(ifNull(greaterOrEquals(row_number, 25), 0), 0), '$$_posthog_breakdown_other_$$', breakdown_value) AS breakdown_value
+  FROM
+    (SELECT arrayMap(number -> plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))))), 1))) AS date,
+            arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
+                                                                                                                                                                                                      and isNull(_match_date)), _days_for_count), _index), 1))), date) AS total,
+            breakdown_value AS breakdown_value,
+            rowNumberInAllBlocks() AS row_number
+     FROM
+       (SELECT sum(total) AS count,
+               day_start AS day_start,
+               breakdown_value AS breakdown_value
+        FROM
+          (SELECT count(DISTINCT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)) AS total,
+                  toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
+                  ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value
+           FROM events AS e SAMPLE 1.0
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
+           GROUP BY day_start,
+                    breakdown_value)
+        GROUP BY day_start,
+                 breakdown_value
+        ORDER BY day_start ASC, breakdown_value ASC)
+     GROUP BY breakdown_value
+     ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC)
+  WHERE isNotNull(breakdown_value)
+  GROUP BY breakdown_value
+  ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       format_csv_allow_double_quotes=0,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestTrends.test_dau_with_breakdown_filtering_with_sampling.1
@@ -1120,7 +1155,11 @@
   '''
   SELECT groupArray(1)(date)[1] AS date,
                       arrayFold((acc, x) -> arrayMap(i -> plus(acc[i], x[i]), range(1, plus(length(date), 1))), groupArray(ifNull(total, 0)), arrayWithConstant(length(date), reinterpretAsFloat64(0))) AS total,
+<<<<<<< HEAD
                       if(ifNull(ifNull(greaterOrEquals(row_number, 25), 0), 0), '$$_posthog_breakdown_other_$$', breakdown_value) AS breakdown_value
+=======
+                      arrayMap(i -> if(ifNull(ifNull(greaterOrEquals(row_number, 25), 0), 0), '$$_posthog_breakdown_other_$$', i), breakdown_value) AS breakdown_value
+>>>>>>> 4f42095f0f8 (Update query snapshots)
   FROM
     (SELECT arrayMap(number -> plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))))), 1))) AS date,
             arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
@@ -1130,11 +1169,19 @@
      FROM
        (SELECT sum(total) AS count,
                day_start AS day_start,
+<<<<<<< HEAD
                breakdown_value AS breakdown_value
         FROM
           (SELECT count(DISTINCT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)) AS total,
                   toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
                   ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value
+=======
+               [ifNull(toString(breakdown_value_1), '$$_posthog_breakdown_null_$$')] AS breakdown_value
+        FROM
+          (SELECT count(DISTINCT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)) AS total,
+                  toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
+                  ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value_1
+>>>>>>> 4f42095f0f8 (Update query snapshots)
            FROM events AS e SAMPLE 1.0
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -1145,6 +1192,7 @@
               HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
            GROUP BY day_start,
+<<<<<<< HEAD
                     breakdown_value)
         GROUP BY day_start,
                  breakdown_value
@@ -1154,6 +1202,17 @@
   WHERE isNotNull(breakdown_value)
   GROUP BY breakdown_value
   ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
+=======
+                    breakdown_value_1)
+        GROUP BY day_start,
+                 breakdown_value_1
+        ORDER BY day_start ASC, breakdown_value ASC)
+     GROUP BY breakdown_value
+     ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC)
+  WHERE arrayExists(x -> isNotNull(x), breakdown_value)
+  GROUP BY breakdown_value
+  ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
+>>>>>>> 4f42095f0f8 (Update query snapshots)
   LIMIT 50000 SETTINGS readonly=2,
                        max_execution_time=60,
                        allow_experimental_object_type=1,
@@ -1931,18 +1990,6 @@
 # ---
 # name: TestTrends.test_person_filtering_in_cohort_in_action
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: TestTrends.test_person_filtering_in_cohort_in_action.1
-  '''
   
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
@@ -1951,7 +1998,7 @@
     AND version = NULL
   '''
 # ---
-# name: TestTrends.test_person_filtering_in_cohort_in_action.2
+# name: TestTrends.test_person_filtering_in_cohort_in_action.1
   '''
   /* cohort_calculation: */
   SELECT count(DISTINCT person_id)
@@ -1959,6 +2006,56 @@
   WHERE team_id = 99999
     AND cohort_id = 99999
     AND version = 0
+  '''
+# ---
+# name: TestTrends.test_person_filtering_in_cohort_in_action.2
+  '''
+  SELECT groupArray(1)(date)[1] AS date,
+                      arrayFold((acc, x) -> arrayMap(i -> plus(acc[i], x[i]), range(1, plus(length(date), 1))), groupArray(ifNull(total, 0)), arrayWithConstant(length(date), reinterpretAsFloat64(0))) AS total,
+                      if(ifNull(ifNull(greaterOrEquals(row_number, 25), 0), 0), '$$_posthog_breakdown_other_$$', breakdown_value) AS breakdown_value
+  FROM
+    (SELECT arrayMap(number -> plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))))), 1))) AS date,
+            arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
+                                                                                                                                                                                                      and isNull(_match_date)), _days_for_count), _index), 1))), date) AS total,
+            breakdown_value AS breakdown_value,
+            rowNumberInAllBlocks() AS row_number
+     FROM
+       (SELECT sum(total) AS count,
+               day_start AS day_start,
+               breakdown_value AS breakdown_value
+        FROM
+          (SELECT count() AS total,
+                  toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
+                  ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value
+           FROM events AS e SAMPLE 1
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), and(equals(e.event, 'sign up'), ifNull(in(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id),
+                                                                                                                                                                                                                                                                                                                                                                          (SELECT cohortpeople.person_id AS person_id
+                                                                                                                                                                                                                                                                                                                                                                           FROM cohortpeople
+                                                                                                                                                                                                                                                                                                                                                                           WHERE and(equals(cohortpeople.team_id, 99999), equals(cohortpeople.cohort_id, 99999), equals(cohortpeople.version, 0)))), 0)))
+           GROUP BY day_start,
+                    breakdown_value)
+        GROUP BY day_start,
+                 breakdown_value
+        ORDER BY day_start ASC, breakdown_value ASC)
+     GROUP BY breakdown_value
+     ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC)
+  WHERE isNotNull(breakdown_value)
+  GROUP BY breakdown_value
+  ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       format_csv_allow_double_quotes=0,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestTrends.test_person_filtering_in_cohort_in_action.3
@@ -2013,18 +2110,6 @@
 # ---
 # name: TestTrends.test_person_filtering_in_cohort_in_action_poe_v2
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: TestTrends.test_person_filtering_in_cohort_in_action_poe_v2.1
-  '''
   
   SELECT count(DISTINCT person_id)
   FROM cohortpeople
@@ -2033,7 +2118,7 @@
     AND version = NULL
   '''
 # ---
-# name: TestTrends.test_person_filtering_in_cohort_in_action_poe_v2.2
+# name: TestTrends.test_person_filtering_in_cohort_in_action_poe_v2.1
   '''
   /* cohort_calculation: */
   SELECT count(DISTINCT person_id)
@@ -2041,6 +2126,56 @@
   WHERE team_id = 99999
     AND cohort_id = 99999
     AND version = 0
+  '''
+# ---
+# name: TestTrends.test_person_filtering_in_cohort_in_action_poe_v2.2
+  '''
+  SELECT groupArray(1)(date)[1] AS date,
+                      arrayFold((acc, x) -> arrayMap(i -> plus(acc[i], x[i]), range(1, plus(length(date), 1))), groupArray(ifNull(total, 0)), arrayWithConstant(length(date), reinterpretAsFloat64(0))) AS total,
+                      if(ifNull(ifNull(greaterOrEquals(row_number, 25), 0), 0), '$$_posthog_breakdown_other_$$', breakdown_value) AS breakdown_value
+  FROM
+    (SELECT arrayMap(number -> plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))))), 1))) AS date,
+            arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
+                                                                                                                                                                                                      and isNull(_match_date)), _days_for_count), _index), 1))), date) AS total,
+            breakdown_value AS breakdown_value,
+            rowNumberInAllBlocks() AS row_number
+     FROM
+       (SELECT sum(total) AS count,
+               day_start AS day_start,
+               breakdown_value AS breakdown_value
+        FROM
+          (SELECT count() AS total,
+                  toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
+                  ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value
+           FROM events AS e SAMPLE 1
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), and(equals(e.event, 'sign up'), ifNull(in(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id),
+                                                                                                                                                                                                                                                                                                                                                                          (SELECT cohortpeople.person_id AS person_id
+                                                                                                                                                                                                                                                                                                                                                                           FROM cohortpeople
+                                                                                                                                                                                                                                                                                                                                                                           WHERE and(equals(cohortpeople.team_id, 99999), equals(cohortpeople.cohort_id, 99999), equals(cohortpeople.version, 0)))), 0)))
+           GROUP BY day_start,
+                    breakdown_value)
+        GROUP BY day_start,
+                 breakdown_value
+        ORDER BY day_start ASC, breakdown_value ASC)
+     GROUP BY breakdown_value
+     ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC)
+  WHERE isNotNull(breakdown_value)
+  GROUP BY breakdown_value
+  ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       format_csv_allow_double_quotes=0,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestTrends.test_person_filtering_in_cohort_in_action_poe_v2.3
@@ -3799,14 +3934,28 @@
 # ---
 # name: TestTrends.test_trends_any_event_total_count
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
+  SELECT arrayMap(number -> plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))))), 1))) AS date,
+         arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
+                                                                                                                                                                                                   and isNull(_match_date)), _days_for_count), _index), 1))), date) AS total
+  FROM
+    (SELECT sum(total) AS count,
+            day_start AS day_start
+     FROM
+       (SELECT count() AS total,
+               toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
+        FROM events AS e SAMPLE 1
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))))
+        GROUP BY day_start)
+     GROUP BY day_start
+     ORDER BY day_start ASC)
+  ORDER BY arraySum(total) DESC
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       format_csv_allow_double_quotes=0,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestTrends.test_trends_any_event_total_count.1
@@ -3821,7 +3970,7 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e SAMPLE 1
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -3863,14 +4012,55 @@
 # ---
 # name: TestTrends.test_trends_breakdown_cumulative
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
+  SELECT groupArray(1)(date)[1] AS date,
+                      arrayFold((acc, x) -> arrayMap(i -> plus(acc[i], x[i]), range(1, plus(length(date), 1))), groupArray(ifNull(total, 0)), arrayWithConstant(length(date), reinterpretAsFloat64(0))) AS total,
+                      if(ifNull(ifNull(greaterOrEquals(row_number, 25), 0), 0), '$$_posthog_breakdown_other_$$', breakdown_value) AS breakdown_value
+  FROM
+    (SELECT arrayMap(number -> plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))))), 1))) AS date,
+            arrayFill(x -> ifNull(greater(x, 0), 0), arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
+                                                                                                                                                                                                                                               and isNull(_match_date)), _days_for_count), _index), 1))), date)) AS total,
+            breakdown_value AS breakdown_value,
+            rowNumberInAllBlocks() AS row_number
+     FROM
+       (SELECT day_start AS day_start,
+               sum(count) OVER (PARTITION BY breakdown_value
+                                ORDER BY day_start ASC) AS count,
+                               breakdown_value AS breakdown_value
+        FROM
+          (SELECT sum(total) AS count,
+                  day_start AS day_start,
+                  breakdown_value AS breakdown_value
+           FROM
+             (SELECT count(DISTINCT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)) AS total,
+                     min(toStartOfDay(toTimeZone(e.timestamp, 'UTC'))) AS day_start,
+                     ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value
+              FROM events AS e SAMPLE 1
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
+              GROUP BY if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id),
+                       breakdown_value)
+           GROUP BY day_start,
+                    breakdown_value
+           ORDER BY day_start ASC, breakdown_value ASC)
+        ORDER BY day_start ASC)
+     GROUP BY breakdown_value
+     ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC)
+  WHERE isNotNull(breakdown_value)
+  GROUP BY breakdown_value
+  ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       format_csv_allow_double_quotes=0,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_cumulative.1
@@ -3928,14 +4118,55 @@
 # ---
 # name: TestTrends.test_trends_breakdown_cumulative_poe_v2
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
+  SELECT groupArray(1)(date)[1] AS date,
+                      arrayFold((acc, x) -> arrayMap(i -> plus(acc[i], x[i]), range(1, plus(length(date), 1))), groupArray(ifNull(total, 0)), arrayWithConstant(length(date), reinterpretAsFloat64(0))) AS total,
+                      if(ifNull(ifNull(greaterOrEquals(row_number, 25), 0), 0), '$$_posthog_breakdown_other_$$', breakdown_value) AS breakdown_value
+  FROM
+    (SELECT arrayMap(number -> plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))))), 1))) AS date,
+            arrayFill(x -> ifNull(greater(x, 0), 0), arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
+                                                                                                                                                                                                                                               and isNull(_match_date)), _days_for_count), _index), 1))), date)) AS total,
+            breakdown_value AS breakdown_value,
+            rowNumberInAllBlocks() AS row_number
+     FROM
+       (SELECT day_start AS day_start,
+               sum(count) OVER (PARTITION BY breakdown_value
+                                ORDER BY day_start ASC) AS count,
+                               breakdown_value AS breakdown_value
+        FROM
+          (SELECT sum(total) AS count,
+                  day_start AS day_start,
+                  breakdown_value AS breakdown_value
+           FROM
+             (SELECT count(DISTINCT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)) AS total,
+                     min(toStartOfDay(toTimeZone(e.timestamp, 'UTC'))) AS day_start,
+                     ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value
+              FROM events AS e SAMPLE 1
+              LEFT OUTER JOIN
+                (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                        person_distinct_id_overrides.distinct_id AS distinct_id
+                 FROM person_distinct_id_overrides
+                 WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                 GROUP BY person_distinct_id_overrides.distinct_id
+                 HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+              WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
+              GROUP BY if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id),
+                       breakdown_value)
+           GROUP BY day_start,
+                    breakdown_value
+           ORDER BY day_start ASC, breakdown_value ASC)
+        ORDER BY day_start ASC)
+     GROUP BY breakdown_value
+     ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC)
+  WHERE isNotNull(breakdown_value)
+  GROUP BY breakdown_value
+  ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       format_csv_allow_double_quotes=0,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_cumulative_poe_v2.1
@@ -4232,18 +4463,6 @@
 # ---
 # name: TestTrends.test_trends_compare_day_interval_relative_range
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: TestTrends.test_trends_compare_day_interval_relative_range.1
-  '''
   SELECT arrayMap(number -> plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))))), 1))) AS date,
          arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
                                                                                                                                                                                                    and isNull(_match_date)), _days_for_count), _index), 1))), date) AS total
@@ -4268,7 +4487,7 @@
                        max_bytes_before_external_group_by=0
   '''
 # ---
-# name: TestTrends.test_trends_compare_day_interval_relative_range.2
+# name: TestTrends.test_trends_compare_day_interval_relative_range.1
   '''
   SELECT arrayMap(number -> plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-21 00:00:00', 6, 'UTC'))), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-21 00:00:00', 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 23:59:59', 6, 'UTC'))))), 1))) AS date,
          arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
@@ -4281,6 +4500,32 @@
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e SAMPLE 1
         WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-21 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
+        GROUP BY day_start)
+     GROUP BY day_start
+     ORDER BY day_start ASC)
+  ORDER BY arraySum(total) DESC
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       format_csv_allow_double_quotes=0,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestTrends.test_trends_compare_day_interval_relative_range.2
+  '''
+  SELECT arrayMap(number -> plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))))), 1))) AS date,
+         arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
+                                                                                                                                                                                                   and isNull(_match_date)), _days_for_count), _index), 1))), date) AS total
+  FROM
+    (SELECT sum(total) AS count,
+            day_start AS day_start
+     FROM
+       (SELECT count() AS total,
+               toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
+        FROM events AS e SAMPLE 1
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -4562,14 +4807,33 @@
 # ---
 # name: TestTrends.test_trends_per_day_cumulative
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
+  SELECT arrayMap(number -> plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))))), 1))) AS date,
+         arrayFill(x -> ifNull(greater(x, 0), 0), arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
+                                                                                                                                                                                                                                            and isNull(_match_date)), _days_for_count), _index), 1))), date)) AS total
+  FROM
+    (SELECT day_start AS day_start,
+            sum(count) OVER (
+                             ORDER BY day_start ASC) AS count
+     FROM
+       (SELECT sum(total) AS count,
+               day_start AS day_start
+        FROM
+          (SELECT count() AS total,
+                  toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
+           FROM events AS e SAMPLE 1
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
+           GROUP BY day_start)
+        GROUP BY day_start
+        ORDER BY day_start ASC)
+     ORDER BY day_start ASC)
+  ORDER BY arraySum(total) DESC
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       format_csv_allow_double_quotes=0,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestTrends.test_trends_per_day_cumulative.1
@@ -4605,14 +4869,40 @@
 # ---
 # name: TestTrends.test_trends_per_day_dau_cumulative
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
+  SELECT arrayMap(number -> plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))))), 1))) AS date,
+         arrayFill(x -> ifNull(greater(x, 0), 0), arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
+                                                                                                                                                                                                                                            and isNull(_match_date)), _days_for_count), _index), 1))), date)) AS total
+  FROM
+    (SELECT day_start AS day_start,
+            sum(count) OVER (
+                             ORDER BY day_start ASC) AS count
+     FROM
+       (SELECT sum(total) AS count,
+               day_start AS day_start
+        FROM
+          (SELECT count(DISTINCT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)) AS total,
+                  min(toStartOfDay(toTimeZone(e.timestamp, 'UTC'))) AS day_start
+           FROM events AS e SAMPLE 1
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
+           GROUP BY if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id))
+        GROUP BY day_start
+        ORDER BY day_start ASC)
+     ORDER BY day_start ASC)
+  ORDER BY arraySum(total) DESC
+  LIMIT 50000 SETTINGS readonly=2,
+                       max_execution_time=60,
+                       allow_experimental_object_type=1,
+                       format_csv_allow_double_quotes=0,
+                       max_ast_elements=4000000,
+                       max_expanded_ast_elements=4000000,
+                       max_bytes_before_external_group_by=0
   '''
 # ---
 # name: TestTrends.test_trends_per_day_dau_cumulative.1

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -1155,11 +1155,7 @@
   '''
   SELECT groupArray(1)(date)[1] AS date,
                       arrayFold((acc, x) -> arrayMap(i -> plus(acc[i], x[i]), range(1, plus(length(date), 1))), groupArray(ifNull(total, 0)), arrayWithConstant(length(date), reinterpretAsFloat64(0))) AS total,
-<<<<<<< HEAD
-                      if(ifNull(ifNull(greaterOrEquals(row_number, 25), 0), 0), '$$_posthog_breakdown_other_$$', breakdown_value) AS breakdown_value
-=======
                       arrayMap(i -> if(ifNull(ifNull(greaterOrEquals(row_number, 25), 0), 0), '$$_posthog_breakdown_other_$$', i), breakdown_value) AS breakdown_value
->>>>>>> 4f42095f0f8 (Update query snapshots)
   FROM
     (SELECT arrayMap(number -> plus(toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toIntervalDay(number)), range(0, plus(coalesce(dateDiff('day', toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC'))), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))))), 1))) AS date,
             arrayMap(_match_date -> arraySum(arraySlice(groupArray(ifNull(count, 0)), indexOf(groupArray(day_start) AS _days_for_count, _match_date) AS _index, plus(minus(arrayLastIndex(x -> ifNull(equals(x, _match_date), isNull(x)
@@ -1169,19 +1165,11 @@
      FROM
        (SELECT sum(total) AS count,
                day_start AS day_start,
-<<<<<<< HEAD
-               breakdown_value AS breakdown_value
-        FROM
-          (SELECT count(DISTINCT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)) AS total,
-                  toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
-                  ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value
-=======
                [ifNull(toString(breakdown_value_1), '$$_posthog_breakdown_null_$$')] AS breakdown_value
         FROM
           (SELECT count(DISTINCT if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)) AS total,
                   toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start,
                   ifNull(nullIf(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$some_property'), ''), 'null'), '^"|"$', '')), ''), '$$_posthog_breakdown_null_$$') AS breakdown_value_1
->>>>>>> 4f42095f0f8 (Update query snapshots)
            FROM events AS e SAMPLE 1.0
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -1192,17 +1180,6 @@
               HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
            WHERE and(equals(e.team_id, 99999), greaterOrEquals(toTimeZone(e.timestamp, 'UTC'), toStartOfDay(assumeNotNull(parseDateTime64BestEffortOrNull('2019-12-28 00:00:00', 6, 'UTC')))), lessOrEquals(toTimeZone(e.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2020-01-04 23:59:59', 6, 'UTC'))), equals(e.event, 'sign up'))
            GROUP BY day_start,
-<<<<<<< HEAD
-                    breakdown_value)
-        GROUP BY day_start,
-                 breakdown_value
-        ORDER BY day_start ASC, breakdown_value ASC)
-     GROUP BY breakdown_value
-     ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC)
-  WHERE isNotNull(breakdown_value)
-  GROUP BY breakdown_value
-  ORDER BY if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_other_$$'), 0), 2, if(ifNull(equals(breakdown_value, '$$_posthog_breakdown_null_$$'), 0), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
-=======
                     breakdown_value_1)
         GROUP BY day_start,
                  breakdown_value_1
@@ -1212,7 +1189,6 @@
   WHERE arrayExists(x -> isNotNull(x), breakdown_value)
   GROUP BY breakdown_value
   ORDER BY if(has(breakdown_value, '$$_posthog_breakdown_other_$$'), 2, if(has(breakdown_value, '$$_posthog_breakdown_null_$$'), 1, 0)) ASC, arraySum(total) DESC, breakdown_value ASC
->>>>>>> 4f42095f0f8 (Update query snapshots)
   LIMIT 50000 SETTINGS readonly=2,
                        max_execution_time=60,
                        allow_experimental_object_type=1,

--- a/posthog/models/dashboard_templates.py
+++ b/posthog/models/dashboard_templates.py
@@ -69,12 +69,29 @@ class DashboardTemplate(UUIDModel):
                     "name": "Daily active users (DAUs)",
                     "type": "INSIGHT",
                     "color": "blue",
-                    "filters": {
-                        "events": [{"id": "$pageview", "math": "dau", "type": "events"}],
-                        "display": "ActionsLineGraph",
-                        "insight": "TRENDS",
-                        "interval": "day",
-                        "date_from": "-30d",
+                    "query": {
+                        "kind": "InsightVizNode",
+                        "source": {
+                            "kind": "TrendsQuery",
+                            "series": [
+                                {"kind": "EventsNode", "math": "dau", "name": "$pageview", "event": "$pageview"}
+                            ],
+                            "interval": "day",
+                            "dateRange": {"date_from": "-30d", "explicitDate": False},
+                            "properties": [],
+                            "trendsFilter": {
+                                "display": "ActionsLineGraph",
+                                "showLegend": False,
+                                "yAxisScaleType": "linear",
+                                "showValuesOnSeries": False,
+                                "smoothingIntervals": 1,
+                                "showPercentStackView": False,
+                                "aggregationAxisFormat": "numeric",
+                                "showAlertThresholdLines": False,
+                            },
+                            "breakdownFilter": {"breakdown_type": "event"},
+                            "filterTestAccounts": False,
+                        },
                     },
                     "layouts": {
                         "sm": {"h": 5, "w": 6, "x": 0, "y": 0, "minH": 5, "minW": 3},
@@ -86,18 +103,29 @@ class DashboardTemplate(UUIDModel):
                     "name": "Weekly active users (WAUs)",
                     "type": "INSIGHT",
                     "color": "green",
-                    "filters": {
-                        "events": [
-                            {
-                                "id": "$pageview",
-                                "math": "dau",
-                                "type": "events",
-                            }
-                        ],
-                        "display": "ActionsLineGraph",
-                        "insight": "TRENDS",
-                        "interval": "week",
-                        "date_from": "-90d",
+                    "query": {
+                        "kind": "InsightVizNode",
+                        "source": {
+                            "kind": "TrendsQuery",
+                            "series": [
+                                {"kind": "EventsNode", "math": "dau", "name": "$pageview", "event": "$pageview"}
+                            ],
+                            "interval": "week",
+                            "dateRange": {"date_from": "-90d", "explicitDate": False},
+                            "properties": [],
+                            "trendsFilter": {
+                                "display": "ActionsLineGraph",
+                                "showLegend": False,
+                                "yAxisScaleType": "linear",
+                                "showValuesOnSeries": False,
+                                "smoothingIntervals": 1,
+                                "showPercentStackView": False,
+                                "aggregationAxisFormat": "numeric",
+                                "showAlertThresholdLines": False,
+                            },
+                            "breakdownFilter": {"breakdown_type": "event"},
+                            "filterTestAccounts": False,
+                        },
                     },
                     "layouts": {
                         "sm": {"h": 5, "w": 6, "x": 6, "y": 0, "minH": 5, "minW": 3},
@@ -109,12 +137,21 @@ class DashboardTemplate(UUIDModel):
                     "name": "Retention",
                     "type": "INSIGHT",
                     "color": "blue",
-                    "filters": {
-                        "period": "Week",
-                        "insight": "RETENTION",
-                        "target_entity": {"id": "$pageview", "type": "events"},
-                        "retention_type": "retention_first_time",
-                        "returning_entity": {"id": "$pageview", "type": "events"},
+                    "query": {
+                        "kind": "InsightVizNode",
+                        "source": {
+                            "kind": "RetentionQuery",
+                            "dateRange": {"date_from": "-7d", "explicitDate": False},
+                            "properties": [],
+                            "retentionFilter": {
+                                "period": "Week",
+                                "targetEntity": {"id": "$pageview", "type": "events"},
+                                "retentionType": "retention_first_time",
+                                "totalIntervals": 11,
+                                "returningEntity": {"id": "$pageview", "type": "events"},
+                            },
+                            "filterTestAccounts": False,
+                        },
                     },
                     "layouts": {
                         "sm": {"h": 5, "w": 6, "x": 6, "y": 5, "minH": 5, "minW": 3},
@@ -126,13 +163,17 @@ class DashboardTemplate(UUIDModel):
                     "name": "Growth accounting",
                     "type": "INSIGHT",
                     "color": "purple",
-                    "filters": {
-                        "events": [{"id": "$pageview", "type": "events"}],
-                        "insight": "LIFECYCLE",
-                        "interval": "week",
-                        "shown_as": "Lifecycle",
-                        "date_from": "-30d",
-                        "entity_type": "events",
+                    "query": {
+                        "kind": "InsightVizNode",
+                        "source": {
+                            "kind": "LifecycleQuery",
+                            "series": [{"kind": "EventsNode", "name": "$pageview", "event": "$pageview"}],
+                            "interval": "week",
+                            "dateRange": {"date_from": "-30d", "explicitDate": False},
+                            "properties": [],
+                            "lifecycleFilter": {"showLegend": False},
+                            "filterTestAccounts": False,
+                        },
                     },
                     "layouts": {
                         "sm": {"h": 5, "w": 6, "x": 0, "y": 5, "minH": 5, "minW": 3},
@@ -144,14 +185,29 @@ class DashboardTemplate(UUIDModel):
                     "name": "Referring domain (last 14 days)",
                     "type": "INSIGHT",
                     "color": "black",
-                    "filters": {
-                        "events": [{"id": "$pageview", "math": "dau", "type": "events"}],
-                        "display": "ActionsBarValue",
-                        "insight": "TRENDS",
-                        "interval": "day",
-                        "breakdown": "$referring_domain",
-                        "date_from": "-14d",
-                        "breakdown_type": "event",
+                    "query": {
+                        "kind": "InsightVizNode",
+                        "source": {
+                            "kind": "TrendsQuery",
+                            "series": [
+                                {"kind": "EventsNode", "math": "dau", "name": "$pageview", "event": "$pageview"}
+                            ],
+                            "interval": "day",
+                            "dateRange": {"date_from": "-14d", "explicitDate": False},
+                            "properties": [],
+                            "trendsFilter": {
+                                "display": "ActionsBarValue",
+                                "showLegend": False,
+                                "yAxisScaleType": "linear",
+                                "showValuesOnSeries": False,
+                                "smoothingIntervals": 1,
+                                "showPercentStackView": False,
+                                "aggregationAxisFormat": "numeric",
+                                "showAlertThresholdLines": False,
+                            },
+                            "breakdownFilter": {"breakdown": "$referring_domain", "breakdown_type": "event"},
+                            "filterTestAccounts": False,
+                        },
                     },
                     "layouts": {
                         "sm": {"h": 5, "w": 6, "x": 0, "y": 10, "minH": 5, "minW": 3},
@@ -163,35 +219,46 @@ class DashboardTemplate(UUIDModel):
                     "name": "Pageview funnel, by browser",
                     "type": "INSIGHT",
                     "color": "green",
-                    "filters": {
-                        "events": [
-                            {
-                                "id": "$pageview",
-                                "type": "events",
-                                "order": 0,
-                                "custom_name": "First page view",
+                    "query": {
+                        "kind": "InsightVizNode",
+                        "source": {
+                            "kind": "FunnelsQuery",
+                            "series": [
+                                {
+                                    "kind": "EventsNode",
+                                    "name": "$pageview",
+                                    "event": "$pageview",
+                                    "custom_name": "First page view",
+                                },
+                                {
+                                    "kind": "EventsNode",
+                                    "name": "$pageview",
+                                    "event": "$pageview",
+                                    "custom_name": "Second page view",
+                                },
+                                {
+                                    "kind": "EventsNode",
+                                    "name": "$pageview",
+                                    "event": "$pageview",
+                                    "custom_name": "Third page view",
+                                },
+                            ],
+                            "interval": "day",
+                            "dateRange": {"date_from": "-7d", "explicitDate": False},
+                            "properties": [],
+                            "funnelsFilter": {
+                                "layout": "horizontal",
+                                "exclusions": [],
+                                "funnelVizType": "steps",
+                                "funnelOrderType": "ordered",
+                                "funnelStepReference": "total",
+                                "funnelWindowInterval": 14,
+                                "breakdownAttributionType": "first_touch",
+                                "funnelWindowIntervalUnit": "day",
                             },
-                            {
-                                "id": "$pageview",
-                                "type": "events",
-                                "order": 1,
-                                "custom_name": "Second page view",
-                            },
-                            {
-                                "id": "$pageview",
-                                "type": "events",
-                                "order": 2,
-                                "custom_name": "Third page view",
-                            },
-                        ],
-                        "layout": "horizontal",
-                        "display": "FunnelViz",
-                        "insight": "FUNNELS",
-                        "interval": "day",
-                        "exclusions": [],
-                        "breakdown_type": "event",
-                        "breakdown": "$browser",
-                        "funnel_viz_type": "steps",
+                            "breakdownFilter": {"breakdown": "$browser", "breakdown_type": "event"},
+                            "filterTestAccounts": False,
+                        },
                     },
                     "layouts": {
                         "sm": {"h": 5, "w": 6, "x": 6, "y": 10, "minH": 5, "minW": 3},
@@ -214,12 +281,29 @@ class DashboardTemplate(UUIDModel):
                     "name": "Daily active users (DAUs)",
                     "type": "INSIGHT",
                     "color": "blue",
-                    "filters": {
-                        "events": [{"id": "$pageview", "math": "dau", "type": "events"}],
-                        "display": "ActionsLineGraph",
-                        "insight": "TRENDS",
-                        "interval": "day",
-                        "date_from": "-30d",
+                    "query": {
+                        "kind": "InsightVizNode",
+                        "source": {
+                            "kind": "TrendsQuery",
+                            "series": [
+                                {"kind": "EventsNode", "math": "dau", "name": "$pageview", "event": "$pageview"}
+                            ],
+                            "interval": "day",
+                            "dateRange": {"date_from": "-30d", "explicitDate": False},
+                            "properties": [],
+                            "trendsFilter": {
+                                "display": "ActionsLineGraph",
+                                "showLegend": False,
+                                "yAxisScaleType": "linear",
+                                "showValuesOnSeries": False,
+                                "smoothingIntervals": 1,
+                                "showPercentStackView": False,
+                                "aggregationAxisFormat": "numeric",
+                                "showAlertThresholdLines": False,
+                            },
+                            "breakdownFilter": {"breakdown_type": "event"},
+                            "filterTestAccounts": False,
+                        },
                     },
                     "layouts": {
                         "sm": {"h": 5, "w": 6, "x": 0, "y": 0, "minH": 5, "minW": 3},
@@ -231,18 +315,29 @@ class DashboardTemplate(UUIDModel):
                     "name": "Weekly active users (WAUs)",
                     "type": "INSIGHT",
                     "color": "green",
-                    "filters": {
-                        "events": [
-                            {
-                                "id": "$pageview",
-                                "math": "dau",
-                                "type": "events",
-                            }
-                        ],
-                        "display": "ActionsLineGraph",
-                        "insight": "TRENDS",
-                        "interval": "week",
-                        "date_from": "-90d",
+                    "query": {
+                        "kind": "InsightVizNode",
+                        "source": {
+                            "kind": "TrendsQuery",
+                            "series": [
+                                {"kind": "EventsNode", "math": "dau", "name": "$pageview", "event": "$pageview"}
+                            ],
+                            "interval": "week",
+                            "dateRange": {"date_from": "-90d", "explicitDate": False},
+                            "properties": [],
+                            "trendsFilter": {
+                                "display": "ActionsLineGraph",
+                                "showLegend": False,
+                                "yAxisScaleType": "linear",
+                                "showValuesOnSeries": False,
+                                "smoothingIntervals": 1,
+                                "showPercentStackView": False,
+                                "aggregationAxisFormat": "numeric",
+                                "showAlertThresholdLines": False,
+                            },
+                            "breakdownFilter": {"breakdown_type": "event"},
+                            "filterTestAccounts": False,
+                        },
                     },
                     "layouts": {
                         "sm": {"h": 5, "w": 6, "x": 6, "y": 0, "minH": 5, "minW": 3},

--- a/posthog/queries/test/__snapshots__/test_trends.ambr
+++ b/posthog/queries/test/__snapshots__/test_trends.ambr
@@ -859,18 +859,6 @@
 # ---
 # name: TestTrends.test_dau_with_breakdown_filtering_with_sampling
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: TestTrends.test_dau_with_breakdown_filtering_with_sampling.1
-  '''
   
   SELECT replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS value,
          count(*) as count
@@ -883,6 +871,58 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0
+  '''
+# ---
+# name: TestTrends.test_dau_with_breakdown_filtering_with_sampling.1
+  '''
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total,
+         breakdown_value
+  FROM
+    (SELECT SUM(total) as count,
+            day_start,
+            breakdown_value
+     FROM
+       (SELECT *
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  ticks.day_start as day_start,
+                  breakdown_value
+           FROM
+             (SELECT toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC')) - toIntervalDay(number) as day_start
+              FROM numbers(8)
+              UNION ALL SELECT toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')) as day_start) as ticks
+           CROSS JOIN
+             (SELECT breakdown_value
+              FROM
+                (SELECT ['other_value', '$$_posthog_breakdown_null_$$', 'value'] as breakdown_value) ARRAY
+              JOIN breakdown_value) as sec
+           ORDER BY breakdown_value,
+                    day_start
+           UNION ALL SELECT count(DISTINCT pdi.person_id) as total,
+                            toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                            transform(ifNull(nullIf(replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', ''), ''), '$$_posthog_breakdown_null_$$'), (['other_value', '$$_posthog_breakdown_null_$$', 'value']), (['other_value', '$$_posthog_breakdown_null_$$', 'value']), '$$_posthog_breakdown_other_$$') as breakdown_value
+           FROM events e SAMPLE 1.0
+           INNER JOIN
+             (SELECT distinct_id,
+                     argMax(person_id, version) as person_id
+              FROM person_distinct_id2
+              WHERE team_id = 99999
+              GROUP BY distinct_id
+              HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
+           WHERE e.team_id = 99999
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+             AND ((event = 'sign up'))
+           GROUP BY day_start,
+                    breakdown_value))
+     GROUP BY day_start,
+              breakdown_value
+     ORDER BY breakdown_value,
+              day_start)
+  GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '''
 # ---
 # name: TestTrends.test_dau_with_breakdown_filtering_with_sampling.10
@@ -1048,6 +1088,22 @@
 # name: TestTrends.test_dau_with_breakdown_filtering_with_sampling.2
   '''
   
+  SELECT replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS value,
+         count(*) as count
+  FROM events e SAMPLE 1.0
+  WHERE team_id = 99999
+    AND event = 'sign up'
+    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
+    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+  GROUP BY value
+  ORDER BY count DESC, value DESC
+  LIMIT 26
+  OFFSET 0
+  '''
+# ---
+# name: TestTrends.test_dau_with_breakdown_filtering_with_sampling.3
+  '''
+  
   SELECT groupArray(day_start) as date,
          groupArray(count) AS total,
          breakdown_value
@@ -1084,9 +1140,9 @@
               GROUP BY distinct_id
               HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
            WHERE e.team_id = 99999
+             AND event = 'sign up'
              AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
              AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
-             AND ((event = 'sign up'))
            GROUP BY day_start,
                     breakdown_value))
      GROUP BY day_start,
@@ -1095,22 +1151,6 @@
               day_start)
   GROUP BY breakdown_value
   ORDER BY breakdown_value
-  '''
-# ---
-# name: TestTrends.test_dau_with_breakdown_filtering_with_sampling.3
-  '''
-  
-  SELECT replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS value,
-         count(*) as count
-  FROM events e SAMPLE 1.0
-  WHERE team_id = 99999
-    AND event = 'sign up'
-    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2019-12-28 00:00:00', 'UTC')
-    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
-  GROUP BY value
-  ORDER BY count DESC, value DESC
-  LIMIT 26
-  OFFSET 0
   '''
 # ---
 # name: TestTrends.test_dau_with_breakdown_filtering_with_sampling.4
@@ -1718,18 +1758,6 @@
 # ---
 # name: TestTrends.test_person_filtering_in_cohort_in_action
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: TestTrends.test_person_filtering_in_cohort_in_action.1
-  '''
   
   SELECT replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS value,
          count(*) as count
@@ -1761,6 +1789,70 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0
+  '''
+# ---
+# name: TestTrends.test_person_filtering_in_cohort_in_action.1
+  '''
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total,
+         breakdown_value
+  FROM
+    (SELECT SUM(total) as count,
+            day_start,
+            breakdown_value
+     FROM
+       (SELECT *
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  ticks.day_start as day_start,
+                  breakdown_value
+           FROM
+             (SELECT toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC')) - toIntervalDay(number) as day_start
+              FROM numbers(8)
+              UNION ALL SELECT toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')) as day_start) as ticks
+           CROSS JOIN
+             (SELECT breakdown_value
+              FROM
+                (SELECT ['$$_posthog_breakdown_null_$$', 'value', 'other_value'] as breakdown_value) ARRAY
+              JOIN breakdown_value) as sec
+           ORDER BY breakdown_value,
+                    day_start
+           UNION ALL SELECT count(*) as total,
+                            toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                            transform(ifNull(nullIf(replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', ''), ''), '$$_posthog_breakdown_null_$$'), (['$$_posthog_breakdown_null_$$', 'value', 'other_value']), (['$$_posthog_breakdown_null_$$', 'value', 'other_value']), '$$_posthog_breakdown_other_$$') as breakdown_value
+           FROM events e
+           INNER JOIN
+             (SELECT distinct_id,
+                     argMax(person_id, version) as person_id
+              FROM person_distinct_id2
+              WHERE team_id = 99999
+              GROUP BY distinct_id
+              HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
+           WHERE e.team_id = 99999
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+             AND ((event = 'sign up'
+                   AND (pdi.person_id IN
+                          (SELECT id
+                           FROM person
+                           WHERE team_id = 99999
+                             AND id IN
+                               (SELECT id
+                                FROM person
+                                WHERE team_id = 99999
+                                  AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, '$some_prop'), '^"|"$', '')))) )
+                           GROUP BY id
+                           HAVING max(is_deleted) = 0
+                           AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1))))
+           GROUP BY day_start,
+                    breakdown_value))
+     GROUP BY day_start,
+              breakdown_value
+     ORDER BY breakdown_value,
+              day_start)
+  GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '''
 # ---
 # name: TestTrends.test_person_filtering_in_cohort_in_action.2
@@ -1829,18 +1921,6 @@
 # ---
 # name: TestTrends.test_person_filtering_in_cohort_in_action_poe_v2
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: TestTrends.test_person_filtering_in_cohort_in_action_poe_v2.1
-  '''
   
   SELECT replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS value,
          count(*) as count
@@ -1873,6 +1953,72 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0
+  '''
+# ---
+# name: TestTrends.test_person_filtering_in_cohort_in_action_poe_v2.1
+  '''
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total,
+         breakdown_value
+  FROM
+    (SELECT SUM(total) as count,
+            day_start,
+            breakdown_value
+     FROM
+       (SELECT *
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  ticks.day_start as day_start,
+                  breakdown_value
+           FROM
+             (SELECT toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC')) - toIntervalDay(number) as day_start
+              FROM numbers(8)
+              UNION ALL SELECT toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')) as day_start) as ticks
+           CROSS JOIN
+             (SELECT breakdown_value
+              FROM
+                (SELECT ['$$_posthog_breakdown_null_$$', 'value', 'other_value'] as breakdown_value) ARRAY
+              JOIN breakdown_value) as sec
+           ORDER BY breakdown_value,
+                    day_start
+           UNION ALL SELECT count(*) as total,
+                            toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                            transform(ifNull(nullIf(replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', ''), ''), '$$_posthog_breakdown_null_$$'), (['$$_posthog_breakdown_null_$$', 'value', 'other_value']), (['$$_posthog_breakdown_null_$$', 'value', 'other_value']), '$$_posthog_breakdown_other_$$') as breakdown_value
+           FROM events e
+           LEFT OUTER JOIN
+             (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                     person_distinct_id_overrides.distinct_id AS distinct_id
+              FROM person_distinct_id_overrides
+              WHERE equals(person_distinct_id_overrides.team_id, 99999)
+              GROUP BY person_distinct_id_overrides.distinct_id
+              HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0)) AS overrides ON e.distinct_id = overrides.distinct_id
+           WHERE e.team_id = 99999
+             AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+             AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+             AND notEmpty(e.person_id)
+             AND ((event = 'sign up'
+                   AND (if(notEmpty(overrides.distinct_id), overrides.person_id, e.person_id) IN
+                          (SELECT id
+                           FROM person
+                           WHERE team_id = 99999
+                             AND id IN
+                               (SELECT id
+                                FROM person
+                                WHERE team_id = 99999
+                                  AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(properties, '$some_prop'), '^"|"$', '')))) )
+                           GROUP BY id
+                           HAVING max(is_deleted) = 0
+                           AND ((has(['some_val'], replaceRegexpAll(JSONExtractRaw(argMax(person.properties, version), '$some_prop'), '^"|"$', '')))) SETTINGS optimize_aggregation_in_order = 1))))
+             AND notEmpty(e.person_id)
+           GROUP BY day_start,
+                    breakdown_value))
+     GROUP BY day_start,
+              breakdown_value
+     ORDER BY breakdown_value,
+              day_start)
+  GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '''
 # ---
 # name: TestTrends.test_person_filtering_in_cohort_in_action_poe_v2.2
@@ -4232,14 +4378,28 @@
 # ---
 # name: TestTrends.test_trends_any_event_total_count
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total
+  FROM
+    (SELECT SUM(total) AS count,
+            day_start
+     FROM
+       (SELECT toUInt16(0) AS total,
+               toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC')) - toIntervalDay(number) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
+        UNION ALL SELECT toUInt16(0) AS total,
+                         toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
+        UNION ALL SELECT count(*) AS total,
+                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+        FROM events e
+        WHERE team_id = 99999
+          AND 1 = 1
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+        GROUP BY date)
+     GROUP BY day_start
+     ORDER BY day_start)
   '''
 # ---
 # name: TestTrends.test_trends_any_event_total_count.1
@@ -4260,7 +4420,7 @@
                          toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
         FROM events e
         WHERE team_id = 99999
-          AND 1 = 1
+          AND event = 'sign up'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
         GROUP BY date)
@@ -4296,18 +4456,6 @@
 # ---
 # name: TestTrends.test_trends_breakdown_cumulative
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: TestTrends.test_trends_breakdown_cumulative.1
-  '''
   
   SELECT replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS value,
          count(*) as count
@@ -4320,6 +4468,66 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0
+  '''
+# ---
+# name: TestTrends.test_trends_breakdown_cumulative.1
+  '''
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total,
+         breakdown_value
+  FROM
+    (SELECT SUM(total) as count,
+            day_start,
+            breakdown_value
+     FROM
+       (SELECT *
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  ticks.day_start as day_start,
+                  breakdown_value
+           FROM
+             (SELECT toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC')) - toIntervalDay(number) as day_start
+              FROM numbers(8)
+              UNION ALL SELECT toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')) as day_start) as ticks
+           CROSS JOIN
+             (SELECT breakdown_value
+              FROM
+                (SELECT ['$$_posthog_breakdown_null_$$', 'value', 'other_value'] as breakdown_value) ARRAY
+              JOIN breakdown_value) as sec
+           ORDER BY breakdown_value,
+                    day_start
+           UNION ALL SELECT count(DISTINCT person_id) as total,
+                            toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                            breakdown_value
+           FROM
+             (SELECT person_id,
+                     min(timestamp) as timestamp,
+                     breakdown_value
+              FROM
+                (SELECT pdi.person_id as person_id, timestamp, transform(ifNull(nullIf(replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', ''), ''), '$$_posthog_breakdown_null_$$'), (['$$_posthog_breakdown_null_$$', 'value', 'other_value']), (['$$_posthog_breakdown_null_$$', 'value', 'other_value']), '$$_posthog_breakdown_other_$$') as breakdown_value
+                 FROM events e
+                 INNER JOIN
+                   (SELECT distinct_id,
+                           argMax(person_id, version) as person_id
+                    FROM person_distinct_id2
+                    WHERE team_id = 99999
+                    GROUP BY distinct_id
+                    HAVING argMax(is_deleted, version) = 0) as pdi ON events.distinct_id = pdi.distinct_id
+                 WHERE e.team_id = 99999
+                   AND event = 'sign up'
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC') )
+              GROUP BY person_id,
+                       breakdown_value) AS pdi
+           GROUP BY day_start,
+                    breakdown_value))
+     GROUP BY day_start,
+              breakdown_value
+     ORDER BY breakdown_value,
+              day_start)
+  GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_cumulative.2
@@ -4384,18 +4592,6 @@
 # ---
 # name: TestTrends.test_trends_breakdown_cumulative_poe_v2
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: TestTrends.test_trends_breakdown_cumulative_poe_v2.1
-  '''
   
   SELECT replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', '') AS value,
          count(*) as count
@@ -4416,6 +4612,68 @@
   ORDER BY count DESC, value DESC
   LIMIT 26
   OFFSET 0
+  '''
+# ---
+# name: TestTrends.test_trends_breakdown_cumulative_poe_v2.1
+  '''
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total,
+         breakdown_value
+  FROM
+    (SELECT SUM(total) as count,
+            day_start,
+            breakdown_value
+     FROM
+       (SELECT *
+        FROM
+          (SELECT toUInt16(0) AS total,
+                  ticks.day_start as day_start,
+                  breakdown_value
+           FROM
+             (SELECT toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC')) - toIntervalDay(number) as day_start
+              FROM numbers(8)
+              UNION ALL SELECT toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')) as day_start) as ticks
+           CROSS JOIN
+             (SELECT breakdown_value
+              FROM
+                (SELECT ['$$_posthog_breakdown_null_$$', 'value', 'other_value'] as breakdown_value) ARRAY
+              JOIN breakdown_value) as sec
+           ORDER BY breakdown_value,
+                    day_start
+           UNION ALL SELECT count(DISTINCT person_id) as total,
+                            toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) as day_start,
+                            breakdown_value
+           FROM
+             (SELECT person_id,
+                     min(timestamp) as timestamp,
+                     breakdown_value
+              FROM
+                (SELECT if(notEmpty(overrides.distinct_id), overrides.person_id, e.person_id) as person_id, timestamp, transform(ifNull(nullIf(replaceRegexpAll(JSONExtractRaw(properties, '$some_property'), '^"|"$', ''), ''), '$$_posthog_breakdown_null_$$'), (['$$_posthog_breakdown_null_$$', 'value', 'other_value']), (['$$_posthog_breakdown_null_$$', 'value', 'other_value']), '$$_posthog_breakdown_other_$$') as breakdown_value
+                 FROM events e
+                 LEFT OUTER JOIN
+                   (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                           person_distinct_id_overrides.distinct_id AS distinct_id
+                    FROM person_distinct_id_overrides
+                    WHERE equals(person_distinct_id_overrides.team_id, 99999)
+                    GROUP BY person_distinct_id_overrides.distinct_id
+                    HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0)) AS overrides ON e.distinct_id = overrides.distinct_id
+                 WHERE e.team_id = 99999
+                   AND event = 'sign up'
+                   AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+                   AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+                   AND notEmpty(e.person_id)
+                   AND notEmpty(e.person_id) )
+              GROUP BY person_id,
+                       breakdown_value) AS pdi
+           GROUP BY day_start,
+                    breakdown_value))
+     GROUP BY day_start,
+              breakdown_value
+     ORDER BY breakdown_value,
+              day_start)
+  GROUP BY breakdown_value
+  ORDER BY breakdown_value
   '''
 # ---
 # name: TestTrends.test_trends_breakdown_cumulative_poe_v2.2
@@ -4596,18 +4854,6 @@
 # ---
 # name: TestTrends.test_trends_compare_day_interval_relative_range
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
-  '''
-# ---
-# name: TestTrends.test_trends_compare_day_interval_relative_range.1
-  '''
   
   SELECT groupArray(day_start) as date,
          groupArray(count) AS total
@@ -4632,7 +4878,7 @@
      ORDER BY day_start)
   '''
 # ---
-# name: TestTrends.test_trends_compare_day_interval_relative_range.2
+# name: TestTrends.test_trends_compare_day_interval_relative_range.1
   '''
   
   SELECT groupArray(day_start) as date,
@@ -4653,6 +4899,32 @@
           AND event = 'sign up'
           AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-21 00:00:00', 'UTC')), 'UTC')
           AND toTimeZone(timestamp, 'UTC') <= toDateTime('2019-12-28 23:59:59', 'UTC')
+        GROUP BY date)
+     GROUP BY day_start
+     ORDER BY day_start)
+  '''
+# ---
+# name: TestTrends.test_trends_compare_day_interval_relative_range.2
+  '''
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total
+  FROM
+    (SELECT SUM(total) AS count,
+            day_start
+     FROM
+       (SELECT toUInt16(0) AS total,
+               toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC')) - toIntervalDay(number) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
+        UNION ALL SELECT toUInt16(0) AS total,
+                         toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
+        UNION ALL SELECT count(*) AS total,
+                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+        FROM events e
+        WHERE team_id = 99999
+          AND event = 'sign up'
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
         GROUP BY date)
      GROUP BY day_start
      ORDER BY day_start)
@@ -4967,14 +5239,28 @@
 # ---
 # name: TestTrends.test_trends_per_day_cumulative
   '''
-  /* celery:posthog.tasks.tasks.sync_insight_caching_state */
-  SELECT team_id,
-         date_diff('second', max(timestamp), now()) AS age
-  FROM events
-  WHERE timestamp > date_sub(DAY, 3, now())
-    AND timestamp < now()
-  GROUP BY team_id
-  ORDER BY age;
+  
+  SELECT groupArray(day_start) as date,
+         groupArray(count) AS total
+  FROM
+    (SELECT SUM(total) AS count,
+            day_start
+     FROM
+       (SELECT toUInt16(0) AS total,
+               toStartOfDay(toDateTime('2020-01-04 23:59:59', 'UTC')) - toIntervalDay(number) AS day_start
+        FROM numbers(dateDiff('day', toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), toDateTime('2020-01-04 23:59:59', 'UTC')))
+        UNION ALL SELECT toUInt16(0) AS total,
+                         toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC'))
+        UNION ALL SELECT count(*) AS total,
+                         toStartOfDay(toTimeZone(toDateTime(timestamp, 'UTC'), 'UTC')) AS date
+        FROM events e
+        WHERE team_id = 99999
+          AND event = 'sign up'
+          AND toTimeZone(timestamp, 'UTC') >= toDateTime(toStartOfDay(toDateTime('2019-12-28 00:00:00', 'UTC')), 'UTC')
+          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
+        GROUP BY date)
+     GROUP BY day_start
+     ORDER BY day_start)
   '''
 # ---
 # name: TestTrends.test_trends_per_day_cumulative.1


### PR DESCRIPTION
## Problem

Follow up to https://github.com/PostHog/posthog/pull/26389.

## Changes

Removes remaining instances of filters in dashboard templates.

## How did you test this code?

- [x] created a new team to test creation of the "DEFAULT_APP" dashboard
- [x] created a feature flag usage dashboard