### PR TITLE
chore: unique upload file names

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -316,7 +316,7 @@ jobs:
               uses: actions/upload-artifact@v4
               if: needs.changes.outputs.backend == 'true' && matrix.segment == 'Core' && matrix.person-on-events == false
               with:
-                  name: email_renders
+                  name: email_renders-${{ matrix.segment }}-${{ matrix.person-on-events }}
                   path: posthog/tasks/test/__emails__
                   retention-days: 5
 

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -242,21 +242,21 @@ jobs:
             - name: Archive test screenshots
               uses: actions/upload-artifact@v4
               with:
-                  name: screenshots-${{ strategy.job-index }}-${{ matrix.chunk }}
+                  name: screenshots-${{ strategy.job-index }}
                   path: cypress/screenshots
               if: ${{ failure() }}
 
             - name: Archive test downloads
               uses: actions/upload-artifact@v4
               with:
-                  name: downloads-${{ strategy.job-index }}-${{ matrix.chunk }}
+                  name: downloads-${{ strategy.job-index }}
                   path: cypress/downloads
               if: ${{ failure() }}
 
             - name: Archive test videos
               uses: actions/upload-artifact@v4
               with:
-                  name: videos-${{ strategy.job-index }}-${{ matrix.chunk }}
+                  name: videos-${{ strategy.job-index }}
                   path: cypress/videos
               if: ${{ failure() }}
 
@@ -264,7 +264,7 @@ jobs:
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
               uses: actions/upload-artifact@v4
               with:
-                  name: accessibility-violations-${{ strategy.job-index }}-${{ matrix.chunk }}
+                  name: accessibility-violations-${{ strategy.job-index }}
                   path: '**/a11y/'
                   if-no-files-found: 'ignore'
 
@@ -272,7 +272,7 @@ jobs:
               # use artefact here, as I think the output will be too large for display in an action
               uses: actions/upload-artifact@v4
               with:
-                  name: logs-${{ strategy.job-index }}-${{ matrix.chunk }}
+                  name: logs-${{ strategy.job-index }}
                   path: /tmp/logs
               if: ${{ failure() }}
 

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -272,7 +272,7 @@ jobs:
               # use artefact here, as I think the output will be too large for display in an action
               uses: actions/upload-artifact@v4
               with:
-                  name: logs--${{ strategy.job-index }}-${{ matrix.chunk }}
+                  name: logs-${{ strategy.job-index }}-${{ matrix.chunk }}
                   path: /tmp/logs
               if: ${{ failure() }}
 

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -242,21 +242,21 @@ jobs:
             - name: Archive test screenshots
               uses: actions/upload-artifact@v4
               with:
-                  name: screenshots
+                  name: screenshots-${{ strategy.job-index }}-${{ matrix.chunk }}
                   path: cypress/screenshots
               if: ${{ failure() }}
 
             - name: Archive test downloads
               uses: actions/upload-artifact@v4
               with:
-                  name: downloads
+                  name: downloads-${{ strategy.job-index }}-${{ matrix.chunk }}
                   path: cypress/downloads
               if: ${{ failure() }}
 
             - name: Archive test videos
               uses: actions/upload-artifact@v4
               with:
-                  name: videos
+                  name: videos-${{ strategy.job-index }}-${{ matrix.chunk }}
                   path: cypress/videos
               if: ${{ failure() }}
 
@@ -264,7 +264,7 @@ jobs:
               if: needs.changes.outputs.shouldTriggerCypress == 'true'
               uses: actions/upload-artifact@v4
               with:
-                  name: accessibility-violations
+                  name: accessibility-violations-${{ strategy.job-index }}-${{ matrix.chunk }}
                   path: '**/a11y/'
                   if-no-files-found: 'ignore'
 
@@ -272,7 +272,7 @@ jobs:
               # use artefact here, as I think the output will be too large for display in an action
               uses: actions/upload-artifact@v4
               with:
-                  name: logs-${{ strategy.job-index }}
+                  name: logs--${{ strategy.job-index }}-${{ matrix.chunk }}
                   path: /tmp/logs
               if: ${{ failure() }}
 


### PR DESCRIPTION
artifiact upload v4 doesn't allow two artifacts with the same name in the same job
v3 used to allow that
sprinkle some unique-ing around