### PR TITLE
feat(llm-observability): Generations view

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -502,7 +502,7 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                                   identifier: Scene.LLMObservability,
                                   label: 'LLM observability',
                                   icon: <IconAI />,
-                                  to: urls.llmObservability(),
+                                  to: urls.llmObservability('dashboard'),
                                   tag: 'beta' as const,
                               }
                             : null,

--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -1423,6 +1423,11 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
                 'The trace ID of the request made to the LLM API. Used to group together multiple generations into a single trace',
             examples: ['c9222e05-8708-41b8-98ea-d4a21849e761'],
         },
+        $ai_request_url: {
+            label: 'AI Request URL (LLM)',
+            description: 'The full URL of the request made to the LLM API',
+            examples: ['https://api.openai.com/v1/chat/completions'],
+        },
     },
     numerical_event_properties: {}, // Same as event properties, see assignment below
     person_properties: {}, // Currently person properties are the same as event properties, see assignment below

--- a/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
+++ b/frontend/src/queries/nodes/DataTable/renderColumnMeta.tsx
@@ -3,7 +3,7 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { SortingIndicator } from 'lib/lemon-ui/LemonTable/sorting'
 
 import { getQueryFeatures, QueryFeature } from '~/queries/nodes/DataTable/queryFeatures'
-import { extractExpressionComment } from '~/queries/nodes/DataTable/utils'
+import { extractExpressionComment, removeExpressionComment } from '~/queries/nodes/DataTable/utils'
 import { DataTableNode, DataVisualizationNode, EventsQuery } from '~/queries/schema'
 import { QueryContext } from '~/queries/types'
 import { isDataTableNode, isHogQLQuery, trimQuotes } from '~/queries/utils'
@@ -52,7 +52,7 @@ export function renderColumnMeta<T extends DataVisualizationNode | DataTableNode
     } else if (key.startsWith('properties.')) {
         title = (
             <PropertyKeyInfo
-                value={trimQuotes(key.substring(11))}
+                value={trimQuotes(removeExpressionComment(key.substring(11)))}
                 type={TaxonomicFilterGroupType.EventProperties}
                 disableIcon
             />

--- a/frontend/src/scenes/llm-observability/LLMObservabilityScene.tsx
+++ b/frontend/src/scenes/llm-observability/LLMObservabilityScene.tsx
@@ -6,6 +6,7 @@ import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
 import { SceneExport } from 'scenes/sceneTypes'
 
+import { navigationLogic } from '~/layout/navigation/navigationLogic'
 import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
 import { InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 
@@ -21,9 +22,15 @@ const Filters = (): JSX.Element => {
         shouldFilterTestAccounts,
     } = useValues(llmObservabilityLogic)
     const { setDates, setShouldFilterTestAccounts } = useActions(llmObservabilityLogic)
+    const { mobileLayout } = useValues(navigationLogic)
 
     return (
-        <div className="mb-4 flex justify-between items-center">
+        <div
+            className={clsx(
+                'sticky flex justify-between items-center py-2 -mt-2 mb-2 bg-bg-3000 border-b z-20',
+                mobileLayout ? 'top-[var(--breadcrumbs-height-full)]' : 'top-[var(--breadcrumbs-height-compact)]'
+            )}
+        >
             <DateFilter dateFrom={dateFrom} dateTo={dateTo} onChange={setDates} />
             <TestAccountFilterSwitch checked={shouldFilterTestAccounts} onChange={setShouldFilterTestAccounts} />
         </div>
@@ -77,7 +84,6 @@ export function LLMObservabilityScene(): JSX.Element {
     return (
         <BindLogic logic={dataNodeCollectionLogic} props={{ key: LLM_OBSERVABILITY_DATA_COLLECTION_NODE_ID }}>
             <IngestionStatusCheck />
-
             <Filters />
             <Tiles />
         </BindLogic>

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -659,5 +659,6 @@ export const routes: Record<string, Scene> = {
     [urls.messagingBroadcasts()]: Scene.MessagingBroadcasts,
     [urls.messagingBroadcast(':id')]: Scene.MessagingBroadcasts,
     [urls.messagingBroadcastNew()]: Scene.MessagingBroadcasts,
-    [urls.llmObservability()]: Scene.LLMObservability,
+    [urls.llmObservability('dashboard')]: Scene.LLMObservability,
+    [urls.llmObservability('generations')]: Scene.LLMObservability,
 }

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -35,6 +35,8 @@ import { SurveysTabs } from './surveys/surveysLogic'
  * Sync the paths with AutoProjectMiddleware!
  */
 
+export type LLMObservabilityTab = 'dashboard' | 'generations'
+
 export const urls = {
     absolute: (path = ''): string => window.location.origin + path,
     default: (): string => '/',
@@ -259,5 +261,6 @@ export const urls = {
     insightAlert: (insightShortId: InsightShortId, alertId: AlertType['id']): string =>
         `/insights/${insightShortId}/alerts?alert_id=${alertId}`,
     sessionAttributionExplorer: (): string => '/web/session-attribution-explorer',
-    llmObservability: (): string => '/llm-observability',
+    llmObservability: (tab?: LLMObservabilityTab): string =>
+        `/llm-observability${tab !== 'dashboard' ? '/' + tab : ''}`,
 }


### PR DESCRIPTION
## Changes

Now possible to view all AI generations:

![Screenshot 2025-01-14 at 23 07 37](https://github.com/user-attachments/assets/410b5ba2-a16e-4cad-9317-6bbac99b0d03)

All the filters are synced between the dashboard and generations views.

## How did you test this code?

Still need to add Storybook stories, will do in a follow-up PR.