### PR TITLE
chore(rust): bump all 1.80 to 1.82

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN pnpm build
 #
 # ---------------------------------------------------------
 #
-FROM ghcr.io/posthog/rust-node-container:bullseye_rust_1.80.1-node_18.19.1 AS plugin-server-build
+FROM ghcr.io/posthog/rust-node-container:bookworm_rust_1.82-node_18.19.1 AS plugin-server-build
 WORKDIR /code
 COPY ./rust ./rust
 COPY ./common/plugin_transpiler/ ./common/plugin_transpiler/
@@ -148,7 +148,7 @@ RUN apt-get update && \
 # ---------------------------------------------------------
 #
 # NOTE: newer images change the base image from bullseye to bookworm which makes compiled openssl versions have all sorts of issues
-FROM unit:1.32.0-python3.11 
+FROM unit:1.32.0-python3.11
 WORKDIR /code
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
 ENV PYTHONUNBUFFERED 1

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/lukemathwalker/cargo-chef:latest-rust-1.80.1-bookworm AS chef
+FROM docker.io/lukemathwalker/cargo-chef:latest-rust-1.82-bookworm AS chef
 ARG BIN
 WORKDIR /app
 

--- a/rust/Dockerfile.migrate-hooks
+++ b/rust/Dockerfile.migrate-hooks
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.80.1-bullseye as builder
+FROM docker.io/library/rust:1.82-bullseye as builder
 
 RUN apt update && apt install build-essential cmake -y
 RUN cargo install sqlx-cli@0.7.3 --locked --no-default-features --features native-tls,postgres --root /app/target/release/


### PR DESCRIPTION
CI/tests already use 1.82, so should everything else