### PR TITLE
feat: Add management command to track workflow executions

### DIFF
--- a/posthog/management/commands/get_temporal_workflow_count.py
+++ b/posthog/management/commands/get_temporal_workflow_count.py
@@ -1,0 +1,100 @@
+import asyncio
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from prometheus_client import Gauge
+
+from posthog.temporal.common.client import connect
+
+
+class Command(BaseCommand):
+    help = "Get a count of Temporal Workflow executions"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--temporal-host",
+            default=settings.TEMPORAL_HOST,
+            help="Hostname for Temporal Server",
+        )
+        parser.add_argument(
+            "--temporal-port",
+            default=settings.TEMPORAL_PORT,
+            help="Port for Temporal Server",
+        )
+        parser.add_argument(
+            "--namespace",
+            default=settings.TEMPORAL_NAMESPACE,
+            help="Namespace to connect to",
+        )
+        parser.add_argument(
+            "--task-queue",
+            default=settings.TEMPORAL_TASK_QUEUE,
+            help=("Temporal task queue where the Workflow executions to count reside in"),
+        )
+        parser.add_argument(
+            "--server-root-ca-cert",
+            default=settings.TEMPORAL_CLIENT_ROOT_CA,
+            help="Optional root server CA cert",
+        )
+        parser.add_argument(
+            "--client-cert",
+            default=settings.TEMPORAL_CLIENT_CERT,
+            help="Optional client cert",
+        )
+        parser.add_argument(
+            "--client-key",
+            default=settings.TEMPORAL_CLIENT_KEY,
+            help="Optional client key",
+        )
+        parser.add_argument(
+            "--status",
+            default="Running",
+            help=(
+                "Optionally, define which state the Workflow executions to count should "
+                "be in. By default, we count 'Running' Workflow executions."
+            ),
+        )
+        parser.add_argument(
+            "--gauge",
+            default=None,
+            help=("Optionally, set a Prometheus gauge to track this count."),
+        )
+
+    def handle(self, *args, **options):
+        """Get count of Temporal Workflow executions.
+
+        Optionally, track the count in a Prometheus gauge if `--gauge` is set.
+        """
+        temporal_host = options["temporal_host"]
+        temporal_port = options["temporal_port"]
+        namespace = options["namespace"]
+        task_queue = options["task_queue"]
+        server_root_ca_cert = options.get("server_root_ca_cert", None)
+        client_cert = options.get("client_cert", None)
+        client_key = options.get("client_key", None)
+        execution_status = options["status"]
+        track_gauge = options.get("gauge", None)
+
+        client = asyncio.run(
+            connect(
+                temporal_host,
+                temporal_port,
+                namespace,
+                server_root_ca_cert=server_root_ca_cert,
+                client_cert=client_cert,
+                client_key=client_key,
+            )
+        )
+
+        result = asyncio.run(
+            client.count_workflows(query=f'`TaskQueue`="{task_queue}" AND `ExecutionStatus`="{execution_status}"')
+        )
+
+        if track_gauge:
+            gauge = Gauge(
+                track_gauge,
+                f"Number of Temporal Workflow executions in '{task_queue}' with status '{execution_status}'.",
+            )
+            gauge.set(result.count)
+
+        return str(result.count)


### PR DESCRIPTION
## Problem

In order to support auto-scaling infrastructure, we need to know how many Temporal Workflows are pending. For this, we need to query Temporal and get the count of workflows in 'Running' status.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Adds a management command to streamline the call to Temporal to get the count.
Management command also supports pushing result to a Prometheus gauge, if configured.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Manually ran command

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
