### PR TITLE
chore: stop timer when query is cancelled

### DIFF
--- a/frontend/src/queries/nodes/DataNode/ElapsedTime.tsx
+++ b/frontend/src/queries/nodes/DataNode/ElapsedTime.tsx
@@ -73,10 +73,14 @@ export function ElapsedTime({ showTimings }: { showTimings?: boolean }): JSX.Ele
     }
 
     if (!isShowingCachedResults && loadingStart && !elapsedTime) {
-        time = performance.now() - loadingStart
-        window.requestAnimationFrame(() => {
-            setTick((tick) => tick + 1)
-        })
+        if (!responseError) {
+            time = performance.now() - loadingStart
+            window.requestAnimationFrame(() => {
+                setTick((tick) => tick + 1)
+            })
+        } else {
+            time = performance.now() - loadingStart
+        }
     }
 
     if (!time) {

--- a/frontend/src/queries/nodes/DataNode/ElapsedTime.tsx
+++ b/frontend/src/queries/nodes/DataNode/ElapsedTime.tsx
@@ -73,13 +73,11 @@ export function ElapsedTime({ showTimings }: { showTimings?: boolean }): JSX.Ele
     }
 
     if (!isShowingCachedResults && loadingStart && !elapsedTime) {
+        time = performance.now() - loadingStart
         if (!responseError) {
-            time = performance.now() - loadingStart
             window.requestAnimationFrame(() => {
                 setTick((tick) => tick + 1)
             })
-        } else {
-            time = performance.now() - loadingStart
         }
     }
 


### PR DESCRIPTION
## Problem

When a query is canceled the timer does not stop.

![before](https://github.com/user-attachments/assets/86baeba3-5a41-4d6f-9be7-44918fa13ee9)

## Changes

Now it does checking for the `responseError` variable.

![after](https://github.com/user-attachments/assets/b17b2bfe-e72f-479f-9677-4534990f8b94)


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

On the local PostHog instance.
