### PR TITLE
fix: no huge lists of dates plz

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEdit.tsx
+++ b/frontend/src/scenes/surveys/SurveyEdit.tsx
@@ -1081,6 +1081,8 @@ export default function SurveyEdit(): JSX.Element {
                                                                 data-attr="survey-iteration-count"
                                                                 size="small"
                                                                 min={1}
+                                                                // NB this is enforced in the API too
+                                                                max={500}
                                                                 value={value || 1}
                                                                 onChange={(newValue) => {
                                                                     if (newValue && newValue > 0) {

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -60,6 +60,7 @@ class SurveySerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
     conditions = serializers.SerializerMethodField(method_name="get_conditions", read_only=True)
     feature_flag_keys = serializers.SerializerMethodField()
+    # NB this is enforced in the UI too
     iteration_count = serializers.IntegerField(required=False, allow_null=True, max_value=500, min_value=0)
 
     def get_feature_flag_keys(self, survey: Survey) -> list:

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -130,6 +130,7 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
     targeting_flag = MinimalFeatureFlagSerializer(read_only=True)
     internal_targeting_flag = MinimalFeatureFlagSerializer(read_only=True)
     created_by = UserBasicSerializer(read_only=True)
+    # NB this is enforced in the UI too
     iteration_count = serializers.IntegerField(required=False, allow_null=True, max_value=500, min_value=0)
 
     class Meta:

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -60,6 +60,7 @@ class SurveySerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
     conditions = serializers.SerializerMethodField(method_name="get_conditions", read_only=True)
     feature_flag_keys = serializers.SerializerMethodField()
+    iteration_count = serializers.IntegerField(required=False, allow_null=True, max_value=500, min_value=0)
 
     def get_feature_flag_keys(self, survey: Survey) -> list:
         return [
@@ -128,6 +129,7 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
     targeting_flag = MinimalFeatureFlagSerializer(read_only=True)
     internal_targeting_flag = MinimalFeatureFlagSerializer(read_only=True)
     created_by = UserBasicSerializer(read_only=True)
+    iteration_count = serializers.IntegerField(required=False, allow_null=True, max_value=500, min_value=0)
 
     class Meta:
         model = Survey

--- a/posthog/api/survey.py
+++ b/posthog/api/survey.py
@@ -43,7 +43,7 @@ from posthog.models.activity_logging.activity_log import (
 )
 from posthog.models.activity_logging.activity_page import activity_page_response
 from posthog.models.feature_flag.feature_flag import FeatureFlag
-from posthog.models.feedback.survey import Survey
+from posthog.models.feedback.survey import Survey, MAX_ITERATION_COUNT
 from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.utils_cors import cors_response
@@ -61,7 +61,9 @@ class SurveySerializer(serializers.ModelSerializer):
     conditions = serializers.SerializerMethodField(method_name="get_conditions", read_only=True)
     feature_flag_keys = serializers.SerializerMethodField()
     # NB this is enforced in the UI too
-    iteration_count = serializers.IntegerField(required=False, allow_null=True, max_value=500, min_value=0)
+    iteration_count = serializers.IntegerField(
+        required=False, allow_null=True, max_value=MAX_ITERATION_COUNT, min_value=0
+    )
 
     def get_feature_flag_keys(self, survey: Survey) -> list:
         return [
@@ -131,7 +133,9 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
     internal_targeting_flag = MinimalFeatureFlagSerializer(read_only=True)
     created_by = UserBasicSerializer(read_only=True)
     # NB this is enforced in the UI too
-    iteration_count = serializers.IntegerField(required=False, allow_null=True, max_value=500, min_value=0)
+    iteration_count = serializers.IntegerField(
+        required=False, allow_null=True, max_value=MAX_ITERATION_COUNT, min_value=0
+    )
 
     class Meta:
         model = Survey

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -427,7 +427,7 @@ class TestSurvey(APIBaseTest):
         assert survey_with_targeting.json() == {
             "type": "validation_error",
             "code": "max_value",
-            "detail": "Ensure this value is less than or equal to 500.",
+            "detail": f"Ensure this value is less than or equal to {MAX_ITERATION_COUNT}.",
             "attr": "iteration_count",
         }
 

--- a/posthog/api/test/test_survey.py
+++ b/posthog/api/test/test_survey.py
@@ -16,7 +16,7 @@ from posthog.api.test.test_personal_api_keys import PersonalAPIKeysBaseTest
 from posthog.constants import AvailableFeature
 from posthog.models import Action, FeatureFlag, Team
 from posthog.models.cohort.cohort import Cohort
-from posthog.models.feedback.survey import Survey
+from posthog.models.feedback.survey import Survey, MAX_ITERATION_COUNT
 from posthog.test.base import (
     APIBaseTest,
     BaseTest,
@@ -402,6 +402,34 @@ class TestSurvey(APIBaseTest):
                 [(res["key"], [survey["id"] for survey in res["surveys"]]) for res in result["results"]],
                 [("flag_0", []), (ff_key, [created_survey1, created_survey2])],
             )
+
+    def test_updating_survey_with_invalid_iteration_count_is_rejected(self):
+        survey_with_targeting = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={
+                "name": "survey with targeting",
+                "type": "popover",
+                "targeting_flag_filters": {
+                    "groups": [
+                        {
+                            "variant": None,
+                            "rollout_percentage": None,
+                        }
+                    ]
+                },
+                "iteration_count": MAX_ITERATION_COUNT + 1,
+                "conditions": {"url": "https://app.posthog.com/notebooks"},
+            },
+            format="json",
+        )
+
+        assert survey_with_targeting.status_code == status.HTTP_400_BAD_REQUEST
+        assert survey_with_targeting.json() == {
+            "type": "validation_error",
+            "code": "max_value",
+            "detail": "Ensure this value is less than or equal to 500.",
+            "attr": "iteration_count",
+        }
 
     def test_updating_survey_with_invalid_targeting_throws_appropriate_error(self):
         cohort_not_valid_for_ff = Cohort.objects.create(

--- a/posthog/models/feedback/survey.py
+++ b/posthog/models/feedback/survey.py
@@ -277,7 +277,9 @@ def update_survey_iterations(sender, instance, *args, **kwargs):
     instance.iteration_start_dates = list(
         rrule(
             DAILY,
-            count=iteration_count,
+            # we have seen users accidentally set a huge range here
+            # and cause performance issues, so we are extra careful with this value
+            count=max(iteration_count, 500),
             interval=iteration_frequency_dates,
             dtstart=instance.start_date,
         )

--- a/posthog/models/feedback/survey.py
+++ b/posthog/models/feedback/survey.py
@@ -12,6 +12,11 @@ from dateutil.rrule import rrule, DAILY
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
 
+# we have seen users accidentally set a huge value for iteration count
+# and cause performance issues, so we are extra careful with this value
+# NB this is enforced in the UI too
+MAX_ITERATION_COUNT = 500
+
 
 class Survey(UUIDModel):
     class SurveyType(models.TextChoices):
@@ -277,10 +282,7 @@ def update_survey_iterations(sender, instance, *args, **kwargs):
     instance.iteration_start_dates = list(
         rrule(
             DAILY,
-            # we have seen users accidentally set a huge range here
-            # and cause performance issues, so we are extra careful with this value
-            # NB this is enforced in the UI too
-            count=max(iteration_count, 500),
+            count=max(iteration_count, MAX_ITERATION_COUNT),
             interval=iteration_frequency_dates,
             dtstart=instance.start_date,
         )

--- a/posthog/models/feedback/survey.py
+++ b/posthog/models/feedback/survey.py
@@ -282,7 +282,7 @@ def update_survey_iterations(sender, instance, *args, **kwargs):
     instance.iteration_start_dates = list(
         rrule(
             DAILY,
-            count=max(iteration_count, MAX_ITERATION_COUNT),
+            count=min(iteration_count, MAX_ITERATION_COUNT),
             interval=iteration_frequency_dates,
             dtstart=instance.start_date,
         )

--- a/posthog/models/feedback/survey.py
+++ b/posthog/models/feedback/survey.py
@@ -279,6 +279,7 @@ def update_survey_iterations(sender, instance, *args, **kwargs):
             DAILY,
             # we have seen users accidentally set a huge range here
             # and cause performance issues, so we are extra careful with this value
+            # NB this is enforced in the UI too
             count=max(iteration_count, 500),
             interval=iteration_frequency_dates,
             dtstart=instance.start_date,


### PR DESCRIPTION
see: https://posthoghelp.zendesk.com/agent/tickets/22957 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/25517)

In this ticket the UI and API allowed the user to accidentally set the survey iteration count to a very large number
we then created a list of dates in postgres with that length
and the UI and ORM could no longer load suvey objects for that team

this adds validation to try and avoid this in future