### PR TITLE
feat: Validate batch export configuration in API

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import enum
 import typing
 from dataclasses import asdict, dataclass, fields
 from uuid import UUID
@@ -65,6 +66,11 @@ class BatchExportsInputsProtocol(typing.Protocol):
     team_id: int
     batch_export_model: BatchExportModel | None = None
     is_backfill: bool = False
+
+
+class S3FileFormat(enum.StrEnum):
+    PARQUET = "Parquet"
+    JSONLINES = "JSONLines"
 
 
 @dataclass


### PR DESCRIPTION
## Problem

When creating batch exports programmatically, users may make mistakes, and we are not informing them on what went wrong. What's worse, sometimes we run batch exports with invalid inputs.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Add a validator to check provided inputs are compatible with corresponding batch export inputs.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
