### PR TITLE
fix(periodic-digest): use derived names for playlists without real names

### DIFF
--- a/posthog/tasks/periodic_digest.py
+++ b/posthog/tasks/periodic_digest.py
@@ -69,9 +69,7 @@ def get_teams_with_new_playlists(end: datetime, begin: datetime) -> QuerySet:
     return SessionRecordingPlaylist.objects.filter(
         created_at__gt=begin,
         created_at__lte=end,
-        name__isnull=False,
-        name__gt="",  # Excludes empty strings
-    ).values("team_id", "name", "short_id")
+    ).values("team_id", "name", "short_id", "derived_name")
 
 
 def get_teams_with_new_experiments_launched(end: datetime, begin: datetime) -> QuerySet:
@@ -151,9 +149,8 @@ def get_periodic_digest_report(all_digest_data: dict[str, Any], team: Team) -> p
             for event_definition in all_digest_data["teams_with_new_event_definitions"].get(team.id, [])
         ],
         new_playlists=[
-            {"name": playlist.get("name"), "id": playlist.get("short_id")}
+            {"name": playlist.get("name") or playlist.get("derived_name", "Untitled"), "id": playlist.get("short_id")}
             for playlist in all_digest_data["teams_with_new_playlists"].get(team.id, [])
-            if playlist.get("name")  # Extra safety check to exclude any playlists without names
         ],
         new_experiments_launched=[
             {

--- a/posthog/tasks/periodic_digest.py
+++ b/posthog/tasks/periodic_digest.py
@@ -66,10 +66,21 @@ def get_teams_with_new_event_definitions(end: datetime, begin: datetime) -> Quer
 
 
 def get_teams_with_new_playlists(end: datetime, begin: datetime) -> QuerySet:
-    return SessionRecordingPlaylist.objects.filter(
-        created_at__gt=begin,
-        created_at__lte=end,
-    ).values("team_id", "name", "short_id", "derived_name")
+    return (
+        SessionRecordingPlaylist.objects.filter(
+            created_at__gt=begin,
+            created_at__lte=end,
+        )
+        .exclude(
+            name__isnull=True,
+            derived_name__isnull=True,
+        )
+        .exclude(
+            name="",
+            derived_name="",
+        )
+        .values("team_id", "name", "short_id", "derived_name")
+    )
 
 
 def get_teams_with_new_experiments_launched(end: datetime, begin: datetime) -> QuerySet:

--- a/posthog/tasks/test/test_periodic_digest.py
+++ b/posthog/tasks/test/test_periodic_digest.py
@@ -49,16 +49,17 @@ class TestPeriodicDigestReport(APIBaseTest):
                 team=self.team,
                 name="Test Playlist",
             )
-            # These should be included in the digest but use the derived name
-            derived_playlist = SessionRecordingPlaylist.objects.create(
+            # This should be excluded from the digest because it has no name and no derived name
+            SessionRecordingPlaylist.objects.create(
                 team=self.team,
                 name=None,
-                derived_name="Derived Playlist",
+                derived_name=None,
             )
-            derived_playlist_2 = SessionRecordingPlaylist.objects.create(
+            # This should be included in the digest but use the derived name
+            derived_playlist = SessionRecordingPlaylist.objects.create(
                 team=self.team,
                 name="",
-                derived_name="Derived Playlist 2",
+                derived_name="Derived Playlist",
             )
 
             # Create experiments
@@ -169,10 +170,6 @@ class TestPeriodicDigestReport(APIBaseTest):
                 {
                     "name": "Derived Playlist",
                     "id": derived_playlist.short_id,
-                },
-                {
-                    "name": "Derived Playlist 2",
-                    "id": derived_playlist_2.short_id,
                 },
             ],
             "new_experiments_launched": [

--- a/posthog/tasks/test/test_periodic_digest.py
+++ b/posthog/tasks/test/test_periodic_digest.py
@@ -49,14 +49,16 @@ class TestPeriodicDigestReport(APIBaseTest):
                 team=self.team,
                 name="Test Playlist",
             )
-            # These should be excluded from the digest
-            SessionRecordingPlaylist.objects.create(
+            # These should be included in the digest but use the derived name
+            derived_playlist = SessionRecordingPlaylist.objects.create(
                 team=self.team,
                 name=None,
+                derived_name="Derived Playlist",
             )
-            SessionRecordingPlaylist.objects.create(
+            derived_playlist_2 = SessionRecordingPlaylist.objects.create(
                 team=self.team,
                 name="",
+                derived_name="Derived Playlist 2",
             )
 
             # Create experiments
@@ -163,7 +165,15 @@ class TestPeriodicDigestReport(APIBaseTest):
                 {
                     "name": "Test Playlist",
                     "id": playlist.short_id,
-                }
+                },
+                {
+                    "name": "Derived Playlist",
+                    "id": derived_playlist.short_id,
+                },
+                {
+                    "name": "Derived Playlist 2",
+                    "id": derived_playlist_2.short_id,
+                },
             ],
             "new_experiments_launched": [
                 {
@@ -366,36 +376,3 @@ class TestPeriodicDigestReport(APIBaseTest):
         # Verify no capture call and no messaging record
         mock_capture.delay.assert_not_called()
         self.assertEqual(MessagingRecord.objects.count(), 0)
-
-    @freeze_time("2024-01-20T00:01:00Z")
-    @patch("posthog.tasks.periodic_digest.capture_report")
-    def test_periodic_digest_excludes_playlists_without_names(self, mock_capture: MagicMock) -> None:
-        # Create test data from "last week"
-        with freeze_time("2024-01-15T00:01:00Z"):
-            # Create playlists with various name states
-            valid_playlist = SessionRecordingPlaylist.objects.create(
-                team=self.team,
-                name="Valid Playlist",
-            )
-            SessionRecordingPlaylist.objects.create(
-                team=self.team,
-                name=None,  # Null name should be excluded
-            )
-            SessionRecordingPlaylist.objects.create(
-                team=self.team,
-                name="",  # Empty string name should be excluded
-            )
-
-        # Run the periodic digest report task
-        send_all_periodic_digest_reports()
-
-        # Extract the playlists from the capture call
-        call_args = mock_capture.delay.call_args
-        self.assertIsNotNone(call_args)
-        full_report_dict = call_args[1]["full_report_dict"]
-        playlists = full_report_dict["new_playlists"]
-
-        # Verify only the valid playlist is included
-        self.assertEqual(len(playlists), 1)
-        self.assertEqual(playlists[0]["name"], "Valid Playlist")
-        self.assertEqual(playlists[0]["id"], valid_playlist.short_id)


### PR DESCRIPTION
## Problem

I had excluded playlists without names, but didn't realize that many playlists use a derived name from the set filters.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

Only exclude if there is no name and no derived name. Otherwise, use the name first, then fall back to the derived name.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

N/A

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Updated test.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
