### PR TITLE
fix(data-warehouse): Update the pyarrows schema to match the existing deltalake table if t…

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -67,6 +67,13 @@ def _evolve_pyarrow_schema(table: pa.Table, delta_schema: deltalake.Schema | Non
                     )
                     table = table.cast(new_schema)
 
+            # If the deltalake schema has a different type to the pyarrows table, then cast to the deltalake field type
+            py_arrow_table_column = table.column(field.name)
+            if field.type != py_arrow_table_column.type:
+                table = table.set_column(
+                    table.schema.get_field_index(field.name), field.name, table.column(field.name).cast(field.type)
+                )
+
     # Change types based on what deltalake tables support
     return table.cast(ensure_delta_compatible_arrow_schema(table.schema))
 


### PR DESCRIPTION
## Problem
- Somehow on incremental syncs the new data may have a different type from the data in the existing deltalake table in S3, causing us to have very vague type coerce errors being thrown like [this](https://posthog.sentry.io/issues/6190877852/?project=4508444747956225&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=30d&stream_index=7)

## Changes
- If there's a diff between the deltalake schema and the incoming pyarrows table schema, then cast the difference pyarrows columns to be that of the deltalake column
  - This is a fairly naive solution right now, and we may need to, _at some point_, look into our own schema management 

## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
Tested with real data from the sentry error above