### PR TITLE
fix: Initialize new csv dict writer when batch file changes

### DIFF
--- a/posthog/temporal/batch_exports/temporary_file.py
+++ b/posthog/temporal/batch_exports/temporary_file.py
@@ -664,10 +664,11 @@ class CSVBatchExportWriter(BatchExportWriter):
         self.quoting = quoting
 
         self._csv_writer: csv.DictWriter | None = None
+        self._csv_writer_file = None
 
     @property
     def csv_writer(self) -> csv.DictWriter:
-        if self._csv_writer is None:
+        if self._csv_writer is None or self._csv_writer_file is not self.batch_export_file:
             self._csv_writer = csv.DictWriter(
                 self.batch_export_file,
                 fieldnames=self.field_names,
@@ -678,6 +679,7 @@ class CSVBatchExportWriter(BatchExportWriter):
                 quoting=self.quoting,
                 lineterminator=self.line_terminator,
             )
+            self._csv_writer_file = self.batch_export_file
 
         return self._csv_writer
 


### PR DESCRIPTION
## Problem

When using CSV `DictWriter` with `multiple_files`, the underlying `self.batch_export_file` changes, but we are not updating the `DictWriter`.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
