### PR TITLE
fix(data-warehouse): Added types for tuples in data viz logic

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/dataVisualizationLogic.ts
@@ -178,6 +178,9 @@ export const convertTableValue = (
 }
 
 const toFriendlyClickhouseTypeName = (type: string): ColumnScalar => {
+    if (type.indexOf('Tuple') !== -1) {
+        return 'TUPLE'
+    }
     if (type.indexOf('Int') !== -1) {
         return 'INTEGER'
     }
@@ -203,8 +206,8 @@ const toFriendlyClickhouseTypeName = (type: string): ColumnScalar => {
     return type as ColumnScalar
 }
 
-const isNumericalType = (type: string): boolean => {
-    if (type.indexOf('Int') !== -1 || type.indexOf('Float') !== -1 || type.indexOf('Decimal') !== -1) {
+const isNumericalType = (type: ColumnScalar): boolean => {
+    if (type === 'INTEGER' || type === 'FLOAT' || type === 'DECIMAL') {
         return true
     }
 
@@ -547,11 +550,13 @@ export const dataVisualizationLogic = kea<dataVisualizationLogicType>([
 
                 return columns.map((column, index) => {
                     const type = types[index]?.[1]
+                    const friendlyClickhouseTypeName = toFriendlyClickhouseTypeName(type)
+
                     return {
                         name: column,
                         type: {
-                            name: toFriendlyClickhouseTypeName(type),
-                            isNumerical: isNumericalType(type),
+                            name: friendlyClickhouseTypeName,
+                            isNumerical: isNumericalType(friendlyClickhouseTypeName),
                         },
                         label: `${column} - ${type}`,
                         dataIndex: index,

--- a/frontend/src/queries/nodes/DataVisualization/types.ts
+++ b/frontend/src/queries/nodes/DataVisualization/types.ts
@@ -1,4 +1,4 @@
-export type ColumnScalar = 'INTEGER' | 'FLOAT' | 'DATETIME' | 'DATE' | 'BOOLEAN' | 'DECIMAL' | 'STRING'
+export type ColumnScalar = 'INTEGER' | 'FLOAT' | 'DATETIME' | 'DATE' | 'BOOLEAN' | 'DECIMAL' | 'STRING' | 'TUPLE'
 
 export interface FormattingTemplate {
     id: string


### PR DESCRIPTION
## Problem
- Sparklines weren't getting rendered correctly in the table of the data viz node
**Prod**
<img width="361" alt="image" src="https://github.com/user-attachments/assets/8da5b4a7-9195-44a1-a32c-defff3bdee17" />


## Changes
- Fix it

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9383e5be-a913-430d-8df3-41e9e8ee1289" />
