### PR TITLE
chore(experiments): Add tests for funnel attribution options

### DIFF
--- a/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
@@ -320,12 +320,12 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             ],
             [
                 BreakdownAttributionType.ALL_EVENTS,
-                # 7 total (one dropped)
+                # 9 total (one duplicated)
                 {
-                    "control_success": 2,
+                    "control_success": 3,
                     "control_failure": 1,
                     "test_success": 3,
-                    "test_failure": 1,
+                    "test_failure": 2,
                 },
             ],
             [
@@ -390,12 +390,14 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     {"event": "purchase", "timestamp": "2020-01-04", "properties": {ff_property: "control"}},
                 ],
                 # control success for "first_touch", "last_touch"
-                # dropped for "all_events"
+                # counted twice for for "all_events"
                 # test success for "steps"
                 "user_mixed_4": [
                     {"event": "seen", "timestamp": "2020-01-02", "properties": {ff_property: "control"}},
-                    {"event": "signup", "timestamp": "2020-01-03", "properties": {ff_property: "test"}},
-                    {"event": "purchase", "timestamp": "2020-01-04", "properties": {ff_property: "control"}},
+                    {"event": "seen", "timestamp": "2020-01-03", "properties": {ff_property: "test"}},
+                    {"event": "signup", "timestamp": "2020-01-04", "properties": {ff_property: "control"}},
+                    {"event": "signup", "timestamp": "2020-01-05", "properties": {ff_property: "test"}},
+                    {"event": "purchase", "timestamp": "2020-01-06", "properties": {ff_property: "control"}},
                 ],
                 # test success always
                 "user_test_5": [

--- a/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
@@ -3,6 +3,7 @@ from posthog.hogql_queries.experiments.experiment_funnels_query_runner import Ex
 from posthog.models.experiment import Experiment, ExperimentHoldout
 from posthog.models.feature_flag.feature_flag import FeatureFlag
 from posthog.schema import (
+    BreakdownAttributionType,
     EventsNode,
     ExperimentFunnelsQuery,
     ExperimentSignificanceCode,
@@ -298,7 +299,7 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
     @parameterized.expand(
         [
             [
-                "first_touch",
+                BreakdownAttributionType.FIRST_TOUCH,
                 # 8 total
                 {
                     "control_success": 3,
@@ -308,7 +309,7 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 },
             ],
             [
-                "last_touch",
+                BreakdownAttributionType.LAST_TOUCH,
                 # 8 total
                 {
                     "control_success": 3,
@@ -318,7 +319,7 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 },
             ],
             [
-                "all_events",
+                BreakdownAttributionType.ALL_EVENTS,
                 # 7 total (one dropped)
                 {
                     "control_success": 2,
@@ -328,7 +329,7 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                 },
             ],
             [
-                "step",
+                BreakdownAttributionType.STEP,
                 # 8 total
                 {
                     "control_success": 2,
@@ -345,7 +346,7 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         experiment = self.create_experiment(feature_flag=feature_flag)
 
         # use the second step when testing step attribution
-        attribution_value = 1 if attribution_type == "steps" else 0
+        attribution_value = 1 if attribution_type == BreakdownAttributionType.STEP else 0
 
         ff_property = f"$feature/{feature_flag.key}"
         funnels_query = FunnelsQuery(

--- a/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
@@ -330,11 +330,11 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             ],
             [
                 BreakdownAttributionType.STEP,
-                # 8 total
+                # 7 total
                 {
-                    "control_success": 2,
-                    "control_failure": 2,
-                    "test_success": 3,
+                    "control_success": 3,
+                    "control_failure": 0,
+                    "test_success": 4,
                     "test_failure": 1,
                 },
             ],
@@ -378,7 +378,8 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
                     {"event": "signup", "timestamp": "2020-01-03", "properties": {ff_property: "control"}},
                     {"event": "purchase", "timestamp": "2020-01-04", "properties": {ff_property: "control"}},
                 ],
-                # control failure always
+                # control failure for "first_touch", "last_touch", and "all_events"
+                # dropped for "steps"
                 "user_control_2": [
                     {"event": "seen", "timestamp": "2020-01-02", "properties": {ff_property: "control"}},
                     # Doesn't sign up or make a purchase


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/27009
I learned a couple things about attribution behavior: https://github.com/PostHog/posthog.com/pull/10412

## Changes

Adds tests for the different attribution types:

![CleanShot 2025-01-21 at 13 20 46@2x](https://github.com/user-attachments/assets/57673645-a461-4d34-bfd4-4c3e60ae8cb6)

## How did you test this code?

Tests should pass.