### PR TITLE
fix(data-warehouse): Fix incremental salesforce jobs

### DIFF
--- a/posthog/temporal/data_imports/pipelines/salesforce/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/salesforce/__init__.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any, Optional
 import dlt
 from urllib.parse import urlencode
@@ -15,7 +16,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
         "User": {
             "name": "User",
             "table_name": "user",
-            **({"primary_key": "Id"} if is_incremental else {}),
+            "primary_key": "Id" if is_incremental else None,
             "write_disposition": {
                 "disposition": "merge",
                 "strategy": "upsert",
@@ -30,7 +31,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                         "type": "incremental",
                         "cursor_path": "SystemModstamp",
                         "initial_value": "2000-01-01T00:00:00.000+0000",
-                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM User WHERE SystemModstamp >= {date_str} ORDER BY Id ASC LIMIT 200",
+                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM User WHERE SystemModstamp >= {date_str.isoformat() if isinstance(date_str, datetime) else date_str} ORDER BY Id ASC LIMIT 200",
                     }
                     if is_incremental
                     else "SELECT FIELDS(ALL) FROM User ORDER BY Id ASC LIMIT 200",
@@ -41,7 +42,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
         "UserRole": {
             "name": "UserRole",
             "table_name": "user_role",
-            **({"primary_key": "Id"} if is_incremental else {}),
+            "primary_key": "Id" if is_incremental else None,
             "write_disposition": {
                 "disposition": "merge",
                 "strategy": "upsert",
@@ -56,7 +57,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                         "type": "incremental",
                         "cursor_path": "SystemModstamp",
                         "initial_value": "2000-01-01T00:00:00.000+0000",
-                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM UserRole WHERE SystemModstamp >= {date_str} ORDER BY Id ASC LIMIT 200",
+                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM UserRole WHERE SystemModstamp >= {date_str.isoformat() if isinstance(date_str, datetime) else date_str} ORDER BY Id ASC LIMIT 200",
                     }
                     if is_incremental
                     else "SELECT FIELDS(ALL) FROM UserRole ORDER BY Id ASC LIMIT 200",
@@ -67,7 +68,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
         "Lead": {
             "name": "Lead",
             "table_name": "lead",
-            **({"primary_key": "Id"} if is_incremental else {}),
+            "primary_key": "Id" if is_incremental else None,
             "write_disposition": {
                 "disposition": "merge",
                 "strategy": "upsert",
@@ -82,7 +83,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                         "type": "incremental",
                         "cursor_path": "SystemModstamp",
                         "initial_value": "2000-01-01T00:00:00.000+0000",
-                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Lead WHERE SystemModstamp >= {date_str} ORDER BY Id ASC LIMIT 200",
+                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Lead WHERE SystemModstamp >= {date_str.isoformat() if isinstance(date_str, datetime) else date_str} ORDER BY Id ASC LIMIT 200",
                     }
                     if is_incremental
                     else "SELECT FIELDS(ALL) FROM Lead ORDER BY Id ASC LIMIT 200",
@@ -93,7 +94,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
         "Contact": {
             "name": "Contact",
             "table_name": "contact",
-            **({"primary_key": "Id"} if is_incremental else {}),
+            "primary_key": "Id" if is_incremental else None,
             "write_disposition": {
                 "disposition": "merge",
                 "strategy": "upsert",
@@ -108,7 +109,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                         "type": "incremental",
                         "cursor_path": "SystemModstamp",
                         "initial_value": "2000-01-01T00:00:00.000+0000",
-                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Contact WHERE SystemModstamp >= {date_str} ORDER BY Id ASC LIMIT 200",
+                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Contact WHERE SystemModstamp >= {date_str.isoformat() if isinstance(date_str, datetime) else date_str} ORDER BY Id ASC LIMIT 200",
                     }
                     if is_incremental
                     else "SELECT FIELDS(ALL) FROM Contact ORDER BY Id ASC LIMIT 200",
@@ -119,7 +120,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
         "Campaign": {
             "name": "Campaign",
             "table_name": "campaign",
-            **({"primary_key": "Id"} if is_incremental else {}),
+            "primary_key": "Id" if is_incremental else None,
             "write_disposition": {
                 "disposition": "merge",
                 "strategy": "upsert",
@@ -134,7 +135,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                         "type": "incremental",
                         "cursor_path": "SystemModstamp",
                         "initial_value": "2000-01-01T00:00:00.000+0000",
-                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Campaign WHERE SystemModstamp >= {date_str} ORDER BY Id ASC LIMIT 200",
+                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Campaign WHERE SystemModstamp >= {date_str.isoformat() if isinstance(date_str, datetime) else date_str} ORDER BY Id ASC LIMIT 200",
                     }
                     if is_incremental
                     else "SELECT FIELDS(ALL) FROM Campaign ORDER BY Id ASC LIMIT 200",
@@ -145,7 +146,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
         "Product2": {
             "name": "Product2",
             "table_name": "product2",
-            **({"primary_key": "Id"} if is_incremental else {}),
+            "primary_key": "Id" if is_incremental else None,
             "write_disposition": {
                 "disposition": "merge",
                 "strategy": "upsert",
@@ -160,7 +161,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                         "type": "incremental",
                         "cursor_path": "SystemModstamp",
                         "initial_value": "2000-01-01T00:00:00.000+0000",
-                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Product2 WHERE SystemModstamp >= {date_str} ORDER BY Id ASC LIMIT 200",
+                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Product2 WHERE SystemModstamp >= {date_str.isoformat() if isinstance(date_str, datetime) else date_str} ORDER BY Id ASC LIMIT 200",
                     }
                     if is_incremental
                     else "SELECT FIELDS(ALL) FROM Product2 ORDER BY Id ASC LIMIT 200",
@@ -171,7 +172,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
         "Pricebook2": {
             "name": "Pricebook2",
             "table_name": "pricebook2",
-            **({"primary_key": "Id"} if is_incremental else {}),
+            "primary_key": "Id" if is_incremental else None,
             "write_disposition": {
                 "disposition": "merge",
                 "strategy": "upsert",
@@ -186,7 +187,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                         "type": "incremental",
                         "cursor_path": "SystemModstamp",
                         "initial_value": "2000-01-01T00:00:00.000+0000",
-                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Pricebook2 WHERE SystemModstamp >= {date_str} ORDER BY Id ASC LIMIT 200",
+                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Pricebook2 WHERE SystemModstamp >= {date_str.isoformat() if isinstance(date_str, datetime) else date_str} ORDER BY Id ASC LIMIT 200",
                     }
                     if is_incremental
                     else "SELECT FIELDS(ALL) FROM Pricebook2 ORDER BY Id ASC LIMIT 200",
@@ -197,7 +198,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
         "PricebookEntry": {
             "name": "PricebookEntry",
             "table_name": "pricebook_entry",
-            **({"primary_key": "Id"} if is_incremental else {}),
+            "primary_key": "Id" if is_incremental else None,
             "write_disposition": {
                 "disposition": "merge",
                 "strategy": "upsert",
@@ -212,7 +213,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                         "type": "incremental",
                         "cursor_path": "SystemModstamp",
                         "initial_value": "2000-01-01T00:00:00.000+0000",
-                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM PricebookEntry WHERE SystemModstamp >= {date_str} ORDER BY Id ASC LIMIT 200",
+                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM PricebookEntry WHERE SystemModstamp >= {date_str.isoformat() if isinstance(date_str, datetime) else date_str} ORDER BY Id ASC LIMIT 200",
                     }
                     if is_incremental
                     else "SELECT FIELDS(ALL) FROM PricebookEntry ORDER BY Id ASC LIMIT 200",
@@ -223,7 +224,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
         "Order": {
             "name": "Order",
             "table_name": "order",
-            **({"primary_key": "Id"} if is_incremental else {}),
+            "primary_key": "Id" if is_incremental else None,
             "write_disposition": {
                 "disposition": "merge",
                 "strategy": "upsert",
@@ -238,7 +239,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                         "type": "incremental",
                         "cursor_path": "SystemModstamp",
                         "initial_value": "2000-01-01T00:00:00.000+0000",
-                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Order WHERE SystemModstamp >= {date_str} ORDER BY Id ASC LIMIT 200",
+                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Order WHERE SystemModstamp >= {date_str.isoformat() if isinstance(date_str, datetime) else date_str} ORDER BY Id ASC LIMIT 200",
                     }
                     if is_incremental
                     else "SELECT FIELDS(ALL) FROM Order ORDER BY Id ASC LIMIT 200",
@@ -249,7 +250,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
         "Opportunity": {
             "name": "Opportunity",
             "table_name": "opportunity",
-            **({"primary_key": "Id"} if is_incremental else {}),
+            "primary_key": "Id" if is_incremental else None,
             "write_disposition": {
                 "disposition": "merge",
                 "strategy": "upsert",
@@ -264,7 +265,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                         "type": "incremental",
                         "cursor_path": "SystemModstamp",
                         "initial_value": "2000-01-01T00:00:00.000+0000",
-                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Opportunity WHERE SystemModstamp >= {date_str} ORDER BY Id ASC LIMIT 200",
+                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Opportunity WHERE SystemModstamp >= {date_str.isoformat() if isinstance(date_str, datetime) else date_str} ORDER BY Id ASC LIMIT 200",
                     }
                     if is_incremental
                     else "SELECT FIELDS(ALL) FROM Opportunity ORDER BY Id ASC LIMIT 200",
@@ -275,7 +276,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
         "Account": {
             "name": "Account",
             "table_name": "account",
-            **({"primary_key": "Id"} if is_incremental else {}),
+            "primary_key": "Id" if is_incremental else None,
             "write_disposition": {
                 "disposition": "merge",
                 "strategy": "upsert",
@@ -290,7 +291,7 @@ def get_resource(name: str, is_incremental: bool) -> EndpointResource:
                         "type": "incremental",
                         "cursor_path": "SystemModstamp",
                         "initial_value": "2000-01-01T00:00:00.000+0000",
-                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Account WHERE SystemModstamp >= {date_str} ORDER BY Id ASC LIMIT 200",
+                        "convert": lambda date_str: f"SELECT FIELDS(ALL) FROM Account WHERE SystemModstamp >= {date_str.isoformat() if isinstance(date_str, datetime) else date_str} ORDER BY Id ASC LIMIT 200",
                     }
                     if is_incremental
                     else "SELECT FIELDS(ALL) FROM Account ORDER BY Id ASC LIMIT 200",
@@ -330,7 +331,7 @@ class SalesforceEndpointPaginator(BasePaginator):
         if self.is_incremental:
             # Cludge: Need to get initial value for date filter
             query = request.params.get("q", "")
-            date_match = re.search(r"SystemModstamp >= (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+\d{4})", query)
+            date_match = re.search(r"SystemModstamp >= (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.+?)\s", query)
             if date_match:
                 date_filter = date_match.group(1)
                 query = f"SELECT FIELDS(ALL) FROM {self._model_name} WHERE Id > '{self._last_record_id}' AND SystemModstamp >= {date_filter} ORDER BY Id ASC LIMIT 200"
@@ -361,7 +362,7 @@ def salesforce_source(
             "paginator": SalesforceEndpointPaginator(instance_url=instance_url, is_incremental=is_incremental),
         },
         "resource_defaults": {
-            **({"primary_key": "id"} if is_incremental else {}),
+            "primary_key": "id" if is_incremental else None,
         },
         "resources": [get_resource(endpoint, is_incremental)],
     }


### PR DESCRIPTION
## Problem
- 85% of the salesforce jobs stopped working on Dec 20th (incremental jobs only)
- This is because we now interpret incremental values as their actual types and not just as strings everywhere
  - Introduced when we started to read the incremental value from our DB instead of DLT S3

## Changes
- Cater for both the `string` and `datetime` version of the incremental value when requesting salesforce API endpoints
- Updated the regex to match the timestamp in the query to support more variants (see screenshot)

<img width="732" alt="image" src="https://github.com/user-attachments/assets/12275d02-baf1-4ddc-95e6-a23efe7c25ab" />


## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested a bunch locally 