### PR TITLE
fix(insights): fix public data color is_global method serializer

### DIFF
--- a/posthog/api/data_color_theme.py
+++ b/posthog/api/data_color_theme.py
@@ -21,14 +21,18 @@ class GlobalThemePermission(BasePermission):
 
 
 class PublicDataColorThemeSerializer(serializers.ModelSerializer):
+    is_global = serializers.SerializerMethodField()
+
     class Meta:
         model = DataColorTheme
         fields = ["id", "name", "colors", "is_global"]
         read_only_fields = ["id", "name", "colors", "is_global"]
 
+    def get_is_global(self, obj):
+        return obj.team_id is None
+
 
 class DataColorThemeSerializer(PublicDataColorThemeSerializer):
-    is_global = serializers.SerializerMethodField()
     created_by = UserBasicSerializer(read_only=True)
 
     class Meta:
@@ -45,9 +49,6 @@ class DataColorThemeSerializer(PublicDataColorThemeSerializer):
         validated_data["team_id"] = self.context["team_id"]
         validated_data["created_by"] = self.context["request"].user
         return super().create(validated_data, *args, **kwargs)
-
-    def get_is_global(self, obj):
-        return obj.team_id is None
 
 
 class DataColorThemeViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
## Problem

https://posthog.sentry.io/issues/6192670387/

This happens when the data color themes are fetched with a sharing token i.e. on a shared insight/dashboard.

## Changes

Moves the serializer method to the public class.

## How did you test this code?

Tried locally