### PR TITLE
fix: make nps trendline a bar chart instead of line chart

### DIFF
--- a/frontend/src/scenes/surveys/SurveyView.tsx
+++ b/frontend/src/scenes/surveys/SurveyView.tsx
@@ -630,6 +630,7 @@ function SurveyNPSResults({ survey }: { survey: Survey }): JSX.Element {
                         ],
                         trendsFilter: {
                             formula: '(A / (A+B+C) * 100) - (C / (A+B+C) * 100)',
+                            display: 'ActionsBar',
                         },
                     },
                 }}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

make NPS trend chart a bar instead of line

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes https://github.com/PostHog/posthog/issues/27324

## Changes

| Before | After |
|--------|--------|
| ![CleanShot 2025-01-16 at 19 52 31@2x](https://github.com/user-attachments/assets/68b11167-9d41-4384-bc0c-193c05c72fab) | ![CleanShot 2025-01-16 at 19 51 46@2x](https://github.com/user-attachments/assets/d2bdcae1-231a-441a-bf80-60becd09b092) | 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
