### PR TITLE
feat(experiments): Add multiple shared metrics at once

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -67,11 +67,7 @@ export function SharedMetricModal({
 
     const availableSharedMetrics = sharedMetrics.filter(
         (metric: SharedMetric) =>
-            !experiment.saved_metrics.some(
-                (savedMetric) =>
-                    savedMetric.saved_metric === metric.id &&
-                    savedMetric.metadata.type === (isSecondary ? 'secondary' : 'primary')
-            )
+            !experiment.saved_metrics.some((savedMetric) => savedMetric.saved_metric === metric.id)
     )
 
     return (

--- a/frontend/src/scenes/experiments/MetricsView/MetricsView.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricsView.tsx
@@ -43,7 +43,7 @@ export function getNiceTickValues(maxAbsValue: number): number[] {
 }
 
 function AddPrimaryMetric(): JSX.Element {
-    const { experiment } = useValues(experimentLogic)
+    const { primaryMetricsLengthWithSharedMetrics } = useValues(experimentLogic)
     const { openPrimaryMetricSourceModal } = useActions(experimentLogic)
 
     return (
@@ -55,7 +55,7 @@ function AddPrimaryMetric(): JSX.Element {
                 openPrimaryMetricSourceModal()
             }}
             disabledReason={
-                experiment.metrics.length >= MAX_PRIMARY_METRICS
+                primaryMetricsLengthWithSharedMetrics >= MAX_PRIMARY_METRICS
                     ? `You can only add up to ${MAX_PRIMARY_METRICS} primary metrics.`
                     : undefined
             }
@@ -66,7 +66,7 @@ function AddPrimaryMetric(): JSX.Element {
 }
 
 export function AddSecondaryMetric(): JSX.Element {
-    const { experiment } = useValues(experimentLogic)
+    const { secondaryMetricsLengthWithSharedMetrics } = useValues(experimentLogic)
     const { openSecondaryMetricSourceModal } = useActions(experimentLogic)
     return (
         <LemonButton
@@ -77,7 +77,7 @@ export function AddSecondaryMetric(): JSX.Element {
                 openSecondaryMetricSourceModal()
             }}
             disabledReason={
-                experiment.metrics_secondary.length >= MAX_SECONDARY_METRICS
+                secondaryMetricsLengthWithSharedMetrics >= MAX_SECONDARY_METRICS
                     ? `You can only add up to ${MAX_SECONDARY_METRICS} secondary metrics.`
                     : undefined
             }

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -273,11 +273,11 @@ export const experimentLogic = kea<experimentLogicType>([
         closePrimarySharedMetricModal: true,
         openSecondarySharedMetricModal: (sharedMetricId: SharedMetric['id'] | null) => ({ sharedMetricId }),
         closeSecondarySharedMetricModal: true,
-        addSharedMetricToExperiment: (
-            sharedMetricId: SharedMetric['id'],
+        addSharedMetricsToExperiment: (
+            sharedMetricIds: SharedMetric['id'][],
             metadata: { type: 'primary' | 'secondary' }
         ) => ({
-            sharedMetricId,
+            sharedMetricIds,
             metadata,
         }),
         removeSharedMetricFromExperiment: (sharedMetricId: SharedMetric['id']) => ({ sharedMetricId }),
@@ -907,15 +907,17 @@ export const experimentLogic = kea<experimentLogicType>([
                 holdout_id: values.experiment.holdout_id,
             })
         },
-        addSharedMetricToExperiment: async ({ sharedMetricId, metadata }) => {
-            const sharedMetricsIds = values.experiment.saved_metrics.map((sharedMetric) => ({
+        addSharedMetricsToExperiment: async ({ sharedMetricIds, metadata }) => {
+            const existingMetricsIds = values.experiment.saved_metrics.map((sharedMetric) => ({
                 id: sharedMetric.saved_metric,
-                metadata,
+                metadata: sharedMetric.metadata,
             }))
-            sharedMetricsIds.push({ id: sharedMetricId, metadata })
+
+            const newMetricsIds = sharedMetricIds.map((id) => ({ id, metadata }))
+            const combinedMetricsIds = [...existingMetricsIds, ...newMetricsIds]
 
             await api.update(`api/projects/${values.currentProjectId}/experiments/${values.experimentId}`, {
-                saved_metrics_ids: sharedMetricsIds,
+                saved_metrics_ids: combinedMetricsIds,
             })
 
             actions.closePrimarySharedMetricModal()

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -913,7 +913,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 metadata: sharedMetric.metadata,
             }))
 
-            const newMetricsIds = sharedMetricIds.map((id) => ({ id, metadata }))
+            const newMetricsIds = sharedMetricIds.map((id: SharedMetric['id']) => ({ id, metadata }))
             const combinedMetricsIds = [...existingMetricsIds, ...newMetricsIds]
 
             await api.update(`api/projects/${values.currentProjectId}/experiments/${values.experimentId}`, {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1744,6 +1744,24 @@ export const experimentLogic = kea<experimentLogicType>([
                 return experiment.stats_config?.version || 1
             },
         ],
+        primaryMetricsLengthWithSharedMetrics: [
+            (s) => [s.experiment],
+            (experiment: Experiment): number => {
+                return (
+                    experiment.metrics.length +
+                    experiment.saved_metrics.filter((savedMetric) => savedMetric.metadata.type === 'primary').length
+                )
+            },
+        ],
+        secondaryMetricsLengthWithSharedMetrics: [
+            (s) => [s.experiment],
+            (experiment: Experiment): number => {
+                return (
+                    experiment.metrics_secondary.length +
+                    experiment.saved_metrics.filter((savedMetric) => savedMetric.metadata.type === 'secondary').length
+                )
+            },
+        ],
     }),
     forms(({ actions }) => ({
         experiment: {


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/27014
See https://posthog.slack.com/archives/C06KJQ2RH1A/p1736523922092219?thread_ts=1736271086.255529&cid=C06KJQ2RH1A

## Changes

Allows multiple shared metrics to be added at once. Addresses this request:

> be able to add multiple shared metrics at once when you add secondary metrics (right now you have to do it individually and it takes ~2 minutes for the page to update before you can add the second one which means like 10 minutes of time just adding 5 metrics to the experiment)

Also filters out any shared metrics that have already been added to the experiment, to prevent 400 error if the user tries to add them again.

Lastly, fixes issue where limit on 'Add primary metric' button didn't accommodate shared metrics.

https://github.com/user-attachments/assets/cdf49287-c189-4a7b-ba6b-5def1a389c63

## How did you test this code?

I went through various permutations of adding shared metrics to an experiment.
