### PR TITLE
feat(experiments): Use 'Single-use' instead of 'Custom'

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/MetricSourceModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/MetricSourceModal.tsx
@@ -47,7 +47,7 @@ export function MetricSourceModal({
                     }}
                 >
                     <div className="font-semibold">
-                        <span>Custom</span>
+                        <span>Single-use</span>
                     </div>
                     <div className="text-muted text-sm leading-relaxed">
                         Create a new metric specific to this experiment.


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/27014

## Changes

Uses 'Single-use' instead of 'Custom' as better contrast to 'Shared'.

**Before**

![CleanShot 2025-01-08 at 07 20 39@2x](https://github.com/user-attachments/assets/ee476bc1-fccb-46b2-b0bb-d2df13d6192a)

**After**

![CleanShot 2025-01-08 at 07 20 14@2x](https://github.com/user-attachments/assets/749b7c9e-1d09-4b2b-99d7-66b71823ca1b)

## How did you test this code?

Visual review.