### PR TITLE
chore(cache-warming): add team id to metrics

### DIFF
--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -168,6 +168,7 @@ def schedule_warming_for_teams_task():
                 properties={
                     "count": len(insight_tuples),
                     "team_id": team.id,
+                    "organization_id": team.organization_id,
                 },
             )
 
@@ -237,6 +238,7 @@ def warm_insight_cache_task(insight_id: int, dashboard_id: Optional[int]):
                         "dashboard_id": dashboard_id,
                         "is_cached": is_cached,
                         "team_id": insight.team_id,
+                        "organization_id": insight.team.organization_id,
                     },
                 )
 

--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -165,7 +165,10 @@ def schedule_warming_for_teams_task():
             capture_ph_event(
                 str(team.uuid),
                 "cache warming - insights to cache",
-                properties={"count": len(insight_tuples)},
+                properties={
+                    "count": len(insight_tuples),
+                    "team_id": team.id,
+                },
             )
 
             # We chain the task execution to prevent queries *for a single team* running at the same time
@@ -233,6 +236,7 @@ def warm_insight_cache_task(insight_id: int, dashboard_id: Optional[int]):
                         "insight_id": insight.pk,
                         "dashboard_id": dashboard_id,
                         "is_cached": is_cached,
+                        "team_id": insight.team_id,
                     },
                 )
 


### PR DESCRIPTION
## Problem
Forgot to add event property for team id when moving away from `report_team_action`

## Changes
Add in the metrics
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
