### PR TITLE
feat(experiments): Lighter border on significance badge

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -845,7 +845,7 @@ function SignificanceHighlight({
         : { color: 'primary', label: 'Not significant' }
 
     const inner = isSignificant ? (
-        <div className="bg-success-highlight text-success-dark px-1.5 py-0.5 flex items-center gap-1 rounded border border-success">
+        <div className="bg-success-highlight text-success-dark px-1.5 py-0.5 flex items-center gap-1 rounded border border-success-light">
             <IconTrending fontSize={20} fontWeight={600} />
             <span className="text-xs font-semibold">{result.label}</span>
         </div>


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/27014

## Changes

Slightly lighter border on the significant badge:

| Before | After |
|--------|--------|
| ![CleanShot 2025-01-10 at 14 16 43@2x](https://github.com/user-attachments/assets/b63a1342-2113-47da-b43b-c0b298bc45ab) | ![CleanShot 2025-01-10 at 14 16 09@2x](https://github.com/user-attachments/assets/e02a9d20-71cd-45c4-ae2c-888496ad41d4) | 


## How did you test this code?

👀 
