### PR TITLE
fix(insights): fix shared insights with color themes

### DIFF
--- a/posthog/api/data_color_theme.py
+++ b/posthog/api/data_color_theme.py
@@ -23,8 +23,8 @@ class GlobalThemePermission(BasePermission):
 class PublicDataColorThemeSerializer(serializers.ModelSerializer):
     class Meta:
         model = DataColorTheme
-        fields = ["id", "name", "colors"]
-        read_only_fields = ["id", "name", "colors"]
+        fields = ["id", "name", "colors", "is_global"]
+        read_only_fields = ["id", "name", "colors", "is_global"]
 
 
 class DataColorThemeSerializer(PublicDataColorThemeSerializer):


### PR DESCRIPTION
## Problem

The default theme can't be determined on shared insights as `is_global` isn't available

## Changes

Adds it

## How did you test this code?

Tried locally