### PR TITLE
fix: Defer grabbing person properties on bulk delete (we don't use them)

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -423,11 +423,11 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if distinct_ids := request.data.get("distinct_ids"):
             if len(distinct_ids) > 1000:
                 raise ValidationError("You can only pass 1000 distinct_ids in one call")
-            persons = self.get_queryset().filter(persondistinctid__distinct_id__in=distinct_ids)
+            persons = self.get_queryset().filter(persondistinctid__distinct_id__in=distinct_ids).defer("properties")
         elif ids := request.data.get("ids"):
             if len(ids) > 1000:
                 raise ValidationError("You can only pass 1000 ids in one call")
-            persons = self.get_queryset().filter(uuid__in=ids)
+            persons = self.get_queryset().filter(uuid__in=ids).defer("properties")
         else:
             raise ValidationError("You need to specify either distinct_ids or ids")
 


### PR DESCRIPTION
## Problem

We have a very heavily taxed database in EU. Person deletes are failing api calls.

## Changes

Reduce the number of fields we are bringing in from PG to speed things up. These properties could be really big.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
