### PR TITLE
fix: first time for user with filters

### DIFF
--- a/posthog/hogql_queries/insights/funnels/base.py
+++ b/posthog/hogql_queries/insights/funnels/base.py
@@ -726,7 +726,9 @@ class FunnelBase(ABC):
             first_time_filter = parse_expr("e.uuid IN {subquery}", placeholders={"subquery": subquery})
             return ast.And(exprs=[*filters, first_time_filter])
         elif entity.math == FunnelMathType.FIRST_TIME_FOR_USER_WITH_FILTERS:
-            subquery = FirstTimeForUserAggregationQuery(self.context, ast.Constant(value=1), filter_expr).to_query()
+            subquery = FirstTimeForUserAggregationQuery(
+                self.context, ast.Constant(value=1), ast.And(exprs=filters)
+            ).to_query()
             first_time_filter = parse_expr("e.uuid IN {subquery}", placeholders={"subquery": subquery})
             return ast.And(exprs=[*filters, first_time_filter])
         elif len(filters) > 1:

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel.py
@@ -4429,6 +4429,19 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
             # classic and udf funnels handle no events differently
             assert len(results) == 0 or results[0]["count"] == 0
 
+            _create_event(
+                team=self.team,
+                event="event2",
+                distinct_id="user_1",
+                timestamp="2024-03-19T13:00:00Z",
+                properties={"property": "woah"},
+            )
+            query.series[0].math = FunnelMathType.FIRST_TIME_FOR_USER_WITH_FILTERS
+            query.dateRange.date_from = "2024-03-19"
+            results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
+            self.assertEqual(results[0]["count"], 1)
+            self.assertEqual(results[1]["count"], 1)
+
         def test_funnel_personless_events_are_supported(self):
             user_id = uuid.uuid4()
             _create_event(

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel.py
@@ -4437,6 +4437,7 @@ def funnel_test_factory(Funnel, event_factory, person_factory):
                 properties={"property": "woah"},
             )
             query.series[0].math = FunnelMathType.FIRST_TIME_FOR_USER_WITH_FILTERS
+            assert query.dateRange is not None
             query.dateRange.date_from = "2024-03-19"
             results = FunnelsQueryRunner(query=query, team=self.team).calculate().results
             self.assertEqual(results[0]["count"], 1)


### PR DESCRIPTION
## Problem

First time for user with filters was not filtering on the event itself, just on the filters

## Changes

AND the event in

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added a unit test for the situation