### PR TITLE
fix: replay playlist loading state

### DIFF
--- a/frontend/src/lib/components/Playlist/Playlist.tsx
+++ b/frontend/src/lib/components/Playlist/Playlist.tsx
@@ -238,10 +238,10 @@ const List = ({
                         const content =
                             'content' in s ? (
                                 s.content
-                            ) : loading && s.key === 'other' ? (
-                                <LoadingState />
                             ) : 'items' in s && !!s.items.length ? (
                                 <ListSection {...s} onClick={setActiveItemId} activeItemId={activeItemId} />
+                            ) : loading ? (
+                                <LoadingState />
                             ) : (
                                 emptyState
                             )


### PR DESCRIPTION
we were always replacing the list when loading, but we should only show a loading state when there isn't a set of results already 🙈 