### PR TITLE
fix(ingest): sanitise token

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
@@ -1,8 +1,8 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
-import { sanitizeString } from 'utils/db/utils'
 
 import { eventDroppedCounter } from '../../../main/ingestion-queues/metrics'
 import { PipelineEvent } from '../../../types'
+import { sanitizeString } from '../../../utils/db/utils'
 import { UUID } from '../../../utils/utils'
 import { captureIngestionWarning } from '../utils'
 import { tokenOrTeamPresentCounter } from './metrics'


### PR DESCRIPTION
Null bytes in tokens are ending up in the ingest pipeline somehow (the change to capture is designed to prevent this going forward, but I have to change the plugin server too because they're already in the queue).