### PR TITLE
chore(data-warehouse): Manually handle garbage collection of large objects

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -507,7 +507,9 @@ def _run(
     reset_pipeline: bool,
 ):
     if settings.TEMPORAL_TASK_QUEUE == DATA_WAREHOUSE_TASK_QUEUE_V2:
-        PipelineNonDLT(source, logger, job_inputs.run_id, schema.is_incremental).run()
+        pipeline = PipelineNonDLT(source, logger, job_inputs.run_id, schema.is_incremental)
+        pipeline.run()
+        del pipeline
     else:
         table_row_counts = DataImportPipelineSync(
             job_inputs, source, logger, reset_pipeline, schema.is_incremental


### PR DESCRIPTION
## Problem
- It looks like garbage collection isn't always cleaning up large data objects, there must be some reference to them somewhere still

## Changes
- Manually delete references to large objects and call `gc.collect()` manually
- A bit of a test to see if this will help with the memory load on the workers