### PR TITLE
fix(batch-exports): Add missing temporal activity

### DIFF
--- a/posthog/temporal/batch_exports/__init__.py
+++ b/posthog/temporal/batch_exports/__init__.py
@@ -19,6 +19,7 @@ from posthog.temporal.batch_exports.http_batch_export import (
 )
 from posthog.temporal.batch_exports.monitoring import (
     BatchExportMonitoringWorkflow,
+    check_for_missing_batch_export_runs,
     get_batch_export,
     get_event_counts,
     update_batch_export_runs,
@@ -86,4 +87,5 @@ ACTIVITIES = [
     get_batch_export,
     get_event_counts,
     update_batch_export_runs,
+    check_for_missing_batch_export_runs,
 ]


### PR DESCRIPTION
## Problem

In the previous PR to add a new activity to the batch exports monitoring job, the activity was missing from the list of registered activities. 

## Changes

Add the missing activity.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

it doesn't have an impact

## How did you test this code?

