### PR TITLE
feat(batch-exports): Split S3 files based on max file size

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -79,6 +79,7 @@ class S3BatchExportInputs:
         region: The AWS region where the bucket is located.
         prefix: A prefix for the file name to be created in S3.
             For example, for one hour batches, this should be 3600.
+        max_file_size_mb: The maximum file size in MB for each file to be uploaded.
         data_interval_end: For manual runs, the end date of the batch. This should be set to `None` for regularly
             scheduled runs and for backfills.
     """
@@ -99,6 +100,7 @@ class S3BatchExportInputs:
     kms_key_id: str | None = None
     endpoint_url: str | None = None
     file_format: str = "JSONLines"
+    max_file_size_mb: int | None = None
     is_backfill: bool = False
     is_earliest_backfill: bool = False
     batch_export_model: BatchExportModel | None = None

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -16,6 +16,12 @@ MAX_CONCURRENT_WORKFLOW_TASKS: int | None = get_from_env(
 MAX_CONCURRENT_ACTIVITIES: int | None = get_from_env("MAX_CONCURRENT_ACTIVITIES", None, optional=True, type_cast=int)
 
 BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES: int = 1024 * 1024 * 50  # 50MB
+# TODO - not sure if this makes sense to be a global setting or not
+# (would obviously be best to allow it to be configurable by the end user)
+# (set to 1GB by default for now)
+BATCH_EXPORT_S3_UPLOAD_MAX_FILE_SIZE_BYTES: int = get_from_env(
+    "BATCH_EXPORT_S3_UPLOAD_MAX_FILE_SIZE_BYTES", 1024 * 1024 * 1024, type_cast=int
+)
 BATCH_EXPORT_S3_RECORD_BATCH_QUEUE_MAX_SIZE_BYTES: int = get_from_env(
     "BATCH_EXPORT_S3_RECORD_BATCH_QUEUE_MAX_SIZE_BYTES", 0, type_cast=int
 )

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -16,12 +16,6 @@ MAX_CONCURRENT_WORKFLOW_TASKS: int | None = get_from_env(
 MAX_CONCURRENT_ACTIVITIES: int | None = get_from_env("MAX_CONCURRENT_ACTIVITIES", None, optional=True, type_cast=int)
 
 BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES: int = 1024 * 1024 * 50  # 50MB
-# TODO - not sure if this makes sense to be a global setting or not
-# (would obviously be best to allow it to be configurable by the end user)
-# (set to 1GB by default for now)
-BATCH_EXPORT_S3_UPLOAD_MAX_FILE_SIZE_BYTES: int = get_from_env(
-    "BATCH_EXPORT_S3_UPLOAD_MAX_FILE_SIZE_BYTES", 1024 * 1024 * 1024, type_cast=int
-)
 BATCH_EXPORT_S3_RECORD_BATCH_QUEUE_MAX_SIZE_BYTES: int = get_from_env(
     "BATCH_EXPORT_S3_RECORD_BATCH_QUEUE_MAX_SIZE_BYTES", 0, type_cast=int
 )

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -630,7 +630,7 @@ async def initialize_and_resume_multipart_upload(
     return s3_upload, details
 
 
-def initialize_upload(inputs: S3InsertInputs, file_number: int | None) -> S3MultiPartUpload:
+def initialize_upload(inputs: S3InsertInputs, file_number: int) -> S3MultiPartUpload:
     """Initialize a S3MultiPartUpload."""
 
     try:

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -770,28 +770,25 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
             [field.with_nullable(True) for field in record_batch_schema]
         )
 
-        async with s3_upload as s3_upload:
-            consumer = S3Consumer(
-                heartbeater=heartbeater,
-                heartbeat_details=details,
-                data_interval_end=data_interval_end,
-                data_interval_start=data_interval_start,
-                writer_format=WriterFormat.from_str(inputs.file_format, "S3"),
-                s3_upload=s3_upload,
-                s3_inputs=inputs,
-            )
-            records_completed = await run_consumer(
-                consumer=consumer,
-                queue=queue,
-                producer_task=producer_task,
-                schema=record_batch_schema,
-                max_bytes=settings.BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES,
-                include_inserted_at=True,
-                writer_file_kwargs={"compression": inputs.compression},
-                max_file_size_bytes=inputs.max_file_size_mb * 1024 * 1024 if inputs.max_file_size_mb else 0,
-            )
-
-            await s3_upload.complete()
+        consumer = S3Consumer(
+            heartbeater=heartbeater,
+            heartbeat_details=details,
+            data_interval_end=data_interval_end,
+            data_interval_start=data_interval_start,
+            writer_format=WriterFormat.from_str(inputs.file_format, "S3"),
+            s3_upload=s3_upload,
+            s3_inputs=inputs,
+        )
+        records_completed = await run_consumer(
+            consumer=consumer,
+            queue=queue,
+            producer_task=producer_task,
+            schema=record_batch_schema,
+            max_bytes=settings.BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES,
+            include_inserted_at=True,
+            writer_file_kwargs={"compression": inputs.compression},
+            max_file_size_bytes=inputs.max_file_size_mb * 1024 * 1024 if inputs.max_file_size_mb else 0,
+        )
 
         return records_completed
 

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -590,6 +590,7 @@ class S3Consumer(Consumer):
             self.heartbeat_details.append_upload_state(self.s3_upload.to_state())
 
         self.heartbeat_details.track_done_range(last_date_range, self.data_interval_start)
+        self.heartbeater.set_from_heartbeat_details(self.heartbeat_details)
 
     async def close(self):
         if self.s3_upload is not None:

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -591,7 +591,6 @@ class S3Consumer(Consumer):
             self.heartbeat_details.append_upload_state(self.s3_upload.to_state())
 
         self.heartbeat_details.track_done_range(last_date_range, self.data_interval_start)
-        self.heartbeater.set_from_heartbeat_details(self.heartbeat_details)
 
     async def close(self):
         if self.s3_upload is not None:

--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -317,6 +317,8 @@ class Consumer:
                     queue.task_done()
                 record_batches_count = 0
 
+            self.heartbeater.set_from_heartbeat_details(self.heartbeat_details)
+
         records_count += writer.records_since_last_flush
 
         await self.logger.adebug(

--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -308,9 +308,7 @@ class Consumer:
 
                 records_count += writer.records_since_last_flush
 
-                if multiple_files:
-                    await writer.hard_flush()
-                elif max_file_size_bytes > 0 and writer.bytes_total >= max_file_size_bytes:
+                if multiple_files or (max_file_size_bytes > 0 and writer.bytes_total >= max_file_size_bytes):
                     await writer.hard_flush()
                 else:
                     await writer.flush()

--- a/posthog/temporal/batch_exports/temporary_file.py
+++ b/posthog/temporal/batch_exports/temporary_file.py
@@ -477,6 +477,15 @@ class BatchExportWriter(abc.ABC):
         self.start_at_since_last_flush = None
         self.end_at_since_last_flush = None
 
+    async def hard_flush(self):
+        """Flush the underlying file by closing the temporary file and creating a new one.
+
+        This is useful is we want to write a whole file, rather than flushing a
+        part of it for example.
+        """
+        await self.close_temporary_file()
+        self._batch_export_file = await asyncio.to_thread(self.create_temporary_file)
+
 
 class WriterFormat(enum.StrEnum):
     JSONL = enum.auto()

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -1854,11 +1854,9 @@ async def test_insert_into_s3_activity_resumes_from_heartbeat(
         override_settings(BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES=1, CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT=1),
         mock.patch("posthog.temporal.batch_exports.s3_batch_export.aioboto3.Session", FakeSession),
     ):
-        try:
+        with pytest.raises(IntermittentUploadPartTimeoutError):
             # we expect this to raise an exception
             await activity_environment.run(insert_into_s3_activity, insert_inputs)
-        except Exception:
-            pass
 
     assert len(heartbeat_details) > 0
 


### PR DESCRIPTION
## Problem

Currently for our S3 batch exports we always export a single file. This file can be very large if there is a lot of data to export, and in many cases would be easier to process downstream if it were split into several smaller files.

## Changes

Rather than always sending a single file to S3, we conditionally split it into multiple based on a new `max_file_size_bytes` parameter.

- We move the handling of the S3 multi-part upload into the consumer loop, as we need to initiate and complete uploads based on current file size.
- We add the `uploaded_files` to the heartbeat details as this is needed to know where to continue from (eg if we're already uploaded 2 files (`*.parquet` and `*-1.parquet`), the next one needs to be `*-2.parquet`)
- A `max_file_size_mb` parameter has been added to the S3 config. This parameter will be added to the frontend in a follow up PR. (This means this PR shouldn't change any behaviour for now, until we allow it to be configured)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Should do.

## How did you test this code?

Have added some new test cases to test different combinations of S3 batch exports and ensure the expected number of files get uploaded to the bucket.

Have also tested manually.
