### PR TITLE
fix: Create pageview event on team creation

### DIFF
--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -109,6 +109,10 @@ class TeamManager(models.Manager):
         create_dashboard_from_template("DEFAULT_APP", dashboard)
         team.primary_dashboard = dashboard
 
+        from posthog.models.event_definition import EventDefinition
+
+        EventDefinition.objects.create(name="$pageview", team=team)
+
         team.save()
         return team
 

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -111,7 +111,7 @@ class TeamManager(models.Manager):
 
         from posthog.models.event_definition import EventDefinition
 
-        EventDefinition.objects.create(name="$pageview", team=team)
+        EventDefinition.objects.update_or_create(name="$pageview", team=team)
 
         team.save()
         return team


### PR DESCRIPTION
## Problem
current incident means we aren't creating new events. especially annoying for new customers.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

by default create $pageview event definition on team creation so at least that event is available.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
