### PR TITLE
feat(data-warehouse): Spawn a new process for compaction and vacuuming

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_subprocess.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_subprocess.py
@@ -1,0 +1,30 @@
+import argparse
+import os
+from deltalake import DeltaTable
+
+
+def _get_credentials():
+    return {
+        "aws_access_key_id": os.getenv("AIRBYTE_BUCKET_KEY", None),
+        "aws_secret_access_key": os.getenv("AIRBYTE_BUCKET_SECRET", None),
+        "region_name": os.getenv("AIRBYTE_BUCKET_REGION", None),
+        "AWS_DEFAULT_REGION": os.getenv("AIRBYTE_BUCKET_REGION", None),
+        "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
+    }
+
+
+def run_operations(table_uri: str) -> None:
+    storage_options = _get_credentials()
+
+    delta_table = DeltaTable(table_uri=table_uri, storage_options=storage_options)
+    delta_table.optimize.compact()
+    delta_table.vacuum(retention_hours=24, enforce_retention_duration=False, dry_run=False)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run Delta operations")
+    parser.add_argument("--table_uri", required=True, help="S3 table_uri for the delta table")
+
+    args = parser.parse_args()
+
+    run_operations(args.table_uri)

--- a/posthog/temporal/data_imports/pipelines/pipeline/delta_table_subprocess.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/delta_table_subprocess.py
@@ -1,9 +1,27 @@
 import argparse
 import os
+import sys
 from deltalake import DeltaTable
 
 
 def _get_credentials():
+    is_test = (
+        "test" in sys.argv
+        or sys.argv[0].endswith("pytest")
+        or os.getenv("TEST", "false").lower() in ("y", "yes", "t", "true", "on", "1")
+    )
+
+    if is_test:
+        return {
+            "endpoint_url": os.getenv("OBJECT_STORAGE_ENDPOINT", "http://localhost:19000"),
+            "aws_access_key_id": os.getenv("AIRBYTE_BUCKET_KEY", None),
+            "aws_secret_access_key": os.getenv("AIRBYTE_BUCKET_SECRET", None),
+            "region_name": os.getenv("AIRBYTE_BUCKET_REGION", None),
+            "AWS_DEFAULT_REGION": os.getenv("AIRBYTE_BUCKET_REGION", None),
+            "AWS_ALLOW_HTTP": "true",
+            "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
+        }
+
     return {
         "aws_access_key_id": os.getenv("AIRBYTE_BUCKET_KEY", None),
         "aws_secret_access_key": os.getenv("AIRBYTE_BUCKET_SECRET", None),

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -139,10 +139,7 @@ class PipelineNonDLT:
             self._logger.debug("No deltalake table, not continuing with post-run ops")
             return
 
-        self._logger.debug("Skipping compact and vacuuming")
-        # self._logger.info("Compacting delta table")
-        # delta_table.optimize.compact()
-        # delta_table.vacuum(retention_hours=24, enforce_retention_duration=False, dry_run=False)
+        self._logger.debug("Spawning new process for deltatable compact and vacuuming")
         process = subprocess.Popen(
             [
                 "python",

--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -1,7 +1,9 @@
 import gc
 import time
 from typing import Any
+import os
 import pyarrow as pa
+import subprocess
 from dlt.sources import DltSource, DltResource
 import deltalake as deltalake
 from posthog.temporal.common.logger import FilteringBoundLogger
@@ -141,6 +143,20 @@ class PipelineNonDLT:
         # self._logger.info("Compacting delta table")
         # delta_table.optimize.compact()
         # delta_table.vacuum(retention_hours=24, enforce_retention_duration=False, dry_run=False)
+        process = subprocess.Popen(
+            [
+                "python",
+                f"{os.getcwd()}/posthog/temporal/data_imports/pipelines/pipeline/delta_table_subprocess.py",
+                "--table_uri",
+                self._delta_table_helper._get_delta_table_uri(),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = process.communicate()
+
+        if process.returncode != 0:
+            raise Exception(f"Delta subprocess failed: {stderr.decode()}")
 
         file_uris = delta_table.file_uris()
         self._logger.info(f"Preparing S3 files - total parquet files: {len(file_uris)}")

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -1,5 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
 import functools
+import os
 import uuid
 from typing import Any, Optional
 from unittest import mock
@@ -218,6 +219,17 @@ async def _execute_run(workflow_id: str, inputs: ExternalDataWorkflowInputs, moc
             AIRBYTE_BUCKET_SECRET=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
             AIRBYTE_BUCKET_REGION="us-east-1",
             AIRBYTE_BUCKET_DOMAIN="objectstorage:19000",
+        ),
+        # Mock os.environ for the deltalake subprocess
+        mock.patch.dict(
+            os.environ,
+            {
+                "BUCKET_URL": f"s3://{BUCKET_NAME}",
+                "AIRBYTE_BUCKET_KEY": settings.OBJECT_STORAGE_ACCESS_KEY_ID,
+                "AIRBYTE_BUCKET_SECRET": settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
+                "AIRBYTE_BUCKET_REGION": "us-east-1",
+                "AIRBYTE_BUCKET_DOMAIN": "objectstorage:19000",
+            },
         ),
         mock.patch.object(AwsCredentials, "to_session_credentials", mock_to_session_credentials),
         mock.patch.object(AwsCredentials, "to_object_store_rs_credentials", mock_to_object_store_rs_credentials),


### PR DESCRIPTION
## Problem
- We believe delta table compact and vacuum is the cause of the memory leaks

## Changes
- Spawn a new child process to conduct the delta lake compact and vacuum operations, this should kill the child process at the end and free up any referenced resources during the operations
- One to do some further testing on Monday after a weekend of data

## Does this work well for both Cloud and self-hosted?
I hope so

## How did you test this code?
Ran it once locally