### PR TITLE
fix: use global pha_client for billing usage reporting

### DIFF
--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -45,6 +45,10 @@ from posthog.warehouse.models import ExternalDataJob
 logger = structlog.get_logger(__name__)
 
 
+global pha_client
+pha_client = Client("sTMFPsFhdP1Ssg")
+
+
 class Period(TypedDict):
     start_inclusive: str
     end_inclusive: str
@@ -314,7 +318,6 @@ def send_report_to_billing_service(org_id: str, report: dict[str, Any]) -> None:
     except Exception as err:
         logger.exception(f"UsageReport failed sending to Billing for organization: {organization.id}: {err}")
         capture_exception(err)
-        pha_client = Client("sTMFPsFhdP1Ssg")
         capture_event(
             pha_client=pha_client,
             name=f"organization usage report to billing service failure",
@@ -652,10 +655,6 @@ def get_teams_with_hog_function_fetch_calls_in_period(
     )
 
     return results
-
-
-global pha_client
-pha_client = Client("sTMFPsFhdP1Ssg")
 
 
 @shared_task(**USAGE_REPORT_TASK_KWARGS, max_retries=0)

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -654,6 +654,10 @@ def get_teams_with_hog_function_fetch_calls_in_period(
     return results
 
 
+global pha_client
+pha_client = Client("sTMFPsFhdP1Ssg")
+
+
 @shared_task(**USAGE_REPORT_TASK_KWARGS, max_retries=0)
 def capture_report(
     *,
@@ -666,7 +670,6 @@ def capture_report(
 ) -> None:
     if not org_id and not team_id:
         raise ValueError("Either org_id or team_id must be provided")
-    pha_client = Client("sTMFPsFhdP1Ssg")
     try:
         capture_event(
             pha_client=pha_client,


### PR DESCRIPTION
## Problem

We are running out of threads running a large amount of usage reporting for billing
https://posthog.sentry.io/issues/6121356415/?project=1899813&query=is:unresolved%20!url:http://billing.dev.posthog.dev&statsPeriod=14d&stream_index=1

## Changes

move the pha client into global space so that we don't have n+1 pha_client threads spinning up for each task (not really helpful)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
