### PR TITLE
fix(experiments): Fix displaying results for no-code experiment

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/MetricsView.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricsView.tsx
@@ -98,7 +98,7 @@ export function MetricsView({ isSecondary }: { isSecondary?: boolean }): JSX.Ele
         credibleIntervalForVariant,
     } = useValues(experimentLogic)
 
-    const variants = experiment.parameters.feature_flag_variants
+    const variants = experiment?.feature_flag?.filters?.multivariate?.variants
     const results = isSecondary ? secondaryMetricResults : metricResults
     const errors = isSecondary ? secondaryMetricsResultErrors : primaryMetricsResultErrors
     const hasSomeResults = results?.some((result) => result?.insight)

--- a/frontend/src/scenes/experiments/MetricsView/MetricsView.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricsView.tsx
@@ -99,6 +99,9 @@ export function MetricsView({ isSecondary }: { isSecondary?: boolean }): JSX.Ele
     } = useValues(experimentLogic)
 
     const variants = experiment?.feature_flag?.filters?.multivariate?.variants
+    if (!variants) {
+        return <></>
+    }
     const results = isSecondary ? secondaryMetricResults : metricResults
     const errors = isSecondary ? secondaryMetricsResultErrors : primaryMetricsResultErrors
     const hasSomeResults = results?.some((result) => result?.insight)


### PR DESCRIPTION
Re-roll of https://github.com/PostHog/posthog/pull/27107
Reported in https://posthoghelp.zendesk.com/agent/tickets/22992 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/25393) and https://posthoghelp.zendesk.com/agent/tickets/23010 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/25396)
See https://github.com/PostHog/posthog/issues/27014

## Changes

Ensures `<MetricsView>` is displayed for no-code web experiments.

A no-code web experiment can be created without `experiment.parameters.feature_flag_variants`, which will then cause this loop to fail. `experiment.feature_flag.filters.multivariate.variants` contains the same data for us.

## How did you test this code?

I verified locally that the results for a no-code web experiment were broken. I then verified that this restores the display of the results.
