### PR TITLE
refactor(insights): capture calls to legacy insight calculation endpoints

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -183,7 +183,7 @@ def capture_legacy_api_call(request: request.Request, team: Team):
         "was_impersonated": is_impersonated_session(request),
     }
 
-    posthoganalytics.capture(distinct_id, event, properties, groups=(groups(team.organization, team.pk)))
+    posthoganalytics.capture(distinct_id, event, properties, groups=(groups(team.organization, team)))
 
 
 class QuerySchemaParser(JSONParser):

--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -89,6 +89,7 @@ from posthog.models.dashboard import Dashboard
 from posthog.models.filters import RetentionFilter
 from posthog.models.filters.path_filter import PathFilter
 from posthog.models.filters.stickiness_filter import StickinessFilter
+from posthog.models.filters.utils import get_filter
 from posthog.models.insight import InsightViewed
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
@@ -169,6 +170,20 @@ def log_and_report_insight_activity(
                 {"insight_id": insight_short_id, **properties},
                 groups=(groups(organization, team) if team_id else groups(organization)),
             )
+
+
+def capture_legacy_api_call(request: request.Request, team: Team):
+    event = "legacy insight endpoint called"
+    distinct_id: str = request.user.distinct_id  # type: ignore
+    properties = {
+        "path": request._request.path,
+        "method": request._request.method,
+        "use_hogql": False,
+        "filter": get_filter(request=request, team=team),
+        "was_impersonated": is_impersonated_session(request),
+    }
+
+    posthoganalytics.capture(distinct_id, event, properties, groups=(groups(team.organization, team.pk)))
 
 
 class QuerySchemaParser(JSONParser):
@@ -969,6 +984,8 @@ When set, the specified dashboard's filters and date range override will be appl
     )
     @action(methods=["GET", "POST"], detail=False, required_scopes=["insight:read"])
     def trend(self, request: request.Request, *args: Any, **kwargs: Any):
+        capture_legacy_api_call(request, self.team)
+
         timings = HogQLTimings()
         try:
             with timings.measure("calculate"):
@@ -1055,6 +1072,8 @@ When set, the specified dashboard's filters and date range override will be appl
     )
     @action(methods=["GET", "POST"], detail=False, required_scopes=["insight:read"])
     def funnel(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
+        capture_legacy_api_call(request, self.team)
+
         timings = HogQLTimings()
         try:
             with timings.measure("calculate"):
@@ -1097,6 +1116,8 @@ When set, the specified dashboard's filters and date range override will be appl
     # ******************************************
     @action(methods=["GET", "POST"], detail=False, required_scopes=["insight:read"])
     def retention(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
+        capture_legacy_api_call(request, self.team)
+
         timings = HogQLTimings()
         try:
             with timings.measure("calculate"):
@@ -1127,6 +1148,8 @@ When set, the specified dashboard's filters and date range override will be appl
     # ******************************************
     @action(methods=["GET", "POST"], detail=False, required_scopes=["insight:read"])
     def path(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
+        capture_legacy_api_call(request, self.team)
+
         timings = HogQLTimings()
         try:
             with timings.measure("calculate"):


### PR DESCRIPTION
## Problem

We want to use HogQL queries for computing the legacy insight API endpoints. We use `/query` everywhere in our codebase, but the endpoints can still be called by customers.

## Changes

Adds tracking to legacy API endcalls.

## How did you test this code?

<img width="1590" alt="Screenshot 2025-01-02 at 09 58 21" src="https://github.com/user-attachments/assets/cb5d634b-8cb5-480d-b84c-f92914702ea1" />