### PR TITLE
fix(flags): switch feature flags taxonomic filter loading to be async + search like insights

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -18,7 +18,6 @@ import { getEventDefinitionIcon, getPropertyDefinitionIcon } from 'scenes/data-m
 import { dataWarehouseJoinsLogic } from 'scenes/data-warehouse/external/dataWarehouseJoinsLogic'
 import { dataWarehouseSceneLogic } from 'scenes/data-warehouse/settings/dataWarehouseSceneLogic'
 import { experimentsLogic } from 'scenes/experiments/experimentsLogic'
-import { featureFlagsLogic } from 'scenes/feature-flags/featureFlagsLogic'
 import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
 import { projectLogic } from 'scenes/projectLogic'
 import { ReplayTaxonomicFilters } from 'scenes/session-recordings/filters/ReplayTaxonomicFilters'
@@ -442,8 +441,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         name: 'Feature Flags',
                         searchPlaceholder: 'feature flags',
                         type: TaxonomicFilterGroupType.FeatureFlags,
-                        logic: featureFlagsLogic,
-                        value: 'featureFlags',
+                        endpoint: combineUrl(`api/projects/${teamId}/feature_flags/`).url,
                         getName: (featureFlag: FeatureFlagType) => featureFlag.key || featureFlag.name,
                         getValue: (featureFlag: FeatureFlagType) => featureFlag.id || '',
                         getPopoverHeader: () => `Feature Flags`,


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

Closes https://github.com/PostHog/posthog/issues/27310

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Before: https://www.loom.com/share/7d7dfd6a62af42e5af2544f7f40f8893

After: https://www.loom.com/share/1da44e6a185147d99fdad10320ab3027

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->
Yes

## How did you test this code?

See looms above
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
