### PR TITLE
fix(tests): restore the latest migration after migration tests

### DIFF
--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -793,7 +793,7 @@ class BaseTestMigrations(QueryMatchingTest):
         pass
 
     def tearDown(self):
-        super().tearDown()
+        super().tearDown()  # type: ignore
         executor = MigrationExecutor(connection)  # Reset Django's migration state
         targets = executor.loader.graph.leaf_nodes()
         executor.migrate(targets)  # Migrate to the latest migration

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -792,8 +792,9 @@ class BaseTestMigrations(QueryMatchingTest):
     def setUpBeforeMigration(self, apps):
         pass
 
-    def tearDown(self):
-        super().tearDown()  # type: ignore
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()  # type: ignore
         executor = MigrationExecutor(connection)  # Reset Django's migration state
         targets = executor.loader.graph.leaf_nodes()
         executor.migrate(targets)  # Migrate to the latest migration

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -792,6 +792,13 @@ class BaseTestMigrations(QueryMatchingTest):
     def setUpBeforeMigration(self, apps):
         pass
 
+    def tearDown(self):
+        super().tearDown()
+        executor = MigrationExecutor(connection)  # Reset Django's migration state
+        targets = executor.loader.graph.leaf_nodes()
+        executor.migrate(targets)  # Migrate to the latest migration
+        executor.loader.build_graph()  # Reload.
+
 
 class TestMigrations(BaseTestMigrations, BaseTest):
     """


### PR DESCRIPTION
## Problem

The migration test classes don't restore the test database to the latest migration. This causes side effects, as I have in #26767.

## Changes

- Restore the test database to the latest migration after a migration test.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing
