### PR TITLE
fix: draft query needs current org id to match

### DIFF
--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -336,7 +336,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                     : await insightsApi.create(insightRequest)
                 savedInsightsLogic.findMounted()?.actions.loadInsights() // Load insights afresh
                 // remove draft query from local storage
-                localStorage.removeItem('draft-query')
+                localStorage.removeItem(`draft-query-${values.currentTeamId}`)
                 actions.saveInsightSuccess()
             } catch (e) {
                 actions.saveInsightFailure()


### PR DESCRIPTION
Update the local storage removal when an insight is saved to include the current org id.
