### PR TITLE
fix: view recording button

### DIFF
--- a/frontend/src/lib/components/ViewRecordingButton.tsx
+++ b/frontend/src/lib/components/ViewRecordingButton.tsx
@@ -26,7 +26,7 @@ export default function ViewRecordingButton({
             onClick={
                 inModal
                     ? () => {
-                          const fiveSecondsBeforeEvent = dayjs(timestamp).valueOf() - 5000
+                          const fiveSecondsBeforeEvent = timestamp ? dayjs(timestamp).valueOf() - 5000 : 0
                           openSessionPlayer({ id: sessionId }, Math.max(fiveSecondsBeforeEvent, 0))
                       }
                     : undefined

--- a/frontend/src/lib/components/ViewRecordingButton.tsx
+++ b/frontend/src/lib/components/ViewRecordingButton.tsx
@@ -10,20 +10,27 @@ import { EventType } from '~/types'
 export default function ViewRecordingButton({
     sessionId,
     timestamp,
+    inModal = false,
     ...props
 }: Pick<LemonButtonProps, 'size' | 'type' | 'data-attr' | 'fullWidth' | 'className' | 'disabledReason'> & {
     sessionId: string
     timestamp?: string | Dayjs
+    // whether to open in a modal or navigate to the replay page
+    inModal?: boolean
 }): JSX.Element {
     const { openSessionPlayer } = useActions(sessionPlayerModalLogic)
 
     return (
         <LemonButton
-            to={urls.replaySingle(sessionId)}
-            onClick={() => {
-                const fiveSecondsBeforeEvent = dayjs(timestamp).valueOf() - 5000
-                openSessionPlayer({ id: sessionId }, Math.max(fiveSecondsBeforeEvent, 0))
-            }}
+            to={inModal ? undefined : urls.replaySingle(sessionId)}
+            onClick={
+                inModal
+                    ? () => {
+                          const fiveSecondsBeforeEvent = dayjs(timestamp).valueOf() - 5000
+                          openSessionPlayer({ id: sessionId }, Math.max(fiveSecondsBeforeEvent, 0))
+                      }
+                    : undefined
+            }
             sideIcon={<IconPlayCircle />}
             {...props}
         >

--- a/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
+++ b/frontend/src/queries/nodes/DataTable/EventRowActions.tsx
@@ -55,6 +55,7 @@ export function EventRowActions({ event }: EventActionProps): JSX.Element {
                     )}
                     <ViewRecordingButton
                         fullWidth
+                        inModal
                         sessionId={event.properties.$session_id}
                         timestamp={event.timestamp}
                         disabledReason={

--- a/frontend/src/queries/nodes/HogQLX/render.tsx
+++ b/frontend/src/queries/nodes/HogQLX/render.tsx
@@ -44,6 +44,7 @@ export function renderHogQLX(value: any): JSX.Element {
             return (
                 <ErrorBoundary>
                     <ViewRecordingButton
+                        inModal
                         sessionId={sessionId}
                         type="primary"
                         size="xsmall"


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/21807 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/24121)

the view recording button is navigating _and_ opening in a modal, when it should do one or the other