### PR TITLE
fix(retention): prevent unnecessary re-renders

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -280,7 +280,7 @@ export function LineGraph_({
     hideYAxis,
     yAxisScaleType,
     legend = { display: false },
-    goalLines = [],
+    goalLines: _goalLines,
 }: LineGraphProps): JSX.Element {
     let datasets = _datasets
 
@@ -405,6 +405,7 @@ export function LineGraph_({
         const seriesNonZeroMax = Math.max(...datasets.flatMap((d) => d.data).filter((n) => !!n && n !== LOG_ZERO))
         const seriesNonZeroMin = Math.min(...datasets.flatMap((d) => d.data).filter((n) => !!n && n !== LOG_ZERO))
         const precision = seriesNonZeroMax < 5 ? 1 : seriesNonZeroMax < 2 ? 2 : 0
+        const goalLines = _goalLines || []
         const goalLinesY = goalLines.map((a) => a.value)
         const goalLinesWithColor = goalLines.filter((goalLine) => Boolean(goalLine.borderColor))
 
@@ -854,7 +855,7 @@ export function LineGraph_({
         formula,
         showValuesOnSeries,
         showPercentStackView,
-        goalLines,
+        _goalLines,
         theme,
     ])
 

--- a/frontend/src/scenes/retention/RetentionLineGraph.tsx
+++ b/frontend/src/scenes/retention/RetentionLineGraph.tsx
@@ -63,6 +63,7 @@ export function RetentionLineGraph({ inSharedMode = false }: RetentionLineGraphP
                 }
             }}
             incompletenessOffsetFromEnd={incompletenessOffsetFromEnd}
+            goalLines={[]}
         />
     ) : (
         <InsightEmptyState />

--- a/frontend/src/scenes/retention/RetentionLineGraph.tsx
+++ b/frontend/src/scenes/retention/RetentionLineGraph.tsx
@@ -63,7 +63,6 @@ export function RetentionLineGraph({ inSharedMode = false }: RetentionLineGraphP
                 }
             }}
             incompletenessOffsetFromEnd={incompletenessOffsetFromEnd}
-            goalLines={[]}
         />
     ) : (
         <InsightEmptyState />


### PR DESCRIPTION
## Problem

`useEffect` compares dependency using shallow equality, requiring a stable ref. Setting the `goalLines` array default in the props signature causes the ref to change on every re-render of the parent component. This is resulting in an infinite loop here.

## Changes

A fix for this issue was already implemented [here](https://github.com/PostHog/posthog/pull/25555), but got un-done in the cleanup [here](https://github.com/PostHog/posthog/pull/27479). This PR simply re-adds the fix.

## How did you test this code?

Added a `console.log` to the component and watched for re-renders