### PR TITLE
feat: cleanup assignee picker

### DIFF
--- a/frontend/src/scenes/error-tracking/AssigneeSelect.tsx
+++ b/frontend/src/scenes/error-tracking/AssigneeSelect.tsx
@@ -1,10 +1,11 @@
-import { IconPerson } from '@posthog/icons'
+import { IconPerson, IconPlusSmall } from '@posthog/icons'
 import { LemonButton, LemonButtonProps, LemonDropdown, LemonInput, Lettermark, ProfilePicture } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { fullName } from 'lib/utils'
 import { useEffect, useMemo, useState } from 'react'
 import { membersLogic } from 'scenes/organization/membersLogic'
 import { userGroupsLogic } from 'scenes/settings/environment/userGroupsLogic'
+import { urls } from 'scenes/urls'
 
 import { OrganizationMemberType, UserGroup } from '~/types'
 
@@ -61,7 +62,7 @@ export const AssigneeSelect = ({
         }
 
         return unassignedUser
-    }, [assignee, meFirstMembers, userGroupsLoading])
+    }, [assignee, meFirstMembers, userGroups])
 
     return (
         <LemonDropdown
@@ -80,21 +81,33 @@ export const AssigneeSelect = ({
                         onChange={setSearch}
                         fullWidth
                     />
-                    <ul className="space-y-px">
+                    <ul className="space-y-2">
                         <Section
-                            loading={membersLoading}
-                            search={!!search}
-                            type="user"
-                            items={filteredMembers.map(userDisplay)}
-                            onSelect={_onChange}
-                            activeId={assignee?.id}
-                        />
-
-                        <Section
+                            title="Groups"
                             loading={userGroupsLoading}
                             search={!!search}
                             type="user_group"
                             items={userGroups.map(groupDisplay)}
+                            onSelect={_onChange}
+                            activeId={assignee?.id}
+                            emptyState={
+                                <LemonButton
+                                    fullWidth
+                                    size="small"
+                                    icon={<IconPlusSmall />}
+                                    to={urls.settings('environment-error-tracking', 'user-groups')}
+                                >
+                                    <div className="text-muted-alt">Create user group</div>
+                                </LemonButton>
+                            }
+                        />
+
+                        <Section
+                            title="Users"
+                            loading={membersLoading}
+                            search={!!search}
+                            type="user"
+                            items={filteredMembers.map(userDisplay)}
                             onSelect={_onChange}
                             activeId={assignee?.id}
                         />
@@ -120,18 +133,22 @@ const Section = ({
     items,
     onSelect,
     activeId,
+    emptyState,
+    title,
 }: {
+    title: string
     loading: boolean
     search: boolean
     type: ErrorTrackingIssueAssignee['type']
     items: AssigneeDisplayType[]
     onSelect: (value: ErrorTrackingIssue['assignee']) => void
     activeId?: string | number
+    emptyState?: JSX.Element
 }): JSX.Element => {
     return (
         <li>
             <section className="space-y-px">
-                <h5 className="mx-2 my-1">{type}s</h5>
+                <h5 className="mx-2 my-0.5">{title}</h5>
                 {items.map((item) => (
                     <li key={item.id}>
                         <LemonButton
@@ -152,9 +169,7 @@ const Section = ({
                 {loading ? (
                     <div className="p-2 text-muted-alt italic truncate border-t">Loading...</div>
                 ) : items.length === 0 ? (
-                    <div className="p-2 text-muted-alt italic truncate border-t">
-                        {search ? <span>No matches</span> : <span>No {type}s</span>}
-                    </div>
+                    <div className="border-t pt-1">{search ? <span>No matches</span> : emptyState}</div>
                 ) : null}
             </section>
         </li>

--- a/frontend/src/scenes/error-tracking/assigneeSelectLogic.tsx
+++ b/frontend/src/scenes/error-tracking/assigneeSelectLogic.tsx
@@ -10,14 +10,9 @@ import { OrganizationMemberType, UserGroup } from '~/types'
 
 import type { assigneeSelectLogicType } from './assigneeSelectLogicType'
 
-type AssigneeDisplayType = { id: string | number; icon: JSX.Element; displayName?: string }
+export type AssigneeDisplayType = { id: string | number; icon: JSX.Element; displayName?: string }
 
-const unassignedUser = {
-    id: 'unassigned',
-    icon: <IconPerson className="rounded-full border border-dashed border-muted text-muted p-0.5" />,
-}
-
-type SidePanelDocsLogicProps = {
+export type ErrorTrackingAssigneeSelectProps = {
     assignee: ErrorTrackingIssue['assignee']
 }
 
@@ -33,9 +28,14 @@ const userDisplay = (member: OrganizationMemberType): AssigneeDisplayType => ({
     icon: <ProfilePicture size="md" user={member.user} />,
 })
 
+const unassignedUser = {
+    id: 'unassigned',
+    icon: <IconPerson className="rounded-full border border-dashed border-muted text-muted p-0.5" />,
+}
+
 export const assigneeSelectLogic = kea<assigneeSelectLogicType>([
     path(['scenes', 'error-tracking', 'assigneeSelectLogic']),
-    props({} as SidePanelDocsLogicProps),
+    props({} as ErrorTrackingAssigneeSelectProps),
 
     connect(() => ({
         values: [

--- a/frontend/src/scenes/error-tracking/assigneeSelectLogic.tsx
+++ b/frontend/src/scenes/error-tracking/assigneeSelectLogic.tsx
@@ -1,0 +1,101 @@
+import { IconPerson } from '@posthog/icons'
+import { Lettermark, ProfilePicture } from '@posthog/lemon-ui'
+import { actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
+import { fullName } from 'lib/utils'
+import { membersLogic } from 'scenes/organization/membersLogic'
+import { userGroupsLogic } from 'scenes/settings/environment/userGroupsLogic'
+
+import { ErrorTrackingIssue } from '~/queries/schema'
+import { OrganizationMemberType, UserGroup } from '~/types'
+
+import type { assigneeSelectLogicType } from './assigneeSelectLogicType'
+
+type AssigneeDisplayType = { id: string | number; icon: JSX.Element; displayName?: string }
+
+const unassignedUser = {
+    id: 'unassigned',
+    icon: <IconPerson className="rounded-full border border-dashed border-muted text-muted p-0.5" />,
+}
+
+type SidePanelDocsLogicProps = {
+    assignee: ErrorTrackingIssue['assignee']
+}
+
+const groupDisplay = (group: UserGroup, index: number): AssigneeDisplayType => ({
+    id: group.id,
+    displayName: group.name,
+    icon: <Lettermark name={group.name} index={index} rounded />,
+})
+
+const userDisplay = (member: OrganizationMemberType): AssigneeDisplayType => ({
+    id: member.user.id,
+    displayName: fullName(member.user),
+    icon: <ProfilePicture size="md" user={member.user} />,
+})
+
+export const assigneeSelectLogic = kea<assigneeSelectLogicType>([
+    path(['scenes', 'error-tracking', 'assigneeSelectLogic']),
+    props({} as SidePanelDocsLogicProps),
+
+    connect(() => ({
+        values: [
+            membersLogic,
+            ['meFirstMembers', 'filteredMembers', 'membersLoading'],
+            userGroupsLogic,
+            ['userGroups', 'filteredGroups', 'userGroupsLoading'],
+        ],
+        actions: [
+            membersLogic,
+            ['setSearch as setMembersSearch', 'ensureAllMembersLoaded'],
+            userGroupsLogic,
+            ['setSearch as setGroupsSearch', 'ensureAllGroupsLoaded'],
+        ],
+    })),
+
+    actions({
+        ensureAssigneeTypesLoaded: true,
+        setSearch: (search) => ({ search }),
+    }),
+
+    reducers({
+        search: ['', { setSearch: (_, { search }) => search }],
+    }),
+
+    listeners(({ values, actions }) => ({
+        setSearch: () => {
+            actions.setGroupsSearch(values.search)
+            actions.setMembersSearch(values.search)
+        },
+        ensureAssigneeTypesLoaded: () => {
+            actions.ensureAllGroupsLoaded()
+            actions.ensureAllMembersLoaded()
+        },
+    })),
+
+    selectors({
+        loading: [
+            (s) => [s.membersLoading, s.userGroupsLoading],
+            (membersLoading, userGroupsLoading): boolean => membersLoading || userGroupsLoading,
+        ],
+
+        groupOptions: [(s) => [s.filteredGroups], (groups): AssigneeDisplayType[] => groups.map(groupDisplay)],
+        memberOptions: [(s) => [s.filteredMembers], (members): AssigneeDisplayType[] => members.map(userDisplay)],
+
+        displayAssignee: [
+            (s, p) => [s.userGroups, s.meFirstMembers, p.assignee],
+            (groups, members, assignee): AssigneeDisplayType => {
+                if (assignee) {
+                    if (assignee.type === 'user_group') {
+                        const assignedGroup = groups.find((group) => group.id === assignee.id)
+                        return assignedGroup ? groupDisplay(assignedGroup, 0) : unassignedUser
+                    }
+
+                    const assignedMember = members.find((member) => member.user.id === assignee.id)
+                    return assignedMember ? userDisplay(assignedMember) : unassignedUser
+                }
+
+                return unassignedUser
+            },
+        ],
+    }),
+])


### PR DESCRIPTION
## Problem

The assignee selector isn't great in production:
- Groups are below users, which isn't obvious when the list is super long
- Search of groups doesn't work

## Changes

- Implement shared search
- Move groups above users
- Add "Create group" button to encourage usage

![better-picker](https://github.com/user-attachments/assets/a6c01ab3-0623-486c-8baa-dea6c7428a19)
