### PR TITLE
fix(batch-exports): Push gateway when tracking batch exports

### DIFF
--- a/posthog/management/commands/get_temporal_workflow_count.py
+++ b/posthog/management/commands/get_temporal_workflow_count.py
@@ -91,7 +91,7 @@ class Command(BaseCommand):
             client.count_workflows(query=f'`TaskQueue`="{task_queue}" AND `ExecutionStatus`="{execution_status}"')
         )
 
-        if track_gauge:
+        if track_gauge and settings.PROM_PUSHGATEWAY_ADDRESS is not None:
             logging.debug(f"Tracking count in Gauge: {track_gauge}")
             registry = CollectorRegistry()
             gauge = Gauge(


### PR DESCRIPTION
## Problem

We are running this command in a short lived service. So, we need to push it to a gateway for prometheus to scrap it.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Push command result to gateway.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
