### PR TITLE
feat(batch-exports): Producer slices record batches

### DIFF
--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -352,7 +352,7 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs) -> Records
     async with (
         Heartbeater() as heartbeater,
         set_status_to_running_task(run_id=inputs.run_id, logger=logger),
-        get_client(team_id=inputs.team_id, max_block_size=10) as client,
+        get_client(team_id=inputs.team_id) as client,
     ):
         if not await client.is_alive():
             raise ConnectionError("Cannot establish connection to ClickHouse")
@@ -402,6 +402,7 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs) -> Records
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
             extra_query_parameters=extra_query_parameters,
+            max_record_batch_size_bytes=1024 * 1024 * 2,  # 2MB
         )
         record_batch_schema = await wait_for_schema_or_producer(queue, producer_task)
         if record_batch_schema is None:


### PR DESCRIPTION
## Problem

We can't control how large will the record batches that clickhouse sends us be. We can try to set `max_block_size` to a low number to force clickhouse to process rows in smaller blocks, and hopefully use this to control the size of resulting record batches. However this method is not reliable, as ultimately is up to clickhouse to decide when to send a record batch, and that may happen whenever regardless of `max_block_size`. Moreover, a lower `max_block_size` also means worse clickhouse performance.

Large record batches are a problem particularly in Redshift, as queries cannot exceed a certain length. However, having a way to control record batch size could open up work in other destinations too.

Luckily for us, Arrow is great: Slicing a record batch is a zero copy operation, as the underlying buffer is not actually copied, just some pointers to it are created. So, we can slice large record batches when producing them for very little cost.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Add new `max_record_batch_size_bytes` and `min_records_per_batch` parameters to `spmc.Producer.start`.
* Define new `slice_record_batch` function that yields slices of a record batch when it exceeds a non-zero `max_record_batch_size_bytes`.
* Producer now uses `slice_record_batch` and produces slices into the queue.
* Set `max_record_batch_size_bytes` to 2MB in Redshift batch export.
  * This is a bit arbitrary: We flush every 8MB, and queries cannot be larger than 16MB. So with 2MB we should be flushing roughly every 4 record batches. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

* Added a few new unit tests.
* Ran Redshift testing pipeline.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
