### PR TITLE
fix: Include partition column if present

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -295,9 +295,14 @@ class BigQueryClient(bigquery.Client):
     ):
         """Attempt to SELECT from table to check for query permissions."""
         job_config = bigquery.QueryJobConfig()
-        query = f"""
-        SELECT 1 FROM  `{table.full_table_id.replace(":", ".", 1)}`
-        """
+        if "timestamp" in [field.name for field in table.schema]:
+            query = f"""
+            SELECT 1 FROM  `{table.full_table_id.replace(":", ".", 1)}` WHERE timestamp IS NOT NULL
+            """
+        else:
+            query = f"""
+            SELECT 1 FROM  `{table.full_table_id.replace(":", ".", 1)}`
+            """
 
         try:
             query_job = self.query(query, job_config=job_config)


### PR DESCRIPTION
## Problem

We need to include the partition column when querying a table partitioned by timestamp.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Include partition column `timestamp` if present.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
