### PR TITLE
feat: Enable CLICKHOUSE_USE_HTTP on local dev setup

### DIFF
--- a/.github/workflows/ci-plugin-server.yml
+++ b/.github/workflows/ci-plugin-server.yml
@@ -170,7 +170,7 @@ jobs:
             - name: Wait for Clickhouse, Redis & Kafka
               if: needs.changes.outputs.plugin-server == 'true'
               run: |
-                  docker compose -f docker-compose.dev.yml up kafka redis clickhouse -d --wait
+                  docker compose -f docker-compose.dev.yml up kafka redis clickhouse query-service -d --wait
                   bin/check_kafka_clickhouse_up
 
             - name: Set up databases
@@ -262,10 +262,10 @@ jobs:
                   pnpm install --frozen-lockfile
                   pnpm build
 
-            - name: Wait for Clickhouse, Redis & Kafka
+            - name: Wait for Clickhouse, Query-service Redis & Kafka
               if: needs.changes.outputs.plugin-server == 'true'
               run: |
-                  docker compose -f docker-compose.dev.yml up kafka redis clickhouse -d --wait
+                  docker compose -f docker-compose.dev.yml up kafka redis clickhouse query-service -d --wait
                   bin/check_kafka_clickhouse_up
 
             - name: Set up databases

--- a/bin/start
+++ b/bin/start
@@ -6,6 +6,7 @@ export DEBUG=${DEBUG:-1}
 export SKIP_SERVICE_VERSION_REQUIREMENTS=${SKIP_SERVICE_VERSION_REQUIREMENTS:-1}
 export BILLING_SERVICE_URL=${BILLING_SERVICE_URL:-https://billing.dev.posthog.dev}
 export HOG_HOOK_URL=${HOG_HOOK_URL:-http://localhost:3300/hoghook}
+export CLICKHOUSE_USE_HTTP=1
 
 [ ! -f ./share/GeoLite2-City.mmdb ] && ( curl -L "https://mmdbcdn.posthog.net/" --http1.1 | brotli --decompress --output=./share/GeoLite2-City.mmdb )
 

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -74,6 +74,10 @@ services:
             timeout: 10s
             retries: 10
 
+    query-service:
+        image: contentsquareplatform/chproxy:v1.26.6
+        restart: on-failure
+
     clickhouse:
         #
         # Note: please keep the default version in sync across
@@ -137,7 +141,7 @@ services:
             DISABLE_SECURE_SSL_REDIRECT: 'true'
             IS_BEHIND_PROXY: 'true'
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
-            CLICKHOUSE_HOST: 'clickhouse'
+            CLICKHOUSE_HOST: 'query-service'
             CLICKHOUSE_DATABASE: 'posthog'
             CLICKHOUSE_SECURE: 'false'
             CLICKHOUSE_VERIFY: 'false'
@@ -202,7 +206,7 @@ services:
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis:6379/'
-            CLICKHOUSE_HOST: 'clickhouse'
+            CLICKHOUSE_HOST: 'query-service'
             CLICKHOUSE_DATABASE: 'posthog'
             CLICKHOUSE_SECURE: 'false'
             CLICKHOUSE_VERIFY: 'false'

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -75,7 +75,7 @@ services:
             retries: 10
 
     query-service:
-        image: contentsquareplatform/chproxy:v1.26.6
+        image: posthog/chproxy:v1.27.1
         restart: on-failure
 
     clickhouse:

--- a/docker-compose.dev-full.yml
+++ b/docker-compose.dev-full.yml
@@ -25,6 +25,11 @@ services:
             service: db
         ports:
             - '5432:5432'
+        # something in the django app when running in dev mode
+        # (maybe only in Pycharm) keeps many idle transactions open
+        # and eventually kills postgres, these settings aim to stop that happening.
+        # They are only for DEV and should not be used in production.
+        command: postgres -c max_connections=1000 -c idle_in_transaction_session_timeout=300000
 
     redis:
         extends:
@@ -33,16 +38,38 @@ services:
         ports:
             - '6379:6379'
 
+    query-service:
+        extends:
+            file: docker-compose.base.yml
+            service: query-service
+        ports:
+            - '8123:8123'
+            - '8443:8443'
+        volumes:
+            - ./docker/chproxy/config.yml:/config.yml
+        depends_on:
+            - clickhouse
+        command: -config /config.yml
+        healthcheck:
+            test: curl 'http://127.0.0.1:9090/ping'
+            interval: 2s
+            timeout: 20s
+            retries: 10
+
     clickhouse:
         extends:
             file: docker-compose.base.yml
             service: clickhouse
         ports:
-            - '8123:8123'
+            - '28123:8123'
+            - '28443:8443'
             - '9000:9000'
             - '9440:9440'
             - '9009:9009'
         volumes:
+            # this new entrypoint file is to fix a bug detailed here https://github.com/ClickHouse/ClickHouse/pull/59991
+            # revert this when we upgrade clickhouse
+            - ./docker/clickhouse/entrypoint.sh:/entrypoint.sh
             - ./posthog/idl:/idl
             - ./docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
             - ./docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
@@ -89,7 +116,7 @@ services:
         ports:
             - '2080:2080'
         environment:
-            - PORT=2080
+            - LISTEN_PORT=2080
 
     worker:
         extends:
@@ -183,18 +210,21 @@ services:
             service: elasticsearch
         expose:
             - 9200
+
     temporal:
         extends:
             file: docker-compose.base.yml
             service: temporal
         ports:
             - 7233:7233
+
     temporal-admin-tools:
         extends:
             file: docker-compose.base.yml
             service: temporal-admin-tools
         depends_on:
             - temporal
+
     temporal-ui:
         extends:
             file: docker-compose.base.yml

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -67,7 +67,7 @@ services:
             - clickhouse
         command: -config /config.yml
         healthcheck:
-            test: curl 'http://127.0.0.1:8123/ping'
+            test: curl 'http://127.0.0.1:8123/metrics'
             interval: 2s
             timeout: 20s
             retries: 10

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,14 +51,35 @@ services:
         ports:
             - '5555:5555'
 
+    query-service:
+        extends:
+            file: docker-compose.base.yml
+            service: query-service
+        environment:
+            - CLICKHOUSE_CLUSTER=default
+            - CLICKHOUSE_USER=default
+        ports:
+            - '8123:8123'
+            - '8443:8443'
+        volumes:
+            - ./docker/chproxy/config.yml:/config.yml
+        depends_on:
+            - clickhouse
+        command: -config /config.yml
+        healthcheck:
+            test: curl 'http://127.0.0.1:8123/ping'
+            interval: 2s
+            timeout: 20s
+            retries: 10
+
     clickhouse:
         extends:
             file: docker-compose.base.yml
             service: clickhouse
         hostname: clickhouse
         ports:
-            - '8123:8123'
-            - '8443:8443'
+            - '28123:8123'
+            - '28443:8443'
             - '9000:9000'
             - '9440:9440'
             - '9009:9009'

--- a/docker/chproxy/config.yml
+++ b/docker/chproxy/config.yml
@@ -1,5 +1,5 @@
 hack_me_please: true
-log_debug: true
+log_debug: false
 allow_ping: true
 
 server:

--- a/docker/chproxy/config.yml
+++ b/docker/chproxy/config.yml
@@ -1,5 +1,5 @@
 hack_me_please: true
-log_debug: false
+log_debug: true
 allow_ping: true
 
 server:

--- a/docker/chproxy/config.yml
+++ b/docker/chproxy/config.yml
@@ -1,0 +1,19 @@
+hack_me_please: true
+log_debug: true
+allow_ping: true
+
+server:
+    http:
+        listen_addr: ':8123'
+
+users:
+    - name: ${CLICKHOUSE_USER}
+      to_user: ${CLICKHOUSE_USER}
+      to_cluster: ${CLICKHOUSE_CLUSTER}
+
+# by default each cluster has `default` user which can be overridden by section `users`
+clusters:
+    - name: ${CLICKHOUSE_CLUSTER}
+      nodes: ['clickhouse:8123']
+      users:
+          - name: ${CLICKHOUSE_USER}

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -182,7 +182,7 @@ export class DB {
             const timeout = timeoutGuard('ClickHouse slow query warning after 30 sec', { query })
             try {
                 const queryResult = await this.clickhouse.querying(query, options)
-                // This is annoying to type, because the result depends on contructor and query options provided
+                // This is annoying to type, because the result depends on constructor and query options provided
                 // at runtime. However, with our options we can safely assume ObjectQueryResult<R>
                 return queryResult as unknown as ClickHouse.ObjectQueryResult<R>
             } finally {


### PR DESCRIPTION
## Problem

We are moving forward with a query-service. We've made decision to use ClickHouse HTTP interface. The local dev environment should be kept in same shape as our prod.

## Changes

Pass ClickHouse queries through query-service.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

I've run local version with migrations and fake data generation.
