### PR TITLE
fix: Drop unset events if the format is incorrect

### DIFF
--- a/plugin-server/src/worker/ingestion/person-state.ts
+++ b/plugin-server/src/worker/ingestion/person-state.ts
@@ -381,6 +381,10 @@ export class PersonState {
         })
         unsetProperties.forEach((propertyKey) => {
             if (propertyKey in personProperties) {
+                if (typeof propertyKey !== 'string') {
+                    status.warn('🔔', 'unset_property_key_not_string', { propertyKey, unsetProperties })
+                    return
+                }
                 updated = true
                 metricsKeys.add(this.getMetricKey(propertyKey))
                 delete personProperties[propertyKey]


### PR DESCRIPTION
## Problem

Noticed [here](https://posthog.sentry.io/issues/5919063581/?project=6423401&query=is%3Aunresolved&referrer=issue-stream&stream_index=1)

## Changes

* Check that the unset value is actually valid

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

* No test yet - focus on fixing
