### PR TITLE
feat: Added support for CDN cache purging

### DIFF
--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -384,7 +384,7 @@ class RemoteConfig(UUIDModel):
 
         logger.info(f"Purging CDN for team {self.team_id}")
 
-        data = {"files": []}
+        data: dict[str, Any] = {"files": []}
 
         for domain in settings.REMOTE_CONFIG_CDN_PURGE_DOMAINS:
             # Check if the domain starts with https:// and if not add it

--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -440,6 +440,29 @@ class TestRemoteConfigCaching(_RemoteConfigBase):
             config = self.remote_config.get_config_via_token(self.team.api_token, request=mock_request)
             assert not config["sessionRecording"]
 
+    @patch("posthog.models.remote_config.requests.post")
+    def test_purges_cdn_cache_on_sync(self, mock_post):
+        with self.settings(
+            REMOTE_CONFIG_CDN_PURGE_ENDPOINT="https://api.cloudflare.com/client/v4/zones/MY_ZONE_ID/purge_cache",
+            REMOTE_CONFIG_CDN_PURGE_TOKEN="MY_TOKEN",
+            REMOTE_CONFIG_CDN_PURGE_DOMAINS=["cdn.posthog.com", "https://cdn2.posthog.com"],
+        ):
+            self.remote_config.sync()
+            mock_post.assert_called_once_with(
+                "https://api.cloudflare.com/client/v4/zones/MY_ZONE_ID/purge_cache",
+                headers={"Authorization": "Bearer MY_TOKEN"},
+                data={
+                    "files": [
+                        {"url": "https://cdn.posthog.com/array/phc_12345/config"},
+                        {"url": "https://cdn.posthog.com/array/phc_12345/config.js"},
+                        {"url": "https://cdn.posthog.com/array/phc_12345/array.js"},
+                        {"url": "https://cdn2.posthog.com/array/phc_12345/config"},
+                        {"url": "https://cdn2.posthog.com/array/phc_12345/config.js"},
+                        {"url": "https://cdn2.posthog.com/array/phc_12345/array.js"},
+                    ]
+                },
+            )
+
 
 class TestRemoteConfigJS(_RemoteConfigBase):
     def test_renders_js_including_config(self):

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -398,3 +398,8 @@ LOGO_DEV_TOKEN = get_from_env("LOGO_DEV_TOKEN", "")
 
 # disables frontend side navigation hooks to make hot-reload work seamlessly
 DEV_DISABLE_NAVIGATION_HOOKS = get_from_env("DEV_DISABLE_NAVIGATION_HOOKS", False, type_cast=bool)
+
+
+REMOTE_CONFIG_CDN_PURGE_ENDPOINT = get_from_env("REMOTE_CONFIG_CDN_PURGE_ENDPOINT", "")
+REMOTE_CONFIG_CDN_PURGE_TOKEN = get_from_env("REMOTE_CONFIG_CDN_PURGE_TOKEN", "")
+REMOTE_CONFIG_CDN_PURGE_DOMAINS = get_list(os.getenv("REMOTE_CONFIG_CDN_PURGE_DOMAINS", ""))


### PR DESCRIPTION
## Problem

We cache the remoteconfig files via the CDN. This has a 5 min ttl but ideally we want to immediately purge the cached files so that changes show up as fast as possible

## Changes

* Adds config options for this
* Adds a step to purge the cache 
* Adds a metric to track this

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
