### PR TITLE
feat: add envs for query-service, to gradually switch

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -62,15 +62,15 @@ _clickhouse_http_pool_mgr = httputil.get_pool_manager(
     block=True,  # makes the maxsize limit per pool, keeps connections
     num_pools=12,  # number of pools
     ca_cert=settings.CLICKHOUSE_CA,  # type: ignore[arg-type]  #  ca_cert default value is None, but the type hint is str instead of Optional[str], https://github.com/ClickHouse/clickhouse-connect/pull/450
-    verify=settings.CLICKHOUSE_VERIFY,
+    verify=settings.QUERYSERVICE_VERIFY,
 )
 
 
 def get_http_client(**overrides):
     kwargs = {
-        "host": settings.CLICKHOUSE_HOST,
+        "host": settings.QUERYSERVICE_HOST,
         "database": settings.CLICKHOUSE_DATABASE,
-        "secure": settings.CLICKHOUSE_SECURE,
+        "secure": settings.QUERYSERVICE_SECURE,
         "username": settings.CLICKHOUSE_USER,
         "password": settings.CLICKHOUSE_PASSWORD,
         "settings": {"mutations_sync": "1"} if settings.TEST else {},

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -148,7 +148,6 @@ CLICKHOUSE_HOST: str = os.getenv("CLICKHOUSE_HOST", "localhost")
 CLICKHOUSE_OFFLINE_CLUSTER_HOST: str | None = os.getenv("CLICKHOUSE_OFFLINE_CLUSTER_HOST", None)
 CLICKHOUSE_USER: str = os.getenv("CLICKHOUSE_USER", "default")
 CLICKHOUSE_PASSWORD: str = os.getenv("CLICKHOUSE_PASSWORD", "")
-CLICKHOUSE_USE_HTTP: str = get_from_env("CLICKHOUSE_USE_HTTP", False, type_cast=str_to_bool)
 CLICKHOUSE_DATABASE: str = CLICKHOUSE_TEST_DB if TEST else os.getenv("CLICKHOUSE_DATABASE", "default")
 CLICKHOUSE_CLUSTER: str = os.getenv("CLICKHOUSE_CLUSTER", "posthog")
 CLICKHOUSE_CA: str | None = os.getenv("CLICKHOUSE_CA", None)
@@ -159,6 +158,11 @@ CLICKHOUSE_SINGLE_SHARD_CLUSTER: str = os.getenv("CLICKHOUSE_SINGLE_SHARD_CLUSTE
 CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER = get_from_env(
     "CLICKHOUSE_FALLBACK_CANCEL_QUERY_ON_CLUSTER", default=True, type_cast=str_to_bool
 )
+
+CLICKHOUSE_USE_HTTP: str = get_from_env("CLICKHOUSE_USE_HTTP", False, type_cast=str_to_bool)
+QUERYSERVICE_HOST: str = get_from_env("QUERYSERVICE_HOST", CLICKHOUSE_HOST)
+QUERYSERVICE_SECURE: bool = get_from_env("QUERYSERVICE_SECURE", CLICKHOUSE_SECURE, type_cast=str_to_bool)
+QUERYSERVICE_VERIFY: bool = get_from_env("QUERYSERVICE_VERIFY", CLICKHOUSE_VERIFY, type_cast=str_to_bool)
 
 CLICKHOUSE_CONN_POOL_MIN: int = get_from_env("CLICKHOUSE_CONN_POOL_MIN", 20, type_cast=int)
 CLICKHOUSE_CONN_POOL_MAX: int = get_from_env("CLICKHOUSE_CONN_POOL_MAX", 1000, type_cast=int)


### PR DESCRIPTION
## Problem

plugin-server is having problem with query-service, own variable would allow to switch only some apps to query-service

## Changes

When connecting through HTTP interface, one can use separate QUERYSERVICE_HOST

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

Run tests.
