### PR TITLE
fix(experiments): Add a WHERE statement to ASOF LEFT JOIN

### DIFF
--- a/posthog/warehouse/models/join.py
+++ b/posthog/warehouse/models/join.py
@@ -128,6 +128,11 @@ class DataWarehouseJoin(CreatedMetaFields, UUIDModel, DeletedMetaFields):
                         }.items()
                     ],
                     select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+                    where=ast.CompareOperation(
+                        op=ast.CompareOperationOp.Eq,
+                        left=ast.Field(chain=["event"]),
+                        right=ast.Constant(value="$feature_flag_called"),
+                    ),
                 ),
                 # ASOF JOIN finds the most recent matching event that occurred at or before each data warehouse timestamp.
                 #


### PR DESCRIPTION
See https://posthog.slack.com/archives/C07PXH2GTGV/p1733936406339719
See https://github.com/PostHog/posthog/issues/26332

## Changes

Adds a WHERE statement to ASOF LEFT JOIN

## How did you test this code?

Tests pass.