### PR TITLE
feat(web-analytics): Add warning when pageviews are sent without a valid session id

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
@@ -3,6 +3,8 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { Link } from 'lib/lemon-ui/Link'
 import { ConversionGoalWarning, webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 
+const KNOWN_SERVER_SIDE_SDKS = ['segment', 'posthog-node', 'posthog-ruby', 'posthog-go', 'posthog-php', 'posthog-java']
+
 export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
     const { statusCheck, conversionGoalWarning } = useValues(webAnalyticsLogic)
 
@@ -49,6 +51,31 @@ export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
                     Please see{' '}
                     <Link to="https://posthog.com/docs/libraries/js">documentation for how to set up posthog-js</Link>.
                 </p>
+            </LemonBanner>
+        )
+    } else if (statusCheck.libSendingPageViewsWithoutSessionIds) {
+        return (
+            <LemonBanner type="warning" className="mt-2">
+                <p>
+                    Some <code>$pageview</code> events have been sent without a <code>$session_id</code>. This page is
+                    optimized for session-based analytics, and some features may not work correctly.
+                </p>
+                {KNOWN_SERVER_SIDE_SDKS.includes(statusCheck.libSendingPageViewsWithoutSessionIds.toLowerCase()) ? (
+                    <p>
+                        Please see{' '}
+                        <Link to="https://posthog.com/docs/data/sessions#server-sdks-and-sessions">
+                            documentation for using Sessions with server-side SDKs
+                        </Link>
+                    </p>
+                ) : (
+                    <p>
+                        Please see{' '}
+                        <Link to="https://posthog.com/docs/libraries/js">
+                            documentation for how to set up posthog-js
+                        </Link>
+                        .
+                    </p>
+                )}
             </LemonBanner>
         )
     } else if (!statusCheck.isSendingPageLeaves) {


### PR DESCRIPTION
## Problem

Sometimes users use server-side SDKs to send events to web analytics that need additional setup to work correctly, i.e. wiring up session ids

A better fix would be to remove the need for additional setup, see https://github.com/PostHog/posthog/issues/27281

## Changes

Warn people that session ids are required.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

* Confirmed that I don't get a warning on my local env.
* Modified the SQL so that I did get a warning