### PR TITLE
fix(digest): send group id properly

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -1611,7 +1611,7 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
         assert mock_client.capture.call_args[1]["timestamp"] == datetime(2021, 10, 10, 23, 1, tzinfo=tzutc())
 
     @patch("posthog.tasks.usage_report.Client")
-    def test_capture_report_transforms_team_id_to_org_id(self, mock_client) -> None:
+    def test_capture_report_transforms_team_id_to_org_id(self, mock_client: MagicMock) -> None:
         mock_posthog = MagicMock()
         mock_client.return_value = mock_posthog
 

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -43,6 +43,7 @@ from posthog.tasks.usage_report import (
     _get_team_report,
     _get_teams_for_usage_reports,
     capture_event,
+    capture_report,
     get_instance_metadata,
     send_all_org_usage_reports,
 )
@@ -1608,6 +1609,33 @@ class SendUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
             timestamp="2021-10-10T23:01:00.00Z",
         )
         assert mock_client.capture.call_args[1]["timestamp"] == datetime(2021, 10, 10, 23, 1, tzinfo=tzutc())
+
+    @patch("posthog.tasks.usage_report.Client")
+    def test_capture_report_transforms_team_id_to_org_id(self, mock_client):
+        mock_posthog = MagicMock()
+        mock_client.return_value = mock_posthog
+
+        # Create a second team in the same organization to verify the mapping
+        team2 = Team.objects.create(organization=self.organization)
+
+        # Create a report with team-level data
+        report = {
+            "organization_name": "Test Org",
+            "date": "2024-01-01",
+        }
+
+        with self.is_cloud(True):
+            # Call capture_report
+            capture_report(capture_event_name="test event", team_id=team2.id, full_report_dict=report)
+
+        # Verify the capture call was made with the organization ID
+        mock_posthog.capture.assert_called_once_with(
+            self.user.distinct_id,
+            "test event",
+            {**report, "scope": "user"},
+            groups={"instance": "http://localhost:8000", "organization": str(self.organization.id)},
+            timestamp=None,
+        )
 
 
 class SendNoUsageTest(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -375,10 +375,11 @@ def capture_event(
             elif team_id:
                 team = Team.objects.get(id=team_id)
                 distinct_ids = [user.distinct_id for user in team.all_users_with_access()]
+                organization_id = str(team.organization_id)
         else:
             if not organization_id:
                 team = Team.objects.get(id=team_id)
-                organization_id = team.organization_id
+                organization_id = str(team.organization_id)
             org_owner = get_org_owner_or_first_user(organization_id) if organization_id else None
             distinct_ids.append(
                 org_owner.distinct_id if org_owner and org_owner.distinct_id else f"org-{organization_id}"


### PR DESCRIPTION
## Problem

Customer.io rejected our periodic digest events because the group ID was missing. 

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Makes sure there is an organization ID on the event groups

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

added a test

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
