### PR TITLE
chore: Add deploy pr hobby cpu

### DIFF
--- a/.github/pr-deploy/hobby.yaml.tmpl
+++ b/.github/pr-deploy/hobby.yaml.tmpl
@@ -20,7 +20,7 @@ spec:
           privileged: true
         resources:
           requests:
-            cpu: 250m
+            cpu: 2
             memory: 500M          
         ports:
         - containerPort: 2375


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

We we want to deploy a PR 250m is not enough to deploy the hobby deployment.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
