### PR TITLE
fix(editor-3001): fix styling regression on sidebar buttons

### DIFF
--- a/frontend/src/layout/navigation-3000/Navigation.scss
+++ b/frontend/src/layout/navigation-3000/Navigation.scss
@@ -376,10 +376,6 @@
             background: var(--accordion-header-background);
         }
     }
-
-    &:not([aria-busy='true']) .Accordion__header .LemonIcon {
-        visibility: hidden;
-    }
 }
 
 .Accordion__header {

--- a/frontend/src/layout/navigation-3000/components/SidebarAccordion.tsx
+++ b/frontend/src/layout/navigation-3000/components/SidebarAccordion.tsx
@@ -23,7 +23,7 @@ export function SidebarAccordion({ category }: SidebarAccordionProps): JSX.Eleme
     const isExpanded = !accordionCollapseMapping[key] && !isEmpty
 
     return (
-        <section className="Accordion" aria-busy={loading} aria-expanded={isExpanded}>
+        <section className="Accordion" aria-busy={loading} aria-disabled={isEmpty} aria-expanded={isExpanded}>
             <div
                 className="Accordion__header"
                 onClick={isExpanded || items.length > 0 ? () => toggleAccordion(key) : undefined}

--- a/frontend/src/layout/navigation-3000/components/SidebarAccordion.tsx
+++ b/frontend/src/layout/navigation-3000/components/SidebarAccordion.tsx
@@ -23,7 +23,7 @@ export function SidebarAccordion({ category }: SidebarAccordionProps): JSX.Eleme
     const isExpanded = !accordionCollapseMapping[key] && !isEmpty
 
     return (
-        <section className="Accordion" aria-busy={loading} aria-disabled={isEmpty} aria-expanded={isExpanded}>
+        <section className="Accordion" aria-busy={loading} aria-expanded={isExpanded}>
             <div
                 className="Accordion__header"
                 onClick={isExpanded || items.length > 0 ? () => toggleAccordion(key) : undefined}


### PR DESCRIPTION
## Problem

- buttons are not visible on empty state

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- update styling so buttons are still visible
![CleanShot 2025-01-15 at 22 27 03@2x](https://github.com/user-attachments/assets/ae2ed8fd-1f15-4963-bff8-622b51cae8d0)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
