### PR TITLE
fix: remove empty session_id values from aggregated count

### DIFF
--- a/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
+++ b/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
@@ -1,6 +1,6 @@
 import { TZLabel } from '@posthog/apps-common'
 import { IconGear } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonDivider, LemonSegmentedButton } from '@posthog/lemon-ui'
+import { LemonButton, LemonCheckbox, LemonDivider, LemonSegmentedButton, Tooltip } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
 import { FeedbackNotice } from 'lib/components/FeedbackNotice'
@@ -44,7 +44,7 @@ export function ErrorTrackingScene(): JSX.Element {
                 render: CustomGroupTitleColumn,
             },
             occurrences: { align: 'center', render: CountColumn },
-            sessions: { align: 'center', render: CountColumn },
+            sessions: { align: 'center', render: SessionCountColumn },
             users: { align: 'center', render: CountColumn },
             volume: { renderTitle: CustomVolumeColumnHeader },
             assignee: { render: AssigneeColumn },
@@ -158,6 +158,17 @@ const CustomGroupTitleColumn: QueryContextColumnComponent = (props) => {
                 }}
             />
         </div>
+    )
+}
+
+const SessionCountColumn: QueryContextColumnComponent = ({ children, ...props }) => {
+    const count = props.value as number
+    return count === 0 ? (
+        <Tooltip title="No $session_id was set for any event in this issue" delayMs={0}>
+            -
+        </Tooltip>
+    ) : (
+        <CountColumn {...props} />
     )
 }
 

--- a/frontend/src/scenes/error-tracking/issue/panels/MetaPanel.tsx
+++ b/frontend/src/scenes/error-tracking/issue/panels/MetaPanel.tsx
@@ -1,11 +1,26 @@
 import { TZLabel } from '@posthog/apps-common'
-import { LemonSkeleton } from '@posthog/lemon-ui'
+import { IconInfo } from '@posthog/icons'
+import { LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import { humanFriendlyLargeNumber } from 'lib/utils'
 import { errorTrackingIssueSceneLogic } from 'scenes/error-tracking/errorTrackingIssueSceneLogic'
 
 export const MetaPanel = (): JSX.Element => {
     const { issue } = useValues(errorTrackingIssueSceneLogic)
+
+    const hasSessionCount = issue && issue.sessions != 0
+
+    const Sessions = (
+        <div className="flex flex-col flex-1">
+            <div className="flex text-muted text-xs space-x-px">
+                <span>Sessions</span>
+                {!hasSessionCount && <IconInfo className="mt-0.5" />}
+            </div>
+            <div className="text-2xl font-semibold">
+                {issue ? (hasSessionCount ? humanFriendlyLargeNumber(issue.sessions) : '-') : null}
+            </div>
+        </div>
+    )
 
     return (
         <div className="space-y-4 p-2">
@@ -20,20 +35,21 @@ export const MetaPanel = (): JSX.Element => {
                     {issue ? <TZLabel time={issue.last_seen} className="border-dotted border-b" /> : <LemonSkeleton />}
                 </div>
             </div>
-            <div className="flex space-x-2 justify-between mr-6">
-                <div>
+            <div className="flex space-x-2 justify-between gap-8">
+                <div className="flex flex-col flex-1">
                     <div className="text-muted text-xs">Occurrences</div>
                     <div className="text-2xl font-semibold">
                         {issue?.occurrences ? humanFriendlyLargeNumber(issue.occurrences) : null}
                     </div>
                 </div>
-                <div>
-                    <div className="text-muted text-xs">Sessions</div>
-                    <div className="text-2xl font-semibold">
-                        {issue?.sessions ? humanFriendlyLargeNumber(issue.sessions) : null}
-                    </div>
-                </div>
-                <div>
+                {hasSessionCount ? (
+                    Sessions
+                ) : (
+                    <Tooltip title="No $session_id was set for any event in this issue" delayMs={0}>
+                        {Sessions}
+                    </Tooltip>
+                )}
+                <div className="flex flex-col flex-1">
                     <div className="text-muted text-xs">Users</div>
                     <div className="text-2xl font-semibold">
                         {issue?.users ? humanFriendlyLargeNumber(issue.users) : null}

--- a/posthog/hogql_queries/error_tracking_query_runner.py
+++ b/posthog/hogql_queries/error_tracking_query_runner.py
@@ -48,7 +48,19 @@ class ErrorTrackingQueryRunner(QueryRunner):
                 alias="occurrences", expr=ast.Call(name="count", distinct=True, args=[ast.Field(chain=["uuid"])])
             ),
             ast.Alias(
-                alias="sessions", expr=ast.Call(name="count", distinct=True, args=[ast.Field(chain=["$session_id"])])
+                alias="sessions",
+                expr=ast.Call(
+                    name="count",
+                    distinct=True,
+                    # the $session_id property can be blank if not set
+                    # we do not want that case counted so cast it to `null` which is excluded by default
+                    args=[
+                        ast.Call(
+                            name="nullIf",
+                            args=[ast.Field(chain=["$session_id"]), ast.Constant(value="")],
+                        )
+                    ],
+                ),
             ),
             ast.Alias(
                 alias="users", expr=ast.Call(name="count", distinct=True, args=[ast.Field(chain=["distinct_id"])])

--- a/posthog/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/posthog/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -2,7 +2,7 @@
 # name: TestErrorTrackingQueryRunner.test_column_names
   '''
   SELECT count(DISTINCT events.uuid) AS occurrences,
-         count(DISTINCT events.`$session_id`) AS sessions,
+         count(DISTINCT nullIf(events.`$session_id`, '')) AS sessions,
          count(DISTINCT events.distinct_id) AS users,
          max(toTimeZone(events.timestamp, 'UTC')) AS last_seen,
          min(toTimeZone(events.timestamp, 'UTC')) AS first_seen,
@@ -30,7 +30,36 @@
 # name: TestErrorTrackingQueryRunner.test_column_names.1
   '''
   SELECT count(DISTINCT events.uuid) AS occurrences,
-         count(DISTINCT events.`$session_id`) AS sessions,
+         count(DISTINCT nullIf(events.`$session_id`, '')) AS sessions,
+         count(DISTINCT events.distinct_id) AS users,
+         max(toTimeZone(events.timestamp, 'UTC')) AS last_seen,
+         min(toTimeZone(events.timestamp, 'UTC')) AS first_seen,
+         if(not(empty(events__exception_issue_override.issue_id)), events__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID')) AS id,
+         argMin(events.properties, toTimeZone(events.timestamp, 'UTC')) AS earliest
+  FROM events
+  LEFT OUTER JOIN
+    (SELECT argMax(error_tracking_issue_fingerprint_overrides.issue_id, error_tracking_issue_fingerprint_overrides.version) AS issue_id,
+            error_tracking_issue_fingerprint_overrides.fingerprint AS fingerprint
+     FROM error_tracking_issue_fingerprint_overrides
+     WHERE equals(error_tracking_issue_fingerprint_overrides.team_id, 99999)
+     GROUP BY error_tracking_issue_fingerprint_overrides.fingerprint
+     HAVING ifNull(equals(argMax(error_tracking_issue_fingerprint_overrides.is_deleted, error_tracking_issue_fingerprint_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__exception_issue_override ON equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', ''), events__exception_issue_override.fingerprint)
+  WHERE and(equals(events.team_id, 99999), equals(events.event, '$exception'), isNotNull(if(not(empty(events__exception_issue_override.issue_id)), events__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID'))), 1, ifNull(equals(if(not(empty(events__exception_issue_override.issue_id)), events__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID')), '01936e7f-d7ff-7314-b2d4-7627981e34f0'), 0))
+  GROUP BY if(not(empty(events__exception_issue_override.issue_id)), events__exception_issue_override.issue_id, accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$exception_issue_id'), ''), 'null'), '^"|"$', ''), 'UUID'))
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_correctly_counts_session_ids
+  '''
+  SELECT count(DISTINCT events.uuid) AS occurrences,
+         count(DISTINCT nullIf(events.`$session_id`, '')) AS sessions,
          count(DISTINCT events.distinct_id) AS users,
          max(toTimeZone(events.timestamp, 'UTC')) AS last_seen,
          min(toTimeZone(events.timestamp, 'UTC')) AS first_seen,
@@ -59,7 +88,7 @@
 # name: TestErrorTrackingQueryRunner.test_hogql_filters
   '''
   SELECT count(DISTINCT events.uuid) AS occurrences,
-         count(DISTINCT events.`$session_id`) AS sessions,
+         count(DISTINCT nullIf(events.`$session_id`, '')) AS sessions,
          count(DISTINCT events.distinct_id) AS users,
          max(toTimeZone(events.timestamp, 'UTC')) AS last_seen,
          min(toTimeZone(events.timestamp, 'UTC')) AS first_seen,
@@ -104,7 +133,7 @@
 # name: TestErrorTrackingQueryRunner.test_issue_grouping
   '''
   SELECT count(DISTINCT events.uuid) AS occurrences,
-         count(DISTINCT events.`$session_id`) AS sessions,
+         count(DISTINCT nullIf(events.`$session_id`, '')) AS sessions,
          count(DISTINCT events.distinct_id) AS users,
          max(toTimeZone(events.timestamp, 'UTC')) AS last_seen,
          min(toTimeZone(events.timestamp, 'UTC')) AS first_seen,
@@ -133,7 +162,7 @@
 # name: TestErrorTrackingQueryRunner.test_ordering
   '''
   SELECT count(DISTINCT events.uuid) AS occurrences,
-         count(DISTINCT events.`$session_id`) AS sessions,
+         count(DISTINCT nullIf(events.`$session_id`, '')) AS sessions,
          count(DISTINCT events.distinct_id) AS users,
          max(toTimeZone(events.timestamp, 'UTC')) AS last_seen,
          min(toTimeZone(events.timestamp, 'UTC')) AS first_seen,
@@ -162,7 +191,7 @@
 # name: TestErrorTrackingQueryRunner.test_ordering.1
   '''
   SELECT count(DISTINCT events.uuid) AS occurrences,
-         count(DISTINCT events.`$session_id`) AS sessions,
+         count(DISTINCT nullIf(events.`$session_id`, '')) AS sessions,
          count(DISTINCT events.distinct_id) AS users,
          max(toTimeZone(events.timestamp, 'UTC')) AS last_seen,
          min(toTimeZone(events.timestamp, 'UTC')) AS first_seen,
@@ -191,7 +220,7 @@
 # name: TestErrorTrackingQueryRunner.test_search_query
   '''
   SELECT count(DISTINCT events.uuid) AS occurrences,
-         count(DISTINCT events.`$session_id`) AS sessions,
+         count(DISTINCT nullIf(events.`$session_id`, '')) AS sessions,
          count(DISTINCT events.distinct_id) AS users,
          max(toTimeZone(events.timestamp, 'UTC')) AS last_seen,
          min(toTimeZone(events.timestamp, 'UTC')) AS first_seen,
@@ -236,7 +265,7 @@
 # name: TestErrorTrackingQueryRunner.test_search_query_with_multiple_search_items
   '''
   SELECT count(DISTINCT events.uuid) AS occurrences,
-         count(DISTINCT events.`$session_id`) AS sessions,
+         count(DISTINCT nullIf(events.`$session_id`, '')) AS sessions,
          count(DISTINCT events.distinct_id) AS users,
          max(toTimeZone(events.timestamp, 'UTC')) AS last_seen,
          min(toTimeZone(events.timestamp, 'UTC')) AS first_seen,
@@ -281,7 +310,7 @@
 # name: TestErrorTrackingQueryRunner.test_user_assignee
   '''
   SELECT count(DISTINCT events.uuid) AS occurrences,
-         count(DISTINCT events.`$session_id`) AS sessions,
+         count(DISTINCT nullIf(events.`$session_id`, '')) AS sessions,
          count(DISTINCT events.distinct_id) AS users,
          max(toTimeZone(events.timestamp, 'UTC')) AS last_seen,
          min(toTimeZone(events.timestamp, 'UTC')) AS first_seen,
@@ -309,7 +338,7 @@
 # name: TestErrorTrackingQueryRunner.test_user_group_assignee
   '''
   SELECT count(DISTINCT events.uuid) AS occurrences,
-         count(DISTINCT events.`$session_id`) AS sessions,
+         count(DISTINCT nullIf(events.`$session_id`, '')) AS sessions,
          count(DISTINCT events.distinct_id) AS users,
          max(toTimeZone(events.timestamp, 'UTC')) AS last_seen,
          min(toTimeZone(events.timestamp, 'UTC')) AS first_seen,


### PR DESCRIPTION
## Problem

We see a ton of issues with large occurrence / user counts but the session count is 1 🤔 

<img width="266" alt="Screenshot 2025-01-17 at 15 42 44" src="https://github.com/user-attachments/assets/75413c26-3128-4059-988d-15f2f091b502" />

We thought this was because `NULL` was being counted as a distinct value but [CH docs](https://clickhouse.com/docs/en/sql-reference/aggregate-functions/reference/count) confirm that NULL values are excluded from the count. Upon investigation it seems like the `$session_id` can sometimes be a blank string, which is a distinct value we want to exclude

## Changes

- Exclude empty string `$session_id` by casting them to NULL
- Handle things nicely on the frontend with tooltips to explain what is going on

![sessions](https://github.com/user-attachments/assets/e779b71a-8c76-49ee-910a-876e20334eb8)
