### PR TITLE
fix(experiments): Use 'Total' Trend math aggregation label

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -668,7 +668,13 @@ export function DeltaChart({
                             {metricType === InsightType.TRENDS ? (
                                 <>
                                     <div className="flex justify-between items-center">
-                                        <span className="text-muted font-semibold">Count:</span>
+                                        <span className="text-muted font-semibold">
+                                            {metricType === InsightType.TRENDS &&
+                                            result.exposure_query?.series?.[0]?.math
+                                                ? 'Total'
+                                                : 'Count'}
+                                            :
+                                        </span>
                                         <span className="font-semibold">
                                             {(() => {
                                                 const count = countDataForVariant(result, tooltipData.variant)


### PR DESCRIPTION
Fixes https://github.com/PostHog/posthog/issues/26981
See https://github.com/PostHog/posthog/issues/26713
See https://github.com/PostHog/posthog/issues/27014

## Changes

Uses 'Total' instead of 'Count' as the label for a Trends math aggregation metric. The value presented is the total, not a count.

**Before**

![CleanShot 2025-01-07 at 13 02 45@2x](https://github.com/user-attachments/assets/195f0514-7056-4f09-9888-4d49ec2b2a4b)

**After**

![CleanShot 2025-01-07 at 13 01 30@2x](https://github.com/user-attachments/assets/4c3c0b8b-a684-46ef-b968-c83c3d242c58)

## How did you test this code?

Visual review.