### PR TITLE
feat(batch-exports): Include `_inserted_at` field in S3 batch exports

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -699,7 +699,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
             # Until we figure it out, we set all fields to nullable. There are some fields we know
             # are not nullable, but I'm opting for the more flexible option until we out why schemas differ
             # between batches.
-            [field.with_nullable(True) for field in record_batch_schema if field.name != "_inserted_at"]
+            [field.with_nullable(True) for field in record_batch_schema]
         )
 
         async with s3_upload as s3_upload:

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -715,6 +715,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
                 writer_format=WriterFormat.from_str(inputs.file_format, "S3"),
                 max_bytes=settings.BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES,
                 s3_upload=s3_upload,
+                include_inserted_at=True,
                 writer_file_kwargs={"compression": inputs.compression},
             )
 

--- a/posthog/temporal/batch_exports/temporary_file.py
+++ b/posthog/temporal/batch_exports/temporary_file.py
@@ -429,7 +429,7 @@ class BatchExportWriter(abc.ABC):
             self.end_at_since_last_flush = raw_end_at
 
         column_names = record_batch.column_names
-        column_names.pop(column_names.index("_inserted_at"))
+        # column_names.pop(column_names.index("_inserted_at"))
 
         await asyncio.to_thread(self._write_record_batch, record_batch.select(column_names))
 

--- a/posthog/temporal/batch_exports/temporary_file.py
+++ b/posthog/temporal/batch_exports/temporary_file.py
@@ -408,7 +408,9 @@ class BatchExportWriter(abc.ABC):
         self.bytes_total = batch_export_file.bytes_total
         self.bytes_since_last_flush = batch_export_file.bytes_since_last_reset
 
-    async def write_record_batch(self, record_batch: pa.RecordBatch, flush: bool = True) -> None:
+    async def write_record_batch(
+        self, record_batch: pa.RecordBatch, flush: bool = True, include_inserted_at: bool = False
+    ) -> None:
         """Issue a record batch write tracking progress and flushing if required."""
         record_batch = record_batch.sort_by("_inserted_at")
 
@@ -429,7 +431,8 @@ class BatchExportWriter(abc.ABC):
             self.end_at_since_last_flush = raw_end_at
 
         column_names = record_batch.column_names
-        # column_names.pop(column_names.index("_inserted_at"))
+        if not include_inserted_at:
+            column_names.pop(column_names.index("_inserted_at"))
 
         await asyncio.to_thread(self._write_record_batch, record_batch.select(column_names))
 

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -251,9 +251,9 @@ async def assert_clickhouse_records_in_s3(
         for record in record_batch.to_pylist():
             expected_record = {}
             for k, v in record.items():
-                if k not in schema_column_names or k == "_inserted_at":
-                    # _inserted_at is not exported, only used for tracking progress.
-                    continue
+                # if k not in schema_column_names or k == "_inserted_at":
+                #     # _inserted_at is not exported, only used for tracking progress.
+                #     continue
 
                 if k in json_columns and v is not None:
                     expected_record[k] = json.loads(v)

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -251,10 +251,6 @@ async def assert_clickhouse_records_in_s3(
         for record in record_batch.to_pylist():
             expected_record = {}
             for k, v in record.items():
-                # if k not in schema_column_names or k == "_inserted_at":
-                #     # _inserted_at is not exported, only used for tracking progress.
-                #     continue
-
                 if k in json_columns and v is not None:
                     expected_record[k] = json.loads(v)
                 elif isinstance(v, dt.datetime):


### PR DESCRIPTION
## Problem

We're not currently sending the `_inserted_at` field in our S3 events batch exports, which can be useful for knowing when the event was actually inserted into ClickHouse.

## Changes

Update S3 events batch exports to include this field. 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Should do

## How did you test this code?

- Updated existing tests
- Tested locally that a batch export to MinIO included `_inserted_at` in the output file
