### PR TITLE
feat(batch-exports): Add manifest file at end of S3 batch export run

### DIFF
--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -141,10 +141,14 @@ def get_allowed_template_variables(inputs) -> dict[str, str]:
     }
 
 
+def get_s3_key_prefix(inputs: S3InsertInputs) -> str:
+    template_variables = get_allowed_template_variables(inputs)
+    return inputs.prefix.format(**template_variables)
+
+
 def get_s3_key(inputs: S3InsertInputs, file_number: int = 0) -> str:
     """Return an S3 key given S3InsertInputs."""
-    template_variables = get_allowed_template_variables(inputs)
-    key_prefix = inputs.prefix.format(**template_variables)
+    key_prefix = get_s3_key_prefix(inputs)
 
     try:
         file_extension = FILE_FORMAT_EXTENSIONS[inputs.file_format]
@@ -167,6 +171,11 @@ def get_s3_key(inputs: S3InsertInputs, file_number: int = 0) -> str:
         key = posixpath.relpath(key, "/")
 
     return key
+
+
+def get_manifest_key(inputs: S3InsertInputs) -> str:
+    key_prefix = get_s3_key_prefix(inputs)
+    return posixpath.join(key_prefix, f"{inputs.data_interval_start}-{inputs.data_interval_end}_manifest.json")
 
 
 class InvalidS3Key(Exception):
@@ -538,7 +547,6 @@ class S3Consumer(Consumer):
         data_interval_start: dt.datetime | str | None,
         data_interval_end: dt.datetime | str,
         writer_format: WriterFormat,
-        s3_upload: S3MultiPartUpload,
         s3_inputs: S3InsertInputs,
     ):
         super().__init__(
@@ -549,9 +557,10 @@ class S3Consumer(Consumer):
             writer_format=writer_format,
         )
         self.heartbeat_details: S3HeartbeatDetails = heartbeat_details
-        self.s3_upload: S3MultiPartUpload | None = s3_upload
+        self.s3_upload: S3MultiPartUpload | None = None
         self.s3_inputs = s3_inputs
         self.file_number = 0
+        self.files_uploaded = []
 
     async def flush(
         self,
@@ -597,6 +606,7 @@ class S3Consumer(Consumer):
                 await s3_upload.complete()
 
         if is_last:
+            self.files_uploaded.append(s3_upload.key)
             self.s3_upload = None
             self.heartbeat_details.mark_file_upload_as_complete()
             self.file_number += 1
@@ -613,6 +623,14 @@ class S3Consumer(Consumer):
             )
             await self.s3_upload.complete()
             self.heartbeat_details.mark_file_upload_as_complete()
+            self.files_uploaded.append(self.s3_upload.key)
+
+        # If using max file size (and therefore potentially expecting more than one file) upload a manifest file
+        # containing the list of files.  This is used to check if the export is complete.
+        if self.s3_inputs.max_file_size_mb:
+            manifest_key = get_manifest_key(self.s3_inputs)
+            await self.logger.ainfo("Uploading manifest file %s", manifest_key)
+            await upload_manifest_file(self.s3_inputs, self.files_uploaded, manifest_key)
 
 
 async def initialize_and_resume_multipart_upload(
@@ -665,6 +683,22 @@ def initialize_upload(inputs: S3InsertInputs, file_number: int) -> S3MultiPartUp
         aws_secret_access_key=inputs.aws_secret_access_key,
         endpoint_url=inputs.endpoint_url or None,
     )
+
+
+async def upload_manifest_file(inputs: S3InsertInputs, files_uploaded: list[str], manifest_key: str):
+    session = aioboto3.Session()
+    async with session.client(
+        "s3",
+        region_name=inputs.region,
+        aws_access_key_id=inputs.aws_access_key_id,
+        aws_secret_access_key=inputs.aws_secret_access_key,
+        endpoint_url=inputs.endpoint_url,
+    ) as client:  # type: ignore
+        await client.put_object(
+            Bucket=inputs.bucket_name,
+            Key=manifest_key,
+            Body=json.dumps({"files": files_uploaded}),
+        )
 
 
 def s3_default_fields() -> list[BatchExportField]:
@@ -728,7 +762,6 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
         if not await client.is_alive():
             raise ConnectionError("Cannot establish connection to ClickHouse")
 
-        s3_upload = initialize_upload(inputs, 0)
         details = S3HeartbeatDetails()
         done_ranges: list[DateRange] = details.done_ranges
 
@@ -794,7 +827,6 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
             data_interval_end=data_interval_end,
             data_interval_start=data_interval_start,
             writer_format=WriterFormat.from_str(inputs.file_format, "S3"),
-            s3_upload=s3_upload,
             s3_inputs=inputs,
         )
         await run_consumer(

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -560,7 +560,7 @@ class S3Consumer(Consumer):
         self.s3_upload: S3MultiPartUpload | None = None
         self.s3_inputs = s3_inputs
         self.file_number = 0
-        self.files_uploaded = []
+        self.files_uploaded: list[str] = []
 
     async def flush(
         self,
@@ -687,13 +687,13 @@ def initialize_upload(inputs: S3InsertInputs, file_number: int) -> S3MultiPartUp
 
 async def upload_manifest_file(inputs: S3InsertInputs, files_uploaded: list[str], manifest_key: str):
     session = aioboto3.Session()
-    async with session.client(
+    async with session.client(  # type: ignore
         "s3",
         region_name=inputs.region,
         aws_access_key_id=inputs.aws_access_key_id,
         aws_secret_access_key=inputs.aws_secret_access_key,
         endpoint_url=inputs.endpoint_url,
-    ) as client:  # type: ignore
+    ) as client:
         await client.put_object(
             Bucket=inputs.bucket_name,
             Key=manifest_key,

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -687,7 +687,7 @@ def initialize_upload(inputs: S3InsertInputs, file_number: int) -> S3MultiPartUp
 
 async def upload_manifest_file(inputs: S3InsertInputs, files_uploaded: list[str], manifest_key: str):
     session = aioboto3.Session()
-    async with session.client(  # type: ignore
+    async with session.client(
         "s3",
         region_name=inputs.region,
         aws_access_key_id=inputs.aws_access_key_id,


### PR DESCRIPTION
## Problem

When using the `max_file_size_mb` parameter for S3 batch exports, it is currently not possible to know when all files have been uploaded to S3. This could be a problem if the batch export fails halfway through and needs to be retried.

Closes #27557

## Changes

We upload a manifest file for S3 batch exports that could potentially result in more than one file being uploaded. The way we determine when to upload a manifest file is based on whether the `max_file_size_mb` config is set or not. If it is not set then we can assume there is only ever going to be one file and therefore do not need a manifest file.

The filename convention of the manifest file will be `{interval_start}-{interval_end}_manifest.json`, for example `2025-01-07T00:00:00+00:00-2025-01-08T00:00:00+00:00_manifest.json`.

Note that the manifest key includes an underscore before the `manifest.json`, whereas data files contain a `-`, for example `2025-01-07T00:00:00+00:00-2025-01-08T00:00:00+00:00-0.jsonl`. This means data files and manifest files can be filtered based on a prefix.

The manifest file is a JSON file that contains a list of files uploaded:
```
{
    "files": [
         key_1,
         key_2,
         ...
    ]
}
```

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Updated existing S3 batch export tests to check for the presence of a manifest file
