### PR TITLE
fix(experiments): Allow `stats_version` to be optional

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -2279,7 +2279,6 @@
                 "probability",
                 "significance_code",
                 "significant",
-                "stats_version",
                 "timezone",
                 "variants"
             ],
@@ -4615,7 +4614,6 @@
                                 "probability",
                                 "significance_code",
                                 "significant",
-                                "stats_version",
                                 "variants"
                             ],
                             "type": "object"
@@ -6176,7 +6174,6 @@
                 "probability",
                 "significant",
                 "significance_code",
-                "stats_version",
                 "p_value",
                 "credible_intervals"
             ],
@@ -9895,7 +9892,6 @@
                         "probability",
                         "significant",
                         "significance_code",
-                        "stats_version",
                         "p_value",
                         "credible_intervals"
                     ],
@@ -10528,7 +10524,6 @@
                         "probability",
                         "significance_code",
                         "significant",
-                        "stats_version",
                         "variants"
                     ],
                     "type": "object"

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -2007,7 +2007,7 @@ export interface ExperimentTrendsQueryResponse {
     probability: Record<string, number>
     significant: boolean
     significance_code: ExperimentSignificanceCode
-    stats_version: integer
+    stats_version?: integer
     p_value: number
     credible_intervals: Record<string, [number, number]>
 }

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5893,7 +5893,7 @@ class CachedExperimentTrendsQueryResponse(BaseModel):
     )
     significance_code: ExperimentSignificanceCode
     significant: bool
-    stats_version: int
+    stats_version: Optional[int] = None
     timezone: str
     variants: list[ExperimentVariantTrendsBaseStats]
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5911,7 +5911,7 @@ class Response10(BaseModel):
     probability: dict[str, float]
     significance_code: ExperimentSignificanceCode
     significant: bool
-    stats_version: int
+    stats_version: Optional[int] = None
     variants: list[ExperimentVariantTrendsBaseStats]
 
 
@@ -6016,7 +6016,7 @@ class ExperimentTrendsQueryResponse(BaseModel):
     probability: dict[str, float]
     significance_code: ExperimentSignificanceCode
     significant: bool
-    stats_version: int
+    stats_version: Optional[int] = None
     variants: list[ExperimentVariantTrendsBaseStats]
 
 
@@ -6345,7 +6345,7 @@ class QueryResponseAlternative16(BaseModel):
     probability: dict[str, float]
     significance_code: ExperimentSignificanceCode
     significant: bool
-    stats_version: int
+    stats_version: Optional[int] = None
     variants: list[ExperimentVariantTrendsBaseStats]
 
 
@@ -6377,7 +6377,7 @@ class QueryResponseAlternative27(BaseModel):
     probability: dict[str, float]
     significance_code: ExperimentSignificanceCode
     significant: bool
-    stats_version: int
+    stats_version: Optional[int] = None
     variants: list[ExperimentVariantTrendsBaseStats]
 
 


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/26713
See https://posthog.slack.com/archives/C02E3BKC78F/p1733938139482479?thread_ts=1733937348.597829&cid=C02E3BKC78F

## Changes

Allows the `stats_version` to be optional on `CachedExperimentTrendsQueryResponse`. There are a lot of cached responses that don't have `stats_version`, and they throw an exception on wakeup right now.

Introduced in https://github.com/PostHog/posthog/pull/26760

## How did you test this code?

I reproduced the original problem locally, and verified the fix.