### PR TITLE
fix: Ignore viewports where width/height is 0

### DIFF
--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -564,7 +564,8 @@ GROUP BY session_id, breakdown_value
                 return parse_expr("tupleElement(breakdown_value, 2) IS NOT NULL")
             case WebStatsBreakdown.VIEWPORT:
                 return parse_expr(
-                    "tupleElement(breakdown_value, 1) IS NOT NULL AND tupleElement(breakdown_value, 2) IS NOT NULL"
+                    "tupleElement(breakdown_value, 1) IS NOT NULL AND tupleElement(breakdown_value, 2) IS NOT NULL AND "
+                    "tupleElement(breakdown_value, 1) != 0 AND tupleElement(breakdown_value, 2) != 0"
                 )
             case (
                 WebStatsBreakdown.INITIAL_UTM_SOURCE


### PR DESCRIPTION
Ignore viewports where width/height is 0, these are not useful for our users. This happens when browsers want to hide information from us, we could look into updating our `posthog-js` script to avoid sending that information, but this is an easier fix for now
![image](https://github.com/user-attachments/assets/931400be-b361-4c66-a0cd-36830685822a)
