### PR TITLE
feat: [1/n] Teams Downgrade Flow Experiment Setup

### DIFF
--- a/frontend/src/layout/GlobalModals.tsx
+++ b/frontend/src/layout/GlobalModals.tsx
@@ -3,6 +3,7 @@ import { ConfirmUpgradeModal } from 'lib/components/ConfirmUpgradeModal/ConfirmU
 import { HedgehogBuddyWithLogic } from 'lib/components/HedgehogBuddy/HedgehogBuddyWithLogic'
 import { TimeSensitiveAuthenticationModal } from 'lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication'
 import { UpgradeModal } from 'lib/components/UpgradeModal/UpgradeModal'
+import { TeamsDowngradeModal } from 'scenes/authentication/TeamsDowngradeModal'
 import { TwoFactorSetupModal } from 'scenes/authentication/TwoFactorSetupModal'
 import { CreateOrganizationModal } from 'scenes/organization/CreateOrganizationModal'
 import { CreateEnvironmentModal } from 'scenes/project/CreateEnvironmentModal'
@@ -70,6 +71,7 @@ export function GlobalModals(): JSX.Element {
             <PreviewingCustomCssModal />
             <TwoFactorSetupModal />
             <HedgehogBuddyWithLogic />
+            <TeamsDowngradeModal />
         </>
     )
 }

--- a/frontend/src/layout/GlobalModals.tsx
+++ b/frontend/src/layout/GlobalModals.tsx
@@ -3,7 +3,6 @@ import { ConfirmUpgradeModal } from 'lib/components/ConfirmUpgradeModal/ConfirmU
 import { HedgehogBuddyWithLogic } from 'lib/components/HedgehogBuddy/HedgehogBuddyWithLogic'
 import { TimeSensitiveAuthenticationModal } from 'lib/components/TimeSensitiveAuthentication/TimeSensitiveAuthentication'
 import { UpgradeModal } from 'lib/components/UpgradeModal/UpgradeModal'
-import { TeamsDowngradeModal } from 'scenes/authentication/TeamsDowngradeModal'
 import { TwoFactorSetupModal } from 'scenes/authentication/TwoFactorSetupModal'
 import { CreateOrganizationModal } from 'scenes/organization/CreateOrganizationModal'
 import { CreateEnvironmentModal } from 'scenes/project/CreateEnvironmentModal'
@@ -71,7 +70,6 @@ export function GlobalModals(): JSX.Element {
             <PreviewingCustomCssModal />
             <TwoFactorSetupModal />
             <HedgehogBuddyWithLogic />
-            <TeamsDowngradeModal />
         </>
     )
 }

--- a/frontend/src/lib/components/FeatureDowngradeModal/FeatureDowngradeModal.tsx
+++ b/frontend/src/lib/components/FeatureDowngradeModal/FeatureDowngradeModal.tsx
@@ -1,0 +1,53 @@
+import { IconWarning } from '@posthog/icons'
+import { LemonButton, LemonModal } from '@posthog/lemon-ui'
+
+export interface DowngradeFeature {
+    title: string
+    warning?: boolean
+}
+
+interface FeatureDowngradeModalProps {
+    isOpen: boolean
+    onClose: () => void
+    onDowngrade: () => void
+    title: string
+    subtitle?: string
+    features: DowngradeFeature[]
+}
+
+export function FeatureDowngradeModal({
+    isOpen,
+    onClose,
+    onDowngrade,
+    title,
+    subtitle = 'You are about to lose access to the following features:',
+    features,
+}: FeatureDowngradeModalProps): JSX.Element {
+    return (
+        <LemonModal
+            title={title}
+            description={subtitle}
+            isOpen={isOpen}
+            onClose={onClose}
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={onClose}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton type="primary" status="danger" onClick={onDowngrade}>
+                        Continue Unsubscribing
+                    </LemonButton>
+                </>
+            }
+        >
+            <div className="space-y-2">
+                {features.map((feature, index) => (
+                    <div key={index} className="flex items-center gap-2">
+                        <IconWarning className="text-warning" />
+                        <div>{feature.title}</div>
+                    </div>
+                ))}
+            </div>
+        </LemonModal>
+    )
+}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -238,6 +238,7 @@ export const FEATURE_FLAGS = {
     REPLAY_LANDING_PAGE: 'replay-landing-page', // owner :#team-replay
     CORE_WEB_VITALS: 'core-web-vitals', // owner: @rafaeelaudibert #team-web-analytics
     LLM_OBSERVABILITY: 'llm-observability', // owner: #team-ai-product-manager
+    TEAMS_DOWNGRADE_FLOW: 'teams-downgrade-flow', // owner: @sjhavar
 } as const
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS]
 

--- a/frontend/src/scenes/authentication/TeamsDowngradeModal.tsx
+++ b/frontend/src/scenes/authentication/TeamsDowngradeModal.tsx
@@ -1,0 +1,30 @@
+import { LemonButton, LemonModal } from '@posthog/lemon-ui'
+import { useActions, useValues } from 'kea'
+
+import { teamsDowngradeLogic } from './teamsDowngradeLogic'
+
+export function TeamsDowngradeModal(): JSX.Element {
+    const { isTeamsDowngradeModalOpen } = useValues(teamsDowngradeLogic)
+    const { hideTeamsDowngradeModal, handleTeamsDowngrade } = useActions(teamsDowngradeLogic)
+
+    return (
+        <LemonModal
+            title="Unsubscribe from Teams"
+            description="You are about to lose access to the following features:"
+            isOpen={isTeamsDowngradeModalOpen}
+            onClose={hideTeamsDowngradeModal}
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={hideTeamsDowngradeModal}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton type="primary" status="danger" onClick={handleTeamsDowngrade}>
+                        Continue Unsubscribing
+                    </LemonButton>
+                </>
+            }
+        >
+            <p>TODO: Add features that are currently being used</p>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/authentication/TeamsDowngradeModal.tsx
+++ b/frontend/src/scenes/authentication/TeamsDowngradeModal.tsx
@@ -1,30 +1,26 @@
-import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
+import { DowngradeFeature, FeatureDowngradeModal } from 'lib/components/FeatureDowngradeModal/FeatureDowngradeModal'
 
 import { teamsDowngradeLogic } from './teamsDowngradeLogic'
+
+const TEAMS_FEATURES: DowngradeFeature[] = [
+    {
+        // Replace hardcoding here
+        title: '2FA Enforcement',
+    },
+]
 
 export function TeamsDowngradeModal(): JSX.Element {
     const { isTeamsDowngradeModalOpen } = useValues(teamsDowngradeLogic)
     const { hideTeamsDowngradeModal, handleTeamsDowngrade } = useActions(teamsDowngradeLogic)
 
     return (
-        <LemonModal
-            title="Unsubscribe from Teams"
-            description="You are about to lose access to the following features:"
+        <FeatureDowngradeModal
             isOpen={isTeamsDowngradeModalOpen}
             onClose={hideTeamsDowngradeModal}
-            footer={
-                <>
-                    <LemonButton type="secondary" onClick={hideTeamsDowngradeModal}>
-                        Cancel
-                    </LemonButton>
-                    <LemonButton type="primary" status="danger" onClick={handleTeamsDowngrade}>
-                        Continue Unsubscribing
-                    </LemonButton>
-                </>
-            }
-        >
-            <p>TODO: Add features that are currently being used</p>
-        </LemonModal>
+            onDowngrade={handleTeamsDowngrade}
+            title="Unsubscribe from Teams"
+            features={TEAMS_FEATURES}
+        />
     )
 }

--- a/frontend/src/scenes/authentication/teamsDowngradeLogic.ts
+++ b/frontend/src/scenes/authentication/teamsDowngradeLogic.ts
@@ -1,0 +1,48 @@
+import { actions, kea, listeners, path, reducers } from 'kea'
+import { UNSUBSCRIBE_SURVEY_ID } from 'lib/constants'
+import { billingProductLogic } from 'scenes/billing/billingProductLogic'
+
+import { BillingProductV2AddonType } from '~/types'
+
+import type { teamsDowngradeLogicType } from './teamsDowngradeLogicType'
+
+export interface TeamsDowngradeModalProps {
+    onClose?: () => void
+}
+
+export const teamsDowngradeLogic = kea<teamsDowngradeLogicType>([
+    path(['scenes', 'authentication', 'teamsDowngradeLogic']),
+    actions({
+        showTeamsDowngradeModal: (addon: BillingProductV2AddonType) => ({ addon }),
+        hideTeamsDowngradeModal: true,
+        handleTeamsDowngrade: true,
+    }),
+
+    reducers({
+        isTeamsDowngradeModalOpen: [
+            false,
+            {
+                showTeamsDowngradeModal: () => true,
+                hideTeamsDowngradeModal: () => false,
+            },
+        ],
+        currentAddon: [
+            null as BillingProductV2AddonType | null,
+            {
+                showTeamsDowngradeModal: (_, { addon }) => addon,
+                hideTeamsDowngradeModal: () => null,
+            },
+        ],
+    }),
+
+    listeners(({ values, actions }) => ({
+        handleTeamsDowngrade: () => {
+            if (values.currentAddon) {
+                const logic = billingProductLogic({ product: values.currentAddon })
+                logic.actions.setSurveyResponse('$survey_response_1', values.currentAddon.type)
+                logic.actions.reportSurveyShown(UNSUBSCRIBE_SURVEY_ID, values.currentAddon.type)
+            }
+            actions.hideTeamsDowngradeModal()
+        },
+    })),
+])

--- a/frontend/src/scenes/billing/BillingProductAddonActions.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddonActions.tsx
@@ -7,6 +7,7 @@ import { More } from 'lib/lemon-ui/LemonButton/More'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { toSentenceCase } from 'lib/utils'
 import { useMemo } from 'react'
+import { teamsDowngradeLogic } from 'scenes/authentication/teamsDowngradeLogic'
 
 import { BillingProductV2AddonType } from '~/types'
 
@@ -25,6 +26,7 @@ export const BillingProductAddonActions = ({ addon, productRef }: BillingProduct
     const { currentAndUpgradePlans, billingProductLoading, trialLoading } = useValues(
         billingProductLogic({ product: addon, productRef })
     )
+    const { showTeamsDowngradeModal } = useActions(teamsDowngradeLogic)
 
     const {
         toggleIsPricingModalOpen,
@@ -74,8 +76,13 @@ export const BillingProductAddonActions = ({ addon, productRef }: BillingProduct
                     <LemonButton
                         fullWidth
                         onClick={() => {
-                            setSurveyResponse('$survey_response_1', addon.type)
-                            reportSurveyShown(UNSUBSCRIBE_SURVEY_ID, addon.type)
+                            if (featureFlags[FEATURE_FLAGS.TEAMS_DOWNGRADE_FLOW] === 'test') {
+                                showTeamsDowngradeModal(addon)
+                            } else {
+                                // Original behavior
+                                setSurveyResponse('$survey_response_1', addon.type)
+                                reportSurveyShown(UNSUBSCRIBE_SURVEY_ID, addon.type)
+                            }
                         }}
                     >
                         Remove add-on

--- a/frontend/src/scenes/billing/BillingProductAddonActions.tsx
+++ b/frontend/src/scenes/billing/BillingProductAddonActions.tsx
@@ -8,6 +8,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { toSentenceCase } from 'lib/utils'
 import { useMemo } from 'react'
 import { teamsDowngradeLogic } from 'scenes/authentication/teamsDowngradeLogic'
+import { TeamsDowngradeModal } from 'scenes/authentication/TeamsDowngradeModal'
 
 import { BillingProductV2AddonType } from '~/types'
 
@@ -71,24 +72,27 @@ export const BillingProductAddonActions = ({ addon, productRef }: BillingProduct
             return null
         }
         return (
-            <More
-                overlay={
-                    <LemonButton
-                        fullWidth
-                        onClick={() => {
-                            if (featureFlags[FEATURE_FLAGS.TEAMS_DOWNGRADE_FLOW] === 'test') {
-                                showTeamsDowngradeModal(addon)
-                            } else {
-                                // Original behavior
-                                setSurveyResponse('$survey_response_1', addon.type)
-                                reportSurveyShown(UNSUBSCRIBE_SURVEY_ID, addon.type)
-                            }
-                        }}
-                    >
-                        Remove add-on
-                    </LemonButton>
-                }
-            />
+            <>
+                <More
+                    overlay={
+                        <LemonButton
+                            fullWidth
+                            onClick={() => {
+                                if (featureFlags[FEATURE_FLAGS.TEAMS_DOWNGRADE_FLOW] === 'test') {
+                                    showTeamsDowngradeModal(addon)
+                                } else {
+                                    // Original behavior
+                                    setSurveyResponse('$survey_response_1', addon.type)
+                                    reportSurveyShown(UNSUBSCRIBE_SURVEY_ID, addon.type)
+                                }
+                            }}
+                        >
+                            Remove add-on
+                        </LemonButton>
+                    }
+                />
+                <TeamsDowngradeModal />
+            </>
         )
     }
 


### PR DESCRIPTION
## Problem

When a user unsubscribes from the teams feature, we want to show them a list of features that they are currently using and will lose access to.

## Changes

In this PR, I'm doing the initial experiment setup and showing the user a basic modal before they can unsubscribe. Next I will add logic to check which features are actually used by the org and update the list.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Cloud: Yes

## How did you test this code?

https://github.com/user-attachments/assets/c7d906e4-9d78-468c-891c-9d2706c68486


Verified modal pops up before they are allowed to unbscribed.
Verified that the user only sees the new flow if they are in the experiment group 
