### PR TITLE
chore(flags): stop checking clickhouse for feature flag status endpoint

### DIFF
--- a/posthog/models/feature_flag/flag_status.py
+++ b/posthog/models/feature_flag/flag_status.py
@@ -23,7 +23,7 @@ class FeatureFlagStatus(StrEnum):
 # - ACTIVE: The feature flag is actively evaluated and the evaluations continue to vary.
 # - STALE: The feature flag has been fully rolled out to users. Its evaluations can not vary.
 # - INACTIVE: The feature flag is not being actively evaluated. STALE takes precedence over INACTIVE.
-#       NOTE: This status is not currently used, but may be used in the future to automatically archive flags.
+#       NOTE: The "inactive" status is not currently used, but may be used in the future to automatically archive flags.
 # - DELETED: The feature flag has been soft deleted.
 # - UNKNOWN: The feature flag is not found in the database.
 class FeatureFlagStatusChecker:

--- a/posthog/models/feature_flag/flag_status.py
+++ b/posthog/models/feature_flag/flag_status.py
@@ -23,6 +23,7 @@ class FeatureFlagStatus(StrEnum):
 # - ACTIVE: The feature flag is actively evaluated and the evaluations continue to vary.
 # - STALE: The feature flag has been fully rolled out to users. Its evaluations can not vary.
 # - INACTIVE: The feature flag is not being actively evaluated. STALE takes precedence over INACTIVE.
+#       NOTE: This status is not currently used, but may be used in the future to automatically archive flags.
 # - DELETED: The feature flag has been soft deleted.
 # - UNKNOWN: The feature flag is not found in the database.
 class FeatureFlagStatusChecker:
@@ -48,10 +49,6 @@ class FeatureFlagStatusChecker:
         is_flag_fully_rolled_out, fully_rolled_out_explanation = self.is_flag_fully_rolled_out(flag)
         if is_flag_fully_rolled_out:
             return FeatureFlagStatus.STALE, fully_rolled_out_explanation
-
-        # Final, and most expensive check: see if the flag has been evaluated recently.
-        if self.is_flag_unevaluated_recently(flag):
-            return FeatureFlagStatus.INACTIVE, "Flag has not been evaluated recently"
 
         return FeatureFlagStatus.ACTIVE, "Flag is not fully rolled out and may still be active"
 


### PR DESCRIPTION
## Problem

We're seeing some clickhouse errors on this endpoint lately: https://posthog.sentry.io/issues/6149399926 + https://posthog.sentry.io/issues/6149406182

We do not actually use the result of this clickhouse query in the UI today, so there's no use letting in cause the endpoint to error out, and no real use in running the query for now either. This PR simply skips that step, leaving the query code in though for later use.

## Changes

 No functional changes to product today

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

Yes

## How did you test this code?

Tested stale flag checks still work as intended

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
