### PR TITLE
fix: get_team_attribute_by_quota_resource always return list

### DIFF
--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -264,7 +264,7 @@ def sync_org_quota_limits(organization: Organization):
             remove_limited_team_tokens(resource, team_attributes, QuotaLimitingCaches.QUOTA_LIMITING_SUSPENDED_KEY)
 
 
-def get_team_attribute_by_quota_resource(organization: Organization):
+def get_team_attribute_by_quota_resource(organization: Organization) -> list[str]:
     team_tokens: list[str] = [x for x in list(organization.teams.values_list("api_token", flat=True)) if x]
 
     if not team_tokens:

--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -269,7 +269,6 @@ def get_team_attribute_by_quota_resource(organization: Organization):
 
     if not team_tokens:
         capture_exception(Exception(f"quota_limiting: No team tokens found for organization: {organization.id}"))
-        return
 
     return team_tokens
 


### PR DESCRIPTION
## Problem

https://posthog.sentry.io/issues/6185491305/?alert_rule_id=14968077&alert_type=issue&notification_uuid=e63c0bfc-9977-4b8b-8b43-2a2c98ed4fa8&project=1899813&referrer=slack

In `get_team_attribute_by_quota_resource`, if the list `team_tokens` is empty, instead of returning the empty list, we returned `None`. That breaks `sync_org_quota_limits` that expects a list when calling that function.

## Changes

We always return a list, even an empty list.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Only for cloud since it's billing.

## How did you test this code?

Current tests are passing.
