### PR TITLE
chore(max): Turn query gen temperature down to 0

### DIFF
--- a/ee/hogai/schema_generator/nodes.py
+++ b/ee/hogai/schema_generator/nodes.py
@@ -55,7 +55,7 @@ class SchemaGeneratorNode(AssistantNode, Generic[Q]):
 
     @property
     def _model(self):
-        return ChatOpenAI(model="gpt-4o", temperature=0.2, streaming=True).with_structured_output(
+        return ChatOpenAI(model="gpt-4o", temperature=0, streaming=True).with_structured_output(
             self.OUTPUT_SCHEMA,
             method="function_calling",
             include_raw=False,

--- a/ee/hogai/taxonomy_agent/nodes.py
+++ b/ee/hogai/taxonomy_agent/nodes.py
@@ -131,7 +131,7 @@ class TaxonomyAgentPlannerNode(AssistantNode):
 
     @property
     def _model(self) -> ChatOpenAI:
-        return ChatOpenAI(model="gpt-4o", temperature=0.2, streaming=True)
+        return ChatOpenAI(model="gpt-4o", temperature=0, streaming=True)
 
     def _get_react_format_prompt(self, toolkit: TaxonomyAgentToolkit) -> str:
         return cast(

--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -147,7 +147,7 @@ def write_sql_from_prompt(prompt: str, *, current_query: Optional[str] = None, t
 def hit_openai(messages, user) -> tuple[str, int, int]:
     result = openai.chat.completions.create(
         model="gpt-4o-mini",
-        temperature=0.8,
+        temperature=0,
         messages=messages,
         user=user,  # The user ID is for tracking within OpenAI in case of overuse/abuse
     )

--- a/posthog/hogql/ai.py
+++ b/posthog/hogql/ai.py
@@ -17,6 +17,7 @@ UNCLEAR_PREFIX = "UNCLEAR:"
 IDENTITY_MESSAGE = "HogQL is PostHog's variant of SQL. It supports most of ClickHouse SQL. You write HogQL based on a prompt. You don't help with other knowledge."
 
 HOGQL_EXAMPLE_MESSAGE = """Example HogQL query for prompt "weekly active users that performed event ACTIVATION_EVENT on example.com/foo/ 3 times or more, by week":
+
 SELECT week_of, countIf(weekly_event_count >= 3)
 FROM (
    SELECT person.id AS person_id, toStartOfWeek(timestamp) AS week_of, count() AS weekly_event_count
@@ -42,8 +43,8 @@ CURRENT_QUERY_MESSAGE = (
 
 REQUEST_MESSAGE = (
     "I need a robust HogQL query to get the following results: {prompt}\n"
-    "Return nothing besides the SQL, just the query. "
-    f'If my request doesn\'t make sense, return short and succint message starting with "{UNCLEAR_PREFIX}". '
+    "Return nothing besides the SQL, just the query. Do not wrap the SQL in backticks or quotes. "
+    f'If my request is irrelevant or doesn\'t make sense, return a short and succint message starting with "{UNCLEAR_PREFIX}". '
 )
 
 


### PR DESCRIPTION
## Problem

[Research](https://arxiv.org/html/2402.05201) suggests factual accuracy in problem-solving by LLMs is constant across the temperature range 0.0-1.0. For us creating queries, 0.0 has the nice property of being roughly deterministic, so let's use that.

## Changes

This updates query generation nodes to use temp 0.0. Doesn't affect the summarization node, which is still at 0.5 – it has a somewhat different goal of also being conversational, so warrants separate tuning.
