### PR TITLE
fix(batch-exports): Add `InvalidS3EndpointError` as a non-retryable error

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -65,8 +65,6 @@ NON_RETRYABLE_ERROR_TYPES = [
     "NoSuchBucket",
     # Couldn't connect to custom S3 endpoint
     "EndpointConnectionError",
-    # Input contained an empty S3 endpoint URL
-    "EmptyS3EndpointURLError",
     # User provided an invalid S3 key
     "InvalidS3Key",
     # All consumers failed with non-retryable errors.
@@ -159,13 +157,6 @@ class IntermittentUploadPartTimeoutError(Exception):
         super().__init__(f"An intermittent `RequestTimeout` was raised while attempting to upload part {part_number}")
 
 
-class EmptyS3EndpointURLError(Exception):
-    """Exception raised when an S3 endpoint URL is empty string."""
-
-    def __init__(self):
-        super().__init__("Endpoint URL cannot be empty.")
-
-
 class InvalidS3EndpointError(Exception):
     """Exception raised when an S3 endpoint is invalid."""
 
@@ -222,7 +213,7 @@ class S3MultiPartUpload:
         self.pending_parts: list[Part] = []
 
         if self.endpoint_url == "":
-            raise EmptyS3EndpointURLError()
+            raise InvalidS3EndpointError("Endpoint URL is empty.")
 
     def to_state(self) -> S3MultiPartUploadState:
         """Produce state tuple that can be used to resume this S3MultiPartUpload."""

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -29,6 +29,7 @@ from posthog.temporal.batch_exports.batch_exports import (
 from posthog.temporal.batch_exports.s3_batch_export import (
     FILE_FORMAT_EXTENSIONS,
     IntermittentUploadPartTimeoutError,
+    InvalidS3EndpointError,
     S3BatchExportInputs,
     S3BatchExportWorkflow,
     S3HeartbeatDetails,
@@ -40,9 +41,7 @@ from posthog.temporal.batch_exports.s3_batch_export import (
 )
 from posthog.temporal.common.clickhouse import ClickHouseClient
 from posthog.temporal.tests.batch_exports.utils import mocked_start_batch_export_run
-from posthog.temporal.tests.utils.events import (
-    generate_test_events_in_clickhouse,
-)
+from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse
 from posthog.temporal.tests.utils.models import (
     acreate_batch_export,
     adelete_batch_export,
@@ -1574,6 +1573,23 @@ async def test_s3_multi_part_upload_raises_retryable_exception(bucket_name, s3_k
 
     with pytest.raises(IntermittentUploadPartTimeoutError):
         await s3_upload.upload_part(io.BytesIO(b"1010"), rewind=False)  # type: ignore
+
+
+async def test_s3_multi_part_upload_raises_exception_if_invalid_endpoint(bucket_name, s3_key_prefix):
+    """Test a InvalidS3EndpointError is raised if the endpoint is invalid."""
+    s3_upload = S3MultiPartUpload(
+        bucket_name=bucket_name,
+        key=s3_key_prefix,
+        encryption=None,
+        kms_key_id=None,
+        region_name="us-east-1",
+        aws_access_key_id="object_storage_root_user",
+        aws_secret_access_key="object_storage_root_password",
+        endpoint_url="some-invalid-endpoint",
+    )
+
+    with pytest.raises(InvalidS3EndpointError):
+        await s3_upload.start()
 
 
 @pytest.mark.parametrize("model", [TEST_S3_MODELS[1], TEST_S3_MODELS[2], None])


### PR DESCRIPTION
## Problem

Currently we retry a batch export if an invalid S3 endpoint was provided.
https://posthog.sentry.io/issues/5143259713/?project=4506225159897088&referrer=issue-stream&statsPeriod=7d&stream_index=0

## Changes

Catch this particular error and raise a custom exception that we can treat as non-retryable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

it doesn't have an impact

## How did you test this code?

Added a test
