### PR TITLE
fix: correctly respond to incorrect list queries

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -338,7 +338,9 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
         try:
             query = RecordingsQuery.model_validate(data_dict)
         except ValidationError as pydantic_validation_error:
-            return Response({"validation_errors": str(pydantic_validation_error)}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"validation_errors": json.loads(pydantic_validation_error.json())}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         self._maybe_report_recording_list_filters_changed(request, team=self.team)
         return list_recordings_response(

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -15,7 +15,8 @@ from django.core.cache import cache
 from django.http import HttpResponse, JsonResponse
 from drf_spectacular.utils import extend_schema
 from prometheus_client import Counter, Histogram
-from rest_framework import exceptions, request, serializers, viewsets
+from pydantic import ValidationError
+from rest_framework import exceptions, request, serializers, viewsets, status
 from rest_framework.mixins import UpdateModelMixin
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
@@ -331,7 +332,19 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
         data_dict = query_as_params_to_dict(request.GET.dict())
         # we used to send `version` and it's not part of query, so we pop to make sure
         data_dict.pop("version", None)
-        query = RecordingsQuery.model_validate(data_dict)
+        # we used to send `hogql_filtering` and it's not part of query, so we pop to make sure
+        data_dict.pop("hogql_filtering", None)
+
+        try:
+            query = RecordingsQuery.model_validate(data_dict)
+        except ValidationError as pydantic_validation_error:
+            # we want to get the invalid keys from the pydantic_validation_error
+            # so we can pass them as a more readable error
+            invalid_keys_dict = {
+                error.get("loc", ("unknown",))[0]: error.get("msg", "Invalid value provided")
+                for error in pydantic_validation_error.errors()
+            }
+            return Response(invalid_keys_dict, status=status.HTTP_400_BAD_REQUEST)
 
         self._maybe_report_recording_list_filters_changed(request, team=self.team)
         return list_recordings_response(

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -338,13 +338,7 @@ class SessionRecordingViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet, U
         try:
             query = RecordingsQuery.model_validate(data_dict)
         except ValidationError as pydantic_validation_error:
-            # we want to get the invalid keys from the pydantic_validation_error
-            # so we can pass them as a more readable error
-            invalid_keys_dict = {
-                error.get("loc", ("unknown",))[0]: error.get("msg", "Invalid value provided")
-                for error in pydantic_validation_error.errors()
-            }
-            return Response(invalid_keys_dict, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"validation_errors": str(pydantic_validation_error)}, status=status.HTTP_400_BAD_REQUEST)
 
         self._maybe_report_recording_list_filters_changed(request, team=self.team)
         return list_recordings_response(

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1215,5 +1215,20 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
-            "validation_errors": "2 validation errors for RecordingsQuery\nsession_ids\n  Input should be a valid list [type=list_type, input_value='invalid', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.9/v/list_type\ntomato\n  Extra inputs are not permitted [type=extra_forbidden, input_value='potato', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.9/v/extra_forbidden",
+            "validation_errors": [
+                {
+                    "type": "list_type",
+                    "loc": ["session_ids"],
+                    "msg": "Input should be a valid list",
+                    "input": "invalid",
+                    "url": "https://errors.pydantic.dev/2.9/v/list_type",
+                },
+                {
+                    "type": "extra_forbidden",
+                    "loc": ["tomato"],
+                    "msg": "Extra inputs are not permitted",
+                    "input": "potato",
+                    "url": "https://errors.pydantic.dev/2.9/v/extra_forbidden",
+                },
+            ],
         }

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1202,12 +1202,14 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_400_when_invalid_list_query(self) -> None:
-        query_params = [
-            f'session_ids="invalid"',
-            "hogql_filtering=1",
-            "tomato=potato",
-            "version=2",
-        ].join("&")
+        query_params = "&".join(
+            [
+                f'session_ids="invalid"',
+                "hogql_filtering=1",
+                "tomato=potato",
+                "version=2",
+            ]
+        )
         response = self.client.get(
             f"/api/projects/{self.team.id}/session_recordings?{query_params}",
         )

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1215,7 +1215,5 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
-            # both version and hogql_filtering are expected invalid and ignored
-            "session_ids": "Input should be a valid list",
-            "tomato": "Extra inputs are not permitted",
+            "validation_errors": "2 validation errors for RecordingsQuery\nsession_ids\n  Input should be a valid list [type=list_type, input_value='invalid', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.9/v/list_type\ntomato\n  Extra inputs are not permitted [type=extra_forbidden, input_value='potato', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.9/v/extra_forbidden",
         }

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1200,3 +1200,20 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             f"/api/projects/{self.team.id}/session_recordings/1/snapshots?",
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_400_when_invalid_list_query(self) -> None:
+        query_params = [
+            f'session_ids="invalid"',
+            "hogql_filtering=1",
+            "tomato=potato",
+            "version=2",
+        ].join("&")
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/session_recordings?{query_params}",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            # both version and hogql_filtering are expected invalid and ignored
+            "session_ids": "Input should be a valid list",
+            "tomato": "Extra inputs are not permitted",
+        }


### PR DESCRIPTION
see https://posthoghelp.zendesk.com/agent/tickets/22752 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/24937)

The user is calling the API with an invalid value and we send a 500 response, silly

Let's respond with a 400 that lists the pydantic validation errors