### PR TITLE
fix: Cache invalidation api

### DIFF
--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -401,7 +401,7 @@ class RemoteConfig(UUIDModel):
             res = requests.post(
                 settings.REMOTE_CONFIG_CDN_PURGE_ENDPOINT,
                 headers={"Authorization": f"Bearer {settings.REMOTE_CONFIG_CDN_PURGE_TOKEN}"},
-                data=data,
+                json=data,
             )
 
             if res.status_code != 200:

--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -457,7 +457,7 @@ class TestRemoteConfigCaching(_RemoteConfigBase):
             mock_post.assert_called_once_with(
                 "https://api.cloudflare.com/client/v4/zones/MY_ZONE_ID/purge_cache",
                 headers={"Authorization": "Bearer MY_TOKEN"},
-                data={
+                json={
                     "files": [
                         {"url": "https://cdn.posthog.com/array/phc_12345/config"},
                         {"url": "https://cdn.posthog.com/array/phc_12345/config.js"},


### PR DESCRIPTION
## Problem

Wans't json encoding to the CF api. Silly me

## Changes

* Fixes it

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
