### PR TITLE
fix: Revert "feat(web-analytics): Add warning when pageviews are sent without a valid session id

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsHealthCheck.tsx
@@ -3,8 +3,6 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { Link } from 'lib/lemon-ui/Link'
 import { ConversionGoalWarning, webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 
-const KNOWN_SERVER_SIDE_SDKS = ['segment', 'posthog-node', 'posthog-ruby', 'posthog-go', 'posthog-php', 'posthog-java']
-
 export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
     const { statusCheck, conversionGoalWarning } = useValues(webAnalyticsLogic)
 
@@ -51,31 +49,6 @@ export const WebAnalyticsHealthCheck = (): JSX.Element | null => {
                     Please see{' '}
                     <Link to="https://posthog.com/docs/libraries/js">documentation for how to set up posthog-js</Link>.
                 </p>
-            </LemonBanner>
-        )
-    } else if (statusCheck.libSendingPageViewsWithoutSessionIds) {
-        return (
-            <LemonBanner type="warning" className="mt-2">
-                <p>
-                    Some <code>$pageview</code> events have been sent without a <code>$session_id</code>. This page is
-                    optimized for session-based analytics, and some features may not work correctly.
-                </p>
-                {KNOWN_SERVER_SIDE_SDKS.includes(statusCheck.libSendingPageViewsWithoutSessionIds.toLowerCase()) ? (
-                    <p>
-                        Please see{' '}
-                        <Link to="https://posthog.com/docs/data/sessions#server-sdks-and-sessions">
-                            documentation for using Sessions with server-side SDKs
-                        </Link>
-                    </p>
-                ) : (
-                    <p>
-                        Please see{' '}
-                        <Link to="https://posthog.com/docs/libraries/js">
-                            documentation for how to set up posthog-js
-                        </Link>
-                        .
-                    </p>
-                )}
             </LemonBanner>
         )
     } else if (!statusCheck.isSendingPageLeaves) {

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -23,7 +23,6 @@ import {
     CompareFilter,
     CustomEventConversionGoal,
     EventsNode,
-    HogQLQuery,
     NodeKind,
     QuerySchema,
     TrendsFilter,
@@ -203,7 +202,6 @@ export interface WebAnalyticsStatusCheck {
     isSendingPageViews: boolean
     isSendingPageLeaves: boolean
     isSendingPageLeavesScroll: boolean
-    libSendingPageViewsWithoutSessionIds: string | undefined
 }
 
 export enum ConversionGoalWarning {
@@ -1633,25 +1631,20 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         statusCheck: {
             __default: null as WebAnalyticsStatusCheck | null,
             loadStatusCheck: async (): Promise<WebAnalyticsStatusCheck> => {
-                const [pageviewResult, pageleaveResult, pageleaveScroll, pageViewsWithoutSessionsResult] =
-                    await Promise.allSettled([
-                        api.eventDefinitions.list({
-                            event_type: EventDefinitionType.Event,
-                            search: '$pageview',
-                        }),
-                        api.eventDefinitions.list({
-                            event_type: EventDefinitionType.Event,
-                            search: '$pageleave',
-                        }),
-                        api.propertyDefinitions.list({
-                            event_names: ['$pageleave'],
-                            properties: ['$prev_pageview_max_content_percentage'],
-                        }),
-                        api.query<HogQLQuery>({
-                            kind: NodeKind.HogQLQuery,
-                            query: "SELECT events.properties.$lib as lib FROM events WHERE event='$pageview' AND or(events.$session_id IS NULL, events.$session_id = '') AND timestamp > today() LIMIT 1",
-                        }),
-                    ])
+                const [pageviewResult, pageleaveResult, pageleaveScroll] = await Promise.allSettled([
+                    api.eventDefinitions.list({
+                        event_type: EventDefinitionType.Event,
+                        search: '$pageview',
+                    }),
+                    api.eventDefinitions.list({
+                        event_type: EventDefinitionType.Event,
+                        search: '$pageleave',
+                    }),
+                    api.propertyDefinitions.list({
+                        event_names: ['$pageleave'],
+                        properties: ['$prev_pageview_max_content_percentage'],
+                    }),
+                ])
 
                 // no need to worry about pagination here, event names beginning with $ are reserved, and we're not
                 // going to add enough reserved event names that match this search term to cause problems
@@ -1670,10 +1663,6 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                         ? pageleaveScroll.value.results.find((r) => r.name === '$prev_pageview_max_content_percentage')
                         : undefined
 
-                const libSendingPageViewsWithoutSessionIds =
-                    pageViewsWithoutSessionsResult.status === 'fulfilled'
-                        ? pageViewsWithoutSessionsResult.value.results?.[0]?.[0]
-                        : undefined
                 const isSendingPageViews = !!pageviewEntry && !isDefinitionStale(pageviewEntry)
                 const isSendingPageLeaves = !!pageleaveEntry && !isDefinitionStale(pageleaveEntry)
                 const isSendingPageLeavesScroll = !!pageleaveScrollEntry && !isDefinitionStale(pageleaveScrollEntry)
@@ -1682,7 +1671,6 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     isSendingPageViews,
                     isSendingPageLeaves,
                     isSendingPageLeavesScroll,
-                    libSendingPageViewsWithoutSessionIds,
                 }
             },
         },


### PR DESCRIPTION


This reverts commit 0c6d721767bbdf615c3db384828267267bf9a97c.

## Problem

This PR showed us a warning on our project when it shouldn't do. I need to revert it, and revisit / rethink.

## Changes

Revert #27269

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
n/a
