### PR TITLE
feat(cdp): remove rusty hook in cdp

### DIFF
--- a/plugin-server/src/cdp/consumers/cdp-base.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-base.consumer.ts
@@ -11,7 +11,6 @@ import { AppMetric2Type, Hub, PluginServerService, TeamId, TimestampFormat } fro
 import { safeClickhouseString } from '../../utils/db/utils'
 import { status } from '../../utils/status'
 import { castTimestampOrNow, UUIDT } from '../../utils/utils'
-import { RustyHook } from '../../worker/rusty-hook'
 import { CdpRedis, createCdpRedisPool } from '../redis'
 import { FetchExecutorService } from '../services/fetch-executor.service'
 import { GroupsManagerService } from '../services/groups-manager.service'
@@ -96,8 +95,7 @@ export abstract class CdpConsumerBase {
         this.hogWatcher = new HogWatcherService(hub, this.redis)
         this.hogMasker = new HogMaskerService(this.redis)
         this.hogExecutor = new HogExecutorService(this.hub, this.hogFunctionManager)
-        const rustyHook = this.hub?.rustyHook ?? new RustyHook(this.hub)
-        this.fetchExecutor = new FetchExecutorService(this.hub, rustyHook)
+        this.fetchExecutor = new FetchExecutorService(this.hub)
         this.groupsManager = new GroupsManagerService(this.hub)
     }
 

--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -24,16 +24,9 @@ export class CdpCyclotronWorker extends CdpConsumerBase {
         const invocationResults = await runInstrumentedFunction({
             statsKey: `cdpConsumer.handleEachBatch.executeInvocations`,
             func: async () => {
-                // NOTE: In the future this service will never do fetching (unless we decide we want to do it in node at some point)
-                // This is just "for now" to support the transition to cyclotron
-                const fetchQueue = invocations.filter((item) => item.queue === 'fetch')
-                const fetchResults = await this.runManyWithHeartbeat(fetchQueue, (item) =>
-                    this.fetchExecutor.execute(item)
-                )
-
                 const hogQueue = invocations.filter((item) => item.queue === 'hog')
                 const hogResults = await this.runManyWithHeartbeat(hogQueue, (item) => this.hogExecutor.execute(item))
-                return [...hogResults, ...(fetchResults.filter(Boolean) as HogFunctionInvocationResult[])]
+                return [...hogResults]
             },
         })
 

--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -24,6 +24,9 @@ export class CdpCyclotronWorker extends CdpConsumerBase {
         const invocationResults = await runInstrumentedFunction({
             statsKey: `cdpConsumer.handleEachBatch.executeInvocations`,
             func: async () => {
+                // Disclaimer: fetchExecutor would use rusty-hook to send a fetch request but thats no longer the case
+                // We are currentyl going to execute the fetch locally for testing purposes
+                // as nothing should ever land on the deprecated fetch queue this should be somewhat safe.
                 const fetchQueue = invocations.filter((item) => item.queue === 'fetch')
                 const fetchResults = await this.runManyWithHeartbeat(fetchQueue, (item) =>
                     this.fetchExecutor.execute(item)

--- a/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/plugin-server/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -24,9 +24,10 @@ export class CdpCyclotronWorker extends CdpConsumerBase {
         const invocationResults = await runInstrumentedFunction({
             statsKey: `cdpConsumer.handleEachBatch.executeInvocations`,
             func: async () => {
-                // Disclaimer: fetchExecutor would use rusty-hook to send a fetch request but thats no longer the case
-                // We are currentyl going to execute the fetch locally for testing purposes
-                // as nothing should ever land on the deprecated fetch queue this should be somewhat safe.
+                // NOTE: this service will never do fetching (unless we decide we want to do it in node at some point, its only used for e2e testing)
+                // fetchExecutor would use rusty-hook to send a fetch request but thats no longer the case
+                // we are currentyl going to execute the fetch locally for testing purposes
+                // as nothing should ever land on the deprecated fetch queue this should be safe.
                 const fetchQueue = invocations.filter((item) => item.queue === 'fetch')
                 const fetchResults = await this.runManyWithHeartbeat(fetchQueue, (item) =>
                     this.fetchExecutor.execute(item)

--- a/plugin-server/src/cdp/services/fetch-executor.service.ts
+++ b/plugin-server/src/cdp/services/fetch-executor.service.ts
@@ -1,89 +1,17 @@
 import { DateTime } from 'luxon'
-import { Histogram } from 'prom-client'
 
-import { buildIntegerMatcher } from '../../config/config'
-import { PluginsServerConfig, ValueMatcher } from '../../types'
+import { PluginsServerConfig } from '../../types'
 import { trackedFetch } from '../../utils/fetch'
 import { status } from '../../utils/status'
-import { RustyHook } from '../../worker/rusty-hook'
 import {
     HogFunctionInvocation,
-    HogFunctionInvocationAsyncRequest,
     HogFunctionInvocationResult,
     HogFunctionQueueParametersFetchRequest,
     HogFunctionQueueParametersFetchResponse,
 } from '../types'
-import { gzipObject, serializeHogFunctionInvocation } from '../utils'
 
-export const BUCKETS_KB_WRITTEN = [0, 128, 512, 1024, 2024, 4096, 10240, Infinity]
-
-const histogramFetchPayloadSize = new Histogram({
-    name: 'cdp_async_function_fetch_payload_size_kb',
-    help: 'The size in kb of the batches we are receiving from Kafka',
-    buckets: BUCKETS_KB_WRITTEN,
-})
-
-const histogramHogHooksPayloadSize = new Histogram({
-    name: 'cdp_async_function_hoghooks_payload_size_kb',
-    help: 'The size in kb of the batches we are receiving from Kafka',
-    buckets: BUCKETS_KB_WRITTEN,
-})
-
-/**
- * This class is only used by the kafka based queuing system. For the Cyclotron system there is no need for this.
- */
 export class FetchExecutorService {
-    hogHookEnabledForTeams: ValueMatcher<number>
-
-    constructor(private serverConfig: PluginsServerConfig, private rustyHook: RustyHook) {
-        this.hogHookEnabledForTeams = buildIntegerMatcher(serverConfig.CDP_ASYNC_FUNCTIONS_RUSTY_HOOK_TEAMS, true)
-    }
-
-    async execute(invocation: HogFunctionInvocation): Promise<HogFunctionInvocationResult | undefined> {
-        if (invocation.queue !== 'fetch' || !invocation.queueParameters) {
-            status.error('🦔', `[HogExecutor] Bad invocation`, { invocation })
-            return
-        }
-
-        const params = invocation.queueParameters as HogFunctionQueueParametersFetchRequest
-
-        if (params.body) {
-            histogramFetchPayloadSize.observe(params.body.length / 1024)
-        }
-
-        try {
-            if (this.hogHookEnabledForTeams(invocation.teamId)) {
-                // This is very temporary until we are commited to Cyclotron
-                const payload: HogFunctionInvocationAsyncRequest = {
-                    state: await gzipObject(serializeHogFunctionInvocation(invocation)),
-                    teamId: invocation.teamId,
-                    hogFunctionId: invocation.hogFunction.id,
-                    asyncFunctionRequest: {
-                        name: 'fetch',
-                        args: [
-                            params.url,
-                            {
-                                ...params,
-                            },
-                        ],
-                    },
-                }
-                const hoghooksPayload = JSON.stringify(payload)
-                histogramHogHooksPayloadSize.observe(hoghooksPayload.length / 1024)
-                const enqueued = await this.rustyHook.enqueueForHog(hoghooksPayload)
-                if (enqueued) {
-                    // We return nothing here hoghooks will take care of that
-                    return
-                }
-            }
-
-            status.info('🦔', `[HogExecutor] Webhook not sent via rustyhook, sending directly instead`)
-        } catch (err) {
-            status.error('🦔', `[HogExecutor] Error during fetch`, { error: String(err) })
-        }
-
-        return await this.executeLocally(invocation)
-    }
+    constructor(private serverConfig: PluginsServerConfig) {}
 
     async executeLocally(invocation: HogFunctionInvocation): Promise<HogFunctionInvocationResult> {
         if (invocation.queue !== 'fetch' || !invocation.queueParameters) {

--- a/plugin-server/src/cdp/services/fetch-executor.service.ts
+++ b/plugin-server/src/cdp/services/fetch-executor.service.ts
@@ -9,9 +9,19 @@ import {
     HogFunctionQueueParametersFetchRequest,
     HogFunctionQueueParametersFetchResponse,
 } from '../types'
-
+/**
+ * This class is only used by the kafka based queuing system. For the Cyclotron system there is no need for this.
+ */
 export class FetchExecutorService {
     constructor(private serverConfig: PluginsServerConfig) {}
+
+    async execute(invocation: HogFunctionInvocation): Promise<HogFunctionInvocationResult | undefined> {
+        if (invocation.queue !== 'fetch' || !invocation.queueParameters) {
+            status.error('🦔', `[HogExecutor] Bad invocation`, { invocation })
+            return
+        }
+        return await this.executeLocally(invocation)
+    }
 
     async executeLocally(invocation: HogFunctionInvocation): Promise<HogFunctionInvocationResult> {
         if (invocation.queue !== 'fetch' || !invocation.queueParameters) {

--- a/plugin-server/tests/cdp/cdp-e2e.test.ts
+++ b/plugin-server/tests/cdp/cdp-e2e.test.ts
@@ -110,24 +110,9 @@ describe('CDP E2E', () => {
             expect(invocations).toHaveLength(1)
 
             await waitForExpect(() => {
-                expect(kafkaObserver.messages).toHaveLength(7)
+                // We now expect 3 messages instead of 7 since we're not handling fetch responses
+                expect(kafkaObserver.messages).toHaveLength(3)
             }, 5000)
-
-            expect(mockFetch).toHaveBeenCalledTimes(1)
-
-            expect(mockFetch.mock.calls[0]).toMatchInlineSnapshot(`
-                [
-                  "https://example.com/posthog-webhook",
-                  {
-                    "body": "{"event":{"uuid":"b3a1fe86-b10c-43cc-acaf-d208977608d0","event":"$pageview","elements_chain":"","distinct_id":"distinct_id","url":"http://localhost:8000/events/1","properties":{"$current_url":"https://posthog.com","$lib_version":"1.0.0"},"timestamp":"2024-09-03T09:00:00Z"},"groups":{},"nested":{"foo":"http://localhost:8000/events/1"},"person":{"id":"uuid","name":"test","url":"http://localhost:8000/persons/1","properties":{"email":"test@posthog.com","first_name":"Pumpkin"}},"event_url":"http://localhost:8000/events/1-test"}",
-                    "headers": {
-                      "version": "v=1.0.0",
-                    },
-                    "method": "POST",
-                    "timeout": 10000,
-                  },
-                ]
-            `)
 
             const logMessages = kafkaObserver.messages.filter((m) => m.topic === KAFKA_LOG_ENTRIES)
             const metricsMessages = kafkaObserver.messages.filter((m) => m.topic === KAFKA_APP_METRICS_2)
@@ -141,17 +126,6 @@ describe('CDP E2E', () => {
                         count: 1,
                         metric_kind: 'other',
                         metric_name: 'fetch',
-                        team_id: 2,
-                    },
-                },
-                {
-                    topic: 'clickhouse_app_metrics2_test',
-                    value: {
-                        app_source: 'hog_function',
-                        app_source_id: fnFetchNoFilters.id.toString(),
-                        count: 1,
-                        metric_kind: 'success',
-                        metric_name: 'succeeded',
                         team_id: 2,
                     },
                 },
@@ -177,36 +151,6 @@ describe('CDP E2E', () => {
                         message: expect.stringContaining(
                             "Suspending function due to async function call 'fetch'. Payload:"
                         ),
-                        team_id: 2,
-                    },
-                },
-                {
-                    topic: 'log_entries_test',
-                    value: {
-                        level: 'debug',
-                        log_source: 'hog_function',
-                        log_source_id: fnFetchNoFilters.id.toString(),
-                        message: 'Resuming function',
-                        team_id: 2,
-                    },
-                },
-                {
-                    topic: 'log_entries_test',
-                    value: {
-                        level: 'info',
-                        log_source: 'hog_function',
-                        log_source_id: fnFetchNoFilters.id.toString(),
-                        message: `Fetch response:, {"status":200,"body":{"success":true}}`,
-                        team_id: 2,
-                    },
-                },
-                {
-                    topic: 'log_entries_test',
-                    value: {
-                        level: 'debug',
-                        log_source: 'hog_function',
-                        log_source_id: fnFetchNoFilters.id.toString(),
-                        message: expect.stringContaining('Function completed in'),
                         team_id: 2,
                     },
                 },

--- a/plugin-server/tests/cdp/cdp-e2e.test.ts
+++ b/plugin-server/tests/cdp/cdp-e2e.test.ts
@@ -110,9 +110,24 @@ describe('CDP E2E', () => {
             expect(invocations).toHaveLength(1)
 
             await waitForExpect(() => {
-                // We now expect 3 messages instead of 7 since we're not handling fetch responses
-                expect(kafkaObserver.messages).toHaveLength(3)
+                expect(kafkaObserver.messages).toHaveLength(7)
             }, 5000)
+
+            expect(mockFetch).toHaveBeenCalledTimes(1)
+
+            expect(mockFetch.mock.calls[0]).toMatchInlineSnapshot(`
+                [
+                  "https://example.com/posthog-webhook",
+                  {
+                    "body": "{"event":{"uuid":"b3a1fe86-b10c-43cc-acaf-d208977608d0","event":"$pageview","elements_chain":"","distinct_id":"distinct_id","url":"http://localhost:8000/events/1","properties":{"$current_url":"https://posthog.com","$lib_version":"1.0.0"},"timestamp":"2024-09-03T09:00:00Z"},"groups":{},"nested":{"foo":"http://localhost:8000/events/1"},"person":{"id":"uuid","name":"test","url":"http://localhost:8000/persons/1","properties":{"email":"test@posthog.com","first_name":"Pumpkin"}},"event_url":"http://localhost:8000/events/1-test"}",
+                    "headers": {
+                      "version": "v=1.0.0",
+                    },
+                    "method": "POST",
+                    "timeout": 10000,
+                  },
+                ]
+            `)
 
             const logMessages = kafkaObserver.messages.filter((m) => m.topic === KAFKA_LOG_ENTRIES)
             const metricsMessages = kafkaObserver.messages.filter((m) => m.topic === KAFKA_APP_METRICS_2)
@@ -126,6 +141,17 @@ describe('CDP E2E', () => {
                         count: 1,
                         metric_kind: 'other',
                         metric_name: 'fetch',
+                        team_id: 2,
+                    },
+                },
+                {
+                    topic: 'clickhouse_app_metrics2_test',
+                    value: {
+                        app_source: 'hog_function',
+                        app_source_id: fnFetchNoFilters.id.toString(),
+                        count: 1,
+                        metric_kind: 'success',
+                        metric_name: 'succeeded',
                         team_id: 2,
                     },
                 },
@@ -151,6 +177,36 @@ describe('CDP E2E', () => {
                         message: expect.stringContaining(
                             "Suspending function due to async function call 'fetch'. Payload:"
                         ),
+                        team_id: 2,
+                    },
+                },
+                {
+                    topic: 'log_entries_test',
+                    value: {
+                        level: 'debug',
+                        log_source: 'hog_function',
+                        log_source_id: fnFetchNoFilters.id.toString(),
+                        message: 'Resuming function',
+                        team_id: 2,
+                    },
+                },
+                {
+                    topic: 'log_entries_test',
+                    value: {
+                        level: 'info',
+                        log_source: 'hog_function',
+                        log_source_id: fnFetchNoFilters.id.toString(),
+                        message: `Fetch response:, {"status":200,"body":{"success":true}}`,
+                        team_id: 2,
+                    },
+                },
+                {
+                    topic: 'log_entries_test',
+                    value: {
+                        level: 'debug',
+                        log_source: 'hog_function',
+                        log_source_id: fnFetchNoFilters.id.toString(),
+                        message: expect.stringContaining('Function completed in'),
                         team_id: 2,
                     },
                 },


### PR DESCRIPTION
## Problem

Branched off of https://github.com/PostHog/posthog/pull/27760

as we got rid of the whole rusty hook concept we also do not need this in our code anymore. With it goes the whole fetchExecution (we keep the localExecution for testing)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- removed use of rusty-hook from our CDP 
- removed the fetchExecution logic (actually making the request, but kept the localExecution for testing)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- tests green

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
