### PR TITLE
fix: Frontend scripts and Tailwind accounting for `products/`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "scripts": {
         "copy-scripts": "mkdir -p frontend/dist/ && ./bin/copy-posthog-js",
         "test": "pnpm test:unit && pnpm test:visual",
-        "test:unit": "jest --testPathPattern=frontend/",
+        "test:unit": "jest --testPathPattern='(frontend/|products/)'",
         "jest": "jest",
         "test:visual:update": "rm -rf frontend/__snapshots__/__failures__/ && docker compose -f docker-compose.playwright.yml run --rm -it --build playwright pnpm test:visual:update:docker --url http://host.docker.internal:6006",
         "test:visual:update:docker": "NODE_OPTIONS=--max-old-space-size=6144 test-storybook -u --browsers chromium webkit --no-index-json",
@@ -45,15 +45,15 @@
         "prettier": "prettier --write \"./**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}\"",
         "prettier:check": "prettier --check \"frontend/**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}\"",
         "typescript:check": "tsc --noEmit && echo \"No errors reported by tsc.\"",
-        "lint:js": "eslint --cache frontend/src cypress",
-        "lint:css": "stylelint \"frontend/**/*.{css,scss}\"",
+        "lint:js": "eslint --cache frontend/src cypress products",
+        "lint:css": "stylelint \"(frontend|products)/**/*.{css,scss}\"",
         "format:backend": "ruff .",
         "format:frontend": "pnpm lint:js --fix && pnpm lint:css --fix && pnpm prettier",
         "format": "pnpm format:backend && pnpm format:frontend",
         "typegen:write": "kea-typegen write --delete --show-ts-errors",
         "typegen:check": "kea-typegen check",
         "typegen:watch": "kea-typegen watch --delete --show-ts-errors",
-        "typegen:clean": "find frontend/src -type f -name '*Type.ts' -delete",
+        "typegen:clean": "find frontend/src products -type f -name '*Type.ts' -delete",
         "storybook": "DEBUG=0 storybook dev -p 6006",
         "build-storybook": "DEBUG=0 storybook build",
         "dev:migrate:postgres": "export DEBUG=1 && source env/bin/activate && python manage.py migrate",
@@ -354,6 +354,10 @@
             "prettier --write"
         ],
         "frontend/src/**/*.{js,jsx,mjs,ts,tsx}": [
+            "eslint --cache -c .eslintrc.js --fix",
+            "prettier --write"
+        ],
+        "products/**/frontend/**/*.{js,jsx,mjs,ts,tsx}": [
             "eslint --cache -c .eslintrc.js --fix",
             "prettier --write"
         ],

--- a/products/llm_observability/frontend/LLMObservabilityTracesScene.tsx
+++ b/products/llm_observability/frontend/LLMObservabilityTracesScene.tsx
@@ -1,12 +1,12 @@
 import { Link, TZLabel, urls } from '@posthog/apps-common'
 import { useActions, useValues } from 'kea'
-import { llmObservabilityLogic } from './llmObservabilityLogic'
 
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
 import { LLMTrace } from '~/queries/schema'
 import { QueryContextColumnComponent } from '~/queries/types'
 import { isTracesQuery } from '~/queries/utils'
 
+import { llmObservabilityLogic } from './llmObservabilityLogic'
 import { formatLLMCost, formatLLMUsage } from './utils'
 
 export function LLMObservabilityTraces(): JSX.Element {

--- a/products/messaging/frontend/Broadcasts.tsx
+++ b/products/messaging/frontend/Broadcasts.tsx
@@ -2,12 +2,13 @@ import { IconPlusSmall } from '@posthog/icons'
 import { useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { broadcastsLogic } from './broadcastsLogic'
-import { FunctionsTable } from './FunctionsTable'
-import { MessagingTabs } from './MessagingTabs'
 import { HogFunctionConfiguration } from 'scenes/pipeline/hogfunctions/HogFunctionConfiguration'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
+
+import { broadcastsLogic } from './broadcastsLogic'
+import { FunctionsTable } from './FunctionsTable'
+import { MessagingTabs } from './MessagingTabs'
 
 export function Broadcasts(): JSX.Element {
     const { broadcastId } = useValues(broadcastsLogic)

--- a/products/messaging/frontend/FunctionsTable.tsx
+++ b/products/messaging/frontend/FunctionsTable.tsx
@@ -4,13 +4,13 @@ import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { updatedAtColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
-import { functionsTableLogic } from './functionsTableLogic'
+import { HogFunctionIcon } from 'scenes/pipeline/hogfunctions/HogFunctionIcon'
+import { HogFunctionStatusIndicator } from 'scenes/pipeline/hogfunctions/HogFunctionStatusIndicator'
 import { hogFunctionUrl } from 'scenes/pipeline/hogfunctions/urls'
 
 import { HogFunctionType, HogFunctionTypeType } from '~/types'
 
-import { HogFunctionIcon } from 'scenes/pipeline/hogfunctions/HogFunctionIcon'
-import { HogFunctionStatusIndicator } from 'scenes/pipeline/hogfunctions/HogFunctionStatusIndicator'
+import { functionsTableLogic } from './functionsTableLogic'
 
 export interface FunctionsTableProps {
     type?: HogFunctionTypeType

--- a/products/messaging/frontend/Providers.tsx
+++ b/products/messaging/frontend/Providers.tsx
@@ -1,11 +1,12 @@
 import { useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
-import { FunctionsTable } from './FunctionsTable'
-import { MessagingTabs } from './MessagingTabs'
-import { providersLogic } from './providersLogic'
 import { HogFunctionConfiguration } from 'scenes/pipeline/hogfunctions/HogFunctionConfiguration'
 import { HogFunctionTemplateList } from 'scenes/pipeline/hogfunctions/list/HogFunctionTemplateList'
 import { SceneExport } from 'scenes/sceneTypes'
+
+import { FunctionsTable } from './FunctionsTable'
+import { MessagingTabs } from './MessagingTabs'
+import { providersLogic } from './providersLogic'
 
 export function Providers(): JSX.Element {
     const { providerId, templateId } = useValues(providersLogic)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,11 @@
 /** @type {import('tailwindcss').Config} */
 const config = {
-    content: ['./frontend/src/**/*.{ts,tsx}', './ee/frontend/**/*.{ts,tsx}', './frontend/src/index.html'],
+    content: [
+        './frontend/src/**/*.{ts,tsx}',
+        './ee/frontend/**/*.{ts,tsx}',
+        './frontend/src/index.html',
+        './products/**/frontend/**/*.{ts,tsx}',
+    ],
     important: true, // Basically this: https://sebastiandedeyne.com/why-we-use-important-with-tailwind
     darkMode: ['selector', '[theme="dark"]'],
     theme: {


### PR DESCRIPTION
## Problem

Frontend scripts don't work for the `/products/**` dir.

## Changes

- Fix jest, eslint, stylelint, and typegen.
- FIx lint-staged.
- Fix tailwind.

I might've missed some other scripts.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Locally
