### PR TITLE
chore(experiments): add Exposure column tooltip

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
@@ -1,5 +1,5 @@
 import { IconInfo, IconRewindPlay } from '@posthog/icons'
-import { LemonButton, LemonTable, LemonTableColumns, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonTable, LemonTableColumns, LemonTag, Tooltip } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import { router } from 'kea-router'
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
@@ -90,7 +90,22 @@ export function SummaryTable({
         })
         columns.push({
             key: 'exposure',
-            title: 'Exposure',
+            title: (
+                <div className="inline-flex items-center space-x-1">
+                    <div className="">Exposure</div>
+                    <Tooltip
+                        title={
+                            <div>
+                                The number of people who were exposed to this variant. By default, this is measured by
+                                the count of <LemonTag type="option">$feature_flag_called</LemonTag> events per unique
+                                user. Check your metric settings to confirm how this is measured.
+                            </div>
+                        }
+                    >
+                        <IconInfo className="text-muted-alt text-base" />
+                    </Tooltip>
+                </div>
+            ),
             render: function Key(_, variant): JSX.Element {
                 const exposure = exposureCountDataForVariant(result, variant.key)
                 if (!exposure) {

--- a/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
@@ -96,7 +96,7 @@ export function SummaryTable({
                     <Tooltip
                         title={
                             <div>
-                                The number of people who were exposed to this variant. By default, this is measured by
+                                The number of users who were exposed to this variant. By default, this is measured by
                                 the count of <LemonTag type="option">$feature_flag_called</LemonTag> events per unique
                                 user. Check your metric settings to confirm how this is measured.
                             </div>


### PR DESCRIPTION
## Changes
Prompted by: https://posthog.slack.com/archives/C07PXH2GTGV/p1737106452316419

![image](https://github.com/user-attachments/assets/4eabecd7-4d1b-4d18-8b53-4b65857dda1e)

## How did you test this code?
👀 