### PR TITLE
chore: Enable web vitals capture

### DIFF
--- a/frontend/src/loadPostHogJS.tsx
+++ b/frontend/src/loadPostHogJS.tsx
@@ -66,6 +66,7 @@ export function loadPostHogJS(): void {
                 autocapture: {
                     capture_copied_text: true,
                 },
+                capture_performance: { web_vitals: true },
                 person_profiles: 'always',
                 __preview_remote_config: true,
 


### PR DESCRIPTION
We want to dogfood our Core Web Vitals dashboard, so let's collect that information
    
This is already happening in our production app because of autocapture, but this settings makes it:
1. explicit
2. work locally