### PR TITLE
fix(product-assistant): loop in the schema generation

### DIFF
--- a/ee/hogai/funnels/test/test_nodes.py
+++ b/ee/hogai/funnels/test/test_nodes.py
@@ -33,6 +33,7 @@ class TestFunnelsGeneratorNode(ClickhouseTestMixin, APIBaseTest):
                 new_state,
                 PartialAssistantState(
                     messages=[VisualizationMessage(answer=self.schema, plan="Plan", id=new_state.messages[0].id)],
-                    intermediate_steps=None,
+                    intermediate_steps=[],
+                    plan="",
                 ),
             )

--- a/ee/hogai/schema_generator/nodes.py
+++ b/ee/hogai/schema_generator/nodes.py
@@ -96,7 +96,8 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
                             content=f"Oops! It looks like I’m having trouble generating this {self.INSIGHT_NAME} insight. Could you please try again?"
                         )
                     ],
-                    intermediate_steps=None,
+                    intermediate_steps=[],
+                    plan="",
                 )
 
             return PartialAssistantState(
@@ -115,7 +116,8 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
                     id=str(uuid4()),
                 )
             ],
-            intermediate_steps=None,
+            intermediate_steps=[],
+            plan="",
         )
 
     def router(self, state: AssistantState):

--- a/ee/hogai/schema_generator/test/test_nodes.py
+++ b/ee/hogai/schema_generator/test/test_nodes.py
@@ -54,7 +54,8 @@ class TestSchemaGeneratorNode(BaseTest):
                 ),
                 {},
             )
-            self.assertIsNone(new_state.intermediate_steps)
+            self.assertEqual(new_state.intermediate_steps, [])
+            self.assertEqual(new_state.plan, "")
             self.assertEqual(len(new_state.messages), 1)
             self.assertEqual(new_state.messages[0].type, "ai/viz")
             self.assertEqual(new_state.messages[0].answer, self.schema)
@@ -316,7 +317,7 @@ class TestSchemaGeneratorNode(BaseTest):
                 ),
                 {},
             )
-            self.assertIsNone(new_state.intermediate_steps)
+            self.assertEqual(new_state.intermediate_steps, [])
 
             new_state = node.run(
                 AssistantState(
@@ -328,7 +329,7 @@ class TestSchemaGeneratorNode(BaseTest):
                 ),
                 {},
             )
-            self.assertIsNone(new_state.intermediate_steps)
+            self.assertEqual(new_state.intermediate_steps, [])
 
     def test_node_leaves_failover_after_second_unsuccessful_attempt(self):
         node = DummyGeneratorNode(self.team)
@@ -348,9 +349,10 @@ class TestSchemaGeneratorNode(BaseTest):
                 ),
                 {},
             )
-            self.assertIsNone(new_state.intermediate_steps)
+            self.assertEqual(new_state.intermediate_steps, [])
             self.assertEqual(len(new_state.messages), 1)
             self.assertIsInstance(new_state.messages[0], FailureMessage)
+            self.assertEqual(new_state.plan, "")
 
     def test_agent_reconstructs_conversation_with_failover(self):
         action = AgentAction(tool="fix", tool_input="validation error", log="exception")

--- a/ee/hogai/trends/test/test_nodes.py
+++ b/ee/hogai/trends/test/test_nodes.py
@@ -38,6 +38,7 @@ class TestTrendsGeneratorNode(ClickhouseTestMixin, APIBaseTest):
                 new_state,
                 PartialAssistantState(
                     messages=[VisualizationMessage(answer=self.schema, plan="Plan", id=new_state.messages[0].id)],
-                    intermediate_steps=None,
+                    intermediate_steps=[],
+                    plan="",
                 ),
             )


### PR DESCRIPTION
## Problem

Pydantic merges None values differently, so `plan` and `intermediate_steps` are not reset. It leads to a cycle in subsequent generations.

## Changes

- Replace Nones with falsy values.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Manual testing and unit tests.