### PR TITLE
fix: Add Vary headers to cors response

### DIFF
--- a/posthog/utils_cors.py
+++ b/posthog/utils_cors.py
@@ -39,4 +39,5 @@ def cors_response(request, response):
     response["Access-Control-Allow-Headers"] = "X-Requested-With,Content-Type" + (
         "," + ",".join(allow_headers) if len(allow_headers) > 0 else ""
     )
+    response["Vary"] = "Origin"
     return response


### PR DESCRIPTION
## Problem

cors headers cache between different domains with posthog installed

varying on origin should fix this.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
