### PR TITLE
fix(batch-exports): Try to handle missing Postgres permissions

### DIFF
--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -54,7 +54,10 @@ from posthog.temporal.batch_exports.utils import (
 )
 from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.heartbeat import Heartbeater
-from posthog.temporal.common.logger import bind_temporal_worker_logger
+from posthog.temporal.common.logger import (
+    bind_temporal_worker_logger,
+    get_internal_logger,
+)
 
 PostgreSQLField = tuple[str, typing.LiteralString]
 Fields = collections.abc.Iterable[PostgreSQLField]
@@ -571,6 +574,7 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs) -> Records
         inputs.schema,
         inputs.table_name,
     )
+    internal_logger = get_internal_logger()
 
     async with (
         Heartbeater() as heartbeater,
@@ -675,7 +679,14 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs) -> Records
             try:
                 columns = await pg_client.aget_table_columns(inputs.schema, inputs.table_name)
                 table_fields = [field for field in table_fields if field[0] in columns]
+            except psycopg.errors.InsufficientPrivilege:
+                await internal_logger.awarning(
+                    "Insufficient privileges to get table columns for table '%s.%s'; will assume all columns are present",
+                    schema=inputs.schema,
+                    table_name=inputs.table_name,
+                )
             except psycopg.errors.UndefinedTable:
+                # this can happen if the table doesn't exist yet
                 pass
 
             schema_columns = [field[0] for field in table_fields]

--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -680,9 +680,9 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs) -> Records
                     "Insufficient privileges to get table columns for table '%s.%s'; "
                     "will assume all columns are present. If this results in an error, please grant SELECT "
                     "permissions on this table or ensure the destination table is using the latest schema "
-                    "as described in the docs.",
-                    schema=inputs.schema,
-                    table_name=inputs.table_name,
+                    "as described in the docs: https://posthog.com/docs/cdp/batch-exports/postgres",
+                    inputs.schema,
+                    inputs.table_name,
                 )
             except psycopg.errors.UndefinedTable:
                 # this can happen if the table doesn't exist yet


### PR DESCRIPTION
## Problem

We try to fetch a list of columns for the destination table in case it doesn't contain all the columns present in the record batch. However this can sometimes fail with permissions errors if we don't have `SELECT` permissions on the destination table.

## Changes

Catch permissions errors and assume all columns are present. Note that this means existing batch exports could still fail during the merge if the destination table is missing columns present in the record batch.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Existing tests