### PR TITLE
chore(batch-exports): Improve batch export alerting by checking for missing runs

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -810,3 +810,27 @@ async def aupdate_records_total_count(
         data_interval_end=interval_end,
     ).aupdate(records_total_count=count)
     return rows_updated
+
+
+async def afetch_batch_export_runs_in_range(
+    batch_export_id: UUID,
+    interval_start: dt.datetime,
+    interval_end: dt.datetime,
+) -> list[BatchExportRun]:
+    """Async fetch all BatchExportRuns for a given batch export within a time interval.
+
+    Arguments:
+        batch_export_id: The UUID of the BatchExport to fetch runs for.
+        interval_start: The start of the time interval to fetch runs from.
+        interval_end: The end of the time interval to fetch runs until.
+
+    Returns:
+        A list of BatchExportRun objects within the given interval, ordered by data_interval_start.
+    """
+    queryset = BatchExportRun.objects.filter(
+        batch_export_id=batch_export_id,
+        data_interval_start__gte=interval_start,
+        data_interval_end__lte=interval_end,
+    ).order_by("data_interval_start")
+
+    return [run async for run in queryset]

--- a/posthog/temporal/batch_exports/monitoring.py
+++ b/posthog/temporal/batch_exports/monitoring.py
@@ -177,9 +177,11 @@ class CheckForMissingBatchExportRunsInputs:
 def _log_warning_for_missing_batch_export_runs(
     batch_export_id: UUID, missing_runs: list[tuple[dt.datetime, dt.datetime]]
 ):
-    message = f"Batch Exports Monitoring: Found {len(missing_runs)} missing runs for batch export {batch_export_id}:\n"
+    message = (
+        f"Batch Exports Monitoring: Found {len(missing_runs)} missing run(s) for batch export {batch_export_id}:\n"
+    )
     for start, end in missing_runs:
-        message += f"- Run {start.strftime('%Y-%m-%d %H:%M:%S')} to {end.strftime('%Y-%m-%d %H:%M:%S')} \n"
+        message += f"- Run {start.strftime('%Y-%m-%d %H:%M:%S')} to {end.strftime('%Y-%m-%d %H:%M:%S')}\n"
 
     activity.logger.warning(message)
 

--- a/posthog/temporal/tests/batch_exports/test_monitoring.py
+++ b/posthog/temporal/tests/batch_exports/test_monitoring.py
@@ -199,7 +199,6 @@ async def test_monitoring_workflow(
         async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
             async with Worker(
                 activity_environment.client,
-                # TODO - not sure if this is the right task queue
                 task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
                 workflows=[BatchExportMonitoringWorkflow],
                 activities=[

--- a/posthog/temporal/tests/batch_exports/test_monitoring.py
+++ b/posthog/temporal/tests/batch_exports/test_monitoring.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import uuid
+from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
@@ -9,6 +10,7 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog import constants
 from posthog.batch_exports.models import BatchExportRun
+from posthog.batch_exports.service import afetch_batch_export_runs_in_range
 from posthog.temporal.batch_exports.monitoring import (
     BatchExportMonitoringInputs,
     BatchExportMonitoringWorkflow,
@@ -150,7 +152,12 @@ async def test_monitoring_workflow_when_no_event_data(batch_export):
     ["every 5 minutes"],
     indirect=True,
 )
+@pytest.mark.parametrize(
+    "simulate_missing_batch_export_runs",
+    [True, False],
+)
 async def test_monitoring_workflow(
+    simulate_missing_batch_export_runs,
     batch_export,
     generate_test_data,
     data_interval_start,
@@ -168,37 +175,63 @@ async def test_monitoring_workflow(
     generated and assert that the expected records count matches the records
     completed.
     """
+
+    expected_missing_runs: list[tuple[dt.datetime, dt.datetime]] = []
+    if simulate_missing_batch_export_runs:
+        # simulate a missing batch export run by deleting the batch export run for the first 5 minutes
+        runs: list[BatchExportRun] = await afetch_batch_export_runs_in_range(
+            batch_export_id=batch_export.id,
+            interval_start=data_interval_start,
+            interval_end=data_interval_start + dt.timedelta(minutes=5),
+        )
+        assert len(runs) == 1
+        for run in runs:
+            assert run.data_interval_start is not None
+            expected_missing_runs.append((run.data_interval_start, run.data_interval_end))
+            await run.adelete()
+
     workflow_id = str(uuid.uuid4())
     inputs = BatchExportMonitoringInputs(batch_export_id=batch_export.id)
-    async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
-        async with Worker(
-            activity_environment.client,
-            # TODO - not sure if this is the right task queue
-            task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
-            workflows=[BatchExportMonitoringWorkflow],
-            activities=[
-                get_batch_export,
-                get_event_counts,
-                check_for_missing_batch_export_runs,
-                update_batch_export_runs,
-            ],
-            workflow_runner=UnsandboxedWorkflowRunner(),
-        ):
-            await activity_environment.client.execute_workflow(
-                BatchExportMonitoringWorkflow.run,
-                inputs,
-                id=workflow_id,
+    with patch(
+        "posthog.temporal.batch_exports.monitoring._log_warning_for_missing_batch_export_runs"
+    ) as mock_log_warning:
+        async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
+            async with Worker(
+                activity_environment.client,
+                # TODO - not sure if this is the right task queue
                 task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
-                retry_policy=RetryPolicy(maximum_attempts=1),
-                execution_timeout=dt.timedelta(seconds=30),
-            )
+                workflows=[BatchExportMonitoringWorkflow],
+                activities=[
+                    get_batch_export,
+                    get_event_counts,
+                    check_for_missing_batch_export_runs,
+                    update_batch_export_runs,
+                ],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                await activity_environment.client.execute_workflow(
+                    BatchExportMonitoringWorkflow.run,
+                    inputs,
+                    id=workflow_id,
+                    task_queue=constants.BATCH_EXPORTS_TASK_QUEUE,
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                    execution_timeout=dt.timedelta(seconds=30),
+                )
 
-    batch_export_runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)
-
-    for run in batch_export_runs:
-        if run.records_completed == 0:
-            # TODO: in the actual monitoring activity it would be better to
-            # update the actual count to 0 rather than None
-            assert run.records_total_count is None
+        if simulate_missing_batch_export_runs:
+            # check that the warning was logged
+            mock_log_warning.assert_called_once_with(batch_export.id, expected_missing_runs)
         else:
-            assert run.records_completed == run.records_total_count
+            # check that the warning was not logged
+            mock_log_warning.assert_not_called()
+
+        # check that the batch export runs were updated correctly
+        batch_export_runs = await afetch_batch_export_runs(batch_export_id=batch_export.id)
+
+        for run in batch_export_runs:
+            if run.records_completed == 0:
+                # TODO: in the actual monitoring activity it would be better to
+                # update the actual count to 0 rather than None
+                assert run.records_total_count is None
+            else:
+                assert run.records_completed == run.records_total_count

--- a/posthog/temporal/tests/batch_exports/test_monitoring.py
+++ b/posthog/temporal/tests/batch_exports/test_monitoring.py
@@ -12,6 +12,7 @@ from posthog.batch_exports.models import BatchExportRun
 from posthog.temporal.batch_exports.monitoring import (
     BatchExportMonitoringInputs,
     BatchExportMonitoringWorkflow,
+    check_for_missing_batch_export_runs,
     get_batch_export,
     get_event_counts,
     update_batch_export_runs,
@@ -118,6 +119,7 @@ async def test_monitoring_workflow_when_no_event_data(batch_export):
             activities=[
                 get_batch_export,
                 get_event_counts,
+                check_for_missing_batch_export_runs,
                 update_batch_export_runs,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),
@@ -177,6 +179,7 @@ async def test_monitoring_workflow(
             activities=[
                 get_batch_export,
                 get_event_counts,
+                check_for_missing_batch_export_runs,
                 update_batch_export_runs,
             ],
             workflow_runner=UnsandboxedWorkflowRunner(),

--- a/posthog/temporal/tests/batch_exports/test_monitoring.py
+++ b/posthog/temporal/tests/batch_exports/test_monitoring.py
@@ -168,10 +168,6 @@ async def test_monitoring_workflow(
 ):
     """Test the monitoring workflow with a batch export that has data.
 
-    We generate 2 hours of data between 13:00 and 15:00, and then run the
-    monitoring workflow at 15:30.  The monitoring workflow should check the data
-    between 14:00 and 15:00, and update the batch export runs.
-
     We generate some dummy batch export runs based on the event data we
     generated and assert that the expected records count matches the records
     completed.


### PR DESCRIPTION
## Problem

We've had an issue recently where Temporal hasn't scheduled a workflow run for some reason and we didn't detect this.

## Changes

Update existing monitoring job to also check for missing batch export runs.

We will log a warning message when this happens, which we can then create an alert for in alertmanager.

## Does this work well for both Cloud and self-hosted?

it doesn't have an impact

## How did you test this code?

Updated existing tests + added a new one
