### PR TITLE
fix(experiments): Fix minimum detectable effect calculator

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/DataCollectionCalculator.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DataCollectionCalculator.tsx
@@ -3,10 +3,10 @@ import { LemonBanner, LemonInput, Link, Tooltip } from '@posthog/lemon-ui'
 import { BindLogic, useActions, useValues } from 'kea'
 import { LemonSlider } from 'lib/lemon-ui/LemonSlider'
 import { humanFriendlyNumber } from 'lib/utils'
-import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { Query } from '~/queries/Query/Query'
+import { ExperimentFunnelsQuery, ExperimentTrendsQuery, NodeKind } from '~/queries/schema'
 import { ExperimentIdType, InsightType } from '~/types'
 
 import { MetricInsightId } from '../constants'
@@ -120,7 +120,16 @@ export function DataCollectionCalculator({ experimentId }: ExperimentCalculatorP
         syncWithUrl: false,
     })
     const { insightProps } = useValues(insightLogicInstance)
-    const { query } = useValues(insightDataLogic(insightProps))
+    let query = null
+    if (experiment.metrics.length > 0) {
+        query = {
+            kind: NodeKind.InsightVizNode,
+            source:
+                metricType === InsightType.FUNNELS
+                    ? (experiment.metrics[0] as ExperimentFunnelsQuery).funnels_query
+                    : (experiment.metrics[0] as ExperimentTrendsQuery).count_query,
+        }
+    }
 
     const funnelConversionRate = conversionMetrics?.totalRate * 100 || 0
 

--- a/frontend/src/scenes/funnels/funnelDataLogic.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.ts
@@ -169,6 +169,7 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                 if (
                     // TODO: Ideally we don't check filters anymore, but tests are still using this
                     insightData?.filters?.insight !== InsightType.FUNNELS &&
+                    querySource &&
                     querySource?.kind !== NodeKind.FunnelsQuery
                 ) {
                     return []
@@ -275,6 +276,7 @@ export const funnelDataLogic = kea<funnelDataLogicType>([
                 if (
                     // TODO: Ideally we don't check filters anymore, but tests are still using this
                     insightData?.filters?.insight !== InsightType.FUNNELS &&
+                    querySource &&
                     querySource?.kind !== NodeKind.FunnelsQuery
                 ) {
                     return false


### PR DESCRIPTION
Fixes https://github.com/PostHog/posthog/issues/26815

## Changes

Fixes the minimum detectable effect calculator by passing the experiment query into the `<Query>` component.

Also updates `funnelDataLogic` to bypass some odd leftover conditional that eats the experiment query (from https://github.com/PostHog/posthog/pull/22126).

**Funnels experiment**

![CleanShot 2024-12-16 at 05 54 58@2x](https://github.com/user-attachments/assets/83914c68-4949-4a83-92b9-cbad26c0a668)

**Trends experiment**

![CleanShot 2024-12-16 at 05 54 12@2x](https://github.com/user-attachments/assets/d78b7186-0696-4bab-95ce-d629965245eb)

## How did you test this code?

Existing tests should pass.

I also opened the Minimum detectable effect calculator for a new Trends experiment and a new Funnels experiment.