### PR TITLE
fix: choosing available taxonomic group types

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/filters/FiltersPanel.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/filters/FiltersPanel.tsx
@@ -6,12 +6,9 @@ import { LemonDivider, LemonSwitch } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { SettingsMenu } from 'lib/components/PanelLayout/PanelLayout'
-import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import UniversalFilters from 'lib/components/UniversalFilters/UniversalFilters'
 import { universalFiltersLogic } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useEffect, useState } from 'react'
 import { DurationFilter } from 'scenes/session-recordings/filters/DurationFilter'
 
@@ -21,12 +18,8 @@ import { FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
 import { sessionRecordingsPlaylistLogic } from '../sessionRecordingsPlaylistLogic'
 
 export const FiltersPanel = (): JSX.Element => {
-    const { filters } = useValues(sessionRecordingsPlaylistLogic({ updateSearchParams: true }))
+    const { filters, taxonomicGroupTypes } = useValues(sessionRecordingsPlaylistLogic({ updateSearchParams: true }))
     const { setFilters } = useActions(sessionRecordingsPlaylistLogic({ updateSearchParams: true }))
-
-    const featureFlags = useValues(featureFlagLogic)
-    const allowReplayHogQLFilters = !!featureFlags[FEATURE_FLAGS.REPLAY_HOGQL_FILTERS]
-    const allowReplayFlagsFilters = !!featureFlags[FEATURE_FLAGS.REPLAY_FLAGS_FILTERS]
 
     /** For the internal users filter */
     const onChangeOperator = (type: FilterLogicalOperator): void => {
@@ -43,22 +36,6 @@ export const FiltersPanel = (): JSX.Element => {
     }
 
     const durationFilter = filters.duration[0]
-
-    const taxonomicGroupTypes = [
-        TaxonomicFilterGroupType.Replay,
-        TaxonomicFilterGroupType.Events,
-        TaxonomicFilterGroupType.Actions,
-        TaxonomicFilterGroupType.Cohorts,
-        TaxonomicFilterGroupType.PersonProperties,
-        TaxonomicFilterGroupType.SessionProperties,
-    ]
-
-    if (allowReplayHogQLFilters) {
-        taxonomicGroupTypes.push(TaxonomicFilterGroupType.HogQLExpression)
-    }
-    if (allowReplayFlagsFilters) {
-        taxonomicGroupTypes.push(TaxonomicFilterGroupType.EventFeatureFlags)
-    }
 
     return (
         <>

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -4,6 +4,7 @@ import { loaders } from 'kea-loaders'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 import api from 'lib/api'
 import { isAnyPropertyfilter, isHogQLPropertyFilter } from 'lib/components/PropertyFilters/utils'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/universalFiltersLogic'
 import {
     isActionFilter,
@@ -674,6 +675,38 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
             (s) => [s.pinnedRecordings, s.otherRecordings],
             (pinnedRecordings, otherRecordings): number => {
                 return otherRecordings.length + pinnedRecordings.length
+            },
+        ],
+
+        allowFlagsFilters: [
+            (s) => [s.featureFlags],
+            (featureFlags): boolean => !!featureFlags[FEATURE_FLAGS.REPLAY_FLAGS_FILTERS],
+        ],
+
+        allowHogQLFilters: [
+            (s) => [s.featureFlags],
+            (featureFlags): boolean => !!featureFlags[FEATURE_FLAGS.REPLAY_HOGQL_FILTERS],
+        ],
+
+        taxonomicGroupTypes: [
+            (s) => [s.allowFlagsFilters, s.allowHogQLFilters],
+            (allowFlagsFilters, allowHogQLFilters): string[] => {
+                const taxonomicGroupTypes = [
+                    TaxonomicFilterGroupType.Replay,
+                    TaxonomicFilterGroupType.Events,
+                    TaxonomicFilterGroupType.Actions,
+                    TaxonomicFilterGroupType.Cohorts,
+                    TaxonomicFilterGroupType.PersonProperties,
+                    TaxonomicFilterGroupType.SessionProperties,
+                ]
+
+                if (allowHogQLFilters) {
+                    taxonomicGroupTypes.push(TaxonomicFilterGroupType.HogQLExpression)
+                }
+                if (allowFlagsFilters) {
+                    taxonomicGroupTypes.push(TaxonomicFilterGroupType.EventFeatureFlags)
+                }
+                return taxonomicGroupTypes
             },
         ],
     }),

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -690,7 +690,7 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
 
         taxonomicGroupTypes: [
             (s) => [s.allowFlagsFilters, s.allowHogQLFilters],
-            (allowFlagsFilters, allowHogQLFilters): string[] => {
+            (allowFlagsFilters, allowHogQLFilters) => {
                 const taxonomicGroupTypes = [
                     TaxonomicFilterGroupType.Replay,
                     TaxonomicFilterGroupType.Events,


### PR DESCRIPTION
something in recent changes meant the feature flags logic wasn't re-rendering the filter panel, so we didn't pick up correct available groups

shifted it into kea selector and validated we do

|before|after|
|-|-|
|<img width="801" alt="Screenshot 2025-01-15 at 13 29 53" src="https://github.com/user-attachments/assets/8819b7ab-07eb-4e0f-9d9e-e739f34bb693" />|<img width="1000" alt="Screenshot 2025-01-15 at 13 30 31" src="https://github.com/user-attachments/assets/9052a3ee-73b6-4b11-a70c-952e8b186c72" />|
