### PR TITLE
fix(batch-exports): Remove zero unicode from error message

### DIFF
--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -902,6 +902,14 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
         for key, value in dataclasses.asdict(inputs).items()
         if key not in not_model_params and value is not None
     }
+
+    latest_error = update_params.get("latest_error", None)
+    if latest_error is not None and isinstance(latest_error, str):
+        # NUL (\x00) bytes are not allowed in PostgreSQL, so we replace them from
+        # the free text field `latest_error`.
+        latest_error = latest_error.replace("\x00", "")
+        update_params["latest_error"] = latest_error
+
     batch_export_run = await database_sync_to_async(update_batch_export_run)(
         run_id=uuid.UUID(inputs.id),
         finished_at=dt.datetime.now(dt.UTC),

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -905,7 +905,7 @@ async def finish_batch_export_run(inputs: FinishBatchExportRunInputs) -> None:
 
     latest_error = update_params.get("latest_error", None)
     if latest_error is not None and isinstance(latest_error, str):
-        # NUL (\x00) bytes are not allowed in PostgreSQL, so we replace them from
+        # NUL (\x00) bytes are not allowed in PostgreSQL, so we replace them in
         # the free text field `latest_error`.
         latest_error = latest_error.replace("\x00", "")
         update_params["latest_error"] = latest_error

--- a/posthog/temporal/tests/batch_exports/test_run_updates.py
+++ b/posthog/temporal/tests/batch_exports/test_run_updates.py
@@ -245,7 +245,7 @@ async def test_finish_batch_export_run_handles_nul_bytes(activity_environment, t
     await activity_environment.run(finish_batch_export_run, finish_inputs)
 
     runs = BatchExportRun.objects.filter(id=run_id)
-    run = await sync_to_async(runs.first)()  # type:ignore
+    run = await sync_to_async(runs.first)()
     assert run is not None
     assert run.status == "Failed"
     assert run.latest_error == "Oh No a NUL byte: !"

--- a/posthog/temporal/tests/batch_exports/test_run_updates.py
+++ b/posthog/temporal/tests/batch_exports/test_run_updates.py
@@ -214,3 +214,38 @@ async def test_finish_batch_export_run_never_pauses_with_small_check_window(acti
     await sync_to_async(batch_export.refresh_from_db)()
 
     assert batch_export.paused is False
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_finish_batch_export_run_handles_nul_bytes(activity_environment, team, batch_export):
+    """Test if 'finish_batch_export_run' will not fail in the prescence of a NUL byte."""
+    start = dt.datetime(2023, 4, 24, tzinfo=dt.UTC)
+    end = dt.datetime(2023, 4, 25, tzinfo=dt.UTC)
+
+    inputs = StartBatchExportRunInputs(
+        team_id=team.id,
+        batch_export_id=str(batch_export.id),
+        data_interval_start=start.isoformat(),
+        data_interval_end=end.isoformat(),
+    )
+
+    batch_export_id = str(batch_export.id)
+
+    run_id = await activity_environment.run(start_batch_export_run, inputs)
+
+    finish_inputs = FinishBatchExportRunInputs(
+        id=str(run_id),
+        batch_export_id=batch_export_id,
+        status=BatchExportRun.Status.FAILED,
+        team_id=inputs.team_id,
+        latest_error="Oh No a NUL byte: \x00!",
+    )
+
+    await activity_environment.run(finish_batch_export_run, finish_inputs)
+
+    runs = BatchExportRun.objects.filter(id=run_id)
+    run = await sync_to_async(runs.first)()  # type:ignore
+    assert run is not None
+    assert run.status == "Failed"
+    assert run.latest_error == "Oh No a NUL byte: !"


### PR DESCRIPTION
## Problem

In a similar vein to #27179, we must also clean-up any null bytes from our own error messages. Error messages in general could use a revisit, but in the meantime, this will address any PostgreSQL errors.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Replace `\x00` byte from `latest_error` before updating batch export run.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Added a unit test that fails without this change.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
