### PR TITLE
fix: product intent registration

### DIFF
--- a/frontend/src/scenes/onboarding/OnboardingProductIntroduction.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingProductIntroduction.tsx
@@ -65,7 +65,7 @@ const GetStartedButton = ({ product }: { product: BillingProductV2Type }): JSX.E
                             setTeamPropertiesForProduct(product.type as ProductKey)
                             addProductIntent({
                                 product_type: product.type as ProductKey,
-                                intent_context: 'onboarding product selected',
+                                intent_context: 'onboarding product selected - primary',
                             })
                             goToNextStep()
                         }}
@@ -85,7 +85,7 @@ const GetStartedButton = ({ product }: { product: BillingProductV2Type }): JSX.E
                             setTeamPropertiesForProduct(product.type as ProductKey)
                             addProductIntent({
                                 product_type: product.type as ProductKey,
-                                intent_context: 'onboarding product selected',
+                                intent_context: 'onboarding product selected - secondary',
                             })
                             completeOnboarding()
                         }}
@@ -100,7 +100,7 @@ const GetStartedButton = ({ product }: { product: BillingProductV2Type }): JSX.E
                                 setTeamPropertiesForProduct(product.type as ProductKey)
                                 addProductIntent({
                                     product_type: product.type as ProductKey,
-                                    intent_context: 'onboarding product selected',
+                                    intent_context: 'onboarding product selected - secondary',
                                 })
                                 goToNextStep()
                             }}


### PR DESCRIPTION
## Problem

We were still logging some generic product intents, now split into primary & secondary.

## Changes

self explanatory

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

didn't (local event ingestion is currently broken for me) - looks harmless
