### PR TITLE
fix(insights): fix resizing insight card

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -95,6 +95,7 @@ function InsightCardInternal(
         loadPriority,
         doNotLoad,
         variablesOverride,
+        children,
         ...divProps
     }: InsightCardProps,
     ref: React.Ref<HTMLDivElement>
@@ -169,6 +170,7 @@ function InsightCardInternal(
                         {canResizeWidth ? <ResizeHandle2D /> : null}
                     </>
                 )}
+                {children /* Extras, such as resize handles */}
             </ErrorBoundary>
         </div>
     )

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -65,6 +65,7 @@ export interface InsightCardProps extends Resizeable {
     variablesOverride?: Record<string, HogQLVariable>
     className?: string
     style?: React.CSSProperties
+    children?: React.ReactNode
 }
 
 function InsightCardInternal(
@@ -170,7 +171,7 @@ function InsightCardInternal(
                         {canResizeWidth ? <ResizeHandle2D /> : null}
                     </>
                 )}
-                {children /* Extras, such as resize handles */}
+                {children /* Extras, specifically resize handles injected by ReactGridLayout */}
             </ErrorBoundary>
         </div>
     )

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -155,6 +155,7 @@ export function DashboardItems(): JSX.Element {
                                     loadPriority={smLayout ? smLayout.y * 1000 + smLayout.x : undefined}
                                     variablesOverride={temporaryVariables}
                                     {...commonTileProps}
+                                    // NOTE: ReactGridLayout additionally injects its resize handles as `children`!
                                 />
                             )
                         }


### PR DESCRIPTION
## Problem

Insight cards on dashboards can't be resized any more.

See also https://posthog.slack.com/archives/C02E3BKC78F/p1736946679981969.

Closes #27567

## Changes

Re-adds children required by react-grid-layout, to make this work again. They were removed in https://github.com/PostHog/posthog/pull/27510.

## How did you test this code?

Tried locally