### PR TITLE
fix: Avoid accessing user when running migrations

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -3,6 +3,7 @@ set -e
 
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 
+export POSTHOG_RUNNING_MIGRATION=true
 # NOTE when running in docker, rust might not exist so we need to check for it
 if [ -d "$SCRIPT_DIR/../rust" ]; then
     bash $SCRIPT_DIR/../rust/bin/migrate-cyclotron
@@ -26,3 +27,5 @@ python manage.py run_async_migrations --complete-noop-migrations
 python manage.py run_async_migrations --check
 
 wait $(jobs -p) # Make sure CH migrations are done before we exit
+
+unset POSTHOG_RUNNING_MIGRATION

--- a/bin/migrate
+++ b/bin/migrate
@@ -3,7 +3,6 @@ set -e
 
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 
-export POSTHOG_RUNNING_MIGRATION=true
 # NOTE when running in docker, rust might not exist so we need to check for it
 if [ -d "$SCRIPT_DIR/../rust" ]; then
     bash $SCRIPT_DIR/../rust/bin/migrate-cyclotron
@@ -27,5 +26,3 @@ python manage.py run_async_migrations --complete-noop-migrations
 python manage.py run_async_migrations --check
 
 wait $(jobs -p) # Make sure CH migrations are done before we exit
-
-unset POSTHOG_RUNNING_MIGRATION

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -48,18 +48,19 @@ class PostHogConfig(AppConfig):
                     {"git_rev": get_git_commit_short(), "git_branch": get_git_branch()},
                 )
 
-            try:
-                user = User.objects.filter(last_login__isnull=False).order_by("-last_login").first()
-            except:
-                user = None
+            if not os.getenv("POSTHOG_RUNNING_MIGRATION"):
+                try:
+                    user = User.objects.filter(last_login__isnull=False).order_by("-last_login").first()
+                except:
+                    user = None
 
-            local_api_key = get_self_capture_api_token(user)
+                local_api_key = get_self_capture_api_token(user)
 
-            if SELF_CAPTURE and local_api_key:
-                posthoganalytics.api_key = local_api_key
-                posthoganalytics.host = settings.SITE_URL
-            else:
-                posthoganalytics.disabled = True
+                if SELF_CAPTURE and local_api_key:
+                    posthoganalytics.api_key = local_api_key
+                    posthoganalytics.host = settings.SITE_URL
+                else:
+                    posthoganalytics.disabled = True
 
         # load feature flag definitions if not already loaded
         if not posthoganalytics.disabled and posthoganalytics.feature_flag_definitions() is None:

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -48,19 +48,18 @@ class PostHogConfig(AppConfig):
                     {"git_rev": get_git_commit_short(), "git_branch": get_git_branch()},
                 )
 
-            if not os.getenv("POSTHOG_RUNNING_MIGRATION"):
-                try:
-                    user = User.objects.filter(last_login__isnull=False).order_by("-last_login").first()
-                except:
-                    user = None
-
+            try:
+                user = User.objects.filter(last_login__isnull=False).order_by("-last_login").first()
                 local_api_key = get_self_capture_api_token(user)
+            except:
+                user = None
+                local_api_key = None
 
-                if SELF_CAPTURE and local_api_key:
-                    posthoganalytics.api_key = local_api_key
-                    posthoganalytics.host = settings.SITE_URL
-                else:
-                    posthoganalytics.disabled = True
+            if SELF_CAPTURE and local_api_key:
+                posthoganalytics.api_key = local_api_key
+                posthoganalytics.host = settings.SITE_URL
+            else:
+                posthoganalytics.disabled = True
 
         # load feature flag definitions if not already loaded
         if not posthoganalytics.disabled and posthoganalytics.feature_flag_definitions() is None:

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -48,18 +48,19 @@ class PostHogConfig(AppConfig):
                     {"git_rev": get_git_commit_short(), "git_branch": get_git_branch()},
                 )
 
-            try:
-                user = User.objects.filter(last_login__isnull=False).order_by("-last_login").first()
-                local_api_key = get_self_capture_api_token(user)
-            except:
-                user = None
-                local_api_key = None
+            if not os.getenv("POSTHOG_RUNNING_MIGRATION"):
+                try:
+                    user = User.objects.filter(last_login__isnull=False).order_by("-last_login").first()
+                except:
+                    user = None
 
-            if SELF_CAPTURE and local_api_key:
-                posthoganalytics.api_key = local_api_key
-                posthoganalytics.host = settings.SITE_URL
-            else:
-                posthoganalytics.disabled = True
+                local_api_key = get_self_capture_api_token(user)
+
+                if SELF_CAPTURE and local_api_key:
+                    posthoganalytics.api_key = local_api_key
+                    posthoganalytics.host = settings.SITE_URL
+                else:
+                    posthoganalytics.disabled = True
 
         # load feature flag definitions if not already loaded
         if not posthoganalytics.disabled and posthoganalytics.feature_flag_definitions() is None:


### PR DESCRIPTION
See https://posthog.slack.com/archives/C0113360FFV/p1737412494845589

## Changes

Fixes this issue when running `DEBUG=1 ./bin/migrate`:

```
django.db.utils.ProgrammingError: column posthog_team.revenue_tracking_config does not exist
LINE 1: ...s", "posthog_team"."cookieless_server_hash_mode", "posthog_t...
```

The app crashes during bootstrap because the column doesn't exist yet. It seems like it should be fine to avoid loading user context when a migration is running, though.

## How did you test this code?

Verified the migration ran as expected and that the application still loaded as expected.