### PR TITLE
feat(cache-warming): enable teams under feature flag

### DIFF
--- a/posthog/caching/test/test_warming.py
+++ b/posthog/caching/test/test_warming.py
@@ -1,4 +1,4 @@
-from posthog.caching.warming import priority_insights, schedule_warming_for_teams_task
+from posthog.caching.warming import insights_to_cache, schedule_warming_for_teams_task
 from posthog.models import Insight, DashboardTile, InsightViewed, Dashboard
 
 from datetime import datetime, timedelta, UTC
@@ -48,7 +48,7 @@ class TestWarming(APIBaseTest):
     @patch("posthog.hogql_queries.query_cache.QueryCacheManager.get_stale_insights")
     def test_priority_insights_no_stale_insights(self, mock_get_stale_insights):
         mock_get_stale_insights.return_value = []
-        insights = list(priority_insights(self.team))
+        insights = list(insights_to_cache(self.team))
         self.assertEqual(insights, [])
 
     @patch("posthog.hogql_queries.query_cache.QueryCacheManager.get_stale_insights")
@@ -56,7 +56,7 @@ class TestWarming(APIBaseTest):
         mock_get_stale_insights.return_value = [
             "2345:",
         ]
-        insights = list(priority_insights(self.team))
+        insights = list(insights_to_cache(self.team))
         exptected_results = [
             (2345, None),
         ]
@@ -68,7 +68,7 @@ class TestWarming(APIBaseTest):
             "1234:5678",
             "3456:7890",
         ]
-        insights = list(priority_insights(self.team))
+        insights = list(insights_to_cache(self.team))
         expected_results = [
             (3456, 7890),
         ]
@@ -82,7 +82,7 @@ class TestWarming(APIBaseTest):
             "3456:7890",
             "8888:7777",
         ]
-        insights = list(priority_insights(self.team))
+        insights = list(insights_to_cache(self.team))
         expected_results = [
             (3456, 7890),
         ]
@@ -91,13 +91,13 @@ class TestWarming(APIBaseTest):
     @patch("posthog.hogql_queries.query_cache.QueryCacheManager.get_stale_insights")
     def test_priority_insights_insights_not_viewed_recently(self, mock_get_stale_insights):
         mock_get_stale_insights.return_value = ["4567:"]
-        insights = list(priority_insights(self.team))
+        insights = list(insights_to_cache(self.team))
         self.assertEqual(insights, [])
 
     @patch("posthog.hogql_queries.query_cache.QueryCacheManager.get_stale_insights")
     def test_priority_insights_dashboards_not_accessed_recently(self, mock_get_stale_insights):
         mock_get_stale_insights.return_value = ["5678:8901"]
-        insights = list(priority_insights(self.team))
+        insights = list(insights_to_cache(self.team))
         self.assertEqual(insights, [])
 
     @patch("posthog.hogql_queries.query_cache.QueryCacheManager.get_stale_insights")
@@ -108,7 +108,7 @@ class TestWarming(APIBaseTest):
             "3456:7890",
             "4567:",
         ]
-        insights = list(priority_insights(self.team))
+        insights = list(insights_to_cache(self.team))
         expected_results = [
             (2345, None),
             (3456, 7890),

--- a/posthog/caching/test/test_warming.py
+++ b/posthog/caching/test/test_warming.py
@@ -1,4 +1,4 @@
-from posthog.caching.warming import insights_to_cache, schedule_warming_for_teams_task
+from posthog.caching.warming import insights_to_keep_fresh, schedule_warming_for_teams_task
 from posthog.models import Insight, DashboardTile, InsightViewed, Dashboard
 
 from datetime import datetime, timedelta, UTC
@@ -48,7 +48,7 @@ class TestWarming(APIBaseTest):
     @patch("posthog.hogql_queries.query_cache.QueryCacheManager.get_stale_insights")
     def test_priority_insights_no_stale_insights(self, mock_get_stale_insights):
         mock_get_stale_insights.return_value = []
-        insights = list(insights_to_cache(self.team))
+        insights = list(insights_to_keep_fresh(self.team))
         self.assertEqual(insights, [])
 
     @patch("posthog.hogql_queries.query_cache.QueryCacheManager.get_stale_insights")
@@ -56,7 +56,7 @@ class TestWarming(APIBaseTest):
         mock_get_stale_insights.return_value = [
             "2345:",
         ]
-        insights = list(insights_to_cache(self.team))
+        insights = list(insights_to_keep_fresh(self.team))
         exptected_results = [
             (2345, None),
         ]
@@ -68,7 +68,7 @@ class TestWarming(APIBaseTest):
             "1234:5678",
             "3456:7890",
         ]
-        insights = list(insights_to_cache(self.team))
+        insights = list(insights_to_keep_fresh(self.team))
         expected_results = [
             (3456, 7890),
         ]
@@ -82,7 +82,7 @@ class TestWarming(APIBaseTest):
             "3456:7890",
             "8888:7777",
         ]
-        insights = list(insights_to_cache(self.team))
+        insights = list(insights_to_keep_fresh(self.team))
         expected_results = [
             (3456, 7890),
         ]
@@ -91,13 +91,13 @@ class TestWarming(APIBaseTest):
     @patch("posthog.hogql_queries.query_cache.QueryCacheManager.get_stale_insights")
     def test_priority_insights_insights_not_viewed_recently(self, mock_get_stale_insights):
         mock_get_stale_insights.return_value = ["4567:"]
-        insights = list(insights_to_cache(self.team))
+        insights = list(insights_to_keep_fresh(self.team))
         self.assertEqual(insights, [])
 
     @patch("posthog.hogql_queries.query_cache.QueryCacheManager.get_stale_insights")
     def test_priority_insights_dashboards_not_accessed_recently(self, mock_get_stale_insights):
         mock_get_stale_insights.return_value = ["5678:8901"]
-        insights = list(insights_to_cache(self.team))
+        insights = list(insights_to_keep_fresh(self.team))
         self.assertEqual(insights, [])
 
     @patch("posthog.hogql_queries.query_cache.QueryCacheManager.get_stale_insights")
@@ -108,7 +108,7 @@ class TestWarming(APIBaseTest):
             "3456:7890",
             "4567:",
         ]
-        insights = list(insights_to_cache(self.team))
+        insights = list(insights_to_keep_fresh(self.team))
         expected_results = [
             (2345, None),
             (3456, 7890),

--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -20,6 +20,9 @@ from posthog.hogql_queries.legacy_compatibility.flagged_conversion_manager impor
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Team, Insight, DashboardTile
 from posthog.tasks.utils import CeleryQueue
+from posthog.event_usage import report_team_action
+import posthoganalytics
+
 
 logger = structlog.get_logger(__name__)
 
@@ -37,9 +40,39 @@ PRIORITY_INSIGHTS_COUNTER = Counter(
 LAST_VIEWED_THRESHOLD = timedelta(days=7)
 
 
-def priority_insights(team: Team, shared_only: bool = False) -> Generator[tuple[int, Optional[int]], None, None]:
+def teams_enabled_for_cache_warming() -> list[int]:
+    all_teams = Team.objects.all()
+    enabled_team_ids = []
+
+    for team in all_teams:
+        enabled = posthoganalytics.feature_enabled(
+            "cache-warming",
+            str(team.uuid),
+            groups={
+                "organization": str(team.organization_id),
+                "project": str(team.id),
+            },
+            group_properties={
+                "organization": {
+                    "id": str(team.organization_id),
+                },
+                "project": {
+                    "id": str(team.id),
+                },
+            },
+            only_evaluate_locally=True,
+            send_feature_flag_events=False,
+        )
+
+        if enabled:
+            enabled_team_ids.append(team.id)
+
+    return enabled_team_ids
+
+
+def insights_to_cache(team: Team, shared_only: bool = False) -> Generator[tuple[int, Optional[int]], None, None]:
     """
-    This is the place to decide which insights should be kept warm.
+    This is the place to decide which insights should be kept warm for the provided team.
     The reasoning is that this will be a yes or no decision. If we need to keep it warm, we try our best
     to not let the cache go stale. There isn't any middle ground, like trying to refresh it once a day, since
     that would be like clock that's only right twice a day.
@@ -47,6 +80,8 @@ def priority_insights(team: Team, shared_only: bool = False) -> Generator[tuple[
 
     threshold = datetime.now(UTC) - LAST_VIEWED_THRESHOLD
     QueryCacheManager.clean_up_stale_insights(team_id=team.pk, threshold=threshold)
+
+    # get all insights currently in the cache for the team
     combos = QueryCacheManager.get_stale_insights(team_id=team.pk, limit=500)
 
     STALE_INSIGHTS_GAUGE.labels(team_id=team.pk).set(len(combos))
@@ -88,20 +123,32 @@ def priority_insights(team: Team, shared_only: bool = False) -> Generator[tuple[
 
 @shared_task(ignore_result=True, expires=60 * 15)
 def schedule_warming_for_teams_task():
+    """
+    Runs every hour and schedule warming for all insights (picked from insights_to_cache)
+    for each team enabled for cache warming.
+
+    We trigger recalculation using ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
+    so even though we might pick all insights for a team to recalculate,
+    only the stale ones (determined by `staleness_threshold_map`) get recalculated.
+    """
     team_ids = largest_teams(limit=10)
     threshold = datetime.now(UTC) - LAST_VIEWED_THRESHOLD
 
-    prio_teams = Team.objects.filter(Q(pk__in=team_ids) | Q(extra_settings__insights_cache_warming=True))
+    enabled_teams = Team.objects.filter(
+        Q(pk__in=team_ids)
+        | Q(extra_settings__insights_cache_warming=True)
+        | Q(pk__in=teams_enabled_for_cache_warming())
+    )
     teams_with_recently_viewed_shared = Team.objects.filter(
         Q(
             Q(sharingconfiguration__dashboard__last_accessed_at__gte=threshold)
             | Q(sharingconfiguration__insight__insightviewed__last_viewed_at__gte=threshold)
         ),
         sharingconfiguration__enabled=True,
-    ).difference(prio_teams)
+    ).difference(enabled_teams)
 
     all_teams = itertools.chain(
-        zip(prio_teams, [False] * len(prio_teams)),
+        zip(enabled_teams, [False] * len(enabled_teams)),
         zip(teams_with_recently_viewed_shared, [True] * len(teams_with_recently_viewed_shared)),
     )
 
@@ -109,7 +156,13 @@ def schedule_warming_for_teams_task():
     expire_after = datetime.now(UTC) + timedelta(minutes=50)
 
     for team, shared_only in all_teams:
-        insight_tuples = priority_insights(team, shared_only=shared_only)
+        insight_tuples = insights_to_cache(team, shared_only=shared_only)
+
+        report_team_action(
+            team,
+            "cache warming - insights to cache",
+            {"count": len(insight_tuples)},
+        )
 
         # We chain the task execution to prevent queries *for a single team* running at the same time
         chain(
@@ -157,11 +210,23 @@ def warm_insight_cache_task(insight_id: int, dashboard_id: Optional[int]):
                 dashboard_id=dashboard_id,
             )
 
+            is_cached = getattr(results, "is_cached", False)
+
             PRIORITY_INSIGHTS_COUNTER.labels(
                 team_id=insight.team_id,
                 dashboard=dashboard_id is not None,
-                is_cached=getattr(results, "is_cached", False),
+                is_cached=is_cached,
             ).inc()
+
+            report_team_action(
+                insight.team,
+                "cache warming - warming insight",
+                {
+                    "insight_id": insight.pk,
+                    "dashboard_id": dashboard_id,
+                    "is_cached": is_cached,
+                },
+            )
         except CHQueryErrorTooManySimultaneousQueries:
             raise
         except Exception as e:

--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -70,7 +70,7 @@ def teams_enabled_for_cache_warming() -> list[int]:
     return enabled_team_ids
 
 
-def insights_to_cache(team: Team, shared_only: bool = False) -> Generator[tuple[int, Optional[int]], None, None]:
+def insights_to_keep_fresh(team: Team, shared_only: bool = False) -> Generator[tuple[int, Optional[int]], None, None]:
     """
     This is the place to decide which insights should be kept warm for the provided team.
     The reasoning is that this will be a yes or no decision. If we need to keep it warm, we try our best
@@ -156,7 +156,7 @@ def schedule_warming_for_teams_task():
     expire_after = datetime.now(UTC) + timedelta(minutes=50)
 
     for team, shared_only in all_teams:
-        insight_tuples = insights_to_cache(team, shared_only=shared_only)
+        insight_tuples = list(insights_to_keep_fresh(team, shared_only=shared_only))
 
         report_team_action(
             team,


### PR DESCRIPTION
## Problem
Cache warming is currently limited to 10 largest teams by event count.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
- Use feature flag to control which teams get cache warming
- Pushing metrics to PostHog, will create graph showing total insights computed for cache warming + % of how many were already cached.
- Documented the cache warming logic a bit more
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
