### PR TITLE
fix(batch-exports): Cast str config values

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -106,6 +106,10 @@ class S3BatchExportInputs:
     batch_export_model: BatchExportModel | None = None
     batch_export_schema: BatchExportSchema | None = None
 
+    def __post_init__(self):
+        if self.max_file_size_mb:
+            self.max_file_size_mb = int(self.max_file_size_mb)
+
 
 @dataclass
 class SnowflakeBatchExportInputs:
@@ -154,6 +158,14 @@ class PostgresBatchExportInputs:
     batch_export_model: BatchExportModel | None = None
     batch_export_schema: BatchExportSchema | None = None
 
+    def __post_init__(self):
+        if self.has_self_signed_cert == "True":  # type: ignore
+            self.has_self_signed_cert = True
+        elif self.has_self_signed_cert == "False":  # type: ignore
+            self.has_self_signed_cert = False
+
+        self.port = int(self.port)
+
 
 @dataclass
 class RedshiftBatchExportInputs(PostgresBatchExportInputs):
@@ -185,6 +197,12 @@ class BigQueryBatchExportInputs:
 
     batch_export_model: BatchExportModel | None = None
     batch_export_schema: BatchExportSchema | None = None
+
+    def __post_init__(self):
+        if self.use_json_type == "True":  # type: ignore
+            self.use_json_type = True
+        elif self.use_json_type == "False":  # type: ignore
+            self.use_json_type = False
 
 
 @dataclass


### PR DESCRIPTION
## Problem

Encrypted fields are cased to str, thus losing type precision. This should affect only a handful of config fields.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Cast a few well-known fields back to their types.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
