### PR TITLE
fix: LineChart error if no color is found

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -325,7 +325,7 @@ export function LineGraph_({
             ? getBarColorFromStatus(dataset.status)
             : isHorizontal
             ? dataset.backgroundColor
-            : getTrendsColor(dataset)
+            : getTrendsColor(dataset) || '#000000' // Default to black if no color found
         const mainColor = isPrevious ? `${themeColor}80` : themeColor
 
         const hoverColor = dataset?.status ? getBarColorFromStatus(dataset.status, true) : mainColor


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

fix type error when no hover color is found when rendering a LineChart

## Changes

| Before | After |
|--------|--------|
| ![CleanShot 2025-01-03 at 13 02 47@2x](https://github.com/user-attachments/assets/091c4a9c-73dd-41c8-9fcd-bfa2368a44e9) | ![CleanShot 2025-01-03 at 13 03 05@2x](https://github.com/user-attachments/assets/e296018c-b239-4a47-b074-6135a1a9d264) | 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
