### PR TITLE
fix: new string time queries are using wrong time

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -678,17 +678,18 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                     const eventIds = existingEvents.map((ee) => ee.id)
                     const earliestTimestamp = timestamps.reduce((a, b) => Math.min(a, b))
                     const latestTimestamp = timestamps.reduce((a, b) => Math.max(a, b))
+
                     try {
                         const query: HogQLQuery = {
                             kind: NodeKind.HogQLQuery,
                             query: hogql`SELECT properties, uuid
                                          FROM events
-                                         WHERE timestamp > ${dayjs(earliestTimestamp - 1000).format(
-                                             'YYYY-MM-DD HH:MM:ss.SSS'
-                                         )}
-                                           AND timestamp < ${dayjs(latestTimestamp + 1000).format(
-                                               'YYYY-MM-DD HH:MM:ss.SSS'
-                                           )}
+                                         WHERE timestamp > ${dayjs(earliestTimestamp - 1000)
+                                             .utc()
+                                             .format('YYYY-MM-DD HH:mm:ss.SSS')}
+                                           AND timestamp < ${dayjs(latestTimestamp + 1000)
+                                               .utc()
+                                               .format('YYYY-MM-DD HH:mm:ss.SSS')}
                                            AND event in ${eventNames}
                                            AND uuid in ${eventIds}`,
                         }

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingDataLogic.ts
@@ -683,12 +683,12 @@ export const sessionRecordingDataLogic = kea<sessionRecordingDataLogicType>([
                             kind: NodeKind.HogQLQuery,
                             query: hogql`SELECT properties, uuid
                                          FROM events
-                                         WHERE timestamp > ${dayjs(earliestTimestamp - 1000)
-                                             .utc()
-                                             .format('YYYY-MM-DD HH:MM:ss.SSS')}
-                                           AND timestamp < ${dayjs(latestTimestamp + 1000)
-                                               .utc()
-                                               .format('YYYY-MM-DD HH:MM:ss.SSS')}
+                                         WHERE timestamp > ${dayjs(earliestTimestamp - 1000).format(
+                                             'YYYY-MM-DD HH:MM:ss.SSS'
+                                         )}
+                                           AND timestamp < ${dayjs(latestTimestamp + 1000).format(
+                                               'YYYY-MM-DD HH:MM:ss.SSS'
+                                           )}
                                            AND event in ${eventNames}
                                            AND uuid in ${eventIds}`,
                         }


### PR DESCRIPTION
follow-up to https://github.com/PostHog/posthog/pull/27339

We're not loading any properties

The date format was HH:MM:ss (which is hour month second)
And shouldn't be 🙈 