### PR TITLE
feat(web-analytics): Support screen events in web analytics queries

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -237,6 +237,7 @@ export const FEATURE_FLAGS = {
     CDP_ACTIVITY_LOG_NOTIFICATIONS: 'cdp-activity-log-notifications', // owner: #team-cdp
     COOKIELESS_SERVER_HASH_MODE_SETTING: 'cookieless-server-hash-mode-setting', // owner: @robbie-c #team-web-analytics
     INSIGHT_COLORS: 'insight-colors', // owner @thmsobrmlr #team-product-analytics
+    WEB_ANALYTICS_FOR_MOBILE: 'web-analytics-for-mobile', // owner @robbie-c #team-web-analytics
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -13408,6 +13408,7 @@
                 "InitialPage",
                 "ExitPage",
                 "ExitClick",
+                "ScreenName",
                 "InitialChannelType",
                 "InitialReferringDomain",
                 "InitialUTMSource",

--- a/frontend/src/queries/schema.ts
+++ b/frontend/src/queries/schema.ts
@@ -1850,6 +1850,7 @@ export enum WebStatsBreakdown {
     InitialPage = 'InitialPage',
     ExitPage = 'ExitPage', // not supported in the legacy version
     ExitClick = 'ExitClick',
+    ScreenName = 'ScreenName',
     InitialChannelType = 'InitialChannelType',
     InitialReferringDomain = 'InitialReferringDomain',
     InitialUTMSource = 'InitialUTMSource',

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -127,6 +127,8 @@ const BreakdownValueTitle: QueryContextColumnTitleComponent = (props) => {
             return <>End Path</>
         case WebStatsBreakdown.ExitClick:
             return <>Exit Click</>
+        case WebStatsBreakdown.ScreenName:
+            return <>Screen Name</>
         case WebStatsBreakdown.InitialChannelType:
             return <>Initial Channel Type</>
         case WebStatsBreakdown.InitialReferringDomain:
@@ -258,6 +260,8 @@ export const webStatsBreakdownToPropertyName = (
             return { key: '$end_pathname', type: PropertyFilterType.Session }
         case WebStatsBreakdown.ExitClick:
             return { key: '$last_external_click_url', type: PropertyFilterType.Session }
+        case WebStatsBreakdown.ScreenName:
+            return { key: '$screen_name', type: PropertyFilterType.Event }
         case WebStatsBreakdown.InitialChannelType:
             return { key: '$channel_type', type: PropertyFilterType.Session }
         case WebStatsBreakdown.InitialReferringDomain:

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -182,6 +182,7 @@ export enum PathTab {
     INITIAL_PATH = 'INITIAL_PATH',
     END_PATH = 'END_PATH',
     EXIT_CLICK = 'EXIT_CLICK',
+    SCREEN_NAME = 'SCREEN_NAME',
 }
 
 export enum GeographyTab {
@@ -559,7 +560,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 }
 
                 const uniqueUserSeries: EventsNode = {
-                    event: '$pageview',
+                    event: featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_FOR_MOBILE] ? '$screen' : '$pageview',
                     kind: NodeKind.EventsNode,
                     math: BaseMathType.UniqueUsers,
                     name: 'Pageview',
@@ -568,7 +569,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 const pageViewsSeries = {
                     ...uniqueUserSeries,
                     math: BaseMathType.TotalCount,
-                    custom_name: 'Page views',
+                    custom_name: featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_FOR_MOBILE] ? 'Screen Views' : 'Page views',
                 }
                 const sessionsSeries = {
                     ...uniqueUserSeries,
@@ -766,149 +767,160 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         },
                         activeTabId: pathTab,
                         setTabId: actions.setPathTab,
-                        tabs: (
-                            [
-                                createTableTab(
-                                    TileId.PATHS,
-                                    PathTab.PATH,
-                                    'Paths',
-                                    'Path',
-                                    WebStatsBreakdown.Page,
-                                    {
-                                        includeScrollDepth: false, // TODO needs some perf work before it can be enabled
-                                        includeBounceRate: true,
-                                        doPathCleaning: !!isPathCleaningEnabled,
-                                    },
-                                    {
-                                        showPathCleaningControls: true,
-                                        docs: {
-                                            url: 'https://posthog.com/docs/web-analytics/dashboard#paths',
-                                            title: 'Paths',
-                                            description: (
-                                                <div>
-                                                    <p>
-                                                        In this view you can validate all of the paths that were
-                                                        accessed in your application, regardless of when they were
-                                                        accessed through the lifetime of a user session.
-                                                    </p>
-                                                    {conversionGoal ? (
-                                                        <p>
-                                                            The conversion rate is the percentage of users who completed
-                                                            the conversion goal in this specific path.
-                                                        </p>
-                                                    ) : (
-                                                        <p>
-                                                            The{' '}
-                                                            <Link to="https://posthog.com/docs/web-analytics/dashboard#bounce-rate">
-                                                                bounce rate
-                                                            </Link>{' '}
-                                                            indicates the percentage of users who left your page
-                                                            immediately after visiting without capturing any event.
-                                                        </p>
-                                                    )}
-                                                </div>
-                                            ),
-                                        },
-                                    }
-                                ),
-                                createTableTab(
-                                    TileId.PATHS,
-                                    PathTab.INITIAL_PATH,
-                                    'Entry paths',
-                                    'Entry path',
-                                    WebStatsBreakdown.InitialPage,
-                                    {
-                                        includeBounceRate: true,
-                                        includeScrollDepth: false,
-                                        doPathCleaning: !!isPathCleaningEnabled,
-                                    },
-                                    {
-                                        showPathCleaningControls: true,
-                                        docs: {
-                                            url: 'https://posthog.com/docs/web-analytics/dashboard#paths',
-                                            title: 'Entry Path',
-                                            description: (
-                                                <div>
-                                                    <p>
-                                                        Entry paths are the paths a user session started, i.e. the first
-                                                        path they saw when they opened your website.
-                                                    </p>
-                                                    {conversionGoal && (
-                                                        <p>
-                                                            The conversion rate is the percentage of users who completed
-                                                            the conversion goal after the first path in their session
-                                                            being this path.
-                                                        </p>
-                                                    )}
-                                                </div>
-                                            ),
-                                        },
-                                    }
-                                ),
-                                createTableTab(
-                                    TileId.PATHS,
-                                    PathTab.END_PATH,
-                                    'End paths',
-                                    'End path',
-                                    WebStatsBreakdown.ExitPage,
-                                    {
-                                        includeBounceRate: false,
-                                        includeScrollDepth: false,
-                                        doPathCleaning: !!isPathCleaningEnabled,
-                                    },
-                                    {
-                                        showPathCleaningControls: true,
-                                        docs: {
-                                            url: 'https://posthog.com/docs/web-analytics/dashboard#paths',
-                                            title: 'End Path',
-                                            description: (
-                                                <div>
-                                                    End paths are the last path a user visited before their session
-                                                    ended, i.e. the last path they saw before leaving your
-                                                    website/closing the browser/turning their computer off.
-                                                </div>
-                                            ),
-                                        },
-                                    }
-                                ),
-                                {
-                                    id: PathTab.EXIT_CLICK,
-                                    title: 'Outbound link clicks',
-                                    linkText: 'Outbound clicks',
-                                    query: {
-                                        full: true,
-                                        kind: NodeKind.DataTableNode,
-                                        source: {
-                                            kind: NodeKind.WebExternalClicksTableQuery,
-                                            properties: webAnalyticsFilters,
-                                            dateRange,
-                                            compareFilter,
-                                            sampling,
-                                            limit: 10,
-                                            filterTestAccounts,
-                                            conversionGoal: featureFlags[
-                                                FEATURE_FLAGS.WEB_ANALYTICS_CONVERSION_GOAL_FILTERS
-                                            ]
-                                                ? conversionGoal
-                                                : undefined,
-                                            stripQueryParams: shouldStripQueryParams,
-                                        },
-                                        embedded: false,
-                                        columns: ['url', 'visitors', 'clicks'],
-                                    },
-                                    insightProps: createInsightProps(TileId.PATHS, PathTab.END_PATH),
-                                    canOpenModal: true,
-                                    docs: {
-                                        title: 'Outbound Clicks',
-                                        description: (
-                                            <div>
-                                                You'll be able to verify when someone leaves your website by clicking an
-                                                outbound link (to a separate domain)
-                                            </div>
-                                        ),
-                                    },
-                                },
-                            ] as (TabsTileTab | undefined)[]
+                        tabs: (featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_FOR_MOBILE]
+                            ? [
+                                  createTableTab(
+                                      TileId.PATHS,
+                                      PathTab.SCREEN_NAME,
+                                      'Screens',
+                                      'Screen',
+                                      WebStatsBreakdown.ScreenName,
+                                      {},
+                                      {}
+                                  ),
+                              ]
+                            : ([
+                                  createTableTab(
+                                      TileId.PATHS,
+                                      PathTab.PATH,
+                                      'Paths',
+                                      'Path',
+                                      WebStatsBreakdown.Page,
+                                      {
+                                          includeScrollDepth: false, // TODO needs some perf work before it can be enabled
+                                          includeBounceRate: true,
+                                          doPathCleaning: !!isPathCleaningEnabled,
+                                      },
+                                      {
+                                          showPathCleaningControls: true,
+                                          docs: {
+                                              url: 'https://posthog.com/docs/web-analytics/dashboard#paths',
+                                              title: 'Paths',
+                                              description: (
+                                                  <div>
+                                                      <p>
+                                                          In this view you can validate all of the paths that were
+                                                          accessed in your application, regardless of when they were
+                                                          accessed through the lifetime of a user session.
+                                                      </p>
+                                                      {conversionGoal ? (
+                                                          <p>
+                                                              The conversion rate is the percentage of users who
+                                                              completed the conversion goal in this specific path.
+                                                          </p>
+                                                      ) : (
+                                                          <p>
+                                                              The{' '}
+                                                              <Link to="https://posthog.com/docs/web-analytics/dashboard#bounce-rate">
+                                                                  bounce rate
+                                                              </Link>{' '}
+                                                              indicates the percentage of users who left your page
+                                                              immediately after visiting without capturing any event.
+                                                          </p>
+                                                      )}
+                                                  </div>
+                                              ),
+                                          },
+                                      }
+                                  ),
+                                  createTableTab(
+                                      TileId.PATHS,
+                                      PathTab.INITIAL_PATH,
+                                      'Entry paths',
+                                      'Entry path',
+                                      WebStatsBreakdown.InitialPage,
+                                      {
+                                          includeBounceRate: true,
+                                          includeScrollDepth: false,
+                                          doPathCleaning: !!isPathCleaningEnabled,
+                                      },
+                                      {
+                                          showPathCleaningControls: true,
+                                          docs: {
+                                              url: 'https://posthog.com/docs/web-analytics/dashboard#paths',
+                                              title: 'Entry Path',
+                                              description: (
+                                                  <div>
+                                                      <p>
+                                                          Entry paths are the paths a user session started, i.e. the
+                                                          first path they saw when they opened your website.
+                                                      </p>
+                                                      {conversionGoal && (
+                                                          <p>
+                                                              The conversion rate is the percentage of users who
+                                                              completed the conversion goal after the first path in
+                                                              their session being this path.
+                                                          </p>
+                                                      )}
+                                                  </div>
+                                              ),
+                                          },
+                                      }
+                                  ),
+                                  createTableTab(
+                                      TileId.PATHS,
+                                      PathTab.END_PATH,
+                                      'End paths',
+                                      'End path',
+                                      WebStatsBreakdown.ExitPage,
+                                      {
+                                          includeBounceRate: false,
+                                          includeScrollDepth: false,
+                                          doPathCleaning: !!isPathCleaningEnabled,
+                                      },
+                                      {
+                                          showPathCleaningControls: true,
+                                          docs: {
+                                              url: 'https://posthog.com/docs/web-analytics/dashboard#paths',
+                                              title: 'End Path',
+                                              description: (
+                                                  <div>
+                                                      End paths are the last path a user visited before their session
+                                                      ended, i.e. the last path they saw before leaving your
+                                                      website/closing the browser/turning their computer off.
+                                                  </div>
+                                              ),
+                                          },
+                                      }
+                                  ),
+                                  {
+                                      id: PathTab.EXIT_CLICK,
+                                      title: 'Outbound link clicks',
+                                      linkText: 'Outbound clicks',
+                                      query: {
+                                          full: true,
+                                          kind: NodeKind.DataTableNode,
+                                          source: {
+                                              kind: NodeKind.WebExternalClicksTableQuery,
+                                              properties: webAnalyticsFilters,
+                                              dateRange,
+                                              compareFilter,
+                                              sampling,
+                                              limit: 10,
+                                              filterTestAccounts,
+                                              conversionGoal: featureFlags[
+                                                  FEATURE_FLAGS.WEB_ANALYTICS_CONVERSION_GOAL_FILTERS
+                                              ]
+                                                  ? conversionGoal
+                                                  : undefined,
+                                              stripQueryParams: shouldStripQueryParams,
+                                          },
+                                          embedded: false,
+                                          columns: ['url', 'visitors', 'clicks'],
+                                      },
+                                      insightProps: createInsightProps(TileId.PATHS, PathTab.END_PATH),
+                                      canOpenModal: true,
+                                      docs: {
+                                          title: 'Outbound Clicks',
+                                          description: (
+                                              <div>
+                                                  You'll be able to verify when someone leaves your website by clicking
+                                                  an outbound link (to a separate domain)
+                                              </div>
+                                          ),
+                                      },
+                                  },
+                              ] as (TabsTileTab | undefined)[])
                         ).filter(isNotNil),
                     },
                     {

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -481,6 +481,8 @@ GROUP BY session_id, breakdown_value
                 return self._apply_path_cleaning(ast.Field(chain=["session", "$end_pathname"]))
             case WebStatsBreakdown.EXIT_CLICK:
                 return ast.Field(chain=["session", "$last_external_click_url"])
+            case WebStatsBreakdown.SCREEN_NAME:
+                return ast.Field(chain=["events", "properties", "$screen_name"])
             case WebStatsBreakdown.INITIAL_REFERRING_DOMAIN:
                 return ast.Field(chain=["session", "$entry_referring_domain"])
             case WebStatsBreakdown.INITIAL_UTM_SOURCE:

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -149,7 +149,7 @@ FROM (
             min(session.$start_timestamp ) AS start_timestamp
         FROM events
         WHERE and(
-            events.event == '$pageview',
+            or(events.event == '$pageview', events.event == '$screen'),
             breakdown_value IS NOT NULL,
             {inside_periods},
             {event_properties},
@@ -172,7 +172,7 @@ LEFT JOIN (
             min(session.$start_timestamp) as start_timestamp
         FROM events
         WHERE and(
-            events.event == '$pageview',
+            or(events.event == '$pageview', events.event == '$screen'),
             breakdown_value IS NOT NULL,
             {inside_periods},
             {event_properties},
@@ -204,7 +204,7 @@ LEFT JOIN (
             min(session.$start_timestamp) AS start_timestamp
         FROM events
         WHERE and(
-            or(events.event == '$pageview', events.event == '$pageleave'),
+            or(events.event == '$pageview', events.event == '$pageleave', events.event == '$screen'),
             breakdown_value IS NOT NULL,
             {inside_periods},
             {event_properties_for_scroll},
@@ -263,7 +263,7 @@ FROM (
             min(session.$start_timestamp) AS start_timestamp
         FROM events
         WHERE and(
-            events.event == '$pageview',
+            or(events.event == '$pageview', events.event == '$screen'),
             {inside_periods},
             {event_properties},
             {session_properties},
@@ -286,7 +286,7 @@ LEFT JOIN (
             min(session.$start_timestamp) AS start_timestamp
         FROM events
         WHERE and(
-            events.event == '$pageview',
+            or(events.event == '$pageview', events.event == '$screen'),
             breakdown_value IS NOT NULL,
             {inside_periods},
             {event_properties},

--- a/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/web_analytics_query_runner.py
@@ -172,8 +172,15 @@ class WebAnalyticsQueryRunner(QueryRunner, ABC):
 
     @cached_property
     def event_type_expr(self) -> ast.Expr:
-        pageview_expr = ast.CompareOperation(
-            op=ast.CompareOperationOp.Eq, left=ast.Field(chain=["event"]), right=ast.Constant(value="$pageview")
+        pageview_expr = ast.Or(
+            exprs=[
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq, left=ast.Field(chain=["event"]), right=ast.Constant(value="$pageview")
+                ),
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq, left=ast.Field(chain=["event"]), right=ast.Constant(value="$screen")
+                ),
+            ]
         )
 
         if self.conversion_goal_expr:

--- a/posthog/hogql_queries/web_analytics/web_goals.py
+++ b/posthog/hogql_queries/web_analytics/web_goals.py
@@ -143,7 +143,7 @@ SELECT
 FROM events
 WHERE and(
     events.`$session_id` IS NOT NULL,
-    event = '$pageview' OR {action_where},
+    event = '$pageview' OR event = '$screen' OR {action_where},
     {periods_expression},
     {event_properties},
     {session_properties}

--- a/posthog/hogql_queries/web_analytics/web_overview.py
+++ b/posthog/hogql_queries/web_analytics/web_overview.py
@@ -88,10 +88,19 @@ class WebOverviewQueryRunner(WebAnalyticsQueryRunner):
             return ast.Call(
                 name="countIf",
                 args=[
-                    ast.CompareOperation(
-                        left=ast.Field(chain=["event"]),
-                        op=ast.CompareOperationOp.Eq,
-                        right=ast.Constant(value="$pageview"),
+                    ast.Or(
+                        exprs=[
+                            ast.CompareOperation(
+                                left=ast.Field(chain=["event"]),
+                                op=ast.CompareOperationOp.Eq,
+                                right=ast.Constant(value="$pageview"),
+                            ),
+                            ast.CompareOperation(
+                                left=ast.Field(chain=["event"]),
+                                op=ast.CompareOperationOp.Eq,
+                                right=ast.Constant(value="$screen"),
+                            ),
+                        ]
                     )
                 ],
             )

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -1717,6 +1717,7 @@ class WebStatsBreakdown(StrEnum):
     INITIAL_PAGE = "InitialPage"
     EXIT_PAGE = "ExitPage"
     EXIT_CLICK = "ExitClick"
+    SCREEN_NAME = "ScreenName"
     INITIAL_CHANNEL_TYPE = "InitialChannelType"
     INITIAL_REFERRING_DOMAIN = "InitialReferringDomain"
     INITIAL_UTM_SOURCE = "InitialUTMSource"


### PR DESCRIPTION
## Problem

See https://posthog.slack.com/archives/C05LJK1N3CP/p1735900802399899

I haven't spent enough time on this to get the quality super high - this is definitely a "ship this quickly as it'll tell us what else needs to be improved"

## Changes
Change web analytics queries to accept $screen events as well as $pageview events.

Adds a feature flag to hide the normal page tiles and replace them with a screen names tile.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Add some tests on the happy path of overview and stats tile. If we decided to add more mobile-specific tiles we'd need to add some test coverage there.
