### PR TITLE
fix(periodic-digest): don't show completed experiments in launched list

### DIFF
--- a/posthog/tasks/periodic_digest.py
+++ b/posthog/tasks/periodic_digest.py
@@ -75,8 +75,16 @@ def get_teams_with_new_playlists(end: datetime, begin: datetime) -> QuerySet:
 
 
 def get_teams_with_new_experiments_launched(end: datetime, begin: datetime) -> QuerySet:
-    return Experiment.objects.filter(start_date__gt=begin, start_date__lte=end, end_date__isnull=True).values(
-        "team_id", "name", "id", "start_date"
+    return (
+        Experiment.objects.filter(
+            start_date__gt=begin,
+            start_date__lte=end,
+        )
+        .exclude(
+            end_date__gt=begin,
+            end_date__lte=end,
+        )
+        .values("team_id", "name", "id", "start_date")
     )
 
 

--- a/posthog/tasks/periodic_digest.py
+++ b/posthog/tasks/periodic_digest.py
@@ -75,7 +75,7 @@ def get_teams_with_new_playlists(end: datetime, begin: datetime) -> QuerySet:
 
 
 def get_teams_with_new_experiments_launched(end: datetime, begin: datetime) -> QuerySet:
-    return Experiment.objects.filter(start_date__gt=begin, start_date__lte=end).values(
+    return Experiment.objects.filter(start_date__gt=begin, start_date__lte=end, end_date__isnull=True).values(
         "team_id", "name", "id", "start_date"
     )
 

--- a/posthog/tasks/test/test_periodic_digest.py
+++ b/posthog/tasks/test/test_periodic_digest.py
@@ -116,8 +116,8 @@ class TestPeriodicDigestReport(APIBaseTest):
             completed_experiment = Experiment.objects.create(
                 team=self.team,
                 name="Completed Experiment",
-                start_date=now() + timedelta(days=1),
-                end_date=now() + timedelta(days=6),
+                start_date=now() + timedelta(days=6),
+                end_date=now() + timedelta(days=7),
                 feature_flag=flag_for_completed_experiment,
             )
 


### PR DESCRIPTION
## Problem

In the digest, if an experiment was both launched and completed in the period, it would show up in both lists, but we should only show it in the completed list.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Filters any experiments from the launched list if they have a completed at date within the period.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

N/A

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Updated test

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
