### PR TITLE
chore(cache-warming): reduce threshold for warming shared insights

### DIFF
--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -38,6 +38,7 @@ PRIORITY_INSIGHTS_COUNTER = Counter(
 )
 
 LAST_VIEWED_THRESHOLD = timedelta(days=7)
+SHARED_INSIGHTS_LAST_VIEWED_THRESHOLD = timedelta(days=3)
 
 
 def teams_enabled_for_cache_warming() -> list[int]:
@@ -80,8 +81,11 @@ def insights_to_keep_fresh(team: Team, shared_only: bool = False) -> Generator[t
     to not let the cache go stale. There isn't any middle ground, like trying to refresh it once a day, since
     that would be like clock that's only right twice a day.
     """
+    # for shared insights, use a lower cut off
+    threshold = datetime.now(UTC) - (
+        LAST_VIEWED_THRESHOLD if not shared_only else SHARED_INSIGHTS_LAST_VIEWED_THRESHOLD
+    )
 
-    threshold = datetime.now(UTC) - LAST_VIEWED_THRESHOLD
     QueryCacheManager.clean_up_stale_insights(team_id=team.pk, threshold=threshold)
 
     # get all insights currently in the cache for the team


### PR DESCRIPTION
## Problem
Shared insights contribute very heavily to cache warming load 
https://us.posthog.com/project/2/dashboard/293590
<!-- Who are we building for, what are their needs, why is this important? -->

## Changes
To prioritise higher paying teams, reducing threshold for how many shared insights to keep warm. Will use the spare capacity to enable more higher paying teams from here
https://us.posthog.com/project/2/insights/CgjHNaQA
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
N/A
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
