### PR TITLE
fix: RemoteConfig legacy site apps

### DIFF
--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -261,7 +261,7 @@ class RemoteConfig(UUIDModel):
             config = get_site_config_from_schema(site_app.config_schema, site_app.config)
             site_apps_js.append(
                 indent_js(
-                    f"\n{{\n  id: '{site_app.token}',\n  init: function(config) {{\n    {indent_js(site_app.source, indent=4)}().inject({{ config:{json.dumps(config)}, posthog:config.posthog }});\n    config.callback();\n return {{}}  }}\n}}"
+                    f"\n{{\n  id: '{site_app.token}',\n  init: function(config) {{\n    {indent_js(site_app.source, indent=4)}().inject({{ config:{json.dumps(config)}, posthog:config.posthog }});\n    config.callback(); return {{}}  }}\n}}"
                 )
             )
         site_functions = (

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -261,7 +261,7 @@ class RemoteConfig(UUIDModel):
             config = get_site_config_from_schema(site_app.config_schema, site_app.config)
             site_apps_js.append(
                 indent_js(
-                    f"\n{{\n  id: '{site_app.token}',\n  init: function(config) {{\n    {indent_js(site_app.source, indent=4)}().inject({{ config:{json.dumps(config)}, posthog:config.posthog }});\n    config.callback();\n  }}\n}}"
+                    f"\n{{\n  id: '{site_app.token}',\n  init: function(config) {{\n    {indent_js(site_app.source, indent=4)}().inject({{ config:{json.dumps(config)}, posthog:config.posthog }});\n    config.callback();\n return {{}}  }}\n}}"
                 )
             )
         site_functions = (

--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -541,22 +541,19 @@ class TestRemoteConfigJS(_RemoteConfigBase):
       id: 'tokentoken',
       init: function(config) {
             (function () { return { inject: (data) => console.log('injected!', data)}; })().inject({ config:{}, posthog:config.posthog });
-        config.callback();
-     return {}  }
+        config.callback(); return {}  }
     },    
     {
       id: 'tokentoken',
       init: function(config) {
             (function () { return { inject: (data) => console.log('injected 2!', data)}; })().inject({ config:{}, posthog:config.posthog });
-        config.callback();
-     return {}  }
+        config.callback(); return {}  }
     },    
     {
       id: 'tokentoken',
       init: function(config) {
             (function () { return { inject: (data) => console.log('injected but disabled!', data)}; })().inject({ config:{}, posthog:config.posthog });
-        config.callback();
-     return {}  }
+        config.callback(); return {}  }
     }]
   }
 })();\

--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -542,21 +542,21 @@ class TestRemoteConfigJS(_RemoteConfigBase):
       init: function(config) {
             (function () { return { inject: (data) => console.log('injected!', data)}; })().inject({ config:{}, posthog:config.posthog });
         config.callback();
-      }
+     return {}  }
     },    
     {
       id: 'tokentoken',
       init: function(config) {
             (function () { return { inject: (data) => console.log('injected 2!', data)}; })().inject({ config:{}, posthog:config.posthog });
         config.callback();
-      }
+     return {}  }
     },    
     {
       id: 'tokentoken',
       init: function(config) {
             (function () { return { inject: (data) => console.log('injected but disabled!', data)}; })().inject({ config:{}, posthog:config.posthog });
         config.callback();
-      }
+     return {}  }
     }]
   }
 })();\


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/27087

Looks like something got missed in the legacy site apps. Side effect of the fact the site app loader uses the remoteconfig regardless of whether enabled (will fix JS side too soon)

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
