### PR TITLE
fix(alerts): edit alert modal fixes

### DIFF
--- a/frontend/src/lib/components/Alerts/alertFormLogic.ts
+++ b/frontend/src/lib/components/Alerts/alertFormLogic.ts
@@ -27,6 +27,15 @@ export type AlertFormType = Pick<
     insight?: QueryBasedInsightModel['id']
 }
 
+export function canCheckOngoingInterval(alert?: AlertType | AlertFormType): boolean {
+    return (
+        (alert?.condition.type === AlertConditionType.ABSOLUTE_VALUE ||
+            alert?.condition.type === AlertConditionType.RELATIVE_INCREASE) &&
+        alert?.threshold.configuration.bounds?.upper != null &&
+        !isNaN(alert?.threshold.configuration.bounds.upper)
+    )
+}
+
 export interface AlertFormLogicProps {
     alert: AlertType | null
     insightId: QueryBasedInsightModel['id']
@@ -85,11 +94,7 @@ export const alertFormLogic = kea<alertFormLogicType>([
                     // can only check ongoing interval for absolute value/increase alerts with upper threshold
                     config: {
                         ...alert.config,
-                        check_ongoing_interval:
-                            (alert.condition.type === AlertConditionType.ABSOLUTE_VALUE ||
-                                alert.condition.type === AlertConditionType.RELATIVE_INCREASE) &&
-                            alert.threshold.configuration.bounds?.upper != null &&
-                            alert.config.check_ongoing_interval,
+                        check_ongoing_interval: canCheckOngoingInterval(alert) && alert.config.check_ongoing_interval,
                     },
                 }
 

--- a/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
@@ -173,14 +173,18 @@ export function EditAlertModal({
                                                 <LemonSelect
                                                     fullWidth
                                                     data-attr="alertForm-series-index"
-                                                    options={alertSeries?.map(({ event }, index) => ({
-                                                        label: isBreakdownValid
-                                                            ? 'any breakdown value'
-                                                            : formula
-                                                            ? `Formula (${formula})`
-                                                            : `${alphabet[index]} - ${event}`,
-                                                        value: isBreakdownValid || formula ? 0 : index,
-                                                    }))}
+                                                    options={alertSeries?.map(
+                                                        ({ custom_name, name, event }, index) => ({
+                                                            label: isBreakdownValid
+                                                                ? 'any breakdown value'
+                                                                : formula
+                                                                ? `Formula (${formula})`
+                                                                : `${alphabet[index]} - ${
+                                                                      custom_name ?? name ?? event
+                                                                  }`,
+                                                            value: isBreakdownValid || formula ? 0 : index,
+                                                        })
+                                                    )}
                                                     disabledReason={
                                                         (isBreakdownValid &&
                                                             `For trends with breakdown, the alert will fire if any of the breakdown

--- a/frontend/src/lib/components/Alerts/views/ManageAlertsModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/ManageAlertsModal.tsx
@@ -45,10 +45,10 @@ export function AlertListItem({ alert, onClick }: AlertListItemProps): JSX.Eleme
 
                     {alert.enabled ? (
                         <div className="text-muted pl-3">
-                            {bounds?.lower !== undefined &&
+                            {bounds?.lower != null &&
                                 `Low ${isPercentage ? bounds.lower * 100 : bounds.lower}${isPercentage ? '%' : ''}`}
-                            {bounds?.lower !== undefined && bounds?.upper ? ' · ' : ''}
-                            {bounds?.upper !== undefined &&
+                            {bounds?.lower != null && bounds?.upper != null ? ' · ' : ''}
+                            {bounds?.upper != null &&
                                 `High ${isPercentage ? bounds.upper * 100 : bounds.upper}${isPercentage ? '%' : ''}`}
                         </div>
                     ) : (

--- a/posthog/tasks/alerts/checks.py
+++ b/posthog/tasks/alerts/checks.py
@@ -222,6 +222,10 @@ def check_alert(alert_id: str, capture_ph_event: Callable = lambda *args, **kwar
             "Skipping alert check because weekend checking is disabled",
             alert=alert,
         )
+
+        # ignore alert check until due again
+        alert.next_check_at = next_check_time(alert)
+        alert.save()
         return
 
     if alert.snoozed_until:

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -408,6 +408,9 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         checks = AlertCheck.objects.filter(alert_configuration=self.alert["id"])
         assert len(checks) == 0
 
+    def test_alert_is_checked_on_weekday_when_skip_weekends_is_true(
+        self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
+    ) -> None:
         # run on week day
         with freeze_time("2024-12-19T07:55:00.000Z"):
             check_alert(self.alert["id"])

--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -411,6 +411,8 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
     def test_alert_is_checked_on_weekday_when_skip_weekends_is_true(
         self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock
     ) -> None:
+        self.skip_weekend(True)
+
         # run on week day
         with freeze_time("2024-12-19T07:55:00.000Z"):
             check_alert(self.alert["id"])

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -66,7 +66,7 @@ def skip_because_of_weekend(alert: AlertConfiguration) -> bool:
     team_timezone = pytz.timezone(alert.team.timezone)
 
     now_local = now.astimezone(team_timezone)
-    return now_local.isoweekday() in [5, 6]
+    return now_local.isoweekday() in [6, 7]
 
 
 def next_check_time(alert: AlertConfiguration) -> datetime:


### PR DESCRIPTION
## Problem
Small fixes for alerts edit form.
Number picker (for threshold) was returning `NaN` when the number was erased, so need to check for this.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
Fixed the above and reloading the alert on edit, so going back to alert form displays updated values.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
