### PR TITLE
fix(defer-unmounting): Defer unmounting of react elements

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDialog/LemonDialog.tsx
@@ -166,10 +166,13 @@ function createAndInsertRoot(): { root: Root; onDestroy: () => void } {
     const div = document.createElement('div')
     const root = createRoot(div)
     function destroy(): void {
-        root.unmount()
-        if (div.parentNode) {
-            div.parentNode.removeChild(div)
-        }
+        // defer the unmounting to avoid collisions with the rendering cycle
+        setTimeout(() => {
+            root.unmount()
+            if (div.parentNode) {
+                div.parentNode.removeChild(div)
+            }
+        }, 0)
     }
 
     document.body.appendChild(div)


### PR DESCRIPTION
## Problem

We are getting a console error when unmounting components in our data warehouse dialogs and I would guess that others receive a similar error.

Console error before:
<img width="562" alt="image" src="https://github.com/user-attachments/assets/027cd159-eca0-4252-85d1-f8c799649761" />

## Changes

- Defer the unmounts to the next tick.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Removed console error, same functionality
