### PR TITLE
fix: event_distinct_ids for personless actors modal

### DIFF
--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -184,6 +184,9 @@ class ActorsQueryRunner(QueryRunner):
         raise ValueError("Source query must have an id column")
 
     def source_distinct_id_column(self, source_query: ast.SelectQuery | ast.SelectSetQuery) -> str | None:
+        if "event_distinct_ids" not in self.query.select:
+            return None
+
         if isinstance(source_query, ast.SelectQuery):
             select = source_query.select
         else:

--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -184,7 +184,7 @@ class ActorsQueryRunner(QueryRunner):
         raise ValueError("Source query must have an id column")
 
     def source_distinct_id_column(self, source_query: ast.SelectQuery | ast.SelectSetQuery) -> str | None:
-        if "event_distinct_ids" not in self.query.select:
+        if self.query.select and "event_distinct_ids" not in self.query.select:
             return None
 
         if isinstance(source_query, ast.SelectQuery):

--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -239,7 +239,7 @@ class ActorsQueryRunner(QueryRunner):
             ),
         )
 
-    def to_query(self, calculate: bool = False) -> ast.SelectQuery:
+    def to_query(self) -> ast.SelectQuery:
         with self.timings.measure("columns"):
             columns = []
             group_by = []

--- a/posthog/hogql_queries/actors_query_runner.py
+++ b/posthog/hogql_queries/actors_query_runner.py
@@ -168,7 +168,14 @@ class ActorsQueryRunner(QueryRunner):
             self.calculating = False
 
     def input_columns(self) -> list[str]:
+        strategy_input_cols = self.strategy.input_columns()
         if self.query.select:
+            if (
+                self.calculating
+                and "event_distinct_ids" in strategy_input_cols
+                and "event_distinct_ids" not in self.query.select
+            ):
+                return [*self.query.select, "event_distinct_ids"]
             return self.query.select
 
         return self.strategy.input_columns()

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_insight_actors_query_runner.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_insight_actors_query_runner.ambr
@@ -312,7 +312,6 @@
          event_distinct_ids AS event_distinct_ids
   FROM
     (SELECT persons.properties___name AS name,
-            source.event_distinct_ids AS event_distinct_ids,
             source.event_distinct_ids AS event_distinct_ids
      FROM
        (SELECT actor_id AS actor_id,
@@ -384,7 +383,6 @@
          event_distinct_ids AS event_distinct_ids
   FROM
     (SELECT persons.properties___name AS name,
-            source.event_distinct_ids AS event_distinct_ids,
             source.event_distinct_ids AS event_distinct_ids
      FROM
        (SELECT actor_id AS actor_id,

--- a/posthog/hogql_queries/insights/test/__snapshots__/test_insight_actors_query_runner.ambr
+++ b/posthog/hogql_queries/insights/test/__snapshots__/test_insight_actors_query_runner.ambr
@@ -312,6 +312,7 @@
          event_distinct_ids AS event_distinct_ids
   FROM
     (SELECT persons.properties___name AS name,
+            source.event_distinct_ids AS event_distinct_ids,
             source.event_distinct_ids AS event_distinct_ids
      FROM
        (SELECT actor_id AS actor_id,
@@ -383,6 +384,7 @@
          event_distinct_ids AS event_distinct_ids
   FROM
     (SELECT persons.properties___name AS name,
+            source.event_distinct_ids AS event_distinct_ids,
             source.event_distinct_ids AS event_distinct_ids
      FROM
        (SELECT actor_id AS actor_id,

--- a/posthog/hogql_queries/insights/test/test_insight_actors_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_insight_actors_query_runner.py
@@ -5,10 +5,20 @@ from freezegun import freeze_time
 
 from posthog.hogql import ast
 from posthog.hogql.query import execute_hogql_query
+from posthog.hogql_queries.actors_query_runner import ActorsQueryRunner
 from posthog.models.group.util import create_group
 from posthog.models.group_type_mapping import GroupTypeMapping
 from posthog.models.team import WeekStartDay
-from posthog.schema import HogQLQueryModifiers, PersonsArgMaxVersion
+from posthog.schema import (
+    HogQLQueryModifiers,
+    PersonsArgMaxVersion,
+    ActorsQuery,
+    InsightActorsQuery,
+    PersonPropertyFilter,
+    TrendsQuery,
+    DateRange,
+    EventsNode,
+)
 from posthog.test.base import (
     APIBaseTest,
     ClickhouseTestMixin,
@@ -213,6 +223,55 @@ class TestInsightActorsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         )
 
         self.assertEqual([("org1",)], response.results)
+
+    def test_insight_persons_trends_query_with_argmaxV1_calculate_adds_event_distinct_ids(self):
+        self._create_test_events()
+        self.team.timezone = "US/Pacific"
+        self.team.save()
+
+        actors_query = ActorsQuery(
+            select=["properties.name"],
+            source=InsightActorsQuery(
+                day="2020-01-09",
+                source=TrendsQuery(
+                    dateRange=DateRange(date_from="2020-01-09", date_to="2020-01-19"),
+                    series=[EventsNode(event="$pageview")],
+                    properties=[
+                        PersonPropertyFilter(type="person", key="email", value="tom@posthog.com", operator="is_not")
+                    ],
+                ),
+            ),
+        )
+        actor_query_response = ActorsQueryRunner(query=actors_query, team=self.team).calculate()
+
+        self.assertTrue("event_distinct_ids" in actor_query_response.columns)
+
+    def test_insight_persons_trends_query_with_argmaxV1_no_event_distinct(self):
+        self._create_test_events()
+        self.team.timezone = "US/Pacific"
+        self.team.save()
+
+        with self.capture_queries(lambda query: re.match(r"^SELECT\s+name\s+AS\s+name", query) is not None) as queries:
+            response = self.select(
+                """
+                select * from (
+                    <ActorsQuery select={['properties.name']}>
+                        <InsightActorsQuery day='2020-01-09'>
+                            <TrendsQuery
+                                dateRange={<DateRange date_from='2020-01-09' date_to='2020-01-19' />}
+                                series={[<EventsNode event='$pageview' />]}
+                                properties={[<PersonPropertyFilter type='person' key='email' value='tom@posthog.com' operator='is_not' />]}
+                            />
+                        </InsightActorsQuery>
+                    </ActorsQuery>
+                )
+                """,
+                modifiers={"personsArgMaxVersion": PersonsArgMaxVersion.V1},
+            )
+
+        self.assertEqual([("p2",)], response.results)
+        assert "in(id," in queries[0]
+        self.assertEqual(2, queries[0].count("toTimeZone(e.timestamp, 'US/Pacific') AS timestamp"))
 
     @snapshot_clickhouse_queries
     def test_insight_persons_trends_query_with_argmaxV1(self):

--- a/posthog/hogql_queries/insights/test/test_insight_actors_query_runner.py
+++ b/posthog/hogql_queries/insights/test/test_insight_actors_query_runner.py
@@ -224,7 +224,7 @@ class TestInsightActorsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             response = self.select(
                 """
                 select * from (
-                    <ActorsQuery select={['properties.name']}>
+                    <ActorsQuery select={['properties.name', 'event_distinct_ids']}>
                         <InsightActorsQuery day='2020-01-09'>
                             <TrendsQuery
                                 dateRange={<DateRange date_from='2020-01-09' date_to='2020-01-19' />}
@@ -252,7 +252,7 @@ class TestInsightActorsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             response = self.select(
                 """
                 select * from (
-                    <ActorsQuery select={['properties.name']}>
+                    <ActorsQuery select={['properties.name', 'event_distinct_ids']}>
                         <InsightActorsQuery day='2020-01-09'>
                             <TrendsQuery
                                 dateRange={<DateRange date_from='2020-01-09' date_to='2020-01-19' />}

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -1551,8 +1551,7 @@
   SELECT persons.id AS id,
          persons.created_at AS created_at,
          source.event_count AS event_count,
-         source.matching_events AS matching_events,
-         source.event_distinct_ids AS event_distinct_ids
+         source.matching_events AS matching_events
   FROM
     (SELECT actor_id AS actor_id,
             count() AS event_count,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -1552,7 +1552,8 @@
   SELECT persons.id AS id,
          persons.created_at AS created_at,
          source.event_count AS event_count,
-         source.matching_events AS matching_events
+         source.matching_events AS matching_events,
+         source.event_distinct_ids AS event_distinct_ids
   FROM
     (SELECT actor_id AS actor_id,
             count() AS event_count,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -241,6 +241,7 @@
          persons.created_at AS created_at,
          source.event_count AS event_count,
          source.matching_events AS matching_events,
+         source.event_distinct_ids,
          source.event_distinct_ids AS event_distinct_ids
   FROM
     (SELECT actor_id AS actor_id,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -240,8 +240,7 @@
   SELECT persons.id AS id,
          persons.created_at AS created_at,
          source.event_count AS event_count,
-         source.matching_events AS matching_events,
-         source.event_distinct_ids AS event_distinct_ids
+         source.matching_events AS matching_events
   FROM
     (SELECT actor_id AS actor_id,
             count() AS event_count,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -1552,6 +1552,7 @@
          persons.created_at AS created_at,
          source.event_count AS event_count,
          source.matching_events AS matching_events,
+         source.event_distinct_ids,
          source.event_distinct_ids AS event_distinct_ids
   FROM
     (SELECT actor_id AS actor_id,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -241,7 +241,6 @@
          persons.created_at AS created_at,
          source.event_count AS event_count,
          source.matching_events AS matching_events,
-         source.event_distinct_ids,
          source.event_distinct_ids AS event_distinct_ids
   FROM
     (SELECT actor_id AS actor_id,

--- a/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
+++ b/posthog/hogql_queries/insights/trends/test/__snapshots__/test_trends.ambr
@@ -240,7 +240,9 @@
   SELECT persons.id AS id,
          persons.created_at AS created_at,
          source.event_count AS event_count,
-         source.matching_events AS matching_events
+         source.matching_events AS matching_events,
+         source.event_distinct_ids,
+         source.event_distinct_ids AS event_distinct_ids
   FROM
     (SELECT actor_id AS actor_id,
             count() AS event_count,


### PR DESCRIPTION
## Problem

When using the actors query "to_query()" function, a user expects that the output is the list of columns passed into the "select" field. We are doing some magic to add a special `event_distinct_id` field in here to make personless events work properly with the actors modal. This causes the SQL to output more columns than requested.

https://github.com/PostHog/posthog/pull/27131

Also there were a couple issues that popped up in sentry.
![image](https://github.com/user-attachments/assets/38aeb547-052d-41b3-96be-3783b7460918)


## Changes

Modify the code so that it only inserts the extra column if the call is coming from the `calculate` method, which then hydrates the data with person data (and uses the `event_distinct_id` field)

Fix the sentry issues by looking at "input columns" for the index of "event_distinct_ids", not just the actors strategy.

Allow for `event_distinct_ids` to be directly requested from hogqlx if needed.

## How did you test this code?

Tested it locally, ran tests.
