### PR TITLE
fix(periodic-digest): use template_name instead of template

### DIFF
--- a/posthog/tasks/periodic_digest.py
+++ b/posthog/tasks/periodic_digest.py
@@ -212,7 +212,7 @@ def send_periodic_digest_report(
     full_report_dict = {
         "team_id": team_id,
         "team_name": team_name,
-        "template": "periodic_digest_report",
+        "template_name": "periodic_digest_report",
         "digest_items_with_data": digest_items_with_data,
         **periodic_digest_report,
         **instance_metadata,

--- a/posthog/tasks/test/test_periodic_digest.py
+++ b/posthog/tasks/test/test_periodic_digest.py
@@ -113,7 +113,7 @@ class TestPeriodicDigestReport(APIBaseTest):
         expected_properties = {
             "team_id": self.team.id,
             "team_name": self.team.name,
-            "template": "periodic_digest_report",
+            "template_name": "periodic_digest_report",
             "users_who_logged_in": [],
             "users_who_logged_in_count": 0,
             "users_who_signed_up": [],
@@ -227,7 +227,7 @@ class TestPeriodicDigestReport(APIBaseTest):
         expected_properties = {
             "team_id": self.team.id,
             "team_name": self.team.name,
-            "template": "periodic_digest_report",
+            "template_name": "periodic_digest_report",
             "users_who_logged_in": [],
             "users_who_logged_in_count": 0,
             "users_who_signed_up": [],


### PR DESCRIPTION
## Problem

All the other events use the `template_name` event prop, not `template`

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
