### PR TITLE
fix(data-warehouse): Fix for decimal overflow tables

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -164,7 +164,11 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
             ExternalDataSource.Type.MYSQL,
             ExternalDataSource.Type.MSSQL,
         ]:
-            if is_posthog_team(inputs.team_id) or is_enabled_for_team(inputs.team_id):
+            if (
+                is_posthog_team(inputs.team_id)
+                or is_enabled_for_team(inputs.team_id)
+                or settings.TEMPORAL_TASK_QUEUE == DATA_WAREHOUSE_TASK_QUEUE_V2
+            ):
                 from posthog.temporal.data_imports.pipelines.sql_database_v2 import sql_source_for_type
             else:
                 from posthog.temporal.data_imports.pipelines.sql_database import sql_source_for_type


### PR DESCRIPTION
## Problem
- [sentry issue](https://posthog.sentry.io/issues/6188954725/?project=4508444747956225&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20%22parse%20decimal%22&referrer=issue-stream&statsPeriod=14d&stream_index=0)
- Because we're loading in data via the V1 SQL source, it passes data into the new pipeline as python objects and it looks like the schema and data has gotten into a weird state. It's set the schema of the table to have `decimal(scale=1, precision=1)`, meaning the value of `12.0` is causing the table to throw an error. Because of this, we can't init the `DeltaTable` object - very odd, but I'm hoping this change helps - will monitor Sentry for the error going forward

## Changes
- Release the V2 SQL source for all jobs on the new workers
- A temp hack to delete the existing bugged tables
  - This doesn't affect any prod data, only the V2 delta table will get deleted

**Todo tomorrow in another PR:**
- Test and set defaults when parsing decimal values, ensuring they're not too small so that this problem doesn't occur
