### PR TITLE
chore: use setting to fallback to kill query on cluster

### DIFF
--- a/posthog/clickhouse/cancel.py
+++ b/posthog/clickhouse/cancel.py
@@ -1,5 +1,6 @@
 from statshog.defaults.django import statsd
 
+from posthog import settings
 from posthog.api.services.query import logger
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import default_client
@@ -32,7 +33,7 @@ def cancel_query_on_cluster(team_id: int, client_query_id: str) -> None:
                 sync_client=client,
             )
         logger.info("Cancelled query %s for team %s, result: %s", client_query_id, team_id, result)
-    else:
+    elif settings.CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER:
         logger.debug("No initiator host found for query %s, cancelling query on cluster", client_query_id)
         result = sync_execute(
             f"KILL QUERY ON CLUSTER '{CLICKHOUSE_CLUSTER}' WHERE query_id LIKE %(client_query_id)s",

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -155,6 +155,9 @@ CLICKHOUSE_SECURE: bool = get_from_env("CLICKHOUSE_SECURE", not TEST and not DEB
 CLICKHOUSE_VERIFY: bool = get_from_env("CLICKHOUSE_VERIFY", True, type_cast=str_to_bool)
 CLICKHOUSE_ENABLE_STORAGE_POLICY: bool = get_from_env("CLICKHOUSE_ENABLE_STORAGE_POLICY", False, type_cast=str_to_bool)
 CLICKHOUSE_SINGLE_SHARD_CLUSTER: str = os.getenv("CLICKHOUSE_SINGLE_SHARD_CLUSTER", "posthog_single_shard")
+CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER = get_from_env(
+    "CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER", default=True, type_cast=str_to_bool
+)
 
 CLICKHOUSE_CONN_POOL_MIN: int = get_from_env("CLICKHOUSE_CONN_POOL_MIN", 20, type_cast=int)
 CLICKHOUSE_CONN_POOL_MAX: int = get_from_env("CLICKHOUSE_CONN_POOL_MAX", 1000, type_cast=int)


### PR DESCRIPTION
## Problem

Even though we are killing queries on the initiator now, many times the `KILL QUERY ON CLUSTER` fallback path is still executed because the `query_id` does not exist in `system.processes` or even the id does not exist at all (not even in the `query_log`).

## Changes

The setting will allow us to monitor if performance is degraded (because maybe we are not killing as many queries as we should). But, if everything looks fine, we will remove the ON CLUSTER path.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Through the PostHog local app.
