### PR TITLE
chore(experiments): Use delta instead of places in tests

### DIFF
--- a/posthog/hogql_queries/experiments/test/test_trends_statistics_count.py
+++ b/posthog/hogql_queries/experiments/test/test_trends_statistics_count.py
@@ -73,12 +73,12 @@ class TestExperimentTrendsStatistics(APIBaseTest):
             self.assertEqual(p_value, 1)
 
             # Control: ~10% conversion rate with wide interval due to small sample
-            self.assertAlmostEqual(intervals["control"][0], 0.055, places=2)  # Lower bound ~5.5%
-            self.assertAlmostEqual(intervals["control"][1], 0.182, places=2)  # Upper bound ~18.2%
+            self.assertAlmostEqual(intervals["control"][0], 0.055, delta=0.02)  # Lower bound ~5.5%
+            self.assertAlmostEqual(intervals["control"][1], 0.182, delta=0.02)  # Upper bound ~18.2%
 
             # Test: ~11% conversion rate with wide interval due to small sample
-            self.assertAlmostEqual(intervals["test"][0], 0.062, places=2)  # Lower bound ~6.2%
-            self.assertAlmostEqual(intervals["test"][1], 0.195, places=2)  # Upper bound ~19.5%
+            self.assertAlmostEqual(intervals["test"][0], 0.062, delta=0.02)  # Lower bound ~6.2%
+            self.assertAlmostEqual(intervals["test"][1], 0.195, delta=0.02)  # Upper bound ~19.5%
 
         self.run_test_for_both_implementations(run_test)
 
@@ -110,12 +110,12 @@ class TestExperimentTrendsStatistics(APIBaseTest):
                 self.assertLess(p_value, 0.001)
 
             # Control: 10% conversion rate with narrow interval due to large sample
-            self.assertAlmostEqual(intervals["control"][0], 0.094, places=2)  # Lower bound ~9.4%
-            self.assertAlmostEqual(intervals["control"][1], 0.106, places=2)  # Upper bound ~10.6%
+            self.assertAlmostEqual(intervals["control"][0], 0.094, delta=0.02)  # Lower bound ~9.4%
+            self.assertAlmostEqual(intervals["control"][1], 0.106, delta=0.02)  # Upper bound ~10.6%
 
             # Test: 12% conversion rate with narrow interval due to large sample
-            self.assertAlmostEqual(intervals["test"][0], 0.114, places=2)  # Lower bound ~11.4%
-            self.assertAlmostEqual(intervals["test"][1], 0.126, places=2)  # Upper bound ~12.6%
+            self.assertAlmostEqual(intervals["test"][0], 0.114, delta=0.02)  # Lower bound ~11.4%
+            self.assertAlmostEqual(intervals["test"][1], 0.126, delta=0.02)  # Upper bound ~12.6%
 
         self.run_test_for_both_implementations(run_test)
 
@@ -147,12 +147,12 @@ class TestExperimentTrendsStatistics(APIBaseTest):
                 self.assertLess(p_value, 0.001)
 
             # Control: 10% conversion rate
-            self.assertAlmostEqual(intervals["control"][0], 0.094, places=2)  # Lower bound ~9.4%
-            self.assertAlmostEqual(intervals["control"][1], 0.106, places=2)  # Upper bound ~10.6%
+            self.assertAlmostEqual(intervals["control"][0], 0.094, delta=0.02)  # Lower bound ~9.4%
+            self.assertAlmostEqual(intervals["control"][1], 0.106, delta=0.02)  # Upper bound ~10.6%
 
             # Test: 15% conversion rate, clearly higher than control
-            self.assertAlmostEqual(intervals["test"][0], 0.143, places=2)  # Lower bound ~14.3%
-            self.assertAlmostEqual(intervals["test"][1], 0.157, places=2)  # Upper bound ~15.7%
+            self.assertAlmostEqual(intervals["test"][0], 0.143, delta=0.02)  # Lower bound ~14.3%
+            self.assertAlmostEqual(intervals["test"][1], 0.157, delta=0.02)  # Upper bound ~15.7%
 
         self.run_test_for_both_implementations(run_test)
 
@@ -194,17 +194,17 @@ class TestExperimentTrendsStatistics(APIBaseTest):
             self.assertEqual(p_value, 1)
 
             # All variants around 10% with overlapping intervals
-            self.assertAlmostEqual(intervals["control"][0], 0.083, places=2)  # ~8.3%
-            self.assertAlmostEqual(intervals["control"][1], 0.119, places=2)  # ~11.9%
+            self.assertAlmostEqual(intervals["control"][0], 0.083, delta=0.02)  # ~8.3%
+            self.assertAlmostEqual(intervals["control"][1], 0.119, delta=0.02)  # ~11.9%
 
-            self.assertAlmostEqual(intervals["test_a"][0], 0.081, places=2)  # ~8.1%
-            self.assertAlmostEqual(intervals["test_a"][1], 0.117, places=2)  # ~11.7%
+            self.assertAlmostEqual(intervals["test_a"][0], 0.081, delta=0.02)  # ~8.1%
+            self.assertAlmostEqual(intervals["test_a"][1], 0.117, delta=0.02)  # ~11.7%
 
-            self.assertAlmostEqual(intervals["test_b"][0], 0.085, places=2)  # ~8.5%
-            self.assertAlmostEqual(intervals["test_b"][1], 0.121, places=2)  # ~12.1%
+            self.assertAlmostEqual(intervals["test_b"][0], 0.085, delta=0.02)  # ~8.5%
+            self.assertAlmostEqual(intervals["test_b"][1], 0.121, delta=0.02)  # ~12.1%
 
-            self.assertAlmostEqual(intervals["test_c"][0], 0.084, places=2)  # ~8.4%
-            self.assertAlmostEqual(intervals["test_c"][1], 0.120, places=2)  # ~12.0%
+            self.assertAlmostEqual(intervals["test_c"][0], 0.084, delta=0.02)  # ~8.4%
+            self.assertAlmostEqual(intervals["test_c"][1], 0.120, delta=0.02)  # ~12.0%
 
         self.run_test_for_both_implementations(run_test)
 
@@ -251,20 +251,20 @@ class TestExperimentTrendsStatistics(APIBaseTest):
                 self.assertLess(p_value, 0.001)
 
             # Control at 10%
-            self.assertAlmostEqual(intervals["control"][0], 0.094, places=2)
-            self.assertAlmostEqual(intervals["control"][1], 0.106, places=2)
+            self.assertAlmostEqual(intervals["control"][0], 0.094, delta=0.02)
+            self.assertAlmostEqual(intervals["control"][1], 0.106, delta=0.02)
 
             # Test A slightly higher at 10.5%
-            self.assertAlmostEqual(intervals["test_a"][0], 0.099, places=2)
-            self.assertAlmostEqual(intervals["test_a"][1], 0.111, places=2)
+            self.assertAlmostEqual(intervals["test_a"][0], 0.099, delta=0.02)
+            self.assertAlmostEqual(intervals["test_a"][1], 0.111, delta=0.02)
 
             # Test B clearly winning at 15%
-            self.assertAlmostEqual(intervals["test_b"][0], 0.143, places=2)
-            self.assertAlmostEqual(intervals["test_b"][1], 0.157, places=2)
+            self.assertAlmostEqual(intervals["test_b"][0], 0.143, delta=0.02)
+            self.assertAlmostEqual(intervals["test_b"][1], 0.157, delta=0.02)
 
             # Test C slightly higher at 11%
-            self.assertAlmostEqual(intervals["test_c"][0], 0.104, places=2)
-            self.assertAlmostEqual(intervals["test_c"][1], 0.116, places=2)
+            self.assertAlmostEqual(intervals["test_c"][0], 0.104, delta=0.02)
+            self.assertAlmostEqual(intervals["test_c"][1], 0.116, delta=0.02)
 
         self.run_test_for_both_implementations(run_test)
 
@@ -286,8 +286,8 @@ class TestExperimentTrendsStatistics(APIBaseTest):
             significance, p_value = are_results_significant(control, [test], probabilities)
             intervals = calculate_credible_intervals([control, test])
             self.assertEqual(len(probabilities), 2)
-            self.assertAlmostEqual(probabilities[1], 0.966, places=2)  # test should be winning
-            self.assertAlmostEqual(probabilities[0], 0.034, places=2)  # control should be losing
+            self.assertAlmostEqual(probabilities[1], 0.966, delta=0.05)  # test should be winning
+            self.assertAlmostEqual(probabilities[0], 0.034, delta=0.05)  # control should be losing
             if stats_version == 2:
                 self.assertEqual(significance, ExperimentSignificanceCode.SIGNIFICANT)
                 self.assertLess(p_value, 0.01)
@@ -330,14 +330,14 @@ class TestExperimentTrendsStatistics(APIBaseTest):
             self.assertEqual(p_value, 1.0)
 
             # Both variants should have wide intervals due to small sample size
-            self.assertAlmostEqual(intervals["control"][0], 0.044, places=2)  # 4.4%
-            self.assertAlmostEqual(intervals["control"][1], 0.229, places=2)  # 22.9%
+            self.assertAlmostEqual(intervals["control"][0], 0.044, delta=0.03)  # 4.4%
+            self.assertAlmostEqual(intervals["control"][1], 0.229, delta=0.03)  # 22.9%
 
-            self.assertAlmostEqual(intervals["test"][0], 0.083, places=2)  # 8.3%
+            self.assertAlmostEqual(intervals["test"][0], 0.083, delta=0.03)  # 8.3%
             if stats_version == 2:
-                self.assertAlmostEqual(intervals["test"][1], 0.309, places=2)  # 30.9%
+                self.assertAlmostEqual(intervals["test"][1], 0.309, delta=0.03)  # 30.9%
             else:
-                self.assertAlmostEqual(intervals["test"][1], 0.315, places=2)  # 31.5%
+                self.assertAlmostEqual(intervals["test"][1], 0.315, delta=0.03)  # 31.5%
 
         self.run_test_for_both_implementations(run_test)
 
@@ -366,11 +366,11 @@ class TestExperimentTrendsStatistics(APIBaseTest):
             self.assertEqual(p_value, 1)
 
             # Both variants should have very small intervals near zero
-            self.assertAlmostEqual(intervals["control"][0], 0.0, places=3)
-            self.assertAlmostEqual(intervals["control"][1], 0.004, places=3)
+            self.assertAlmostEqual(intervals["control"][0], 0.0, delta=0.01)
+            self.assertAlmostEqual(intervals["control"][1], 0.004, delta=0.01)
 
-            self.assertAlmostEqual(intervals["test"][0], 0.0, places=3)
-            self.assertAlmostEqual(intervals["test"][1], 0.004, places=3)
+            self.assertAlmostEqual(intervals["test"][0], 0.0, delta=0.01)
+            self.assertAlmostEqual(intervals["test"][1], 0.004, delta=0.01)
 
         self.run_test_for_both_implementations(run_test)
 


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/26713

## Changes

Uses `delta` with `assertAlmostEqual` instead of `places` to account for some degree of variability in statistical evaluations.

## How did you test this code?

Tests should pass.