### PR TITLE
fix(experiments): Disable custom exposure for data warehouse

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/TrendsMetricForm.scss
+++ b/frontend/src/scenes/experiments/Metrics/TrendsMetricForm.scss
@@ -1,0 +1,6 @@
+.trends-metric-form__exposure-button.LemonButton {
+    .LemonButton__chrome,
+    .LemonButton__content {
+        display: block;
+    }
+}

--- a/frontend/src/scenes/experiments/Metrics/TrendsMetricForm.tsx
+++ b/frontend/src/scenes/experiments/Metrics/TrendsMetricForm.tsx
@@ -1,3 +1,5 @@
+import './TrendsMetricForm.scss'
+
 import { IconCheckCircle } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonLabel, LemonTabs, LemonTag } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
@@ -127,7 +129,7 @@ export function TrendsMetricForm({ isSecondary = false }: { isSecondary?: boolea
                             <>
                                 <div className="flex gap-4 mb-4">
                                     <LemonButton
-                                        className={`flex-1 cursor-pointer p-4 rounded border ${
+                                        className={`trends-metric-form__exposure-button flex-1 cursor-pointer p-4 rounded border ${
                                             !currentMetric.exposure_query
                                                 ? 'border-primary bg-primary-highlight'
                                                 : 'border-border'
@@ -144,23 +146,21 @@ export function TrendsMetricForm({ isSecondary = false }: { isSecondary?: boolea
                                             })
                                         }}
                                     >
-                                        <div>
-                                            <div className="font-semibold flex justify-between items-center">
-                                                <span>Default</span>
-                                                {!currentMetric.exposure_query && (
-                                                    <IconCheckCircle fontSize={18} color="var(--primary)" />
-                                                )}
-                                            </div>
-                                            <div className="text-muted text-sm leading-relaxed">
-                                                Uses the number of unique users who trigger the{' '}
-                                                <LemonTag>$feature_flag_called</LemonTag> event as your exposure count.
-                                                This is the recommended setting for most experiments, as it accurately
-                                                tracks variant exposure.
-                                            </div>
+                                        <div className="font-semibold flex justify-between items-center">
+                                            <span>Default</span>
+                                            {!currentMetric.exposure_query && (
+                                                <IconCheckCircle fontSize={18} color="var(--primary)" />
+                                            )}
+                                        </div>
+                                        <div className="text-muted text-sm leading-relaxed mt-1">
+                                            Uses the number of unique users who trigger the{' '}
+                                            <LemonTag>$feature_flag_called</LemonTag> event as your exposure count. This
+                                            is the recommended setting for most experiments, as it accurately tracks
+                                            variant exposure.
                                         </div>
                                     </LemonButton>
                                     <LemonButton
-                                        className={`flex-1 cursor-pointer p-4 rounded border ${
+                                        className={`trends-metric-form__exposure-button flex-1 cursor-pointer p-4 rounded border ${
                                             currentMetric.exposure_query
                                                 ? 'border-primary bg-primary-highlight'
                                                 : 'border-border'
@@ -209,18 +209,16 @@ export function TrendsMetricForm({ isSecondary = false }: { isSecondary?: boolea
                                             })
                                         }}
                                     >
-                                        <div>
-                                            <div className="font-semibold flex justify-between items-center">
-                                                <span>Custom</span>
-                                                {currentMetric.exposure_query && (
-                                                    <IconCheckCircle fontSize={18} color="var(--primary)" />
-                                                )}
-                                            </div>
-                                            <div className="text-muted text-sm leading-relaxed">
-                                                Define your own exposure metric for specific use cases, such as counting
-                                                by sessions instead of users. This gives you full control but requires
-                                                careful configuration.
-                                            </div>
+                                        <div className="font-semibold flex justify-between items-center">
+                                            <span>Custom</span>
+                                            {currentMetric.exposure_query && (
+                                                <IconCheckCircle fontSize={18} color="var(--primary)" />
+                                            )}
+                                        </div>
+                                        <div className="text-muted text-sm leading-relaxed mt-1">
+                                            Define your own exposure metric for specific use cases, such as counting by
+                                            sessions instead of users. This gives you full control but requires careful
+                                            configuration.
                                         </div>
                                     </LemonButton>
                                 </div>

--- a/frontend/src/scenes/experiments/Metrics/TrendsMetricForm.tsx
+++ b/frontend/src/scenes/experiments/Metrics/TrendsMetricForm.tsx
@@ -74,6 +74,19 @@ export function TrendsMetricForm({ isSecondary = false }: { isSecondary?: boolea
                                             MathAvailability.All
                                         )
 
+                                        // Custom exposure metrics are not supported for data warehouse metrics
+                                        if (series[0].kind === NodeKind.DataWarehouseNode) {
+                                            const metricsField = isSecondary ? 'metrics_secondary' : 'metrics'
+                                            setExperiment({
+                                                ...experiment,
+                                                [metricsField]: metrics.map((metric, idx) =>
+                                                    idx === metricIdx
+                                                        ? { ...metric, exposure_query: undefined }
+                                                        : metric
+                                                ),
+                                            })
+                                        }
+
                                         setTrendsMetric({
                                             metricIdx,
                                             series,

--- a/frontend/src/scenes/experiments/Metrics/TrendsMetricForm.tsx
+++ b/frontend/src/scenes/experiments/Metrics/TrendsMetricForm.tsx
@@ -1,5 +1,5 @@
 import { IconCheckCircle } from '@posthog/icons'
-import { LemonInput, LemonLabel, LemonTabs, LemonTag } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonLabel, LemonTabs, LemonTag } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
 import { EXPERIMENT_DEFAULT_DURATION } from 'lib/constants'
@@ -35,6 +35,8 @@ export function TrendsMetricForm({ isSecondary = false }: { isSecondary?: boolea
     }
 
     const currentMetric = metrics[metricIdx] as ExperimentTrendsQuery
+
+    const isDataWarehouseMetric = currentMetric.count_query?.series[0]?.kind === NodeKind.DataWarehouseNode
 
     return (
         <>
@@ -124,7 +126,7 @@ export function TrendsMetricForm({ isSecondary = false }: { isSecondary?: boolea
                         content: (
                             <>
                                 <div className="flex gap-4 mb-4">
-                                    <div
+                                    <LemonButton
                                         className={`flex-1 cursor-pointer p-4 rounded border ${
                                             !currentMetric.exposure_query
                                                 ? 'border-primary bg-primary-highlight'
@@ -142,25 +144,32 @@ export function TrendsMetricForm({ isSecondary = false }: { isSecondary?: boolea
                                             })
                                         }}
                                     >
-                                        <div className="font-semibold flex justify-between items-center">
-                                            <span>Default</span>
-                                            {!currentMetric.exposure_query && (
-                                                <IconCheckCircle fontSize={18} color="var(--primary)" />
-                                            )}
+                                        <div>
+                                            <div className="font-semibold flex justify-between items-center">
+                                                <span>Default</span>
+                                                {!currentMetric.exposure_query && (
+                                                    <IconCheckCircle fontSize={18} color="var(--primary)" />
+                                                )}
+                                            </div>
+                                            <div className="text-muted text-sm leading-relaxed">
+                                                Uses the number of unique users who trigger the{' '}
+                                                <LemonTag>$feature_flag_called</LemonTag> event as your exposure count.
+                                                This is the recommended setting for most experiments, as it accurately
+                                                tracks variant exposure.
+                                            </div>
                                         </div>
-                                        <div className="text-muted text-sm leading-relaxed">
-                                            Uses the number of unique users who trigger the{' '}
-                                            <LemonTag>$feature_flag_called</LemonTag> event as your exposure count. This
-                                            is the recommended setting for most experiments, as it accurately tracks
-                                            variant exposure.
-                                        </div>
-                                    </div>
-                                    <div
+                                    </LemonButton>
+                                    <LemonButton
                                         className={`flex-1 cursor-pointer p-4 rounded border ${
                                             currentMetric.exposure_query
                                                 ? 'border-primary bg-primary-highlight'
                                                 : 'border-border'
                                         }`}
+                                        disabledReason={
+                                            isDataWarehouseMetric
+                                                ? 'Custom exposure events are not supported for data warehouse metrics. Please contact support if you need this feature.'
+                                                : undefined
+                                        }
                                         onClick={() => {
                                             const metricsField = isSecondary ? 'metrics_secondary' : 'metrics'
                                             setExperiment({
@@ -200,18 +209,20 @@ export function TrendsMetricForm({ isSecondary = false }: { isSecondary?: boolea
                                             })
                                         }}
                                     >
-                                        <div className="font-semibold flex justify-between items-center">
-                                            <span>Custom</span>
-                                            {currentMetric.exposure_query && (
-                                                <IconCheckCircle fontSize={18} color="var(--primary)" />
-                                            )}
+                                        <div>
+                                            <div className="font-semibold flex justify-between items-center">
+                                                <span>Custom</span>
+                                                {currentMetric.exposure_query && (
+                                                    <IconCheckCircle fontSize={18} color="var(--primary)" />
+                                                )}
+                                            </div>
+                                            <div className="text-muted text-sm leading-relaxed">
+                                                Define your own exposure metric for specific use cases, such as counting
+                                                by sessions instead of users. This gives you full control but requires
+                                                careful configuration.
+                                            </div>
                                         </div>
-                                        <div className="text-muted text-sm leading-relaxed">
-                                            Define your own exposure metric for specific use cases, such as counting by
-                                            sessions instead of users. This gives you full control but requires careful
-                                            configuration.
-                                        </div>
-                                    </div>
+                                    </LemonButton>
                                 </div>
                                 {currentMetric.exposure_query && (
                                     <>


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/27014
See https://github.com/PostHog/posthog/issues/27542

## Changes

Disables the custom exposure event UI for data warehouse metrics:

![CleanShot 2025-01-15 at 04 33 50@2x](https://github.com/user-attachments/assets/4e69b0e6-c0a3-4dfa-b1a1-3b924b32932d)

Non-data warehouse metrics can still use the picker:

![CleanShot 2025-01-15 at 04 32 16@2x](https://github.com/user-attachments/assets/7e972d21-73f4-41a2-b3e0-045b79e4a3de)

Also ensures the exposure event is reset when data warehouse is selected.

Lastly, updates UI to use `<LemonButton>` for slightly more semantic HTML.

## How did you test this code?

👀 