### PR TITLE
feat(product-assistant): interruption flag for human-in-the-loop

### DIFF
--- a/ee/hogai/assistant.py
+++ b/ee/hogai/assistant.py
@@ -155,13 +155,8 @@ class Assistant:
         if snapshot.next:
             saved_state = validate_state_update(snapshot.values)
             self._state = saved_state
-            if saved_state.intermediate_steps:
-                intermediate_steps = saved_state.intermediate_steps.copy()
-                intermediate_steps[-1] = (intermediate_steps[-1][0], self._latest_message.content)
-                self._graph.update_state(
-                    config,
-                    PartialAssistantState(messages=[self._latest_message], intermediate_steps=intermediate_steps),
-                )
+            self._graph.update_state(config, PartialAssistantState(messages=[self._latest_message], resumed=True))
+
             return None
         initial_state = self._initial_state
         self._state = initial_state

--- a/ee/hogai/taxonomy_agent/nodes.py
+++ b/ee/hogai/taxonomy_agent/nodes.py
@@ -267,12 +267,14 @@ class TaxonomyAgentPlannerToolsNode(AssistantNode, ABC):
             )
         if input.name == "ask_user_for_help":
             # The agent has requested help, so we interrupt the graph.
-            if not observation:
+            if not state.resumed:
                 raise NodeInterrupt(input.arguments)
 
             # Feedback was provided.
+            last_message = state.messages[-1]
             return PartialAssistantState(
-                intermediate_steps=[*intermediate_steps[:-1], (action, observation)],
+                resumed=False,
+                intermediate_steps=[*intermediate_steps[:-1], (action, last_message.content)],
             )
 
         output = ""

--- a/ee/hogai/taxonomy_agent/nodes.py
+++ b/ee/hogai/taxonomy_agent/nodes.py
@@ -272,9 +272,13 @@ class TaxonomyAgentPlannerToolsNode(AssistantNode, ABC):
 
             # Feedback was provided.
             last_message = state.messages[-1]
+            response = ""
+            if isinstance(last_message, HumanMessage):
+                response = last_message.content
+
             return PartialAssistantState(
                 resumed=False,
-                intermediate_steps=[*intermediate_steps[:-1], (action, last_message.content)],
+                intermediate_steps=[*intermediate_steps[:-1], (action, response)],
             )
 
         output = ""

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -35,7 +35,7 @@ class AssistantState(_SharedAssistantState):
 
 
 class PartialAssistantState(_SharedAssistantState):
-    messages: Sequence[AssistantMessageUnion] = Field(default=None)
+    messages: Optional[Sequence[AssistantMessageUnion]] = Field(default=None)
 
 
 class AssistantNodeName(StrEnum):

--- a/ee/hogai/utils/types.py
+++ b/ee/hogai/utils/types.py
@@ -27,6 +27,7 @@ class _SharedAssistantState(BaseModel):
     The ID of the message from which the conversation started.
     """
     plan: Optional[str] = Field(default=None)
+    resumed: Optional[bool] = Field(default=None)
 
 
 class AssistantState(_SharedAssistantState):
@@ -34,7 +35,7 @@ class AssistantState(_SharedAssistantState):
 
 
 class PartialAssistantState(_SharedAssistantState):
-    messages: Optional[Annotated[Sequence[AssistantMessageUnion], operator.add]] = Field(default=None)
+    messages: Sequence[AssistantMessageUnion] = Field(default=None)
 
 
 class AssistantNodeName(StrEnum):


### PR DESCRIPTION
## Problem

We need a generalized approach with a human in the loop. For the initial implementation, I decided to change state values, but this approach doesn't work if there are interruptions in more than one node. Let's use a flag to mark that the graph has been interrupted so nodes will handle the new state on their own.

## Changes

- Add the flag `resumed` marking that the node has been resumed after a human in the loop.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Unit tests.
