### PR TITLE
fix: Hog function template defaults

### DIFF
--- a/ee/api/test/test_hooks.py
+++ b/ee/api/test/test_hooks.py
@@ -1,6 +1,8 @@
 from typing import cast
 from unittest.mock import ANY
 
+from inline_snapshot import snapshot
+
 from ee.api.hooks import valid_domain
 from ee.api.test.base import APILicensedTest
 from ee.models.hook import Hook
@@ -116,6 +118,19 @@ class TestHooksAPI(ClickhouseTestMixin, APILicensedTest):
             "actions": [{"id": str(self.action.id), "name": "", "type": "actions", "order": 0}],
             "bytecode": ["_H", HOGQL_BYTECODE_VERSION, 32, "$pageview", 32, "event", 1, 1, 11, 3, 1, 4, 1],
         }
+
+        assert hog_function.hog == snapshot(
+            """\
+let res := fetch(f'https://hooks.zapier.com/{inputs.hook}', {
+  'method': 'POST',
+  'body': inputs.body
+});
+
+if (inputs.debug) {
+  print('Response', res.status, res.body);
+}\
+"""
+        )
 
         assert hog_function.inputs == {
             "body": {

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -244,8 +244,6 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         if is_create:
             if not attrs.get("hog"):
                 raise serializers.ValidationError({"hog": "Required."})
-            if not attrs.get("inputs_schema"):
-                raise serializers.ValidationError({"inputs_schema": "Required."})
 
         return super().validate(attrs)
 

--- a/posthog/api/test/test_hog_function.py
+++ b/posthog/api/test/test_hog_function.py
@@ -316,10 +316,8 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_functions/",
             data={
-                "type": "destination",
+                **EXAMPLE_FULL,
                 "name": "Fetch URL",
-                "description": "Test description",
-                "hog": "fetch(inputs.url);",
             },
         )
         assert response.status_code == status.HTTP_201_CREATED, response.json()
@@ -666,8 +664,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_functions/",
             data={
-                "type": "destination",
-                "name": "Fetch URL",
+                **EXAMPLE_FULL,
                 "hog": "let i := 0;\nwhile(i < 3) {\n  i := i + 1;\n  fetch(inputs.url, {\n    'headers': {\n      'x-count': f'{i}'\n    },\n    'body': inputs.payload,\n    'method': inputs.method\n  });\n}",
             },
         )
@@ -908,7 +905,10 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
                 response = self.client.post(
                     f"/api/projects/{self.team.id}/hog_functions/",
-                    data={"type": "destination", "name": "Fetch URL", "hog": "fetch(inputs.url);", "enabled": True},
+                    data={
+                        **EXAMPLE_FULL,
+                        "name": "Fetch URL",
+                    },
                 )
                 id = response.json()["id"]
 
@@ -1136,11 +1136,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
     def test_cannot_modify_type_of_existing_hog_function(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_functions/",
-            data={
-                "name": "Site Destination Function",
-                "hog": "export function onLoad() { console.log('Hello, site_destination'); }",
-                "type": "site_destination",
-            },
+            data=EXAMPLE_FULL,
         )
 
         assert response.status_code == status.HTTP_201_CREATED, response.json()
@@ -1160,11 +1156,7 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
     def test_transpiled_field_not_populated_for_other_types(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/hog_functions/",
-            data={
-                "name": "Regular Function",
-                "hog": "fetch(inputs.url);",
-                "type": "destination",
-            },
+            data=EXAMPLE_FULL,
         )
 
         assert response.status_code == status.HTTP_201_CREATED, response.json()


### PR DESCRIPTION
## Problem

Found a bug with hog function creation. We were only pulling from the template if they didn't have the addon whereas we actually want to pull from it if it isn't set.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
