### PR TITLE
chore: Bump luxon types

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -111,7 +111,7 @@
         "@types/ioredis": "^4.26.4",
         "@types/jest": "^28.1.1",
         "@types/long": "4.x.x",
-        "@types/luxon": "^1.27.0",
+        "@types/luxon": "^3.4.2",
         "@types/node": "^16.0.0",
         "@types/node-fetch": "^2.5.10",
         "@types/node-schedule": "^2.1.0",

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -214,8 +214,8 @@ devDependencies:
     specifier: 4.x.x
     version: 4.0.2
   '@types/luxon':
-    specifier: ^1.27.0
-    version: 1.27.1
+    specifier: ^3.4.2
+    version: 3.4.2
   '@types/node':
     specifier: ^16.0.0
     version: 16.18.25
@@ -3797,8 +3797,8 @@ packages:
     resolution: {integrity: sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==}
     dev: false
 
-  /@types/luxon@1.27.1:
-    resolution: {integrity: sha512-cPiXpOvPFDr2edMnOXlz3UBDApwUfR+cpizvxCy0n3vp9bz/qe8BWzHPIEFcy+ogUOyjKuCISgyq77ELZPmkkg==}
+  /@types/luxon@3.4.2:
+    resolution: {integrity: sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==}
     dev: true
 
   /@types/markdown-it@12.2.3:

--- a/plugin-server/src/utils/db/utils.ts
+++ b/plugin-server/src/utils/db/utils.ts
@@ -18,7 +18,10 @@ import { status } from '../../utils/status'
 import { areMapsEqual, castTimestampOrNow } from '../../utils/utils'
 
 export function unparsePersonPartial(person: Partial<InternalPerson>): Partial<RawPerson> {
-    return { ...(person as BasePerson), ...(person.created_at ? { created_at: person.created_at.toISO() } : {}) }
+    return {
+        ...(person as BasePerson),
+        ...(person.created_at ? { created_at: person.created_at.toISO() ?? undefined } : {}),
+    }
 }
 
 export function escapeQuotes(input: string): string {


### PR DESCRIPTION
## Problem

We're using a version of @types/luxon which doesn't match our version of luxon.

I want to use other luxon functions in a different PR, and the types have changed. That other PR is big, so I just pulled this out its own PR

## Changes

Bump the types

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tests still pass
