### PR TITLE
feat: directly filter replay by flags

### DIFF
--- a/frontend/src/lib/components/UniversalFilters/UniversalFilterButton.tsx
+++ b/frontend/src/lib/components/UniversalFilters/UniversalFilterButton.tsx
@@ -1,6 +1,6 @@
 import './UniversalFilterButton.scss'
 
-import { IconFilter, IconX } from '@posthog/icons'
+import { IconFilter, IconLogomark, IconX } from '@posthog/icons'
 import { LemonButton, PopoverReferenceContext } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useValues } from 'kea'
@@ -78,15 +78,19 @@ const PropertyLabel = ({ filter }: { filter: AnyPropertyFilter }): JSX.Element =
     const { cohortsById } = useValues(cohortsModel)
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
 
-    const label = formatPropertyLabel(
+    let label = formatPropertyLabel(
         filter,
         cohortsById,
         (s) => formatPropertyValueForDisplay(filter.key, s)?.toString() || '?'
     )
+    const isEventFeature = label.startsWith('$feature/')
+    if (isEventFeature) {
+        label = label.replace('$feature/', 'Feature: ')
+    }
 
     return (
         <>
-            <PropertyFilterIcon type={filter.type} />
+            {isEventFeature ? <IconLogomark /> : <PropertyFilterIcon type={filter.type} />}
             <span className="UniversalFilterButton-content" title={label}>
                 {typeof label === 'string' ? midEllipsis(label, 32) : label}
             </span>

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -238,6 +238,7 @@ export const FEATURE_FLAGS = {
     COOKIELESS_SERVER_HASH_MODE_SETTING: 'cookieless-server-hash-mode-setting', // owner: @robbie-c #team-web-analytics
     INSIGHT_COLORS: 'insight-colors', // owner @thmsobrmlr #team-product-analytics
     WEB_ANALYTICS_FOR_MOBILE: 'web-analytics-for-mobile', // owner @robbie-c #team-web-analytics
+    REPLAY_FLAGS_FILTERS: 'replay-flags-filters', // owner @pauldambra #team-replay
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -33,7 +33,6 @@ import {
     CohortType,
     DashboardBasicType,
     EarlyAccessFeatureType,
-    EventPropertyFilter,
     FeatureFlagGroupType,
     FeatureFlagRollbackConditions,
     FeatureFlagStatusResponse,
@@ -192,32 +191,36 @@ export const getRecordingFilterForFlagVariant = (
     variantKey: string | null,
     hasEnrichedAnalytics?: boolean
 ): Partial<RecordingUniversalFilters> => {
-    const flagFilter: EventPropertyFilter = {
-        type: PropertyFilterType.Event,
-        key: `$feature/${flagKey}`,
-        operator: PropertyOperator.Exact,
-        value: [variantKey ? variantKey : 'true'],
-    }
     return {
         filter_group: {
             type: FilterLogicalOperator.And,
             values: [
-                hasEnrichedAnalytics
-                    ? {
-                          id: '$feature_interaction',
-                          type: 'events',
-                          order: 0,
-                          name: '$feature_interaction',
-                          properties: [
-                              {
-                                  key: 'feature_flag',
-                                  value: [flagKey],
-                                  operator: PropertyOperator.Exact,
+                {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        hasEnrichedAnalytics
+                            ? {
+                                  id: '$feature_interaction',
+                                  type: 'events',
+                                  order: 0,
+                                  name: '$feature_interaction',
+                                  properties: [
+                                      {
+                                          key: 'feature_flag',
+                                          value: [flagKey],
+                                          operator: PropertyOperator.Exact,
+                                          type: PropertyFilterType.Event,
+                                      },
+                                  ],
+                              }
+                            : {
                                   type: PropertyFilterType.Event,
+                                  key: `$feature/${flagKey}`,
+                                  operator: PropertyOperator.Exact,
+                                  value: [variantKey ? variantKey : 'true'],
                               },
-                          ],
-                      }
-                    : flagFilter,
+                    ],
+                },
             ],
         },
     }

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -33,6 +33,7 @@ import {
     CohortType,
     DashboardBasicType,
     EarlyAccessFeatureType,
+    EventPropertyFilter,
     FeatureFlagGroupType,
     FeatureFlagRollbackConditions,
     FeatureFlagStatusResponse,
@@ -191,55 +192,32 @@ export const getRecordingFilterForFlagVariant = (
     variantKey: string | null,
     hasEnrichedAnalytics?: boolean
 ): Partial<RecordingUniversalFilters> => {
+    const flagFilter: EventPropertyFilter = {
+        type: PropertyFilterType.Event,
+        key: `$feature/${flagKey}`,
+        operator: PropertyOperator.Exact,
+        value: [variantKey ? variantKey : 'true'],
+    }
     return {
         filter_group: {
             type: FilterLogicalOperator.And,
             values: [
-                {
-                    type: FilterLogicalOperator.And,
-                    values: [
-                        hasEnrichedAnalytics
-                            ? {
-                                  id: '$feature_interaction',
-                                  type: 'events',
-                                  order: 0,
-                                  name: '$feature_interaction',
-                                  properties: [
-                                      {
-                                          key: 'feature_flag',
-                                          value: [flagKey],
-                                          operator: PropertyOperator.Exact,
-                                          type: PropertyFilterType.Event,
-                                      },
-                                  ],
-                              }
-                            : {
-                                  id: '$feature_flag_called',
-                                  name: '$feature_flag_called',
-                                  type: 'events',
-                                  properties: [
-                                      {
-                                          key: '$feature/' + flagKey,
-                                          type: PropertyFilterType.Event,
-                                          value: [variantKey ? variantKey : 'false'],
-                                          operator: variantKey ? PropertyOperator.Exact : PropertyOperator.IsNot,
-                                      },
-                                      {
-                                          key: '$feature/' + flagKey,
-                                          type: PropertyFilterType.Event,
-                                          value: 'is_set',
-                                          operator: PropertyOperator.IsSet,
-                                      },
-                                      {
-                                          key: '$feature_flag',
-                                          type: PropertyFilterType.Event,
-                                          value: flagKey,
-                                          operator: PropertyOperator.Exact,
-                                      },
-                                  ],
+                hasEnrichedAnalytics
+                    ? {
+                          id: '$feature_interaction',
+                          type: 'events',
+                          order: 0,
+                          name: '$feature_interaction',
+                          properties: [
+                              {
+                                  key: 'feature_flag',
+                                  value: [flagKey],
+                                  operator: PropertyOperator.Exact,
+                                  type: PropertyFilterType.Event,
                               },
-                    ],
-                },
+                          ],
+                      }
+                    : flagFilter,
             ],
         },
     }

--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilters.tsx
@@ -21,6 +21,7 @@ export const RecordingsUniversalFilters = ({
     setFilters,
     className,
     allowReplayHogQLFilters = false,
+    allowReplayFlagsFilters = false,
 }: {
     filters: RecordingUniversalFilters
     setFilters: (filters: Partial<RecordingUniversalFilters>) => void
@@ -44,6 +45,10 @@ export const RecordingsUniversalFilters = ({
 
     if (allowReplayHogQLFilters) {
         taxonomicGroupTypes.push(TaxonomicFilterGroupType.HogQLExpression)
+    }
+
+    if (allowReplayFlagsFilters) {
+        taxonomicGroupTypes.push(TaxonomicFilterGroupType.EventFeatureFlags)
     }
 
     return (

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylist.tsx
@@ -49,6 +49,7 @@ export function SessionRecordingsPlaylist({
     const { featureFlags } = useValues(featureFlagLogic)
     const isTestingSaved = featureFlags[FEATURE_FLAGS.SAVED_NOT_PINNED] === 'test'
     const allowReplayHogQLFilters = !!featureFlags[FEATURE_FLAGS.REPLAY_HOGQL_FILTERS]
+    const allowReplayFlagsFilters = !!featureFlags[FEATURE_FLAGS.REPLAY_FLAGS_FILTERS]
 
     const pinnedDescription = isTestingSaved ? 'Saved' : 'Pinned'
 
@@ -101,6 +102,7 @@ export function SessionRecordingsPlaylist({
                         setFilters={setFilters}
                         className="border"
                         allowReplayHogQLFilters={allowReplayHogQLFilters}
+                        allowReplayFlagsFilters={allowReplayFlagsFilters}
                     />
                 )}
                 <Playlist

--- a/frontend/src/scenes/session-recordings/utils.ts
+++ b/frontend/src/scenes/session-recordings/utils.ts
@@ -12,15 +12,8 @@ export const isUniversalFilters = (
     return 'filter_group' in filters
 }
 
-const isUniversalFiltersGroup = (group: unknown): group is UniversalFiltersGroup => {
-    return !!group && typeof group === 'object' && 'values' in group && 'type' in group
-}
-
 // TODO we shouldn't be ever converting to filters any more, but I won't unpick this in this PR
 export const filtersFromUniversalFilterGroups = (filters: RecordingUniversalFilters): UniversalFilterValue[] => {
-    const filterGroupValues = filters.filter_group.values
-    if (isUniversalFiltersGroup(filterGroupValues)) {
-        return filterGroupValues.values[0] as UniversalFilterValue[]
-    }
-    return filterGroupValues as UniversalFilterValue[]
+    const group = filters.filter_group.values[0] as UniversalFiltersGroup
+    return group.values as UniversalFilterValue[]
 }

--- a/frontend/src/scenes/session-recordings/utils.ts
+++ b/frontend/src/scenes/session-recordings/utils.ts
@@ -12,7 +12,15 @@ export const isUniversalFilters = (
     return 'filter_group' in filters
 }
 
+const isUniversalFiltersGroup = (group: unknown): group is UniversalFiltersGroup => {
+    return !!group && typeof group === 'object' && 'values' in group && 'type' in group
+}
+
+// TODO we shouldn't be ever converting to filters any more, but I won't unpick this in this PR
 export const filtersFromUniversalFilterGroups = (filters: RecordingUniversalFilters): UniversalFilterValue[] => {
-    const group = filters.filter_group.values[0] as UniversalFiltersGroup
-    return group.values as UniversalFilterValue[]
+    const filterGroupValues = filters.filter_group.values
+    if (isUniversalFiltersGroup(filterGroupValues)) {
+        return filterGroupValues.values[0] as UniversalFilterValue[]
+    }
+    return filterGroupValues as UniversalFilterValue[]
 }

--- a/posthog/session_recordings/queries/session_recording_list_from_query.py
+++ b/posthog/session_recordings/queries/session_recording_list_from_query.py
@@ -83,12 +83,12 @@ def _strip_person_and_event_and_cohort_properties(
         return None
 
     properties_to_keep = [
-        g
-        for g in properties
-        if not is_event_property(g)
-        and not is_person_property(g)
-        and not is_group_property(g)
-        and not is_cohort_property(g)
+        p
+        for p in properties
+        if not is_event_property(p)
+        and not is_person_property(p)
+        and not is_group_property(p)
+        and not is_cohort_property(p)
     ]
 
     return properties_to_keep

--- a/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_query.ambr
+++ b/posthog/session_recordings/queries/test/__snapshots__/test_session_recording_list_from_query.ambr
@@ -798,6 +798,126 @@
                     allow_experimental_analyzer=0
   '''
 # ---
+# name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_0_session_1_matches_target_flag_is_True
+  '''
+  SELECT s.session_id AS session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
+         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
+         dateDiff('SECOND', start_time, end_time) AS duration,
+         argMinMerge(s.first_url) AS first_url,
+         sum(s.click_count) AS click_count,
+         sum(s.keypress_count) AS keypress_count,
+         sum(s.mouse_activity_count) AS mouse_activity_count,
+         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
+         minus(duration, active_seconds) AS inactive_seconds,
+         sum(s.console_log_count) AS console_log_count,
+         sum(s.console_warn_count) AS console_warn_count,
+         sum(s.console_error_count) AS console_error_count,
+         ifNull(greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2021-01-21 19:55:00.000000', 6, 'UTC')), 0) AS ongoing,
+         round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
+  FROM session_replay_events AS s
+  WHERE and(equals(s.team_id, 99999), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-18 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), globalIn(s.session_id,
+                                                                                                                                                                                                                                                                                                                                                                                                                                  (SELECT events.`$session_id` AS session_id
+                                                                                                                                                                                                                                                                                                                                                                                                                                   FROM events
+                                                                                                                                                                                                                                                                                                                                                                                                                                   WHERE and(equals(events.team_id, 99999), notEmpty(events.`$session_id`), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), now64(6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-17 23:58:00.000000', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/target-flag'), ''), 'null'), '^"|"$', ''), 'true'), 0))
+                                                                                                                                                                                                                                                                                                                                                                                                                                   GROUP BY events.`$session_id`
+                                                                                                                                                                                                                                                                                                                                                                                                                                   HAVING 1)))
+  GROUP BY s.session_id
+  HAVING 1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    allow_experimental_analyzer=0
+  '''
+# ---
+# name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_1_session_2_matches_target_flag_is_False
+  '''
+  SELECT s.session_id AS session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
+         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
+         dateDiff('SECOND', start_time, end_time) AS duration,
+         argMinMerge(s.first_url) AS first_url,
+         sum(s.click_count) AS click_count,
+         sum(s.keypress_count) AS keypress_count,
+         sum(s.mouse_activity_count) AS mouse_activity_count,
+         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
+         minus(duration, active_seconds) AS inactive_seconds,
+         sum(s.console_log_count) AS console_log_count,
+         sum(s.console_warn_count) AS console_warn_count,
+         sum(s.console_error_count) AS console_error_count,
+         ifNull(greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2021-01-21 19:55:00.000000', 6, 'UTC')), 0) AS ongoing,
+         round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
+  FROM session_replay_events AS s
+  WHERE and(equals(s.team_id, 99999), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-18 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), globalIn(s.session_id,
+                                                                                                                                                                                                                                                                                                                                                                                                                                  (SELECT events.`$session_id` AS session_id
+                                                                                                                                                                                                                                                                                                                                                                                                                                   FROM events
+                                                                                                                                                                                                                                                                                                                                                                                                                                   WHERE and(equals(events.team_id, 99999), notEmpty(events.`$session_id`), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), now64(6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-17 23:58:00.000000', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/target-flag'), ''), 'null'), '^"|"$', ''), 'false'), 0))
+                                                                                                                                                                                                                                                                                                                                                                                                                                   GROUP BY events.`$session_id`
+                                                                                                                                                                                                                                                                                                                                                                                                                                   HAVING 1)))
+  GROUP BY s.session_id
+  HAVING 1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    allow_experimental_analyzer=0
+  '''
+# ---
+# name: TestSessionRecordingsListFromQuery.test_can_filter_for_flags_2_sessions_1_and_2_match_target_flag_is_set
+  '''
+  SELECT s.session_id AS session_id,
+         any(s.team_id),
+         any(s.distinct_id),
+         min(toTimeZone(s.min_first_timestamp, 'UTC')) AS start_time,
+         max(toTimeZone(s.max_last_timestamp, 'UTC')) AS end_time,
+         dateDiff('SECOND', start_time, end_time) AS duration,
+         argMinMerge(s.first_url) AS first_url,
+         sum(s.click_count) AS click_count,
+         sum(s.keypress_count) AS keypress_count,
+         sum(s.mouse_activity_count) AS mouse_activity_count,
+         divide(sum(s.active_milliseconds), 1000) AS active_seconds,
+         minus(duration, active_seconds) AS inactive_seconds,
+         sum(s.console_log_count) AS console_log_count,
+         sum(s.console_warn_count) AS console_warn_count,
+         sum(s.console_error_count) AS console_error_count,
+         ifNull(greaterOrEquals(max(toTimeZone(s._timestamp, 'UTC')), toDateTime64('2021-01-21 19:55:00.000000', 6, 'UTC')), 0) AS ongoing,
+         round(multiply(divide(plus(plus(plus(divide(sum(s.active_milliseconds), 1000), sum(s.click_count)), sum(s.keypress_count)), sum(s.console_error_count)), plus(plus(plus(plus(sum(s.mouse_activity_count), dateDiff('SECOND', start_time, end_time)), sum(s.console_error_count)), sum(s.console_log_count)), sum(s.console_warn_count))), 100), 2) AS activity_score
+  FROM session_replay_events AS s
+  WHERE and(equals(s.team_id, 99999), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), 0), ifNull(greaterOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-18 00:00:00.000000', 6, 'UTC')), 0), ifNull(lessOrEquals(toTimeZone(s.min_first_timestamp, 'UTC'), toDateTime64('2021-01-21 20:00:00.000000', 6, 'UTC')), 0), globalIn(s.session_id,
+                                                                                                                                                                                                                                                                                                                                                                                                                                  (SELECT events.`$session_id` AS session_id
+                                                                                                                                                                                                                                                                                                                                                                                                                                   FROM events
+                                                                                                                                                                                                                                                                                                                                                                                                                                   WHERE and(equals(events.team_id, 99999), notEmpty(events.`$session_id`), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2020-12-31 20:00:00.000000', 6, 'UTC')), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), now64(6, 'UTC')), greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toDateTime64('2021-01-17 23:58:00.000000', 6, 'UTC')), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$feature/target-flag'), ''), 'null'), '^"|"$', '')))
+                                                                                                                                                                                                                                                                                                                                                                                                                                   GROUP BY events.`$session_id`
+                                                                                                                                                                                                                                                                                                                                                                                                                                   HAVING 1)))
+  GROUP BY s.session_id
+  HAVING 1
+  ORDER BY start_time DESC
+  LIMIT 51
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    allow_experimental_analyzer=0
+  '''
+# ---
 # name: TestSessionRecordingsListFromQuery.test_date_from_filter
   '''
   SELECT s.session_id AS session_id,


### PR DESCRIPTION
if you want to filter replay by flags you have to manually set a bunch of filters which require relatively intimate knowledge of PostHog

We should take the magic away. This adds `flags` as a top-level taxonomic filter for replay

<img width="981" alt="Screenshot 2025-01-07 at 11 32 48" src="https://github.com/user-attachments/assets/2ef668e3-6967-45c6-a8a0-02fa49ec566e" />
