### PR TITLE
fix(batch-exports): Remove zero unicode in PostgreSQL

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -1,3 +1,4 @@
+import asyncio
 import collections.abc
 import contextlib
 import csv
@@ -387,7 +388,10 @@ class PostgreSQLClient:
                         fields=sql.SQL(",").join(sql.Identifier(column) for column in schema_columns),
                     )
                 ) as copy:
-                    while data := tsv_file.read():
+                    while data := await asyncio.to_thread(tsv_file.read):
+                        # \u0000 cannot be present in PostgreSQL's jsonb type, and will cause an error.
+                        # See: https://www.postgresql.org/docs/17/datatype-json.html
+                        data = data.replace(b"\\u0000", b"")
                         await copy.write(data)
 
 

--- a/posthog/temporal/tests/batch_exports/conftest.py
+++ b/posthog/temporal/tests/batch_exports/conftest.py
@@ -239,7 +239,7 @@ async def generate_test_data(
         count_outside_range=10,
         count_other_team=10,
         duplicate=True,
-        properties={"$browser": "Chrome", "$os": "Mac OS X"},
+        properties={"$browser": "Chrome", "$os": "Mac OS X", "unicode": "\u0000"},
         person_properties={"utm_medium": "referral", "$initial_os": "Linux"},
         table=table,
     )

--- a/posthog/temporal/tests/batch_exports/conftest.py
+++ b/posthog/temporal/tests/batch_exports/conftest.py
@@ -220,9 +220,19 @@ def data_interval_end(request, interval):
     return dt.datetime(2023, 4, 25, 15, 0, 0, tzinfo=dt.UTC)
 
 
+@pytest.fixture
+def test_properties(request):
+    """Set test data properties."""
+    try:
+        return request.param
+    except AttributeError:
+        pass
+    return {"$browser": "Chrome", "$os": "Mac OS X"}
+
+
 @pytest_asyncio.fixture
 async def generate_test_data(
-    ateam, clickhouse_client, exclude_events, data_interval_start, data_interval_end, interval
+    ateam, clickhouse_client, exclude_events, data_interval_start, data_interval_end, interval, test_properties
 ):
     """Generate test data in ClickHouse."""
     if interval != "every 5 minutes":
@@ -239,7 +249,7 @@ async def generate_test_data(
         count_outside_range=10,
         count_other_team=10,
         duplicate=True,
-        properties={"$browser": "Chrome", "$os": "Mac OS X", "unicode": "\u0000"},
+        properties=test_properties,
         person_properties={"utm_medium": "referral", "$initial_os": "Linux"},
         table=table,
     )

--- a/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
@@ -136,6 +136,11 @@ async def assert_clickhouse_records_in_postgres(
                     # bq_ingested_timestamp cannot be compared as it comes from an unstable function.
                     continue
 
+                if isinstance(v, str):
+                    v = v.replace("\\u0000", "")
+                elif isinstance(v, bytes):
+                    v = v.replace(b"\\u0000", b"")
+
                 if k in {"properties", "set", "set_once", "person_properties", "elements"} and v is not None:
                     expected_record[k] = json.loads(v)
                 elif isinstance(v, dt.datetime):

--- a/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
@@ -165,6 +165,12 @@ async def assert_clickhouse_records_in_postgres(
 
 
 @pytest.fixture
+def test_properties(request):
+    """Include a \u0000 unicode escape sequence in properties."""
+    return {"$browser": "Chrome", "$os": "Mac OS X", "unicode": "\u0000"}
+
+
+@pytest.fixture
 def postgres_config():
     return {
         "user": settings.PG_USER,


### PR DESCRIPTION
## Problem

PostgreSQL doesn't support the unicode code point `\u0000` in JSON type. This should only be ever present in arbitrary event properties. So, let's do a blanket replace all from the data to clean it up before exporting.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Remove any \u0000 sequences in PostgreSQL batch export. Since these are dumped, they will be escaped as \\u0000.
* Extend tests to include a unicode field with the \u0000 sequence, to ensure it is not exported.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

New test setup.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
