### PR TITLE
fix(batch-exports): Reset batch exports backfill form errors on submit

### DIFF
--- a/frontend/src/scenes/pipeline/BatchExportBackfillModal.tsx
+++ b/frontend/src/scenes/pipeline/BatchExportBackfillModal.tsx
@@ -18,7 +18,8 @@ export function BatchExportBackfillModal({ id }: BatchExportRunsLogicProps): JSX
     const logic = batchExportRunsLogic({ id })
 
     const { batchExportConfig, isBackfillModalOpen, isBackfillFormSubmitting, isEarliestBackfill } = useValues(logic)
-    const { closeBackfillModal, setEarliestBackfill, unsetEarliestBackfill } = useActions(logic)
+    const { closeBackfillModal, setEarliestBackfill, unsetEarliestBackfill, setBackfillFormManualErrors } =
+        useActions(logic)
 
     if (!batchExportConfig) {
         return <NotFound object="batch export" />
@@ -46,6 +47,7 @@ export function BatchExportBackfillModal({ id }: BatchExportRunsLogicProps): JSX
                         type="primary"
                         data-attr="batch-export-backfill-submit"
                         loading={isBackfillFormSubmitting}
+                        onClick={() => setBackfillFormManualErrors({})}
                     >
                         Schedule runs
                     </LemonButton>


### PR DESCRIPTION
## Problem

If a validation error is raised (for example if the end date is before the start date) it is no longer possible to submit the backfill form, even after fixing the error. See below issue for more details.

Closes #27687 

## Changes

Reset form errors when submitting. This allows the form to be resubmitted after fixing any validation errors, and will re-raise them if they are still present.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Manual testing:

Create a validation error by setting end date before start date and submitting. Then set end date to after start date and resubmit form.
