### PR TITLE
fix(data-warehouse): Pop the incremental value when changing to/from incremental

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -101,6 +101,9 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
                 schema.sync_type_config.get("incremental_field_type"),
             )
 
+        if schema.is_incremental:
+            logger.debug(f"Incremental last value being used is: {processed_incremental_last_value}")
+
         source = None
         if model.pipeline.source_type == ExternalDataSource.Type.STRIPE:
             from posthog.temporal.data_imports.pipelines.stripe import stripe_source

--- a/posthog/warehouse/api/external_data_schema.py
+++ b/posthog/warehouse/api/external_data_schema.py
@@ -141,6 +141,8 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
             payload = instance.sync_type_config
             payload["incremental_field"] = data.get("incremental_field")
             payload["incremental_field_type"] = data.get("incremental_field_type")
+            payload["incremental_field_last_value"] = None
+            payload["incremental_field_last_value_v2"] = None
 
             validated_data["sync_type_config"] = payload
         else:

--- a/posthog/warehouse/api/external_data_schema.py
+++ b/posthog/warehouse/api/external_data_schema.py
@@ -147,6 +147,8 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
             payload = instance.sync_type_config
             payload.pop("incremental_field", None)
             payload.pop("incremental_field_type", None)
+            payload.pop("incremental_field_last_value", None)
+            payload.pop("incremental_field_last_value_v2", None)
 
             validated_data["sync_type_config"] = payload
 


### PR DESCRIPTION
## Problem
- We dont reset the stored last incremental value when changing a schema from full refresh to incremental or vice versa, causing odd bugs to occur 

## Changes
- Reset the incremental value
- Log out the incremental value used at the beginning of the sync