### PR TITLE
feat(experiments): More shared metrics refinements

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -15,6 +15,7 @@ import { isCoreFilter, PROPERTY_KEYS } from 'lib/taxonomy'
 import { objectClean } from 'lib/utils'
 import posthog from 'posthog-js'
 import { Holdout } from 'scenes/experiments/holdoutsLogic'
+import { SharedMetric } from 'scenes/experiments/SharedMetrics/sharedMetricLogic'
 import { isFilterWithDisplay, isFunnelsFilter, isTrendsFilter } from 'scenes/insights/sharedUtils'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { EventIndex } from 'scenes/session-recordings/player/eventIndex'
@@ -494,7 +495,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             experimentId: ExperimentIdType
             holdoutId: Holdout['id']
         }) => ({ experimentId, holdoutId }),
-
+        reportExperimentSharedMetricCreated: (sharedMetric: SharedMetric) => ({ sharedMetric }),
+        reportExperimentSharedMetricAssigned: (experimentId: ExperimentIdType, sharedMetric: SharedMetric) => ({
+            experimentId,
+            sharedMetric,
+        }),
         // Definition Popover
         reportDataManagementDefinitionHovered: (type: TaxonomicFilterGroupType) => ({ type }),
         reportDataManagementDefinitionClickView: (type: TaxonomicFilterGroupType) => ({ type }),
@@ -1092,6 +1097,21 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             posthog.capture('experiment holdout assigned', {
                 experiment_id: experimentId,
                 holdout_id: holdoutId,
+            })
+        },
+        reportExperimentSharedMetricCreated: ({ sharedMetric }) => {
+            posthog.capture('experiment shared metric created', {
+                name: sharedMetric.name,
+                id: sharedMetric.id,
+                kind: sharedMetric.query.kind,
+            })
+        },
+        reportExperimentSharedMetricAssigned: ({ experimentId, sharedMetric }) => {
+            posthog.capture('experiment shared metric assigned', {
+                experiment_id: experimentId,
+                shared_metric_name: sharedMetric.name,
+                shared_metric_id: sharedMetric.id,
+                shared_metric_kind: sharedMetric.query.kind,
             })
         },
         reportPropertyGroupFilterAdded: () => {

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -120,46 +120,62 @@ export function SharedMetricModal({
             {mode === 'create' && (
                 <div className="space-y-2">
                     {availableSharedMetrics.length > 0 ? (
-                        <LemonTable
-                            dataSource={availableSharedMetrics}
-                            columns={[
-                                {
-                                    title: '',
-                                    key: 'checkbox',
-                                    render: (_, metric: SharedMetric) => (
-                                        <input
-                                            type="checkbox"
-                                            checked={selectedMetricIds.includes(metric.id)}
-                                            onChange={(e) => {
-                                                if (e.target.checked) {
-                                                    setSelectedMetricIds([...selectedMetricIds, metric.id])
-                                                } else {
-                                                    setSelectedMetricIds(
-                                                        selectedMetricIds.filter((id) => id !== metric.id)
-                                                    )
-                                                }
-                                            }}
-                                        />
-                                    ),
-                                },
-                                {
-                                    title: 'Name',
-                                    dataIndex: 'name',
-                                    key: 'name',
-                                },
-                                {
-                                    title: 'Description',
-                                    dataIndex: 'description',
-                                    key: 'description',
-                                },
-                                {
-                                    title: 'Type',
-                                    key: 'type',
-                                    render: (_, metric: SharedMetric) =>
-                                        metric.query.kind.replace('Experiment', '').replace('Query', ''),
-                                },
-                            ]}
-                        />
+                        <>
+                            {experiment.saved_metrics.length > 0 && (
+                                <LemonBanner type="info">
+                                    {`Hiding ${experiment.saved_metrics.length} shared ${
+                                        experiment.saved_metrics.length > 1 ? 'metrics' : 'metric'
+                                    } already in use with this experiment.`}
+                                </LemonBanner>
+                            )}
+                            <LemonTable
+                                dataSource={availableSharedMetrics}
+                                columns={[
+                                    {
+                                        title: '',
+                                        key: 'checkbox',
+                                        render: (_, metric: SharedMetric) => (
+                                            <input
+                                                type="checkbox"
+                                                checked={selectedMetricIds.includes(metric.id)}
+                                                onChange={(e) => {
+                                                    if (e.target.checked) {
+                                                        setSelectedMetricIds([...selectedMetricIds, metric.id])
+                                                    } else {
+                                                        setSelectedMetricIds(
+                                                            selectedMetricIds.filter((id) => id !== metric.id)
+                                                        )
+                                                    }
+                                                }}
+                                            />
+                                        ),
+                                    },
+                                    {
+                                        title: 'Name',
+                                        dataIndex: 'name',
+                                        key: 'name',
+                                    },
+                                    {
+                                        title: 'Description',
+                                        dataIndex: 'description',
+                                        key: 'description',
+                                    },
+                                    {
+                                        title: 'Type',
+                                        key: 'type',
+                                        render: (_, metric: SharedMetric) =>
+                                            metric.query.kind.replace('Experiment', '').replace('Query', ''),
+                                    },
+                                ]}
+                                footer={
+                                    <div className="flex items-center justify-center m-2">
+                                        <LemonButton to={urls.experimentsSharedMetrics()} size="xsmall" type="tertiary">
+                                            See all shared metrics
+                                        </LemonButton>
+                                    </div>
+                                }
+                            />
+                        </>
                     ) : (
                         <LemonBanner
                             className="w-full"

--- a/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedMetrics.tsx
@@ -4,6 +4,8 @@ import { useValues } from 'kea'
 import { router } from 'kea-router'
 import { createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { createdAtColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
+import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import stringWithWBR from 'lib/utils/stringWithWBR'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -20,7 +22,12 @@ const columns: LemonTableColumns<SharedMetric> = [
         key: 'name',
         title: 'Name',
         render: (_, sharedMetric) => {
-            return <div className="font-semibold">{sharedMetric.name}</div>
+            return (
+                <LemonTableLink
+                    to={sharedMetric.id ? urls.experimentsSharedMetric(sharedMetric.id) : undefined}
+                    title={stringWithWBR(sharedMetric.name, 17)}
+                />
+            )
         },
     },
     {

--- a/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/sharedMetricLogic.tsx
@@ -3,6 +3,7 @@ import { actions, connect, kea, key, listeners, path, props, reducers, selectors
 import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
 import api from 'lib/api'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 
 import { UserBasicType } from '~/types'
 
@@ -35,7 +36,7 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
     path((key) => ['scenes', 'experiments', 'sharedMetricLogic', key]),
     key((props) => props.sharedMetricId || 'new'),
     connect(() => ({
-        actions: [sharedMetricsLogic, ['loadSharedMetrics']],
+        actions: [sharedMetricsLogic, ['loadSharedMetrics'], eventUsageLogic, ['reportExperimentSharedMetricCreated']],
     })),
     actions({
         setSharedMetric: (metric: Partial<SharedMetric>) => ({ metric }),
@@ -63,6 +64,7 @@ export const sharedMetricLogic = kea<sharedMetricLogicType>([
             const response = await api.create(`api/projects/@current/experiment_saved_metrics/`, values.sharedMetric)
             if (response.id) {
                 lemonToast.success('Shared metric created successfully')
+                actions.reportExperimentSharedMetricCreated(response)
                 actions.loadSharedMetrics()
                 router.actions.push('/experiments/shared-metrics')
             }

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -156,6 +156,7 @@ export const experimentLogic = kea<experimentLogicType>([
                 'reportExperimentResultsLoadingTimeout',
                 'reportExperimentReleaseConditionsViewed',
                 'reportExperimentHoldoutAssigned',
+                'reportExperimentSharedMetricAssigned',
             ],
             teamLogic,
             ['addProductIntent'],
@@ -902,6 +903,12 @@ export const experimentLogic = kea<experimentLogicType>([
             }))
 
             const newMetricsIds = sharedMetricIds.map((id: SharedMetric['id']) => ({ id, metadata }))
+            newMetricsIds.forEach((metricId) => {
+                const metric = values.sharedMetrics.find((m: SharedMetric) => m.id === metricId.id)
+                if (metric) {
+                    actions.reportExperimentSharedMetricAssigned(values.experimentId, metric)
+                }
+            })
             const combinedMetricsIds = [...existingMetricsIds, ...newMetricsIds]
 
             await api.update(`api/projects/${values.currentProjectId}/experiments/${values.experimentId}`, {


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/27014

## Changes

Updates the "Select one or more shared metrics" UI to communicate why some are hidden and link to all:

![CleanShot 2025-01-13 at 13 17 13@2x](https://github.com/user-attachments/assets/a88d4ccf-b919-432c-953b-f12e95987d5d)

Links the title of a shared metric to make it easier to edit:

![CleanShot 2025-01-13 at 13 17 28@2x](https://github.com/user-attachments/assets/859f99bb-3a13-43ea-9260-4a7ae8b61104)

Adds `experiment shared metric created` and `experiment shared metric assigned` events.

## How did you test this code?

I visually reviewed all of the UI.

I also verified the events fired with the expected properties.