### PR TITLE
fix(experiments): Properly validate Trends experiment exposures

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -223,6 +223,7 @@ export function NoResultsEmptyState({ metricIndex = 0 }: { metricIndex?: number 
             'no-flag-info': 'Feature flag information not present on the events',
             'no-control-variant': 'Events with the control variant not received',
             'no-test-variant': 'Events with at least one test variant not received',
+            'no-exposures': 'Exposure events not received',
         }
 
         const successText = {
@@ -230,6 +231,7 @@ export function NoResultsEmptyState({ metricIndex = 0 }: { metricIndex?: number 
             'no-flag-info': 'Feature flag information is present on the events',
             'no-control-variant': 'Events with the control variant received',
             'no-test-variant': 'Events with at least one test variant received',
+            'no-exposures': 'Exposure events have been received',
         }
 
         return (

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -606,14 +606,17 @@ export function DeltaChart({
                                             <span className="font-semibold">
                                                 {(() => {
                                                     try {
-                                                        const detail = JSON.parse(error.detail)
-                                                        return Object.values(detail).filter((v) => v === false).length
+                                                        return Object.values(error.detail).filter((v) => v === false)
+                                                            .length
                                                     } catch {
                                                         return '0'
                                                     }
                                                 })()}
                                             </span>
-                                            /<span className="font-semibold">4</span>
+                                            /
+                                            <span className="font-semibold">
+                                                {metricType === InsightType.TRENDS ? '5' : '4'}
+                                            </span>
                                         </LemonTag>
                                     ) : (
                                         <LemonTag size="small" type="danger" className="mr-1">

--- a/frontend/src/scenes/experiments/MetricsView/NoResultEmptyState.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/NoResultEmptyState.tsx
@@ -5,7 +5,7 @@ export function NoResultEmptyState({ error }: { error: any }): JSX.Element {
         return <></>
     }
 
-    type ErrorCode = 'no-events' | 'no-flag-info' | 'no-control-variant' | 'no-test-variant'
+    type ErrorCode = 'no-events' | 'no-flag-info' | 'no-control-variant' | 'no-test-variant' | 'no-exposures'
 
     const { statusCode, hasDiagnostics } = error
 
@@ -15,6 +15,7 @@ export function NoResultEmptyState({ error }: { error: any }): JSX.Element {
             'no-flag-info': 'Feature flag information not present on the events',
             'no-control-variant': 'Events with the control variant not received',
             'no-test-variant': 'Events with at least one test variant not received',
+            'no-exposures': 'Exposure events not received',
         }
 
         const successText = {
@@ -22,6 +23,7 @@ export function NoResultEmptyState({ error }: { error: any }): JSX.Element {
             'no-flag-info': 'Feature flag information is present on the events',
             'no-control-variant': 'Events with the control variant received',
             'no-test-variant': 'Events with at least one test variant received',
+            'no-exposures': 'Exposure events have been received',
         }
 
         return (

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -263,6 +263,7 @@ class ExperimentNoResultsErrorKeys(StrEnum):
     NO_CONTROL_VARIANT = "no-control-variant"
     NO_TEST_VARIANT = "no-test-variant"
     NO_RESULTS = "no-results"
+    NO_EXPOSURES = "no-exposures"
 
 
 class PropertyOperatorType(StrEnum):

--- a/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
@@ -1660,6 +1660,7 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         expected_errors = json.dumps(
             {
+                ExperimentNoResultsErrorKeys.NO_EXPOSURES: True,
                 ExperimentNoResultsErrorKeys.NO_EVENTS: True,
                 ExperimentNoResultsErrorKeys.NO_FLAG_INFO: True,
                 ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
@@ -1698,6 +1699,7 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         expected_errors = json.dumps(
             {
+                ExperimentNoResultsErrorKeys.NO_EXPOSURES: True,
                 ExperimentNoResultsErrorKeys.NO_EVENTS: False,
                 ExperimentNoResultsErrorKeys.NO_FLAG_INFO: False,
                 ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
@@ -1715,6 +1717,14 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         journeys_for(
             {
                 "user_control": [
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2020-01-02",
+                        "properties": {
+                            "$feature_flag_response": "control",
+                            "$feature_flag": feature_flag.key,
+                        },
+                    },
                     {"event": "$pageview", "timestamp": "2020-01-02", "properties": {ff_property: "control"}},
                 ],
             },
@@ -1736,6 +1746,7 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         expected_errors = json.dumps(
             {
+                ExperimentNoResultsErrorKeys.NO_EXPOSURES: False,
                 ExperimentNoResultsErrorKeys.NO_EVENTS: False,
                 ExperimentNoResultsErrorKeys.NO_FLAG_INFO: False,
                 ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: False,
@@ -1752,9 +1763,25 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         journeys_for(
             {
                 "user_no_flag_1": [
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2020-01-02",
+                        "properties": {
+                            "$feature_flag": feature_flag.key,
+                            "$feature_flag_response": "control",
+                        },
+                    },
                     {"event": "$pageview", "timestamp": "2020-01-02"},
                 ],
                 "user_no_flag_2": [
+                    {
+                        "event": "$feature_flag_called",
+                        "timestamp": "2020-01-02",
+                        "properties": {
+                            "$feature_flag": feature_flag.key,
+                            "$feature_flag_response": "control",
+                        },
+                    },
                     {"event": "$pageview", "timestamp": "2020-01-03"},
                 ],
             },
@@ -1776,10 +1803,63 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         expected_errors = json.dumps(
             {
+                ExperimentNoResultsErrorKeys.NO_EXPOSURES: False,
                 ExperimentNoResultsErrorKeys.NO_EVENTS: True,
                 ExperimentNoResultsErrorKeys.NO_FLAG_INFO: True,
                 ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
                 ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: True,
+            }
+        )
+        self.assertEqual(cast(list, context.exception.detail)[0], expected_errors)
+
+    @freeze_time("2020-01-01T12:00:00Z")
+    def test_validate_event_variants_no_exposure(self):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(feature_flag=feature_flag)
+
+        ff_property = f"$feature/{feature_flag.key}"
+
+        journeys_for(
+            {
+                "user_control": [
+                    {"event": "$pageview", "timestamp": "2020-01-02", "properties": {ff_property: "control"}},
+                ],
+                "user_test": [
+                    {"event": "$pageview", "timestamp": "2020-01-02", "properties": {ff_property: "test"}},
+                ],
+            },
+            self.team,
+        )
+
+        flush_persons_and_events()
+
+        count_query = TrendsQuery(series=[EventsNode(event="$pageview")])
+        exposure_query = TrendsQuery(series=[EventsNode(event="$feature_flag_called")])
+
+        count_query = TrendsQuery(series=[EventsNode(event="$pageview")])
+        exposure_query = TrendsQuery(series=[EventsNode(event="$feature_flag_called")])
+
+        experiment_query = ExperimentTrendsQuery(
+            experiment_id=experiment.id,
+            kind="ExperimentTrendsQuery",
+            count_query=count_query,
+            exposure_query=exposure_query,
+        )
+
+        experiment.metrics = [{"type": "primary", "query": experiment_query.model_dump()}]
+        experiment.save()
+
+        query_runner = ExperimentTrendsQueryRunner(query=experiment_query, team=self.team)
+        with self.assertRaises(ValidationError) as context:
+            query_runner.calculate()
+
+        expected_errors = json.dumps(
+            {
+                ExperimentNoResultsErrorKeys.NO_EXPOSURES: True,
+                ExperimentNoResultsErrorKeys.NO_EVENTS: False,
+                ExperimentNoResultsErrorKeys.NO_FLAG_INFO: False,
+                ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: False,
+                ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: False,
             }
         )
         self.assertEqual(cast(list, context.exception.detail)[0], expected_errors)


### PR DESCRIPTION
## Changes

Validates Trends experiment exposures instead of erroneously returning `1` as the exposure value.

### Before

**Multiple metrics UI v2**

![CleanShot 2025-01-07 at 06 30 42@2x](https://github.com/user-attachments/assets/c710a548-28a6-43e1-9450-cca16c562fe5)

**Primary metric UI v1**

![CleanShot 2025-01-07 at 06 29 57@2x](https://github.com/user-attachments/assets/40b5920a-690b-409d-970d-d678e41b9b0b)

**Secondary metrics UI v1**

![CleanShot 2025-01-07 at 06 30 08@2x](https://github.com/user-attachments/assets/12543443-dfce-432d-a5d2-b520c1d78dca)

### After

**Multiple metrics UI v2**

![CleanShot 2025-01-07 at 06 32 10@2x](https://github.com/user-attachments/assets/df240112-e88f-4e54-9e10-8b355e881f27)

**Primary metric UI v1**

![CleanShot 2025-01-07 at 06 33 46@2x](https://github.com/user-attachments/assets/46a8c121-d311-4ce9-98b6-f61dace4ec67)


**Secondary metrics UI v1**

![CleanShot 2025-01-07 at 06 34 01@2x](https://github.com/user-attachments/assets/0cbfa495-1aa5-453d-adeb-338937e6b884)


## How did you test this code?

Tests should pass. I also manually reviewed the various permutations of UI.