### PR TITLE
chore(data-warehouse): Remove single workflow constraint on V2 worker

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from temporalio.runtime import PrometheusConfig, Runtime, TelemetryConfig
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
-from posthog.constants import DATA_WAREHOUSE_TASK_QUEUE_V2
 from posthog.temporal.common.client import connect
 from posthog.temporal.common.posthog_client import PostHogClientInterceptor
 from posthog.temporal.common.sentry import SentryInterceptor
@@ -37,35 +36,18 @@ async def start_worker(
         runtime=runtime,
     )
 
-    if task_queue == DATA_WAREHOUSE_TASK_QUEUE_V2:
-        worker = Worker(
-            client,
-            task_queue=task_queue,
-            workflows=workflows,
-            activities=activities,
-            workflow_runner=UnsandboxedWorkflowRunner(),
-            graceful_shutdown_timeout=timedelta(minutes=5),
-            interceptors=[SentryInterceptor(), PostHogClientInterceptor()],
-            activity_executor=ThreadPoolExecutor(max_workers=max_concurrent_activities or 50),
-            # Only run one workflow at a time
-            max_concurrent_activities=1,
-            max_concurrent_workflow_task_polls=1,
-            max_concurrent_workflow_tasks=1,
-            max_cached_workflows=0,
-        )
-    else:
-        worker = Worker(
-            client,
-            task_queue=task_queue,
-            workflows=workflows,
-            activities=activities,
-            workflow_runner=UnsandboxedWorkflowRunner(),
-            graceful_shutdown_timeout=timedelta(minutes=5),
-            interceptors=[SentryInterceptor(), PostHogClientInterceptor()],
-            activity_executor=ThreadPoolExecutor(max_workers=max_concurrent_activities or 50),
-            max_concurrent_activities=max_concurrent_activities or 50,
-            max_concurrent_workflow_tasks=max_concurrent_workflow_tasks,
-        )
+    worker = Worker(
+        client,
+        task_queue=task_queue,
+        workflows=workflows,
+        activities=activities,
+        workflow_runner=UnsandboxedWorkflowRunner(),
+        graceful_shutdown_timeout=timedelta(minutes=5),
+        interceptors=[SentryInterceptor(), PostHogClientInterceptor()],
+        activity_executor=ThreadPoolExecutor(max_workers=max_concurrent_activities or 50),
+        max_concurrent_activities=max_concurrent_activities or 50,
+        max_concurrent_workflow_tasks=max_concurrent_workflow_tasks,
+    )
 
     # catch the TERM signal, and stop the worker gracefully
     # https://github.com/temporalio/sdk-python#worker-shutdown


### PR DESCRIPTION
## Changes
- V2 workers seem to be behaving themselves now
- Lets remove the constraint of only running one temporal activity at a time on the V2 workers 