### PR TITLE
perf(session-replay): Filter event data by iso instead of int

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -683,8 +683,12 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                             kind: NodeKind.HogQLQuery,
                             query: hogql`SELECT properties, uuid
                                          FROM events
-                                         WHERE timestamp > ${(earliestTimestamp - 1000) / 1000}
-                                           AND timestamp < ${(latestTimestamp + 1000) / 1000}
+                                         WHERE timestamp > ${dayjs(earliestTimestamp - 1000)
+                                             .utc()
+                                             .toISOString()}
+                                           AND timestamp < ${dayjs(latestTimestamp + 1000)
+                                               .utc()
+                                               .toISOString()}
                                            AND event in ${eventNames}
                                            AND uuid in ${eventIds}`,
                         }


### PR DESCRIPTION
## Problem

These queries hit all partitions as clickhouse isn't smart enough to be able to filter down partitions when the right hand side is an int.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

query on isoformat instead, make queries go BRRR

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
