### PR TITLE
fix: Fix conflict between posthog toolbar and Tanstack dev tools

### DIFF
--- a/frontend/src/toolbar/ToolbarApp.tsx
+++ b/frontend/src/toolbar/ToolbarApp.tsx
@@ -40,9 +40,19 @@ export function ToolbarApp(props: ToolbarProps = {}): JSX.Element {
               }
     )
 
+    // There's a small conflict between our toolbar and the Tanstack React Dev library
+    // because Tanstack is polluting the global event listeners with a mouse down listener
+    // which conflicts with our toolbar's internal mouse down listeners
+    //
+    // To workaround that we simply prevent the event from bubbling further than the toolbar
+    // See https://github.com/PostHog/posthog-js/issues/1425
+    const onMouseDown = ({ nativeEvent: event }: React.MouseEvent<HTMLDivElement>): void => {
+        event.stopImmediatePropagation()
+    }
+
     return (
         <>
-            <root.div id={TOOLBAR_ID} className="ph-no-capture" ref={shadowRef}>
+            <root.div id={TOOLBAR_ID} className="ph-no-capture" ref={shadowRef} onMouseDown={onMouseDown}>
                 <div id="posthog-toolbar-styles" />
                 {didRender && (didLoadStyles || props.disableExternalStyles) ? <ToolbarContainer /> : null}
                 <ToastContainer


### PR DESCRIPTION
This was surfaced by an issue in the posthog-js repo: https://github.com/PostHog/posthog-js/issues/1425

https://github.com/rmanganiello figured that the problem happens because tanstack dev tools are creating a global `onMouseDown` event that's overriding our clicks detection.

We can solve this by guaranteeing that no event crosses the boundary of our toolbar, by calling `stopImmediatePropagation` at the top level.

Here's a video showing how it works locally now. I've set up a very basic Tanstack wrapper around our app to make sure their devtools were showing up just fine alongside ours.


https://github.com/user-attachments/assets/25986bd3-81fe-431b-9ae6-86c7d33fba00



Closes PostHog/posthog-js#1425