### PR TITLE
feat(cdp): site destination mapping templates

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -871,6 +871,20 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                 ...(cache.configFromUrl ?? {}),
             }
 
+            if (values.template?.mapping_templates) {
+                config.mappings = [
+                    ...(config.mappings ?? []),
+                    ...values.template.mapping_templates
+                        .filter((t) => t.include_by_default)
+                        .map((template) => ({
+                            ...template,
+                            inputs: template.inputs_schema?.reduce((acc, input) => {
+                                acc[input.key] = { value: input.default }
+                                return acc
+                            }, {} as Record<string, HogFunctionInputType>),
+                        })),
+                ]
+            }
             const paramsFromUrl = cache.paramsFromUrl ?? {}
             const unsavedConfigurationToApply =
                 (values.unsavedConfiguration?.timestamp ?? 0) > Date.now() - UNSAVED_CONFIGURATION_TTL

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -824,8 +824,11 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                 return subTemplate
             },
         ],
-
         forcedSubTemplateId: [() => [router.selectors.searchParams], ({ sub_template }) => !!sub_template],
+        mappingTemplates: [
+            (s) => [s.hogFunction, s.template],
+            (hogFunction, template) => template?.mapping_templates ?? hogFunction?.template?.mapping_templates ?? [],
+        ],
     })),
 
     listeners(({ actions, values, cache }) => ({

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -454,7 +454,7 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                     mappings:
                         data.type === 'site_destination' && (!data.mappings || data.mappings.length === 0)
                             ? 'You must add at least one mapping'
-                            : '',
+                            : undefined,
                     ...(values.inputFormErrors as any),
                 }
             },

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -451,6 +451,10 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             errors: (data) => {
                 return {
                     name: !data.name ? 'Name is required' : undefined,
+                    mappings:
+                        data.type === 'site_destination' && (!data.mappings || data.mappings.length === 0)
+                            ? 'You must add at least one mapping'
+                            : '',
                     ...(values.inputFormErrors as any),
                 }
             },
@@ -809,7 +813,6 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                 return hogFunction?.template?.hog && hogFunction.template.hog !== configuration.hog
             },
         ],
-
         subTemplate: [
             (s) => [s.template, s.subTemplateId],
             (template, subTemplateId) => {

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -643,8 +643,26 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             },
         ],
         matchingFilters: [
-            (s) => [s.configuration],
-            (configuration): PropertyGroupFilter => {
+            (s) => [s.configuration, s.useMapping],
+            (configuration, useMapping): PropertyGroupFilter => {
+                // We're using mappings, but none are provided, so match zero events.
+                if (useMapping && !configuration.mappings?.length) {
+                    return {
+                        type: FilterLogicalOperator.And,
+                        values: [
+                            {
+                                type: FilterLogicalOperator.And,
+                                values: [
+                                    {
+                                        type: PropertyFilterType.HogQL,
+                                        key: 'false',
+                                    },
+                                ],
+                            },
+                        ],
+                    }
+                }
+
                 const seriesProperties: PropertyGroupFilterValue = {
                     type: FilterLogicalOperator.Or,
                     values: [],

--- a/frontend/src/scenes/pipeline/hogfunctions/mapping/HogFunctionMapping.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/mapping/HogFunctionMapping.tsx
@@ -17,7 +17,7 @@ import { HogFunctionInputs } from '../HogFunctionInputs'
 
 export function HogFunctionMapping(): JSX.Element | null {
     const { groupsTaxonomicTypes } = useValues(groupsModel)
-    const { useMapping, showSource, template } = useValues(hogFunctionConfigurationLogic)
+    const { useMapping, showSource, mappingTemplates } = useValues(hogFunctionConfigurationLogic)
     const [selectedMappingTemplate, setSelectedMappingTemplate] = useState<string | null>(null)
 
     if (!useMapping) {
@@ -121,12 +121,12 @@ export function HogFunctionMapping(): JSX.Element | null {
                         <div className="border bg-bg-light rounded p-3 space-y-2">
                             <LemonLabel>New Mapping</LemonLabel>
                             <div className="flex gap-2">
-                                {template?.mapping_templates?.length ? (
+                                {mappingTemplates.length ? (
                                     <LemonSelect
                                         placeholder="Select a template"
                                         value={selectedMappingTemplate}
                                         onChange={setSelectedMappingTemplate}
-                                        options={template.mapping_templates.map((t) => ({
+                                        options={mappingTemplates.map((t) => ({
                                             label: t.name,
                                             value: t.name,
                                         }))}
@@ -137,13 +137,13 @@ export function HogFunctionMapping(): JSX.Element | null {
                                     data-attr="add-action-event-button"
                                     icon={<IconPlusSmall />}
                                     disabledReason={
-                                        template?.mapping_templates?.length && !selectedMappingTemplate
+                                        mappingTemplates.length && !selectedMappingTemplate
                                             ? 'Select a mapping template'
                                             : undefined
                                     }
                                     onClick={() => {
                                         if (selectedMappingTemplate) {
-                                            const mappingTemplate = template?.mapping_templates?.find(
+                                            const mappingTemplate = mappingTemplates.find(
                                                 (t) => t.name === selectedMappingTemplate
                                             )
                                             if (mappingTemplate) {

--- a/frontend/src/scenes/pipeline/hogfunctions/mapping/HogFunctionMapping.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/mapping/HogFunctionMapping.tsx
@@ -1,10 +1,11 @@
 import { IconPlus, IconPlusSmall, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonLabel } from '@posthog/lemon-ui'
+import { LemonButton, LemonLabel, LemonSelect } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import { Group } from 'kea-forms'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { getDefaultEventName } from 'lib/utils/getAppContext'
+import { useState } from 'react'
 import { ActionFilter } from 'scenes/insights/filters/ActionFilter/ActionFilter'
 import { MathAvailability } from 'scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow'
 
@@ -16,7 +17,8 @@ import { HogFunctionInputs } from '../HogFunctionInputs'
 
 export function HogFunctionMapping(): JSX.Element | null {
     const { groupsTaxonomicTypes } = useValues(groupsModel)
-    const { useMapping, showSource } = useValues(hogFunctionConfigurationLogic)
+    const { useMapping, showSource, template } = useValues(hogFunctionConfigurationLogic)
+    const [selectedMappingTemplate, setSelectedMappingTemplate] = useState<string | null>(null)
 
     if (!useMapping) {
         return null
@@ -34,16 +36,14 @@ export function HogFunctionMapping(): JSX.Element | null {
                                     <LemonLabel info="When an event matches these filters, the function is run with the appended inputs.">
                                         Mapping #{index + 1}
                                     </LemonLabel>
-                                    {mappings.length > 1 ? (
-                                        <LemonButton
-                                            key="delete"
-                                            icon={<IconTrash />}
-                                            title="Delete graph series"
-                                            data-attr={`delete-prop-filter-${index}`}
-                                            noPadding
-                                            onClick={() => onChange(mappings.filter((_, i) => i !== index))}
-                                        />
-                                    ) : null}
+                                    <LemonButton
+                                        key="delete"
+                                        icon={<IconTrash />}
+                                        title="Delete graph series"
+                                        data-attr={`delete-prop-filter-${index}`}
+                                        noPadding
+                                        onClick={() => onChange(mappings.filter((_, i) => i !== index))}
+                                    />
                                 </div>
                                 <ActionFilter
                                     bordered
@@ -119,40 +119,73 @@ export function HogFunctionMapping(): JSX.Element | null {
                             </div>
                         ))}
                         <div className="border bg-bg-light rounded p-3 space-y-2">
-                            <LemonButton
-                                type="tertiary"
-                                data-attr="add-action-event-button"
-                                icon={<IconPlusSmall />}
-                                onClick={() => {
-                                    const inputsSchema =
-                                        mappings.length > 0
-                                            ? structuredClone(mappings[mappings.length - 1].inputs_schema || [])
-                                            : []
-                                    const newMapping = {
-                                        inputs_schema: inputsSchema,
-                                        inputs: Object.fromEntries(
-                                            inputsSchema
-                                                .filter((m) => m.default !== undefined)
-                                                .map((m) => [m.key, { value: structuredClone(m.default) }])
-                                        ),
-                                        filters: {
-                                            events: [
-                                                {
-                                                    id: getDefaultEventName(),
-                                                    name: getDefaultEventName(),
-                                                    type: EntityTypes.EVENTS,
-                                                    order: 0,
-                                                    properties: [],
-                                                },
-                                            ],
-                                            actions: [],
-                                        },
+                            <LemonLabel>New Mapping</LemonLabel>
+                            <div className="flex gap-2">
+                                {template?.mapping_templates?.length ? (
+                                    <LemonSelect
+                                        placeholder="Select a template"
+                                        value={selectedMappingTemplate}
+                                        onChange={setSelectedMappingTemplate}
+                                        options={template.mapping_templates.map((t) => ({
+                                            label: t.name,
+                                            value: t.name,
+                                        }))}
+                                    />
+                                ) : null}
+                                <LemonButton
+                                    type="secondary"
+                                    data-attr="add-action-event-button"
+                                    icon={<IconPlusSmall />}
+                                    disabledReason={
+                                        template?.mapping_templates?.length && !selectedMappingTemplate
+                                            ? 'Select a mapping template'
+                                            : undefined
                                     }
-                                    onChange([...mappings, newMapping])
-                                }}
-                            >
-                                Add mapping
-                            </LemonButton>
+                                    onClick={() => {
+                                        if (selectedMappingTemplate) {
+                                            const mappingTemplate = template?.mapping_templates?.find(
+                                                (t) => t.name === selectedMappingTemplate
+                                            )
+                                            if (mappingTemplate) {
+                                                const { name, ...mapping } = mappingTemplate
+                                                const inputs = mapping.inputs_schema
+                                                    ? Object.fromEntries(
+                                                          mapping.inputs_schema
+                                                              .filter((m) => m.default !== undefined)
+                                                              .map((m) => [
+                                                                  m.key,
+                                                                  { value: structuredClone(m.default) },
+                                                              ])
+                                                      )
+                                                    : {}
+                                                onChange([...mappings, { ...mapping, inputs }])
+                                            }
+                                            setSelectedMappingTemplate(null)
+                                            return
+                                        }
+
+                                        const newMapping = {
+                                            inputs_schema: [],
+                                            inputs: {},
+                                            filters: {
+                                                events: [
+                                                    {
+                                                        id: getDefaultEventName(),
+                                                        name: getDefaultEventName(),
+                                                        type: EntityTypes.EVENTS,
+                                                        order: 0,
+                                                        properties: [],
+                                                    },
+                                                ],
+                                                actions: [],
+                                            },
+                                        }
+                                        onChange([...mappings, newMapping])
+                                    }}
+                                >
+                                    Add mapping
+                                </LemonButton>
+                            </div>
                         </div>
                     </>
                 )

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4661,6 +4661,7 @@ export interface HogFunctionMappingType {
 }
 export interface HogFunctionMappingTemplateType extends HogFunctionMappingType {
     name: string
+    include_by_default?: boolean
 }
 
 export type HogFunctionTypeType =

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4659,6 +4659,9 @@ export interface HogFunctionMappingType {
     inputs?: Record<string, HogFunctionInputType> | null
     filters?: HogFunctionFiltersType | null
 }
+export interface HogFunctionMappingTemplateType extends HogFunctionMappingType {
+    name: string
+}
 
 export type HogFunctionTypeType =
     | 'destination'
@@ -4715,6 +4718,7 @@ export type HogFunctionTemplateType = Pick<
 > & {
     status: HogFunctionTemplateStatus
     sub_templates?: HogFunctionSubTemplateType[]
+    mapping_templates?: HogFunctionMappingTemplateType[]
 }
 
 export type HogFunctionIconResponse = {

--- a/posthog/api/hog_function_template.py
+++ b/posthog/api/hog_function_template.py
@@ -6,7 +6,12 @@ from rest_framework.response import Response
 from rest_framework.exceptions import NotFound
 
 from posthog.cdp.templates import HOG_FUNCTION_TEMPLATES
-from posthog.cdp.templates.hog_function_template import HogFunctionMapping, HogFunctionTemplate, HogFunctionSubTemplate
+from posthog.cdp.templates.hog_function_template import (
+    HogFunctionMapping,
+    HogFunctionMappingTemplate,
+    HogFunctionTemplate,
+    HogFunctionSubTemplate,
+)
 from rest_framework_dataclasses.serializers import DataclassSerializer
 
 
@@ -18,14 +23,20 @@ class HogFunctionMappingSerializer(DataclassSerializer):
         dataclass = HogFunctionMapping
 
 
+class HogFunctionMappingTemplateSerializer(DataclassSerializer):
+    class Meta:
+        dataclass = HogFunctionMappingTemplate
+
+
 class HogFunctionSubTemplateSerializer(DataclassSerializer):
     class Meta:
         dataclass = HogFunctionSubTemplate
 
 
 class HogFunctionTemplateSerializer(DataclassSerializer):
-    sub_templates = HogFunctionSubTemplateSerializer(many=True, required=False)
+    mapping_templates = HogFunctionMappingTemplateSerializer(many=True, required=False)
     mappings = HogFunctionMappingSerializer(many=True, required=False)
+    sub_templates = HogFunctionSubTemplateSerializer(many=True, required=False)
 
     class Meta:
         dataclass = HogFunctionTemplate

--- a/posthog/api/test/__snapshots__/test_decide.ambr
+++ b/posthog/api/test/__snapshots__/test_decide.ambr
@@ -3890,6 +3890,7 @@
          "posthog_hogfunction"."inputs",
          "posthog_hogfunction"."encrypted_inputs",
          "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
          "posthog_hogfunction"."masking",
          "posthog_hogfunction"."template_id",
          "posthog_team"."id",
@@ -4260,6 +4261,7 @@
          "posthog_hogfunction"."inputs",
          "posthog_hogfunction"."encrypted_inputs",
          "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
          "posthog_hogfunction"."masking",
          "posthog_hogfunction"."template_id"
   FROM "posthog_hogfunction"
@@ -4693,6 +4695,7 @@
          "posthog_hogfunction"."inputs",
          "posthog_hogfunction"."encrypted_inputs",
          "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
          "posthog_hogfunction"."masking",
          "posthog_hogfunction"."template_id"
   FROM "posthog_hogfunction"
@@ -4986,6 +4989,7 @@
          "posthog_hogfunction"."inputs",
          "posthog_hogfunction"."encrypted_inputs",
          "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
          "posthog_hogfunction"."masking",
          "posthog_hogfunction"."template_id"
   FROM "posthog_hogfunction"
@@ -5171,6 +5175,7 @@
          "posthog_hogfunction"."inputs",
          "posthog_hogfunction"."encrypted_inputs",
          "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
          "posthog_hogfunction"."masking",
          "posthog_hogfunction"."template_id",
          "posthog_team"."id",
@@ -5602,6 +5607,7 @@
          "posthog_hogfunction"."inputs",
          "posthog_hogfunction"."encrypted_inputs",
          "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
          "posthog_hogfunction"."masking",
          "posthog_hogfunction"."template_id"
   FROM "posthog_hogfunction"
@@ -5834,6 +5840,7 @@
          "posthog_hogfunction"."inputs",
          "posthog_hogfunction"."encrypted_inputs",
          "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
          "posthog_hogfunction"."masking",
          "posthog_hogfunction"."template_id"
   FROM "posthog_hogfunction"
@@ -6165,6 +6172,7 @@
          "posthog_hogfunction"."inputs",
          "posthog_hogfunction"."encrypted_inputs",
          "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
          "posthog_hogfunction"."masking",
          "posthog_hogfunction"."template_id"
   FROM "posthog_hogfunction"
@@ -6344,6 +6352,7 @@
          "posthog_hogfunction"."inputs",
          "posthog_hogfunction"."encrypted_inputs",
          "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
          "posthog_hogfunction"."masking",
          "posthog_hogfunction"."template_id"
   FROM "posthog_hogfunction"
@@ -6475,6 +6484,7 @@
          "posthog_hogfunction"."inputs",
          "posthog_hogfunction"."encrypted_inputs",
          "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
          "posthog_hogfunction"."masking",
          "posthog_hogfunction"."template_id",
          "posthog_team"."id",
@@ -6906,6 +6916,7 @@
          "posthog_hogfunction"."inputs",
          "posthog_hogfunction"."encrypted_inputs",
          "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
          "posthog_hogfunction"."masking",
          "posthog_hogfunction"."template_id"
   FROM "posthog_hogfunction"
@@ -7138,6 +7149,7 @@
          "posthog_hogfunction"."inputs",
          "posthog_hogfunction"."encrypted_inputs",
          "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
          "posthog_hogfunction"."masking",
          "posthog_hogfunction"."template_id"
   FROM "posthog_hogfunction"
@@ -7465,6 +7477,7 @@
          "posthog_hogfunction"."inputs",
          "posthog_hogfunction"."encrypted_inputs",
          "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
          "posthog_hogfunction"."masking",
          "posthog_hogfunction"."template_id"
   FROM "posthog_hogfunction"
@@ -7640,6 +7653,7 @@
          "posthog_hogfunction"."inputs",
          "posthog_hogfunction"."encrypted_inputs",
          "posthog_hogfunction"."filters",
+         "posthog_hogfunction"."mappings",
          "posthog_hogfunction"."masking",
          "posthog_hogfunction"."template_id"
   FROM "posthog_hogfunction"

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -273,6 +273,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
             "filters": None,
             "masking": None,
             "mappings": None,
+            "mapping_templates": None,
             "sub_templates": response.json()["template"]["sub_templates"],
         }
 

--- a/posthog/api/test/test_hog_function_templates.py
+++ b/posthog/api/test/test_hog_function_templates.py
@@ -18,6 +18,7 @@ EXPECTED_FIRST_RESULT = {
     "filters": template.filters,
     "masking": template.masking,
     "mappings": template.mappings,
+    "mapping_templates": template.mapping_templates,
     "icon_url": template.icon_url,
 }
 

--- a/posthog/cdp/templates/_internal/template_blank.py
+++ b/posthog/cdp/templates/_internal/template_blank.py
@@ -54,6 +54,7 @@ export function onEvent({ inputs, posthog }) {
     mapping_templates=[
         HogFunctionMappingTemplate(
             name="Aquisition",
+            include_by_default=True,
             filters={"events": [{"id": "$pageview", "type": "events"}]},
             inputs_schema=[
                 {

--- a/posthog/cdp/templates/_internal/template_blank.py
+++ b/posthog/cdp/templates/_internal/template_blank.py
@@ -1,4 +1,4 @@
-from posthog.cdp.templates.hog_function_template import HogFunctionMapping, HogFunctionTemplate
+from posthog.cdp.templates.hog_function_template import HogFunctionMappingTemplate, HogFunctionTemplate
 
 blank_site_destination: HogFunctionTemplate = HogFunctionTemplate(
     status="client-side",
@@ -50,8 +50,10 @@ export function onEvent({ inputs, posthog }) {
             "required": True,
         },
     ],
-    mappings=[
-        HogFunctionMapping(
+    mappings=[],
+    mapping_templates=[
+        HogFunctionMappingTemplate(
+            name="Aquisition",
             filters={"events": [{"id": "$pageview", "type": "events"}]},
             inputs_schema=[
                 {
@@ -76,7 +78,8 @@ export function onEvent({ inputs, posthog }) {
                 },
             ],
         ),
-        HogFunctionMapping(
+        HogFunctionMappingTemplate(
+            name="Conversion",
             filters={"events": [{"id": "$autocapture", "type": "events"}]},
             inputs_schema=[
                 {
@@ -101,7 +104,8 @@ export function onEvent({ inputs, posthog }) {
                 },
             ],
         ),
-        HogFunctionMapping(
+        HogFunctionMappingTemplate(
+            name="Retention",
             filters={"events": [{"id": "$pageleave", "type": "events"}]},
             inputs_schema=[
                 {

--- a/posthog/cdp/templates/hog_function_template.py
+++ b/posthog/cdp/templates/hog_function_template.py
@@ -33,6 +33,7 @@ class HogFunctionMapping:
 @dataclasses.dataclass(frozen=True)
 class HogFunctionMappingTemplate:
     name: str
+    include_by_default: Optional[bool] = None
     filters: Optional[dict] = None
     inputs: Optional[dict] = None
     inputs_schema: Optional[list[dict]] = None

--- a/posthog/cdp/templates/hog_function_template.py
+++ b/posthog/cdp/templates/hog_function_template.py
@@ -31,6 +31,14 @@ class HogFunctionMapping:
 
 
 @dataclasses.dataclass(frozen=True)
+class HogFunctionMappingTemplate:
+    name: str
+    filters: Optional[dict] = None
+    inputs: Optional[dict] = None
+    inputs_schema: Optional[list[dict]] = None
+
+
+@dataclasses.dataclass(frozen=True)
 class HogFunctionTemplate:
     status: Literal["alpha", "beta", "stable", "free", "client-side"]
     type: Literal[
@@ -54,6 +62,7 @@ class HogFunctionTemplate:
     sub_templates: Optional[list[HogFunctionSubTemplate]] = None
     filters: Optional[dict] = None
     mappings: Optional[list[HogFunctionMapping]] = None
+    mapping_templates: Optional[list[HogFunctionMappingTemplate]] = None
     masking: Optional[dict] = None
     icon_url: Optional[str] = None
 


### PR DESCRIPTION
## Problem

We want to make it easy to subscribe to predefined mappings for destinations.

## Changes

Adds "mapping templates"

![2024-12-12 13 02 35](https://github.com/user-attachments/assets/705d07e3-127d-4d6f-95af-b158d891774f)

## How did you test this code?

In the browser for now