### PR TITLE
docs: fix wrong links to HogQL docs in the HogQLEditor

### DIFF
--- a/frontend/src/lib/components/HogQLEditor/HogQLEditor.tsx
+++ b/frontend/src/lib/components/HogQLEditor/HogQLEditor.tsx
@@ -73,7 +73,7 @@ export function HogQLEditor({
             </LemonButton>
             <div className="flex mt-1 gap-1">
                 <div className={`w-full text-right select-none ${CLICK_OUTSIDE_BLOCK_CLASS}`}>
-                    <Link to="https://posthog.com/manual/hogql" target="_blank">
+                    <Link to="https://posthog.com/docs/hogql" target="_blank">
                         Learn more about HogQL
                     </Link>
                 </div>


### PR DESCRIPTION
## Problem

Wrong link to https://posthog.com/manual/hogql which is 404

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
