### PR TITLE
feat(batch-exports): Add `max_file_size_mb` to S3 batch exports config

### DIFF
--- a/frontend/src/scenes/pipeline/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/pipeline/batch-exports/BatchExportEditForm.tsx
@@ -194,6 +194,12 @@ export function BatchExportsEditFields({
                                 label="Max file size (MiB)"
                                 showOptional
                                 className="flex-1"
+                                info={
+                                    <>
+                                        Files over this max file size will be split into multiple files. Leave empty or
+                                        set to 0 for no splitting regardless of file size
+                                    </>
+                                }
                             >
                                 <LemonInput type="number" min={0} />
                             </LemonField>

--- a/frontend/src/scenes/pipeline/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/pipeline/batch-exports/BatchExportEditForm.tsx
@@ -180,6 +180,26 @@ export function BatchExportsEditFields({
                         </LemonField>
 
                         <div className="flex gap-4">
+                            <LemonField name="file_format" label="Format" className="flex-1">
+                                <LemonSelect
+                                    options={[
+                                        { value: 'JSONLines', label: 'JSON lines' },
+                                        { value: 'Parquet', label: 'Apache Parquet' },
+                                    ]}
+                                />
+                            </LemonField>
+
+                            <LemonField
+                                name="max_file_size_mb"
+                                label="Max file size (MiB)"
+                                showOptional
+                                className="flex-1"
+                            >
+                                <LemonInput type="number" min={0} />
+                            </LemonField>
+                        </div>
+
+                        <div className="flex gap-4">
                             <LemonField name="compression" label="Compression" className="flex-1">
                                 <LemonSelect
                                     options={[
@@ -196,15 +216,6 @@ export function BatchExportsEditFields({
                                         { value: 'AES256', label: 'AES256' },
                                         { value: 'aws:kms', label: 'aws:kms' },
                                         { value: null, label: 'No encryption' },
-                                    ]}
-                                />
-                            </LemonField>
-
-                            <LemonField name="file_format" label="Format" className="flex-1">
-                                <LemonSelect
-                                    options={[
-                                        { value: 'JSONLines', label: 'JSON lines' },
-                                        { value: 'Parquet', label: 'Apache Parquet' },
                                     ]}
                                 />
                             </LemonField>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4239,6 +4239,7 @@ export type BatchExportServiceS3 = {
         kms_key_id: string | null
         endpoint_url: string | null
         file_format: string
+        max_file_size_mb: number | null
     }
 }
 


### PR DESCRIPTION
## Problem

The backend now supports splitting S3 files based on a max file size. This config needs to be exposed on the front end

## Changes

Added new field for `max_file_size_mb`. It's a numerical field that is optional. If it's empty then no file splitting will be done, which is the same as if it set to 0.

I moved this, together with file format onto a new line (as we previously had 3 fields in one line, I thought it made sense to display these 2x2 rather than 4x1 or 3x1 + 1)

### Before

<img width="843" alt="image" src="https://github.com/user-attachments/assets/1643b372-9675-42d2-8fc9-d0eb42370a56" />


### After

<img width="850" alt="image" src="https://github.com/user-attachments/assets/04871ebb-745f-4627-bc43-89dfe56f2289" />


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing with an existing local batch export. Tested leaving it empty, setting to 0 and setting it to 10.
