### PR TITLE
fix(lifecycle): fix legacy trends endpoint for lifecycle queries

### DIFF
--- a/posthog/api/insight.py
+++ b/posthog/api/insight.py
@@ -1064,8 +1064,10 @@ When set, the specified dashboard's filters and date range override will be appl
 
         # we use the legacy caching mechanism (@cached_by_filters decorator), no need to cache in the query runner
         result = query_runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
-        assert isinstance(result, schema.CachedTrendsQueryResponse) or isinstance(
-            result, schema.CachedStickinessQueryResponse
+        assert (
+            isinstance(result, schema.CachedTrendsQueryResponse)
+            or isinstance(result, schema.CachedStickinessQueryResponse)
+            or isinstance(result, schema.CachedLifecycleQueryResponse)
         )
 
         return {"result": result.results, "timezone": team.timezone}


### PR DESCRIPTION
## Problem

Looks like someone is using the legacy trends api with a lifecycle filter, but an assertion for the result type fails: https://posthog.sentry.io/issues/6218099648/.

## Changes

Adapts an assertion to allow lifecycle queries.

## How did you test this code?

Called the API endpoint http://localhost:8000/api/projects/1/insights/trend with payload

```json
{
  "insight": "LIFECYCLE",
  "events": [
    {
      "id": "$pageview",
      "math": "total",
      "type": "events",
      "order": 0
    }
  ],
  "date_from": "-4w",
  "interval": "month"
}
```