### PR TITLE
ci: Add a lot more memory to PR previews

### DIFF
--- a/.github/pr-deploy/hobby.yaml.tmpl
+++ b/.github/pr-deploy/hobby.yaml.tmpl
@@ -20,8 +20,8 @@ spec:
           privileged: true
         resources:
           requests:
-            cpu: 2
-            memory: 500M          
+            cpu: 4
+            memory: 4G          
         ports:
         - containerPort: 2375
         - containerPort: 80


### PR DESCRIPTION
## Problem

I suspect 4G is the bare minimum to run hobby deploys
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
