### PR TITLE
chore(data-warehouse): Temp disable compact and table vacuum

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -137,9 +137,10 @@ class PipelineNonDLT:
             self._logger.debug("No deltalake table, not continuing with post-run ops")
             return
 
-        self._logger.info("Compacting delta table")
-        delta_table.optimize.compact()
-        delta_table.vacuum(retention_hours=24, enforce_retention_duration=False, dry_run=False)
+        self._logger.debug("Skipping compact and vacuuming")
+        # self._logger.info("Compacting delta table")
+        # delta_table.optimize.compact()
+        # delta_table.vacuum(retention_hours=24, enforce_retention_duration=False, dry_run=False)
 
         file_uris = delta_table.file_uris()
         self._logger.info(f"Preparing S3 files - total parquet files: {len(file_uris)}")


### PR DESCRIPTION
## Problem
- We still have some memory issues with memory spikes not reducing after a workflow has finished

## Changes
- Check to see if its the delta table compact and vacuum that's causing these issues - diable them just for the V2 pipeline

