### PR TITLE
feat: adding white label event capture for sharing

### DIFF
--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -65,7 +65,7 @@ export function SharingModalContent({
         iframeProperties,
         shareLink,
     } = useValues(sharingLogic(logicProps))
-    const { setIsEnabled, togglePreview } = useActions(sharingLogic(logicProps))
+    const { setIsEnabled, togglePreview, captureWhitelabelToggled } = useActions(sharingLogic(logicProps))
     const { guardAvailableFeature } = useValues(upgradeModalLogic)
 
     const [iframeLoaded, setIframeLoaded] = useState(false)
@@ -174,9 +174,10 @@ export function SharingModalContent({
                                                         </div>
                                                     }
                                                     onChange={() =>
-                                                        guardAvailableFeature(AvailableFeature.WHITE_LABELLING, () =>
+                                                        guardAvailableFeature(AvailableFeature.WHITE_LABELLING, () => {
                                                             onChange(!value)
-                                                        )
+                                                            captureWhitelabelToggled(!value)
+                                                        })
                                                     }
                                                     checked={!value}
                                                 />

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -65,7 +65,7 @@ export function SharingModalContent({
         iframeProperties,
         shareLink,
     } = useValues(sharingLogic(logicProps))
-    const { setIsEnabled, togglePreview, captureWhitelabelToggled } = useActions(sharingLogic(logicProps))
+    const { setIsEnabled, togglePreview, setIsWhitelabelEnabled } = useActions(sharingLogic(logicProps))
     const { guardAvailableFeature } = useValues(upgradeModalLogic)
 
     const [iframeLoaded, setIframeLoaded] = useState(false)
@@ -176,7 +176,7 @@ export function SharingModalContent({
                                                     onChange={() =>
                                                         guardAvailableFeature(AvailableFeature.WHITE_LABELLING, () => {
                                                             onChange(!value)
-                                                            captureWhitelabelToggled(!value)
+                                                            setIsWhitelabelEnabled(!value)
                                                         })
                                                     }
                                                     checked={!value}

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -65,7 +65,7 @@ export function SharingModalContent({
         iframeProperties,
         shareLink,
     } = useValues(sharingLogic(logicProps))
-    const { setIsEnabled, togglePreview, setEmbedConfig } = useActions(sharingLogic(logicProps))
+    const { setIsEnabled, togglePreview, setEmbedConfigValue } = useActions(sharingLogic(logicProps))
     const { guardAvailableFeature } = useValues(upgradeModalLogic)
 
     const [iframeLoaded, setIframeLoaded] = useState(false)
@@ -175,7 +175,7 @@ export function SharingModalContent({
                                                     }
                                                     onChange={() =>
                                                         guardAvailableFeature(AvailableFeature.WHITE_LABELLING, () => {
-                                                            setEmbedConfig({ whitelabel: !value })
+                                                            setEmbedConfigValue('whitelabel', !value)
                                                         })
                                                     }
                                                     checked={!value}

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -65,7 +65,7 @@ export function SharingModalContent({
         iframeProperties,
         shareLink,
     } = useValues(sharingLogic(logicProps))
-    const { setIsEnabled, togglePreview, setIsWhitelabelEnabled } = useActions(sharingLogic(logicProps))
+    const { setIsEnabled, togglePreview, setEmbedConfig } = useActions(sharingLogic(logicProps))
     const { guardAvailableFeature } = useValues(upgradeModalLogic)
 
     const [iframeLoaded, setIframeLoaded] = useState(false)
@@ -159,7 +159,7 @@ export function SharingModalContent({
                                             </LemonField>
                                         )}
                                         <LemonField name="whitelabel">
-                                            {({ value, onChange }) => (
+                                            {({ value }) => (
                                                 <LemonSwitch
                                                     fullWidth
                                                     bordered
@@ -175,8 +175,7 @@ export function SharingModalContent({
                                                     }
                                                     onChange={() =>
                                                         guardAvailableFeature(AvailableFeature.WHITE_LABELLING, () => {
-                                                            onChange(!value)
-                                                            setIsWhitelabelEnabled(!value)
+                                                            setEmbedConfig({ whitelabel: !value })
                                                         })
                                                     }
                                                     checked={!value}

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -175,6 +175,7 @@ export function SharingModalContent({
                                                     }
                                                     onChange={() =>
                                                         guardAvailableFeature(AvailableFeature.WHITE_LABELLING, () => {
+                                                            // setEmbedConfigValue is used to update the form state and call the reportDashboardWhitelabelToggled event
                                                             setEmbedConfigValue('whitelabel', !value)
                                                         })
                                                     }

--- a/frontend/src/lib/components/Sharing/sharingLogic.ts
+++ b/frontend/src/lib/components/Sharing/sharingLogic.ts
@@ -3,6 +3,7 @@ import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
+import posthog from 'posthog-js'
 import { getInsightId } from 'scenes/insights/utils'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
@@ -57,6 +58,7 @@ export const sharingLogic = kea<sharingLogicType>([
 
     actions({
         togglePreview: true,
+        captureWhitelabelToggled: (enabled: boolean) => ({ enabled }),
     }),
     reducers({
         showPreview: [true, { togglePreview: (state) => !state }],
@@ -86,8 +88,10 @@ export const sharingLogic = kea<sharingLogicType>([
                 dashboardsModel.actions.loadDashboards()
             }
         },
+        captureWhitelabelToggled: ({ enabled }) => {
+            posthog.capture('sharing insight whitelabel toggled', { enabled })
+        },
     })),
-
     forms({
         embedConfig: {
             defaults: defaultEmbedConfig,

--- a/frontend/src/lib/components/Sharing/sharingLogic.ts
+++ b/frontend/src/lib/components/Sharing/sharingLogic.ts
@@ -3,7 +3,6 @@ import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
-import posthog from 'posthog-js'
 import { getInsightId } from 'scenes/insights/utils'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { urls } from 'scenes/urls'
@@ -58,7 +57,7 @@ export const sharingLogic = kea<sharingLogicType>([
 
     actions({
         togglePreview: true,
-        captureWhitelabelToggled: (enabled: boolean) => ({ enabled }),
+        setIsWhitelabelEnabled: (enabled: boolean) => ({ enabled }),
     }),
     reducers({
         showPreview: [true, { togglePreview: (state) => !state }],
@@ -88,8 +87,10 @@ export const sharingLogic = kea<sharingLogicType>([
                 dashboardsModel.actions.loadDashboards()
             }
         },
-        captureWhitelabelToggled: ({ enabled }) => {
-            posthog.capture('sharing insight whitelabel toggled', { enabled })
+        setIsWhitelabelEnabled: (enabled) => {
+            if (props.dashboardId) {
+                eventUsageLogic.actions.reportDashboardWhitelabelToggled(enabled)
+            }
         },
     })),
 

--- a/frontend/src/lib/components/Sharing/sharingLogic.ts
+++ b/frontend/src/lib/components/Sharing/sharingLogic.ts
@@ -92,6 +92,7 @@ export const sharingLogic = kea<sharingLogicType>([
             posthog.capture('sharing insight whitelabel toggled', { enabled })
         },
     })),
+
     forms({
         embedConfig: {
             defaults: defaultEmbedConfig,

--- a/frontend/src/lib/components/Sharing/sharingLogic.ts
+++ b/frontend/src/lib/components/Sharing/sharingLogic.ts
@@ -57,16 +57,9 @@ export const sharingLogic = kea<sharingLogicType>([
 
     actions({
         togglePreview: true,
-        setEmbedConfig: (embedConfig: EmbedConfig) => ({ embedConfig }),
     }),
     reducers({
         showPreview: [true, { togglePreview: (state) => !state }],
-        embedConfig: [
-            defaultEmbedConfig,
-            {
-                setEmbedConfig: (state, { embedConfig }) => ({ ...state, ...embedConfig }),
-            },
-        ],
     }),
 
     loaders(({ props }) => ({
@@ -93,9 +86,9 @@ export const sharingLogic = kea<sharingLogicType>([
                 dashboardsModel.actions.loadDashboards()
             }
         },
-        setEmbedConfig: ({ embedConfig }) => {
-            if (props.dashboardId && 'whitelabel' in embedConfig) {
-                eventUsageLogic.actions.reportDashboardWhitelabelToggled(embedConfig.whitelabel)
+        setEmbedConfigValue: ({ name, value }) => {
+            if (name === 'whitelabel' && props.dashboardId) {
+                eventUsageLogic.actions.reportDashboardWhitelabelToggled(value)
             }
         },
     })),

--- a/frontend/src/lib/components/Sharing/sharingLogic.ts
+++ b/frontend/src/lib/components/Sharing/sharingLogic.ts
@@ -57,10 +57,16 @@ export const sharingLogic = kea<sharingLogicType>([
 
     actions({
         togglePreview: true,
-        setIsWhitelabelEnabled: (enabled: boolean) => ({ enabled }),
+        setEmbedConfig: (embedConfig: EmbedConfig) => ({ embedConfig }),
     }),
     reducers({
         showPreview: [true, { togglePreview: (state) => !state }],
+        embedConfig: [
+            defaultEmbedConfig,
+            {
+                setEmbedConfig: (state, { embedConfig }) => ({ ...state, ...embedConfig }),
+            },
+        ],
     }),
 
     loaders(({ props }) => ({
@@ -87,9 +93,9 @@ export const sharingLogic = kea<sharingLogicType>([
                 dashboardsModel.actions.loadDashboards()
             }
         },
-        setIsWhitelabelEnabled: (enabled) => {
-            if (props.dashboardId) {
-                eventUsageLogic.actions.reportDashboardWhitelabelToggled(enabled)
+        setEmbedConfig: ({ embedConfig }) => {
+            if (props.dashboardId && 'whitelabel' in embedConfig) {
+                eventUsageLogic.actions.reportDashboardWhitelabelToggled(embedConfig.whitelabel)
             }
         },
     })),

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -399,6 +399,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             newLength: number
         ) => ({ attribute, originalLength, newLength }),
         reportDashboardShareToggled: (isShared: boolean) => ({ isShared }),
+        reportDashboardWhitelabelToggled: (isWhitelabelToggled: boolean) => ({ isWhitelabelToggled }),
         reportUpgradeModalShown: (featureName: string) => ({ featureName }),
         reportTimezoneComponentViewed: (
             component: 'label' | 'indicator',
@@ -790,6 +791,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         },
         reportDashboardShareToggled: async ({ isShared }) => {
             posthog.capture(`dashboard share toggled`, { is_shared: isShared })
+        },
+        reportDashboardWhitelabelToggled: async ({ isWhitelabelToggled }) => {
+            posthog.capture(`dashboard whitelabel toggled`, { is_whitelabel_toggled: isWhitelabelToggled })
         },
         reportUpgradeModalShown: async (payload) => {
             posthog.capture('upgrade modal shown', payload)

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -792,8 +792,8 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportDashboardShareToggled: async ({ isShared }) => {
             posthog.capture(`dashboard share toggled`, { is_shared: isShared })
         },
-        reportDashboardWhitelabelToggled: async ({ isWhitelabelled }) => {
-            posthog.capture(`dashboard whitelabelled`, { is_whitelabelled: isWhitelabelled })
+        reportDashboardWhitelabelToggled: async ({ isWhiteLabelled }) => {
+            posthog.capture(`dashboard whitelabelled`, { is_whitelabelled: isWhiteLabelled })
         },
         reportUpgradeModalShown: async (payload) => {
             posthog.capture('upgrade modal shown', payload)

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -399,7 +399,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             newLength: number
         ) => ({ attribute, originalLength, newLength }),
         reportDashboardShareToggled: (isShared: boolean) => ({ isShared }),
-        reportDashboardWhitelabelToggled: (isWhitelabelToggled: boolean) => ({ isWhitelabelToggled }),
+        reportDashboardWhitelabelToggled: (isWhiteLabelled: boolean) => ({ isWhiteLabelled }),
         reportUpgradeModalShown: (featureName: string) => ({ featureName }),
         reportTimezoneComponentViewed: (
             component: 'label' | 'indicator',
@@ -792,8 +792,8 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportDashboardShareToggled: async ({ isShared }) => {
             posthog.capture(`dashboard share toggled`, { is_shared: isShared })
         },
-        reportDashboardWhitelabelToggled: async ({ isWhitelabelToggled }) => {
-            posthog.capture(`dashboard whitelabel toggled`, { is_whitelabel_toggled: isWhitelabelToggled })
+        reportDashboardWhitelabelToggled: async ({ isWhitelabelled }) => {
+            posthog.capture(`dashboard whitelabelled`, { is_whitelabelled: isWhitelabelled })
         },
         reportUpgradeModalShown: async (payload) => {
             posthog.capture('upgrade modal shown', payload)

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -793,7 +793,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             posthog.capture(`dashboard share toggled`, { is_shared: isShared })
         },
         reportDashboardWhitelabelToggled: async ({ isWhiteLabelled }) => {
-            posthog.capture(`dashboard whitelabelled`, { is_whitelabelled: isWhiteLabelled })
+            posthog.capture(`dashboard whitelabel toggled`, { is_whitelabelled: isWhiteLabelled })
         },
         reportUpgradeModalShown: async (payload) => {
             posthog.capture('upgrade modal shown', payload)


### PR DESCRIPTION
## Problem

In this PR, I'm adding whitelabel capture event for sharing dashboards

In the following PR's,

I will add changes to 

- [ ] whitelabelling in surveys
- [ ] Shared insights

## Changes

The event capture happens in the frontend since this feature is purely built in the frontend.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Cloud: Yes

## How did you test this code?

Shared a dashboards, and toggled the whitelabel button. Verified logs showed up:

![image](https://github.com/user-attachments/assets/956e93fe-008a-436c-91e4-5e0b18f528ad)

