### PR TITLE
fix(batch-exports): Fix missing key in S3 complete multipart upload

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -327,7 +327,7 @@ class S3MultiPartUpload:
 
         return self.upload_id
 
-    async def complete(self) -> str:
+    async def complete(self) -> str | None:
         if self.is_upload_in_progress() is False:
             raise NoUploadInProgressError()
 
@@ -343,7 +343,7 @@ class S3MultiPartUpload:
         self.upload_id = None
         self.parts = []
 
-        return response["Location"]
+        return response.get("Key")
 
     async def abort(self):
         """Abort this S3 multi-part upload."""


### PR DESCRIPTION
## Problem

Sometimes the `Location` key is not returned in the S3 complete multipart upload response.

## Changes

It doesn't matter too much what we return since we're not using the returned value anywhere. Therefore we just try to get the `Key`, else return `None`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Existing tests should cover this
