### PR TITLE
fix(cdp): Ensure the source global exists at the right point

### DIFF
--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -252,7 +252,6 @@ export class HogExecutor {
                         name: hogFunction.name ?? `Hog function: ${hogFunction.id}`,
                         url: `${triggerGlobals.project.url}/pipeline/destinations/hog-${hogFunction.id}/configuration/`,
                     },
-                    inputs,
                 }
 
                 const globalsWithInputs = buildGlobalsWithInputs(globalsWithSource, inputs)

--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -241,12 +241,23 @@ export class HogExecutor {
             }
         }
 
-        const _buildGlobalsWithInputs = (
+        const _buildInvocation = (
             hogFunction: HogFunctionType,
             inputs: HogFunctionType['inputs']
-        ): HogFunctionInvocationGlobalsWithInputs | null => {
+        ): HogFunctionInvocation | null => {
             try {
-                return buildGlobalsWithInputs(triggerGlobals, inputs)
+                const globalsWithSource = {
+                    ...triggerGlobals,
+                    source: {
+                        name: hogFunction.name ?? `Hog function: ${hogFunction.id}`,
+                        url: `${triggerGlobals.project.url}/pipeline/destinations/hog-${hogFunction.id}/configuration/`,
+                    },
+                    inputs,
+                }
+
+                const globalsWithInputs = buildGlobalsWithInputs(globalsWithSource, inputs)
+
+                return createInvocation(globalsWithInputs, hogFunction)
             } catch (error) {
                 logs.push({
                     team_id: hogFunction.team_id,
@@ -255,7 +266,7 @@ export class HogExecutor {
                     instance_id: new UUIDT().toString(), // random UUID, like it would be for an invocation
                     timestamp: DateTime.now(),
                     level: 'error',
-                    message: `Error filtering event ${triggerGlobals.event.uuid}: ${error.message}`,
+                    message: `Error building inputs for event ${triggerGlobals.event.uuid}: ${error.message}`,
                 })
 
                 return null
@@ -268,15 +279,15 @@ export class HogExecutor {
                 if (!_filterHogFunction(hogFunction, hogFunction.filters, filterGlobals)) {
                     return
                 }
-                const globals = _buildGlobalsWithInputs(hogFunction, {
+                const invocation = _buildInvocation(hogFunction, {
                     ...(hogFunction.inputs ?? {}),
                     ...(hogFunction.encrypted_inputs ?? {}),
                 })
-                if (!globals) {
+                if (!invocation) {
                     return
                 }
 
-                invocations.push(createInvocation(globals, hogFunction))
+                invocations.push(invocation)
                 return
             }
 
@@ -289,16 +300,16 @@ export class HogExecutor {
                     return
                 }
 
-                const globals = _buildGlobalsWithInputs(hogFunction, {
+                const invocation = _buildInvocation(hogFunction, {
                     ...(hogFunction.inputs ?? {}),
                     ...(hogFunction.encrypted_inputs ?? {}),
                     ...(mapping.inputs ?? {}),
                 })
-                if (!globals) {
+                if (!invocation) {
                     return
                 }
 
-                invocations.push(createInvocation(globals, hogFunction))
+                invocations.push(invocation)
             })
         })
 

--- a/plugin-server/src/cdp/hog-executor.ts
+++ b/plugin-server/src/cdp/hog-executor.ts
@@ -268,6 +268,14 @@ export class HogExecutor {
                     message: `Error building inputs for event ${triggerGlobals.event.uuid}: ${error.message}`,
                 })
 
+                metrics.push({
+                    team_id: hogFunction.team_id,
+                    app_source_id: hogFunction.id,
+                    metric_kind: 'failure',
+                    metric_name: 'inputs_failed',
+                    count: 1,
+                })
+
                 return null
             }
         }

--- a/plugin-server/src/cdp/utils.ts
+++ b/plugin-server/src/cdp/utils.ts
@@ -314,18 +314,9 @@ export function createInvocation(
     hogFunction: HogFunctionType,
     functionToExecute?: [string, any[]]
 ): HogFunctionInvocation {
-    // Add the source of the trigger to the globals
-    const modifiedGlobals: HogFunctionInvocationGlobalsWithInputs = {
-        ...globals,
-        source: {
-            name: hogFunction.name ?? `Hog function: ${hogFunction.id}`,
-            url: `${globals.project.url}/pipeline/destinations/hog-${hogFunction.id}/configuration/`,
-        },
-    }
-
     return {
         id: new UUIDT().toString(),
-        globals: modifiedGlobals,
+        globals,
         teamId: hogFunction.team_id,
         hogFunction,
         queue: 'hog',

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -1266,6 +1266,7 @@ export type AppMetric2Type = {
         | 'disabled_permanently'
         | 'masked'
         | 'filtering_failed'
+        | 'inputs_failed'
         | 'fetch'
     count: number
 }

--- a/plugin-server/tests/cdp/hog-executor.test.ts
+++ b/plugin-server/tests/cdp/hog-executor.test.ts
@@ -75,6 +75,7 @@ describe('Hog Executor', () => {
 
         it('can execute an invocation', () => {
             const invocation = createInvocation(hogFunction)
+
             const result = executor.execute(invocation)
             expect(result).toEqual({
                 capturedPostHogEvents: [],
@@ -318,6 +319,26 @@ describe('Hog Executor', () => {
     })
 
     describe('filtering', () => {
+        it('builds the correct globals object when filtering', () => {
+            const fn = createHogFunction({
+                ...HOG_EXAMPLES.simple_fetch,
+                ...HOG_INPUTS_EXAMPLES.simple_fetch,
+                ...HOG_FILTERS_EXAMPLES.no_filters,
+            })
+            mockFunctionManager.getTeamHogFunctions.mockReturnValue([fn])
+
+            const inputGlobals = createHogExecutionGlobals({ groups: {} })
+            expect(inputGlobals.source).toBeUndefined()
+            const results = executor.findHogFunctionInvocations(inputGlobals)
+
+            expect(results.invocations).toHaveLength(1)
+
+            expect(results.invocations[0].globals.source).toEqual({
+                name: 'Hog Function',
+                url: `http://localhost:8000/projects/1/pipeline/destinations/hog-${fn.id}/configuration/`,
+            })
+        })
+
         it('can filters incoming messages correctly', () => {
             const fn = createHogFunction({
                 ...HOG_EXAMPLES.simple_fetch,


### PR DESCRIPTION
## Problem

Tricky issue - the change meant that we weren't passing in `source` to the globals that are used to build the inputs. This only shows for hog functions that use `{source.url}` in the inputs


## Changes

* Fixes the issue
* Once we have https://github.com/PostHog/posthog/pull/27247 we can write better tests to catch exactly this.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
