### PR TITLE
fix: toolbar toast theming by adding is isDarkModeOn logic

### DIFF
--- a/frontend/src/toolbar/ToolbarApp.tsx
+++ b/frontend/src/toolbar/ToolbarApp.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from 'react'
 import root from 'react-shadow'
 import { Slide, ToastContainer } from 'react-toastify'
 
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 import { ToolbarContainer } from '~/toolbar/ToolbarContainer'
 import { ToolbarProps } from '~/types'
@@ -14,7 +15,7 @@ type HTMLElementWithShadowRoot = HTMLElement & { shadowRoot: ShadowRoot }
 
 export function ToolbarApp(props: ToolbarProps = {}): JSX.Element {
     const { apiURL } = useValues(toolbarConfigLogic(props))
-
+    const { isDarkModeOn } = useValues(themeLogic)
     const shadowRef = useRef<HTMLElementWithShadowRoot | null>(null)
     const [didLoadStyles, setDidLoadStyles] = useState(false)
 
@@ -61,6 +62,7 @@ export function ToolbarApp(props: ToolbarProps = {}): JSX.Element {
                     closeOnClick={false}
                     draggable={false}
                     position="bottom-center"
+                    theme={isDarkModeOn ? 'dark' : 'light'}
                 />
             </root.div>
         </>


### PR DESCRIPTION
## Problem

Toasts which are launched from the toolbar were not adhering to the light/dark theme of the toolbar/app.

## Changes
Before:
<img width="502" alt="image" src="https://github.com/user-attachments/assets/2fa3ea4e-2cbd-4edb-bcc6-8c26b3c58449" />

After:
<img width="519" alt="image" src="https://github.com/user-attachments/assets/028db5ae-8812-4824-bdb8-f025d1d1a333" />

## Does this work well for both Cloud and self-hosted?
N/A

## How did you test this code?
Launching the toolbar in different apps, switching themes inside toolbar etc