### PR TITLE
fix: unneeded horizontal scrolling on Onboarding pages

### DIFF
--- a/frontend/src/scenes/onboarding/OnboardingProductIntroduction.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingProductIntroduction.tsx
@@ -195,7 +195,7 @@ export function OnboardingProductIntroduction({ stepKey }: { stepKey: Onboarding
     return (
         <OnboardingStep title="Product Intro" stepKey={stepKey} continueOverride={<></>} hideHeader>
             {billingProduct ? (
-                <div className="unsubscribed-product-landing-page -m-4 -mt-8">
+                <div className="unsubscribed-product-landing-page -m-scene-padding -mt-8">
                     <header className="bg-primary-alt-highlight border-b border-t border-border flex justify-center p-8">
                         <div className="grid md:grid-cols-2 items-center gap-8 w-full max-w-screen-xl">
                             <div className="">

--- a/frontend/src/scenes/onboarding/OnboardingProductIntroduction.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingProductIntroduction.tsx
@@ -195,7 +195,7 @@ export function OnboardingProductIntroduction({ stepKey }: { stepKey: Onboarding
     return (
         <OnboardingStep title="Product Intro" stepKey={stepKey} continueOverride={<></>} hideHeader>
             {billingProduct ? (
-                <div className="unsubscribed-product-landing-page -m-6 -mt-8">
+                <div className="unsubscribed-product-landing-page -m-4 -mt-8">
                     <header className="bg-primary-alt-highlight border-b border-t border-border flex justify-center p-8">
                         <div className="grid md:grid-cols-2 items-center gap-8 w-full max-w-screen-xl">
                             <div className="">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -82,6 +82,7 @@ const config = {
                 // All whole number values divisible by 20 up to 200 ensured above
                 248: '62rem',
                 300: '75rem',
+                'scene-padding': 'var(--scene-padding)',
             },
             rotate: {
                 270: '270deg',


### PR DESCRIPTION
## Problem

Fixes https://github.com/PostHog/posthog/issues/25527.

There's extra margin on the posthog onboarding pages that's causing an horizontal scroll.

## Changes

| Before | Header |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/38f57894-0aed-4f14-9890-ce39d84fcaa4) | ![CleanShot 2024-12-23 at 12 34 00@2x](https://github.com/user-attachments/assets/1e8ec70d-a86d-454b-8738-6c80220e05ea) | 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

N/A

## How did you test this code?

Verified on localhost, since it's a UI only change

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
