### PR TITLE
fix(experiments): fix allowed agg. type on shared metrics

### DIFF
--- a/frontend/src/scenes/experiments/SharedMetrics/SharedTrendsMetricForm.tsx
+++ b/frontend/src/scenes/experiments/SharedMetrics/SharedTrendsMetricForm.tsx
@@ -66,7 +66,7 @@ export function SharedTrendsMetricForm(): JSX.Element {
                                     showSeriesIndicator={true}
                                     entitiesLimit={1}
                                     showNumericalPropsOnly={true}
-                                    onlyPropertyMathDefinitions={[PropertyMathType.Average]}
+                                    onlyPropertyMathDefinitions={[PropertyMathType.Sum]}
                                     {...commonActionFilterProps}
                                 />
                                 <div className="mt-4 space-y-4">


### PR DESCRIPTION
## Problem
On shared metrics, with still showed average as the only option in the metrics form.

<img width="391" alt="Screenshot 2025-01-16 at 10 30 50" src="https://github.com/user-attachments/assets/1122c026-99a0-4140-bf90-85a76490338c" />


Side note: We should probably generalize the metric form component to avoid having to maintain the configuration two places.


## Changes
Replaces avg with sum

<img width="609" alt="Screenshot 2025-01-16 at 10 31 52" src="https://github.com/user-attachments/assets/3d45126c-5509-4bb6-86ab-c28edaaa0289" />

## How did you test this code?
Tested locally
