### PR TITLE
fix(experiments): Couple of UX bug fixes

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -19,10 +19,10 @@ import { ReleaseConditionsModal, ReleaseConditionsTable } from './ReleaseConditi
 import { SummaryTable } from './SummaryTable'
 
 const ResultsTab = (): JSX.Element => {
-    const { experiment, metricResults } = useValues(experimentLogic)
+    const { experiment, metricResults, primaryMetricsLengthWithSharedMetrics } = useValues(experimentLogic)
     const hasSomeResults = metricResults?.some((result) => result?.insight)
 
-    const hasSinglePrimaryMetric = experiment.metrics.length === 1
+    const hasSinglePrimaryMetric = primaryMetricsLengthWithSharedMetrics === 1
 
     return (
         <>

--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -2,7 +2,7 @@ import { LemonBanner, LemonButton, LemonModal, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { urls } from 'scenes/urls'
 
 import { Experiment } from '~/types'
@@ -37,15 +37,7 @@ export function SharedMetricModal({
     } = useActions(experimentLogic({ experimentId }))
 
     const [selectedMetricIds, setSelectedMetricIds] = useState<SharedMetric['id'][]>([])
-    const [selectedMetricId, setSelectedMetricId] = useState<SharedMetric['id'] | null>(null)
-    const [mode, setMode] = useState<'create' | 'edit'>('create')
-
-    useEffect(() => {
-        if (editingSharedMetricId) {
-            setSelectedMetricId(editingSharedMetricId)
-            setMode('edit')
-        }
-    }, [editingSharedMetricId])
+    const mode = editingSharedMetricId ? 'edit' : 'create'
 
     if (!sharedMetrics) {
         return <></>
@@ -196,10 +188,10 @@ export function SharedMetricModal({
                 </div>
             )}
 
-            {selectedMetricId && (
+            {editingSharedMetricId && (
                 <div>
                     {(() => {
-                        const metric = sharedMetrics.find((m: SharedMetric) => m.id === selectedMetricId)
+                        const metric = sharedMetrics.find((m: SharedMetric) => m.id === editingSharedMetricId)
                         if (!metric) {
                             return <></>
                         }

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -534,8 +534,6 @@ export const experimentLogic = kea<experimentLogicType>([
             {
                 openPrimarySharedMetricModal: (_, { sharedMetricId }) => sharedMetricId,
                 openSecondarySharedMetricModal: (_, { sharedMetricId }) => sharedMetricId,
-                closePrimarySharedMetricModal: () => null,
-                closeSecondarySharedMetricModal: () => null,
                 updateExperimentGoal: () => null,
             },
         ],


### PR DESCRIPTION
From https://posthog.slack.com/archives/C011L071P8U/p1737408120718289

## Changes

Fixes a couple of UX bugs discovered during a customer interview.

First, includes shared metrics in the calculation of `hasSinglePrimaryMetric` so the first metric's detailed results don't erroneously appear after the shared metrics:

| Before | After |
|--------|--------|
| ![CleanShot 2025-01-20 at 13 56 02@2x](https://github.com/user-attachments/assets/390e231b-b3b2-4b56-8030-21e15db6c6ec) | ![CleanShot 2025-01-20 at 13 57 22@2x](https://github.com/user-attachments/assets/7f4d2523-935b-4c58-adbc-f4d271f42cc2) | 

Second, derives the shared metrics modal mode from `editingSharedMetricId` instead of `useEffect()` which can get out of sync and cause the modal to get stuck in editing mode. I also removed `closePrimarySharedMetricModal: () => null, closeSecondarySharedMetricModal: () => null,` because it can cause 'create' mode to temporarily appear when the modal is closed.

**Before**

https://github.com/user-attachments/assets/4cef13e8-d4a2-4c03-82de-c8eb61ec1b4d

**After**

https://github.com/user-attachments/assets/14a21e06-d52a-42ee-ab11-8b34421f2837

## How did you test this code?

👀 
