### PR TITLE
fix(experiments): Prevent long selectors from overflowing

### DIFF
--- a/frontend/src/toolbar/experiments/WebExperimentTransformHeader.tsx
+++ b/frontend/src/toolbar/experiments/WebExperimentTransformHeader.tsx
@@ -22,7 +22,7 @@ export function WebExperimentTransformHeader({
 
     return (
         <div className="flex w-full gap-4 items-center">
-            <div className="flex-1">
+            <div className="flex-1 overflow-hidden">
                 <h2>{transform.selector || 'Select element'}</h2>
             </div>
 


### PR DESCRIPTION
## Changes

Prevents long selectors in the web toolbar from overflowing.

| **Before** | **After** |
|--------|--------|
| ![CleanShot 2024-12-12 at 16 42 59@2x](https://github.com/user-attachments/assets/fb69f94e-9bf5-44c5-8dba-19dd14403d27) | ![CleanShot 2024-12-12 at 16 42 26@2x](https://github.com/user-attachments/assets/57b83336-afdb-42b8-9af5-2e0de10da85f) |

Reported in https://posthoghelp.zendesk.com/agent/tickets/21963 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/23809)

## How did you test this code?

Visual review.