### PR TITLE
fix: safeguard for empy tokens in remove_limited_team_tokens

### DIFF
--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -68,6 +68,12 @@ def add_limited_team_tokens(resource: QuotaResource, tokens: Mapping[str, int], 
 
 
 def remove_limited_team_tokens(resource: QuotaResource, tokens: list[str], cache_key: QuotaLimitingCaches) -> None:
+    # This check exists because the * unpacking operator
+    # doesn't return anything with an empty list,
+    # so zrem only receives one argument and it fails.
+    if not tokens:
+        return
+
     redis_client = get_client()
     redis_client.zrem(f"{cache_key.value}{resource.value}", *tokens)
 


### PR DESCRIPTION
## Problem

https://posthog.sentry.io/issues/6190930318/?alert_rule_id=7093241&alert_type=issue&notification_uuid=4052990c-be61-49a7-8643-900d66d0982d&project=1899813&referrer=slack

Self explanatory with the comment, but basically if we pass an empty list `redis.zrem` fails

## Changes

If the argument is an empty list, we just skip the function.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._
