### PR TITLE
chore(flags): hide flag status indicator when status in inactive

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagStatusIndicator.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagStatusIndicator.tsx
@@ -10,7 +10,12 @@ export function FeatureFlagStatusIndicator({
 }): JSX.Element | null {
     if (
         !flagStatus ||
-        [FeatureFlagStatus.ACTIVE, FeatureFlagStatus.DELETED, FeatureFlagStatus.UNKNOWN].includes(flagStatus.status)
+        [
+            FeatureFlagStatus.ACTIVE,
+            FeatureFlagStatus.INACTIVE,
+            FeatureFlagStatus.DELETED,
+            FeatureFlagStatus.UNKNOWN,
+        ].includes(flagStatus.status)
     ) {
         return null
     }


### PR DESCRIPTION
## Problem

When a Posthog user only uses /decide to check flag values and never an explicit singular flag check in an SDK, they would have no $feature_flag_called  events despite using the flag value, which is how the inactive state is determined. 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- Hide flag status indicator when status is "inactive"

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->
Yes

## How did you test this code?

Loaded previously-inactive flag UI to make sure it is hidden

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
