### PR TITLE
chore(dev): Make mprocs faster and installed automatically

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -20,6 +20,6 @@ procs:
 
     docker-compose:
         # docker-compose makes sure the stack is up, and then follows its logs - but doesn't tear down on exit for speed
-        shell: 'docker compose -f docker-compose.dev.yml up -d && docker compose -f docker-compose.dev.yml logs -f'
+        shell: 'docker compose -f docker-compose.dev.yml up -d && docker compose -f docker-compose.dev.yml logs --tail=0 -f'
 
 mouse_scroll_speed: 1

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -19,8 +19,7 @@ procs:
         shell: 'bin/check_kafka_clickhouse_up && bin/check_temporal_up && python manage.py start_temporal_worker'
 
     docker-compose:
-        shell: 'docker compose -f docker-compose.dev.yml up'
-        stop:
-            send-keys: ['<C-c>']
+        # docker-compose makes sure the stack is up, and then follows its logs - but doesn't tear down on exit for speed
+        shell: 'docker compose -f docker-compose.dev.yml up -d && docker compose -f docker-compose.dev.yml logs -f'
 
 mouse_scroll_speed: 1

--- a/bin/start
+++ b/bin/start
@@ -9,4 +9,14 @@ export HOG_HOOK_URL=${HOG_HOOK_URL:-http://localhost:3300/hoghook}
 
 [ ! -f ./share/GeoLite2-City.mmdb ] && ( curl -L "https://mmdbcdn.posthog.net/" --http1.1 | brotli --decompress --output=./share/GeoLite2-City.mmdb )
 
+if ! command -v mprocs &> /dev/null; then
+    if command -v brew &> /dev/null; then
+        echo "🔁 Installing mprocs via Homebrew..."
+        brew install mprocs
+    else
+        echo "👉 To run bin/start, install mprocs: https://github.com/pvolok/mprocs#installation"
+        exit 1
+    fi
+fi
+
 exec mprocs --config bin/mprocs.yaml


### PR DESCRIPTION
## Changes

Automated mprocs installation in bin/start for a zero-effort migration (thanks for pointing out @daibhin), and way faster mprocs quitting, as we no longer wait for the docker compose stack to be stopped.