### PR TITLE
chore(experiments): capture metric timeout events

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -25,7 +25,7 @@ import { filtersFromUniversalFilterGroups } from 'scenes/session-recordings/util
 import { NewSurvey, SurveyTemplateType } from 'scenes/surveys/constants'
 import { userLogic } from 'scenes/userLogic'
 
-import { Node } from '~/queries/schema'
+import { ExperimentFunnelsQuery, ExperimentTrendsQuery, Node } from '~/queries/schema'
 import {
     getBreakdown,
     getCompareFilter,
@@ -504,6 +504,13 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportExperimentDashboardCreated: (experiment: Experiment, dashboardId: number) => ({
             experiment,
             dashboardId,
+        }),
+        reportExperimentMetricTimeout: (
+            experimentId: ExperimentIdType,
+            metric: ExperimentTrendsQuery | ExperimentFunnelsQuery
+        ) => ({
+            experimentId,
+            metric,
         }),
         // Definition Popover
         reportDataManagementDefinitionHovered: (type: TaxonomicFilterGroupType) => ({ type }),
@@ -1128,6 +1135,9 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 experiment_id: experiment.id,
                 dashboard_id: dashboardId,
             })
+        },
+        reportExperimentMetricTimeout: ({ experimentId, metric }) => {
+            posthog.capture('experiment metric timeout', { experiment_id: experimentId, metric })
         },
         reportPropertyGroupFilterAdded: () => {
             posthog.capture('property group filter added')

--- a/frontend/src/queries/query.ts
+++ b/frontend/src/queries/query.ts
@@ -29,6 +29,7 @@ import {
 
 const QUERY_ASYNC_MAX_INTERVAL_SECONDS = 3
 const QUERY_ASYNC_TOTAL_POLL_SECONDS = 10 * 60 + 6 // keep in sync with backend-side timeout (currently 10min) + a small buffer
+export const QUERY_TIMEOUT_ERROR_MESSAGE = 'Query timed out'
 
 //get export context for a given query
 export function queryExportContext<N extends DataNode>(
@@ -76,7 +77,7 @@ export async function pollForResults(
             throw e
         }
     }
-    throw new Error('Query timed out')
+    throw new Error(QUERY_TIMEOUT_ERROR_MESSAGE)
 }
 
 let socket: null | QueryWebSocketManager = null


### PR DESCRIPTION
## Changes
Capture `experiment metric timeout` event when an experiment metric result times out. This will give us a better idea about how often it happens and for what queries, so that we can take some action.

Note: I'm aware of the duplication of the main metric/secondary metric loader, will refactor this in a follow up.

## How did you test this code?
👀 