### PR TITLE
fix(data-warehouse): Ensure we dont try to downscale an existing delta table decimal column

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -1,22 +1,27 @@
 from collections.abc import Sequence
 from conditional_cache import lru_cache
 from typing import Any
+import deltalake.exceptions
 import pyarrow as pa
 from dlt.common.libs.deltalake import ensure_delta_compatible_arrow_schema
 from dlt.common.normalizers.naming.snake_case import NamingConvention
 import deltalake as deltalake
 from django.conf import settings
+from sentry_sdk import capture_exception
 from posthog.settings.base_variables import TEST
+from posthog.temporal.common.logger import FilteringBoundLogger
 from posthog.warehouse.models import ExternalDataJob
 
 
 class DeltaTableHelper:
     _resource_name: str
     _job: ExternalDataJob
+    _logger: FilteringBoundLogger
 
-    def __init__(self, resource_name: str, job: ExternalDataJob) -> None:
+    def __init__(self, resource_name: str, job: ExternalDataJob, logger: FilteringBoundLogger) -> None:
         self._resource_name = resource_name
         self._job = job
+        self._logger = logger
 
     def _get_credentials(self):
         if TEST:
@@ -100,15 +105,27 @@ class DeltaTableHelper:
                 delta_table = deltalake.DeltaTable.create(
                     table_uri=self._get_delta_table_uri(), schema=data.schema, storage_options=storage_options
                 )
+            try:
+                deltalake.write_deltalake(
+                    table_or_uri=delta_table,
+                    data=data,
+                    partition_by=None,
+                    mode=mode,
+                    schema_mode=schema_mode,
+                    engine="rust",
+                )  # type: ignore
+            except deltalake.exceptions.SchemaMismatchError as e:
+                self._logger.debug("SchemaMismatchError: attempting to overwrite schema instead", exc_info=e)
+                capture_exception(e)
 
-            deltalake.write_deltalake(
-                table_or_uri=delta_table,
-                data=data,
-                partition_by=None,
-                mode=mode,
-                schema_mode=schema_mode,
-                engine="rust",
-            )  # type: ignore
+                deltalake.write_deltalake(
+                    table_or_uri=delta_table,
+                    data=data,
+                    partition_by=None,
+                    mode=mode,
+                    schema_mode="overwrite",
+                    engine="rust",
+                )  # type: ignore
 
         delta_table = self.get_delta_table()
         assert delta_table is not None

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -47,7 +47,7 @@ class PipelineNonDLT:
         assert schema is not None
         self._schema = schema
 
-        self._delta_table_helper = DeltaTableHelper(resource_name, self._job)
+        self._delta_table_helper = DeltaTableHelper(resource_name, self._job, self._logger)
         self._internal_schema = HogQLSchema()
 
     def run(self):

--- a/posthog/temporal/data_imports/pipelines/sql_database_v2/__init__.py
+++ b/posthog/temporal/data_imports/pipelines/sql_database_v2/__init__.py
@@ -124,6 +124,7 @@ def sql_source_for_type(
         db_incremental_field_last_value=db_incremental_field_last_value,
         team_id=team_id,
         connect_args=connect_args,
+        chunk_size=DEFAULT_CHUNK_SIZE,
     )
 
     return db_source
@@ -198,6 +199,7 @@ def snowflake_source(
         table_names=table_names,
         incremental=incremental,
         db_incremental_field_last_value=db_incremental_field_last_value,
+        chunk_size=DEFAULT_CHUNK_SIZE,
     )
 
     return db_source
@@ -243,6 +245,7 @@ def bigquery_source(
         table_names=[table_name],
         incremental=incremental,
         db_incremental_field_last_value=db_incremental_field_last_value,
+        chunk_size=DEFAULT_CHUNK_SIZE,
     )
 
 


### PR DESCRIPTION
## Problem
- Attempting to fix this error: https://posthog.sentry.io/issues/6188668833/events/5a59d8452897495abbd271b2a39c3f52/
- Trying to down scale a decimal in delta causes an error to be thrown

## Changes
- Ensure we don't try to downscale a decimal128 value when writing to the delta table

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
Added a test 