### PR TITLE
feat(experiments): Refine multiple metrics UI

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -12,6 +12,7 @@ import {
     Link,
     Tooltip,
 } from '@posthog/lemon-ui'
+import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { AnimationType } from 'lib/animations/animations'
 import { Animation } from 'lib/components/Animation/Animation'
@@ -43,11 +44,13 @@ export function VariantTag({
     variantKey,
     muted = false,
     fontSize,
+    className,
 }: {
     experimentId: ExperimentIdType
     variantKey: string
     muted?: boolean
     fontSize?: number
+    className?: string
 }): JSX.Element {
     const { experiment, getIndexForVariant, metricResults } = useValues(experimentLogic({ experimentId }))
 
@@ -57,7 +60,7 @@ export function VariantTag({
 
     if (experiment.holdout && variantKey === `holdout-${experiment.holdout_id}`) {
         return (
-            <span className="flex items-center min-w-0">
+            <span className={clsx('flex items-center min-w-0', className)}>
                 <div
                     className="w-2 h-2 rounded-full shrink-0"
                     // eslint-disable-next-line react/forbid-dom-props
@@ -73,7 +76,7 @@ export function VariantTag({
     }
 
     return (
-        <span className="flex items-center min-w-0">
+        <span className={clsx('flex items-center min-w-0', className)}>
             <div
                 className="w-2 h-2 rounded-full shrink-0"
                 // eslint-disable-next-line react/forbid-dom-props

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -202,10 +202,10 @@ export function DeltaChart({
     }, [])
 
     return (
-        <div className="rounded bg-[var(--bg-table)] flex">
+        <div className="rounded bg-[var(--bg-table)]">
             {/* Metric title panel */}
             {/* eslint-disable-next-line react/forbid-dom-props */}
-            <div style={{ width: metricTitlePanelWidth, verticalAlign: 'top' }}>
+            <div style={{ width: metricTitlePanelWidth, verticalAlign: 'top', display: 'inline-block' }}>
                 {isFirstMetric && (
                     <svg
                         // eslint-disable-next-line react/forbid-dom-props
@@ -265,6 +265,8 @@ export function DeltaChart({
                 style={{
                     width: `calc(100% - ${metricTitlePanelWidth})`,
                     verticalAlign: 'top',
+                    display: 'inline-block',
+                    minWidth: '900px',
                 }}
             >
                 {/* Ticks */}

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -131,7 +131,9 @@ export function DeltaChart({
     }
 
     const BAR_HEIGHT = 8 + getScaleAddition(variants.length)
-    const BAR_PADDING = 10 + getScaleAddition(variants.length)
+    const FIRST_BAR_PADDING = 6
+    const LAST_BAR_PADDING = 6
+    const BAR_PADDING = 14 + getScaleAddition(variants.length)
     const TICK_PANEL_HEIGHT = 20
     const VIEW_BOX_WIDTH = 800
     const HORIZONTAL_PADDING = 20
@@ -152,7 +154,8 @@ export function DeltaChart({
     }
 
     // Update chart height calculation to include only one BAR_PADDING for each space between bars
-    const chartHeight = BAR_PADDING + (BAR_HEIGHT + BAR_PADDING) * variants.length
+    const chartHeight =
+        FIRST_BAR_PADDING + LAST_BAR_PADDING + BAR_PADDING + (BAR_HEIGHT + BAR_PADDING) * variants.length
 
     const valueToX = (value: number): number => {
         // Scale the value to fit within the padded area
@@ -160,9 +163,7 @@ export function DeltaChart({
         return HORIZONTAL_PADDING + percentage * (VIEW_BOX_WIDTH - 2 * HORIZONTAL_PADDING)
     }
 
-    const metricTitlePanelWidth = '20%'
-    const variantsPanelWidth = '10%'
-    const detailedResultsPanelWidth = '125px'
+    const metricTitlePanelWidth = '25%'
 
     const ticksSvgRef = useRef<SVGSVGElement>(null)
     const chartSvgRef = useRef<SVGSVGElement>(null)
@@ -201,10 +202,10 @@ export function DeltaChart({
     }, [])
 
     return (
-        <div className="w-full rounded bg-[var(--bg-table)]">
+        <div className="rounded bg-[var(--bg-table)] flex">
             {/* Metric title panel */}
             {/* eslint-disable-next-line react/forbid-dom-props */}
-            <div style={{ display: 'inline-block', width: metricTitlePanelWidth, verticalAlign: 'top' }}>
+            <div style={{ width: metricTitlePanelWidth, verticalAlign: 'top' }}>
                 {isFirstMetric && (
                     <svg
                         // eslint-disable-next-line react/forbid-dom-props
@@ -215,7 +216,7 @@ export function DeltaChart({
                 <div
                     // eslint-disable-next-line react/forbid-dom-props
                     style={{ height: `${chartSvgHeight}px`, borderRight: `1px solid ${COLORS.BOUNDARY_LINES}` }}
-                    className="p-1 overflow-auto"
+                    className="p-2 overflow-auto"
                 >
                     <div className="text-xs font-semibold whitespace-nowrap overflow-hidden">
                         <div className="space-y-1 pl-1">
@@ -258,102 +259,11 @@ export function DeltaChart({
                     </div>
                 </div>
             </div>
-            {/* Detailed results panel */}
-            <div
-                // eslint-disable-next-line react/forbid-dom-props
-                style={{
-                    display: 'inline-block',
-                    width: detailedResultsPanelWidth,
-                    verticalAlign: 'top',
-                }}
-            >
-                {isFirstMetric && (
-                    <svg
-                        // eslint-disable-next-line react/forbid-dom-props
-                        style={{ height: `${ticksSvgHeight}px`, width: '100%' }}
-                    />
-                )}
-                {isFirstMetric && <div className="w-full border-t border-border" />}
-                {result && (
-                    <div
-                        // eslint-disable-next-line react/forbid-dom-props
-                        style={{
-                            height: `${chartSvgHeight}px`,
-                            borderRight: result ? `1px solid ${COLORS.BOUNDARY_LINES}` : 'none',
-                            display: 'flex',
-                            flexDirection: 'column',
-                        }}
-                    >
-                        {experiment.metrics.length > 1 && (
-                            <div className="flex justify-center">
-                                <LemonButton
-                                    className="mt-1"
-                                    type="secondary"
-                                    size="xsmall"
-                                    icon={<IconGraph />}
-                                    onClick={() => setIsModalOpen(true)}
-                                >
-                                    Detailed results
-                                </LemonButton>
-                            </div>
-                        )}
-                    </div>
-                )}
-            </div>
-            {/* Variants panel */}
-            {/* eslint-disable-next-line react/forbid-dom-props */}
-            <div style={{ display: 'inline-block', width: variantsPanelWidth, verticalAlign: 'top' }}>
-                {isFirstMetric && (
-                    <svg
-                        // eslint-disable-next-line react/forbid-dom-props
-                        style={{ height: `${ticksSvgHeight}px`, width: '100%' }}
-                    />
-                )}
-                {isFirstMetric && <div className="w-full border-t border-border" />}
-                {/* eslint-disable-next-line react/forbid-dom-props */}
-                <div style={{ height: `${chartSvgHeight}px` }}>
-                    {result &&
-                        variants.map((variant) => (
-                            <div
-                                key={variant.key}
-                                // eslint-disable-next-line react/forbid-dom-props
-                                style={{
-                                    height: `${100 / variants.length}%`,
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    paddingLeft: '10px',
-                                    position: 'relative',
-                                    minWidth: 0,
-                                    overflow: 'hidden',
-                                }}
-                            >
-                                <div
-                                    className="absolute inset-0"
-                                    // eslint-disable-next-line react/forbid-dom-props
-                                    style={{
-                                        backgroundColor: 'var(--bg-light)',
-                                        opacity: 0.4,
-                                        pointerEvents: 'none',
-                                    }}
-                                />
-                                <div className="w-full overflow-hidden whitespace-nowrap">
-                                    <VariantTag
-                                        experimentId={experimentId}
-                                        variantKey={variant.key}
-                                        fontSize={11}
-                                        muted
-                                    />
-                                </div>
-                            </div>
-                        ))}
-                </div>
-            </div>
             {/* SVGs container */}
             <div
                 // eslint-disable-next-line react/forbid-dom-props
                 style={{
-                    display: 'inline-block',
-                    width: `calc(100% - ${metricTitlePanelWidth} - ${variantsPanelWidth} - ${detailedResultsPanelWidth})`,
+                    width: `calc(100% - ${metricTitlePanelWidth})`,
                     verticalAlign: 'top',
                 }}
             >
@@ -363,6 +273,9 @@ export function DeltaChart({
                         ref={ticksSvgRef}
                         viewBox={`0 0 ${VIEW_BOX_WIDTH} ${TICK_PANEL_HEIGHT}`}
                         preserveAspectRatio="xMidYMid meet"
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={{ minHeight: `${TICK_PANEL_HEIGHT}px` }}
+                        className="pl-14"
                     >
                         {tickValues.map((value, index) => {
                             const x = valueToX(value)
@@ -387,16 +300,31 @@ export function DeltaChart({
                 {isFirstMetric && <div className="w-full border-t border-border" />}
                 {/* Chart */}
                 {result ? (
-                    <div className="relative">
+                    <div className="relative pl-14">
                         <SignificanceHighlight
                             className="absolute top-2 left-2"
                             metricIndex={metricIndex}
                             isSecondary={isSecondary}
                         />
+                        {isSecondary ||
+                            (!isSecondary && experiment.metrics.length > 1 && (
+                                <div className="absolute bottom-2 left-2 flex justify-center">
+                                    <LemonButton
+                                        type="secondary"
+                                        size="xsmall"
+                                        icon={<IconGraph />}
+                                        onClick={() => setIsModalOpen(true)}
+                                    >
+                                        Details
+                                    </LemonButton>
+                                </div>
+                            ))}
                         <svg
                             ref={chartSvgRef}
                             viewBox={`0 0 ${VIEW_BOX_WIDTH} ${chartHeight}`}
                             preserveAspectRatio="xMidYMid meet"
+                            // eslint-disable-next-line react/forbid-dom-props
+                            style={{ minHeight: `${chartHeight}px` }}
                         >
                             {/* Vertical grid lines */}
                             {tickValues.map((value, index) => {
@@ -446,7 +374,7 @@ export function DeltaChart({
                                     delta = variantRate && controlRate ? (variantRate - controlRate) / controlRate : 0
                                 }
 
-                                const y = BAR_PADDING + (BAR_HEIGHT + BAR_PADDING) * index
+                                const y = FIRST_BAR_PADDING + BAR_PADDING + (BAR_HEIGHT + BAR_PADDING) * index
                                 const x1 = valueToX(lower)
                                 const x2 = valueToX(upper)
                                 const deltaX = valueToX(delta)
@@ -464,6 +392,23 @@ export function DeltaChart({
                                         }}
                                         onMouseLeave={() => setTooltipData(null)}
                                     >
+                                        {/* Add variant name using VariantTag */}
+                                        <foreignObject
+                                            x={x1 - 8} // Keep same positioning as the text element
+                                            y={y + BAR_HEIGHT / 2 - 10}
+                                            width="90"
+                                            height="16"
+                                            transform="translate(-90, 0)" // Move left to accommodate tag width
+                                        >
+                                            <VariantTag
+                                                className="justify-end"
+                                                experimentId={experimentId}
+                                                variantKey={variant.key}
+                                                fontSize={10}
+                                                muted
+                                            />
+                                        </foreignObject>
+
                                         {variant.key === 'control' ? (
                                             // Control variant - single gray bar
                                             <>
@@ -888,14 +833,14 @@ function SignificanceHighlight({
         : { color: 'primary', label: 'Not significant' }
 
     const inner = isSignificant ? (
-        <div className="bg-success-highlight text-success px-1 xl:py-0.5 xl:px-1.5 flex items-center gap-1 rounded border border-success">
+        <div className="bg-success-highlight text-success-dark px-1 py-0.5 flex items-center gap-1 rounded border border-success">
             <IconTrending fontSize={20} fontWeight={600} />
-            <span className="text-xxs xl:text-xs font-semibold">{result.label}</span>
+            <span className="text-xs font-semibold">{result.label}</span>
         </div>
     ) : (
-        <div className="bg-warning-highlight text-warning px-1 xl:py-0.5 xl:px-1.5 flex items-center gap-1 rounded border border-warning">
+        <div className="bg-warning-highlight text-warning-dark px-1 py-0.5 flex items-center gap-1 rounded border border-warning">
             <IconMinus fontSize={20} fontWeight={600} />
-            <span className="text-xxs xl:text-xs font-semibold">{result.label}</span>
+            <span className="text-xs font-semibold">{result.label}</span>
         </div>
     )
 

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -130,7 +130,7 @@ export function DeltaChart({
         return 0
     }
 
-    const BAR_HEIGHT = 8 + getScaleAddition(variants.length)
+    const BAR_HEIGHT = 10 + getScaleAddition(variants.length)
     const FIRST_BAR_PADDING = 6
     const LAST_BAR_PADDING = 6
     const BAR_PADDING = 14 + getScaleAddition(variants.length)
@@ -401,7 +401,7 @@ export function DeltaChart({
                                             transform="translate(-90, 0)" // Move left to accommodate tag width
                                         >
                                             <VariantTag
-                                                className="justify-end"
+                                                className="justify-end mt-0.5"
                                                 experimentId={experimentId}
                                                 variantKey={variant.key}
                                                 fontSize={10}

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -302,13 +302,18 @@ export function DeltaChart({
                 {/* Chart */}
                 {result ? (
                     <div className="relative">
-                        <SignificanceHighlight
-                            className="absolute top-2 left-2"
-                            metricIndex={metricIndex}
-                            isSecondary={isSecondary}
-                        />
+                        {/* Chart is z-index 100, so we need to be above it */}
+                        {/* eslint-disable-next-line react/forbid-dom-props */}
+                        <div className="absolute top-2 left-2" style={{ zIndex: 102 }}>
+                            <SignificanceHighlight metricIndex={metricIndex} isSecondary={isSecondary} />
+                        </div>
                         {(isSecondary || (!isSecondary && experiment.metrics.length > 1)) && (
-                            <div className="absolute bottom-2 left-2 flex justify-center">
+                            <div
+                                className="absolute bottom-2 left-2 flex justify-center bg-[var(--bg-table)]"
+                                // Chart is z-index 100, so we need to be above it
+                                // eslint-disable-next-line react/forbid-dom-props
+                                style={{ zIndex: 101 }}
+                            >
                                 <LemonButton
                                     type="secondary"
                                     size="xsmall"
@@ -856,7 +861,7 @@ function SignificanceHighlight({
             <div
                 className={clsx({
                     'cursor-default': true,
-                    'bg-white': true,
+                    'bg-[var(--bg-table)]': true,
                     [className]: true,
                 })}
             >
@@ -864,6 +869,6 @@ function SignificanceHighlight({
             </div>
         </Tooltip>
     ) : (
-        <div className={clsx({ 'bg-white': true, [className]: true })}>{inner}</div>
+        <div className={clsx({ 'bg-[var(--bg-table)]': true, [className]: true })}>{inner}</div>
     )
 }

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -163,7 +163,7 @@ export function DeltaChart({
         return HORIZONTAL_PADDING + percentage * (VIEW_BOX_WIDTH - 2 * HORIZONTAL_PADDING)
     }
 
-    const metricTitlePanelWidth = '25%'
+    const metricTitlePanelWidth = '20%'
 
     const ticksSvgRef = useRef<SVGSVGElement>(null)
     const chartSvgRef = useRef<SVGSVGElement>(null)
@@ -266,7 +266,7 @@ export function DeltaChart({
                     width: `calc(100% - ${metricTitlePanelWidth})`,
                     verticalAlign: 'top',
                     display: 'inline-block',
-                    minWidth: '900px',
+                    minWidth: '780px',
                 }}
             >
                 {/* Ticks */}
@@ -277,7 +277,6 @@ export function DeltaChart({
                         preserveAspectRatio="xMidYMid meet"
                         // eslint-disable-next-line react/forbid-dom-props
                         style={{ minHeight: `${TICK_PANEL_HEIGHT}px` }}
-                        className="pl-14"
                     >
                         {tickValues.map((value, index) => {
                             const x = valueToX(value)
@@ -302,7 +301,7 @@ export function DeltaChart({
                 {isFirstMetric && <div className="w-full border-t border-border" />}
                 {/* Chart */}
                 {result ? (
-                    <div className="relative pl-14">
+                    <div className="relative">
                         <SignificanceHighlight
                             className="absolute top-2 left-2"
                             metricIndex={metricIndex}

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -306,19 +306,18 @@ export function DeltaChart({
                             metricIndex={metricIndex}
                             isSecondary={isSecondary}
                         />
-                        {isSecondary ||
-                            (!isSecondary && experiment.metrics.length > 1 && (
-                                <div className="absolute bottom-2 left-2 flex justify-center">
-                                    <LemonButton
-                                        type="secondary"
-                                        size="xsmall"
-                                        icon={<IconGraph />}
-                                        onClick={() => setIsModalOpen(true)}
-                                    >
-                                        Details
-                                    </LemonButton>
-                                </div>
-                            ))}
+                        {(isSecondary || (!isSecondary && experiment.metrics.length > 1)) && (
+                            <div className="absolute bottom-2 left-2 flex justify-center">
+                                <LemonButton
+                                    type="secondary"
+                                    size="xsmall"
+                                    icon={<IconGraph />}
+                                    onClick={() => setIsModalOpen(true)}
+                                >
+                                    Details
+                                </LemonButton>
+                            </div>
+                        )}
                         <svg
                             ref={chartSvgRef}
                             viewBox={`0 0 ${VIEW_BOX_WIDTH} ${chartHeight}`}

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -139,6 +139,7 @@ export function DeltaChart({
     const HORIZONTAL_PADDING = 20
     const CONVERSION_RATE_RECT_WIDTH = 2
     const TICK_FONT_SIZE = 9
+    const CHART_MAX_WIDTH = 1000
 
     const { isDarkModeOn } = useValues(themeLogic)
     const COLORS = {
@@ -271,32 +272,34 @@ export function DeltaChart({
             >
                 {/* Ticks */}
                 {isFirstMetric && (
-                    <svg
-                        ref={ticksSvgRef}
-                        viewBox={`0 0 ${VIEW_BOX_WIDTH} ${TICK_PANEL_HEIGHT}`}
-                        preserveAspectRatio="xMidYMid meet"
-                        // eslint-disable-next-line react/forbid-dom-props
-                        style={{ minHeight: `${TICK_PANEL_HEIGHT}px` }}
-                    >
-                        {tickValues.map((value, index) => {
-                            const x = valueToX(value)
-                            return (
-                                <g key={index}>
-                                    <text
-                                        x={x}
-                                        y={TICK_PANEL_HEIGHT / 2}
-                                        textAnchor="middle"
-                                        dominantBaseline="middle"
-                                        fontSize={TICK_FONT_SIZE}
-                                        fill={COLORS.TICK_TEXT_COLOR}
-                                        fontWeight="600"
-                                    >
-                                        {formatTickValue(value)}
-                                    </text>
-                                </g>
-                            )
-                        })}
-                    </svg>
+                    <div className="flex justify-center">
+                        <svg
+                            ref={ticksSvgRef}
+                            viewBox={`0 0 ${VIEW_BOX_WIDTH} ${TICK_PANEL_HEIGHT}`}
+                            preserveAspectRatio="xMidYMid meet"
+                            // eslint-disable-next-line react/forbid-dom-props
+                            style={{ minHeight: `${TICK_PANEL_HEIGHT}px`, maxWidth: `${CHART_MAX_WIDTH}px` }}
+                        >
+                            {tickValues.map((value, index) => {
+                                const x = valueToX(value)
+                                return (
+                                    <g key={index}>
+                                        <text
+                                            x={x}
+                                            y={TICK_PANEL_HEIGHT / 2}
+                                            textAnchor="middle"
+                                            dominantBaseline="middle"
+                                            fontSize={TICK_FONT_SIZE}
+                                            fill={COLORS.TICK_TEXT_COLOR}
+                                            fontWeight="600"
+                                        >
+                                            {formatTickValue(value)}
+                                        </text>
+                                    </g>
+                                )
+                            })}
+                        </svg>
+                    </div>
                 )}
                 {isFirstMetric && <div className="w-full border-t border-border" />}
                 {/* Chart */}
@@ -319,134 +322,136 @@ export function DeltaChart({
                                 </LemonButton>
                             </div>
                         )}
-                        <svg
-                            ref={chartSvgRef}
-                            viewBox={`0 0 ${VIEW_BOX_WIDTH} ${chartHeight}`}
-                            preserveAspectRatio="xMidYMid meet"
-                            // eslint-disable-next-line react/forbid-dom-props
-                            style={{ minHeight: `${chartHeight}px` }}
-                        >
-                            {/* Vertical grid lines */}
-                            {tickValues.map((value, index) => {
-                                const x = valueToX(value)
-                                return (
-                                    <line
-                                        key={index}
-                                        x1={x}
-                                        y1={0}
-                                        x2={x}
-                                        y2={chartSvgHeight + 20}
-                                        stroke={value === 0 ? COLORS.ZERO_LINE : COLORS.BOUNDARY_LINES}
-                                        strokeWidth={value === 0 ? 1 : 0.5}
-                                    />
-                                )
-                            })}
+                        <div className="flex justify-center">
+                            <svg
+                                ref={chartSvgRef}
+                                viewBox={`0 0 ${VIEW_BOX_WIDTH} ${chartHeight}`}
+                                preserveAspectRatio="xMidYMid meet"
+                                // eslint-disable-next-line react/forbid-dom-props
+                                style={{ minHeight: `${chartHeight}px`, maxWidth: `${CHART_MAX_WIDTH}px` }}
+                            >
+                                {/* Vertical grid lines */}
+                                {tickValues.map((value, index) => {
+                                    const x = valueToX(value)
+                                    return (
+                                        <line
+                                            key={index}
+                                            x1={x}
+                                            y1={0}
+                                            x2={x}
+                                            y2={chartSvgHeight + 20}
+                                            stroke={value === 0 ? COLORS.ZERO_LINE : COLORS.BOUNDARY_LINES}
+                                            strokeWidth={value === 0 ? 1 : 0.5}
+                                        />
+                                    )
+                                })}
 
-                            {variants.map((variant, index) => {
-                                const interval = credibleIntervalForVariant(result, variant.key, metricType)
-                                const [lower, upper] = interval ? [interval[0] / 100, interval[1] / 100] : [0, 0]
+                                {variants.map((variant, index) => {
+                                    const interval = credibleIntervalForVariant(result, variant.key, metricType)
+                                    const [lower, upper] = interval ? [interval[0] / 100, interval[1] / 100] : [0, 0]
 
-                                let delta: number
-                                if (metricType === InsightType.TRENDS) {
-                                    const controlVariant = result.variants.find(
-                                        (v: TrendExperimentVariant) => v.key === 'control'
-                                    ) as TrendExperimentVariant
+                                    let delta: number
+                                    if (metricType === InsightType.TRENDS) {
+                                        const controlVariant = result.variants.find(
+                                            (v: TrendExperimentVariant) => v.key === 'control'
+                                        ) as TrendExperimentVariant
 
-                                    const variantData = result.variants.find(
-                                        (v: TrendExperimentVariant) => v.key === variant.key
-                                    ) as TrendExperimentVariant
+                                        const variantData = result.variants.find(
+                                            (v: TrendExperimentVariant) => v.key === variant.key
+                                        ) as TrendExperimentVariant
 
-                                    if (
-                                        !variantData?.count ||
-                                        !variantData?.absolute_exposure ||
-                                        !controlVariant?.count ||
-                                        !controlVariant?.absolute_exposure
-                                    ) {
-                                        delta = 0
+                                        if (
+                                            !variantData?.count ||
+                                            !variantData?.absolute_exposure ||
+                                            !controlVariant?.count ||
+                                            !controlVariant?.absolute_exposure
+                                        ) {
+                                            delta = 0
+                                        } else {
+                                            const controlMean = controlVariant.count / controlVariant.absolute_exposure
+                                            const variantMean = variantData.count / variantData.absolute_exposure
+                                            delta = (variantMean - controlMean) / controlMean
+                                        }
                                     } else {
-                                        const controlMean = controlVariant.count / controlVariant.absolute_exposure
-                                        const variantMean = variantData.count / variantData.absolute_exposure
-                                        delta = (variantMean - controlMean) / controlMean
+                                        const variantRate = conversionRateForVariant(result, variant.key)
+                                        const controlRate = conversionRateForVariant(result, 'control')
+                                        delta =
+                                            variantRate && controlRate ? (variantRate - controlRate) / controlRate : 0
                                     }
-                                } else {
-                                    const variantRate = conversionRateForVariant(result, variant.key)
-                                    const controlRate = conversionRateForVariant(result, 'control')
-                                    delta = variantRate && controlRate ? (variantRate - controlRate) / controlRate : 0
-                                }
 
-                                const y = FIRST_BAR_PADDING + BAR_PADDING + (BAR_HEIGHT + BAR_PADDING) * index
-                                const x1 = valueToX(lower)
-                                const x2 = valueToX(upper)
-                                const deltaX = valueToX(delta)
+                                    const y = FIRST_BAR_PADDING + BAR_PADDING + (BAR_HEIGHT + BAR_PADDING) * index
+                                    const x1 = valueToX(lower)
+                                    const x2 = valueToX(upper)
+                                    const deltaX = valueToX(delta)
 
-                                return (
-                                    <g
-                                        key={variant.key}
-                                        onMouseEnter={(e) => {
-                                            const rect = e.currentTarget.getBoundingClientRect()
-                                            setTooltipData({
-                                                x: rect.left + rect.width / 2,
-                                                y: rect.top - 10,
-                                                variant: variant.key,
-                                            })
-                                        }}
-                                        onMouseLeave={() => setTooltipData(null)}
-                                    >
-                                        {/* Add variant name using VariantTag */}
-                                        <foreignObject
-                                            x={x1 - 8} // Keep same positioning as the text element
-                                            y={y + BAR_HEIGHT / 2 - 10}
-                                            width="90"
-                                            height="16"
-                                            transform="translate(-90, 0)" // Move left to accommodate tag width
+                                    return (
+                                        <g
+                                            key={variant.key}
+                                            onMouseEnter={(e) => {
+                                                const rect = e.currentTarget.getBoundingClientRect()
+                                                setTooltipData({
+                                                    x: rect.left + rect.width / 2,
+                                                    y: rect.top - 10,
+                                                    variant: variant.key,
+                                                })
+                                            }}
+                                            onMouseLeave={() => setTooltipData(null)}
                                         >
-                                            <VariantTag
-                                                className="justify-end mt-0.5"
-                                                experimentId={experimentId}
-                                                variantKey={variant.key}
-                                                fontSize={10}
-                                                muted
-                                            />
-                                        </foreignObject>
+                                            {/* Add variant name using VariantTag */}
+                                            <foreignObject
+                                                x={x1 - 8} // Keep same positioning as the text element
+                                                y={y + BAR_HEIGHT / 2 - 10}
+                                                width="90"
+                                                height="16"
+                                                transform="translate(-90, 0)" // Move left to accommodate tag width
+                                            >
+                                                <VariantTag
+                                                    className="justify-end mt-0.5"
+                                                    experimentId={experimentId}
+                                                    variantKey={variant.key}
+                                                    fontSize={10}
+                                                    muted
+                                                />
+                                            </foreignObject>
 
-                                        {variant.key === 'control' ? (
-                                            // Control variant - single gray bar
-                                            <>
-                                                <rect
-                                                    x={x1}
-                                                    y={y}
-                                                    width={x2 - x1}
-                                                    height={BAR_HEIGHT}
-                                                    fill="transparent"
-                                                />
-                                                <rect
-                                                    x={x1}
-                                                    y={y}
-                                                    width={x2 - x1}
-                                                    height={BAR_HEIGHT}
-                                                    fill={COLORS.BAR_CONTROL}
-                                                    stroke={COLORS.BOUNDARY_LINES}
-                                                    strokeWidth={1}
-                                                    strokeDasharray="2,2"
-                                                    rx={4}
-                                                    ry={4}
-                                                />
-                                            </>
-                                        ) : (
-                                            // Test variants - split into positive and negative sections if needed
-                                            <>
-                                                <rect
-                                                    x={x1}
-                                                    y={y}
-                                                    width={x2 - x1}
-                                                    height={BAR_HEIGHT}
-                                                    fill="transparent"
-                                                />
-                                                {lower < 0 && upper > 0 ? (
-                                                    // Bar spans across zero - need to split
-                                                    <>
-                                                        <path
-                                                            d={`
+                                            {variant.key === 'control' ? (
+                                                // Control variant - single gray bar
+                                                <>
+                                                    <rect
+                                                        x={x1}
+                                                        y={y}
+                                                        width={x2 - x1}
+                                                        height={BAR_HEIGHT}
+                                                        fill="transparent"
+                                                    />
+                                                    <rect
+                                                        x={x1}
+                                                        y={y}
+                                                        width={x2 - x1}
+                                                        height={BAR_HEIGHT}
+                                                        fill={COLORS.BAR_CONTROL}
+                                                        stroke={COLORS.BOUNDARY_LINES}
+                                                        strokeWidth={1}
+                                                        strokeDasharray="2,2"
+                                                        rx={4}
+                                                        ry={4}
+                                                    />
+                                                </>
+                                            ) : (
+                                                // Test variants - split into positive and negative sections if needed
+                                                <>
+                                                    <rect
+                                                        x={x1}
+                                                        y={y}
+                                                        width={x2 - x1}
+                                                        height={BAR_HEIGHT}
+                                                        fill="transparent"
+                                                    />
+                                                    {lower < 0 && upper > 0 ? (
+                                                        // Bar spans across zero - need to split
+                                                        <>
+                                                            <path
+                                                                d={`
                                                                 M ${x1 + 4} ${y}
                                                                 H ${valueToX(0)}
                                                                 V ${y + BAR_HEIGHT}
@@ -455,10 +460,10 @@ export function DeltaChart({
                                                                 V ${y + 4}
                                                                 Q ${x1} ${y} ${x1 + 4} ${y}
                                                             `}
-                                                            fill={COLORS.BAR_NEGATIVE}
-                                                        />
-                                                        <path
-                                                            d={`
+                                                                fill={COLORS.BAR_NEGATIVE}
+                                                            />
+                                                            <path
+                                                                d={`
                                                                 M ${valueToX(0)} ${y}
                                                                 H ${x2 - 4}
                                                                 Q ${x2} ${y} ${x2} ${y + 4}
@@ -467,39 +472,42 @@ export function DeltaChart({
                                                                 H ${valueToX(0)}
                                                                 V ${y}
                                                             `}
-                                                            fill={COLORS.BAR_POSITIVE}
+                                                                fill={COLORS.BAR_POSITIVE}
+                                                            />
+                                                        </>
+                                                    ) : (
+                                                        // Bar is entirely positive or negative
+                                                        <rect
+                                                            x={x1}
+                                                            y={y}
+                                                            width={x2 - x1}
+                                                            height={BAR_HEIGHT}
+                                                            fill={
+                                                                upper <= 0 ? COLORS.BAR_NEGATIVE : COLORS.BAR_POSITIVE
+                                                            }
+                                                            rx={4}
+                                                            ry={4}
                                                         />
-                                                    </>
-                                                ) : (
-                                                    // Bar is entirely positive or negative
-                                                    <rect
-                                                        x={x1}
-                                                        y={y}
-                                                        width={x2 - x1}
-                                                        height={BAR_HEIGHT}
-                                                        fill={upper <= 0 ? COLORS.BAR_NEGATIVE : COLORS.BAR_POSITIVE}
-                                                        rx={4}
-                                                        ry={4}
-                                                    />
-                                                )}
-                                            </>
-                                        )}
-                                        {/* Delta marker */}
-                                        <rect
-                                            x={deltaX - CONVERSION_RATE_RECT_WIDTH / 2}
-                                            y={y}
-                                            width={CONVERSION_RATE_RECT_WIDTH}
-                                            height={BAR_HEIGHT}
-                                            fill={
-                                                variant.key === 'control'
-                                                    ? COLORS.BAR_MIDDLE_POINT_CONTROL
-                                                    : COLORS.BAR_MIDDLE_POINT
-                                            }
-                                        />
-                                    </g>
-                                )
-                            })}
-                        </svg>
+                                                    )}
+                                                </>
+                                            )}
+                                            {/* Delta marker */}
+                                            <rect
+                                                x={deltaX - CONVERSION_RATE_RECT_WIDTH / 2}
+                                                y={y}
+                                                width={CONVERSION_RATE_RECT_WIDTH}
+                                                height={BAR_HEIGHT}
+                                                fill={
+                                                    variant.key === 'control'
+                                                        ? COLORS.BAR_MIDDLE_POINT_CONTROL
+                                                        : COLORS.BAR_MIDDLE_POINT
+                                                }
+                                            />
+                                        </g>
+                                    )
+                                })}
+                            </svg>
+                        </div>
                     </div>
                 ) : metricResultsLoading ? (
                     <svg

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -888,12 +888,12 @@ function SignificanceHighlight({
         : { color: 'primary', label: 'Not significant' }
 
     const inner = isSignificant ? (
-        <div className="bg-success-highlight text-success px-1 xl:py-1 xl:px-1.5 flex items-center gap-1 rounded border border-success">
+        <div className="bg-success-highlight text-success px-1 xl:py-0.5 xl:px-1.5 flex items-center gap-1 rounded border border-success">
             <IconTrending fontSize={20} fontWeight={600} />
             <span className="text-xxs xl:text-xs font-semibold">{result.label}</span>
         </div>
     ) : (
-        <div className="bg-warning-highlight text-warning px-1 xl:py-1 xl:px-1.5 flex items-center gap-1 rounded border border-warning">
+        <div className="bg-warning-highlight text-warning px-1 xl:py-0.5 xl:px-1.5 flex items-center gap-1 rounded border border-warning">
             <IconMinus fontSize={20} fontWeight={600} />
             <span className="text-xxs xl:text-xs font-semibold">{result.label}</span>
         </div>

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -274,7 +274,7 @@ export function DeltaChart({
                             ref={ticksSvgRef}
                             viewBox={`0 0 ${VIEW_BOX_WIDTH} ${TICK_PANEL_HEIGHT}`}
                             preserveAspectRatio="xMidYMid meet"
-                            className="mx-14"
+                            className="ml-12"
                             // eslint-disable-next-line react/forbid-dom-props
                             style={{ minHeight: `${TICK_PANEL_HEIGHT}px`, maxWidth: `${CHART_MAX_WIDTH}px` }}
                         >
@@ -330,7 +330,7 @@ export function DeltaChart({
                                 ref={chartSvgRef}
                                 viewBox={`0 0 ${VIEW_BOX_WIDTH} ${chartHeight}`}
                                 preserveAspectRatio="xMidYMid meet"
-                                className="mx-14"
+                                className="ml-12"
                                 // eslint-disable-next-line react/forbid-dom-props
                                 style={{ minHeight: `${chartHeight}px`, maxWidth: `${CHART_MAX_WIDTH}px` }}
                             >

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -274,6 +274,7 @@ export function DeltaChart({
                             ref={ticksSvgRef}
                             viewBox={`0 0 ${VIEW_BOX_WIDTH} ${TICK_PANEL_HEIGHT}`}
                             preserveAspectRatio="xMidYMid meet"
+                            className="mx-14"
                             // eslint-disable-next-line react/forbid-dom-props
                             style={{ minHeight: `${TICK_PANEL_HEIGHT}px`, maxWidth: `${CHART_MAX_WIDTH}px` }}
                         >
@@ -329,6 +330,7 @@ export function DeltaChart({
                                 ref={chartSvgRef}
                                 viewBox={`0 0 ${VIEW_BOX_WIDTH} ${chartHeight}`}
                                 preserveAspectRatio="xMidYMid meet"
+                                className="mx-14"
                                 // eslint-disable-next-line react/forbid-dom-props
                                 style={{ minHeight: `${chartHeight}px`, maxWidth: `${CHART_MAX_WIDTH}px` }}
                             >

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -130,9 +130,9 @@ export function DeltaChart({
         return 0
     }
 
-    const BAR_HEIGHT = 10 + getScaleAddition(variants.length)
-    const FIRST_BAR_PADDING = 6
-    const LAST_BAR_PADDING = 6
+    const BAR_HEIGHT = 8 + getScaleAddition(variants.length)
+    const FIRST_BAR_PADDING = 2
+    const LAST_BAR_PADDING = 2
     const BAR_PADDING = 14 + getScaleAddition(variants.length)
     const TICK_PANEL_HEIGHT = 20
     const VIEW_BOX_WIDTH = 800
@@ -833,12 +833,12 @@ function SignificanceHighlight({
         : { color: 'primary', label: 'Not significant' }
 
     const inner = isSignificant ? (
-        <div className="bg-success-highlight text-success-dark px-1 py-0.5 flex items-center gap-1 rounded border border-success">
+        <div className="bg-success-highlight text-success-dark px-1.5 py-0.5 flex items-center gap-1 rounded border border-success">
             <IconTrending fontSize={20} fontWeight={600} />
             <span className="text-xs font-semibold">{result.label}</span>
         </div>
     ) : (
-        <div className="bg-warning-highlight text-warning-dark px-1 py-0.5 flex items-center gap-1 rounded border border-warning">
+        <div className="bg-warning-highlight text-warning-dark px-1.5 py-0.5 flex items-center gap-1 rounded border border-warning">
             <IconMinus fontSize={20} fontWeight={600} />
             <span className="text-xs font-semibold">{result.label}</span>
         </div>

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -131,9 +131,7 @@ export function DeltaChart({
     }
 
     const BAR_HEIGHT = 8 + getScaleAddition(variants.length)
-    const FIRST_BAR_PADDING = 2
-    const LAST_BAR_PADDING = 2
-    const BAR_PADDING = 14 + getScaleAddition(variants.length)
+    const BAR_PADDING = 10 + getScaleAddition(variants.length)
     const TICK_PANEL_HEIGHT = 20
     const VIEW_BOX_WIDTH = 800
     const HORIZONTAL_PADDING = 20
@@ -155,8 +153,7 @@ export function DeltaChart({
     }
 
     // Update chart height calculation to include only one BAR_PADDING for each space between bars
-    const chartHeight =
-        FIRST_BAR_PADDING + LAST_BAR_PADDING + BAR_PADDING + (BAR_HEIGHT + BAR_PADDING) * variants.length
+    const chartHeight = BAR_PADDING + (BAR_HEIGHT + BAR_PADDING) * variants.length
 
     const valueToX = (value: number): number => {
         // Scale the value to fit within the padded area
@@ -220,7 +217,7 @@ export function DeltaChart({
                     className="p-2 overflow-auto"
                 >
                     <div className="text-xs font-semibold whitespace-nowrap overflow-hidden">
-                        <div className="space-y-1 pl-1">
+                        <div className="space-y-1">
                             <div className="flex items-center gap-2">
                                 <div className="cursor-default text-xs font-semibold whitespace-nowrap overflow-hidden text-ellipsis flex-grow flex items-center">
                                     <span className="mr-1">{metricIndex + 1}.</span>
@@ -379,7 +376,7 @@ export function DeltaChart({
                                             variantRate && controlRate ? (variantRate - controlRate) / controlRate : 0
                                     }
 
-                                    const y = FIRST_BAR_PADDING + BAR_PADDING + (BAR_HEIGHT + BAR_PADDING) * index
+                                    const y = BAR_PADDING + (BAR_HEIGHT + BAR_PADDING) * index
                                     const x1 = valueToX(lower)
                                     const x2 = valueToX(upper)
                                     const deltaX = valueToX(delta)

--- a/frontend/src/scenes/experiments/MetricsView/MetricsView.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricsView.tsx
@@ -217,7 +217,7 @@ export function MetricsView({ isSecondary }: { isSecondary?: boolean }): JSX.Ele
             </div>
             {metrics.length > 0 ? (
                 <div className="w-full overflow-x-auto">
-                    <div className="min-w-[1300px]">
+                    <div className="min-w-[1000px]">
                         {metrics.map((metric, metricIndex) => {
                             const result = results?.[metricIndex]
                             const isFirstMetric = metricIndex === 0

--- a/frontend/src/scenes/experiments/MetricsView/MetricsView.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricsView.tsx
@@ -217,7 +217,7 @@ export function MetricsView({ isSecondary }: { isSecondary?: boolean }): JSX.Ele
             </div>
             {metrics.length > 0 ? (
                 <div className="w-full overflow-x-auto">
-                    <div className="min-w-[1000px]">
+                    <div className="min-w-[1300px]">
                         {metrics.map((metric, metricIndex) => {
                             const result = results?.[metricIndex]
                             const isFirstMetric = metricIndex === 0


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/27014

## Changes

Refines multiple metrics UI:
* Moves significance indicator and 'Details' button into the chart cell but positions to the left.
* Puts the variant name right next to its credible interval.
* Always shows the 'Details' button for secondary metrics. The 'Details' button only shows for a primary metric when there are more than one.
* Adds a little bit of padding throughout.

The massive SVG diff is simply indentation.

**Before**

![CleanShot 2025-01-10 at 10 00 32@2x](https://github.com/user-attachments/assets/0c4fe6db-ec84-4890-8bfa-578d6ad0ad07)

**After**

![CleanShot 2025-01-10 at 10 01 19@2x](https://github.com/user-attachments/assets/670a52d9-d480-427d-aa1d-5a3f5bacc9f7)

**Narrow width**

| Before | After |
|--------|--------|
| ![CleanShot 2025-01-10 at 10 05 17@2x](https://github.com/user-attachments/assets/582ca389-3f37-4dd0-8277-99f84b8e7236) | ![CleanShot 2025-01-10 at 10 04 57@2x](https://github.com/user-attachments/assets/7e2eada3-4cfc-431e-a4a0-223fd0c796c1) | 

**Wide width**

| Before | After |
|--------|--------|
| ![CleanShot 2025-01-10 at 10 05 33@2x](https://github.com/user-attachments/assets/fd5951cc-50c2-405c-9ea6-6b801196794b) | ![CleanShot 2025-01-10 at 10 05 53@2x](https://github.com/user-attachments/assets/320b579d-33b6-4ab5-8cb3-7e03bba07363) | 

## How did you test this code?

Lots of visual review.