### PR TITLE
chore: Make FeatureNotSupported non-retryable in pg batch export

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -719,6 +719,9 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
                 "PostgreSQLConnectionError",
                 # Raised when merging without a primary key.
                 "MissingPrimaryKeyError",
+                # Raised when the database doesn't support a particular feature we use.
+                # Generally, we have seen this when the database is read-only.
+                "FeatureNotSupported",
             ],
             finish_inputs=finish_inputs,
         )


### PR DESCRIPTION
## Problem

`FeatureNotSupported` exception is retryable, when it shouldn't be. We have seen this fire off when we can't set a transaction to read-write, likely because the database is read-only.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Make `FeatureNotSupported` non-retryable.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
