### PR TITLE
fix(insights): handle large numbers correctly

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -20,7 +20,7 @@ export interface OperatorValueSelectProps {
     type?: PropertyFilterType
     propertyKey?: string
     operator?: PropertyOperator | null
-    value?: string | number | Array<string | number> | null
+    value?: string | number | bigint | Array<string | number | bigint> | null
     placeholder?: string
     endpoint?: string
     onChange: (operator: PropertyOperator, value: PropertyFilterValue) => void

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyFilterDatePicker.tsx
@@ -7,11 +7,11 @@ import { useEffect, useState } from 'react'
 import { PropertyOperator } from '~/types'
 
 const dayJSMightParse = (
-    candidateDateTimeValue: string | number | (string | number)[] | null | undefined
+    candidateDateTimeValue: string | number | bigint | (string | number | bigint)[] | null | undefined
 ): candidateDateTimeValue is string | number | undefined => ['string', 'number'].includes(typeof candidateDateTimeValue)
 
 const narrowToString = (
-    candidateDateTimeValue: string | number | (string | number)[] | null | undefined
+    candidateDateTimeValue: string | number | bigint | (string | number | bigint)[] | null | undefined
 ): candidateDateTimeValue is string | null | undefined =>
     candidateDateTimeValue == undefined || typeof candidateDateTimeValue === 'string'
 
@@ -19,7 +19,7 @@ interface PropertyFilterDatePickerProps {
     autoFocus: boolean
     operator: PropertyOperator
     setValue: (newValue: PropertyValueProps['value']) => void
-    value: string | number | (string | number)[] | null | undefined
+    value: string | number | bigint | (string | number | bigint)[] | null | undefined
 }
 
 const dateAndTimeFormat = 'YYYY-MM-DD HH:mm:ss'

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -21,7 +21,7 @@ export interface PropertyValueProps {
     endpoint?: string // Endpoint to fetch options from
     placeholder?: string
     onSet: CallableFunction
-    value?: string | number | Array<string | number> | null
+    value?: string | number | bigint | Array<string | number | bigint> | null
     operator: PropertyOperator
     autoFocus?: boolean
     eventNames?: string[]

--- a/frontend/src/scenes/insights/utils.test.ts
+++ b/frontend/src/scenes/insights/utils.test.ts
@@ -400,6 +400,28 @@ describe('formatBreakdownLabel()', () => {
         expect(formatBreakdownLabel('661', breakdownFilter2, undefined, formatter, 0)).toEqual('661s')
     })
 
+    it('handles large stringified numbers', () => {
+        const formatter = (_breakdown: any, v: any): any => `${v}s`
+
+        const breakdownFilter1: BreakdownFilter = {
+            breakdown: '$session_duration',
+            breakdown_type: 'session',
+        }
+        expect(formatBreakdownLabel('661', breakdownFilter1, undefined, formatter)).toEqual('661s')
+
+        const breakdownFilter2: BreakdownFilter = {
+            breakdowns: [
+                {
+                    property: '$session_duration',
+                    type: 'session',
+                },
+            ],
+        }
+        expect(formatBreakdownLabel('987654321012345678', breakdownFilter2, undefined, formatter, 0)).toEqual(
+            '987654321012345678s'
+        )
+    })
+
     it('handles array first', () => {
         const formatter = (_: any, value: any, type: any): any => (type === 'session' ? `${value}s` : value)
 

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -332,12 +332,14 @@ export function formatBreakdownLabel(
         )
     }
 
-    const maybeNumericValue = Number.isSafeInteger(Number(breakdown_value))
-        ? Number(breakdown_value)
-        : BigInt(breakdown_value)
-    if (!Number.isNaN(maybeNumericValue)) {
+    // stringified numbers
+    if (!Number.isNaN(Number(breakdown_value))) {
+        const numericValue =
+            Number.isInteger(Number(breakdown_value)) && !Number.isSafeInteger(Number(breakdown_value))
+                ? BigInt(breakdown_value!)
+                : Number(breakdown_value)
         return formatNumericBreakdownLabel(
-            maybeNumericValue,
+            numericValue,
             breakdownFilter,
             formatPropertyValueForDisplay,
             multipleBreakdownIndex

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -219,7 +219,7 @@ export function isOtherBreakdown(breakdown_value: string | number | null | undef
     )
 }
 
-export function isNullBreakdown(breakdown_value: string | number | null | undefined): boolean {
+export function isNullBreakdown(breakdown_value: string | number | bigint | null | undefined): boolean {
     return (
         breakdown_value === BREAKDOWN_NULL_STRING_LABEL ||
         breakdown_value === BREAKDOWN_NULL_NUMERIC_LABEL ||
@@ -241,7 +241,7 @@ function isValidJsonArray(maybeJson: string): boolean {
 }
 
 function formatNumericBreakdownLabel(
-    breakdown_value: number,
+    breakdown_value: number | bigint,
     breakdownFilter: BreakdownFilter | null | undefined,
     formatPropertyValueForDisplay: FormatPropertyValueForDisplayFunction | undefined,
     multipleBreakdownIndex: number | undefined
@@ -332,7 +332,9 @@ export function formatBreakdownLabel(
         )
     }
 
-    const maybeNumericValue = Number(breakdown_value)
+    const maybeNumericValue = Number.isSafeInteger(Number(breakdown_value))
+        ? Number(breakdown_value)
+        : BigInt(breakdown_value)
     if (!Number.isNaN(maybeNumericValue)) {
         return formatNumericBreakdownLabel(
             maybeNumericValue,

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -332,7 +332,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                     return f
                                 }
                                 const oldValue = (Array.isArray(f.value) ? f.value : [f.value]).filter(isNotNil)
-                                let newValue: (string | number)[]
+                                let newValue: (string | number | bigint)[]
                                 if (oldValue.includes(value)) {
                                     // If there are multiple values for this filter, reduce that to just the one being clicked
                                     if (oldValue.length > 1) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -657,7 +657,7 @@ export interface ToolbarProps extends ToolbarParams {
 
 export type PathCleaningFilter = { alias?: string; regex?: string }
 
-export type PropertyFilterValue = string | number | (string | number)[] | null
+export type PropertyFilterValue = string | number | bigint | (string | number | bigint)[] | null
 
 /** Sync with plugin-server/src/types.ts */
 export enum PropertyOperator {


### PR DESCRIPTION
## Problem

Breakdown values for large numbers (>= 2^53) aren't represented accurately.

Customer issues: 
https://posthoghelp.zendesk.com/agent/tickets/22533 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/25178)
https://posthoghelp.zendesk.com/agent/tickets/22460 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/25173)
https://posthoghelp.zendesk.com/agent/tickets/22756 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/25204)

<img width="383" alt="Screenshot 2025-01-07 at 16 16 27" src="https://github.com/user-attachments/assets/fc79ba89-c4f5-4ef4-b8cd-3f5af2b0d424" />

## Changes

Handles these numbers as `BigInt`.

## How did you test this code?

Breakdown by HogQL `987654321012345678`.