### PR TITLE
fix: revert "fix: propdefs print debug statements for team 2"

### DIFF
--- a/rust/property-defs-rs/src/app_context.rs
+++ b/rust/property-defs-rs/src/app_context.rs
@@ -8,7 +8,7 @@ use crate::{
     config::Config,
     metrics_consts::{
         CACHE_WARMING_STATE, GROUP_TYPE_READS, GROUP_TYPE_RESOLVE_TIME, UPDATES_ISSUED,
-        UPDATE_TRANSACTION_TIME,
+        UPDATES_SKIPPED, UPDATE_TRANSACTION_TIME,
     },
     types::{GroupType, Update},
 };
@@ -78,6 +78,8 @@ impl AppContext {
                         // If we hit a constraint violation, we just skip the update. We see
                         // this in production for group-type-indexes not being resolved, and it's
                         // not worth aborting the whole batch for.
+                        metrics::counter!(UPDATES_SKIPPED, &[("reason", "constraint_violation")])
+                            .increment(1);
                         warn!("Failed to issue update: {:?}", e);
                     }
                     Err(e) => {

--- a/rust/property-defs-rs/src/app_context.rs
+++ b/rust/property-defs-rs/src/app_context.rs
@@ -8,7 +8,7 @@ use crate::{
     config::Config,
     metrics_consts::{
         CACHE_WARMING_STATE, GROUP_TYPE_READS, GROUP_TYPE_RESOLVE_TIME, SINGLE_UPDATE_ISSUE_TIME,
-        UPDATES_ISSUED, UPDATES_SKIPPED, UPDATE_TRANSACTION_TIME,
+        UPDATES_SKIPPED, UPDATE_TRANSACTION_TIME,
     },
     types::{GroupType, Update},
 };
@@ -61,8 +61,6 @@ impl AppContext {
             metrics::gauge!(CACHE_WARMING_STATE, &[("state", "hot")]).set(1.0);
         }
 
-        let update_count = updates.len();
-
         let group_type_resolve_time = common_metrics::timing_guard(GROUP_TYPE_RESOLVE_TIME, &[]);
         self.resolve_group_types_indexes(updates).await?;
         group_type_resolve_time.fin();
@@ -96,7 +94,6 @@ impl AppContext {
         }
         transaction_time.fin();
 
-        metrics::counter!(UPDATES_ISSUED).increment(update_count as u64);
         Ok(())
     }
 

--- a/rust/property-defs-rs/src/app_context.rs
+++ b/rust/property-defs-rs/src/app_context.rs
@@ -2,7 +2,7 @@ use health::{HealthHandle, HealthRegistry};
 use quick_cache::sync::Cache;
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use time::Duration;
-use tracing::{debug, warn};
+use tracing::warn;
 
 use crate::{
     config::Config,
@@ -72,10 +72,6 @@ impl AppContext {
             let mut tx = self.pool.begin().await?;
 
             for update in updates {
-                if update.team_id() == 2 {
-                    debug!("issued update {:?}", update)
-                }
-
                 match update.issue(&mut *tx).await {
                     Ok(_) => {}
                     Err(sqlx::Error::Database(e)) if e.constraint().is_some() => {

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -22,3 +22,4 @@ pub const SKIPPED_DUE_TO_TEAM_FILTER: &str = "prop_defs_skipped_due_to_team_filt
 pub const ISSUE_FAILED: &str = "prop_defs_issue_failed";
 pub const CHUNK_SIZE: &str = "prop_defs_chunk_size";
 pub const DUPLICATES_IN_BATCH: &str = "prop_defs_duplicates_in_batch";
+pub const SINGLE_UPDATE_ISSUE_TIME: &str = "prop_defs_single_update_issue_time_ms";

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -7,7 +7,7 @@ use sqlx::{Executor, Postgres};
 use tracing::warn;
 use uuid::Uuid;
 
-use crate::metrics_consts::{EVENTS_SKIPPED, UPDATES_SKIPPED};
+use crate::metrics_consts::{EVENTS_SKIPPED, UPDATES_ISSUED, UPDATES_SKIPPED};
 
 // We skip updates for events we generate
 pub const EVENTS_WITHOUT_PROPERTIES: [&str; 1] = ["$$plugin_metrics"];
@@ -424,7 +424,7 @@ impl EventDefinition {
     where
         E: Executor<'c, Database = Postgres>,
     {
-        sqlx::query!(
+        let res = sqlx::query!(
             r#"
             INSERT INTO posthog_eventdefinition (id, name, volume_30_day, query_usage_30_day, team_id, project_id, last_seen_at, created_at)
             VALUES ($1, $2, NULL, NULL, $3, $4, $5, NOW()) ON CONFLICT
@@ -436,7 +436,11 @@ impl EventDefinition {
             self.team_id,
             self.project_id,
             Utc::now() // We floor the update datetime to the nearest day for cache purposes, but can insert the exact time we see the event
-        ).execute(executor).await.map(|_| ())
+        ).execute(executor).await.map(|_| ());
+
+        metrics::counter!(UPDATES_ISSUED, &[("type", "event_definition")]).increment(1);
+
+        res
     }
 }
 
@@ -468,7 +472,7 @@ impl PropertyDefinition {
             return Ok(());
         }
 
-        sqlx::query!(
+        let res = sqlx::query!(
             r#"
             INSERT INTO posthog_propertydefinition (id, name, type, group_type_index, is_numerical, volume_30_day, query_usage_30_day, team_id, project_id, property_type)
             VALUES ($1, $2, $3, $4, $5, NULL, NULL, $6, $7, $8)
@@ -483,7 +487,11 @@ impl PropertyDefinition {
             self.team_id,
             self.project_id,
             self.property_type.as_ref().map(|t| t.to_string())
-        ).execute(executor).await.map(|_| ())
+        ).execute(executor).await.map(|_| ());
+
+        metrics::counter!(UPDATES_ISSUED, &[("type", "property_definition")]).increment(1);
+
+        res
     }
 }
 
@@ -492,7 +500,7 @@ impl EventProperty {
     where
         E: Executor<'c, Database = Postgres>,
     {
-        sqlx::query!(
+        let res = sqlx::query!(
             r#"INSERT INTO posthog_eventproperty (event, property, team_id, project_id) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING"#,
             self.event,
             self.property,
@@ -501,7 +509,11 @@ impl EventProperty {
         )
         .execute(executor)
         .await
-        .map(|_| ())
+        .map(|_| ());
+
+        metrics::counter!(UPDATES_ISSUED, &[("type", "event_property")]).increment(1);
+
+        res
     }
 }
 

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -131,14 +131,6 @@ impl Update {
             Update::EventProperty(ep) => ep.issue(executor).await,
         }
     }
-
-    pub fn team_id(&self) -> i32 {
-        match self {
-            Update::Event(e) => e.team_id,
-            Update::Property(p) => p.team_id,
-            Update::EventProperty(ep) => ep.team_id,
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Reverts PostHog/posthog#27345

was useless, I don't want the debug logs