### PR TITLE
fix(product-assistant): correct exception to stop the async iterator

### DIFF
--- a/ee/hogai/utils/asgi.py
+++ b/ee/hogai/utils/asgi.py
@@ -1,0 +1,34 @@
+from collections.abc import AsyncIterator, Callable, Iterable, Iterator
+from typing import TypeVar
+
+from asgiref.sync import sync_to_async
+
+T = TypeVar("T")
+
+
+class SyncIterableToAsync(AsyncIterator[T]):
+    def __init__(self, iterable: Iterable[T]) -> None:
+        self._iterable: Iterable[T] = iterable
+        # async versions of the `next` and `iter` functions
+        self.next_async: Callable = sync_to_async(self.next, thread_sensitive=False)
+        self.iter_async: Callable = sync_to_async(iter, thread_sensitive=False)
+        self.sync_iterator: Iterator[T] | None = None
+
+    def __aiter__(self) -> AsyncIterator[T]:
+        return self
+
+    async def __anext__(self) -> T:
+        if self.sync_iterator is None:
+            self.sync_iterator = await self.iter_async(self._iterable)
+        return await self.next_async(self.sync_iterator)
+
+    @staticmethod
+    def next(it: Iterator[T]) -> T:
+        """
+        asyncio expects `StopAsyncIteration` in place of `StopIteration`,
+        so here's a modified in-built `next` function that can handle this.
+        """
+        try:
+            return next(it)
+        except StopIteration:
+            raise StopAsyncIteration


### PR DESCRIPTION
## Problem

An async iterator must throw the StopAsyncIteration exception instead of a regular StopIteration. Currently, it doesn't happen, so the stream stays open until it gets killed by a timeout (my best guess now). After this fix, I haven't observed this issue locally on the ASGI webserver.

[Related Sentry log.](https://posthog.sentry.io/issues/6152906293/?query=is:unresolved%20issue.priority:%5Bhigh,%20medium%5D%20%22conversations%22&statsPeriod=90d&stream_index=0)

## Changes

- Implement a sync to async iterator conversion based on an asgiref implementation.
- Catch StopIteration and raise StopAsyncIteration, so the `sync_to_async` of asgiref can stop the iterator.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Unit tests.
