### PR TITLE
chore(data-warehouse): Added SSL error as a non retryable error

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -67,6 +67,7 @@ Non_Retryable_Schema_Errors: dict[ExternalDataSource.Type, list[str]] = {
         "password authentication failed for user",
         "No primary key defined for table",
         "failed: timeout expired",
+        "SSL connection has been closed unexpectedly",
     ],
     ExternalDataSource.Type.ZENDESK: ["404 Client Error: Not Found for url", "403 Client Error: Forbidden for url"],
     ExternalDataSource.Type.MYSQL: ["Can't connect to MySQL server on", "No primary key defined for table"],


### PR DESCRIPTION
## Problem
- getting 8k of these errors a day https://posthog.sentry.io/issues/6134614538/events/0b84cd66d7834bd6bf42a8331afb8335/

## Changes
- Turn off schemas that experience SSL connection errors (mostly just one source hosted on render.com)
