### PR TITLE
feat(experiments): Default new experiments to stats v2

### DIFF
--- a/ee/clickhouse/views/experiments.py
+++ b/ee/clickhouse/views/experiments.py
@@ -301,6 +301,9 @@ class ExperimentSerializer(serializers.ModelSerializer):
         feature_flag_serializer.is_valid(raise_exception=True)
         feature_flag = feature_flag_serializer.save()
 
+        if not validated_data.get("stats_config"):
+            validated_data["stats_config"] = {"version": 2}
+
         experiment = Experiment.objects.create(
             team_id=self.context["team_id"], feature_flag=feature_flag, **validated_data
         )

--- a/ee/clickhouse/views/test/test_clickhouse_experiments.py
+++ b/ee/clickhouse/views/test/test_clickhouse_experiments.py
@@ -102,11 +102,11 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.json()["name"], "Test Experiment")
         self.assertEqual(response.json()["feature_flag_key"], ff_key)
-        self.assertEqual(response.json()["stats_config"], {})
+        self.assertEqual(response.json()["stats_config"], {"version": 2})
 
         id = response.json()["id"]
         experiment = Experiment.objects.get(pk=id)
-        self.assertEqual(experiment.get_stats_config("version"), None)
+        self.assertEqual(experiment.get_stats_config("version"), 2)
 
         created_ff = FeatureFlag.objects.get(key=ff_key)
 
@@ -120,7 +120,7 @@ class TestExperimentCRUD(APILicensedTest):
         # Now update
         response = self.client.patch(
             f"/api/projects/{self.team.id}/experiments/{id}",
-            {"description": "Bazinga", "end_date": end_date, "stats_config": {"version": 2}},
+            {"description": "Bazinga", "end_date": end_date, "stats_config": {"version": 1}},
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -128,7 +128,7 @@ class TestExperimentCRUD(APILicensedTest):
         experiment = Experiment.objects.get(pk=id)
         self.assertEqual(experiment.description, "Bazinga")
         self.assertEqual(experiment.end_date.strftime("%Y-%m-%dT%H:%M"), end_date)
-        self.assertEqual(experiment.get_stats_config("version"), 2)
+        self.assertEqual(experiment.get_stats_config("version"), 1)
 
     def test_creating_updating_web_experiment(self):
         ff_key = "a-b-tests"


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/26713

Following up from https://github.com/PostHog/posthog/pull/27146

## Changes

Defaults newly created experiments to stats methodology v2.

## How did you test this code?

Tests should pass. I also verified that creating a new experiment through the UI defaults the experiment to v2 methodology.