### PR TITLE
fix: debug posthoganalytics token retrieval during migrations

### DIFF
--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -50,10 +50,9 @@ class PostHogConfig(AppConfig):
 
             try:
                 user = User.objects.filter(last_login__isnull=False).order_by("-last_login").first()
+                local_api_key = get_self_capture_api_token(user)
             except:
-                user = None
-
-            local_api_key = get_self_capture_api_token(user)
+                local_api_key = None
 
             if SELF_CAPTURE and local_api_key:
                 posthoganalytics.api_key = local_api_key


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/27669 partially fixes the underlying issue, but the token retrieval function still contains a team model, which breaks migrations when schemas are different.

Related fix: https://github.com/PostHog/posthog/pull/27708.

## Changes

Move the `get_self_capture_api_token` under try/except.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually
