### PR TITLE
feat(experiments): Prevent refresh when no modifications made

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/DataCollection.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DataCollection.tsx
@@ -177,9 +177,8 @@ export function DataCollectionGoalModal({ experimentId }: { experimentId: Experi
         trendMetricInsightLoading,
         funnelMetricInsightLoading,
     } = useValues(experimentLogic({ experimentId }))
-    const { closeExperimentCollectionGoalModal, updateExperimentCollectionGoal } = useActions(
-        experimentLogic({ experimentId })
-    )
+    const { closeExperimentCollectionGoalModal, updateExperimentCollectionGoal, restoreUnmodifiedExperiment } =
+        useActions(experimentLogic({ experimentId }))
 
     const isInsightLoading =
         _getMetricType(experiment.metrics[0]) === InsightType.TRENDS
@@ -197,13 +196,19 @@ export function DataCollectionGoalModal({ experimentId }: { experimentId: Experi
                     <LemonButton
                         form="edit-experiment-exposure-form"
                         type="secondary"
-                        onClick={closeExperimentCollectionGoalModal}
+                        onClick={() => {
+                            restoreUnmodifiedExperiment()
+                            closeExperimentCollectionGoalModal()
+                        }}
                     >
                         Cancel
                     </LemonButton>
                     <LemonButton
                         form="edit-experiment-exposure-form"
-                        onClick={() => updateExperimentCollectionGoal()}
+                        onClick={() => {
+                            updateExperimentCollectionGoal()
+                            closeExperimentCollectionGoalModal()
+                        }}
                         type="primary"
                         data-attr="create-annotation-submit"
                     >

--- a/frontend/src/scenes/experiments/Metrics/MetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/MetricModal.tsx
@@ -24,8 +24,13 @@ export function MetricModal({
         editingPrimaryMetricIndex,
         editingSecondaryMetricIndex,
     } = useValues(experimentLogic({ experimentId }))
-    const { updateExperimentGoal, setExperiment, closePrimaryMetricModal, closeSecondaryMetricModal, loadExperiment } =
-        useActions(experimentLogic({ experimentId }))
+    const {
+        updateExperimentGoal,
+        setExperiment,
+        closePrimaryMetricModal,
+        closeSecondaryMetricModal,
+        restoreUnmodifiedExperiment,
+    } = useActions(experimentLogic({ experimentId }))
 
     const metricIdx = isSecondary ? editingSecondaryMetricIndex : editingPrimaryMetricIndex
     const metricsField = isSecondary ? 'metrics_secondary' : 'metrics'
@@ -40,8 +45,7 @@ export function MetricModal({
     const funnelStepsLength = (metric as ExperimentFunnelsQuery)?.funnels_query?.series?.length || 0
 
     const onClose = (): void => {
-        // :KLUDGE: Removes any local changes and resets the experiment to the server state
-        loadExperiment()
+        restoreUnmodifiedExperiment()
         isSecondary ? closeSecondaryMetricModal() : closePrimaryMetricModal()
     }
 
@@ -69,6 +73,7 @@ export function MetricModal({
                                             [metricsField]: newMetrics,
                                         })
                                         updateExperimentGoal()
+                                        isSecondary ? closeSecondaryMetricModal() : closePrimaryMetricModal()
                                     },
                                     size: 'small',
                                 },
@@ -95,6 +100,7 @@ export function MetricModal({
                             form="edit-experiment-goal-form"
                             onClick={() => {
                                 updateExperimentGoal()
+                                isSecondary ? closeSecondaryMetricModal() : closePrimaryMetricModal()
                             }}
                             type="primary"
                             loading={experimentLoading}

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -33,7 +33,7 @@ export function SharedMetricModal({
         closeSecondarySharedMetricModal,
         addSharedMetricsToExperiment,
         removeSharedMetricFromExperiment,
-        loadExperiment,
+        restoreUnmodifiedExperiment,
     } = useActions(experimentLogic({ experimentId }))
 
     const [selectedMetricIds, setSelectedMetricIds] = useState<SharedMetric['id'][]>([])
@@ -52,9 +52,8 @@ export function SharedMetricModal({
     }
 
     const isOpen = isSecondary ? isSecondarySharedMetricModalOpen : isPrimarySharedMetricModalOpen
-    const closeModal = (): void => {
-        // :KLUDGE: Removes any local changes and resets the experiment to the server state
-        loadExperiment()
+    const onClose = (): void => {
+        restoreUnmodifiedExperiment()
         isSecondary ? closeSecondarySharedMetricModal() : closePrimarySharedMetricModal()
     }
 
@@ -78,7 +77,7 @@ export function SharedMetricModal({
     return (
         <LemonModal
             isOpen={isOpen}
-            onClose={closeModal}
+            onClose={onClose}
             width={500}
             title={mode === 'create' ? 'Select one or more shared metrics' : 'Shared metric'}
             footer={
@@ -87,7 +86,10 @@ export function SharedMetricModal({
                         {editingSharedMetricId && (
                             <LemonButton
                                 status="danger"
-                                onClick={() => removeSharedMetricFromExperiment(editingSharedMetricId)}
+                                onClick={() => {
+                                    removeSharedMetricFromExperiment(editingSharedMetricId)
+                                    isSecondary ? closeSecondarySharedMetricModal() : closePrimarySharedMetricModal()
+                                }}
                                 type="secondary"
                             >
                                 Remove from experiment
@@ -95,7 +97,7 @@ export function SharedMetricModal({
                         )}
                     </div>
                     <div className="flex gap-2">
-                        <LemonButton onClick={closeModal} type="secondary">
+                        <LemonButton onClick={onClose} type="secondary">
                             Cancel
                         </LemonButton>
                         {/* Changing the existing metric is a pain because saved metrics are stored separately */}
@@ -106,6 +108,7 @@ export function SharedMetricModal({
                                     addSharedMetricsToExperiment(selectedMetricIds, {
                                         type: isSecondary ? 'secondary' : 'primary',
                                     })
+                                    isSecondary ? closeSecondarySharedMetricModal() : closePrimarySharedMetricModal()
                                 }}
                                 type="primary"
                                 disabledReason={addSharedMetricDisabledReason()}

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -278,6 +278,8 @@ export const experimentLogic = kea<experimentLogicType>([
         removeSharedMetricFromExperiment: (sharedMetricId: SharedMetric['id']) => ({ sharedMetricId }),
         createExperimentDashboard: true,
         setIsCreatingExperimentDashboard: (isCreating: boolean) => ({ isCreating }),
+        setUnmodifiedExperiment: (experiment: Experiment) => ({ experiment }),
+        restoreUnmodifiedExperiment: true,
     }),
     reducers({
         experiment: [
@@ -473,6 +475,12 @@ export const experimentLogic = kea<experimentLogicType>([
                 setExperiment: () => true,
                 loadExperiment: () => false,
                 updateExperiment: () => false,
+            },
+        ],
+        unmodifiedExperiment: [
+            null as Experiment | null,
+            {
+                setUnmodifiedExperiment: (_, { experiment }) => experiment,
             },
         ],
         tabKey: [
@@ -728,8 +736,6 @@ export const experimentLogic = kea<experimentLogicType>([
                     minimum_detectable_effect: minimumDetectableEffect,
                 },
             })
-            actions.closePrimaryMetricModal()
-            actions.closeSecondaryMetricModal()
         },
         updateExperimentCollectionGoal: async () => {
             const { recommendedRunningTime, recommendedSampleSize, minimumDetectableEffect } = values
@@ -742,12 +748,6 @@ export const experimentLogic = kea<experimentLogicType>([
                     minimum_detectable_effect: minimumDetectableEffect || 0,
                 },
             })
-            actions.closeExperimentCollectionGoalModal()
-        },
-        closeExperimentCollectionGoalModal: () => {
-            if (values.experimentValuesChangedLocally) {
-                actions.loadExperiment()
-            }
         },
         resetRunningExperiment: async () => {
             actions.updateExperiment({ start_date: null, end_date: null, archived: false })
@@ -917,8 +917,6 @@ export const experimentLogic = kea<experimentLogicType>([
                 saved_metrics_ids: combinedMetricsIds,
             })
 
-            actions.closePrimarySharedMetricModal()
-            actions.closeSecondarySharedMetricModal()
             actions.loadExperiment()
         },
         removeSharedMetricFromExperiment: async ({ sharedMetricId }) => {
@@ -932,8 +930,6 @@ export const experimentLogic = kea<experimentLogicType>([
                 saved_metrics_ids: sharedMetricsIds,
             })
 
-            actions.closePrimarySharedMetricModal()
-            actions.closeSecondarySharedMetricModal()
             actions.loadExperiment()
         },
         createExperimentDashboard: async () => {
@@ -1003,16 +999,22 @@ export const experimentLogic = kea<experimentLogicType>([
             }
             actions.setIsCreatingExperimentDashboard(false)
         },
+        restoreUnmodifiedExperiment: () => {
+            if (values.unmodifiedExperiment) {
+                actions.setExperiment(structuredClone(values.unmodifiedExperiment))
+            }
+        },
     })),
     loaders(({ actions, props, values }) => ({
         experiment: {
             loadExperiment: async () => {
                 if (props.experimentId && props.experimentId !== 'new') {
                     try {
-                        const response = await api.get(
+                        const response: Experiment = await api.get(
                             `api/projects/${values.currentProjectId}/experiments/${props.experimentId}`
                         )
-                        return response as Experiment
+                        actions.setUnmodifiedExperiment(structuredClone(response))
+                        return response
                     } catch (error: any) {
                         if (error.status === 404) {
                             actions.setExperimentMissing()
@@ -1028,6 +1030,7 @@ export const experimentLogic = kea<experimentLogicType>([
                     `api/projects/${values.currentProjectId}/experiments/${values.experimentId}`,
                     update
                 )
+                actions.setUnmodifiedExperiment(structuredClone(response))
                 return response
             },
         },


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/21795#issuecomment-2593057793
> For both primary and secondary metrics, if I click the edit icon, it opens the popup, and when I close it without making changes, the whole experiments results page reloads. That freaks me out, I am like “shoot, did I make changes?”

## Changes

Prevents the experiment from refreshing when "Cancel" is clicked inside of a modal by:
* Storing the original experiment response in `unmodifiedExperiment` when the experiment is loaded or updated.
* Restoring `unmodifiedExperiment` when clicking "Cancel" inside of a modal instead of making a request to the server.

Also moves `restoreUnmodifiedExperiment()` to the various modal `onClose` events. I think it's weird/confusing/bad for `closePrimaryMetricModal`, etc. to have undocumented side effects.

**Before**

https://github.com/user-attachments/assets/6774f4c9-a994-429e-9226-5fbf7a2527f6

**After**

https://github.com/user-attachments/assets/4afa3a2c-4cb8-4265-87db-cad45467b10d

## How did you test this code?

Editing metrics:
* Clicked "Add primary metric" -> "Single-use" -> "Cancel" and verified the modal closed without refreshing the experiment.
* Clicked "Add primary metric" -> "Shared" -> "Cancel" and verified the modal closed without refreshing the experiment.
* Clicked "Add primary metric" -> "Single-use" -> "Save", verified the experiment refreshed as expected, and verified my new metric appeared as expected.
* Clicked "Add primary metric" -> "Shared" -> "Save", verified the experiment refreshed as expected, and verified my new metric appeared as expected.
* Clicked on an existing shared primary metric -> "Remove from experiment", verified the experiment refreshed as expected, and verified the metric was removed from the experiment.
* Ditto above for "Add secondary metric"

Others:
* Clicked on "Edit MDE", made a change, clicked "Cancel", and verified the old number was restored.
* Clicked on "Edit MDE", made a change, clicked "Save", and verified the experiment refreshed as expected.

Notably, didn't touch `<DistributionModal>` and `<ReleaseConditionsModal>` because they interact with the feature flags logic.