### PR TITLE
fix(experiments): Force refresh when `start_date` is provided

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -766,11 +766,12 @@ export const experimentLogic = kea<experimentLogicType>([
             values.experiment && actions.reportExperimentReset(values.experiment)
             actions.loadSecondaryMetricResultsSuccess([])
         },
-        updateExperimentSuccess: async ({ experiment }) => {
+        updateExperimentSuccess: async ({ experiment, payload }) => {
             actions.updateExperiments(experiment)
             if (experiment.start_date) {
-                actions.loadMetricResults()
-                actions.loadSecondaryMetricResults()
+                const forceRefresh = payload?.start_date !== undefined
+                actions.loadMetricResults(forceRefresh)
+                actions.loadSecondaryMetricResults(forceRefresh)
             } else {
                 actions.loadMetricResultsSuccess([])
                 actions.loadSecondaryMetricResultsSuccess([])


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/27014

## Changes

Force refreshes experiment results when a `start_date` is included in the update payload. Previously, relaunching an experiment with a new start date could unexpectedly use cached experiment results, causing erroneous display of data.

**Before**

https://github.com/user-attachments/assets/4941af51-00c3-4342-a3db-b24a51a836c4

**After**

https://github.com/user-attachments/assets/ea4201ac-0ac4-4259-bd59-fff61152f50f


## How did you test this code?

I reset an existing experiment and launched it again. Without these changes, the prior experiment results displayed. With these changes, "Results not yet available" displays as expected.