### PR TITLE
fix(surveys): favor "properties" to "user properties", given that we can target by user and group properties

### DIFF
--- a/cypress/e2e/surveys.cy.ts
+++ b/cypress/e2e/surveys.cy.ts
@@ -92,7 +92,7 @@ describe('Surveys', () => {
         cy.get('.LemonCollapsePanel').contains('Display conditions').click()
         cy.contains('All users').click()
         cy.get('.Popover__content').contains('Users who match').click()
-        cy.contains('Add user targeting').click()
+        cy.contains('Add property targeting').click()
 
         // select the first property
         cy.get('[data-attr="property-select-toggle-0"]').click()
@@ -144,7 +144,7 @@ describe('Surveys', () => {
 
         // remove user targeting properties
         cy.get('.LemonCollapsePanel').contains('Display conditions').click()
-        cy.contains('Remove all user properties').click()
+        cy.contains('Remove all property targeting').click()
 
         // save
         cy.get('[data-attr="save-survey"]').eq(0).click()
@@ -197,7 +197,7 @@ describe('Surveys', () => {
         cy.get('.LemonCollapsePanel').contains('Display conditions').click()
         cy.contains('All users').click()
         cy.get('.Popover__content').contains('Users who match').click()
-        cy.contains('Add user targeting').click()
+        cy.contains('Add property targeting').click()
         cy.get('[data-attr="property-select-toggle-0"]').click()
         cy.get('[data-attr="prop-filter-person_properties-0"]').click()
         cy.get('[data-attr=prop-val]').click({ force: true })

--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -719,7 +719,7 @@ export default function SurveyEdit(): JSX.Element {
                                                     </>
                                                 )}
                                             </LemonField>
-                                            <LemonField.Pure label="User properties">
+                                            <LemonField.Pure label="Properties">
                                                 <BindLogic
                                                     logic={featureFlagLogic}
                                                     props={{ id: survey.targeting_flag?.id || 'new' }}
@@ -743,7 +743,7 @@ export default function SurveyEdit(): JSX.Element {
                                                                 setSurveyValue('remove_targeting_flag', false)
                                                             }}
                                                         >
-                                                            Add user targeting
+                                                            Add property targeting
                                                         </LemonButton>
                                                     )}
                                                     {targetingFlagFilters && (
@@ -772,7 +772,7 @@ export default function SurveyEdit(): JSX.Element {
                                                                     setSurveyValue('remove_targeting_flag', true)
                                                                 }}
                                                             >
-                                                                Remove all user properties
+                                                                Remove all property targeting
                                                             </LemonButton>
                                                         </>
                                                     )}


### PR DESCRIPTION
## Problem

The info is in the title; I noticed that we were saying "user properties" for all of our targeting but we can technically target groups too, so this is more correct IMO.