### PR TITLE
feat: [1/2] access control capture (without test)

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1,4 +1,6 @@
 import json
+import posthoganalytics
+
 from datetime import UTC, datetime, timedelta
 from functools import cached_property
 from typing import Any, Optional, cast
@@ -52,7 +54,6 @@ from posthog.utils import (
     get_ip_address,
     get_week_start_for_country_code,
 )
-import posthoganalytics
 
 
 class PremiumMultiProjectPermissions(BasePermission):  # TODO: Rename to include "Env" in name

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -28,6 +28,7 @@ from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.schedule import describe_schedule
 from posthog.test.base import APIBaseTest
 from posthog.utils import get_instance_realm
+from posthog.event_usage import groups
 
 
 def team_api_test_factory():
@@ -1222,6 +1223,49 @@ def team_api_test_factory():
             response = self.client.patch("/api/environments/@current/", {"session_recording_linked_flag": config})
             assert response.status_code == expected_status, response.json()
             return response
+
+        @patch("posthoganalytics.capture")
+        def test_access_control_toggle_capture(self, mock_capture):
+            self.organization_membership.level = OrganizationMembership.Level.ADMIN
+            self.organization_membership.save()
+
+            mock_capture.reset_mock()
+
+            response = self.client.patch(f"/api/environments/@current/", {"access_control": True})
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            mock_capture.assert_called_with(
+                str(self.user.distinct_id),
+                "project access control toggled",
+                properties={
+                    "enabled": True,
+                    "project_id": str(self.team.id),
+                    "project_name": self.team.name,
+                    "organization_id": str(self.organization.id),
+                    "organization_name": self.organization.name,
+                    "user_role": OrganizationMembership.Level.ADMIN,
+                },
+                groups=groups(self.organization),
+            )
+
+            # Test toggling back to false
+            mock_capture.reset_mock()
+            response = self.client.patch(f"/api/environments/@current/", {"access_control": False})
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            mock_capture.assert_called_with(
+                str(self.user.distinct_id),
+                "project access control toggled",
+                properties={
+                    "enabled": False,
+                    "project_id": str(self.team.id),
+                    "project_name": self.team.name,
+                    "organization_id": str(self.organization.id),
+                    "organization_name": self.organization.name,
+                    "user_role": OrganizationMembership.Level.ADMIN,
+                },
+                groups=groups(self.organization),
+            )
 
     return TestTeamAPI
 

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -1228,7 +1228,6 @@ def team_api_test_factory():
         def test_access_control_toggle_capture(self, mock_capture):
             self.organization_membership.level = OrganizationMembership.Level.ADMIN
             self.organization_membership.save()
-            mock_capture.reset_mock()
 
             response = self.client.get("/api/environments/@current/")
             assert response.status_code == status.HTTP_200_OK

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -28,7 +28,6 @@ from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.schedule import describe_schedule
 from posthog.test.base import APIBaseTest
 from posthog.utils import get_instance_realm
-from posthog.event_usage import groups
 
 
 def team_api_test_factory():
@@ -1223,33 +1222,6 @@ def team_api_test_factory():
             response = self.client.patch("/api/environments/@current/", {"session_recording_linked_flag": config})
             assert response.status_code == expected_status, response.json()
             return response
-
-        @patch("posthoganalytics.capture")
-        def test_access_control_toggle_capture(self, mock_capture):
-            self.organization_membership.level = OrganizationMembership.Level.ADMIN
-            self.organization_membership.save()
-
-            response = self.client.get("/api/environments/@current/")
-            assert response.status_code == status.HTTP_200_OK
-
-            current_access_control = response.json()["access_control"]
-            new_setting = not current_access_control
-            response = self.client.patch(f"/api/environments/@current/", {"access_control": new_setting})
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-            mock_capture.assert_called_with(
-                str(self.user.distinct_id),
-                "project access control toggled",
-                properties={
-                    "enabled": new_setting,
-                    "project_id": str(self.team.id),
-                    "project_name": self.team.name,
-                    "organization_id": str(self.organization.id),
-                    "organization_name": self.organization.name,
-                    "user_role": OrganizationMembership.Level.ADMIN,
-                },
-                groups=groups(self.organization),
-            )
 
     return TestTeamAPI
 


### PR DESCRIPTION
## Problem

We want to capture logs when the user toggles on/off access control feature under teams.

Remaining features include:

- [ ]  SSO enforcement which is turned on after verifying a domain.
- [X]  Project permissions - so if someone toggles project private/public
- [X]  Ingestion taxonomy - if someone marks events as verified
- [ ]  White label branding - surveys and sharing dashboards

## Changes

Changes only add logs in the backend, no frontend changes

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Cloud: Yes

## How did you test this code?

Locally verified that the activity monitor showed the events and add tests
![image](https://github.com/user-attachments/assets/32fcfd17-1709-452d-b81b-e31ba44f206d)

