### PR TITLE
feat: render indvidual settings

### DIFF
--- a/frontend/src/scenes/settings/Settings.scss
+++ b/frontend/src/scenes/settings/Settings.scss
@@ -6,7 +6,6 @@
 
     .Settings__sections {
         position: sticky;
-        top: 4rem;
         flex-shrink: 0;
         width: 20%;
         min-width: 14rem;

--- a/frontend/src/scenes/settings/settingsLogic.ts
+++ b/frontend/src/scenes/settings/settingsLogic.ts
@@ -33,7 +33,7 @@ export const settingsLogic = kea<settingsLogicType>([
     actions({
         selectSection: (section: SettingSectionId, level: SettingLevelId) => ({ section, level }),
         selectLevel: (level: SettingLevelId) => ({ level }),
-        selectSetting: (setting: string) => ({ setting }),
+        selectSetting: (setting: SettingId) => ({ setting }),
         openCompactNavigation: true,
         closeCompactNavigation: true,
     }),
@@ -53,6 +53,12 @@ export const settingsLogic = kea<settingsLogicType>([
                 selectSection: (_, { section }) => section,
             },
         ],
+        selectedSettingRaw: [
+            (props.settingId ?? null) as SettingId | null,
+            {
+                selectSetting: (_, { setting }) => setting,
+            },
+        ],
 
         isCompactNavigationOpen: [
             false,
@@ -61,6 +67,7 @@ export const settingsLogic = kea<settingsLogicType>([
                 closeCompactNavigation: () => false,
                 selectLevel: () => false,
                 selectSection: () => false,
+                selectSetting: () => false,
             },
         ],
     })),
@@ -142,6 +149,12 @@ export const settingsLogic = kea<settingsLogicType>([
             (s) => [s.sections, s.selectedSectionId],
             (sections, selectedSectionId): SettingSection | null => {
                 return sections.find((x) => x.id === selectedSectionId) ?? null
+            },
+        ],
+        selectedSettingId: [
+            (s) => [s.settings, s.settingId],
+            (settings, settingId): Setting['id'] | null => {
+                return settings.find((s) => s.id === settingId)?.id ?? null
             },
         ],
         settings: [


### PR DESCRIPTION
## Problem

You cannot render the individual settings within a section in the settings sidebar. Would love to be able to reuse the Settings component elsewhere in the app (e.g. within error tracking) to display an individual sections settings.

## Changes

- Abstract rendering of sidebar via nested `options`
- When `sectionId` is specified, render the individual sections settings rather than the level / sections options

## How did you test this code?

Clicked around and everything seemed to work still
