### PR TITLE
feat(experiments): Modify test account filters for DW support

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -53,7 +53,6 @@ from posthog.hogql.database.schema.error_tracking_issue_fingerprint_overrides im
 from posthog.hogql.database.schema.person_distinct_ids import (
     PersonDistinctIdsTable,
     RawPersonDistinctIdsTable,
-    join_data_warehouse_experiment_table_with_person_distinct_ids_table,
 )
 from posthog.hogql.database.schema.persons import (
     PersonsTable,
@@ -457,14 +456,6 @@ def create_hogql_database(
                     else join.join_function()
                 ),
             )
-
-            if "events" in join.joining_table_name and join.configuration.get("experiments_optimized"):
-                source_table.fields["pdi"] = LazyJoin(
-                    from_field=from_field,
-                    join_table=PersonDistinctIdsTable(),
-                    join_function=join_data_warehouse_experiment_table_with_person_distinct_ids_table,
-                )
-                source_table.fields["person"] = FieldTraverser(chain=["pdi", "person"])
 
             if join.source_table_name == "persons":
                 person_field = database.events.fields["person"]

--- a/posthog/hogql/database/schema/person_distinct_ids.py
+++ b/posthog/hogql/database/schema/person_distinct_ids.py
@@ -67,29 +67,6 @@ def join_with_person_distinct_ids_table(
     return join_expr
 
 
-def join_data_warehouse_experiment_table_with_person_distinct_ids_table(
-    join_to_add: LazyJoinToAdd,
-    context: HogQLContext,
-    node: SelectQuery,
-):
-    from posthog.hogql import ast
-
-    if not join_to_add.fields_accessed:
-        raise ResolutionError("No fields requested from person_distinct_ids")
-    join_expr = ast.JoinExpr(table=select_from_person_distinct_ids_table(join_to_add.fields_accessed))
-    join_expr.join_type = "LEFT JOIN"
-    join_expr.alias = join_to_add.to_table
-    join_expr.constraint = ast.JoinConstraint(
-        expr=ast.CompareOperation(
-            op=ast.CompareOperationOp.Eq,
-            left=ast.Field(chain=[join_to_add.from_table, *join_to_add.lazy_join.from_field]),
-            right=ast.Field(chain=[join_to_add.to_table, "distinct_id"]),
-        ),
-        constraint_type="ON",
-    )
-    return join_expr
-
-
 class RawPersonDistinctIdsTable(Table):
     fields: dict[str, FieldOrTable] = {
         **PERSON_DISTINCT_IDS_FIELDS,

--- a/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
@@ -812,7 +812,13 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 "value": "@posthog.com",
                 "operator": "not_icontains",
                 "type": "person",
-            }
+            },
+            {
+                "key": "$host",
+                "type": "event",
+                "value": "^(localhost|127\\.0\\.0\\.1)($|:)",
+                "operator": "not_regex",
+            },
         ]
         self.team.save()
         count_query = TrendsQuery(
@@ -938,7 +944,7 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             )
 
             # Assert the expected join condition in the clickhouse SQL
-            expected_join_condition = f"and(equals(events.team_id, {query_runner.count_query_runner.team.id}), equals(event, %(hogql_val_11)s), greaterOrEquals(timestamp, assumeNotNull(parseDateTime64BestEffortOrNull(%(hogql_val_12)s, 6, %(hogql_val_13)s))), lessOrEquals(timestamp, assumeNotNull(parseDateTime64BestEffortOrNull(%(hogql_val_14)s, 6, %(hogql_val_15)s))))) AS e__events ON"
+            expected_join_condition = f"and(equals(events.team_id, {query_runner.count_query_runner.team.id}), equals(event, %(hogql_val_9)s), greaterOrEquals(timestamp, assumeNotNull(parseDateTime64BestEffortOrNull(%(hogql_val_10)s, 6, %(hogql_val_11)s))), lessOrEquals(timestamp, assumeNotNull(parseDateTime64BestEffortOrNull(%(hogql_val_12)s, 6, %(hogql_val_13)s))))) AS e__events ON"
             self.assertIn(
                 expected_join_condition,
                 str(response.clickhouse),

--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -698,7 +698,16 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
             and len(self.team.test_account_filters) > 0
         ):
             for property in self.team.test_account_filters:
-                filters.append(property_to_expr(property, self.team))
+                if is_data_warehouse_series:
+                    if property["type"] in ("event", "person"):
+                        if property["type"] == "event":
+                            property["key"] = f"events.properties.{property['key']}"
+                        elif property["type"] == "person":
+                            property["key"] = f"events.person.properties.{property['key']}"
+                        property["type"] = "data_warehouse"
+                    filters.append(property_to_expr(property, self.team))
+                else:
+                    filters.append(property_to_expr(property, self.team))
 
         # Properties
         if self.query.properties is not None and self.query.properties != []:


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/26332
Reverts https://github.com/PostHog/posthog/pull/26947
See https://posthog.slack.com/archives/C07PXH2GTGV/p1733936406339719

## Changes

Directly modifies the test account filters in `TrendsQueryBuilder`, and reverts auto-joining the `persons` table from https://github.com/PostHog/posthog/pull/26947.

Auto-joining the `persons` table isn't the right approach because the test account filters support all sorts of property types.

Instead, we'll leverage all of the existing fancy auto-joining behavior for the `events` table by updating the properties to reference the location of the `events` table on the data warehouse table.

Not all of the filter types are supported yet. I created https://github.com/PostHog/posthog/issues/27012 as a follow-up.

## How did you test this code?

Tests should pass.