### PR TITLE
chore(import-v2): enable v2 sql for allowlist

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -17,7 +17,7 @@ from posthog.temporal.data_imports.pipelines.bigquery import delete_all_temp_des
 
 from posthog.temporal.data_imports.pipelines.pipeline.pipeline import PipelineNonDLT
 from posthog.temporal.data_imports.pipelines.pipeline_sync import DataImportPipelineSync, PipelineInputs
-from posthog.temporal.data_imports.util import is_posthog_team
+from posthog.temporal.data_imports.util import is_posthog_team, is_enabled_for_team
 from posthog.warehouse.models import (
     ExternalDataJob,
     ExternalDataSource,
@@ -164,7 +164,9 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
             ExternalDataSource.Type.MYSQL,
             ExternalDataSource.Type.MSSQL,
         ]:
-            if is_posthog_team(inputs.team_id):
+            if is_posthog_team(inputs.team_id) or (
+                settings.TEMPORAL_TASK_QUEUE == DATA_WAREHOUSE_TASK_QUEUE_V2 and is_enabled_for_team(inputs.team_id)
+            ):
                 from posthog.temporal.data_imports.pipelines.sql_database_v2 import sql_source_for_type
             else:
                 from posthog.temporal.data_imports.pipelines.sql_database import sql_source_for_type


### PR DESCRIPTION
## Problem

- use v2 sql source on v2 pipeline for select teams

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- enable v2 sql

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
