### PR TITLE
fix: Decide backwards compat

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -53,11 +53,17 @@ def get_base_config(token: str, team: Team, request: HttpRequest, skip_db: bool 
     )
 
     if use_remote_config:
-        response = RemoteConfig.get_config_via_token(token)
+        response = RemoteConfig.get_config_via_token(token, request=request)
 
-        if _session_recording_domain_not_allowed(team, request):
-            # Fallback for sessionRecording domain check - new endpoint will be used differently
-            response["sessionRecording"] = False
+        # Add in a bunch of backwards compatibility stuff
+        response["isAuthenticated"] = False
+        response["toolbarParams"] = {}
+        response["config"] = {"enable_collect_everything": True}
+        response["surveys"] = True if len(response["surveys"]) > 0 else False
+
+        # Remove some stuff that is specific to the new RemoteConfig
+        del response["hasFeatureFlags"]
+        del response["token"]
 
         return response
 

--- a/posthog/api/test/test_decide.py
+++ b/posthog/api/test/test_decide.py
@@ -5,6 +5,7 @@ import time
 from typing import Optional
 from unittest.mock import patch, Mock
 
+from inline_snapshot import snapshot
 import pytest
 from django.conf import settings
 from django.core.cache import cache
@@ -3590,10 +3591,38 @@ class TestDecideRemoteConfig(TestDecide):
     use_remote_config = True
 
     def test_definitely_loads_via_remote_config(self, *args):
-        response = self._post_decide(api_version=3)
-        # NOTE: Using these as a sanity check as they are subtly different in format
-        assert response.json()["surveys"] == []
-        assert response.json()["hasFeatureFlags"] is False
+        # NOTE: This is a sanity check test that we aren't just using the old decide logic
+
+        with patch.object(
+            RemoteConfig, "get_config_via_token", wraps=RemoteConfig.get_config_via_token
+        ) as wrapped_get_config_via_token:
+            response = self._post_decide(api_version=3)
+            wrapped_get_config_via_token.assert_called_once()
+
+        # NOTE: If this changes it indicates something is wrong as we should keep this exact format
+        # for backwards compatibility
+        assert response.json() == snapshot(
+            {
+                "supportedCompression": ["gzip", "gzip-js"],
+                "captureDeadClicks": False,
+                "capturePerformance": {"network_timing": True, "web_vitals": False, "web_vitals_allowed_metrics": None},
+                "autocapture_opt_out": False,
+                "autocaptureExceptions": False,
+                "analytics": {"endpoint": "/i/v0/e/"},
+                "elementsChainAsString": True,
+                "sessionRecording": False,
+                "heatmaps": False,
+                "surveys": False,
+                "defaultIdentifiedOnly": True,
+                "siteApps": [],
+                "isAuthenticated": False,
+                "toolbarParams": {},
+                "config": {"enable_collect_everything": True},
+                "featureFlags": {},
+                "errorsWhileComputingFlags": False,
+                "featureFlagPayloads": {},
+            }
+        )
 
 
 class TestDatabaseCheckForDecide(BaseTest, QueryMatchingTest):


### PR DESCRIPTION
## Problem

Decide is subtly different to before when using the remote config which it shouldn't be as it is meant to be a fully backwards compat endpoint

## Changes

* Fixes this

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
