### PR TITLE
fix: token retrieval for sdk in debug

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -48,9 +48,13 @@ class PostHogConfig(AppConfig):
                     {"git_rev": get_git_commit_short(), "git_branch": get_git_branch()},
                 )
 
-            local_api_key = get_self_capture_api_token(
-                User.objects.filter(last_login__isnull=False).order_by("-last_login").first()
-            )
+            try:
+                user = User.objects.filter(last_login__isnull=False).order_by("-last_login").first()
+            except:
+                user = None
+
+            local_api_key = get_self_capture_api_token(user)
+
             if SELF_CAPTURE and local_api_key:
                 posthoganalytics.api_key = local_api_key
                 posthoganalytics.host = settings.SITE_URL


### PR DESCRIPTION
## Problem

When the User model doesn't exist, Django will fail to initialize—more context: https://posthog.slack.com/archives/C06NZEZ7V3Q/p1737205157108649.

## Changes

Catch an exception and skip the SDK initialization.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

N/A
