### PR TITLE
feat: exposing enforce_2fa in the feature list

### DIFF
--- a/frontend/src/lib/components/FeatureDowngradeModal/FeatureDowngradeModal.tsx
+++ b/frontend/src/lib/components/FeatureDowngradeModal/FeatureDowngradeModal.tsx
@@ -3,7 +3,6 @@ import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 
 export interface DowngradeFeature {
     title: string
-    warning?: boolean
 }
 
 interface FeatureDowngradeModalProps {

--- a/frontend/src/scenes/authentication/TeamsDowngradeModal.tsx
+++ b/frontend/src/scenes/authentication/TeamsDowngradeModal.tsx
@@ -1,16 +1,17 @@
+import { IconWarning } from '@posthog/icons'
 import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 
 import { teamsDowngradeLogic } from './teamsDowngradeLogic'
 
 export function TeamsDowngradeModal(): JSX.Element {
-    const { isTeamsDowngradeModalOpen } = useValues(teamsDowngradeLogic)
+    const { isTeamsDowngradeModalOpen, enforce2FA } = useValues(teamsDowngradeLogic)
     const { hideTeamsDowngradeModal, handleTeamsDowngrade } = useActions(teamsDowngradeLogic)
 
     return (
         <LemonModal
             title="Unsubscribe from Teams"
-            description="You are about to lose access to the following features:"
+            description="Your team is currently using the following features and will lose access to them if you unsubscribe:"
             isOpen={isTeamsDowngradeModalOpen}
             onClose={hideTeamsDowngradeModal}
             footer={
@@ -24,7 +25,15 @@ export function TeamsDowngradeModal(): JSX.Element {
                 </>
             }
         >
-            <p>TODO: Add features that are currently being used</p>
+            <div className="space-y-2">
+                <p>TODO: Add features that are currently being used</p>
+                {enforce2FA && (
+                    <div className="flex items-center gap-2">
+                        <IconWarning className="text-warning" />
+                        <span>Enforced 2FA</span>
+                    </div>
+                )}
+            </div>
         </LemonModal>
     )
 }

--- a/frontend/src/scenes/authentication/TeamsDowngradeModal.tsx
+++ b/frontend/src/scenes/authentication/TeamsDowngradeModal.tsx
@@ -1,18 +1,21 @@
 import { useActions, useValues } from 'kea'
 import { DowngradeFeature, FeatureDowngradeModal } from 'lib/components/FeatureDowngradeModal/FeatureDowngradeModal'
 
+import { AvailableFeature } from '~/types'
+
 import { teamsDowngradeLogic } from './teamsDowngradeLogic'
 
-const TEAMS_FEATURES: DowngradeFeature[] = [
-    {
-        // Replace hardcoding here
-        title: '2FA Enforcement',
-    },
-]
-
 export function TeamsDowngradeModal(): JSX.Element {
-    const { isTeamsDowngradeModalOpen } = useValues(teamsDowngradeLogic)
+    const { isTeamsDowngradeModalOpen, enforce2FA } = useValues(teamsDowngradeLogic)
     const { hideTeamsDowngradeModal, handleTeamsDowngrade } = useActions(teamsDowngradeLogic)
+
+    const teamFeatures: DowngradeFeature[] = []
+
+    if (enforce2FA) {
+        teamFeatures.push({
+            title: AvailableFeature.TWOFA_ENFORCEMENT,
+        })
+    }
 
     return (
         <FeatureDowngradeModal
@@ -20,7 +23,7 @@ export function TeamsDowngradeModal(): JSX.Element {
             onClose={hideTeamsDowngradeModal}
             onDowngrade={handleTeamsDowngrade}
             title="Unsubscribe from Teams"
-            features={TEAMS_FEATURES}
+            features={teamFeatures}
         />
     )
 }

--- a/frontend/src/scenes/authentication/teamsDowngradeLogic.ts
+++ b/frontend/src/scenes/authentication/teamsDowngradeLogic.ts
@@ -1,6 +1,7 @@
-import { actions, kea, listeners, path, reducers } from 'kea'
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { UNSUBSCRIBE_SURVEY_ID } from 'lib/constants'
 import { billingProductLogic } from 'scenes/billing/billingProductLogic'
+import { organizationLogic } from 'scenes/organizationLogic'
 
 import { BillingProductV2AddonType } from '~/types'
 
@@ -12,6 +13,15 @@ export interface TeamsDowngradeModalProps {
 
 export const teamsDowngradeLogic = kea<teamsDowngradeLogicType>([
     path(['scenes', 'authentication', 'teamsDowngradeLogic']),
+    connect({
+        values: [organizationLogic, ['currentOrganization']],
+    }),
+    selectors({
+        enforce2FA: [
+            (s) => [s.currentOrganization],
+            (currentOrganization) => currentOrganization?.enforce_2fa || false,
+        ],
+    }),
     actions({
         showTeamsDowngradeModal: (addon: BillingProductV2AddonType) => ({ addon }),
         hideTeamsDowngradeModal: true,


### PR DESCRIPTION
## Problem

We want to expose the list of features that the user is currently using. I've started off with enforce_2fa since it was the most straightforward. If the design here looks reasonable, I'll add a larger change including the other features.


## Changes

![image](https://github.com/user-attachments/assets/3dedd731-6763-4fd1-ae2e-bb3d596f2b01)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Cloud: yes

## How did you test this code?

Verified manually if the list gets updated if the org has 2fac enforced.
