### PR TITLE
fix(cohort): Fix creating static cohort from SQL

### DIFF
--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -266,7 +266,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                                 Edit SQL directly
                                             </LemonButton>
                                         )}
-                                    {showCohortButton && (
+                                    {hogQL && showCohortButton && (
                                         <LemonButton
                                             data-attr="edit-insight-sql"
                                             onClick={() => {

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -242,9 +242,11 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                             label="Debug panel"
                                         />
                                     ) : null}
-                                    {hogQL && (
-                                        <>
-                                            <LemonDivider />
+
+                                    {(hogQL || showCohortButton) && <LemonDivider />}
+                                    {hogQL &&
+                                        !isHogQLQuery(query) &&
+                                        !(isDataVisualizationNode(query) && isHogQLQuery(query.source)) && (
                                             <LemonButton
                                                 data-attr="edit-insight-sql"
                                                 onClick={() => {
@@ -263,50 +265,47 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                             >
                                                 Edit SQL directly
                                             </LemonButton>
-                                            {showCohortButton && (
-                                                <LemonButton
-                                                    data-attr="edit-insight-sql"
-                                                    onClick={() => {
-                                                        LemonDialog.openForm({
-                                                            title: 'Save as static cohort',
-                                                            description: (
-                                                                <div className="mt-2">
-                                                                    Your query must export a <code>person_id</code>,{' '}
-                                                                    <code>actor_id</code> or <code>id</code> column,
-                                                                    which must match the <code>id</code> of the{' '}
-                                                                    <code>persons</code> table
-                                                                </div>
-                                                            ),
-                                                            initialValues: {
-                                                                name: '',
-                                                            },
-                                                            content: (
-                                                                <LemonField name="name">
-                                                                    <LemonInput
-                                                                        data-attr="insight-name"
-                                                                        placeholder="Name of the new cohort"
-                                                                        autoFocus
-                                                                    />
-                                                                </LemonField>
-                                                            ),
-                                                            errors: {
-                                                                name: (name) =>
-                                                                    !name ? 'You must enter a name' : undefined,
-                                                            },
-                                                            onSubmit: async ({ name }) => {
-                                                                createStaticCohort(name, {
-                                                                    kind: NodeKind.HogQLQuery,
-                                                                    query: hogQL,
-                                                                })
-                                                            },
+                                        )}
+                                    {showCohortButton && (
+                                        <LemonButton
+                                            data-attr="edit-insight-sql"
+                                            onClick={() => {
+                                                LemonDialog.openForm({
+                                                    title: 'Save as static cohort',
+                                                    description: (
+                                                        <div className="mt-2">
+                                                            Your query must export a <code>person_id</code>,{' '}
+                                                            <code>actor_id</code> or <code>id</code> column, which must
+                                                            match the <code>id</code> of the <code>persons</code> table
+                                                        </div>
+                                                    ),
+                                                    initialValues: {
+                                                        name: '',
+                                                    },
+                                                    content: (
+                                                        <LemonField name="name">
+                                                            <LemonInput
+                                                                data-attr="insight-name"
+                                                                placeholder="Name of the new cohort"
+                                                                autoFocus
+                                                            />
+                                                        </LemonField>
+                                                    ),
+                                                    errors: {
+                                                        name: (name) => (!name ? 'You must enter a name' : undefined),
+                                                    },
+                                                    onSubmit: async ({ name }) => {
+                                                        createStaticCohort(name, {
+                                                            kind: NodeKind.HogQLQuery,
+                                                            query: hogQL,
                                                         })
-                                                    }}
-                                                    fullWidth
-                                                >
-                                                    Save as static cohort
-                                                </LemonButton>
-                                            )}
-                                        </>
+                                                    },
+                                                })
+                                            }}
+                                            fullWidth
+                                        >
+                                            Save as static cohort
+                                        </LemonButton>
                                     )}
                                     {hasDashboardItemId && (
                                         <>

--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -13,7 +13,7 @@ import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { getDefaultQuery, queryFromKind } from '~/queries/nodes/InsightViz/utils'
 import { queryExportContext } from '~/queries/query'
 import { DataVisualizationNode, InsightVizNode, Node, NodeKind } from '~/queries/schema/schema-general'
-import { isDataTableNode, isDataVisualizationNode, isHogQuery, isInsightVizNode } from '~/queries/utils'
+import { isDataTableNode, isDataVisualizationNode, isHogQLQuery, isHogQuery, isInsightVizNode } from '~/queries/utils'
 import { ExportContext, InsightLogicProps, InsightType } from '~/types'
 
 import { teamLogic } from '../teamLogic'
@@ -171,8 +171,16 @@ export const insightDataLogic = kea<insightDataLogicType>([
         ],
 
         hogQL: [
-            (s) => [s.insightData],
-            (insightData): string | null => {
+            (s) => [s.insightData, s.query],
+            (insightData, query): string | null => {
+                // Try to get it from the query itself, so we don't have to wait for the response
+                if (isDataVisualizationNode(query) && isHogQLQuery(query.source)) {
+                    return query.source.query
+                }
+                if (isHogQLQuery(query)) {
+                    return query.query
+                }
+                // Otherwise, get it from the response
                 if (insightData && 'hogql' in insightData && insightData.hogql !== '') {
                     return insightData.hogql
                 }


### PR DESCRIPTION
## Problem

Creating a static cohort from Hogql sometimes fails because it takes the SQL of the output and not the node, which sometimes adds properties_custom_group which ends up not being valid hogql (tbd why).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

take the hogql from the node instead of the response. This is nicer anyway b/c it means you can always save a query as cohort even if you haven't saved it yet
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
