### PR TITLE
refactor(batch-exports): S3 does not resume

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -728,7 +728,8 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
         if not await client.is_alive():
             raise ConnectionError("Cannot establish connection to ClickHouse")
 
-        s3_upload, details = await initialize_and_resume_multipart_upload(inputs)
+        s3_upload = initialize_upload(inputs, 0)
+        details = S3HeartbeatDetails()
         done_ranges: list[DateRange] = details.done_ranges
 
         model: BatchExportModel | BatchExportSchema | None = None


### PR DESCRIPTION
## Problem

Resuming from heartbeats causes problems if heartbeats are not flushed. Since we can't really force a flush, and it's all up to temporal, let's not resume anymore at least in S3 and see what happens.

We'll likely take a performance hit by doing this, but we can invest in parallelizing with multiple consumers next.
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes

* Always initialize S3 upload with file number 0
* Always initialize empty heartbeat.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
