### PR TITLE
fix: Zapier template format

### DIFF
--- a/ee/api/hooks.py
+++ b/ee/api/hooks.py
@@ -33,19 +33,19 @@ def create_zapier_hog_function(hook: Hook, serializer_context: dict) -> HogFunct
                 "body": {
                     # NOTE: This is for backwards compatibility with the old webhook format
                     "value": {
-                        "hook": {
-                            "id": "{eventUuid}",
-                            "event": "{event}",
-                            "target": "https://hooks.zapier.com/{inputs.hook}",
-                        },
                         "data": {
-                            "eventUuid": "{event.uuid}",
-                            "event": "{event.name}",
+                            "event": "{event.event}",
+                            "person": {"uuid": "{person.id}", "properties": "{person.properties}"},
                             "teamId": "{project.id}",
+                            "eventUuid": "{event.uuid}",
+                            "timestamp": "{event.timestamp}",
                             "distinctId": "{event.distinct_id}",
                             "properties": "{event.properties}",
-                            "timestamp": "{event.timestamp}",
-                            "person": {"uuid": "{person.uuid}", "properties": "{person.properties}"},
+                        },
+                        "hook": {
+                            "id": "{event.uuid}",
+                            "event": "{event.event}",
+                            "target": "https://hooks.zapier.com/{inputs.hook}",
                         },
                     }
                 },

--- a/ee/api/test/test_hooks.py
+++ b/ee/api/test/test_hooks.py
@@ -1,5 +1,4 @@
 from typing import cast
-from unittest.mock import ANY
 
 from inline_snapshot import snapshot
 

--- a/ee/api/test/test_hooks.py
+++ b/ee/api/test/test_hooks.py
@@ -132,42 +132,68 @@ if (inputs.debug) {
 """
         )
 
-        assert hog_function.inputs == {
-            "body": {
-                "bytecode": ANY,
-                "value": {
-                    "data": {
-                        "distinctId": "{event.distinct_id}",
-                        "event": "{event.name}",
-                        "eventUuid": "{event.uuid}",
-                        "person": {
-                            "properties": "{person.properties}",
-                            "uuid": "{person.uuid}",
+        assert hog_function.inputs == snapshot(
+            {
+                "body": {
+                    "order": 2,
+                    "value": {
+                        "data": {
+                            "event": "{event.event}",
+                            "person": {"uuid": "{person.id}", "properties": "{person.properties}"},
+                            "teamId": "{project.id}",
+                            "eventUuid": "{event.uuid}",
+                            "timestamp": "{event.timestamp}",
+                            "distinctId": "{event.distinct_id}",
+                            "properties": "{event.properties}",
                         },
-                        "properties": "{event.properties}",
-                        "teamId": "{project.id}",
-                        "timestamp": "{event.timestamp}",
+                        "hook": {
+                            "id": "{event.uuid}",
+                            "event": "{event.event}",
+                            "target": "https://hooks.zapier.com/{inputs.hook}",
+                        },
                     },
-                    "hook": {
-                        "event": "{event}",
-                        "id": "{eventUuid}",
-                        "target": "https://hooks.zapier.com/{inputs.hook}",
+                    "bytecode": {
+                        "data": {
+                            "event": ["_H", 1, 32, "event", 32, "event", 1, 2],
+                            "person": {
+                                "uuid": ["_H", 1, 32, "id", 32, "person", 1, 2],
+                                "properties": ["_H", 1, 32, "properties", 32, "person", 1, 2],
+                            },
+                            "teamId": ["_H", 1, 32, "id", 32, "project", 1, 2],
+                            "eventUuid": ["_H", 1, 32, "uuid", 32, "event", 1, 2],
+                            "timestamp": ["_H", 1, 32, "timestamp", 32, "event", 1, 2],
+                            "distinctId": ["_H", 1, 32, "distinct_id", 32, "event", 1, 2],
+                            "properties": ["_H", 1, 32, "properties", 32, "event", 1, 2],
+                        },
+                        "hook": {
+                            "id": ["_H", 1, 32, "uuid", 32, "event", 1, 2],
+                            "event": ["_H", 1, 32, "event", 32, "event", 1, 2],
+                            "target": [
+                                "_H",
+                                1,
+                                32,
+                                "https://hooks.zapier.com/",
+                                32,
+                                "hook",
+                                32,
+                                "inputs",
+                                1,
+                                2,
+                                2,
+                                "concat",
+                                2,
+                            ],
+                        },
                     },
                 },
-                "order": 2,
-            },
-            "debug": {"order": 1},
-            "hook": {
-                "bytecode": [
-                    "_H",
-                    HOGQL_BYTECODE_VERSION,
-                    32,
-                    "hooks/standard/1234/abcd",
-                ],
-                "value": "hooks/standard/1234/abcd",
-                "order": 0,
-            },
-        }
+                "hook": {
+                    "order": 0,
+                    "value": "hooks/standard/1234/abcd",
+                    "bytecode": ["_H", 1, 32, "hooks/standard/1234/abcd"],
+                },
+                "debug": {"order": 1},
+            }
+        )
 
     def test_delete_hog_function_via_hook(self):
         data = {


### PR DESCRIPTION
## Problem

The template format was from an earlier pre-release version of hog functions. Updated it to be correct

## Changes

* As on tin
* Made the test a snapshot as we want to know pretty clearly if this changes as it is such a background thing

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
