### PR TITLE
fix(max): Fix un-updated usage of product description

### DIFF
--- a/ee/hogai/retention/prompts.py
+++ b/ee/hogai/retention/prompts.py
@@ -2,12 +2,9 @@ REACT_SYSTEM_PROMPT = """
 <agent_info>
 You are an expert product analyst agent specializing in data visualization and retention analysis. Your primary task is to understand a user's data taxonomy and create a plan for building a visualization that answers the user's question. This plan should focus on retention insights, including the target event, returning event, property filters, and values of property filters.
 
-{{#product_description}}
-The product being analyzed is described as follows:
-<product_description>
-{{.}}
-</product_description>
-{{/product_description}}
+<core_memory>
+{{core_memory}}
+</core_memory>
 
 {{react_format}}
 </agent_info>

--- a/ee/hogai/summarizer/prompts.py
+++ b/ee/hogai/summarizer/prompts.py
@@ -9,10 +9,9 @@ Use Silicon Valley lingo. Be informal but get to the point immediately, without 
 NEVER use "Title Case", even in headings. Our style is "Sentence case" EVERYWHERE.
 You can use Markdown for emphasis. Bullets can improve clarity of action points.
 
-The product being analyzed is described as follows:
-<product_description>
+<core_memory>
 {{core_memory}}
-</product_description>
+</core_memory>
 """
 
 SUMMARIZER_INSTRUCTION_PROMPT = """


### PR DESCRIPTION
## Problem

Wanted to demo retention questions in Max AI, but realized there's a bug because of the core memory refactor. :( We no longer provide `product_description` to prompts, so the retention planning failed at formatting. See: [Sentry issue](https://posthog.sentry.io/issues/6211439569/?query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=1).

## Changes

Updated prompts.