### PR TITLE
fix(data-warehouse): Trim whitespace in job inputs

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -51,6 +51,21 @@ def process_incremental_last_value(value: Any | None, field_type: IncrementalFie
         return parser.parse(value).date()
 
 
+def _trim_source_job_inputs(source: ExternalDataSource) -> None:
+    if not source.job_inputs:
+        return
+
+    did_update_inputs = False
+    for key, value in source.job_inputs.items():
+        if isinstance(value, str):
+            if value.startswith(" ") or value.endswith(" "):
+                source.job_inputs[key] = value.strip()
+                did_update_inputs = True
+
+    if did_update_inputs:
+        source.save()
+
+
 @activity.defn
 def import_data_activity_sync(inputs: ImportDataActivityInputs):
     logger = bind_temporal_worker_logger_sync(team_id=inputs.team_id)
@@ -72,6 +87,8 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
             job_type=ExternalDataSource.Type(model.pipeline.source_type),
             dataset_name=model.folder_path(),
         )
+
+        _trim_source_job_inputs(model.pipeline)
 
         reset_pipeline = model.pipeline.job_inputs.get("reset_pipeline", "False") == "True"
 
@@ -526,4 +543,5 @@ def _run(
 
     source = ExternalDataSource.objects.get(id=inputs.source_id)
     source.job_inputs.pop("reset_pipeline", None)
+
     source.save()

--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -299,6 +299,13 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 data={"message": "Monthly sync limit reached. Please increase your billing limit to resume syncing."},
             )
 
+        # Strip leading and trailing whitespace
+        payload = request.data["payload"]
+        if payload is not None:
+            for key, value in payload.items():
+                if isinstance(value, str):
+                    payload[key] = value.strip()
+
         # TODO: remove dummy vars
         if source_type == ExternalDataSource.Type.STRIPE:
             new_source_model = self._handle_stripe_source(request, *args, **kwargs)


### PR DESCRIPTION
## Problem
- Some values in source job_inputs have accidental whitespace, leading to API errors like [this](https://posthog.sentry.io/issues/6188782449/?project=4508444747956225&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=5)

## Changes
- Trim whitespace both when creating a source and when running the pipeline

## Does this work well for both Cloud and self-hosted?
Yup

## How did you test this code?
Unit tests