### PR TITLE
fix: handle unexpected shaped test account filters

### DIFF
--- a/posthog/session_recordings/queries/session_recording_list_from_query.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_query.py
@@ -182,7 +182,7 @@ class SessionRecordingListFromQuery:
     def _test_account_filters(self) -> list[AnyPropertyFilter]:
         prop_filters: list[AnyPropertyFilter] = []
         for prop in self._team.test_account_filters:
-            match prop["type"]:
+            match prop.get("type", None):
                 case "person":
                     prop_filters.append(PersonPropertyFilter(**prop))
                 case "event":
@@ -191,6 +191,9 @@ class SessionRecordingListFromQuery:
                     prop_filters.append(GroupPropertyFilter(**prop))
                 case "hogql":
                     prop_filters.append(HogQLPropertyFilter(**prop))
+                case None:
+                    logger.warn("test account filter had no type", filter=prop)
+                    prop_filters.append(EventPropertyFilter(**prop))
 
         return prop_filters
 

--- a/posthog/session_recordings/queries/test/test_session_recording_list_from_query.py
+++ b/posthog/session_recordings/queries/test/test_session_recording_list_from_query.py
@@ -3316,7 +3316,9 @@ class TestSessionRecordingsListFromQuery(ClickhouseTestMixin, APIBaseTest):
                 "key": "is_internal_user",
                 "value": ["false"],
                 "operator": "exact",
-                "type": "event",
+                # in production some test account filters don't include type
+                # we default to event in that case
+                # "type": "event",
             },
             {"key": "properties.$browser == 'Chrome'", "type": "hogql"},
         ]


### PR DESCRIPTION
see: https://posthoghelp.zendesk.com/agent/tickets/22322 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/24436)

We made the assumption that all test account filters would include a "type" which wasn't true for this user.

Re-saving the filters fixed them, but let's also log when we see this and default the type