### PR TITLE
feat: Added way to skip person processing

### DIFF
--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -24,7 +24,7 @@ LOG_FILE=$(mktemp)
 
 echo '::group::Starting plugin server'
 
-NODE_OPTIONS='--max_old_space_size=4096' ./node_modules/.bin/c8 --reporter html node dist/src/index.js >"$LOG_FILE" 2>&1 &
+NODE_OPTIONS='--max_old_space_size=4096' ./node_modules/.bin/c8 --reporter html node dist/index.js >"$LOG_FILE" 2>&1 &
 SERVER_PID=$!
 SECONDS=0
 

--- a/plugin-server/bin/ci_functional_tests.sh
+++ b/plugin-server/bin/ci_functional_tests.sh
@@ -24,7 +24,7 @@ LOG_FILE=$(mktemp)
 
 echo '::group::Starting plugin server'
 
-NODE_OPTIONS='--max_old_space_size=4096' ./node_modules/.bin/c8 --reporter html node dist/index.js >"$LOG_FILE" 2>&1 &
+NODE_OPTIONS='--max_old_space_size=4096' ./node_modules/.bin/c8 --reporter html node dist/src/index.js >"$LOG_FILE" 2>&1 &
 SERVER_PID=$!
 SECONDS=0
 

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -127,6 +127,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         EXTERNAL_REQUEST_TIMEOUT_MS: 10 * 1000, // 10 seconds
         DROP_EVENTS_BY_TOKEN_DISTINCT_ID: '',
         DROP_EVENTS_BY_TOKEN: '',
+        SKIP_PERSONS_PROCESSING_BY_TOKEN_DISTINCT_ID: '',
         PIPELINE_STEP_STALLED_LOG_TIMEOUT: 30,
         RELOAD_PLUGIN_JITTER_MAX_MS: 60000,
         RUSTY_HOOK_FOR_TEAMS: '',

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -250,6 +250,7 @@ export interface PluginsServerConfig extends CdpConfig {
     EXTERNAL_REQUEST_TIMEOUT_MS: number
     DROP_EVENTS_BY_TOKEN_DISTINCT_ID: string
     DROP_EVENTS_BY_TOKEN: string
+    SKIP_PERSONS_PROCESSING_BY_TOKEN_DISTINCT_ID: string
     RELOAD_PLUGIN_JITTER_MAX_MS: number
     RUSTY_HOOK_FOR_TEAMS: string
     RUSTY_HOOK_ROLLOUT_PERCENTAGE: number
@@ -349,6 +350,7 @@ export interface Hub extends PluginsServerConfig {
     pluginConfigsToSkipElementsParsing: ValueMatcher<number>
     // lookups
     eventsToDropByToken: Map<string, string[]>
+    eventsToSkipPersonsProcessingByToken: Map<string, string[]>
     encryptedFields: EncryptedFields
 }
 

--- a/plugin-server/src/utils/db/hub.ts
+++ b/plugin-server/src/utils/db/hub.ts
@@ -189,6 +189,9 @@ export async function createHub(
         actionManager,
         pluginConfigsToSkipElementsParsing: buildIntegerMatcher(process.env.SKIP_ELEMENTS_PARSING_PLUGINS, true),
         eventsToDropByToken: createEventsToDropByToken(process.env.DROP_EVENTS_BY_TOKEN_DISTINCT_ID),
+        eventsToSkipPersonsProcessingByToken: createEventsToDropByToken(
+            process.env.SKIP_PERSONS_PROCESSING_BY_TOKEN_DISTINCT_ID
+        ),
         appMetrics: new AppMetrics(
             kafkaProducer,
             serverConfig.APP_METRICS_FLUSH_FREQUENCY_MS,

--- a/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
@@ -71,7 +71,7 @@ export async function populateTeamDataStep(
     const skipPersonsProcessingForDistinctIds = runner.hub.eventsToSkipPersonsProcessingByToken.get(event.token!)
 
     const forceOptOutPersonProfiles =
-        !!team.person_processing_opt_out || skipPersonsProcessingForDistinctIds?.includes(event.distinct_id)
+        team.person_processing_opt_out || skipPersonsProcessingForDistinctIds?.includes(event.distinct_id)
 
     // We allow teams to set the person processing mode on a per-event basis, but override
     // it with the team-level setting, if it's set to opt-out (since this is billing related,

--- a/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/populateTeamDataStep.ts
@@ -68,11 +68,16 @@ export async function populateTeamDataStep(
         throw new Error(`Not a valid UUID: "${event.uuid}"`)
     }
 
+    const skipPersonsProcessingForDistinctIds = runner.hub.eventsToSkipPersonsProcessingByToken.get(event.token!)
+
+    const forceOptOutPersonProfiles =
+        !!team.person_processing_opt_out || skipPersonsProcessingForDistinctIds?.includes(event.distinct_id)
+
     // We allow teams to set the person processing mode on a per-event basis, but override
     // it with the team-level setting, if it's set to opt-out (since this is billing related,
     // we go with preferring not to do the processing even if the event says to do it, if the
     // setting says not to).
-    if (team.person_processing_opt_out) {
+    if (forceOptOutPersonProfiles) {
         if (event.properties) {
             event.properties.$process_person_profile = false
         } else {

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -143,6 +143,7 @@ export class EventPipelineRunner {
         const kafkaAcks: Promise<void>[] = []
 
         let processPerson = true // The default.
+
         // Set either at capture time, or in the populateTeamData step, if team-level opt-out is enabled.
         if (event.properties && '$process_person_profile' in event.properties) {
             const propValue = event.properties.$process_person_profile


### PR DESCRIPTION
## Problem

Sometimes we recognize bad incoming data is slowing things down due to person processing.

## Changes

* Adds an option to skip the heavier part of person processing using the provided env

NOTE: I don't love the positioning of this code but it "works" for now and will be much cleaner in the upcoming refactors

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
