### PR TITLE
feat(experiments): Reorder web experiment transform buttons

### DIFF
--- a/frontend/src/toolbar/experiments/WebExperimentTransformField.tsx
+++ b/frontend/src/toolbar/experiments/WebExperimentTransformField.tsx
@@ -110,16 +110,6 @@ export function WebExperimentTransformField({
                 fullWidth
                 options={[
                     {
-                        value: 'html',
-                        label: 'HTML',
-                        icon:
-                            transform.html && transform.html.length > 0 ? (
-                                <IconCheckCircle className="text-success" />
-                            ) : (
-                                <IconCode />
-                            ),
-                    },
-                    {
                         value: 'text',
                         label: 'Text',
                         icon:
@@ -137,6 +127,16 @@ export function WebExperimentTransformField({
                                 <IconCheckCircle className="text-success" />
                             ) : (
                                 <IconAIText />
+                            ),
+                    },
+                    {
+                        value: 'html',
+                        label: 'HTML',
+                        icon:
+                            transform.html && transform.html.length > 0 ? (
+                                <IconCheckCircle className="text-success" />
+                            ) : (
+                                <IconCode />
                             ),
                     },
                 ]}


### PR DESCRIPTION
Related https://github.com/PostHog/posthog/issues/26936

## Changes

Reorders the web experiment transform buttons to put "HTML" in the last position instead of the first position.

I've seen a few instances of users putting text in the HTML field, which causes unexpected outcomes. Hopefully putting it last will make the issue less common.

**Before**

![CleanShot 2025-01-03 at 04 14 53@2x](https://github.com/user-attachments/assets/6b5574c8-1623-46b3-8476-394928078d1b)

**After**

![CleanShot 2025-01-03 at 04 14 15@2x](https://github.com/user-attachments/assets/55595f20-1034-4a89-acc0-12f6855b4fca)

## How did you test this code?

I visually verified the change.