### PR TITLE
fix(experiments): Fix adding/removing metric race condition

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/MetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/MetricModal.tsx
@@ -40,6 +40,7 @@ export function MetricModal({
     const funnelStepsLength = (metric as ExperimentFunnelsQuery)?.funnels_query?.series?.length || 0
 
     const onClose = (): void => {
+        // :KLUDGE: Removes any local changes and resets the experiment to the server state
         loadExperiment()
         isSecondary ? closeSecondaryMetricModal() : closePrimaryMetricModal()
     }

--- a/frontend/src/scenes/experiments/Metrics/MetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/MetricModal.tsx
@@ -24,9 +24,8 @@ export function MetricModal({
         editingPrimaryMetricIndex,
         editingSecondaryMetricIndex,
     } = useValues(experimentLogic({ experimentId }))
-    const { updateExperimentGoal, setExperiment, closePrimaryMetricModal, closeSecondaryMetricModal } = useActions(
-        experimentLogic({ experimentId })
-    )
+    const { updateExperimentGoal, setExperiment, closePrimaryMetricModal, closeSecondaryMetricModal, loadExperiment } =
+        useActions(experimentLogic({ experimentId }))
 
     const metricIdx = isSecondary ? editingSecondaryMetricIndex : editingPrimaryMetricIndex
     const metricsField = isSecondary ? 'metrics_secondary' : 'metrics'
@@ -40,10 +39,15 @@ export function MetricModal({
     const metricType = _getMetricType(metric)
     const funnelStepsLength = (metric as ExperimentFunnelsQuery)?.funnels_query?.series?.length || 0
 
+    const onClose = (): void => {
+        loadExperiment()
+        isSecondary ? closeSecondaryMetricModal() : closePrimaryMetricModal()
+    }
+
     return (
         <LemonModal
             isOpen={isSecondary ? isSecondaryMetricModalOpen : isPrimaryMetricModalOpen}
-            onClose={isSecondary ? closeSecondaryMetricModal : closePrimaryMetricModal}
+            onClose={onClose}
             width={1000}
             title="Edit experiment metric"
             footer={
@@ -78,11 +82,7 @@ export function MetricModal({
                         Delete
                     </LemonButton>
                     <div className="flex items-center gap-2 ml-auto">
-                        <LemonButton
-                            form="edit-experiment-goal-form"
-                            type="secondary"
-                            onClick={isSecondary ? closeSecondaryMetricModal : closePrimaryMetricModal}
-                        >
+                        <LemonButton form="edit-experiment-goal-form" type="secondary" onClick={onClose}>
                             Cancel
                         </LemonButton>
                         <LemonButton

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -43,6 +43,7 @@ export function SharedMetricModal({
 
     const isOpen = isSecondary ? isSecondarySharedMetricModalOpen : isPrimarySharedMetricModalOpen
     const closeModal = (): void => {
+        // :KLUDGE: Removes any local changes and resets the experiment to the server state
         loadExperiment()
         isSecondary ? closeSecondarySharedMetricModal() : closePrimarySharedMetricModal()
     }

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -24,6 +24,7 @@ export function SharedMetricModal({
         closeSecondarySharedMetricModal,
         addSharedMetricToExperiment,
         removeSharedMetricFromExperiment,
+        loadExperiment,
     } = useActions(experimentLogic({ experimentId }))
 
     const [selectedMetricId, setSelectedMetricId] = useState<SharedMetric['id'] | null>(null)
@@ -41,7 +42,10 @@ export function SharedMetricModal({
     }
 
     const isOpen = isSecondary ? isSecondarySharedMetricModalOpen : isPrimarySharedMetricModalOpen
-    const closeModal = isSecondary ? closeSecondarySharedMetricModal : closePrimarySharedMetricModal
+    const closeModal = (): void => {
+        loadExperiment()
+        isSecondary ? closeSecondarySharedMetricModal() : closePrimarySharedMetricModal()
+    }
 
     return (
         <LemonModal

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -746,18 +746,6 @@ export const experimentLogic = kea<experimentLogicType>([
                 actions.loadExperiment()
             }
         },
-        closePrimaryMetricModal: () => {
-            actions.loadExperiment()
-        },
-        closeSecondaryMetricModal: () => {
-            actions.loadExperiment()
-        },
-        closePrimarySharedMetricModal: () => {
-            actions.loadExperiment()
-        },
-        closeSecondarySharedMetricModal: () => {
-            actions.loadExperiment()
-        },
         resetRunningExperiment: async () => {
             actions.updateExperiment({ start_date: null, end_date: null, archived: false })
             values.experiment && actions.reportExperimentReset(values.experiment)


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/27014
See https://posthog.slack.com/archives/C07PXH2GTGV/p1736429896581889

## Changes

Fixes a race condition when adding a metric to or removing a metric from an experiment.

`updateExperimentGoal` calls `closePrimaryMetricModal` and `closeSecondaryMetricModal`, each of which call `loadExperiment`. If the `GET /api/projects/1/experiments/88/` return value is stale, the old experiment result will be displayed instead of the new one.

Instead, it's better to have `closePrimaryMetricModal` and `closeSecondaryMetricModal` responsible solely for closing the modal, and call `loadExperiment` inside of the component.

## How did you test this code?

Added a metric to an experiment and verified it displayed.

Started adding a metric to an experiment and verified the experiment was refreshed after I closed the modal without saving.