### PR TITLE
fix: select none for product cards in onboarding

### DIFF
--- a/frontend/src/scenes/products/Products.tsx
+++ b/frontend/src/scenes/products/Products.tsx
@@ -68,7 +68,7 @@ export function SelectableProductCard({
                     </div>
                 </Tooltip>
             )}
-            <div className="grid grid-rows-[repeat(2,_48px)] justify-items-center">
+            <div className="grid grid-rows-[repeat(2,_48px)] justify-items-center select-none">
                 <div className="self-center">{getProductIcon(product.iconColor, product.icon, 'text-2xl')}</div>
                 <div className="font-bold text-center self-start text-md">{product.name}</div>
             </div>


### PR DESCRIPTION
## Problem

Was a bit awkward to select product cards due to text being selectable.

## Changes

Add select none 🛑

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

locally
