### PR TITLE
fix: processEvent for site apps

### DIFF
--- a/posthog/cdp/site_functions.py
+++ b/posthog/cdp/site_functions.py
@@ -122,9 +122,13 @@ def get_transpiled_function(hog_function: HogFunction) -> str:
             callback(true);
         }
 
-        return {
-            processEvent: (globals) => processEvent(globals, posthog)
+        const response = {}
+
+        if (processEvent) {
+            response.processEvent = (globals) => processEvent(globals, posthog)
         }
+
+        return response
     }
 
     return { init: init };"""

--- a/posthog/cdp/test/test_site_functions.py
+++ b/posthog/cdp/test/test_site_functions.py
@@ -98,9 +98,13 @@ function onLoad() {
             callback(true);
         }
 
-        return {
-            processEvent: (globals) => processEvent(globals, posthog)
+        const response = {}
+
+        if (processEvent) {
+            response.processEvent = (globals) => processEvent(globals, posthog)
         }
+
+        return response
     }
 
     return { init: init };

--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -740,9 +740,13 @@ class TestRemoteConfigJS(_RemoteConfigBase):
                     callback(true);
                 }
         
-                return {
-                    processEvent: (globals) => processEvent(globals, posthog)
+                const response = {}
+        
+                if (processEvent) {
+                    response.processEvent = (globals) => processEvent(globals, posthog)
                 }
+        
+                return response
             }
         
             return { init: init };
@@ -786,9 +790,13 @@ class TestRemoteConfigJS(_RemoteConfigBase):
                     callback(true);
                 }
         
-                return {
-                    processEvent: (globals) => processEvent(globals, posthog)
+                const response = {}
+        
+                if (processEvent) {
+                    response.processEvent = (globals) => processEvent(globals, posthog)
                 }
+        
+                return response
             }
         
             return { init: init };


### PR DESCRIPTION
## Problem

Site apps don't have processEvent but the code returned it as if it does.

## Changes

* Fixes that

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
