### PR TITLE
fix(experiments): Use `absolute_exposure` not relative exposure

### DIFF
--- a/posthog/hogql_queries/experiments/test/test_trends_statistics.py
+++ b/posthog/hogql_queries/experiments/test/test_trends_statistics.py
@@ -279,16 +279,10 @@ class TestExperimentTrendsStatistics(APIBaseTest):
             intervals = calculate_credible_intervals([control, test])
 
             self.assertEqual(len(probabilities), 2)
-            if stats_version == 2:
-                self.assertTrue(probabilities[0] < 0.1)
-                self.assertTrue(0.9 < probabilities[1])
-                self.assertEqual(significance, ExperimentSignificanceCode.SIGNIFICANT)
-                self.assertEqual(p_value, 0)
-            else:
-                self.assertTrue(0.4 < probabilities[0] < 0.6)  # Close to 50/50
-                self.assertTrue(0.4 < probabilities[1] < 0.6)  # Close to 50/50
-                self.assertEqual(significance, ExperimentSignificanceCode.LOW_WIN_PROBABILITY)
-                self.assertEqual(p_value, 1)
+            self.assertTrue(0.4 < probabilities[0] < 0.6)  # Close to 50/50
+            self.assertTrue(0.4 < probabilities[1] < 0.6)  # Close to 50/50
+            self.assertEqual(significance, ExperimentSignificanceCode.LOW_WIN_PROBABILITY)
+            self.assertEqual(p_value, 1)
 
             # Control at ~10% conversion rate
             self.assertAlmostEqual(intervals["control"][0], 0.094, places=2)

--- a/posthog/hogql_queries/experiments/trends_statistics_v2.py
+++ b/posthog/hogql_queries/experiments/trends_statistics_v2.py
@@ -57,7 +57,7 @@ def calculate_probabilities_v2(
 
     # Calculate posterior parameters for control
     alpha_control = PRIOR_ALPHA + control_variant.count
-    beta_control = PRIOR_BETA + control_variant.exposure
+    beta_control = PRIOR_BETA + control_variant.absolute_exposure
 
     # Draw samples from control posterior
     samples_control = gamma.rvs(alpha_control, scale=1 / beta_control, size=SAMPLE_SIZE)
@@ -66,7 +66,7 @@ def calculate_probabilities_v2(
     test_samples = []
     for test in test_variants:
         alpha_test = PRIOR_ALPHA + test.count
-        beta_test = PRIOR_BETA + test.exposure
+        beta_test = PRIOR_BETA + test.absolute_exposure
         test_samples.append(gamma.rvs(alpha_test, scale=1 / beta_test, size=SAMPLE_SIZE))
 
     # Calculate probabilities


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/26713

## Changes

Use `absolute_exposure`, not relative exposure, in `calculate_probabilities_v2`.

## How did you test this code?

Tests should pass.