### PR TITLE
feat: Indicate if you are using groups but dont have the addon

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionConfiguration.tsx
@@ -18,6 +18,7 @@ import { Form } from 'kea-forms'
 import { combineUrl } from 'kea-router'
 import { NotFound } from 'lib/components/NotFound'
 import { PageHeader } from 'lib/components/PageHeader'
+import { PayGateButton } from 'lib/components/PayGateMini/PayGateButton'
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { Sparkline } from 'lib/components/Sparkline'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -81,6 +82,8 @@ export function HogFunctionConfiguration({
         template,
         templateHasChanged,
         type,
+        usesGroups,
+        hasGroupsAddon,
     } = useValues(logic)
     const {
         submitConfiguration,
@@ -382,6 +385,20 @@ export function HogFunctionConfiguration({
                         <div className="space-y-4 flex-2 min-w-100">
                             <div className="p-3 space-y-2 border rounded bg-bg-light">
                                 <div className="space-y-2">
+                                    {usesGroups && !hasGroupsAddon ? (
+                                        <LemonBanner type="warning">
+                                            <span className="flex items-center gap-2">
+                                                This function appears to use Groups but you do not have the Groups
+                                                Analytics addon. Without it, you may see empty values where you use
+                                                templates like {'"{groups.kind.properties}"'}
+                                                <PayGateButton
+                                                    feature={AvailableFeature.GROUP_ANALYTICS}
+                                                    type="secondary"
+                                                />
+                                            </span>
+                                        </LemonBanner>
+                                    ) : null}
+
                                     <HogFunctionInputs
                                         configuration={configuration}
                                         setConfigurationValue={setConfigurationValue}

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -845,7 +845,7 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
             (configuration) => {
                 // NOTE: Bit hacky but works good enough...
                 const configStr = JSON.stringify(configuration)
-                return configStr.includes('{groups')
+                return configStr.includes('groups.') || configStr.includes('{groups}')
             },
         ],
     })),

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionConfigurationLogic.tsx
@@ -483,6 +483,12 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
                 return hasAvailableFeature(AvailableFeature.DATA_PIPELINES)
             },
         ],
+        hasGroupsAddon: [
+            (s) => [s.hasAvailableFeature],
+            (hasAvailableFeature) => {
+                return hasAvailableFeature(AvailableFeature.GROUP_ANALYTICS)
+            },
+        ],
         showPaygate: [
             (s) => [s.template, s.hasAddon],
             (template, hasAddon) => {
@@ -832,6 +838,15 @@ export const hogFunctionConfigurationLogic = kea<hogFunctionConfigurationLogicTy
         mappingTemplates: [
             (s) => [s.hogFunction, s.template],
             (hogFunction, template) => template?.mapping_templates ?? hogFunction?.template?.mapping_templates ?? [],
+        ],
+
+        usesGroups: [
+            (s) => [s.configuration],
+            (configuration) => {
+                // NOTE: Bit hacky but works good enough...
+                const configStr = JSON.stringify(configuration)
+                return configStr.includes('{groups')
+            },
         ],
     })),
 


### PR DESCRIPTION
## Problem

Someone reported issues with groups. Turns out they didn't have the addon.

## Changes

* Adds a warning banner
![2025-01-13 16 18 02](https://github.com/user-attachments/assets/4939cf27-0f59-4bcf-a57e-ba06989ea1bb)


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
