### PR TITLE
fix: typo in dashboard template configuration

### DIFF
--- a/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
+++ b/frontend/src/scenes/onboarding/productAnalyticsSteps/DashboardTemplateConfigureStep.tsx
@@ -136,7 +136,7 @@ export const SiteChooser = (): JSX.Element => {
                     ) : combinedSnippetAndLiveEventsHosts.length > 0 ? (
                         <>
                             <p>
-                                Not seeing the site you want? Try clikcing around on your site to trigger a few events.
+                                Not seeing the site you want? Try clicking around on your site to trigger a few events.
                                 If you haven't yet,{' '}
                                 <Link onClick={() => setStepKey(OnboardingStepKey.INSTALL)}>install posthog-js</Link> or
                                 the HTML snippet wherever you want to track events, then come back here.


### PR DESCRIPTION
## Problem

Noticed a typo when trying out the onboarding experience and looked like an easy fix.

`https://us.posthog.com/project/<projectId>/onboarding/product_analytics?step=dashboard_template_configure`

![typo](https://github.com/user-attachments/assets/5191941c-675c-42ae-8357-a09ee19b63a1)

## Changes

Fixed the typo

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

No impact

## How did you test this code?

Ran the unit tests locally (`pnpm test:unit`), did not appear to break anything.
