### PR TITLE
feat: add Dagster DAGs to the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -47,3 +47,4 @@ rust/target
 rust/cyclotron-node/dist
 rust/cyclotron-node/node_modules
 rust/cyclotron-node/index.node
+!dags

--- a/Dockerfile
+++ b/Dockerfile
@@ -215,6 +215,7 @@ COPY --chown=posthog:posthog manage.py manage.py
 COPY --chown=posthog:posthog posthog posthog/
 COPY --chown=posthog:posthog ee ee/
 COPY --chown=posthog:posthog hogvm hogvm/
+COPY --chown=posthog:posthog dags dags/
 
 # Keep server command backwards compatible
 RUN cp ./bin/docker-server-unit ./bin/docker-server


### PR DESCRIPTION
## Problem

We cannot use dagster code locations without the dags code.

## Changes

Update the Docker image to add the dagster dags.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes
