### PR TITLE
perf(quereies): run queries over websockets

### DIFF
--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -6,6 +6,7 @@ import posthog from 'posthog-js'
 
 import { OnlineExportContext, QueryExportContext } from '~/types'
 
+import { QueryWebSocketManager } from './queryWebSocket'
 import {
     DashboardFilter,
     DataNode,
@@ -78,6 +79,8 @@ export async function pollForResults(
     throw new Error('Query timed out')
 }
 
+let socket: null | QueryWebSocketManager = null
+
 /**
  * Execute a query node and return the response, use async query if enabled
  */
@@ -100,9 +103,19 @@ async function executeQuery<N extends DataNode>(
         !SYNC_ONLY_QUERY_KINDS.includes(queryNode.kind) &&
         !!featureFlagLogic.findMounted()?.values.featureFlags?.[FEATURE_FLAGS.QUERY_ASYNC]
 
+    const refreshParam: RefreshType | undefined =
+        refresh && isAsyncQuery ? 'force_async' : isAsyncQuery ? 'async' : refresh
+
+    if (posthog.isFeatureEnabled('query-websocket')) {
+        if (!socket) {
+            socket = new QueryWebSocketManager(
+                `${window.location.protocol == 'https:' ? 'wss' : 'ws'}://${window.location.host}/ws/query/`
+            )
+        }
+        return socket.sendQuery(queryNode, methodOptions, refreshParam, queryId, filtersOverride, variablesOverride)
+    }
+
     if (!pollOnly) {
-        const refreshParam: RefreshType | undefined =
-            refresh && isAsyncQuery ? 'force_async' : isAsyncQuery ? 'async' : refresh
         const response = await api.query(
             queryNode,
             methodOptions,

--- a/frontend/src/queries/queryWebSocket.ts
+++ b/frontend/src/queries/queryWebSocket.ts
@@ -10,7 +10,7 @@ export class QueryWebSocketManager {
         { payload: any; resolve: (value: any) => void; reject: (reason?: any) => void }
     >()
     private idleTimeout: NodeJS.Timeout | null = null
-    private idleTimeoutDuration = 30000 // 30 seconds of idle time before disconnecting
+    private idleTimeoutDuration = 20000 // 20 seconds of idle time before disconnecting
 
     constructor(url: string) {
         this.url = url

--- a/frontend/src/queries/queryWebSocket.ts
+++ b/frontend/src/queries/queryWebSocket.ts
@@ -1,0 +1,121 @@
+import { ApiMethodOptions } from 'lib/api'
+
+import { DashboardFilter, DataNode, HogQLVariable, RefreshType } from './schema'
+
+export class QueryWebSocketManager {
+    private socket: WebSocket | null = null
+    private url: string
+    private pendingQueries = new Map<
+        string,
+        { payload: any; resolve: (value: any) => void; reject: (reason?: any) => void }
+    >()
+    private idleTimeout: NodeJS.Timeout | null = null
+    private idleTimeoutDuration = 30000 // 30 seconds of idle time before disconnecting
+
+    constructor(url: string) {
+        this.url = url
+    }
+
+    private connect(): void {
+        if (
+            this.socket &&
+            (this.socket.readyState === WebSocket.OPEN || this.socket.readyState === WebSocket.CONNECTING)
+        ) {
+            return // Avoid redundant connections
+        }
+
+        this.socket = new WebSocket(this.url)
+
+        this.socket.onopen = () => {
+            this.resendPendingQueries()
+        }
+
+        this.socket.onmessage = (event) => {
+            const response = JSON.parse(event.data)
+            const { client_query_id, data, error } = response
+
+            if (this.pendingQueries.has(client_query_id)) {
+                const { resolve, reject } = this.pendingQueries.get(client_query_id)!
+                this.pendingQueries.delete(client_query_id)
+                if (error) {
+                    reject(new Error(error))
+                } else {
+                    resolve(data)
+                }
+                this.startIdleTimeout() // Restart idle timeout after handling a message
+            }
+        }
+
+        this.socket.onclose = () => {
+            if (this.pendingQueries.size > 0) {
+                this.connect()
+            }
+        }
+    }
+
+    private disconnect(): void {
+        if (this.socket) {
+            this.socket.close()
+            this.socket = null
+        }
+    }
+
+    private resendPendingQueries(): void {
+        for (const [_, { payload }] of this.pendingQueries) {
+            this.socket?.send(JSON.stringify(payload))
+        }
+    }
+
+    private startIdleTimeout(): void {
+        if (this.idleTimeout) {
+            clearTimeout(this.idleTimeout)
+        }
+        if (this.pendingQueries.size === 0) {
+            this.idleTimeout = setTimeout(() => this.disconnect(), this.idleTimeoutDuration)
+        }
+    }
+
+    public sendQuery<N extends DataNode>(
+        queryNode: N,
+        methodOptions?: ApiMethodOptions,
+        refreshParam?: RefreshType | undefined,
+        queryId?: string,
+        filtersOverride?: DashboardFilter | null,
+        variablesOverride?: Record<string, HogQLVariable> | null
+        /**
+         * Whether to limit the function to just polling the provided query ID.
+         * This is important in shared contexts, where we cannot create arbitrary queries via POST – we can only GET.
+         */
+    ): Promise<NonNullable<N['response']>> {
+        const client_query_id = queryId || Math.random().toString(36).substring(2)
+
+        const payload = {
+            query: queryNode,
+            methodOptions: methodOptions,
+            refresh: refreshParam,
+            client_query_id: client_query_id,
+            filtersOverride: filtersOverride,
+            variablesOverride: variablesOverride,
+        }
+
+        return new Promise((resolve, reject) => {
+            this.pendingQueries.set(client_query_id, { payload, resolve, reject })
+
+            if (!this.socket || this.socket.readyState === WebSocket.CLOSED) {
+                this.connect()
+            }
+
+            if (this.socket?.readyState === WebSocket.OPEN) {
+                this.socket.send(JSON.stringify(payload))
+            }
+
+            // Add a timeout for the query
+            setTimeout(() => {
+                if (this.pendingQueries.has(client_query_id)) {
+                    this.pendingQueries.delete(client_query_id)
+                    reject(new Error('Query timed out.'))
+                }
+            }, 600000) // 600 seconds timeout
+        })
+    }
+}

--- a/posthog/api/query_ws.py
+++ b/posthog/api/query_ws.py
@@ -1,0 +1,115 @@
+from posthog.api.services.query import process_query_model
+from posthog.hogql_queries.query_runner import ExecutionMode, execution_mode_from_refresh
+from posthog.clickhouse.query_tagging import tag_queries
+from pydantic import BaseModel
+from posthog.errors import ExposedCHQueryError
+from posthog.hogql.errors import ExposedHogQLError
+from sentry_sdk import capture_exception
+from asgiref.sync import sync_to_async
+
+from posthog.rate_limit import ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle, HogQLQueryThrottle
+from posthog.api.websocket import BaseWebsocketConsumer
+import json
+import uuid
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class Response(BaseModel, Generic[T]):
+    status: int
+    result: T
+    client_query_id: str
+
+
+def _query(user, query, execution_mode, query_id):
+    return process_query_model(
+        user.team,
+        query,
+        execution_mode=execution_mode,
+        query_id=query_id,
+        user=user,
+    )
+
+
+class QueryConsumer(BaseWebsocketConsumer):
+    def get_throttles(self, data):
+        if query := data.get("query"):
+            if isinstance(query, dict) and query.get("kind") == "HogQLQuery":
+                return [HogQLQueryThrottle()]
+        return [ClickHouseBurstRateThrottle(), ClickHouseSustainedRateThrottle()]
+
+    async def connect(self):
+        # Accept the WebSocket connection
+        if not await self.check_authentication():
+            return
+        await self.accept()
+
+    async def disconnect(self, close_code):
+        # Handle WebSocket disconnection (if needed)
+        pass
+
+    async def receive(self, text_data):
+        try:
+            data = json.loads(text_data)
+            if not await self.check_throttling(data):
+                return
+
+            # Extract and process the query
+            client_query_id = data.get("client_query_id") or uuid.uuid4().hex
+            execution_mode = execution_mode_from_refresh(data.get("refresh"))
+            response_status = 200
+
+            # Add tagging if needed
+            # self._tag_client_query_id(client_query_id)
+
+            # websockets we always want to "block"
+            if execution_mode in [
+                ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
+                ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+                ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE,
+            ]:
+                execution_mode = ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE
+            if execution_mode in [ExecutionMode.CALCULATE_ASYNC_ALWAYS]:
+                execution_mode = ExecutionMode.CALCULATE_BLOCKING_ALWAYS
+
+            tag_queries(query=data["query"])
+
+            # Execute query asynchronously
+            result = await sync_to_async(_query)(
+                self.scope["user"],
+                data["query"],
+                execution_mode=execution_mode,
+                query_id=client_query_id,
+            )
+
+            # Send response back to the client
+            response: Response = Response(status=response_status, result=result, client_query_id=client_query_id)
+            await self.send(response.model_dump_json(by_alias=True))
+
+        except (ExposedHogQLError, ExposedCHQueryError) as e:
+            # Handle validation errors
+            await self.send(
+                json.dumps(
+                    {
+                        "status": 400,
+                        "error": str(e),
+                        "client_query_id": client_query_id,
+                        "code": getattr(e, "code_name", None),
+                    }
+                )
+            )
+
+        except Exception as e:
+            # Handle unexpected errors
+            capture_exception(e)
+            await self.send(
+                json.dumps(
+                    {
+                        "status": 500,
+                        "error": "Internal server error",
+                        "client_query_id": client_query_id,
+                        "exception": str(e),
+                    }
+                )
+            )

--- a/posthog/api/test/test_query_ws.py
+++ b/posthog/api/test/test_query_ws.py
@@ -1,0 +1,98 @@
+from unittest.mock import patch
+from freezegun import freeze_time
+from channels.testing import WebsocketCommunicator
+from django.test import TransactionTestCase
+from posthog.rate_limit import ClickHouseSustainedRateThrottle
+from asgiref.sync import sync_to_async
+from posthog.models.organization import Organization
+from posthog.models.team import Team
+from posthog.models.user import User
+from posthog.models.project import Project
+import random
+
+
+from posthog.asgi import application
+
+from typing import Optional
+
+import functools
+
+
+class AuthWebsocketCommunicator(WebsocketCommunicator):
+    def __init__(self, application, path, user, *args, **kwargs):
+        super().__init__(self._asgi_with_user(application, user), path, *args, **kwargs)
+
+    @classmethod
+    def _asgi_with_user(cls, asgi_app, user):
+        """
+        Update the scope of an ASGI app such that a particular user
+        is already assumed to have been authenticated.
+        """
+
+        async def app(scope, receive, send):
+            scope["user"] = user
+            return await asgi_app(scope, receive, send)
+
+        functools.update_wrapper(app, asgi_app)
+        return app
+
+
+class TestQueryConsumer(TransactionTestCase):
+    user: Optional[User] = None
+
+    async def _create_user(self):
+        # self.team = self.create_team_with_organization(self.organization)
+        # self.user = self.create_user_with_organization(self.organization)
+
+        if self.user:
+            return self.user
+        org = await Organization.objects.acreate(slug=f"org-{random.randint(1, 1000000)}")
+        project_id = await sync_to_async(Team.objects.increment_id_sequence)()
+        project = await Project.objects.acreate(id=project_id, organization=org)
+        await Team.objects.acreate(organization=org, project=project)
+        self.user = await User.objects.acreate(email=f"bla-{random.randint(1, 10000000)}@bla.com")
+
+        await sync_to_async(org.members.add)(self.user)
+        return self.user
+
+    @freeze_time("2025-01-01 12:00:00")
+    async def test_query_consumer_success(self):
+        # Test a successful query
+        communicator = AuthWebsocketCommunicator(application, "/ws/query/", await self._create_user())
+        connected, _ = await communicator.connect()
+        self.assertTrue(connected)
+
+        query = {"query": {"select": ["count()", "event"], "where": ["event == 'sign up'"]}}
+        await communicator.send_json_to(query)
+
+        response = await communicator.receive_json_from()
+        self.assertEqual(response["status"], 200, response)
+        self.assertIn("result", response)
+        self.assertIn("client_query_id", response)
+
+        await communicator.disconnect()
+
+    @freeze_time("2025-01-01 12:00:00")
+    async def test_rate_limit_exceeded(self):
+        # Test rate limit exceeded scenario
+        with patch.object(ClickHouseSustainedRateThrottle, "allow_request", return_value=False):
+            communicator = AuthWebsocketCommunicator(application, "/ws/query/", await self._create_user())
+            # Authenticate the user
+            connected, _ = await communicator.connect()
+            self.assertTrue(connected)
+
+            query = {"query": {"select": ["count()", "event"]}}
+            await communicator.send_json_to(query)
+
+            response = await communicator.receive_json_from()
+            self.assertEqual(response["status"], 429, response)
+            self.assertEqual(response["error"], "Rate limit exceeded: Request was throttled.")
+
+            await communicator.disconnect()
+
+    async def test_unauthenticated_access(self):
+        # Test unauthenticated access
+        communicator = WebsocketCommunicator(application, "/ws/query/")
+        connected, code = await communicator.connect()
+        self.assertFalse(connected)
+        self.assertEqual(code, 401)

--- a/posthog/api/websocket.py
+++ b/posthog/api/websocket.py
@@ -1,0 +1,45 @@
+from channels.generic.websocket import AsyncWebsocketConsumer
+from rest_framework.exceptions import Throttled
+from rest_framework.views import APIView
+from rest_framework.request import Request
+from django.contrib.auth.models import AnonymousUser
+from asgiref.sync import sync_to_async
+
+from django.test import RequestFactory
+from typing import cast
+import json
+
+
+class BaseWebsocketConsumer(AsyncWebsocketConsumer):
+    async def check_authentication(self):
+        """Check if the user is authenticated."""
+        user = self.scope.get("user", AnonymousUser())
+
+        if not user.is_authenticated:
+            await self.close(code=401)
+            return False
+        return True
+
+    async def check_throttling(self, data):
+        # Apply throttling
+        throttles = self.get_throttles(data)
+        view = APIView()  # DRF expects a view instance
+        view.request = cast(Request, RequestFactory())
+        view.request.user = self.scope["user"]  # Attach the user object
+
+        try:
+            for throttle in throttles:
+                if not await sync_to_async(throttle.allow_request)(view.request, view):
+                    raise Throttled()
+        except Throttled as e:
+            await self.send(
+                json.dumps(
+                    {
+                        "status": 429,
+                        "error": f"Rate limit exceeded: {str(e.detail)}",
+                    }
+                )
+            )
+            return False
+
+        return True

--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass
 from typing import Optional, Union
-from datetime import timedelta
-from posthog.cache_utils import cache_for
 
 from posthog.hogql import ast
 from posthog.hogql.database.models import ExpressionField
@@ -62,7 +60,6 @@ if(
     )
 
 
-@cache_for(timedelta(minutes=30))
 def create_initial_channel_type(name: str, custom_rules: Optional[list[CustomChannelRule]] = None):
     return ExpressionField(
         name=name,

--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 from typing import Optional, Union
+from datetime import timedelta
+from posthog.cache_utils import cache_for
 
 from posthog.hogql import ast
 from posthog.hogql.database.models import ExpressionField
@@ -60,6 +62,7 @@ if(
     )
 
 
+@cache_for(timedelta(minutes=30))
 def create_initial_channel_type(name: str, custom_rules: Optional[list[CustomChannelRule]] = None):
     return ExpressionField(
         name=name,

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -60,6 +60,7 @@ DECIDE_SESSION_REPLAY_QUOTA_CHECK = get_from_env("DECIDE_SESSION_REPLAY_QUOTA_CH
 # Application definition
 
 INSTALLED_APPS = [
+    "daphne",
     "whitenoise.runserver_nostatic",  # makes sure that whitenoise handles static files in development
     "django.contrib.admin",
     "django.contrib.auth",
@@ -86,6 +87,7 @@ INSTALLED_APPS = [
     # 'two_factor.plugins.yubikey',  # <- for yubikey capability.
 ]
 
+ASGI_APPLICATION = "posthog.asgi.application"
 
 MIDDLEWARE = [
     "posthog.middleware.PrometheusBeforeMiddlewareWithTeamIds",

--- a/requirements.in
+++ b/requirements.in
@@ -121,3 +121,5 @@ grpcio~=1.63.2 # Version constrained so that `deepeval` can be installed in in d
 tenacity~=8.4.2  # Version constrained so that `deepeval` can be installed in in dev
 markdown-it-py~=3.0.0
 tzlocal~=5.1
+channels==4.2.0
+daphne==4.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,10 @@ anyio==4.6.2.post1
     #   starlette
     #   watchfiles
 asgiref==3.7.2
-    # via django
+    # via
+    #   channels
+    #   daphne
+    #   django
 asn1crypto==1.5.1
     # via snowflake-connector-python
 astunparse==1.6.3
@@ -106,6 +109,8 @@ cffi==1.16.0
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
+channels==4.2.0
+    # via -r requirements.in
 charset-normalizer==2.1.0
     # via
     #   requests
@@ -142,14 +147,18 @@ coloredlogs==14.0
     # via dagster
 conditional-cache==1.2
     # via -r requirements.in
+constantly==23.10.4
+    # via twisted
 croniter==5.0.1
     # via dagster
 cryptography==39.0.2
     # via
     #   -r requirements.in
+    #   autobahn
     #   paramiko
     #   pyjwt
     #   pyopenssl
+    #   service-identity
     #   snowflake-connector-python
     #   social-auth-core
     #   urllib3
@@ -174,6 +183,8 @@ dagster-postgres==0.25.8
     # via -r requirements.in
 dagster-webserver==1.9.8
     # via -r requirements.in
+daphne==4.1.2
+    # via -r requirements.in
 dataclasses-json==0.6.7
     # via langchain-community
 decorator==5.1.1
@@ -191,6 +202,7 @@ dj-database-url==0.5.0
 django==4.2.15
     # via
     #   -r requirements.in
+    #   channels
     #   django-axes
     #   django-cors-headers
     #   django-deprecate-fields
@@ -369,15 +381,23 @@ humanfriendly==10.0
     # via coloredlogs
 humanize==4.9.0
     # via dlt
+hyperlink==21.0.0
+    # via
+    #   autobahn
+    #   twisted
 idna==3.10
     # via
     #   anyio
     #   httpx
+    #   hyperlink
     #   requests
     #   snowflake-connector-python
     #   trio
+    #   twisted
     #   urllib3
     #   yarl
+incremental==24.7.2
+    # via twisted
 infi-clickhouse-orm @ git+https://github.com/PostHog/infi.clickhouse_orm@9578c79f29635ee2c1d01b7979e89adab8383de2
     # via -r requirements.in
 inflection==0.5.1
@@ -884,6 +904,10 @@ trio==0.26.0
     #   trio-websocket
 trio-websocket==0.11.1
     # via selenium
+twisted==24.11.0
+    # via daphne
+txaio==23.1.1
+    # via autobahn
 types-protobuf==4.22.0.0
     # via temporalio
 types-setuptools==69.0.0.0
@@ -905,6 +929,7 @@ typing-extensions==4.12.2
     #   sqlalchemy
     #   stripe
     #   temporalio
+    #   twisted
     #   typing-inspect
 typing-inspect==0.9.0
     # via dataclasses-json


### PR DESCRIPTION
## Problem

It takes a long time to get a result when doing polling, sometimes due to browser priority contention, sometimes the server just takes a while to respond

TODO in future RPs: 
- If the browser loses connection and reconnects, I'm pretty sure the query won't ever complete
- pref improvements https://github.com/PostHog/posthog/pull/27576#discussion_r1918056521
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Behind a feature flag, do queries over websockets instead of polling

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
