### PR TITLE
fix(batch-exports): Set queries to cancel after disconnect

### DIFF
--- a/posthog/temporal/common/clickhouse.py
+++ b/posthog/temporal/common/clickhouse.py
@@ -510,6 +510,7 @@ async def get_client(
         max_execution_time=settings.CLICKHOUSE_MAX_EXECUTION_TIME,
         max_memory_usage=settings.CLICKHOUSE_MAX_MEMORY_USAGE,
         max_block_size=max_block_size,
+        cancel_http_readonly_queries_on_client_close=1,
         output_format_arrow_string_as_string="true",
         http_send_timeout=0,
         **kwargs,


### PR DESCRIPTION
## Problem

Addresses [#26317](https://github.com/PostHog/posthog/issues/26317)

PR #25248 was (I believe) accidentally reverted in PR #25579. We've recently seen some issues with ClickHouse queries not being cleaned up correctly so want to ensure we cancel queries on disconnect. 

## Changes

Basically, re-implementing PR #25248 which sets the `cancel_http_readonly_queries_on_client_close`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?


## How did you test this code?

