### PR TITLE
fix: make full width funnels time to convert not jump around 

### DIFF
--- a/frontend/src/scenes/funnels/FunnelHistogram.tsx
+++ b/frontend/src/scenes/funnels/FunnelHistogram.tsx
@@ -29,6 +29,7 @@ export function FunnelHistogram(): JSX.Element | null {
         <div
             className={clsx('FunnelHistogram', {
                 scrollable: !isInDashboardContext,
+                'overflow-hidden': isInDashboardContext,
                 'dashboard-wrapper': isInDashboardContext,
             })}
             ref={ref}


### PR DESCRIPTION
## Problem
Full width histograms are jumping around
https://posthoghelp.zendesk.com/agent/tickets/21262 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/24470)

## Changes
Make them not by removing the scroll bars

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Replicated locally. Saw it went away.
