### PR TITLE
feat(experiments): Tweak inline message UI for delta chart

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -1,6 +1,7 @@
 import {
     IconActivity,
     IconArrowRight,
+    IconClock,
     IconFunnels,
     IconGraph,
     IconMinus,
@@ -274,7 +275,7 @@ export function DeltaChart({
                             ref={ticksSvgRef}
                             viewBox={`0 0 ${VIEW_BOX_WIDTH} ${TICK_PANEL_HEIGHT}`}
                             preserveAspectRatio="xMidYMid meet"
-                            className="ml-12"
+                            className={result ? 'ml-12' : undefined}
                             // eslint-disable-next-line react/forbid-dom-props
                             style={{ minHeight: `${TICK_PANEL_HEIGHT}px`, maxWidth: `${CHART_MAX_WIDTH}px` }}
                         >
@@ -541,25 +542,23 @@ export function DeltaChart({
                         preserveAspectRatio="xMidYMid meet"
                     >
                         {!experiment.start_date ? (
-                            <foreignObject
-                                x={VIEW_BOX_WIDTH / 2 - 100}
-                                y={chartHeight / 2 - 10}
-                                width="250"
-                                height="20"
-                            >
+                            <foreignObject x="0" y={chartHeight / 2 - 10} width={VIEW_BOX_WIDTH} height="20">
                                 <div
-                                    className="flex items-center justify-center text-muted cursor-default"
+                                    className="flex items-center ml-2 xl:ml-0 xl:justify-center text-muted cursor-default"
                                     // eslint-disable-next-line react/forbid-dom-props
                                     style={{ fontSize: '10px', fontWeight: 400 }}
                                 >
+                                    <LemonTag size="small" className="mr-2">
+                                        <IconClock fontSize="1em" />
+                                    </LemonTag>
                                     <span>Waiting for experiment to start&hellip;</span>
                                 </div>
                             </foreignObject>
                         ) : (
                             <foreignObject
-                                x={VIEW_BOX_WIDTH / 2 - 100 - (result ? 0 : 200)}
+                                x={0}
                                 y={chartHeight / 2 - 10}
-                                width="250"
+                                width={VIEW_BOX_WIDTH}
                                 height="20"
                                 onMouseEnter={(e) => {
                                     const rect = e.currentTarget.getBoundingClientRect()
@@ -572,7 +571,7 @@ export function DeltaChart({
                                 onMouseLeave={() => setEmptyStateTooltipVisible(false)}
                             >
                                 <div
-                                    className="flex items-center justify-center text-muted cursor-default"
+                                    className="flex items-center ml-2 xl:ml-0 xl:justify-center text-muted cursor-default"
                                     // eslint-disable-next-line react/forbid-dom-props
                                     style={{ fontSize: '10px', fontWeight: 400 }}
                                 >


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/27014

## Changes

* Centers the messages using pure CSS, instead of trying to calculate SVG width and offset.
* Adds an icon to "Waiting for the experiment to start&hellip;"

| Header | After |
|--------|--------|
| ![CleanShot 2025-01-13 at 07 22 23@2x](https://github.com/user-attachments/assets/84d4bb1c-77a1-4941-a530-8cb485a19b27) | ![CleanShot 2025-01-13 at 07 19 53@2x](https://github.com/user-attachments/assets/5ef72c16-4c1c-433e-b7b7-583a48964365) | 

| Header | After |
|--------|--------|
| ![CleanShot 2025-01-13 at 07 23 14@2x](https://github.com/user-attachments/assets/fef0aec7-0e46-4623-b974-de32ee0cc089) | ![CleanShot 2025-01-13 at 07 20 39@2x](https://github.com/user-attachments/assets/384e2a3f-e2d4-4a3d-9c4c-94f3abf7186e) | 

## How did you test this code?

👀 