### PR TITLE
fix: Prevent exception when IP address is 192.168.x.x

### DIFF
--- a/posthog/geoip.py
+++ b/posthog/geoip.py
@@ -42,7 +42,7 @@ def get_geoip_properties(ip_address: Optional[str]) -> dict[str, str]:
         $geoip_postal_code
         $geoip_time_zone
     """
-    if not ip_address or not geoip or ip_address == "127.0.0.1":
+    if not ip_address or not geoip or ip_address == "127.0.0.1" or ip_address.startswith("192.168."):
         # "127.0.0.1" would throw "The address 127.0.0.1 is not in the database." below
         return {}
 

--- a/posthog/helpers/tests/test_geoip.py
+++ b/posthog/helpers/tests/test_geoip.py
@@ -11,6 +11,7 @@ australia_ip = "13.106.122.3"
 uk_ip = "31.28.64.3"
 us_ip_v6 = "2600:6c52:7a00:11c:1b6:b7b0:ea19:6365"
 local_ip = "127.0.0.1"
+local_ip_2 = "192.168.97.1"
 mexico_ip = "187.188.10.252"
 australia_ip_2 = "13.106.122.3"
 
@@ -48,6 +49,11 @@ class TestGeoIPDBError(TestCase):
 class TestGeoIPError(TestCase):
     def test_geoip_on_local_ip_returns_successfully(self):
         properties = get_geoip_properties(local_ip)
+
+        self.assertEqual(properties, {})
+
+    def test_geoip_on_local_ip_2_returns_successfully(self):
+        properties = get_geoip_properties(local_ip_2)
 
         self.assertEqual(properties, {})
 


### PR DESCRIPTION
## Changes

Avoids an exception when the IP address is 192.168.x.x. I'm sending in some events locally using a script.

## How did you test this code?

Tests should pass.