### PR TITLE
fix(data-warehouse): Stringify UUID fields in pyarrows

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -118,6 +118,9 @@ def _convert_uuid_to_string(table_data: list[Any]) -> list[dict]:
 
 def table_from_py_list(table_data: list[Any]) -> pa.Table:
     try:
+        if len(table_data) == 0:
+            return pa.Table.from_pylist(table_data)
+
         uuid_exists = any(isinstance(value, uuid.UUID) for value in table_data[0].values())
         if uuid_exists:
             return pa.Table.from_pylist(_convert_uuid_to_string(table_data))

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -1081,3 +1081,16 @@ async def test_inconsistent_types_in_data(team, stripe_balance_transaction):
             {"id": "txn_1MiN3gLkdIwHu7ixxapQrznl", "type": ["transfer", "another_value"]},
         ],
     )
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_postgres_uuid_type(team, postgres_config, postgres_connection):
+    await _run(
+        team=team,
+        schema_name="BalanceTransaction",
+        table_name="stripe_balancetransaction",
+        source_type="Stripe",
+        job_inputs={"stripe_secret_key": "test-key", "stripe_account_id": "acct_id"},
+        mock_data_response=[{"id": uuid.uuid4()}],
+    )


### PR DESCRIPTION
## Problem
- Pyarrows dont understand the python `UUID` type

## Changes
- Stringify uuids 

## Does this work well for both Cloud and self-hosted?
Yup

## How did you test this code?
Added a test