### PR TITLE
chore: capture insight whitelabel

### DIFF
--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -175,7 +175,7 @@ export function SharingModalContent({
                                                     }
                                                     onChange={() =>
                                                         guardAvailableFeature(AvailableFeature.WHITE_LABELLING, () => {
-                                                            // setEmbedConfigValue is used to update the form state and call the reportDashboardWhitelabelToggled event
+                                                            // setEmbedConfigValue is used to update the form state and report the event
                                                             setEmbedConfigValue('whitelabel', !value)
                                                         })
                                                     }

--- a/frontend/src/lib/components/Sharing/sharingLogic.ts
+++ b/frontend/src/lib/components/Sharing/sharingLogic.ts
@@ -90,6 +90,9 @@ export const sharingLogic = kea<sharingLogicType>([
             if (name === 'whitelabel' && props.dashboardId) {
                 eventUsageLogic.actions.reportDashboardWhitelabelToggled(value)
             }
+            if (name === 'whitelabel' && props.insightShortId) {
+                eventUsageLogic.actions.reportInsightWhitelabelToggled(value)
+            }
         },
     })),
 

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -337,6 +337,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 type?: EntityType
             }>
         ) => ({ filters }),
+        reportInsightWhitelabelToggled: (isWhiteLabelled: boolean) => ({ isWhiteLabelled }),
         reportEntityFilterVisibilitySet: (index: number, visible: boolean) => ({ index, visible }),
         reportInsightsTableCalcToggled: (mode: string) => ({ mode }),
         reportPropertyGroupFilterAdded: true,
@@ -830,6 +831,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         },
         reportInsightFilterSet: async ({ filters }) => {
             posthog.capture('filters set', { filters })
+        },
+        reportInsightWhitelabelToggled: async ({ isWhiteLabelled }) => {
+            posthog.capture(`insight whitelabel toggled`, { is_whitelabelled: isWhiteLabelled })
         },
         reportEntityFilterVisibilitySet: async ({ index, visible }) => {
             posthog.capture('entity filter visbility set', { index, visible })


### PR DESCRIPTION
## Problem

Adding a capture for the user toggling the whitelabel button for insights

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Cloud: yes

## How did you test this code?

Toggled the button on and off and verified that the capture event is seen in the debugger console:

![image](https://github.com/user-attachments/assets/e4b0aa70-5a3a-4665-8a37-afede2efd64a)

