### PR TITLE
fix(batch-exports): Ignore completed upload ids in S3 when retrying

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -641,7 +641,9 @@ async def initialize_and_resume_multipart_upload(
         try:
             await s3_upload.continue_from_state(details.upload_state)
         except UploadAlreadyFinishedError:
-            pass
+            await logger.awarning(
+                f"Attempted resume already finished upload. Upload '{details.upload_state.upload_id}' will be ignored"
+            )
 
         if inputs.compression == "brotli":
             # Even if we receive details we cannot resume a brotli compressed upload as

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -1901,6 +1901,143 @@ async def test_insert_into_s3_activity_resumes_from_heartbeat(
     )
 
 
+async def test_insert_into_s3_activity_ignores_completed_upload_id(
+    clickhouse_client, ateam, bucket_name, s3_batch_export, minio_client, activity_environment, s3_key_prefix
+):
+    """Test that if the insert_into_s3_activity activity fails, it will ignore completed uploads."""
+    data_interval_end = dt.datetime.fromisoformat("2023-04-20T14:30:00.000000+00:00")
+    data_interval_start = data_interval_end - s3_batch_export.interval_time_delta
+
+    n_expected_parts = 3
+
+    for i in range(1, n_expected_parts + 1):
+        part_inserted_at = data_interval_end - s3_batch_export.interval_time_delta / i
+
+        await generate_test_events_in_clickhouse(
+            client=clickhouse_client,
+            team_id=ateam.pk,
+            start_time=data_interval_start,
+            end_time=data_interval_end,
+            count=1,
+            count_outside_range=0,
+            count_other_team=0,
+            duplicate=False,
+            # We need at least 5MB for a multi-part upload which is what we are testing.
+            properties={"$chonky": ("a" * 5 * 2048**2)},
+            inserted_at=part_inserted_at,
+        )
+
+    attempt = 0
+
+    class FakeSession(aioboto3.Session):
+        @contextlib.asynccontextmanager
+        async def client(self, *args, **kwargs):
+            client = self._session.create_client(*args, **kwargs)
+
+            async with client as client:
+                original_upload_part = client.upload_part
+
+                async def faulty_upload_part(*args, **kwargs):
+                    nonlocal attempt
+
+                    attempt = attempt + 1
+
+                    if attempt >= 2:
+                        raise botocore.exceptions.ClientError(
+                            error_response={
+                                "Error": {"Code": "RequestTimeout", "Message": "Oh no!"},
+                                "ResponseMetadata": {"MaxAttemptsReached": True, "RetryAttempts": 2},  # type: ignore
+                            },
+                            operation_name="UploadPart",
+                        )
+                    else:
+                        return await original_upload_part(*args, **kwargs)
+
+                client.upload_part = faulty_upload_part
+
+                yield client
+
+    heartbeat_details: list[S3HeartbeatDetails] = []
+
+    def track_hearbeat_details(*details):
+        """Record heartbeat details received."""
+        nonlocal heartbeat_details
+
+        s3_details = S3HeartbeatDetails.from_activity_details(details)
+        heartbeat_details.append(s3_details)
+
+    activity_environment.on_heartbeat = track_hearbeat_details
+
+    insert_inputs = S3InsertInputs(
+        bucket_name=bucket_name,
+        region="us-east-1",
+        prefix=s3_key_prefix,
+        team_id=ateam.pk,
+        data_interval_start=data_interval_start.isoformat(),
+        data_interval_end=data_interval_end.isoformat(),
+        aws_access_key_id="object_storage_root_user",
+        aws_secret_access_key="object_storage_root_password",
+        endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
+    )
+
+    with (
+        override_settings(BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES=1, CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT=1),
+        mock.patch("posthog.temporal.batch_exports.s3_batch_export.aioboto3.Session", FakeSession),
+    ):
+        with pytest.raises(IntermittentUploadPartTimeoutError):
+            # we expect this to raise an exception
+            await activity_environment.run(insert_into_s3_activity, insert_inputs)
+
+    assert len(heartbeat_details) > 0
+
+    detail = heartbeat_details[-1]
+
+    # we expect to have only uploaded part 1 of first file
+    assert detail.files_uploaded == 0
+    assert detail.upload_state is not None
+    assert detail.upload_state.upload_id is not None
+    assert len(detail.upload_state.parts) == 1
+
+    assert len(detail.done_ranges) == 1
+
+    # now we resume from the heartbeat
+    previous_info = asdict(activity_environment.info)
+    previous_info["heartbeat_details"] = detail.serialize_details()
+    await minio_client.complete_multipart_upload(
+        Bucket=bucket_name,
+        Key=get_s3_key(insert_inputs),
+        UploadId=detail.upload_state.upload_id,
+        MultipartUpload={"Parts": detail.upload_state.parts},
+    )
+
+    new_info = activity.Info(
+        **previous_info,
+    )
+    activity_environment.info = new_info
+    with override_settings(BATCH_EXPORT_S3_UPLOAD_CHUNK_SIZE_BYTES=1, CLICKHOUSE_MAX_BLOCK_SIZE_DEFAULT=1):
+        await activity_environment.run(insert_into_s3_activity, insert_inputs)
+
+    assert len(heartbeat_details) > 0
+    detail = heartbeat_details[-1]
+    # we expect to have uploaded the file now
+    assert detail.files_uploaded == 1
+    assert detail.upload_state is None
+    assert len(detail.done_ranges) == 1
+    assert detail.done_ranges[0] == (data_interval_start, data_interval_end)
+
+    await assert_clickhouse_records_in_s3(
+        s3_compatible_client=minio_client,
+        clickhouse_client=clickhouse_client,
+        bucket_name=bucket_name,
+        key_prefix=s3_key_prefix,
+        team_id=ateam.pk,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        # When we resume from a heartbeat, we expect duplicates (the last done range will be re-exported)
+        allow_duplicates=True,
+    )
+
+
 async def test_s3_multi_part_upload_raises_retryable_exception(bucket_name, s3_key_prefix):
     """Test a retryable exception is raised instead of a `RequestTimeout`.
 


### PR DESCRIPTION
## Problem

When retrying, Temporal may not have flushed latest heartbeat. We should account for upload ids being potentially already done.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
