### PR TITLE
fix(experiments): dont show avg. as default if not enabled

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -685,7 +685,6 @@ function useMathSelectorOptions({
         if (isPropertyValueMath(math)) {
             return math
         }
-        // If onlyPropertyMathDefinitions is defined, use its first value as default
         if (onlyPropertyMathDefinitions?.length) {
             return onlyPropertyMathDefinitions[0] as PropertyMathType
         }

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -681,9 +681,17 @@ function useMathSelectorOptions({
         staticActorsOnlyMathDefinitions,
     } = useValues(mathsLogic)
 
-    const [propertyMathTypeShown, setPropertyMathTypeShown] = useState<PropertyMathType>(
-        isPropertyValueMath(math) ? math : PropertyMathType.Average
-    )
+    const [propertyMathTypeShown, setPropertyMathTypeShown] = useState<PropertyMathType>(() => {
+        if (isPropertyValueMath(math)) {
+            return math
+        }
+        // If onlyPropertyMathDefinitions is defined, use its first value as default
+        if (onlyPropertyMathDefinitions?.length) {
+            return onlyPropertyMathDefinitions[0] as PropertyMathType
+        }
+        return PropertyMathType.Average
+    })
+
     const [countPerActorMathTypeShown, setCountPerActorMathTypeShown] = useState<CountPerActorMathType>(
         isCountPerActorMath(math) ? math : CountPerActorMathType.Average
     )


### PR DESCRIPTION
## Problem

The `onlyPropertyMathDefinitions` is not respected when picking a default value to show. So when only `sum` is allowed, `avg` still shows.
<img width="530" alt="Screenshot 2025-01-16 at 08 21 17" src="https://github.com/user-attachments/assets/a14d743e-0c6e-4309-b9c8-5ca1ff5a6bfe" />

## Changes
Respect `onlyPropertyMathDefinitions` when picking a default value to show
<img width="551" alt="Screenshot 2025-01-16 at 08 23 51" src="https://github.com/user-attachments/assets/6ef4d58e-e51f-43a3-91c8-6a5a5a32c384" />


## How did you test this code?
Tested locally
