### PR TITLE
fix(experiments): Normalize credible interval for delta chart

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1391,8 +1391,8 @@ export const experimentLogic = kea<experimentLogicType>([
                 },
         ],
         credibleIntervalForVariant: [
-            () => [],
-            () =>
+            (s) => [s.experimentStatsVersion],
+            (experimentStatsVersion) =>
                 (
                     metricResult:
                         | Partial<ExperimentResults['result']>
@@ -1428,13 +1428,25 @@ export const experimentLogic = kea<experimentLogicType>([
                     const controlVariant = (metricResult.variants as TrendExperimentVariant[]).find(
                         ({ key }) => key === 'control'
                     ) as TrendExperimentVariant
+                    const variant = (metricResult.variants as TrendExperimentVariant[]).find(
+                        ({ key }) => key === variantKey
+                    ) as TrendExperimentVariant
 
                     const controlMean = controlVariant.count / controlVariant.absolute_exposure
 
+                    const meanLowerBound =
+                        experimentStatsVersion === 2
+                            ? credibleInterval[0] / variant.absolute_exposure
+                            : credibleInterval[0]
+                    const meanUpperBound =
+                        experimentStatsVersion === 2
+                            ? credibleInterval[1] / variant.absolute_exposure
+                            : credibleInterval[1]
+
                     // Calculate the percentage difference between the credible interval bounds of the variant and the control's mean.
                     // This represents the range in which the true percentage change relative to the control is likely to fall.
-                    const lowerBound = ((credibleInterval[0] - controlMean) / controlMean) * 100
-                    const upperBound = ((credibleInterval[1] - controlMean) / controlMean) * 100
+                    const lowerBound = ((meanLowerBound - controlMean) / controlMean) * 100
+                    const upperBound = ((meanUpperBound - controlMean) / controlMean) * 100
                     return [lowerBound, upperBound]
                 },
         ],
@@ -1756,6 +1768,12 @@ export const experimentLogic = kea<experimentLogicType>([
                     (filters?.events && filters.events.length > 0) ||
                     (filters?.data_warehouse && filters.data_warehouse.length > 0)
                 )
+            },
+        ],
+        experimentStatsVersion: [
+            (s) => [s.experiment],
+            (experiment: Experiment): number => {
+                return experiment.stats_config?.version || 1
             },
         ],
     }),


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/26713
See https://github.com/PostHog/posthog/issues/27014
See https://posthog.slack.com/archives/C07PXH2GTGV/p1736205944905079

## Changes

For experiments using stats v2, this PR converts the Trends credible interval upper and lower bounds to mean values so the relative difference to the control can be computed.

**Stats v1**

![CleanShot 2025-01-06 at 17 57 52@2x](https://github.com/user-attachments/assets/b80953f5-3464-4a1b-bacf-d2396f0e2f4b)

**Stats v2 - After**

![CleanShot 2025-01-06 at 17 58 15@2x](https://github.com/user-attachments/assets/43ff224f-537f-4b03-a450-d3ab68275f0e)

**Stats v2 - Before**

![CleanShot 2025-01-06 at 17 58 56@2x](https://github.com/user-attachments/assets/44ed94c6-35f8-40a1-b855-71edeea6236b)

## How did you test this code?

Visually verified the results.