### PR TITLE
fix: no polling when hidden

### DIFF
--- a/cypress/e2e/insights-navigation-open-sql-insight-first.cy.ts
+++ b/cypress/e2e/insights-navigation-open-sql-insight-first.cy.ts
@@ -56,6 +56,9 @@ describe('Insights', () => {
 
             it('can open a new stickiness insight', () => {
                 insight.clickTab('STICKINESS')
+                // this test flaps, so check for a parent element, that is present even when failing
+                // in the hope that it slows the test down a little and stops it flapping
+                cy.get('.InsightVizDisplay--type-stickiness').should('exist')
                 cy.get('.TrendsInsight canvas').should('exist')
             })
 

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic.tsx
@@ -174,7 +174,7 @@ export const sidePanelActivityLogic = kea<sidePanelActivityLogicType>([
         ],
     })),
 
-    listeners(({ values, actions }) => ({
+    listeners(({ values, actions, cache }) => ({
         setActiveTab: ({ tab }) => {
             if (tab === SidePanelActivityTab.All && !values.allActivityResponseLoading) {
                 actions.loadAllActivity()
@@ -189,6 +189,13 @@ export const sidePanelActivityLogic = kea<sidePanelActivityLogicType>([
         openSidePanel: ({ options }) => {
             if (options) {
                 actions.setActiveTab(options as SidePanelActivityTab)
+            }
+        },
+        togglePolling: ({ pageIsVisible }) => {
+            if (pageIsVisible) {
+                actions.loadImportantChanges()
+            } else {
+                clearTimeout(cache.pollTimeout)
             }
         },
     })),


### PR DESCRIPTION
i noticed that a backgrounded tab had checked for important changes every 5 minutes for over a day

<img width="826" alt="Screenshot 2024-12-13 at 21 34 53" src="https://github.com/user-attachments/assets/2723c25b-0b1c-47c3-b551-15134d494972" />

that seems unecessary, let's pause that when hidden and restart when not

