### PR TITLE
fix: expose rust capture in docker stack

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -160,6 +160,8 @@ services:
             args:
                 BIN: capture
         restart: on-failure
+        ports:
+            - 3000:3000
         environment:
             ADDRESS: '0.0.0.0:3000'
             KAFKA_TOPIC: 'events_plugin_ingestion'

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -160,8 +160,6 @@ services:
             args:
                 BIN: capture
         restart: on-failure
-        ports:
-            - 3000:3000
         environment:
             ADDRESS: '0.0.0.0:3000'
             KAFKA_TOPIC: 'events_plugin_ingestion'

--- a/docker-compose.dev-full.yml
+++ b/docker-compose.dev-full.yml
@@ -129,6 +129,8 @@ services:
         extends:
             file: docker-compose.base.yml
             service: capture
+        ports:
+            - 3000:3000
         environment:
             - DEBUG=1
         depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -131,6 +131,8 @@ services:
         extends:
             file: docker-compose.base.yml
             service: capture
+        ports:
+            - 3000:3000
         environment:
             - DEBUG=1
         depends_on:


### PR DESCRIPTION
Django in some setups (e.g. local dev) is trying to redirect event traffic to rust capture

let's let that work