### PR TITLE
fix: notebook table sorting

### DIFF
--- a/frontend/src/scenes/notebooks/NotebooksTable/NotebooksTable.tsx
+++ b/frontend/src/scenes/notebooks/NotebooksTable/NotebooksTable.tsx
@@ -39,9 +39,9 @@ function titleColumn(): LemonTableColumn<NotebookListItemType, 'title'> {
 }
 
 export function NotebooksTable(): JSX.Element {
-    const { notebooksAndTemplates, filters, notebooksResponseLoading, notebookTemplates, sortValue, pagination } =
+    const { notebooksAndTemplates, filters, notebooksResponseLoading, notebookTemplates, tableSorting, pagination } =
         useValues(notebooksTableLogic)
-    const { loadNotebooks, setFilters, setSortValue } = useActions(notebooksTableLogic)
+    const { loadNotebooks, setFilters, tableSortingChanged } = useActions(notebooksTableLogic)
     const { selectNotebook } = useActions(notebookPanelLogic)
 
     useEffect(() => {
@@ -132,13 +132,10 @@ export function NotebooksTable(): JSX.Element {
                 rowKey="short_id"
                 columns={columns}
                 loading={notebooksResponseLoading}
-                defaultSorting={{ columnKey: '-created_at', order: 1 }}
+                defaultSorting={tableSorting}
                 emptyState="No notebooks matching your filters!"
                 nouns={['notebook', 'notebooks']}
-                sorting={sortValue ? { columnKey: sortValue, order: sortValue.startsWith('-') ? -1 : 1 } : undefined}
-                onSort={(newSorting) =>
-                    setSortValue(newSorting ? `${newSorting.order === -1 ? '-' : ''}${newSorting.columnKey}` : null)
-                }
+                onSort={tableSortingChanged}
             />
         </div>
     )

--- a/frontend/src/scenes/notebooks/NotebooksTable/notebooksTableLogic.ts
+++ b/frontend/src/scenes/notebooks/NotebooksTable/notebooksTableLogic.ts
@@ -1,4 +1,4 @@
-import { PaginationManual } from '@posthog/lemon-ui'
+import { PaginationManual, Sorting } from '@posthog/lemon-ui'
 import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import api, { CountedPaginatedResponse } from 'lib/api'
@@ -23,13 +23,16 @@ export const DEFAULT_FILTERS: NotebooksListFilters = {
 }
 
 const RESULTS_PER_PAGE = 50
+const DEFAULT_SORTING: Sorting = { columnKey: '-created_at', order: 1 }
 
 export const notebooksTableLogic = kea<notebooksTableLogicType>([
     path(['scenes', 'notebooks', 'NotebooksTable', 'notebooksTableLogic']),
     actions({
         loadNotebooks: true,
         setFilters: (filters: Partial<NotebooksListFilters>) => ({ filters }),
-        setSortValue: (sortValue: string | null) => ({ sortValue }),
+        tableSortingChanged: (sorting: Sorting | null) => ({
+            sorting,
+        }),
         setPage: (page: number) => ({ page }),
     }),
     connect({
@@ -59,6 +62,13 @@ export const notebooksTableLogic = kea<notebooksTableLogicType>([
                 setPage: (_, { page }) => page,
                 setFilters: () => 1,
                 setSortValue: () => 1,
+            },
+        ],
+        tableSorting: [
+            DEFAULT_SORTING,
+            { persist: true },
+            {
+                tableSortingChanged: (_, { sorting }) => sorting || DEFAULT_SORTING,
             },
         ],
     }),


### PR DESCRIPTION
While we were looking at how things hung together we spotted that notebooks table sorting doesn't work correctly... you can only sort in one direction... yuck

Well, not any more (because I copied how a working scene does it)

![2025-01-14 22 19 10](https://github.com/user-attachments/assets/620d3549-606c-4826-a6cd-648a041592a9)
