### PR TITLE
fix: avoid feature flag collisions

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -20,6 +20,7 @@ const ExperimentFormFields = (): JSX.Element => {
         useActions(experimentLogic)
     const { webExperimentsAvailable } = useValues(experimentsLogic)
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
+    const { takenKeys } = useValues(experimentsLogic)
 
     return (
         <div>
@@ -45,7 +46,9 @@ const ExperimentFormFields = (): JSX.Element => {
                                             : 'Fill out the experiment name first.'
                                     }
                                     onClick={() => {
-                                        setExperiment({ feature_flag_key: dynamicFeatureFlagKey })
+                                        setExperiment({
+                                            feature_flag_key: generateFeatureFlagKey(experiment.name, takenKeys),
+                                        })
                                     }}
                                 >
                                     <IconMagicWand className="mr-1" /> Generate
@@ -289,4 +292,20 @@ export function ExperimentForm(): JSX.Element {
             </Form>
         </div>
     )
+}
+
+const generateFeatureFlagKey = (name: string, takenKeys: string[]): string => {
+    const baseKey = name
+        .toLowerCase()
+        .replace(/[^A-Za-z0-9-_]+/g, '-')
+        .replace(/-+$/, '')
+        .replace(/^-+/, '')
+
+    let key = baseKey
+    let counter = 1
+    while (takenKeys.includes(key)) {
+        key = `${baseKey}-${counter}`
+        counter++
+    }
+    return key
 }

--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -15,7 +15,7 @@ import { experimentsLogic } from 'scenes/experiments/experimentsLogic'
 import { experimentLogic } from './experimentLogic'
 
 const ExperimentFormFields = (): JSX.Element => {
-    const { experiment, groupTypes, aggregationLabel, dynamicFeatureFlagKey } = useValues(experimentLogic)
+    const { experiment, groupTypes, aggregationLabel } = useValues(experimentLogic)
     const { addExperimentGroup, removeExperimentGroup, setExperiment, createExperiment, setExperimentType } =
         useActions(experimentLogic)
     const { webExperimentsAvailable } = useValues(experimentsLogic)
@@ -41,8 +41,8 @@ const ExperimentFormFields = (): JSX.Element => {
                                     type="secondary"
                                     size="xsmall"
                                     tooltip={
-                                        dynamicFeatureFlagKey
-                                            ? "Use '" + dynamicFeatureFlagKey + "' as the feature flag key."
+                                        experiment.name
+                                            ? 'Generate a key from the experiment name'
                                             : 'Fill out the experiment name first.'
                                     }
                                     onClick={() => {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1158,16 +1158,6 @@ export const experimentLogic = kea<experimentLogicType>([
     })),
     selectors({
         props: [() => [(_, props) => props], (props) => props],
-        dynamicFeatureFlagKey: [
-            (s) => [s.experiment],
-            (experiment: Experiment): string => {
-                return experiment.name
-                    .toLowerCase()
-                    .replace(/[^A-Za-z0-9-_]+/g, '-')
-                    .replace(/-+$/, '')
-                    .replace(/^-+/, '')
-            },
-        ],
         experimentId: [
             () => [(_, props) => props.experimentId ?? 'new'],
             (experimentId): Experiment['id'] => experimentId,

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -161,6 +161,10 @@ export const experimentsLogic = kea<experimentsLogicType>([
             () => [featureFlagLogic.selectors.featureFlags],
             (featureFlags: FeatureFlagsSet) => featureFlags[FEATURE_FLAGS.WEB_EXPERIMENTS],
         ],
+        takenKeys: [
+            (s) => [s.experiments],
+            (experiments: Experiment[]) => experiments.map((experiment) => experiment.feature_flag_key),
+        ],
     })),
     events(({ actions }) => ({
         afterMount: () => {

--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -161,6 +161,7 @@ export const experimentsLogic = kea<experimentsLogicType>([
             () => [featureFlagLogic.selectors.featureFlags],
             (featureFlags: FeatureFlagsSet) => featureFlags[FEATURE_FLAGS.WEB_EXPERIMENTS],
         ],
+        // This only checks the first page, which is very large so it's not a big deal
         takenKeys: [
             (s) => [s.experiments],
             (experiments: Experiment[]) => experiments.map((experiment) => experiment.feature_flag_key),


### PR DESCRIPTION
## Problem

We currently generate flag keys that a user has already used. This avoids collisions when generating flag keys based off of the name.

## Changes

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Generated a few flags
