### PR TITLE
fix(data-warehouse): Clear the delta lake table cache after a pipeline has run

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -100,8 +100,14 @@ class PipelineNonDLT:
             self._post_run_operations(row_count=row_count)
         finally:
             # Help reduce the memory footprint of each job
+            delta_table = self._delta_table_helper.get_delta_table()
+            self._delta_table_helper.get_delta_table.cache_clear()
+            if delta_table:
+                del delta_table
+
             del self._resource
             del self._delta_table_helper
+
             if "buffer" in locals() and buffer is not None:
                 del buffer
             if "py_table" in locals() and py_table is not None:


### PR DESCRIPTION
## Problem
- The new workers are still holding onto memory for _some_ reason, after checking the logs and memory charts I've deduced that we're not releasing the actual `deltalake.DeltaTable` object after the pipeline has ran until the next pipelines run has downloaded their table. This can cause a OOM if both tables are fairly large
  - another side problem is that creating a `deltalake.DeltaTable` object and running the `optimize.compaction()` func loads a lot of the delta table data into memory

**Memory spike:**
<img width="1238" alt="image" src="https://github.com/user-attachments/assets/792abfcb-4136-48b2-ba4a-f476924039d7" />

**Logs from the same time period:**
<img width="2436" alt="image" src="https://github.com/user-attachments/assets/b084f3cb-5d05-4233-a457-8a7026bdfcae" />


## Changes
- Clear the delta table cache after finishing the pipeline run

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Runs locally 