### PR TITLE
fix: add more posthog props to taxonomy

### DIFF
--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -244,6 +244,35 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
     event_properties: {
         distinct_id: {} as CoreFilterDefinition, // Copied from `metadata` down below
         $session_duration: {} as CoreFilterDefinition, // Copied from `sessions` down below
+        $session_is_sampled: {
+            label: 'Whether the session is sampled',
+            description: 'Whether the session is sampled for session recording.',
+            examples: ['true', 'false'],
+            system: true,
+        },
+        $geoip_postal_code_confidence: {
+            label: 'Postal Code identification confidence score',
+            description: 'If provided by the licensed geoip database',
+            examples: ['null', '0.1'],
+            system: true,
+        },
+        $geoip_subdivision_2_confidence: {
+            label: 'Subdivision 2 identification confidence score',
+            description: 'If provided by the licensed geoip database',
+            examples: ['null', '0.1'],
+            system: true,
+        },
+        $browser_language_prefix: {
+            label: 'Browser Language Prefix',
+            description: 'Language prefix.',
+            examples: ['en', 'ja'],
+        },
+        $prev_pageview_id: {
+            label: 'Previous pageview ID',
+            description: 'posthog-js adds these to the page leave event, they are used in web analytics calculations',
+            examples: ['1'],
+            system: True,
+        },
         $copy_type: {
             label: 'Copy Type',
             description: 'Type of copy event.',

--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -271,7 +271,7 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
             label: 'Previous pageview ID',
             description: 'posthog-js adds these to the page leave event, they are used in web analytics calculations',
             examples: ['1'],
-            system: True,
+            system: true,
         },
         $copy_type: {
             label: 'Copy Type',

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -295,6 +295,13 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "system": True,
             "ignored_in_assistant": True,
         },
+        "$session_is_sampled": {
+            "label": "Whether the session is sampled",
+            "description": "Whether the session is sampled for session recording.",
+            "examples": ["true", "false"],
+            "system": True,
+            "ignored_in_assistant": True,
+        },
         "$feature_flag_payloads": {
             "label": "Feature Flag Payloads",
             "description": "Feature flag payloads active in the environment.",
@@ -508,6 +515,12 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "description": "Approximated postal code matched to this event's IP address.",
             "examples": ["2000", "600004", "11211"],
         },
+        "$geoip_postal_code_confidence": {
+            "label": "Postal Code identification confidence score",
+            "description": "If provided by the licensed geoip database",
+            "examples": ["null", "0.1"],
+            "ignored_in_assistant": True,
+        },
         "$geoip_latitude": {
             "label": "Latitude",
             "description": "Approximated latitude matched to this event's IP address.",
@@ -540,6 +553,12 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$geoip_subdivision_2_code": {
             "label": "Subdivision 2 Code",
             "description": "Code of the second subdivision matched to this event's IP address.",
+        },
+        "$geoip_subdivision_2_confidence": {
+            "label": "Subdivision 2 identification confidence score",
+            "description": "If provided by the licensed geoip database",
+            "examples": ["null", "0.1"],
+            "ignored_in_assistant": True,
         },
         "$geoip_subdivision_3_name": {
             "label": "Subdivision 3 Name",
@@ -759,6 +778,14 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Browser Language",
             "description": "Language.",
             "examples": ["en", "en-US", "cn", "pl-PL"],
+        },
+        "$browser_language_prefix": {
+            "label": "Browser Language Prefix",
+            "description": "Language prefix.",
+            "examples": [
+                "en",
+                "ja",
+            ],
         },
         "$current_url": {
             "label": "Current URL",
@@ -1137,6 +1164,12 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Previous pageview last scroll",
             "description": "posthog-js adds these to the page leave event, they are used in web analytics calculations",
             "examples": [0],
+        },
+        "$prev_pageview_id": {
+            "label": "Previous pageview ID",
+            "description": "posthog-js adds these to the page leave event, they are used in web analytics calculations",
+            "examples": ["1"],
+            "system": True,
         },
         "$prev_pageview_last_scroll_percentage": {
             "label": "Previous pageview last scroll percentage",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -519,6 +519,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Postal Code identification confidence score",
             "description": "If provided by the licensed geoip database",
             "examples": ["null", "0.1"],
+            "system": True,
             "ignored_in_assistant": True,
         },
         "$geoip_latitude": {


### PR DESCRIPTION
we've added more props to posthog-js without adding them to the taxonomy, so they aren't hidden when we set "hide posthog properties"

well, not any more!


| before | after |
| - | - | 
|<img width="458" alt="Screenshot 2025-01-10 at 07 41 11" src="https://github.com/user-attachments/assets/12eae7e6-8e7b-4722-82c6-d22bbe8c2a84" />|<img width="471" alt="Screenshot 2025-01-10 at 07 45 58" src="https://github.com/user-attachments/assets/32ded796-1abf-4ead-83af-622617bf1507" />|

