### PR TITLE
feat(trends): use hogql for legacy insight trends api (based on flag)

### DIFF
--- a/posthog/hogql_queries/legacy_compatibility/feature_flag.py
+++ b/posthog/hogql_queries/legacy_compatibility/feature_flag.py
@@ -63,3 +63,28 @@ def insight_funnels_use_udf_trends(team: Team) -> bool:
         only_evaluate_locally=False,
         send_feature_flag_events=False,
     )
+
+
+def insight_api_use_hogql(team: Team) -> bool:
+    """
+    Feature flag to enable calculation based on HogQL query runners for the
+    legacy insight api endpoints.
+    """
+    return posthoganalytics.feature_enabled(
+        "insight-api-use-hogql",
+        str(team.uuid),
+        groups={
+            "organization": str(team.organization_id),
+            "project": str(team.id),
+        },
+        group_properties={
+            "organization": {
+                "id": str(team.organization_id),
+            },
+            "project": {
+                "id": str(team.id),
+            },
+        },
+        only_evaluate_locally=True,
+        send_feature_flag_events=False,
+    )


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

- [ ] add a test
- [ ] add a pagination test
- [ ] add a stickiness test
- [ ] add a csv test
- [ ] use_hogql should be a filter, so that responses are cached separately

## How did you test this code?

http://localhost:8000/api/projects/1/insights/trend
http://localhost:8000/api/projects/1/insights/trend?hogql=1

```json
{
  "events": [
    {
      "id": "$pageview",
      "math": "total",
      "type": "events",
      "order": 0
    }
  ],
  "date_from": "-4w",
  "interval": "month"
}
```

- Ran `pytest posthog/api/test/test_insight.py` while overriding `use_hogql=True`
- Ran `pytest posthog/api/test/test_stickiness.py` while overriding `use_hogql=True`