### PR TITLE
fix(data-warehouse): Dont throw when updating incremental value with an empty table

### DIFF
--- a/mypy-baseline.txt
+++ b/mypy-baseline.txt
@@ -146,8 +146,6 @@ posthog/hogql_queries/legacy_compatibility/filter_to_query.py:0: error: Dict ent
 posthog/hogql_queries/legacy_compatibility/filter_to_query.py:0: error: Dict entry 0 has incompatible type "str": "PathsFilter"; expected "str": "TrendsFilter"  [dict-item]
 posthog/hogql_queries/legacy_compatibility/filter_to_query.py:0: error: Dict entry 0 has incompatible type "str": "LifecycleFilter"; expected "str": "TrendsFilter"  [dict-item]
 posthog/hogql_queries/legacy_compatibility/filter_to_query.py:0: error: Dict entry 0 has incompatible type "str": "StickinessFilter"; expected "str": "TrendsFilter"  [dict-item]
-posthog/warehouse/models/external_data_schema.py:0: error: Incompatible types in assignment (expression has type "str", variable has type "int | float")  [assignment]
-posthog/warehouse/models/external_data_schema.py:0: error: Incompatible types in assignment (expression has type "str", variable has type "int | float")  [assignment]
 posthog/session_recordings/models/session_recording.py:0: error: Argument "distinct_id" to "MissingPerson" has incompatible type "str | None"; expected "str"  [arg-type]
 posthog/session_recordings/models/session_recording.py:0: error: Incompatible type for lookup 'persondistinctid__team_id': (got "Team", expected "str | int")  [misc]
 posthog/models/hog_functions/hog_function.py:0: error: Argument 1 to "get" of "dict" has incompatible type "str | None"; expected "str"  [arg-type]

--- a/posthog/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_sync.py
@@ -445,6 +445,12 @@ def save_last_incremental_value(schema_id: str, team_id: str, source: DltSource,
 
     logger.debug(f"Updating incremental_field_last_value with {last_value}")
 
+    if last_value is None:
+        logger.debug(
+            f"Incremental value is None. This could mean the table has zero rows. Full incremental object: {incremental_object}"
+        )
+        return
+
     schema.update_incremental_field_last_value(last_value)
 
 

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -77,6 +77,10 @@ class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
         incremental_field_type = self.sync_type_config.get("incremental_field_type")
 
         last_value_py = last_value.item() if isinstance(last_value, numpy.generic) else last_value
+        last_value_json: Any
+
+        if last_value_py is None:
+            return
 
         if (
             incremental_field_type == IncrementalFieldType.Integer
@@ -85,9 +89,17 @@ class ExternalDataSchema(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
             if isinstance(last_value_py, int | float):
                 last_value_json = last_value_py
             elif isinstance(last_value_py, datetime):
-                last_value_json = str(last_value_py)
+                last_value_json = last_value_py.isoformat()
             else:
                 last_value_json = int(last_value_py)
+        elif (
+            incremental_field_type == IncrementalFieldType.DateTime
+            or incremental_field_type == IncrementalFieldType.Timestamp
+        ):
+            if isinstance(last_value_py, datetime):
+                last_value_json = last_value_py.isoformat()
+            else:
+                last_value_json = str(last_value_py)
         else:
             last_value_json = str(last_value_py)
 


### PR DESCRIPTION
## Problem
- If you're trying to sync an empty table as an incremental table, then we get no `last incremental value` back, and thus an error is raised cos this is unhandled

## Changes
- handle the case when the incremental value is `None` - we just don't update the DB
- Also updated how we store datetime incremental values - use the proper ISO format and not just `str(...)` the `datetime`

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Tested locally