### PR TITLE
fix: update various search UX's

### DIFF
--- a/frontend/src/lib/components/CommandBar/SearchResult.tsx
+++ b/frontend/src/lib/components/CommandBar/SearchResult.tsx
@@ -37,7 +37,9 @@ export const SearchResult = ({ result, resultIndex, focused }: SearchResultProps
             if ((ref.current as any)?.scrollIntoViewIfNeeded) {
                 ;(ref.current as any).scrollIntoViewIfNeeded(false)
             } else {
-                ref.current?.scrollIntoView()
+                ref.current?.scrollIntoView({
+                    block: 'nearest',
+                })
             }
         }
     }, [focused])

--- a/frontend/src/lib/components/CommandBar/SearchResult.tsx
+++ b/frontend/src/lib/components/CommandBar/SearchResult.tsx
@@ -1,7 +1,6 @@
 import { LemonSkeleton } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
-import { useWindowSize } from 'lib/hooks/useWindowSize'
 import { capitalizeFirstLetter } from 'lib/utils'
 import { useLayoutEffect, useRef } from 'react'
 import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
@@ -9,6 +8,7 @@ import { Notebook } from 'scenes/notebooks/Notebook/Notebook'
 import { JSONContent } from 'scenes/notebooks/Notebook/utils'
 import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
 
+import { navigation3000Logic } from '~/layout/navigation-3000/navigationLogic'
 import { getQueryFromInsightLike } from '~/queries/nodes/InsightViz/utils'
 
 import { tabToName } from './constants'
@@ -24,10 +24,10 @@ type SearchResultProps = {
 export const SearchResult = ({ result, resultIndex, focused }: SearchResultProps): JSX.Element => {
     const { aggregationLabel } = useValues(searchBarLogic)
     const { setActiveResultIndex, openResult } = useActions(searchBarLogic)
+    const { mobileLayout } = useValues(navigation3000Logic)
+    const { hideNavOnMobile } = useActions(navigation3000Logic)
 
     const ref = useRef<HTMLDivElement | null>(null)
-
-    const { isWindowLessThan } = useWindowSize()
 
     useLayoutEffect(() => {
         if (focused) {
@@ -50,11 +50,13 @@ export const SearchResult = ({ result, resultIndex, focused }: SearchResultProps
                     focused ? 'bg-bg-3000 border-l-primary-3000' : 'bg-bg-light'
                 )}
                 onClick={() => {
-                    if (isWindowLessThan('md')) {
-                        openResult(resultIndex)
-                    } else {
-                        setActiveResultIndex(resultIndex)
+                    if (mobileLayout) {
+                        hideNavOnMobile()
                     }
+                    openResult(resultIndex)
+                }}
+                onMouseOver={() => {
+                    setActiveResultIndex(resultIndex)
                 }}
                 ref={ref}
             >

--- a/frontend/src/lib/components/CommandBar/SearchResults.tsx
+++ b/frontend/src/lib/components/CommandBar/SearchResults.tsx
@@ -17,8 +17,8 @@ export const SearchResults = (): JSX.Element => {
                     <DetectiveHog height={150} width={150} />
                 </div>
             ) : (
-                <div className="md:grid md:grid-cols-[320px_1fr] overflow-auto">
-                    <div className="border-r border-b md:border-b-0 bg-bg-3000 overscroll-contain overflow-y-auto">
+                <div className="md:grid md:grid-cols-[320px_1fr] overflow-y-auto overflow-x-hidden">
+                    <div className="border-r border-b md:border-b-0 bg-bg-3000 overscroll-contain overflow-y-auto overflow-x-hidden">
                         {combinedSearchLoading && (
                             <>
                                 <SearchResultSkeleton />

--- a/frontend/src/lib/components/CommandBar/SearchResults.tsx
+++ b/frontend/src/lib/components/CommandBar/SearchResults.tsx
@@ -17,7 +17,7 @@ export const SearchResults = (): JSX.Element => {
                     <DetectiveHog height={150} width={150} />
                 </div>
             ) : (
-                <div className="md:grid md:grid-cols-[320px_1fr]">
+                <div className="md:grid md:grid-cols-[320px_1fr] overflow-auto">
                     <div className="border-r border-b md:border-b-0 bg-bg-3000 overscroll-contain overflow-y-auto">
                         {combinedSearchLoading && (
                             <>


### PR DESCRIPTION
## Problem

Search result clicks showed the preview to the right instead of navigating to the page, this interaction added an extra click, and confused some people.
 
## Changes
* desktop: show search preview on mouse over (instead of click, click now navigates)
* mobile: search items now scrollable (fix) by adding overflow-auto
* mobile: hide nav on search result click
* firefox: scrollIntoView was buggy, changed to block: "nearest" to prevent focus from running wild and going down/up the page on it's own.

Firefox scroll into view fix, and clicking result navigates:
![firefox-scoll-and-desktop-click](https://github.com/user-attachments/assets/9435f9e4-77d2-4d9f-b198-8890ed1f6433)

Mobile scroll fix, hide nav when clicking result
![mobile-scroll-fix](https://github.com/user-attachments/assets/d3145926-dcb1-4c4a-ac9f-17ff216d66d4)


## Does this work well for both Cloud and self-hosted?

doesn't have an impact

## How did you test this code?

On chrome, firefox
