### PR TITLE
fix(experiments): Disable custom exposure metric for dw queries

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Goal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Goal.tsx
@@ -250,6 +250,11 @@ export function Goal(): JSX.Element {
     const [isModalOpen, setIsModalOpen] = useState(false)
     const metricType = getMetricType(0)
 
+    // :FLAG: CLEAN UP AFTER MIGRATION
+    const isDataWarehouseMetric =
+        featureFlags[FEATURE_FLAGS.EXPERIMENTS_HOGQL] &&
+        (experiment.metrics[0] as ExperimentTrendsQuery).count_query.series[0].kind === NodeKind.DataWarehouseNode
+
     return (
         <div>
             <div>
@@ -322,16 +327,18 @@ export function Goal(): JSX.Element {
                             Change goal
                         </LemonButton>
                     </div>
-                    {metricType === InsightType.TRENDS && !experimentMathAggregationForTrends() && (
-                        <>
-                            <LemonDivider className="" vertical />
-                            <div className="">
-                                <div className="mt-auto ml-auto">
-                                    <ExposureMetric experimentId={experimentId} />
+                    {metricType === InsightType.TRENDS &&
+                        !experimentMathAggregationForTrends() &&
+                        !isDataWarehouseMetric && (
+                            <>
+                                <LemonDivider className="" vertical />
+                                <div className="">
+                                    <div className="mt-auto ml-auto">
+                                        <ExposureMetric experimentId={experimentId} />
+                                    </div>
                                 </div>
-                            </div>
-                        </>
-                    )}
+                            </>
+                        )}
                 </div>
             )}
             <PrimaryMetricModal

--- a/posthog/hogql_queries/experiments/experiment_trends_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_trends_query_runner.py
@@ -178,9 +178,10 @@ class ExperimentTrendsQueryRunner(QueryRunner):
 
         # 1. If math aggregation is used, we construct an implicit exposure query: unique users for the count event
         uses_math_aggregation = self._uses_math_aggregation_by_user_or_property_value(self.query.count_query)
+        prepared_count_query = TrendsQuery(**self.query.count_query.model_dump())
 
         if uses_math_aggregation:
-            prepared_exposure_query = TrendsQuery(**self.query.count_query.model_dump())
+            prepared_exposure_query = prepared_count_query
             prepared_exposure_query.dateRange = self._get_insight_date_range()
             prepared_exposure_query.trendsFilter = TrendsFilter(display=ChartDisplayType.ACTIONS_LINE_GRAPH_CUMULATIVE)
 
@@ -226,7 +227,7 @@ class ExperimentTrendsQueryRunner(QueryRunner):
                     raise ValueError("Expected first series item to have an 'event' attribute")
 
         # 2. Otherwise, if an exposure query is provided, we use it as is, adapting the date range and breakdown
-        elif self.query.exposure_query:
+        elif self.query.exposure_query and not self._is_data_warehouse_query(prepared_count_query):
             prepared_exposure_query = TrendsQuery(**self.query.exposure_query.model_dump())
             prepared_exposure_query.dateRange = self._get_insight_date_range()
             prepared_exposure_query.trendsFilter = TrendsFilter(display=ChartDisplayType.ACTIONS_LINE_GRAPH_CUMULATIVE)

--- a/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
@@ -532,7 +532,11 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     team=self.team,
                     event="$feature_flag_called",
                     distinct_id=f"user_{variant}_{i}",
-                    properties={feature_flag_property: variant},
+                    properties={
+                        "$feature_flag_response": variant,
+                        feature_flag_property: variant,
+                        "$feature_flag": feature_flag.key,
+                    },
                     timestamp=datetime(2023, 1, i + 1),
                 )
 
@@ -546,7 +550,11 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             team=self.team,
             event="$feature_flag_called",
             distinct_id="user_test_3",
-            properties={feature_flag_property: "control"},
+            properties={
+                feature_flag_property: "control",
+                "$feature_flag_response": "control",
+                "$feature_flag": feature_flag.key,
+            },
             timestamp=datetime(2023, 1, 3),
         )
         _create_event(
@@ -560,7 +568,11 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             team=self.team,
             event="$feature_flag_called",
             distinct_id="user_test_3",
-            properties={feature_flag_property: "control"},
+            properties={
+                feature_flag_property: "control",
+                "$feature_flag_response": "control",
+                "$feature_flag": feature_flag.key,
+            },
             timestamp=datetime(2023, 1, 9),
         )
 


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/26332
See https://posthog.slack.com/archives/C07PXH2GTGV/p1733928472898169?thread_ts=1733847219.869179&cid=C07PXH2GTGV

## Changes

Disables custom exposure metrics for data warehouse queries:

![CleanShot 2024-12-11 at 07 30 55@2x](https://github.com/user-attachments/assets/79e542c7-34c7-4b9b-b253-27c88e7c1d58)

## How did you test this code?

I verified the UI element no longer appears for data warehouse queries. I also verified it still appears as expected for non-data warehouse queries.