### PR TITLE
fix: Use `False` inside `or` Clickhouse query

### DIFF
--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -88,8 +88,9 @@ class WebAnalyticsQueryRunner(QueryRunner, ABC):
         )
 
     def _previous_period_expression(self, field="start_timestamp"):
+        # NOTE: Returning `ast.Constant(value=None)` is painfully slow, make sure we return a boolean
         if not self.query_compare_to_date_range:
-            return ast.Constant(value=None)
+            return ast.Constant(value=False)
 
         return ast.Call(
             name="and",


### PR DESCRIPTION
We're running this query in our big production account with a `OR(..., NULL)` and it's painfully slow. Running it on Metabase with `OR(..., False)` is much faster.