### PR TITLE
fix(batch-exports): Handle unpaired surrogates in BigQuery

### DIFF
--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -326,6 +326,11 @@ class BigQueryClient(bigquery.Client):
         else:
             fields_to_cast = set()
 
+        # The following `REGEXP_REPLACE` functions are used to clean-up un-paired
+        # surrogates, as they are rejected by `PARSE_JSON`. Since BigQuery's regex
+        # engine has no lookahead / lookback, we instead use an OR to match both
+        # valid pairs and invalid single high or low surrogates, and replacing only
+        # with the valid pair in both cases.
         stage_table_fields = ",".join(
             f"""
             PARSE_JSON(
@@ -395,6 +400,11 @@ class BigQueryClient(bigquery.Client):
                 values += ", "
                 field_names += ", "
 
+            # The following `REGEXP_REPLACE` functions are used to clean-up un-paired
+            # surrogates, as they are rejected by `PARSE_JSON`. Since BigQuery's regex
+            # engine has no lookahead / lookback, we instead use an OR to match both
+            # valid pairs and invalid single high or low surrogates, and replacing only
+            # with the valid pair in both cases.
             stage_field = (
                 f"""
                 PARSE_JSON(

--- a/posthog/temporal/tests/batch_exports/conftest.py
+++ b/posthog/temporal/tests/batch_exports/conftest.py
@@ -250,9 +250,26 @@ def test_properties(request):
     return {"$browser": "Chrome", "$os": "Mac OS X"}
 
 
+@pytest.fixture
+def test_person_properties(request):
+    """Set test person data properties."""
+    try:
+        return request.param
+    except AttributeError:
+        pass
+    return {"utm_medium": "referral", "$initial_os": "Linux"}
+
+
 @pytest_asyncio.fixture
 async def generate_test_data(
-    ateam, clickhouse_client, exclude_events, data_interval_start, data_interval_end, interval, test_properties
+    ateam,
+    clickhouse_client,
+    exclude_events,
+    data_interval_start,
+    data_interval_end,
+    interval,
+    test_properties,
+    test_person_properties,
 ):
     """Generate test data in ClickHouse."""
     if interval != "every 5 minutes":
@@ -310,7 +327,7 @@ async def generate_test_data(
         end_time=data_interval_end,
         count=10,
         count_other_team=1,
-        properties={"utm_medium": "referral", "$initial_os": "Linux"},
+        properties=test_person_properties,
     )
 
     persons_to_export_created = []

--- a/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
@@ -179,6 +179,15 @@ async def assert_clickhouse_records_in_bigquery(
                         continue
 
                     if k in json_columns and v is not None:
+                        # We remove unpaired surrogates in BigQuery, so we have to remove them here to so
+                        # that comparison doesn't fail. The problem is that at some point our unpaired surrogate gets
+                        # escaped (which is correct, as unpaired surrogates are not valid). But then the
+                        # comparison fails as in BigQuery we remove unpaired surrogates, not just escape them.
+                        # So, we hardcode replace the test properties. Not ideal, but this works as we get the
+                        # expected result in BigQuery and the comparison is still useful.
+                        v = v.replace("\\ud83e\\udd23\\udd23", "\\ud83e\\udd23").replace(
+                            "\\ud83e\\udd23\\ud83e", "\\ud83e\\udd23"
+                        )
                         expected_record[k] = json.loads(v)
                     elif isinstance(v, dt.datetime):
                         expected_record[k] = v.replace(tzinfo=dt.UTC)
@@ -316,6 +325,38 @@ TEST_MODELS: list[BatchExportModel | BatchExportSchema | None] = [
 @pytest.mark.parametrize("exclude_events", [None, ["test-exclude"]], indirect=True)
 @pytest.mark.parametrize("use_json_type", [False, True], indirect=True)
 @pytest.mark.parametrize("model", TEST_MODELS)
+@pytest.mark.parametrize(
+    "test_properties",
+    [
+        {
+            "$browser": "Chrome",
+            "$os": "Mac OS X",
+            "emoji": "🤣",
+            "newline": "\n",
+            "emoji_with_high_surrogate": "🤣\ud83e",
+            "emoji_with_low_surrogate": "🤣\udd23",
+            "emoji_with_high_surrogate_and_newline": "🤣\ud83e\n",
+            "emoji_with_low_surrogate_and_newline": "🤣\udd23\n",
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "test_person_properties",
+    [
+        {
+            "utm_medium": "referral",
+            "$initial_os": "Linux",
+            "emoji": "🤣",
+            "newline": "\n",
+            "emoji_with_high_surrogate": "🤣\ud83e",
+            "emoji_with_low_surrogate": "🤣\udd23",
+            "emoji_with_high_surrogate_and_newline": "🤣\ud83e\n",
+            "emoji_with_low_surrogate_and_newline": "🤣\udd23\n",
+        }
+    ],
+    indirect=True,
+)
 async def test_insert_into_bigquery_activity_inserts_data_into_bigquery_table(
     clickhouse_client,
     activity_environment,


### PR DESCRIPTION
## Problem

This is similar to a problem we had some time ago in Redshift. Strictly speaking, the JSON format cannot handle unpaired surrogates. However, depending on the implementation, these unpaired surrogates can be allowed. The problem arises when we try to send data from an implementation that accepts unpaired surrogate pairs to one that doesn't.

This is happening in BigQuery: ClickHouse is completely cool with unpaired surrogates. But BigQuery's `PARSE_JSON` will scream at you. This is also a problem with newline characters, which must be escaped, but some implementations are fine without the escape. 
 
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Do three very fun regular expressions when merging data into JSON type in BigQuery. I'll cover the regular expressions more in detail below.
* Update tests to send garbage to bigquery, and also remove that garbage when comparing data.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## The regular expressions

Let's break these down. First, we need to match each surrogate that makes up a pair:
* `\\u[dD][89A-Ba-b][0-9A-Fa-f]{{2}}`: Matches a high surrogate in the range D800–DBFF (according to https://symbl.cc/en/unicode/blocks/high-surrogates/).
  * `[dD]`: Matches the start of a surrogate (upper or lower case).
  * `[89A-Ba-b]`: Matches the first character, which in hexadecimal representation goes from 8 to B (or b in lowercase, we cover both).
  * `[0-9A-Fa-f]{{2}}`: Matches the two characters that follow, which go from 0 to f (again, in hex, and covering both uppercase and lowercase).
* `\\u[dD][c-fC-F][0-9A-Fa-f]{{2}}`: Matches a low surrogate in the range DC00–DFFF (according to https://symbl.cc/en/unicode/blocks/low-surrogates/).
  * `[dD]`: Matches the start of a surrogate (upper or lower case).
  * `[c-fC-F]`: Matches the first character, which in hexadecimal representation goes from C to F (or c, f in lowercase, we cover both).
  * `[0-9A-Fa-f]{{2}}`: Matches the two characters that follow, which go from 0 to f (again, in hex, and covering both uppercase and lowercase).

Now that we can match individual surrogates, we need to match and remove those surrogates that are not in a pair. However, BigQuery's regular expression engine (https://github.com/google/re2/wiki/Syntax) does not support lookaheads / lookbacks. So, we need to get clever.
 
For simplicity, I'll be replacing the two expressions we have already broken down for "{HighSurrogate}" and "{LowSurrogate}" in the breakdowns that follow.

* `REGEXP_REPLACE({field.name}, r'({HighSurrogate}{LowSurrogate})|({HighSurrogate})', '\\1')`
  * This expression is matching either a pair of high surrogate, low surrogate, or a single high surrogate. 
  * What we care about is removing a single high surrogate (the pattern after the `|` OR), while preserving the pair (the pattern before the `|` OR).
  * So, we can exploit the fact that we can replace with only one of the parenthesized capture groups.
  * If we match the first expression, then we replace with a valid pair.
  * If we match the second expression, then we still replace with a valid pair. **But this capture group empty!** So we end up in fact just removing the unpaired high surrogate.

* `REGEXP_REPLACE({field.name}, r'({HighSurrogate}{LowSurrogate})|({LowSurrogate})', '\\1')` 
  * This just repeats the same pattern as the previous example, but now for removing low surrogates.

Finally, the last regular expression: `r'[\\n\\r]'`. This is much simpler and designed to replace any un-escaped new line characters with their escaped variant.

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Ran updated tests, and previous ones, all passing.
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
