### PR TITLE
chore: shifting usage reports a few hours back

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -113,14 +113,8 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     # Send all instance usage to the Billing service
-    # Sends later on Sunday due to clickhouse things that happen on Sunday at ~00:00 UTC
     sender.add_periodic_task(
-        crontab(hour="3", minute="15", day_of_week="mon"),
-        send_org_usage_reports.s(),
-        name="send instance usage report, monday",
-    )
-    sender.add_periodic_task(
-        crontab(hour="2", minute="15", day_of_week="tue,wed,thu,fri,sat,sun"),
+        crontab(hour="4", minute="0", day_of_week="*"),
         send_org_usage_reports.s(),
         name="send instance usage report",
     )

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -114,7 +114,7 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
 
     # Send all instance usage to the Billing service
     sender.add_periodic_task(
-        crontab(hour="4", minute="0", day_of_week="*"),
+        crontab(hour="4", minute="0"),
         send_org_usage_reports.s(),
         name="send instance usage report",
     )


### PR DESCRIPTION
## Changes

This is shift usage reports to run at 4am UTC instead of the current 2:15 am UTC and 3:15 am UTC in order to make sure all events from the previous day were fully ingested and the usage being pulled is accurate. 

4am UTC = 8pm PT and 11pm ET so this should not affect north American users at all. 

Usage reports should be completing in under 4 hours based on the latest changes.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
