### PR TITLE
chore: remove README

### DIFF
--- a/frontend/utils.mjs
+++ b/frontend/utils.mjs
@@ -543,7 +543,7 @@ export function gatherProductUrls(products) {
 }
 
 export function gatherProductManifests() {
-    const products = fse.readdirSync('products').filter((p) => p !== '__pycache__')
+    const products = fse.readdirSync('products').filter((p) => !['__pycache__', 'README.md'].includes(p))
     const allScenes = {}
     const allRoutes = {}
     const allRedirects = {}


### PR DESCRIPTION
|Before|After|
|----|----|
| <img width="935" alt="Screenshot 2025-01-21 at 10 03 22" src="https://github.com/user-attachments/assets/07faadd1-36e5-49af-9c86-f249b67a154d" /> | <img width="525" alt="Screenshot 2025-01-21 at 10 03 01" src="https://github.com/user-attachments/assets/d8a0d4c2-2393-41a8-902e-194fbfad955b" /> |

Couldn't figure out why it thinks `README.md` is a directory but this makes the error go away. Feel free to merge if you're seeing a similar thing @mariusandra 