### PR TITLE
perf(batch-exports): Skip backfill runs without data

### DIFF
--- a/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
+++ b/ee/clickhouse/views/test/funnel/__snapshots__/test_clickhouse_funnel_person.ambr
@@ -56,6 +56,7 @@
                               e."$group_0" as aggregation_target,
                               if(notEmpty(pdi.distinct_id), pdi.person_id, e.person_id) as person_id,
                               person.person_props as person_props,
+                              person.pmat_email as pmat_email,
                               if(event = 'step one', 1, 0) as step_0,
                               if(step_0 = 1, timestamp, null) as latest_0,
                               if(event = 'step two', 1, 0) as step_1,
@@ -79,6 +80,7 @@
                           HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
                        INNER JOIN
                          (SELECT id,
+                                 argMax(pmat_email, version) as pmat_email,
                                  argMax(properties, version) as person_props
                           FROM person
                           WHERE team_id = 99999
@@ -95,7 +97,7 @@
                          AND event IN ['step one', 'step three', 'step two']
                          AND toTimeZone(timestamp, 'UTC') >= toDateTime('2021-05-01 00:00:00', 'UTC')
                          AND toTimeZone(timestamp, 'UTC') <= toDateTime('2021-05-10 23:59:59', 'UTC')
-                         AND ((replaceRegexpAll(JSONExtractRaw(person_props, 'email'), '^"|"$', '') ILIKE '%g0%'
+                         AND (("pmat_email" ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(person_props, 'name'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(e.properties, 'distinct_id'), '^"|"$', '') ILIKE '%g0%'
                                OR replaceRegexpAll(JSONExtractRaw(group_properties_0, 'name'), '^"|"$', '') ILIKE '%g0%'

--- a/posthog/api/test/batch_exports/test_backfill.py
+++ b/posthog/api/test/batch_exports/test_backfill.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from unittest.mock import ANY, patch
 
 import pytest
 from django.test.client import Client as HttpClient
@@ -6,14 +7,15 @@ from freezegun import freeze_time
 from rest_framework import status
 
 from posthog.api.test.batch_exports.conftest import start_test_worker
+from posthog.api.test.batch_exports.fixtures import create_organization
 from posthog.api.test.batch_exports.operations import (
     backfill_batch_export,
     create_batch_export_ok,
 )
-from posthog.api.test.batch_exports.fixtures import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
 from posthog.temporal.common.client import sync_connect
+from posthog.test.base import _create_event
 
 pytestmark = [
     pytest.mark.django_db,
@@ -365,3 +367,109 @@ def test_batch_export_backfill_created_in_timezone(client: HttpClient):
 
         assert response.status_code == status.HTTP_200_OK, data
         assert data["backfill_id"] == f"{batch_export_id}-Backfill-2021-01-01T05:00:00+00:00-2021-10-01T04:00:00+00:00"
+
+
+def test_batch_export_backfill_when_start_at_is_before_earliest_backfill_start_at(client: HttpClient):
+    """Test that a BatchExport backfill will use the earliest possible backfill start date if start_at is before this.
+
+    For example if the timestamp of the earliest event is 2021-01-02T00:10:00+00:00, and the BatchExport is created with
+    a start_at of 2021-01-01T00:00:00+00:00, then the backfill will use 2021-01-02T00:00:00+00:00 as the start_at date.
+    """
+    temporal = sync_connect()
+
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "my-production-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "posthog-events/",
+            "aws_access_key_id": "abc123",
+            "aws_secret_access_key": "secret",
+        },
+    }
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": destination_data,
+        "interval": "day",
+    }
+
+    organization = create_organization("Test Org")
+    team = create_team(organization)
+    user = create_user("test@user.com", "Test User", organization)
+    client.force_login(user)
+
+    _create_event(
+        team=team, event="$pageview", distinct_id="person_1", timestamp=dt.datetime(2021, 1, 2, 0, 10, 0, tzinfo=dt.UTC)
+    )
+    with start_test_worker(temporal):
+        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+        batch_export_id = batch_export["id"]
+        with patch("posthog.batch_exports.http.backfill_export", return_value=batch_export_id) as mock_backfill_export:
+            response = backfill_batch_export(
+                client,
+                team.pk,
+                batch_export_id,
+                "2021-01-01T00:00:00+00:00",
+                "2021-01-03T00:00:00+00:00",
+            )
+            assert response.status_code == status.HTTP_200_OK, response.json()
+
+            mock_backfill_export.assert_called_with(
+                ANY,  # temporal instance will be a different object
+                batch_export_id,
+                team.pk,
+                dt.datetime.fromisoformat("2021-01-02T00:00:00+00:00").astimezone(team.timezone_info),
+                dt.datetime.fromisoformat("2021-01-03T00:00:00+00:00").astimezone(team.timezone_info),
+            )
+
+
+def test_batch_export_backfill_when_backfill_end_at_is_before_earliest_event(client: HttpClient):
+    """Test a BatchExport backfill fails if the end_at is before the earliest event.
+
+    In this case, we know that the backfill range doesn't contain any data, so we can fail fast.
+
+    For example if the timestamp of the earliest event is 2021-01-03T00:10:00+00:00, and the BatchExport is created with a
+    start_at of 2021-01-01T00:00:00+00:00 and an end_at of 2021-01-02T00:00:00+00:00, then the backfill will fail.
+    """
+    temporal = sync_connect()
+
+    destination_data = {
+        "type": "S3",
+        "config": {
+            "bucket_name": "my-production-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "posthog-events/",
+            "aws_access_key_id": "abc123",
+            "aws_secret_access_key": "secret",
+        },
+    }
+    batch_export_data = {
+        "name": "my-production-s3-bucket-destination",
+        "destination": destination_data,
+        "interval": "day",
+    }
+
+    organization = create_organization("Test Org")
+    team = create_team(organization)
+    user = create_user("test@user.com", "Test User", organization)
+    client.force_login(user)
+
+    _create_event(
+        team=team, event="$pageview", distinct_id="person_1", timestamp=dt.datetime(2021, 1, 3, 0, 10, 0, tzinfo=dt.UTC)
+    )
+    with start_test_worker(temporal):
+        batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+        batch_export_id = batch_export["id"]
+        with patch("posthog.batch_exports.http.backfill_export", return_value=batch_export_id):
+            response = backfill_batch_export(
+                client,
+                team.pk,
+                batch_export_id,
+                "2021-01-01T00:00:00+00:00",
+                "2021-01-02T00:00:00+00:00",
+            )
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+            assert (
+                response.json()["detail"]
+                == "The provided backfill date range contains no data. The earliest possible backfill start date is 2021-01-03 00:00:00"
+            )

--- a/posthog/api/test/batch_exports/test_delete.py
+++ b/posthog/api/test/batch_exports/test_delete.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime as dt
 
 import pytest
 import temporalio.client
@@ -20,6 +21,7 @@ from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.schedule import describe_schedule
+from posthog.test.base import _create_event
 
 pytestmark = [
     pytest.mark.django_db,
@@ -141,6 +143,14 @@ def test_delete_batch_export_cancels_backfills(client: HttpClient):
 
         start_at = "2023-10-23T00:00:00+00:00"
         end_at = "2023-10-24T00:00:00+00:00"
+
+        # ensure there is data to backfill, otherwise validation will fail
+        _create_event(
+            team=team,
+            event="$pageview",
+            distinct_id="person_1",
+            timestamp=dt.datetime(2023, 10, 23, 0, 0, 0, tzinfo=dt.UTC),
+        )
         batch_export_backfill = backfill_batch_export_ok(client, team.pk, batch_export_id, start_at, end_at)
 
         # In order for the backfill to be cancelable, it needs to be running and requesting backfills.

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -1,11 +1,11 @@
 import datetime as dt
 from typing import Any, TypedDict, cast
-from loginas.utils import is_impersonated_session
 
 import posthoganalytics
 import structlog
 from django.db import transaction
 from django.utils.timezone import now
+from loginas.utils import is_impersonated_session
 from rest_framework import filters, request, response, serializers, viewsets
 from rest_framework.exceptions import (
     NotAuthenticated,
@@ -28,6 +28,7 @@ from posthog.batch_exports.service import (
     backfill_export,
     cancel_running_batch_export_run,
     disable_and_delete_export,
+    fetch_earliest_backfill_start_at,
     pause_batch_export,
     sync_batch_export,
     unpause_batch_export,
@@ -421,6 +422,31 @@ class BatchExportViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.ModelVi
             end_at = validate_date_input(end_at_input, self.team)
         else:
             end_at = None
+
+        if start_at is not None:
+            # testing
+            earliest_backfill_start_at = fetch_earliest_backfill_start_at(
+                team_id=self.team_id,
+                model=batch_export.model,
+                interval_time_delta=batch_export.interval_time_delta,
+                exclude_events=batch_export.destination.config.get("exclude_events", []),
+                include_events=batch_export.destination.config.get("include_events", []),
+            )
+
+            if end_at is not None and end_at < earliest_backfill_start_at:
+                raise ValidationError(
+                    "The provided backfill date range contains no data. The earliest possible backfill start date is "
+                    f"{earliest_backfill_start_at.strftime('%Y-%m-%d %H:%M:%S')}",
+                )
+
+            if start_at < earliest_backfill_start_at:
+                logger.info(
+                    "Backfill start_at '%s' is before the earliest possible backfill start_at '%s', setting start_at "
+                    "to earliest_backfill_start_at",
+                    start_at,
+                    earliest_backfill_start_at,
+                )
+                start_at = earliest_backfill_start_at
 
         if start_at is None or end_at is None:
             backfill_id = backfill_export(temporal, str(batch_export.pk), self.team_id, start_at, end_at)

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -431,6 +431,9 @@ class BatchExportViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.ModelVi
                 exclude_events=batch_export.destination.config.get("exclude_events", []),
                 include_events=batch_export.destination.config.get("include_events", []),
             )
+            if earliest_backfill_start_at is None:
+                raise ValidationError("There is no data to backfill for this model.")
+
             earliest_backfill_start_at = earliest_backfill_start_at.astimezone(self.team.timezone_info)
 
             if end_at is not None and end_at < earliest_backfill_start_at:

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -423,8 +423,7 @@ class BatchExportViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.ModelVi
         else:
             end_at = None
 
-        if start_at is not None:
-            # testing
+        if start_at is not None or end_at is not None:
             earliest_backfill_start_at = fetch_earliest_backfill_start_at(
                 team_id=self.team_id,
                 model=batch_export.model,
@@ -440,7 +439,7 @@ class BatchExportViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.ModelVi
                     f"{earliest_backfill_start_at.strftime('%Y-%m-%d %H:%M:%S')}",
                 )
 
-            if start_at < earliest_backfill_start_at:
+            if start_at is not None and start_at < earliest_backfill_start_at:
                 logger.info(
                     "Backfill start_at '%s' is before the earliest possible backfill start_at '%s', setting start_at "
                     "to earliest_backfill_start_at",

--- a/posthog/batch_exports/http.py
+++ b/posthog/batch_exports/http.py
@@ -432,6 +432,7 @@ class BatchExportViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.ModelVi
                 exclude_events=batch_export.destination.config.get("exclude_events", []),
                 include_events=batch_export.destination.config.get("include_events", []),
             )
+            earliest_backfill_start_at = earliest_backfill_start_at.astimezone(self.team.timezone_info)
 
             if end_at is not None and end_at < earliest_backfill_start_at:
                 raise ValidationError(

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -858,12 +858,12 @@ def fetch_earliest_backfill_start_at(
     interval_time_delta: dt.timedelta,
     exclude_events: collections.abc.Iterable[str] | None = None,
     include_events: collections.abc.Iterable[str] | None = None,
-) -> dt.datetime:
+) -> dt.datetime | None:
     """Get the earliest start_at for a batch export backfill.
 
-    Note that this query will return the unix epoch if no events or persons exist.
+    If there is no data for the given model, return None.
     """
-    interval_seconds = interval_time_delta.total_seconds()
+    interval_seconds = int(interval_time_delta.total_seconds())
     if model == "events":
         exclude_events = exclude_events or []
         include_events = include_events or []
@@ -891,4 +891,7 @@ def fetch_earliest_backfill_start_at(
             "interval_seconds": interval_seconds,
         }
 
-    return sync_execute(query, query_args)[0][0]
+    result = sync_execute(query, query_args)[0][0]
+    if result == dt.datetime.fromtimestamp(0, dt.UTC):
+        return None
+    return result

--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -859,7 +859,10 @@ def fetch_earliest_backfill_start_at(
     exclude_events: collections.abc.Iterable[str] | None = None,
     include_events: collections.abc.Iterable[str] | None = None,
 ) -> dt.datetime:
-    """Get the earliest start_at for a batch export backfill."""
+    """Get the earliest start_at for a batch export backfill.
+
+    Note that this query will return the unix epoch if no events or persons exist.
+    """
     interval_seconds = interval_time_delta.total_seconds()
     if model == "events":
         exclude_events = exclude_events or []


### PR DESCRIPTION
## Problem

When backfilling a batch export, we will iterate through all the runs in the backfill interval, even if there is no data to export in those intervals.

Closes #27397 

## Changes

If both the start and end times are before the earliest timestamp we have data for, then return an error. If only the start time is before the earliest data timestamp, then use that as the start time instead.

Example of error message:
![image](https://github.com/user-attachments/assets/898a233b-4f8a-453d-8061-e496240f0195)


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

New automated tests + tested locally
