### PR TITLE
feat: add replay view

### DIFF
--- a/posthog/clickhouse/migrations/0096_add_replay_view.py
+++ b/posthog/clickhouse/migrations/0096_add_replay_view.py
@@ -1,0 +1,8 @@
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.session_recordings.sql.session_replay_event_sql import (
+    GROUPED_SESSION_REPLAY_EVENTS_VIEW_SQL,
+)
+
+operations = [
+    run_sql_with_exceptions(GROUPED_SESSION_REPLAY_EVENTS_VIEW_SQL()),
+]

--- a/posthog/hogql/database/schema/session_replay_events.py
+++ b/posthog/hogql/database/schema/session_replay_events.py
@@ -1,3 +1,4 @@
+from posthog.hogql import ast
 from posthog.hogql.ast import SelectQuery, JoinExpr
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import (
@@ -7,11 +8,9 @@ from posthog.hogql.database.models import (
     IntegerDatabaseField,
     LazyJoin,
     FieldTraverser,
-    DatabaseField,
-    LazyTable,
     FieldOrTable,
-    LazyTableToAdd,
     LazyJoinToAdd,
+    StringArrayDatabaseField,
 )
 from posthog.hogql.database.schema.events import EventsTable
 from posthog.hogql.database.schema.log_entries import ReplayConsoleLogsLogEntriesTable
@@ -30,8 +29,6 @@ from posthog.hogql.errors import ResolutionError
 def join_replay_table_to_sessions_table_v1(
     join_to_add: LazyJoinToAdd, context: HogQLContext, node: SelectQuery
 ) -> JoinExpr:
-    from posthog.hogql import ast
-
     if not join_to_add.fields_accessed:
         raise ResolutionError("No fields requested from replay")
 
@@ -52,8 +49,6 @@ def join_replay_table_to_sessions_table_v1(
 def join_replay_table_to_sessions_table_v2(
     join_to_add: LazyJoinToAdd, context: HogQLContext, node: SelectQuery
 ) -> JoinExpr:
-    from posthog.hogql import ast
-
     if not join_to_add.fields_accessed:
         raise ResolutionError("No fields requested from replay")
 
@@ -76,8 +71,6 @@ def join_with_events_table(
     context: HogQLContext,
     node: SelectQuery,
 ):
-    from posthog.hogql import ast
-
     requested_fields = join_to_add.fields_accessed
     if "$session_id" not in join_to_add.fields_accessed:
         requested_fields = {**join_to_add.fields_accessed, "$session_id": ["$session_id"]}
@@ -109,8 +102,6 @@ def join_with_events_table(
 
 
 def _clamp_to_ttl(chain: list[str | int]):
-    from posthog.hogql import ast
-
     # TRICKY: tests can freeze time, if we use `now()` in the ClickHouse queries then the tests will fail
     # because the time in the query will be different from the time in the test
     # so we generate now in Python and pass it in
@@ -133,8 +124,6 @@ def join_with_console_logs_log_entries_table(
     context: HogQLContext,
     node: SelectQuery,
 ):
-    from posthog.hogql import ast
-
     requested_fields = join_to_add.fields_accessed
     if "log_source_id" not in join_to_add.fields_accessed:
         requested_fields = {**requested_fields, "log_source_id": ["log_source_id"]}
@@ -160,26 +149,25 @@ def join_with_console_logs_log_entries_table(
     return join_expr
 
 
-RAW_ONLY_FIELDS = ["min_first_timestamp", "max_last_timestamp"]
-
 SESSION_REPLAY_EVENTS_COMMON_FIELDS: dict[str, FieldOrTable] = {
     "session_id": StringDatabaseField(name="session_id"),
     "team_id": IntegerDatabaseField(name="team_id"),
     "distinct_id": StringDatabaseField(name="distinct_id"),
-    "min_first_timestamp": DateTimeDatabaseField(name="min_first_timestamp"),
-    "max_last_timestamp": DateTimeDatabaseField(name="max_last_timestamp"),
-    "first_url": DatabaseField(name="first_url"),
+    "first_url": StringDatabaseField(name="first_url", nullable=True),
+    "all_urls": StringArrayDatabaseField(name="all_urls"),
     "click_count": IntegerDatabaseField(name="click_count"),
+    "active_milliseconds": IntegerDatabaseField(name="active_milliseconds"),
     "keypress_count": IntegerDatabaseField(name="keypress_count"),
     "mouse_activity_count": IntegerDatabaseField(name="mouse_activity_count"),
-    "active_milliseconds": IntegerDatabaseField(name="active_milliseconds"),
     "console_log_count": IntegerDatabaseField(name="console_log_count"),
     "console_warn_count": IntegerDatabaseField(name="console_warn_count"),
     "console_error_count": IntegerDatabaseField(name="console_error_count"),
     "size": IntegerDatabaseField(name="size"),
     "event_count": IntegerDatabaseField(name="event_count"),
     "message_count": IntegerDatabaseField(name="message_count"),
-    "snapshot_source": StringDatabaseField(name="snapshot_source"),
+    "snapshot_source": StringDatabaseField(name="snapshot_source", nullable=True),
+    "snapshot_library": StringDatabaseField(name="snapshot_library", nullable=True),
+    "_timestamp": DateTimeDatabaseField(name="_timestamp"),
     "events": LazyJoin(
         from_field=["session_id"],
         join_table=EventsTable(),
@@ -212,12 +200,10 @@ class RawSessionReplayEventsTable(Table):
         **SESSION_REPLAY_EVENTS_COMMON_FIELDS,
         "min_first_timestamp": DateTimeDatabaseField(name="min_first_timestamp"),
         "max_last_timestamp": DateTimeDatabaseField(name="max_last_timestamp"),
-        "first_url": DatabaseField(name="first_url"),
-        "_timestamp": DateTimeDatabaseField(name="_timestamp"),
     }
 
     def avoid_asterisk_fields(self) -> list[str]:
-        return ["first_url"]
+        return [f for f in self.fields if f in ["session_id"]]
 
     def to_printed_clickhouse(self, context):
         return "session_replay_events"
@@ -226,62 +212,15 @@ class RawSessionReplayEventsTable(Table):
         return "raw_session_replay_events"
 
 
-def select_from_session_replay_events_table(requested_fields: dict[str, list[str | int]]):
-    from posthog.hogql import ast
-
-    table_name = "raw_session_replay_events"
-
-    aggregate_fields = {
-        "start_time": ast.Call(name="min", args=[ast.Field(chain=[table_name, "min_first_timestamp"])]),
-        "end_time": ast.Call(name="max", args=[ast.Field(chain=[table_name, "max_last_timestamp"])]),
-        "first_url": ast.Call(name="argMinMerge", args=[ast.Field(chain=[table_name, "first_url"])]),
-        "click_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "click_count"])]),
-        "keypress_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "keypress_count"])]),
-        "mouse_activity_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "mouse_activity_count"])]),
-        "active_milliseconds": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "active_milliseconds"])]),
-        "console_log_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "console_log_count"])]),
-        "console_warn_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "console_warn_count"])]),
-        "console_error_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "console_error_count"])]),
-        "distinct_id": ast.Call(name="any", args=[ast.Field(chain=[table_name, "distinct_id"])]),
-        "size": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "size"])]),
-        "event_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "event_count"])]),
-        "message_count": ast.Call(name="sum", args=[ast.Field(chain=[table_name, "message_count"])]),
-    }
-
-    select_fields: list[ast.Expr] = []
-    group_by_fields: list[ast.Expr] = []
-
-    for name, chain in requested_fields.items():
-        if name in RAW_ONLY_FIELDS:
-            # these fields are accounted for by start_time and end_time, so can be skipped in the "not raw" table
-            continue
-
-        if name in aggregate_fields:
-            select_fields.append(ast.Alias(alias=name, expr=aggregate_fields[name]))
-        else:
-            select_fields.append(ast.Alias(alias=name, expr=ast.Field(chain=[table_name, *chain])))
-            group_by_fields.append(ast.Field(chain=[table_name, *chain]))
-
-    return ast.SelectQuery(
-        select=select_fields,
-        select_from=ast.JoinExpr(table=ast.Field(chain=[table_name])),
-        group_by=group_by_fields,
-    )
-
-
-class SessionReplayEventsTable(LazyTable):
+class SessionReplayEventsTable(Table):
     fields: dict[str, FieldOrTable] = {
-        **{k: v for k, v in SESSION_REPLAY_EVENTS_COMMON_FIELDS.items() if k not in RAW_ONLY_FIELDS},
+        **SESSION_REPLAY_EVENTS_COMMON_FIELDS,
         "start_time": DateTimeDatabaseField(name="start_time"),
         "end_time": DateTimeDatabaseField(name="end_time"),
-        "first_url": StringDatabaseField(name="first_url"),
     }
 
-    def lazy_select(self, table_to_add: LazyTableToAdd, context, node):
-        return select_from_session_replay_events_table(table_to_add.fields_accessed)
-
     def to_printed_clickhouse(self, context):
-        return "session_replay_events"
+        return "grouped_session_replay_events"
 
     def to_printed_hogql(self):
         return "session_replay_events"

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -9,7 +9,7 @@
   SELECT groups.group_type_index AS index, groups.group_key AS key 
   FROM groups 
   WHERE equals(groups.team_id, 420) 
-  GROUP BY groups.group_type_index, groups.group_key) AS groups) AS events__some_field ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.person_properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), events__some_field.events__some_field___key) 
+  GROUP BY groups.group_type_index, groups.group_key) AS groups) AS events__some_field ON equals(nullIf(nullIf(mat_pp_email, ''), 'null'), events__some_field.events__some_field___key) 
   WHERE equals(events.team_id, 420) 
   LIMIT 50000
   '''
@@ -734,12 +734,32 @@
                   "table": null,
                   "type": "string"
               },
+              "all_urls": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "all_urls",
+                  "id": null,
+                  "name": "all_urls",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "array"
+              },
               "click_count": {
                   "chain": null,
                   "fields": null,
                   "hogql_value": "click_count",
                   "id": null,
                   "name": "click_count",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "active_milliseconds": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "active_milliseconds",
+                  "id": null,
+                  "name": "active_milliseconds",
                   "schema_valid": true,
                   "table": null,
                   "type": "integer"
@@ -760,16 +780,6 @@
                   "hogql_value": "mouse_activity_count",
                   "id": null,
                   "name": "mouse_activity_count",
-                  "schema_valid": true,
-                  "table": null,
-                  "type": "integer"
-              },
-              "active_milliseconds": {
-                  "chain": null,
-                  "fields": null,
-                  "hogql_value": "active_milliseconds",
-                  "id": null,
-                  "name": "active_milliseconds",
                   "schema_valid": true,
                   "table": null,
                   "type": "integer"
@@ -843,6 +853,26 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
+              },
+              "snapshot_library": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "snapshot_library",
+                  "id": null,
+                  "name": "snapshot_library",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "_timestamp": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "_timestamp",
+                  "id": null,
+                  "name": "_timestamp",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
               },
               "events": {
                   "chain": null,
@@ -2545,12 +2575,32 @@
                   "table": null,
                   "type": "string"
               },
+              "all_urls": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "all_urls",
+                  "id": null,
+                  "name": "all_urls",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "array"
+              },
               "click_count": {
                   "chain": null,
                   "fields": null,
                   "hogql_value": "click_count",
                   "id": null,
                   "name": "click_count",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "integer"
+              },
+              "active_milliseconds": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "active_milliseconds",
+                  "id": null,
+                  "name": "active_milliseconds",
                   "schema_valid": true,
                   "table": null,
                   "type": "integer"
@@ -2571,16 +2621,6 @@
                   "hogql_value": "mouse_activity_count",
                   "id": null,
                   "name": "mouse_activity_count",
-                  "schema_valid": true,
-                  "table": null,
-                  "type": "integer"
-              },
-              "active_milliseconds": {
-                  "chain": null,
-                  "fields": null,
-                  "hogql_value": "active_milliseconds",
-                  "id": null,
-                  "name": "active_milliseconds",
                   "schema_valid": true,
                   "table": null,
                   "type": "integer"
@@ -2654,6 +2694,26 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "string"
+              },
+              "snapshot_library": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "snapshot_library",
+                  "id": null,
+                  "name": "snapshot_library",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
+              "_timestamp": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "_timestamp",
+                  "id": null,
+                  "name": "_timestamp",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "datetime"
               },
               "events": {
                   "chain": null,

--- a/posthog/hogql/functions/mapping.py
+++ b/posthog/hogql/functions/mapping.py
@@ -1021,6 +1021,7 @@ HOGQL_AGGREGATIONS: dict[str, HogQLFunctionMeta] = {
     # "groupArrayLast": HogQLFunctionMeta("groupArrayLast", 1, 1, aggregate=True),
     # "groupArrayLastIf": HogQLFunctionMeta("groupArrayLastIf", 2, 2, aggregate=True),
     "groupUniqArray": HogQLFunctionMeta("groupUniqArray", 1, 1, aggregate=True),
+    "groupUniqArrayArray": HogQLFunctionMeta("groupUniqArrayArray", 1, 1, aggregate=True),
     "groupUniqArrayIf": HogQLFunctionMeta("groupUniqArrayIf", 2, 2, aggregate=True),
     "groupArrayInsertAt": HogQLFunctionMeta("groupArrayInsertAt", 2, 2, aggregate=True),
     "groupArrayInsertAtIf": HogQLFunctionMeta("groupArrayInsertAtIf", 3, 3, aggregate=True),

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -89,6 +89,7 @@ from posthog.session_recordings.sql.session_replay_event_sql import (
     DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL,
     DROP_SESSION_REPLAY_EVENTS_TABLE_SQL,
     SESSION_REPLAY_EVENTS_TABLE_SQL,
+    GROUPED_SESSION_REPLAY_EVENTS_VIEW_SQL,
 )
 from posthog.test.assert_faster_than import assert_faster_than
 
@@ -1042,6 +1043,7 @@ class ClickhouseDestroyTablesMixin(BaseTest):
                 DISTRIBUTED_SESSION_REPLAY_EVENTS_TABLE_SQL(),
                 DISTRIBUTED_SESSIONS_TABLE_SQL(),
                 DISTRIBUTED_RAW_SESSIONS_TABLE_SQL(),
+                GROUPED_SESSION_REPLAY_EVENTS_VIEW_SQL(),
             ]
         )
         run_clickhouse_statement_in_parallel(


### PR DESCRIPTION
using session replay data in hogql is really hard because you have to know the definition of the columns in the aggregating merge tree table

let's keep `raw_session_replay_events` in  hogql because we can use it for fancy queries like in listing

but create a view that encapsulates the aggregations needed so you can do `select * from session_replay_events` in hogql

allows things like

```
select * from session_replay_events 
where session_replay_events.start_time <= now() 
and session_replay_events.start_time >= now() - interval 1 day
and properties.$current_url ilike '%chat%'
```

while still allowing things like

```
select session_id, groupUniqArrayArray(all_urls) 
from raw_session_replay_events 
where min_first_timestamp <= now() 
and min_first_timestamp >= now() - interval 1 day
and properties.$current_url ilike '%chat%'
group by session_id
```