### PR TITLE
feat(batch-exports): Add `created_at` to Snowflake persons batch export

### DIFF
--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 import snowflake.connector
 from django.conf import settings
 from snowflake.connector.connection import SnowflakeConnection
+from snowflake.connector.cursor import ResultMetadata
 from snowflake.connector.errors import InterfaceError, OperationalError
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
@@ -64,6 +65,8 @@ NON_RETRYABLE_ERROR_TYPES = [
     "ForbiddenError",
     # Our own exception when we can't connect to Snowflake, usually due to invalid parameters.
     "SnowflakeConnectionError",
+    # Raised when a table is not found in Snowflake.
+    "SnowflakeTableNotFoundError",
 ]
 
 
@@ -232,7 +235,7 @@ class SnowflakeClient:
         parameters: dict | None = None,
         file_stream=None,
         poll_interval: float = 1.0,
-    ) -> list[tuple] | list[dict]:
+    ) -> tuple[list[tuple] | list[dict], list[ResultMetadata]]:
         """Wrap Snowflake connector's polling API in a coroutine.
 
         This enables asynchronous execution of queries to release the event loop to execute other tasks
@@ -243,6 +246,11 @@ class SnowflakeClient:
             query: A query string to run asynchronously.
             parameters: An optional dictionary of parameters to bind to the query.
             poll_interval: Specify how long to wait in between polls.
+
+        Returns:
+            A tuple containing:
+            - The query results as a list of tuples or dicts
+            - The cursor description (containing list of fields in result)
         """
         with self.connection.cursor() as cursor:
             # Snowflake docs incorrectly state that the 'params' argument is named 'parameters'.
@@ -259,7 +267,8 @@ class SnowflakeClient:
         with self.connection.cursor() as cursor:
             cursor.get_results_from_sfqid(query_id)
             results = cursor.fetchall()
-        return results
+            description = cursor.description
+        return results, description
 
     async def aremove_internal_stage_files(self, table_name: str, table_stage_prefix: str) -> None:
         """Asynchronously remove files from internal table stage.
@@ -302,31 +311,26 @@ class SnowflakeClient:
         await self.execute_async_query(query)
         return None
 
-    async def aget_table_columns(self, table_name: str) -> list[SnowflakeField]:
-        """Get the column names and types for a given table.
+    async def aget_table_columns(self, table_name: str) -> list[str]:
+        """Get the column names for a given table.
 
         Arguments:
             table_name: The name of the table to get columns for.
 
         Returns:
-            A list of tuples containing (column_name, column_type).
+            A list of column names.
         """
-        results = await self.execute_async_query(f"""
-            SELECT
-                column_name,
-                data_type
-            FROM
-                information_schema.columns
-            WHERE
-                table_name = '{table_name}'
-            ORDER BY
-                ordinal_position
-        """)
+        try:
+            _, metadata = await self.execute_async_query(f"""
+                SELECT * FROM "{table_name}" LIMIT 0
+            """)
+        except snowflake.connector.errors.ProgrammingError as e:
+            if "does not exist" in str(e):
+                raise SnowflakeTableNotFoundError(table_name)
+            else:
+                raise
 
-        if not results:
-            raise SnowflakeTableNotFoundError(table_name)
-
-        return [(str(row[0]), str(row[1])) for row in results]
+        return [row.name for row in metadata]
 
     @contextlib.asynccontextmanager
     async def managed_table(
@@ -420,7 +424,7 @@ class SnowflakeClient:
         MATCH_BY_COLUMN_NAME = CASE_SENSITIVE
         PURGE = TRUE
         """
-        results = await self.execute_async_query(query)
+        results, _ = await self.execute_async_query(query)
 
         for query_result in results:
             if not isinstance(query_result, tuple):
@@ -459,8 +463,7 @@ class SnowflakeClient:
 
         # handle the case where the final table doesn't contain all the fields present in the stage table
         # (for example, if we've added new fields to the person model)
-        final_table_columns = await self.aget_table_columns(final_table)
-        final_table_column_names = [field[0] for field in final_table_columns]
+        final_table_column_names = await self.aget_table_columns(final_table)
         update_when_matched = [field for field in update_when_matched if field[0] in final_table_column_names]
 
         merge_condition = "ON "

--- a/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
@@ -54,6 +54,17 @@ from posthog.temporal.tests.utils.persons import (
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
 
+EXPECTED_PERSONS_BATCH_EXPORT_FIELDS = [
+    "team_id",
+    "distinct_id",
+    "person_id",
+    "properties",
+    "person_version",
+    "person_distinct_id_version",
+    "created_at",
+    "_inserted_at",
+]
+
 
 class FakeSnowflakeCursor:
     """A fake Snowflake cursor that can fail on PUT and COPY queries."""
@@ -835,6 +846,7 @@ async def assert_clickhouse_records_in_snowflake(
     batch_export_model: BatchExportModel | BatchExportSchema | None = None,
     is_backfill: bool = False,
     sort_key: str = "event",
+    expected_fields: list[str] | None = None,
 ):
     """Assert ClickHouse records are written to Snowflake table.
 
@@ -848,6 +860,7 @@ async def assert_clickhouse_records_in_snowflake(
         exclude_events: Event names to be excluded from the export.
         include_events: Event names to be included in the export.
         batch_export_schema: Custom schema used in the batch export.
+        expected_fields: List of fields expected to be in the destination table.
     """
     snowflake_cursor.execute(f'SELECT * FROM "{table_name}"')
 
@@ -869,7 +882,9 @@ async def assert_clickhouse_records_in_snowflake(
         for row in rows
     ]
 
-    schema_column_names = [field["alias"] for field in snowflake_default_fields()]
+    schema_column_names = (
+        expected_fields if expected_fields is not None else [field["alias"] for field in snowflake_default_fields()]
+    )
     if batch_export_model is not None:
         if isinstance(batch_export_model, BatchExportModel):
             batch_export_schema = batch_export_model.schema
@@ -879,15 +894,9 @@ async def assert_clickhouse_records_in_snowflake(
         if batch_export_schema is not None:
             schema_column_names = [field["alias"] for field in batch_export_schema["fields"]]
         elif isinstance(batch_export_model, BatchExportModel) and batch_export_model.name == "persons":
-            schema_column_names = [
-                "team_id",
-                "distinct_id",
-                "person_id",
-                "properties",
-                "person_version",
-                "person_distinct_id_version",
-                "_inserted_at",
-            ]
+            schema_column_names = (
+                expected_fields if expected_fields is not None else EXPECTED_PERSONS_BATCH_EXPORT_FIELDS
+            )
 
     expected_records = []
     async for record_batch in iter_model_records(
@@ -900,6 +909,7 @@ async def assert_clickhouse_records_in_snowflake(
         include_events=include_events,
         destination_default_fields=snowflake_default_fields(),
         is_backfill=is_backfill,
+        use_latest_schema=True,
     ):
         for record in record_batch.to_pylist():
             expected_record = {}
@@ -1658,3 +1668,93 @@ def test_snowflake_heartbeat_details_parses_from_tuple(details):
             dt.datetime.fromisoformat(expected_done_ranges[0][1]),
         )
     ]
+
+
+@SKIP_IF_MISSING_REQUIRED_ENV_VARS
+async def test_insert_into_snowflake_activity_handles_person_schema_changes(
+    clickhouse_client,
+    activity_environment,
+    snowflake_cursor,
+    snowflake_config,
+    generate_test_data,
+    data_interval_start,
+    data_interval_end,
+    ateam,
+):
+    """Test that the `insert_into_snowflake_activity` handles changes to the
+    person schema.
+
+    If we update the schema of the persons model we export, we should still be
+    able to export the data without breaking existing exports. For example, any
+    new fields should not be added to the destination (in future we may want to
+    allow this but for now we don't).
+
+    To replicate this situation we first export the data with the original
+    schema, then delete a column in the destination and then rerun the export.
+    """
+    model = BatchExportModel(name="persons", schema=None)
+
+    table_name = f"test_insert_activity_migration_table_{ateam.pk}"
+    insert_inputs = SnowflakeInsertInputs(
+        team_id=ateam.pk,
+        table_name=table_name,
+        data_interval_start=data_interval_start.isoformat(),
+        data_interval_end=data_interval_end.isoformat(),
+        batch_export_model=model,
+        **snowflake_config,
+    )
+
+    await activity_environment.run(insert_into_snowflake_activity, insert_inputs)
+
+    await assert_clickhouse_records_in_snowflake(
+        snowflake_cursor=snowflake_cursor,
+        clickhouse_client=clickhouse_client,
+        table_name=table_name,
+        team_id=ateam.pk,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        batch_export_model=model,
+        sort_key="person_id",
+    )
+
+    # Drop the created_at column from the Snowflake table
+    snowflake_cursor.execute(f'ALTER TABLE "{table_name}" DROP COLUMN "created_at"')
+
+    _, persons_to_export_created = generate_test_data
+
+    for old_person in persons_to_export_created[: len(persons_to_export_created) // 2]:
+        new_person_id = uuid.uuid4()
+        new_person, _ = await generate_test_persons_in_clickhouse(
+            client=clickhouse_client,
+            team_id=ateam.pk,
+            start_time=data_interval_start,
+            end_time=data_interval_end,
+            person_id=new_person_id,
+            count=1,
+            properties={"utm_medium": "referral", "$initial_os": "Linux", "new_property": "Something"},
+        )
+
+        await generate_test_person_distinct_id2_in_clickhouse(
+            clickhouse_client,
+            ateam.pk,
+            person_id=uuid.UUID(new_person[0]["id"]),
+            distinct_id=old_person["distinct_id"],
+            version=old_person["version"] + 1,
+            timestamp=old_person["_timestamp"],
+        )
+
+    await activity_environment.run(insert_into_snowflake_activity, insert_inputs)
+
+    # This time we don't expect there to be a created_at column
+    expected_fields = [field for field in EXPECTED_PERSONS_BATCH_EXPORT_FIELDS if field != "created_at"]
+    await assert_clickhouse_records_in_snowflake(
+        snowflake_cursor=snowflake_cursor,
+        clickhouse_client=clickhouse_client,
+        table_name=table_name,
+        team_id=ateam.pk,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        batch_export_model=model,
+        sort_key="person_id",
+        expected_fields=expected_fields,
+    )

--- a/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
@@ -126,6 +126,9 @@ class FakeSnowflakeCursor:
         else:
             return [("test", "LOADED", 100, 99, 1, 1, "Some error on copy", 3)]
 
+    def description(self):
+        return []
+
 
 class FakeSnowflakeConnection:
     def __init__(


### PR DESCRIPTION
## Problem

We're not currently sending the `created_at` field in Snowflake persons batch exports

## Changes

Add the `created_at` field

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Should do

## How did you test this code?

Added a new test and updated existing ones
