### PR TITLE
feat(batch-exports): Partition S3 files by max file size more accurately

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -753,6 +753,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
             extra_query_parameters=extra_query_parameters,
+            max_record_batch_size_bytes=1024 * 1024 * 10,  # 10MB
         )
         records_completed = 0
 


### PR DESCRIPTION
## Problem

Currently, we aim to split S3 files based on max file size, however there are a couple of ways the files can end up larger than the max file size:
1. if the record batch size is larger than max file size
2. if the `BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES` is larger than the max file size


## Changes

To solve these problems we do the following:
1. Use the `max_record_batch_size_bytes` parameter, introduced by #27259
2. Flush either based on `max_bytes` or `max_file_size_bytes`

I also tried moving the `should_hard_flush` logic into the writer class for better encapsulation (I ignored it for the `RedshiftInsertBatchExportWriter` as it doesn't seem to make sense in this context)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Should do

## How did you test this code?

Manual testing + existing automated tests
