### PR TITLE
chore(data-warehouse): Bump V2 jobs to 100%

### DIFF
--- a/posthog/temporal/data_imports/external_data_job.py
+++ b/posthog/temporal/data_imports/external_data_job.py
@@ -21,7 +21,6 @@ from posthog.constants import DATA_WAREHOUSE_TASK_QUEUE_V2
 from posthog.settings.base_variables import TEST
 from posthog.temporal.batch_exports.base import PostHogWorkflow
 from posthog.temporal.common.client import sync_connect
-from posthog.temporal.data_imports.util import is_posthog_team, is_enabled_for_team, randomly_enabled
 from posthog.temporal.data_imports.workflow_activities.check_billing_limits import (
     CheckBillingLimitsActivityInputs,
     check_billing_limits_activity,
@@ -210,11 +209,7 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
     async def run(self, inputs: ExternalDataWorkflowInputs):
         assert inputs.external_data_schema_id is not None
 
-        if (
-            settings.TEMPORAL_TASK_QUEUE != DATA_WAREHOUSE_TASK_QUEUE_V2
-            and not TEST
-            and (is_posthog_team(inputs.team_id) or is_enabled_for_team(inputs.team_id) or randomly_enabled())
-        ):
+        if settings.TEMPORAL_TASK_QUEUE != DATA_WAREHOUSE_TASK_QUEUE_V2 and not TEST:
             await workflow.execute_activity(
                 trigger_pipeline_v2,
                 inputs,

--- a/posthog/temporal/data_imports/util.py
+++ b/posthog/temporal/data_imports/util.py
@@ -1,4 +1,3 @@
-import random
 from typing import Optional
 from posthog.settings.utils import get_from_env
 from posthog.utils import str_to_bool
@@ -49,7 +48,3 @@ def is_posthog_team(team_id: int) -> bool:
 
 def is_enabled_for_team(team_id: int) -> bool:
     return str(team_id) in settings.V2_PIPELINE_ENABLED_TEAM_IDS
-
-
-def randomly_enabled() -> bool:
-    return random.random() < 0.2


### PR DESCRIPTION
## Changes
- Bump V2 jobs to run on 100% of the jobs
- Needed to test load on current workers before releasing