### PR TITLE
feat(experiments): Allow launching with primary shared metric

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1721,9 +1721,9 @@ export const experimentLogic = kea<experimentLogicType>([
             },
         ],
         hasGoalSet: [
-            (s) => [s.experiment],
-            (experiment): boolean => {
-                return !!experiment.metrics[0]
+            (s) => [s.primaryMetricsLengthWithSharedMetrics],
+            (primaryMetricsLengthWithSharedMetrics): boolean => {
+                return primaryMetricsLengthWithSharedMetrics > 0
             },
         ],
         experimentStatsVersion: [


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/27014
Reported in https://posthoghelp.zendesk.com/agent/tickets/23115 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/25235)

## Changes

Allows launching an experiment when it has only has one primary metric and that primary metric is a shared metric.

## How did you test this code?

I verified that I could click the "Launch" button on an experiment that only had a shared metric assigned as the primary metric.