### PR TITLE
perf: Cache initial_channel_types

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict
 from sentry_sdk import capture_exception
 
 from posthog.hogql import ast
+from posthog.settings import TEST
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.timings import HogQLTimings
 from posthog.hogql.database.models import (
@@ -336,7 +337,7 @@ def create_hogql_database(
             database.persons.fields["$virt_initial_channel_type"] = create_initial_channel_type(
                 "$virt_initial_channel_type",
                 modifiers.customChannelTypeRules,
-                use_cache=True,  # This is normally implied but mocking tests is impossible otherwise
+                use_cache=not TEST,  # This is normally implied but mocking tests is impossible otherwise
             )
 
     with timings.measure("group_type_mapping"):

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -334,7 +334,9 @@ def create_hogql_database(
             )
         with timings.measure("initial_channel_type"):
             database.persons.fields["$virt_initial_channel_type"] = create_initial_channel_type(
-                "$virt_initial_channel_type", modifiers.customChannelTypeRules
+                "$virt_initial_channel_type",
+                modifiers.customChannelTypeRules,
+                use_cache=True,  # This is normally implied but mocking tests is impossible otherwise
             )
 
     with timings.measure("group_type_mapping"):

--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -1,9 +1,13 @@
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Optional, Union
 
 from posthog.hogql import ast
 from posthog.hogql.database.models import ExpressionField
 from posthog.hogql.parser import parse_expr
+from posthog.cache_utils import cache_for
+
+
 from posthog.schema import (
     CustomChannelRule,
     CustomChannelOperator,
@@ -61,6 +65,9 @@ if(
     )
 
 
+@cache_for(
+    timedelta(days=30)
+)  # Cached in runtime, so a new deploy will refresh cache. Only way output changes is if customchannelrule changes
 def create_initial_channel_type(name: str, custom_rules: Optional[list[CustomChannelRule]] = None):
     return ExpressionField(
         name=name,

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -279,7 +279,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
         query = print_ast(parse_select(sql), context, dialect="clickhouse")
         assert (
             query
-            == f"SELECT numbers.number AS number, multiply(numbers.number, 2) AS double, plus(plus(1, 1), numbers.number) AS expression_number FROM numbers(2) AS numbers LIMIT {MAX_SELECT_RETURNED_ROWS}"
+            == f"SELECT numbers.number AS number, multiply(numbers.number, 2) AS double, plus(plus(1, 1), numbers.number) FROM numbers(2) AS numbers LIMIT {MAX_SELECT_RETURNED_ROWS}"
         ), query
 
         sql = "select double from (select double from numbers(2))"

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -598,6 +598,7 @@ class TestDatabase(BaseTest, QueryMatchingTest):
 
         print_ast(parse_select("select person.some_field.key from events"), context, dialect="clickhouse")
 
+    @patch("posthog.hogql.database.database.TEST", False)
     def test_create_hogql_database_caching(self):
         # mock_cache.return_value = False
         from posthog.hogql.database.database import create_hogql_database


### PR DESCRIPTION
## Problem

initial channel types is surprisingly slow (avg 250ms)   and is the item [we spent most time on](https://metabase.prod-us.posthog.dev/question/1198-hogql-timings-for-create-hogql-database).

The reason to cache intitial_channel_types but not the whole of create_hogql_database is that initial_channel_type returns the same for all teams (except ones that have custom channel rules, which is only 30 on prod), so caching it on every machine makes sense. cache also gets invalidated automatically if those rules are updated.

create_hogql_database does a lot of database calls which could be updated at any point, and we can't store the result in redis as we can't picke/unpickle the Database object.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Cache it locally
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
