### PR TITLE
feat: add a custom google backend for sso

### DIFF
--- a/ee/api/test/test_authentication.py
+++ b/ee/api/test/test_authentication.py
@@ -12,12 +12,14 @@ from django.utils import timezone
 from freezegun.api import freeze_time
 from rest_framework import status
 from social_core.exceptions import AuthFailed, AuthMissingParameter
+from social_django.models import UserSocialAuth
 
 from ee.api.test.base import APILicensedTest
 from ee.models.license import License
 from posthog.constants import AvailableFeature
 from posthog.models import OrganizationMembership, User
 from posthog.models.organization_domain import OrganizationDomain
+from ee.api.authentication import CustomGoogleOAuth2
 
 SAML_MOCK_SETTINGS = {
     "SOCIAL_AUTH_SAML_SECURITY_CONFIG": {
@@ -707,3 +709,62 @@ YotAcSbU3p5bzd11wpyebYHB"""
 
         assert "1.3.13" == xmlsec.__version__
         assert "4.9.4" == lxml.__version__
+
+
+class TestCustomGoogleOAuth2(APILicensedTest):
+    def setUp(self):
+        super().setUp()
+        self.google_oauth = CustomGoogleOAuth2()
+        self.details = {"email": "test@posthog.com"}
+        self.sub = "google-oauth2|123456789"
+
+    def test_get_user_id_existing_user_with_sub(self):
+        """Test that a user with sub as uid continues using that sub."""
+        # Create user with sub as uid
+        UserSocialAuth.objects.create(provider="google-oauth2", uid=self.sub, user=self.user)
+
+        response = {"email": "test@posthog.com", "sub": self.sub}
+
+        uid = self.google_oauth.get_user_id(self.details, response)
+
+        self.assertEqual(uid, self.sub)
+        # Verify no migration occurred (count should be 1)
+        self.assertEqual(UserSocialAuth.objects.filter(provider="google-oauth2").count(), 1)
+        # Verify uid is still sub
+        self.assertEqual(UserSocialAuth.objects.get(provider="google-oauth2").uid, self.sub)
+
+    def test_get_user_id_migrates_email_to_sub(self):
+        """Test that a user with email as uid gets migrated to using sub."""
+        # Create user with email as uid (legacy format)
+        social_auth = UserSocialAuth.objects.create(provider="google-oauth2", uid="test@posthog.com", user=self.user)
+
+        response = {"email": "test@posthog.com", "sub": self.sub}
+
+        uid = self.google_oauth.get_user_id(self.details, response)
+
+        self.assertEqual(uid, self.sub)
+        # Verify the uid was updated
+        social_auth.refresh_from_db()
+        self.assertEqual(social_auth.uid, self.sub)
+
+    def test_get_user_id_new_user_uses_sub(self):
+        """Test that a new user gets sub as uid."""
+        response = {"email": "test@posthog.com", "sub": self.sub}
+
+        uid = self.google_oauth.get_user_id(self.details, response)
+
+        self.assertEqual(uid, self.sub)
+        # Verify no UserSocialAuth objects were created
+        self.assertEqual(UserSocialAuth.objects.filter(provider="google-oauth2").count(), 0)
+
+    def test_get_user_id_missing_sub_raises_error(self):
+        """Test that missing sub in response raises ValueError."""
+        response = {
+            "email": "test@posthog.com",
+            # no sub provided
+        }
+
+        with self.assertRaises(ValueError) as e:
+            self.google_oauth.get_user_id(self.details, response)
+
+        self.assertEqual(str(e.exception), "Google OAuth response missing 'sub' claim")

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -12,7 +12,7 @@ from posthog.utils import str_to_bool
 AUTHENTICATION_BACKENDS = [
     *AUTHENTICATION_BACKENDS,
     "ee.api.authentication.MultitenantSAMLAuth",
-    "social_core.backends.google.GoogleOAuth2",
+    "ee.api.authentication.CustomGoogleOAuth2",
 ]
 
 # SAML base attributes

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -655,6 +655,7 @@ class TestSignupAPI(APIBaseTest):
         mock_request.return_value.json.return_value = {
             "access_token": "123",
             "email": "jane@hogflix.posthog.com",
+            "sub": "123",
         }
 
         response = self.client.get(url, follow=True)
@@ -789,6 +790,7 @@ class TestSignupAPI(APIBaseTest):
             mock_request.return_value.json.return_value = {
                 "access_token": "123",
                 "email": "jane@hogflix.posthog.com",
+                "sub": "123",
             }
 
             response = self.client.get(url, follow=True)
@@ -828,6 +830,7 @@ class TestSignupAPI(APIBaseTest):
         mock_request.return_value.json.return_value = {
             "access_token": "123",
             "email": "alice@posthog.net",
+            "sub": "123",
         }
 
         response = self.client.get(url, follow=True)
@@ -857,6 +860,7 @@ class TestSignupAPI(APIBaseTest):
         mock_request.return_value.json.return_value = {
             "access_token": "123",
             "email": "alice@posthog.net",
+            "sub": "123",
         }
 
         response = self.client.get(url, follow=True)
@@ -886,6 +890,7 @@ class TestSignupAPI(APIBaseTest):
         mock_request.return_value.json.return_value = {
             "access_token": "123",
             "email": "alice@evil.com",
+            "sub": "123",
         }  # note evil.com
 
         response = self.client.get(url, follow=True)
@@ -911,6 +916,7 @@ class TestSignupAPI(APIBaseTest):
             mock_request.return_value.json.return_value = {
                 "access_token": "123",
                 "email": "jane@hogflix.posthog.com",
+                "sub": "123",
             }
             response = self.client.get(url, follow=True)
 


### PR DESCRIPTION
## Changes

Our current system stores `google-oauth2` uids as emails which makes it so if a customer changes their domain in GSuite, none of their users can login because it's looking against the old email domain. This PR updates our system to use the OpenID `sub`, which is guaranteed to be a unique and consistent identifier for the user. 

It inherits from the existing class so all other functions will fall to the inheritance. 

It's implemented in a way that it has backwards compatibility for existing users and slowly migrates them as they login. Over time this custom class could be removed and it be updated to use the default social core `get_user_id` and setting the `settings.USE_UNIQUE_USER_ID = True` option.

Here is the social core method: https://github.com/python-social-auth/social-core/blob/master/social_core/backends/google.py#L12-L20

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Add light tests manually tested:
- existing user with email as uid
- existing user with sub as uid
- new user
