### PR TITLE
feat(experiments): add button to refresh experiment results

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -315,9 +315,8 @@ export function PageHeaderCustom(): JSX.Element {
                                 }}
                                 data-attr="refresh-experiment"
                                 icon={<IconRefresh />}
-                            >
-                                Refresh
-                            </LemonButton>
+                                tooltip="Refresh experiment results"
+                            />
                             <ResetButton experimentId={experiment.id} />
                             {!experiment.end_date && (
                                 <LemonButton

--- a/frontend/src/scenes/experiments/ExperimentView/components.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/components.tsx
@@ -1,4 +1,4 @@
-import { IconFlask } from '@posthog/icons'
+import { IconFlask, IconRefresh } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
@@ -302,25 +302,22 @@ export function PageHeaderCustom(): JSX.Element {
                                             >
                                                 {exposureCohortId ? 'View' : 'Create'} exposure cohort
                                             </LemonButton>
-                                            <LemonButton
-                                                onClick={() => loadMetricResults(true)}
-                                                fullWidth
-                                                data-attr="refresh-experiment"
-                                            >
-                                                Refresh primary metrics
-                                            </LemonButton>
-                                            <LemonButton
-                                                onClick={() => loadSecondaryMetricResults(true)}
-                                                fullWidth
-                                                data-attr="refresh-secondary-metrics"
-                                            >
-                                                Refresh secondary metrics
-                                            </LemonButton>
                                         </>
                                     }
                                 />
                                 <LemonDivider vertical />
                             </>
+                            <LemonButton
+                                type="secondary"
+                                onClick={() => {
+                                    loadMetricResults(true)
+                                    loadSecondaryMetricResults(true)
+                                }}
+                                data-attr="refresh-experiment"
+                                icon={<IconRefresh />}
+                            >
+                                Refresh
+                            </LemonButton>
                             <ResetButton experimentId={experiment.id} />
                             {!experiment.end_date && (
                                 <LemonButton


### PR DESCRIPTION
## Problem
Refreshing experiment results is buried in a menu in the three dots up to the right. Several users has been confused lately because their results are out of date and are wondering if somehing is wrong, as it does not update on a page refresh.
<img width="429" alt="Screenshot 2025-01-13 at 10 44 25" src="https://github.com/user-attachments/assets/101d5d34-7c04-475a-ad57-c46fdcbef7d5" />


## Changes
Added a "Refresh" button.
<img width="1284" alt="Screenshot 2025-01-14 at 16 09 54" src="https://github.com/user-attachments/assets/42a8009c-1c67-44b3-a51e-e5ff41674329" />


## How did you test this code?
tested locally