### PR TITLE
fix(flags): Do not search orgs by `group_key``

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -539,7 +539,6 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                     endpoint: combineUrl(`api/environments/${teamId}/groups/`, {
                         group_type_index: type.group_type_index,
                     }).url,
-                    searchAlias: 'group_key',
                     getPopoverHeader: () => `Group Names`,
                     getName: (group: Group) => groupDisplayId(group.group_key, group.group_properties),
                     getValue: (group: Group) => group.group_key,


### PR DESCRIPTION
When adding a condition to a feature flag, the default property search can also search for groups when "Match by" is set to a group type. This search is defined by a `TaxonomicFilterGroup` with a `searchAlias` of `group_key`.

What this means in practice is rather than searching on a company or project name, it searches on the key, which isn't a very user-friendly thing to search by. It turns out that the default `searchAlias` for a `TaxonomicFilterGroup` is `search` which works very well!

So this PR is hours of work ending in a one-line deletion. It reminds me of the parable of [The Old Engineer and the Hammer](https://www.tyrell.co/2019/05/the-old-engineer-and-hammer.html). 😆 

For context, this feature was introduced in #9299 in a20d57ada32cefe2ed1aa8f705029db63de722b5.

## Problem

Closes #26825

## Changes

Just removed a line where `searchAlias` is overwritten.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually tested it. Check out [the exciting video!](https://www.loom.com/share/2d4de9823d2a4087a563938e0f1e4fa9?sid=942e5394-4ed4-4535-b843-e1a9dda15f5f)