### PR TITLE
feat: [2/2] Tests For Access Control Capture

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1,4 +1,6 @@
 import json
+import posthoganalytics
+
 from datetime import UTC, datetime, timedelta
 from functools import cached_property
 from typing import Any, Optional, cast
@@ -52,7 +54,6 @@ from posthog.utils import (
     get_ip_address,
     get_week_start_for_country_code,
 )
-import posthoganalytics
 
 
 class PremiumMultiProjectPermissions(BasePermission):  # TODO: Rename to include "Env" in name

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -375,7 +375,9 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
     def update(self, instance: Team, validated_data: dict[str, Any]) -> Team:
         before_update = instance.__dict__.copy()
 
+        print("access_control check", validated_data)  # noqa: T201
         if "access_control" in validated_data and validated_data["access_control"] != instance.access_control:
+            print("in access control toggle")  # noqa: T201
             user = cast(User, self.context["request"].user)
             posthoganalytics.capture(
                 str(user.distinct_id),
@@ -390,6 +392,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
                 },
                 groups=groups(instance.organization),
             )
+        print("after access control toggle")  # noqa: T201
 
         if "survey_config" in validated_data:
             if instance.survey_config is not None and validated_data.get("survey_config") is not None:

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -1235,9 +1235,15 @@ def team_api_test_factory():
 
             current_access_control = response.json()["access_control"]
             new_setting = not current_access_control
-            response = self.client.patch(f"/api/environments/@current/", {"access_control": new_setting})
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            print("response", response.json())  # noqa: T201
+            # response = self.client.patch(f"/api/environments/@current/", {"access_control": new_setting})
+            # self.assertEqual(response.status_code, status.HTTP_200_OK)
+            # print("response", response.json())  # noqa: T201
+
+            with patch("posthog.api.team.TeamSerializer.update") as mock_update:
+                response = self.client.patch(f"/api/environments/@current/", {"access_control": new_setting})
+                print("Update method called:", mock_update.called)  # noqa: T201
+                print("PATCH response:", response.json())  # noqa: T201
+                print("Mock update calls:", mock_update.call_args_list if mock_update.called else "No calls")  # noqa: T201
 
             mock_capture.assert_called_with(
                 str(self.user.distinct_id),

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -28,6 +28,7 @@ from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.schedule import describe_schedule
 from posthog.test.base import APIBaseTest
 from posthog.utils import get_instance_realm
+from posthog.event_usage import groups
 
 
 def team_api_test_factory():
@@ -1222,6 +1223,34 @@ def team_api_test_factory():
             response = self.client.patch("/api/environments/@current/", {"session_recording_linked_flag": config})
             assert response.status_code == expected_status, response.json()
             return response
+
+        @patch("posthoganalytics.capture")
+        def test_access_control_toggle_capture(self, mock_capture):
+            self.organization_membership.level = OrganizationMembership.Level.ADMIN
+            self.organization_membership.save()
+            mock_capture.reset_mock()
+
+            response = self.client.get("/api/environments/@current/")
+            assert response.status_code == status.HTTP_200_OK
+
+            current_access_control = response.json()["access_control"]
+            new_setting = not current_access_control
+            response = self.client.patch(f"/api/environments/@current/", {"access_control": new_setting})
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            mock_capture.assert_called_with(
+                str(self.user.distinct_id),
+                "project access control toggled",
+                properties={
+                    "enabled": new_setting,
+                    "project_id": str(self.team.id),
+                    "project_name": self.team.name,
+                    "organization_id": str(self.organization.id),
+                    "organization_name": self.organization.name,
+                    "user_role": OrganizationMembership.Level.ADMIN,
+                },
+                groups=groups(self.organization),
+            )
 
     return TestTeamAPI
 

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -28,6 +28,7 @@ from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.schedule import describe_schedule
 from posthog.test.base import APIBaseTest
 from posthog.utils import get_instance_realm
+from posthog.event_usage import groups
 
 
 def team_api_test_factory():
@@ -1222,6 +1223,49 @@ def team_api_test_factory():
             response = self.client.patch("/api/environments/@current/", {"session_recording_linked_flag": config})
             assert response.status_code == expected_status, response.json()
             return response
+
+        @patch("posthoganalytics.capture")
+        def test_access_control_toggle_capture(self, mock_capture):
+            self.organization_membership.level = OrganizationMembership.Level.ADMIN
+            self.organization_membership.save()
+
+            mock_capture.reset_mock()
+
+            response = self.client.patch(f"/api/environments/@current/", {"access_control": True})
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            mock_capture.assert_called_with(
+                str(self.user.distinct_id),
+                "project access control toggled",
+                properties={
+                    "enabled": True,
+                    "project_id": str(self.team.id),
+                    "project_name": self.team.name,
+                    "organization_id": str(self.organization.id),
+                    "organization_name": self.organization.name,
+                    "user_role": OrganizationMembership.Level.ADMIN,
+                },
+                groups=groups(self.organization),
+            )
+
+            # Test toggling back to false
+            mock_capture.reset_mock()
+            response = self.client.patch(f"/api/environments/@current/", {"access_control": False})
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            mock_capture.assert_called_with(
+                str(self.user.distinct_id),
+                "project access control toggled",
+                properties={
+                    "enabled": False,
+                    "project_id": str(self.team.id),
+                    "project_name": self.team.name,
+                    "organization_id": str(self.organization.id),
+                    "organization_name": self.organization.name,
+                    "user_role": OrganizationMembership.Level.ADMIN,
+                },
+                groups=groups(self.organization),
+            )
 
     return TestTeamAPI
 

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -1237,6 +1237,7 @@ def team_api_test_factory():
             new_setting = not current_access_control
             response = self.client.patch(f"/api/environments/@current/", {"access_control": new_setting})
             self.assertEqual(response.status_code, status.HTTP_200_OK)
+            print("response", response.json())  # noqa: T201
 
             mock_capture.assert_called_with(
                 str(self.user.distinct_id),


### PR DESCRIPTION
When the user sets the access control on a project level, we have logs that are captured [here](https://github.com/PostHog/posthog/pull/27031) and we want tests to make sure that these logs are captured correctly. This PR covers the tests needed, however, there is a small issue with them failing remotely and I'm looking for feedback

Logs for test passing locally:
```

(env) surbhijhavar@Surbhis-MacBook-Pro posthog % pytest posthog/api/test/test_team.py -k test_access_control_toggle_capture -v   
/Users/surbhijhavar/posthog/env/lib/python3.11/site-packages/deepeval/__init__.py:53: UserWarning: You are using deepeval version 1.5.5, however version 2.0.9 is available. You should consider upgrading via the "pip install --upgrade deepeval" command.
  warnings.warn(
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.11.10, pytest-8.0.2, pluggy-1.5.0 -- /Users/surbhijhavar/posthog/env/bin/python3.11
cachedir: .pytest_cache
django: settings: posthog.settings (from ini)
rootdir: /Users/surbhijhavar/posthog
configfile: pytest.ini
plugins: inline-snapshot-0.12.1, icdiff-0.6, repeat-0.9.3, flaky-3.7.0, cov-4.1.0, asyncio-0.21.1, mock-3.11.1, Faker-17.5.0, deepeval-1.5.5, split-0.9.0, django-4.5.2, env-0.8.2, anyio-4.6.2.post1, xdist-3.6.1, syrupy-4.6.4
asyncio: mode=Mode.STRICT
collected 70 items / 69 deselected / 1 selected                                                                                                           

posthog/api/test/test_team.py::TestTeamAPI::test_access_control_toggle_capture PASSED                                                               [100%]Running teardown with pytest sessionfinish...

===================================================================== inline snapshot =====================================================================

======================= 1 passed, 69 deselected in 3.78s =======================
```