### PR TITLE
feat: add check to disable usage reports

### DIFF
--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1045,6 +1045,14 @@ def send_all_org_usage_reports(
     skip_capture_event: bool = False,
     only_organization_id: Optional[str] = None,
 ) -> None:
+    import posthoganalytics
+    from sentry_sdk import capture_message
+
+    are_usage_reports_disabled = posthoganalytics.feature_enabled("disabled-usage-reports", "internal_billing_events")
+    if are_usage_reports_disabled:
+        capture_message(f"Usage reports are disabled for {at}")
+        return
+
     capture_event_name = capture_event_name or "organization usage report"
 
     at_date = parser.parse(at) if at else None

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1048,7 +1048,7 @@ def send_all_org_usage_reports(
     import posthoganalytics
     from sentry_sdk import capture_message
 
-    are_usage_reports_disabled = posthoganalytics.feature_enabled("disabled-usage-reports", "internal_billing_events")
+    are_usage_reports_disabled = posthoganalytics.feature_enabled("disable-usage-reports", "internal_billing_events")
     if are_usage_reports_disabled:
         capture_message(f"Usage reports are disabled for {at}")
         return


### PR DESCRIPTION
## Changes

If there is an outage related to ingested we don't want to run usage reporting because it could be missing events. This uses a feature flag to skip usage reporting if the flag is set - which we will manually do when there is an outage. Then after the outage is resolved we can disabled the flag and re-run the reports for the missing days. 

Note: this is done here because we want to limit the number of feature flag checks, if we do it in billing it will need to be checked for every customer. The downside of this is that it can miss a few instances because usage reports run multiple ways: 
- via the management command `sync_usage_reports`
- via the API view for usage (which this PR is handing)
- when a customer is updated and their `customer.primary_stripe_subscription_id` changes. 

Flag: https://us.posthog.com/project/2/feature_flags/97562

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
