### PR TITLE
chore: Add nonretryable foreign key violation

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -812,6 +812,8 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
                 # We do not create any ourselves, so this generally is a user-managed check, so we
                 # should not retry.
                 "CheckViolation",
+                # We do not create foreign keys, so this is a user managed check we have failed.
+                "ForeignKeyViolation",
             ],
             finish_inputs=finish_inputs,
         )


### PR DESCRIPTION
## Problem

Another non-retryable error type for constraints we do not manage.

<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* `ForeignKeyViolation` is now non-retryable on Postgres batch export.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
