### PR TITLE
feat(batch-exports): Add `created_at` to S3 persons batch export

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -754,6 +754,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
             include_events=inputs.include_events,
             extra_query_parameters=extra_query_parameters,
             max_record_batch_size_bytes=1024 * 1024 * 10,  # 10MB
+            use_latest_schema=True,
         )
         records_completed = 0
 

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -251,6 +251,7 @@ async def assert_clickhouse_records_in_s3(
                 "person_version",
                 "person_distinct_id_version",
                 "_inserted_at",
+                "created_at",
             ]
 
     expected_records = []
@@ -264,6 +265,7 @@ async def assert_clickhouse_records_in_s3(
         include_events=include_events,
         destination_default_fields=s3_default_fields(),
         is_backfill=is_backfill,
+        use_latest_schema=True,
     ):
         for record in record_batch.to_pylist():
             expected_record = {}


### PR DESCRIPTION
## Problem

We're not currently sending the `created_at` field in S3 persons batch exports

## Changes

- Add the `created_at` field

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Automated tests
