### PR TITLE
fix: Attempt to disable send timeout

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -6,11 +6,11 @@ import json
 import ssl
 import typing
 import uuid
-import structlog
 
 import aiohttp
 import pyarrow as pa
 import requests
+import structlog
 from django.conf import settings
 
 import posthog.temporal.common.asyncpa as asyncpa
@@ -511,6 +511,7 @@ async def get_client(
         max_memory_usage=settings.CLICKHOUSE_MAX_MEMORY_USAGE,
         max_block_size=max_block_size,
         output_format_arrow_string_as_string="true",
+        http_send_timeout=0,
         **kwargs,
     ) as client:
         yield client


### PR DESCRIPTION
## Problem

ClickHouse is sometimes timing out our queries.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Let's tell clickhouse not to do that.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
