### PR TITLE
fix(all): improve a11y for checkbox

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonCheckbox/LemonCheckbox.scss
+++ b/frontend/src/lib/lemon-ui/LemonCheckbox/LemonCheckbox.scss
@@ -6,6 +6,13 @@
     width: fit-content;
     font-weight: 500;
     line-height: 1.5rem;
+    outline-offset: 2px;
+
+    &:has(:focus-visible) {
+        .LemonCheckbox__box {
+            outline: -webkit-focus-ring-color auto 1px;
+        }
+    }
 
     .LemonCheckbox__input {
         width: 0 !important;

--- a/frontend/src/lib/lemon-ui/LemonCheckbox/LemonCheckbox.scss
+++ b/frontend/src/lib/lemon-ui/LemonCheckbox/LemonCheckbox.scss
@@ -6,7 +6,6 @@
     width: fit-content;
     font-weight: 500;
     line-height: 1.5rem;
-    outline-offset: 2px;
 
     &:has(:focus-visible) {
         .LemonCheckbox__box {


### PR DESCRIPTION
## Problem
With the change here: https://github.com/PostHog/posthog/pull/26992, I found that checkboxes were missing their focus styles, so this is adding that.

## Changes
<img width="170" alt="image" src="https://github.com/user-attachments/assets/f02cd045-e9be-4cdb-9f43-06b22c4ad1ad" />
<img width="169" alt="image" src="https://github.com/user-attachments/assets/fa6487cc-70c4-4a6d-82bb-d64406a6bbbc" />

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
tabbing onto element => show style changes, clicking element => show no style changes