### PR TITLE
fix(experiments): Restore editing Trends exposure metric

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Goal.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Goal.tsx
@@ -114,7 +114,9 @@ export function MetricDisplayOld({ filters }: { filters?: FilterType }): JSX.Ele
 
 export function ExposureMetric({ experimentId }: { experimentId: Experiment['id'] }): JSX.Element {
     const { experiment, featureFlags } = useValues(experimentLogic({ experimentId }))
-    const { updateExperimentGoal, loadExperiment, setExperiment } = useActions(experimentLogic({ experimentId }))
+    const { updateExperimentGoal, loadExperiment, setExperiment, setEditingPrimaryMetricIndex } = useActions(
+        experimentLogic({ experimentId })
+    )
     const [isModalOpen, setIsModalOpen] = useState(false)
 
     const metricIdx = 0
@@ -201,6 +203,7 @@ export function ExposureMetric({ experimentId }: { experimentId: Experiment['id'
                                     })
                                 }
                             }
+                            setEditingPrimaryMetricIndex(metricIdx)
                             setIsModalOpen(true)
                         }}
                         className="mr-2"
@@ -232,6 +235,7 @@ export function ExposureMetric({ experimentId }: { experimentId: Experiment['id'
                 isOpen={isModalOpen}
                 onClose={() => {
                     setIsModalOpen(false)
+                    setEditingPrimaryMetricIndex(null)
                     loadExperiment()
                 }}
             />

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -275,6 +275,7 @@ export const experimentLogic = kea<experimentLogicType>([
         openPrimaryMetricModal: (index: number) => ({ index }),
         closePrimaryMetricModal: true,
         setPrimaryMetricsResultErrors: (errors: any[]) => ({ errors }),
+        setEditingPrimaryMetricIndex: (index: number | null) => ({ index }),
         updateDistributionModal: (featureFlag: FeatureFlagType) => ({ featureFlag }),
         openSecondaryMetricModal: (index: number) => ({ index }),
         closeSecondaryMetricModal: true,
@@ -511,6 +512,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 openPrimaryMetricModal: (_, { index }) => index,
                 closePrimaryMetricModal: () => null,
                 updateExperimentGoal: () => null,
+                setEditingPrimaryMetricIndex: (_, { index }) => index,
             },
         ],
         primaryMetricsResultErrors: [


### PR DESCRIPTION
## Changes

Restores the ability to edit a Trends exposure metric.

Reported in https://posthoghelp.zendesk.com/agent/tickets/22654 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/25010)

**Before**

![CleanShot 2025-01-03 at 04 38 54](https://github.com/user-attachments/assets/a05631e5-7b88-43da-b7c0-b8849b9b0c27)

**After**

![CleanShot 2025-01-03 at 04 40 03](https://github.com/user-attachments/assets/2dbc64ef-7232-4526-8f1f-8e2eb7f132ae)

## How did you test this code?

I created a new Trends experiment, reproduced the original issue, and then verified that this change restores the ability to edit the exposure metric.