### PR TITLE
feat(product-analytics): most used property values for the agent

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -5630,8 +5630,11 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
-                "property": {
-                    "type": "string"
+                "properties": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
                 },
                 "response": {
                     "$ref": "#/definitions/EventTaxonomyQueryResponse"

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -5630,6 +5630,9 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
+                "property": {
+                    "type": "string"
+                },
                 "response": {
                     "$ref": "#/definitions/EventTaxonomyQueryResponse"
                 }

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -2420,7 +2420,7 @@ export type EventTaxonomyResponse = EventTaxonomyItem[]
 export interface EventTaxonomyQuery extends DataNode<EventTaxonomyQueryResponse> {
     kind: NodeKind.EventTaxonomyQuery
     event: string
-    property?: string
+    properties?: string[]
 }
 
 export type EventTaxonomyQueryResponse = AnalyticsQueryResponseBase<EventTaxonomyResponse>

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -2420,6 +2420,7 @@ export type EventTaxonomyResponse = EventTaxonomyItem[]
 export interface EventTaxonomyQuery extends DataNode<EventTaxonomyQueryResponse> {
     kind: NodeKind.EventTaxonomyQuery
     event: string
+    property?: string
 }
 
 export type EventTaxonomyQueryResponse = AnalyticsQueryResponseBase<EventTaxonomyResponse>

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5582,7 +5582,7 @@ class EventTaxonomyQuery(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    property: Optional[str] = None
+    properties: Optional[list[str]] = None
     response: Optional[EventTaxonomyQueryResponse] = None
 
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5582,6 +5582,7 @@ class EventTaxonomyQuery(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    property: Optional[str] = None
     response: Optional[EventTaxonomyQueryResponse] = None
 
 


### PR DESCRIPTION
## Problem

To scrape info about a business, we need to get the most frequent origins or app bundle IDs. There isn't a query that can do that.

## Changes

Modify the EventTaxonomyQuery to support an optional property filtering. If properties are used, we'll remove the descending ordering by the timestamp and output the five most frequent values.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unit tests.