### PR TITLE
refactor: Couple touches for Core Web Vitals

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -14,11 +14,11 @@ import {
     TaxonomicFilterGroup,
     TaxonomicFilterGroupType,
 } from 'lib/components/TaxonomicFilter/types'
-import { STALE_EVENT_SECONDS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { pluralize } from 'lib/utils'
+import { isDefinitionStale } from 'lib/utils/definitions'
 import { useState } from 'react'
 import { AutoSizer } from 'react-virtualized/dist/es/AutoSizer'
 import { List, ListRowProps, ListRowRenderer } from 'react-virtualized/dist/es/List'
@@ -86,9 +86,7 @@ const renderItemContents = ({
 }): JSX.Element | string => {
     const parsedLastSeen = (item as EventDefinition).last_seen_at ? dayjs((item as EventDefinition).last_seen_at) : null
     const isStale =
-        listGroupType === TaxonomicFilterGroupType.Events &&
-        'id' in item &&
-        (!parsedLastSeen || dayjs().diff(parsedLastSeen, 'seconds') > STALE_EVENT_SECONDS)
+        listGroupType === TaxonomicFilterGroupType.Events && 'id' in item && !isDefinitionStale(item as EventDefinition)
 
     const isUnusedEventProperty =
         (listGroupType === TaxonomicFilterGroupType.NumericalEventProperties ||

--- a/frontend/src/lib/utils/definitions.ts
+++ b/frontend/src/lib/utils/definitions.ts
@@ -1,0 +1,9 @@
+import { STALE_EVENT_SECONDS } from 'lib/constants'
+import { dayjs } from 'lib/dayjs'
+
+import { EventDefinition, PropertyDefinition } from '~/types'
+
+export const isDefinitionStale = (definition?: EventDefinition | PropertyDefinition): boolean => {
+    const parsedLastSeen = definition?.last_seen_at ? dayjs(definition.last_seen_at) : null
+    return !!parsedLastSeen && dayjs().diff(parsedLastSeen, 'seconds') > STALE_EVENT_SECONDS
+}

--- a/frontend/src/queries/nodes/CoreWebVitals/CoreWebVitals.tsx
+++ b/frontend/src/queries/nodes/CoreWebVitals/CoreWebVitals.tsx
@@ -17,20 +17,26 @@ export function CoreWebVitals(props: {
     cachedResults?: AnyResponseType
     context: QueryContext
 }): JSX.Element | null {
+    const { onData, loadPriority, dataNodeCollectionId } = props.context.insightProps ?? {}
     const [key] = useState(() => `CoreWebVitals.${uniqueNode++}`)
+
     const logic = dataNodeLogic({
         query: props.query,
         key,
         cachedResults: props.cachedResults,
-        loadPriority: 0,
-        onData: () => {},
-        dataNodeCollectionId: key,
+        loadPriority,
+        onData,
+        dataNodeCollectionId: dataNodeCollectionId ?? key,
     })
 
     const { coreWebVitalsPercentile, coreWebVitalsTab, coreWebVitalsMetricQuery } = useValues(webAnalyticsLogic)
     const { setCoreWebVitalsTab } = useActions(webAnalyticsLogic)
-    const { response } = useValues(logic)
-    const coreWebVitalsQueryResponse = response as CoreWebVitalsQueryResponse | undefined
+    const { response, responseLoading } = useValues(logic)
+
+    // Manually handle loading state when loading to avoid showing stale data while refreshing
+    const coreWebVitalsQueryResponse = responseLoading
+        ? undefined
+        : (response as CoreWebVitalsQueryResponse | undefined)
 
     const INP = useMemo(
         () => getMetric(coreWebVitalsQueryResponse?.results, 'INP', coreWebVitalsPercentile),

--- a/frontend/src/queries/nodes/CoreWebVitals/CoreWebVitalsProgressBar.tsx
+++ b/frontend/src/queries/nodes/CoreWebVitals/CoreWebVitalsProgressBar.tsx
@@ -4,12 +4,12 @@ import { CoreWebVitalsThreshold } from 'scenes/web-analytics/webAnalyticsLogic'
 import { getMetricBand, getThresholdColor } from './definitions'
 
 interface CoreWebVitalsProgressBarProps {
-    value: number
+    value?: number
     threshold: CoreWebVitalsThreshold
 }
 
 export function CoreWebVitalsProgressBar({ value, threshold }: CoreWebVitalsProgressBarProps): JSX.Element {
-    const indicatorPercentage = Math.min((value / threshold.end) * 100, 100)
+    const indicatorPercentage = Math.min((value ?? 0 / threshold.end) * 100, 100)
 
     const thresholdColor = getThresholdColor(value, threshold)
     const band = getMetricBand(value, threshold)
@@ -42,14 +42,16 @@ export function CoreWebVitalsProgressBar({ value, threshold }: CoreWebVitalsProg
             />
 
             {/* Indicator line */}
-            <div
-                className={clsx('absolute w-0.5 h-3 -top-1', `bg-${thresholdColor}`)}
-                // eslint-disable-next-line react/forbid-dom-props
-                style={{
-                    left: `${indicatorPercentage}%`,
-                    transform: 'translateX(-50%)',
-                }}
-            />
+            {value != null && (
+                <div
+                    className={clsx('absolute w-0.5 h-3 -top-1', `bg-${thresholdColor}`)}
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{
+                        left: `${indicatorPercentage}%`,
+                        transform: 'translateX(-50%)',
+                    }}
+                />
+            )}
         </div>
     )
 }

--- a/frontend/src/queries/nodes/CoreWebVitals/CoreWebVitalsTab.tsx
+++ b/frontend/src/queries/nodes/CoreWebVitals/CoreWebVitalsTab.tsx
@@ -44,13 +44,13 @@ export function CoreWebVitalsTab({
 
             <div className="flex flex-row items-end">
                 <span className={clsx('text-2xl', `text-${thresholdColor}`)}>
-                    {parsedValue || <LemonSkeleton fade className="w-4 h-4" />}
+                    {parsedValue || <LemonSkeleton fade className="w-20 h-8" />}
                 </span>
                 {inSeconds && <span className="text-xs ml-1 mb-1">{unit}</span>}
             </div>
 
             <div className="w-full mt-2 hidden sm:block">
-                {value != null && <CoreWebVitalsProgressBar value={value} threshold={threshold} />}
+                <CoreWebVitalsProgressBar value={value} threshold={threshold} />
             </div>
         </div>
     )

--- a/frontend/src/queries/nodes/CoreWebVitals/CoreWebVitalsTab.tsx
+++ b/frontend/src/queries/nodes/CoreWebVitals/CoreWebVitalsTab.tsx
@@ -26,14 +26,10 @@ export function CoreWebVitalsTab({
     setTab,
     inSeconds = false,
 }: CoreWebVitalsTabProps): JSX.Element {
-    // TODO: Go back to using an actual value
-    // Will keep this as is while we test what the UI looks like
-    // const {value: parsedValue, unit } = getValueWithUnit(value, inSeconds)
-    const newValue = true ? (inSeconds ? Math.random() * 10000 : Math.random()) : value
-    const { value: parsedValue, unit } = getValueWithUnit(newValue, inSeconds)
+    const { value: parsedValue, unit } = getValueWithUnit(value, inSeconds)
 
     const threshold = CORE_WEB_VITALS_THRESHOLDS[metric]
-    const thresholdColor = getThresholdColor(newValue, threshold)
+    const thresholdColor = getThresholdColor(value, threshold)
 
     return (
         <div
@@ -54,7 +50,7 @@ export function CoreWebVitalsTab({
             </div>
 
             <div className="w-full mt-2 hidden sm:block">
-                {newValue && <CoreWebVitalsProgressBar value={newValue} threshold={threshold} />}
+                {value != null && <CoreWebVitalsProgressBar value={value} threshold={threshold} />}
             </div>
         </div>
     )

--- a/frontend/src/queries/nodes/CoreWebVitals/definitions.ts
+++ b/frontend/src/queries/nodes/CoreWebVitals/definitions.ts
@@ -75,7 +75,11 @@ export const getMetric = (
         ?.data.slice(-1)[0]
 }
 
-export const getMetricBand = (value: number, threshold: CoreWebVitalsThreshold): MetricBand => {
+export const getMetricBand = (value: number | undefined, threshold: CoreWebVitalsThreshold): MetricBand | 'none' => {
+    if (value === undefined) {
+        return 'none'
+    }
+
     if (value <= threshold.good) {
         return 'good'
     }

--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -46,7 +46,7 @@ export function WebOverview(props: {
 
     const samplingRate = webOverviewQueryResponse?.samplingRate
 
-    const numSkeletons = props.query.conversionGoal ? 4 : 6
+    const numSkeletons = props.query.conversionGoal ? 4 : 5
 
     return (
         <>

--- a/frontend/src/scenes/llm-observability/llmObservabilityLogic.tsx
+++ b/frontend/src/scenes/llm-observability/llmObservabilityLogic.tsx
@@ -3,8 +3,7 @@ import { loaders } from 'kea-loaders'
 import { urlToAction } from 'kea-router'
 import api from 'lib/api'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { STALE_EVENT_SECONDS } from 'lib/constants'
-import { dayjs } from 'lib/dayjs'
+import { isDefinitionStale } from 'lib/utils/definitions'
 import { LLMObservabilityTab, urls } from 'scenes/urls'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -13,7 +12,6 @@ import {
     AnyPropertyFilter,
     BaseMathType,
     ChartDisplayType,
-    EventDefinition,
     EventDefinitionType,
     HogQLMathType,
     PropertyMathType,
@@ -33,11 +31,6 @@ export interface QueryTile {
     layout?: {
         className?: string
     }
-}
-
-const isDefinitionStale = (definition: EventDefinition): boolean => {
-    const parsedLastSeen = definition.last_seen_at ? dayjs(definition.last_seen_at) : null
-    return !!parsedLastSeen && dayjs().diff(parsedLastSeen, 'seconds') > STALE_EVENT_SECONDS
 }
 
 export const llmObservabilityLogic = kea<llmObservabilityLogicType>([

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -1,4 +1,5 @@
 import { IconExpand45, IconInfo, IconOpenSidebar, IconX } from '@posthog/icons'
+import { Tooltip } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
@@ -75,7 +76,14 @@ const Filters = (): JSX.Element => {
                         onChange={setCoreWebVitalsPercentile}
                         options={[
                             { value: PropertyMathType.P75, label: 'P75' },
-                            { value: PropertyMathType.P90, label: 'P90' },
+                            {
+                                value: PropertyMathType.P90,
+                                label: (
+                                    <Tooltip title="P90 is recommended by the standard as a good baseline" delayMs={0}>
+                                        P90
+                                    </Tooltip>
+                                ),
+                            },
                             { value: PropertyMathType.P99, label: 'P99' },
                         ]}
                     />

--- a/frontend/src/scenes/web-analytics/WebDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebDashboard.tsx
@@ -367,7 +367,9 @@ export const WebAnalyticsDashboard = (): JSX.Element => {
                 <VersionCheckerBanner />
                 <div className="WebAnalyticsDashboard w-full flex flex-col">
                     <div className="flex flex-col sm:flex-row gap-2 justify-between items-center sm:items-start w-full border-b pb-2 mb-2 sm:mb-0">
-                        <WebAnalyticsLiveUserCount />
+                        <div>
+                            <WebAnalyticsLiveUserCount />
+                        </div>
 
                         {featureFlags[FEATURE_FLAGS.CORE_WEB_VITALS] && (
                             <LemonSegmentedSelect

--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsTile.tsx
@@ -370,15 +370,13 @@ export const webAnalyticsDataTableQueryContext: QueryContext = {
     },
 }
 
+type QueryWithInsightProps<Q extends QuerySchema> = { query: Q; insightProps: InsightLogicProps }
+
 export const WebStatsTrendTile = ({
     query,
     showIntervalTile,
     insightProps,
-}: {
-    query: InsightVizNode
-    showIntervalTile?: boolean
-    insightProps: InsightLogicProps
-}): JSX.Element => {
+}: QueryWithInsightProps<InsightVizNode> & { showIntervalTile?: boolean }): JSX.Element => {
     const { togglePropertyFilter, setInterval } = useActions(webAnalyticsLogic)
     const {
         hasCountryFilter,
@@ -449,10 +447,8 @@ export const WebStatsTableTile = ({
     breakdownBy,
     insightProps,
     control,
-}: {
-    query: DataTableNode
+}: QueryWithInsightProps<DataTableNode> & {
     breakdownBy: WebStatsBreakdown
-    insightProps: InsightLogicProps
     control?: JSX.Element
 }): JSX.Element => {
     const { togglePropertyFilter } = useActions(webAnalyticsLogic)
@@ -550,13 +546,7 @@ const getBreakdownValue = (record: unknown, breakdownBy: WebStatsBreakdown): str
     return breakdownValue
 }
 
-export const WebGoalsTile = ({
-    query,
-    insightProps,
-}: {
-    query: DataTableNode
-    insightProps: InsightLogicProps
-}): JSX.Element | null => {
+export const WebGoalsTile = ({ query, insightProps }: QueryWithInsightProps<DataTableNode>): JSX.Element | null => {
     const { actions, actionsLoading } = useValues(actionsModel)
     const { updateHasSeenProductIntroFor } = useActions(userLogic)
 
@@ -595,10 +585,7 @@ export const WebGoalsTile = ({
 export const WebExternalClicksTile = ({
     query,
     insightProps,
-}: {
-    query: DataTableNode
-    insightProps: InsightLogicProps
-}): JSX.Element | null => {
+}: QueryWithInsightProps<DataTableNode>): JSX.Element | null => {
     const { shouldStripQueryParams } = useValues(webAnalyticsLogic)
     const { setShouldStripQueryParams } = useActions(webAnalyticsLogic)
     return (
@@ -618,8 +605,11 @@ export const WebExternalClicksTile = ({
     )
 }
 
-export const CoreWebVitalsQueryTile = ({ query }: { query: CoreWebVitalsQuery }): JSX.Element => {
-    return <Query query={query} readOnly context={{}} />
+export const CoreWebVitalsQueryTile = ({
+    query,
+    insightProps,
+}: QueryWithInsightProps<CoreWebVitalsQuery>): JSX.Element => {
+    return <Query query={query} readOnly context={{ ...webAnalyticsDataTableQueryContext, insightProps }} />
 }
 
 export const WebQuery = ({
@@ -627,11 +617,9 @@ export const WebQuery = ({
     showIntervalSelect,
     control,
     insightProps,
-}: {
-    query: QuerySchema
+}: QueryWithInsightProps<QuerySchema> & {
     showIntervalSelect?: boolean
     control?: JSX.Element
-    insightProps: InsightLogicProps
 }): JSX.Element => {
     if (query.kind === NodeKind.DataTableNode && query.source.kind === NodeKind.WebStatsTableQuery) {
         return (
@@ -657,7 +645,7 @@ export const WebQuery = ({
     }
 
     if (query.kind === NodeKind.CoreWebVitalsQuery) {
-        return <CoreWebVitalsQueryTile query={query} />
+        return <CoreWebVitalsQueryTile query={query} insightProps={insightProps} />
     }
 
     return <Query query={query} readOnly={true} context={{ ...webAnalyticsDataTableQueryContext, insightProps }} />

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -4,14 +4,14 @@ import { loaders } from 'kea-loaders'
 import { actionToUrl, urlToAction } from 'kea-router'
 import { windowValues } from 'kea-window-values'
 import api from 'lib/api'
-import { FEATURE_FLAGS, RETENTION_FIRST_TIME, STALE_EVENT_SECONDS } from 'lib/constants'
-import { dayjs } from 'lib/dayjs'
+import { FEATURE_FLAGS, RETENTION_FIRST_TIME } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
 import { Link, PostHogComDocsURL } from 'lib/lemon-ui/Link/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getDefaultInterval, isNotNil, objectsEqual, updateDatesWithInterval } from 'lib/utils'
+import { isDefinitionStale } from 'lib/utils/definitions'
 import { errorTrackingQuery } from 'scenes/error-tracking/queries'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -41,7 +41,6 @@ import {
     BaseMathType,
     Breadcrumb,
     ChartDisplayType,
-    EventDefinition,
     EventDefinitionType,
     FilterLogicalOperator,
     InsightLogicProps,
@@ -49,7 +48,6 @@ import {
     IntervalType,
     PluginConfigTypeNew,
     PluginType,
-    PropertyDefinition,
     PropertyFilterType,
     PropertyMathType,
     PropertyOperator,
@@ -2106,11 +2104,6 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
         })
     }),
 ])
-
-const isDefinitionStale = (definition: EventDefinition | PropertyDefinition): boolean => {
-    const parsedLastSeen = definition.last_seen_at ? dayjs(definition.last_seen_at) : null
-    return !!parsedLastSeen && dayjs().diff(parsedLastSeen, 'seconds') > STALE_EVENT_SECONDS
-}
 
 const checkCustomEventConversionGoalHasSessionIdsHelper = async (
     conversionGoal: WebAnalyticsConversionGoal | null,

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -783,7 +783,11 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                     properties: webAnalyticsFilters,
                                 },
                             },
-                            insightProps: {},
+                            insightProps: {
+                                dashboardItemId: getDashboardItemId(TileId.WEB_VITALS, 'web-vitals-overview', false),
+                                loadPriority: 0,
+                                dataNodeCollectionId: WEB_ANALYTICS_DATA_COLLECTION_NODE_ID,
+                            },
                             canOpenInsight: false,
                             canOpenModal: false,
                             showIntervalSelect: true,


### PR DESCRIPTION
These are a bunch of small fixes to the Core Web Vitals view

- Remove dummy random numbers
- Align core web vitals select to the right at all times
- Note that P90 is the preferred value
- Render a taller skeleton while loading
- Display only 6 skeletons for Web Analytics (forgot to do this when removing LCP view)
- Update data when reloading/changing filters
- Extract definition staleness check to separate shared utils file