### PR TITLE
perf(clickhouse): Always pass `distributed_product_mode=global` in client settings

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -67,6 +67,12 @@ def default_client():
 
 @cache
 def make_ch_pool(**overrides) -> ChPool:
+    client_settings = {
+        "distributed_product_mode": "global",
+    }
+    if settings.TEST:
+        client_settings["mutations_sync"] = "1"
+
     kwargs = {
         "host": settings.CLICKHOUSE_HOST,
         "database": settings.CLICKHOUSE_DATABASE,
@@ -77,7 +83,7 @@ def make_ch_pool(**overrides) -> ChPool:
         "verify": settings.CLICKHOUSE_VERIFY,
         "connections_min": settings.CLICKHOUSE_CONN_POOL_MIN,
         "connections_max": settings.CLICKHOUSE_CONN_POOL_MAX,
-        "settings": {"mutations_sync": "1"} if settings.TEST else {},
+        "settings": client_settings,
         # Without this, OPTIMIZE table and other queries will regularly run into timeouts
         "send_receive_timeout": 30 if settings.TEST else 999_999_999,
         **overrides,


### PR DESCRIPTION
## Problem

Keep dev and local environments consistent with posthog/posthog-cloud-infra#3356

> This should reduce load on the cluster by reducing the number of queries run when evaluating some queries that include `JOIN` and/or `IN` clauses, and also improve performance or prevent query failures for some of those queries. This is particularly important for clusters with larger shard counts since they are more impacted by the amplified number queries from having more shards potentially executing these subqueries.
>
> Details: https://posthog.slack.com/archives/C076R4753Q8/p1734370951106969?thread_ts=1734366570.748959&cid=C076R4753Q8

## Changes

Always pass `distributed_product_mode=global` in client settings.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

```
(env) ted@revuelto posthog % DEBUG=1 python manage.py shell
[…]
>>> from posthog.clickhouse.client.connection import make_ch_pool
>>> p = make_ch_pool()
>>> with p.get_client() as c:
...   print(c.execute("SELECT Settings['distributed_product_mode'] FROM system.processes"))
... 
[('global',)]
```