### PR TITLE
chore: adding event logs for when a member is removed from org

### DIFF
--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -144,6 +144,8 @@ class OrganizationMemberViewSet(
         requesting_user = cast(User, self.request.user)
         removed_user = cast(User, instance.user)
 
+        is_self_removal = requesting_user.id == removed_user.id
+
         posthoganalytics.capture(
             str(requesting_user.distinct_id),
             "organization member removed",
@@ -152,9 +154,9 @@ class OrganizationMemberViewSet(
                 "removed_by_id": requesting_user.distinct_id,
                 "organization_id": instance.organization_id,
                 "organization_name": instance.organization.name,
+                "removal_type": "self_removal" if is_self_removal else "removed_by_other",
             },
             groups=groups(instance.organization),
         )
 
-        instance = cast(OrganizationMembership, instance)
         instance.user.leave(organization=instance.organization)

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -50,8 +50,9 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json(), self.permission_denied_response())
 
+    @patch("posthoganalytics.capture")
     @patch("posthog.models.user.User.update_billing_organization_users")
-    def test_delete_organization_member(self, mock_update_billing_organization_users):
+    def test_delete_organization_member(self, mock_update_billing_organization_users, mock_capture):
         user = User.objects.create_and_join(self.organization, "test@x.com", None, "X")
         membership_queryset = OrganizationMembership.objects.filter(user=user, organization=self.organization)
         self.assertTrue(membership_queryset.exists())
@@ -66,19 +67,43 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.status_code, 204)
         self.assertFalse(membership_queryset.exists(), False)
 
+        mock_capture.assert_called_with(
+            self.user.distinct_id,  # requesting user
+            "organization member removed",
+            properties={
+                "removed_member_id": user.distinct_id,
+                "removed_by_id": self.user.distinct_id,
+                "organization_id": self.organization.id,
+                "organization_name": self.organization.name,
+            },
+            groups={"instance": "http://localhost:8010", "organization": str(self.organization.id)},
+        )
         assert mock_update_billing_organization_users.call_count == 2
         assert mock_update_billing_organization_users.call_args_list == [
             call(self.organization),
             call(self.organization),
         ]
 
+    @patch("posthoganalytics.capture")
     @patch("posthog.models.user.User.update_billing_organization_users")
-    def test_leave_organization(self, mock_update_billing_organization_users):
+    def test_leave_organization(self, mock_update_billing_organization_users, mock_capture):
         membership_queryset = OrganizationMembership.objects.filter(user=self.user, organization=self.organization)
         self.assertEqual(membership_queryset.count(), 1)
         response = self.client.delete(f"/api/organizations/@current/members/{self.user.uuid}/")
         self.assertEqual(response.status_code, 204)
         self.assertEqual(membership_queryset.count(), 0)
+
+        mock_capture.assert_called_with(
+            self.user.distinct_id,
+            "organization member removed",
+            properties={
+                "removed_member_id": self.user.distinct_id,
+                "removed_by_id": self.user.distinct_id,
+                "organization_id": self.organization.id,
+                "organization_name": self.organization.name,
+            },
+            groups={"instance": "http://localhost:8010", "organization": str(self.organization.id)},
+        )
 
         assert mock_update_billing_organization_users.call_count == 1
         assert mock_update_billing_organization_users.call_args_list == [

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -75,6 +75,7 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
                 "removed_by_id": self.user.distinct_id,
                 "organization_id": self.organization.id,
                 "organization_name": self.organization.name,
+                "removal_type": "removed_by_other",
             },
             groups={"instance": "http://localhost:8010", "organization": str(self.organization.id)},
         )
@@ -101,6 +102,7 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
                 "removed_by_id": self.user.distinct_id,
                 "organization_id": self.organization.id,
                 "organization_name": self.organization.name,
+                "removal_type": "self_removal",
             },
             groups={"instance": "http://localhost:8010", "organization": str(self.organization.id)},
         )


### PR DESCRIPTION
## Problem

This was based on a customer request. We should be able to see when and who is removing members from an org.

## Changes

When the use deleted the member, I've added capture events with the user deleted, and the user to sends the request to capture the event

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Cloud: yes

## How did you test this code?

ran pytests
since i couldn't get the activity tab to load to to see the events, I manually triggered breakpoints to ensure that all the fields were being captured as expected.
