### PR TITLE
fix: Capture ingestion warning if group insert is too large

### DIFF
--- a/plugin-server/src/worker/ingestion/properties-updater.ts
+++ b/plugin-server/src/worker/ingestion/properties-updater.ts
@@ -1,9 +1,9 @@
 import { Properties } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
-import { MessageSizeTooLarge } from 'utils/db/error'
 
 import { Group, GroupTypeIndex, TeamId } from '../../types'
 import { DB } from '../../utils/db/db'
+import { MessageSizeTooLarge } from '../../utils/db/error'
 import { PostgresUse } from '../../utils/db/postgres'
 import { RaceConditionError } from '../../utils/utils'
 import { captureIngestionWarning } from './utils'

--- a/plugin-server/src/worker/ingestion/properties-updater.ts
+++ b/plugin-server/src/worker/ingestion/properties-updater.ts
@@ -1,10 +1,12 @@
 import { Properties } from '@posthog/plugin-scaffold'
 import { DateTime } from 'luxon'
+import { MessageSizeTooLarge } from 'utils/db/error'
 
 import { Group, GroupTypeIndex, TeamId } from '../../types'
 import { DB } from '../../utils/db/db'
 import { PostgresUse } from '../../utils/db/postgres'
 import { RaceConditionError } from '../../utils/utils'
+import { captureIngestionWarning } from './utils'
 
 interface PropertiesUpdate {
     updated: boolean
@@ -71,18 +73,24 @@ export async function upsertGroup(
         )
 
         if (propertiesUpdate.updated) {
-            await Promise.all([
-                db.upsertGroupClickhouse(
-                    teamId,
-                    groupTypeIndex,
-                    groupKey,
-                    propertiesUpdate.properties,
-                    createdAt,
-                    version
-                ),
-            ])
+            await db.upsertGroupClickhouse(
+                teamId,
+                groupTypeIndex,
+                groupKey,
+                propertiesUpdate.properties,
+                createdAt,
+                version
+            )
         }
     } catch (error) {
+        if (error instanceof MessageSizeTooLarge) {
+            // Message is too large, for kafka - this is unrecoverable so we capture an ingestion warning instead
+            await captureIngestionWarning(db.kafkaProducer, teamId, 'message_size_too_large', {
+                groupTypeIndex,
+                groupKey,
+            })
+            return
+        }
         if (error instanceof RaceConditionError) {
             // Try again - lock the row and insert!
             return upsertGroup(db, teamId, projectId, groupTypeIndex, groupKey, properties, timestamp)

--- a/plugin-server/src/worker/ingestion/properties-updater.ts
+++ b/plugin-server/src/worker/ingestion/properties-updater.ts
@@ -85,7 +85,7 @@ export async function upsertGroup(
     } catch (error) {
         if (error instanceof MessageSizeTooLarge) {
             // Message is too large, for kafka - this is unrecoverable so we capture an ingestion warning instead
-            await captureIngestionWarning(db.kafkaProducer, teamId, 'message_size_too_large', {
+            await captureIngestionWarning(db.kafkaProducer, teamId, 'group_upsert_message_size_too_large', {
                 groupTypeIndex,
                 groupKey,
             })


### PR DESCRIPTION
## Problem

We already do this for events but not for groups

## Changes

* Catch message size too large errors and capture ingestion warning instead

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
