### PR TITLE
fix(web-analytics): Fix opening session attribution explorer from web analytics dashboard

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -86,6 +86,7 @@ export enum TileId {
 export enum ProductTab {
     ANALYTICS = 'analytics',
     WEB_VITALS = 'web-vitals',
+    SESSION_ATTRIBUTION_EXPLORER = 'session-attribution-explorer',
 }
 
 export type WebVitalsPercentile = PropertyMathType.P75 | PropertyMathType.P90 | PropertyMathType.P99
@@ -2045,6 +2046,10 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 percentile,
             }: Record<string, any>
         ): void => {
+            if (![ProductTab.ANALYTICS, ProductTab.WEB_VITALS].includes(productTab)) {
+                return
+            }
+
             const parsedFilters = isWebAnalyticsPropertyFilters(filters) ? filters : undefined
 
             if (parsedFilters && !objectsEqual(parsedFilters, values.webAnalyticsFilters)) {


### PR DESCRIPTION
## Problem

We were a bit too eager in `urlToAction`
## Changes

Fix

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Trying it out on localhost, with both the link in the `...` menu, and in the channel types tooltip.