### PR TITLE
fix(cdp): batch exports only in destinations list

### DIFF
--- a/frontend/src/scenes/pipeline/destinations/destinationsLogic.tsx
+++ b/frontend/src/scenes/pipeline/destinations/destinationsLogic.tsx
@@ -338,10 +338,12 @@ export const pipelineDestinationsLogic = kea<pipelineDestinationsLogicType>([
         },
     })),
 
-    afterMount(({ actions }) => {
+    afterMount(({ actions, props }) => {
         actions.loadPlugins()
         actions.loadPluginConfigs()
-        actions.loadBatchExports()
+        if (props.types.includes('destination')) {
+            actions.loadBatchExports()
+        }
         actions.loadHogFunctions()
     }),
 ])


### PR DESCRIPTION
## Problem

Batch exports were showing up under "site apps"

## Changes

Now they will only show up for destinations.

## How did you test this code?

Locally the export I had made disappeared from the list.