### PR TITLE
chore(cache-warming): find how much cache warming triggered due to sh…

### DIFF
--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -169,6 +169,7 @@ def schedule_warming_for_teams_task():
                     "count": len(insight_tuples),
                     "team_id": team.id,
                     "organization_id": team.organization_id,
+                    "shared_only": shared_only,
                 },
             )
 


### PR DESCRIPTION
## Problem
Need to find out what % of cache warming is contributed by shared insights.

## Changes
Tracking `shared_only`
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
