### PR TITLE
fix(webdriver): update webdriver-manager to resolve installation issue

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -98,7 +98,7 @@ sqlparse==0.4.4
 temporalio==1.7.1
 token-bucket==0.3.0
 toronado==0.1.0
-webdriver_manager==4.0.1
+webdriver_manager==4.0.2
 whitenoise==6.5.0
 mimesis==5.2.1
 more-itertools==9.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -790,7 +790,7 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.6
     # via prompt-toolkit
-webdriver-manager==4.0.1
+webdriver-manager==4.0.2
     # via -r requirements.in
 wheel==0.42.0
     # via astunparse


### PR DESCRIPTION
## Problem

There's a bug in webdriver-manager 4.0.1 that prevents new installations from succeeding. See https://github.com/SergeyPirogov/webdriver_manager/pull/666.

> OSError: [Errno 8] Exec format error: '/Users/thomas/.wdm/drivers/chromedriver/mac64/131.0.6778.108/chromedriver-mac-arm64/THIRD_PARTY_NOTICES.chromedriver'

## Changes

Upgrades webdriver-manager to 4.0.2

## How did you test this code?

Successfully exported an image with 4.0.2 and clicked around the interface