### PR TITLE
fix: Add churned Accounts to Vitally import

### DIFF
--- a/posthog/temporal/data_imports/pipelines/vitally/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/vitally/__init__.py
@@ -55,6 +55,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                 "params": {
                     "limit": 100,
                     "sortBy": "updatedAt",
+                    "status": "activeOrChurned",
                     "updatedAt": {
                         "type": "incremental",
                         "cursor_path": "updatedAt",


### PR DESCRIPTION
## Problem

Vitally sync didn't include churned accounts which is helpful for revenue and sales stuff.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

I'm hoping someone else can help with that :)
