### PR TITLE
fix(experiments): Prevent Goal component from crashing

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Goal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Goal.tsx
@@ -253,7 +253,8 @@ export function Goal(): JSX.Element {
     // :FLAG: CLEAN UP AFTER MIGRATION
     const isDataWarehouseMetric =
         featureFlags[FEATURE_FLAGS.EXPERIMENTS_HOGQL] &&
-        (experiment.metrics[0] as ExperimentTrendsQuery).count_query.series[0].kind === NodeKind.DataWarehouseNode
+        metricType === InsightType.TRENDS &&
+        (experiment.metrics[0] as ExperimentTrendsQuery).count_query?.series[0].kind === NodeKind.DataWarehouseNode
 
     return (
         <div>


### PR DESCRIPTION
Introduced in https://github.com/PostHog/posthog/pull/26818

Addresses https://posthog.sentry.io/issues/6138030309/ and https://posthog.sentry.io/issues/6138027513/

## Changes

Fixes the goal component for Funnels.

## How did you test this code?

I opened both trends and funnel experiments to verify neither crashed.
