### PR TITLE
fix: Make batch exports jitter more than 1 min

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -682,7 +682,7 @@ def sync_batch_export(batch_export: BatchExport, created: bool):
             start_at=batch_export.start_at,
             end_at=batch_export.end_at,
             intervals=[ScheduleIntervalSpec(every=batch_export.interval_time_delta)],
-            jitter=min(dt.timedelta(minutes=1), (batch_export.interval_time_delta / 6)),
+            jitter=max(dt.timedelta(minutes=1), (batch_export.interval_time_delta / 6)),
             time_zone_name=batch_export.team.timezone,
         ),
         state=state,


### PR DESCRIPTION
## Problem

Bug introduced in https://github.com/PostHog/posthog/pull/26517. This should be `max` if we want the jitter to be _at least_ 1 minute, but potentially more  than that.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
