### PR TITLE
feat(cdp): split executor in transformation & destination

### DIFF
--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -193,7 +193,7 @@ export class CdpApi {
                             response = await this.fetchExecutor!.executeLocally(invocation)
                         }
                     } else {
-                        response = this.hogExecutor.execute(invocation)
+                        response = this.hogExecutor.executeDestination(invocation)
                     }
 
                     logs = logs.concat(response.logs)

--- a/plugin-server/src/cdp/cdp-consumers.ts
+++ b/plugin-server/src/cdp/cdp-consumers.ts
@@ -480,7 +480,7 @@ export class CdpProcessedEventsConsumer extends CdpConsumerBase {
                 statsKey: `cdpConsumer.handleEachBatch.executeInvocations`,
                 func: async () => {
                     const hogResults = await this.runManyWithHeartbeat(kafkaInvocations, (item) =>
-                        this.hogExecutor.execute(item)
+                        this.hogExecutor.executeDestination(item)
                     )
                     return [...hogResults]
                 },
@@ -721,7 +721,9 @@ export class CdpFunctionCallbackConsumer extends CdpConsumerBase {
                 )
 
                 const hogQueue = invocations.filter((item) => item.queue === 'hog')
-                const hogResults = await this.runManyWithHeartbeat(hogQueue, (item) => this.hogExecutor.execute(item))
+                const hogResults = await this.runManyWithHeartbeat(hogQueue, (item) =>
+                    this.hogExecutor.executeDestination(item)
+                )
                 return [...hogResults, ...(fetchResults.filter(Boolean) as HogFunctionInvocationResult[])]
             },
         })
@@ -842,7 +844,9 @@ export class CdpCyclotronWorker extends CdpConsumerBase {
                 )
 
                 const hogQueue = invocations.filter((item) => item.queue === 'hog')
-                const hogResults = await this.runManyWithHeartbeat(hogQueue, (item) => this.hogExecutor.execute(item))
+                const hogResults = await this.runManyWithHeartbeat(hogQueue, (item) =>
+                    this.hogExecutor.executeDestination(item)
+                )
                 return [...hogResults, ...(fetchResults.filter(Boolean) as HogFunctionInvocationResult[])]
             },
         })

--- a/plugin-server/src/cdp/templates/test/test-helpers.ts
+++ b/plugin-server/src/cdp/templates/test/test-helpers.ts
@@ -129,7 +129,7 @@ export class TemplateTester {
 
         const globalsWithInputs = buildGlobalsWithInputs(globals, hogFunction.inputs)
         const invocation = createInvocation(globalsWithInputs, hogFunction)
-        return this.executor.execute(invocation)
+        return this.executor.executeTransformation(invocation)
     }
 
     invokeFetchResponse(invocation: HogFunctionInvocation, response: HogFunctionQueueParametersFetchResponse) {
@@ -139,6 +139,6 @@ export class TemplateTester {
             queueParameters: response,
         }
 
-        return this.executor.execute(modifiedInvocation)
+        return this.executor.executeTransformation(modifiedInvocation)
     }
 }


### PR DESCRIPTION
## Problem

- execution of transformations (only sync operations & execResult is important) is very different to execution of destinations (async operations and no execResult is needed as we send data elsewhere)
- splitting those two things gives us more control in every aspect (logging, testing, railguards)


<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- split execution logic into two separate functions

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- tests still run as expected

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
