### PR TITLE
feat(insights): use glyph to indicate colors feature

### DIFF
--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
@@ -1,5 +1,5 @@
 import { IconFlag } from '@posthog/icons'
-import clsx from 'clsx'
+import { LemonButton } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 import { LemonCheckbox } from 'lib/lemon-ui/LemonCheckbox'
@@ -7,7 +7,6 @@ import { LemonRow } from 'lib/lemon-ui/LemonRow'
 import { LemonTable, LemonTableColumn, LemonTableColumnGroup } from 'lib/lemon-ui/LemonTable'
 import { Lettermark, LettermarkColor } from 'lib/lemon-ui/Lettermark'
 import { humanFriendlyDuration, humanFriendlyNumber, percentage } from 'lib/utils'
-import { useState } from 'react'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { funnelPersonsModalLogic } from 'scenes/funnels/funnelPersonsModalLogic'
 import { getVisibilityKey } from 'scenes/funnels/funnelUtils'
@@ -21,7 +20,7 @@ import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { FlattenedFunnelStepByBreakdown } from '~/types'
 
 import { resultCustomizationsModalLogic } from '../../../../queries/nodes/InsightViz/resultCustomizationsModalLogic'
-import { CustomizationIcon } from '../InsightsTable/columns/SeriesColumn'
+import { CustomizationIcon } from '../InsightsTable/columns/ColorCustomizationColumn'
 import { getActionFilterFromFunnelStep, getSignificanceFromBreakdownStep } from './funnelStepTableUtils'
 
 export function FunnelStepsTable(): JSX.Element | null {
@@ -81,29 +80,28 @@ export function FunnelStepsTable(): JSX.Element | null {
                         _: void,
                         breakdown: FlattenedFunnelStepByBreakdown
                     ): JSX.Element {
-                        const [isHovering, setIsHovering] = useState(false)
                         // :KLUDGE: `BreakdownStepValues` is always wrapped into an array, which doesn't work for the
                         // formatBreakdownLabel logic. Instead, we unwrap speculatively
                         const value =
                             breakdown.breakdown_value?.length == 1
                                 ? breakdown.breakdown_value[0]
                                 : breakdown.breakdown_value
+
+                        const color = getFunnelsColor(breakdown)
+
                         const label = (
-                            <div
-                                className={clsx('flex justify-between items-center', {
-                                    'cursor-pointer': showCustomizationIcon,
-                                })}
-                                onClick={showCustomizationIcon ? () => openModal(breakdown) : undefined}
-                                onMouseEnter={() => setIsHovering(true)}
-                                onMouseLeave={() => setIsHovering(false)}
-                            >
+                            <div className="flex justify-between items-center">
                                 {formatBreakdownLabel(
                                     value,
                                     breakdownFilter,
                                     cohorts.results,
                                     formatPropertyValueForDisplay
                                 )}
-                                {showCustomizationIcon && <CustomizationIcon isVisible={isHovering} />}
+                                {showCustomizationIcon && (
+                                    <LemonButton onClick={() => openModal(breakdown)}>
+                                        <CustomizationIcon color={color} />
+                                    </LemonButton>
+                                )}
                             </div>
                         )
                         return isOnlySeries ? (

--- a/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx
@@ -11,6 +11,7 @@ import { IndexedTrendResult } from 'scenes/trends/types'
 
 import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { resultCustomizationsModalLogic } from '~/queries/nodes/InsightViz/resultCustomizationsModalLogic'
 import { isValidBreakdown } from '~/queries/utils'
 import { ChartDisplayType, ItemMode } from '~/types'
 
@@ -18,6 +19,7 @@ import { entityFilterLogic } from '../../filters/ActionFilter/entityFilterLogic'
 import { countryCodeToName } from '../WorldMap'
 import { AggregationColumnItem, AggregationColumnTitle } from './columns/AggregationColumn'
 import { BreakdownColumnItem, BreakdownColumnTitle, MultipleBreakdownColumnTitle } from './columns/BreakdownColumn'
+import { ColorCustomizationColumnItem, ColorCustomizationColumnTitle } from './columns/ColorCustomizationColumn'
 import { SeriesCheckColumnItem, SeriesCheckColumnTitle } from './columns/SeriesCheckColumn'
 import { SeriesColumnItem } from './columns/SeriesColumn'
 import { ValueColumnItem, ValueColumnTitle } from './columns/ValueColumn'
@@ -80,6 +82,7 @@ export function InsightsTable({
     const { toggleHiddenLegendIndex, updateHiddenLegendIndexes } = useActions(trendsDataLogic(insightProps))
     const { aggregation, allowAggregation } = useValues(insightsTableDataLogic(insightProps))
     const { setAggregationType } = useActions(insightsTableDataLogic(insightProps))
+    const { hasInsightColors } = useValues(resultCustomizationsModalLogic(insightProps))
 
     const handleSeriesEditClick = (item: IndexedTrendResult): void => {
         const entityFilter = entityFilterLogic.findMounted({
@@ -207,6 +210,14 @@ export function InsightsTable({
                     return compareFn()(labelA, labelB)
                 },
             })
+        })
+    }
+
+    if (hasInsightColors) {
+        columns.push({
+            title: <ColorCustomizationColumnTitle />,
+            render: (_, item) => <ColorCustomizationColumnItem item={item} />,
+            key: 'color',
         })
     }
 

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/BreakdownColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/BreakdownColumn.tsx
@@ -1,18 +1,11 @@
 import { Link } from '@posthog/lemon-ui'
-import clsx from 'clsx'
-import { useActions, useValues } from 'kea'
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { isURL } from 'lib/utils'
 import stringWithWBR from 'lib/utils/stringWithWBR'
-import { useState } from 'react'
-import { insightLogic } from 'scenes/insights/insightLogic'
 import { formatBreakdownType } from 'scenes/insights/utils'
 import { IndexedTrendResult } from 'scenes/trends/types'
 
 import { BreakdownFilter } from '~/queries/schema'
-
-import { resultCustomizationsModalLogic } from '../../../../../queries/nodes/InsightViz/resultCustomizationsModalLogic'
-import { CustomizationIcon } from './SeriesColumn'
 
 interface BreakdownColumnTitleProps {
     breakdownFilter: BreakdownFilter
@@ -36,21 +29,11 @@ type BreakdownColumnItemProps = {
 }
 
 export function BreakdownColumnItem({ item, formatItemBreakdownLabel }: BreakdownColumnItemProps): JSX.Element {
-    const [isHovering, setIsHovering] = useState(false)
-    const { insightProps } = useValues(insightLogic)
-    const { hasInsightColors } = useValues(resultCustomizationsModalLogic(insightProps))
-    const { openModal } = useActions(resultCustomizationsModalLogic(insightProps))
-
     const breakdownLabel = formatItemBreakdownLabel(item)
     const formattedLabel = stringWithWBR(breakdownLabel, 20)
 
     return (
-        <div
-            className={clsx('flex justify-between items-center', { 'cursor-pointer': hasInsightColors })}
-            onClick={hasInsightColors ? () => openModal(item) : undefined}
-            onMouseEnter={() => setIsHovering(true)}
-            onMouseLeave={() => setIsHovering(false)}
-        >
+        <div className="flex justify-between items-center">
             {breakdownLabel && (
                 <>
                     {isURL(breakdownLabel) ? (
@@ -62,8 +45,6 @@ export function BreakdownColumnItem({ item, formatItemBreakdownLabel }: Breakdow
                             {formattedLabel}
                         </div>
                     )}
-
-                    <CustomizationIcon isVisible={isHovering} />
                 </>
             )}
         </div>

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/ColorCustomizationColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/ColorCustomizationColumn.tsx
@@ -1,0 +1,46 @@
+import { LemonButton } from '@posthog/lemon-ui'
+import { useActions, useValues } from 'kea'
+import { ColorGlyph } from 'lib/components/SeriesGlyph'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
+import { IndexedTrendResult } from 'scenes/trends/types'
+
+import { resultCustomizationsModalLogic } from '~/queries/nodes/InsightViz/resultCustomizationsModalLogic'
+
+type CustomizationIconProps = {
+    color?: string
+}
+
+export const CustomizationIcon = ({ color }: CustomizationIconProps): JSX.Element | null => {
+    return (
+        <div className="w-4 h-4 flex">
+            <ColorGlyph color={color} className="w-4 h-4" />
+        </div>
+    )
+}
+
+export function ColorCustomizationColumnTitle(): JSX.Element {
+    return <>Color</>
+}
+
+export function ColorCustomizationColumnItem({ item }: { item: IndexedTrendResult }): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { getTrendsColor } = useValues(trendsDataLogic(insightProps))
+    const { openModal } = useActions(resultCustomizationsModalLogic(insightProps))
+
+    const color = getTrendsColor(item)
+
+    return (
+        <LemonButton
+            onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+
+                openModal(item)
+            }}
+            size="small"
+        >
+            <CustomizationIcon isVisible={true} color={color} />
+        </LemonButton>
+    )
+}

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/ColorCustomizationColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/ColorCustomizationColumn.tsx
@@ -40,7 +40,7 @@ export function ColorCustomizationColumnItem({ item }: { item: IndexedTrendResul
             }}
             size="small"
         >
-            <CustomizationIcon isVisible={true} color={color} />
+            <CustomizationIcon color={color} />
         </LemonButton>
     )
 }

--- a/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesColumn.tsx
+++ b/frontend/src/scenes/insights/views/InsightsTable/columns/SeriesColumn.tsx
@@ -1,31 +1,9 @@
-import { IconPencil } from '@posthog/icons'
 import clsx from 'clsx'
-import { useActions, useValues } from 'kea'
 import { InsightLabel } from 'lib/components/InsightLabel'
 import { capitalizeFirstLetter } from 'lib/utils'
-import { useState } from 'react'
-import { insightLogic } from 'scenes/insights/insightLogic'
 import { IndexedTrendResult } from 'scenes/trends/types'
 
 import { TrendResult } from '~/types'
-
-import { resultCustomizationsModalLogic } from '../../../../../queries/nodes/InsightViz/resultCustomizationsModalLogic'
-
-type CustomizationIconProps = {
-    isVisible: boolean
-}
-
-export const CustomizationIcon = ({ isVisible }: CustomizationIconProps): JSX.Element | null => {
-    const { insightProps } = useValues(insightLogic)
-    const { hasInsightColors } = useValues(resultCustomizationsModalLogic(insightProps))
-
-    if (!hasInsightColors) {
-        return null
-    }
-
-    // we always render a spacer so that hovering doesn't result in layout shifts
-    return <div className="w-4 h-4 flex">{isVisible && <IconPencil fontSize={14} />}</div>
-}
 
 type SeriesColumnItemProps = {
     item: IndexedTrendResult
@@ -44,30 +22,10 @@ export function SeriesColumnItem({
     hasMultipleSeries,
     hasBreakdown,
 }: SeriesColumnItemProps): JSX.Element {
-    const [isHovering, setIsHovering] = useState(false)
-    const { insightProps } = useValues(insightLogic)
-    const { hasInsightColors } = useValues(resultCustomizationsModalLogic(insightProps))
-    const { openModal } = useActions(resultCustomizationsModalLogic(insightProps))
-
     const showCountedByTag = !!indexedResults.find(({ action }) => action?.math && action.math !== 'total')
-    const showCustomizationIcon = hasInsightColors && !hasBreakdown
 
     return (
-        <div
-            className="series-name-wrapper-col space-x-1"
-            onClick={
-                showCustomizationIcon
-                    ? (e) => {
-                          e.preventDefault()
-                          e.stopPropagation()
-
-                          openModal(item)
-                      }
-                    : undefined
-            }
-            onMouseEnter={() => setIsHovering(true)}
-            onMouseLeave={() => setIsHovering(false)}
-        >
+        <div className="series-name-wrapper-col space-x-1">
             <InsightLabel
                 action={item.action}
                 fallbackName={item.breakdown_value === '' ? 'None' : item.label}
@@ -81,12 +39,8 @@ export function SeriesColumnItem({
                 })}
                 pillMaxWidth={165}
                 compareValue={item.compare ? formatCompareLabel(item) : undefined}
-                onLabelClick={
-                    canEditSeriesNameInline && !showCustomizationIcon ? () => handleEditClick(item) : undefined
-                }
+                onLabelClick={canEditSeriesNameInline ? () => handleEditClick(item) : undefined}
             />
-            {/* rendering and visibility are separated, so that we can render a placeholder */}
-            {showCustomizationIcon && <CustomizationIcon isVisible={isHovering} />}
         </div>
     )
 }


### PR DESCRIPTION
## Problem

Currently the insight colors feature is hidden behind a hoverable pencil icon.

## Changes

Replaces it with an always visible color glyph.

Implementation for trend insights:
<img width="460" alt="Screenshot 2025-01-16 at 18 33 50" src="https://github.com/user-attachments/assets/34b803f9-99a2-4155-bec7-3a1bc1edf1ca" />

Implementation for funnel insights:
<img width="475" alt="Screenshot 2025-01-16 at 18 33 59" src="https://github.com/user-attachments/assets/123d857f-530a-46bb-8e7f-01981ecb5991" />


## How did you test this code?

:eyes: