### PR TITLE
feat(experiments): improve "no results" diagnostics

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -590,7 +590,7 @@ export function DeltaChart({
                                             </span>
                                             /
                                             <span className="font-semibold">
-                                                {metricType === InsightType.TRENDS ? '5' : '4'}
+                                                {metricType === InsightType.TRENDS ? '3' : '2'}
                                             </span>
                                         </LemonTag>
                                     ) : (
@@ -785,12 +785,13 @@ export function DeltaChart({
                             borderRadius: '6px',
                             fontSize: '13px',
                             boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
-                            pointerEvents: 'none',
                             zIndex: 100,
                             minWidth: '200px',
                         }}
+                        onMouseEnter={() => setEmptyStateTooltipVisible(true)}
+                        onMouseLeave={() => setEmptyStateTooltipVisible(false)}
                     >
-                        <NoResultEmptyState error={error} />
+                        <NoResultEmptyState error={error} metric={metric} />
                     </div>
                 )}
             </div>

--- a/frontend/src/scenes/experiments/MetricsView/NoResultEmptyState.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/NoResultEmptyState.tsx
@@ -1,29 +1,78 @@
 import { IconCheck, IconX } from '@posthog/icons'
+import { Link, Tooltip } from '@posthog/lemon-ui'
+import { useValues } from 'kea'
+import { combineUrl } from 'kea-router/lib/utils'
+import { IconOpenInNew } from 'lib/lemon-ui/icons'
+import { urls } from 'scenes/urls'
 
-export function NoResultEmptyState({ error }: { error: any }): JSX.Element {
+import { NodeKind } from '~/queries/schema'
+import { ActivityTab, InsightType } from '~/types'
+
+import { experimentLogic } from '../experimentLogic'
+
+export enum ExperimentErrorCode {
+    NO_CONTROL_VARIANT = 'no-control-variant',
+    NO_TEST_VARIANT = 'no-test-variant',
+    NO_EXPOSURES = 'no-exposures',
+}
+
+export function NoResultEmptyState({ error, metric }: { error: any; metric: any }): JSX.Element {
+    const { experiment, variants, getMetricType } = useValues(experimentLogic)
+
     if (!error) {
         return <></>
     }
 
-    type ErrorCode = 'no-events' | 'no-flag-info' | 'no-control-variant' | 'no-test-variant' | 'no-exposures'
-
     const { statusCode, hasDiagnostics } = error
 
-    function ChecklistItem({ errorCode, value }: { errorCode: ErrorCode; value: boolean }): JSX.Element {
-        const failureText = {
-            'no-events': 'Metric events not received',
-            'no-flag-info': 'Feature flag information not present on the events',
-            'no-control-variant': 'Events with the control variant not received',
-            'no-test-variant': 'Events with at least one test variant not received',
-            'no-exposures': 'Exposure events not received',
+    function ChecklistItem({ errorCode, value }: { errorCode: ExperimentErrorCode; value: boolean }): JSX.Element {
+        const failureText: Record<ExperimentErrorCode, string> = {
+            [ExperimentErrorCode.NO_CONTROL_VARIANT]: 'Events with the control variant not received',
+            [ExperimentErrorCode.NO_TEST_VARIANT]: 'Events with at least one test variant not received',
+            [ExperimentErrorCode.NO_EXPOSURES]: 'Exposure events not received',
         }
 
-        const successText = {
-            'no-events': 'Experiment events have been received',
-            'no-flag-info': 'Feature flag information is present on the events',
-            'no-control-variant': 'Events with the control variant received',
-            'no-test-variant': 'Events with at least one test variant received',
-            'no-exposures': 'Exposure events have been received',
+        const successText: Record<ExperimentErrorCode, string> = {
+            [ExperimentErrorCode.NO_CONTROL_VARIANT]: 'Events with the control variant received',
+            [ExperimentErrorCode.NO_TEST_VARIANT]: 'Events with at least one test variant received',
+            [ExperimentErrorCode.NO_EXPOSURES]: 'Exposure events have been received',
+        }
+
+        const metricType = getMetricType(metric)
+        const requiredEvent =
+            metricType === InsightType.TRENDS
+                ? errorCode === ExperimentErrorCode.NO_EXPOSURES
+                    ? metric.exposure_query?.series[0]?.event || '$feature_flag_called'
+                    : metric.count_query?.series[0]?.event
+                : metric.funnels_query?.series[0]?.event
+
+        const query = {
+            kind: NodeKind.DataTableNode,
+            full: true,
+            source: {
+                kind: NodeKind.EventsQuery,
+                select: ['*', 'event', `properties."$feature/${experiment.feature_flag?.key}"`, 'timestamp'],
+                orderBy: ['timestamp DESC'],
+                after: experiment.start_date,
+                event: requiredEvent,
+                properties: [
+                    {
+                        key: `$feature/${experiment.feature_flag?.key}`,
+                        value: [
+                            `${
+                                errorCode === ExperimentErrorCode.NO_CONTROL_VARIANT
+                                    ? 'control'
+                                    : variants.slice(1).map((variant) => variant.key)
+                            }`,
+                        ],
+                        operator: 'exact',
+                        type: 'event',
+                    },
+                ],
+                filterTestAccounts: metric.count_query?.filter_test_accounts,
+            },
+            propertiesViaUrl: true,
+            showPersistentColumnConfigurator: true,
         }
 
         return (
@@ -37,6 +86,15 @@ export function NoResultEmptyState({ error }: { error: any }): JSX.Element {
                     <span className="flex items-center space-x-2">
                         <IconX className="text-danger" fontSize={16} />
                         <span>{failureText[errorCode]}</span>
+                        <Tooltip title="Verify missing events in the Activity tab">
+                            <Link
+                                target="_blank"
+                                className="font-semibold"
+                                to={combineUrl(urls.activity(ActivityTab.ExploreEvents), {}, { q: query }).url}
+                            >
+                                <IconOpenInNew fontSize="16" className="-ml-1" />
+                            </Link>
+                        </Tooltip>
                     </span>
                 )}
             </div>
@@ -45,8 +103,10 @@ export function NoResultEmptyState({ error }: { error: any }): JSX.Element {
 
     if (hasDiagnostics) {
         const checklistItems = []
-        for (const [errorCode, value] of Object.entries(error.detail as Record<ErrorCode, boolean>)) {
-            checklistItems.push(<ChecklistItem key={errorCode} errorCode={errorCode as ErrorCode} value={value} />)
+        for (const [errorCode, value] of Object.entries(error.detail as Record<ExperimentErrorCode, boolean>)) {
+            checklistItems.push(
+                <ChecklistItem key={errorCode} errorCode={errorCode as ExperimentErrorCode} value={value} />
+            )
         }
 
         return <div>{checklistItems}</div>

--- a/posthog/hogql_queries/experiments/experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_funnels_query_runner.py
@@ -175,16 +175,12 @@ class ExperimentFunnelsQueryRunner(QueryRunner):
 
     def _validate_event_variants(self, funnels_result: FunnelsQueryResponse):
         errors = {
-            ExperimentNoResultsErrorKeys.NO_EVENTS: True,
-            ExperimentNoResultsErrorKeys.NO_FLAG_INFO: True,
             ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
             ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: True,
         }
 
         if not funnels_result.results or not funnels_result.results:
             raise ValidationError(code="no-results", detail=json.dumps(errors))
-
-        errors[ExperimentNoResultsErrorKeys.NO_EVENTS] = False
 
         # Funnels: the first step must be present for *any* results to show up
         eventsWithOrderZero = []
@@ -199,7 +195,6 @@ class ExperimentFunnelsQueryRunner(QueryRunner):
             event_variant = event.get("breakdown_value", [None])[0]
             if event_variant == "control":
                 errors[ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT] = False
-                errors[ExperimentNoResultsErrorKeys.NO_FLAG_INFO] = False
                 break
 
         # Check if at least one of the test variants is present
@@ -208,7 +203,6 @@ class ExperimentFunnelsQueryRunner(QueryRunner):
             event_variant = event.get("breakdown_value", [None])[0]
             if event_variant in test_variants:
                 errors[ExperimentNoResultsErrorKeys.NO_TEST_VARIANT] = False
-                errors[ExperimentNoResultsErrorKeys.NO_FLAG_INFO] = False
                 break
 
         has_errors = any(errors.values())

--- a/posthog/hogql_queries/experiments/experiment_trends_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_trends_query_runner.py
@@ -370,7 +370,6 @@ class ExperimentTrendsQueryRunner(QueryRunner):
             event_variant = event.get("breakdown_value")
             if event_variant == "control":
                 errors[ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT] = False
-                errors[ExperimentNoResultsErrorKeys.NO_FLAG_INFO] = False
                 break
         # Check if at least one of the test variants is present
         test_variants = [variant for variant in self.variants if variant != "control"]
@@ -379,7 +378,6 @@ class ExperimentTrendsQueryRunner(QueryRunner):
             event_variant = event.get("breakdown_value")
             if event_variant in test_variants:
                 errors[ExperimentNoResultsErrorKeys.NO_TEST_VARIANT] = False
-                errors[ExperimentNoResultsErrorKeys.NO_FLAG_INFO] = False
                 break
 
         has_errors = any(errors.values())

--- a/posthog/hogql_queries/experiments/experiment_trends_query_runner.py
+++ b/posthog/hogql_queries/experiments/experiment_trends_query_runner.py
@@ -353,8 +353,6 @@ class ExperimentTrendsQueryRunner(QueryRunner):
     def _validate_event_variants(self, count_result: TrendsQueryResponse, exposure_result: TrendsQueryResponse):
         errors = {
             ExperimentNoResultsErrorKeys.NO_EXPOSURES: True,
-            ExperimentNoResultsErrorKeys.NO_EVENTS: True,
-            ExperimentNoResultsErrorKeys.NO_FLAG_INFO: True,
             ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
             ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: True,
         }
@@ -366,8 +364,6 @@ class ExperimentTrendsQueryRunner(QueryRunner):
 
         if not count_result.results or not count_result.results[0]:
             raise ValidationError(code="no-results", detail=json.dumps(errors))
-
-        errors[ExperimentNoResultsErrorKeys.NO_EVENTS] = False
 
         # Check if "control" is present
         for event in count_result.results:

--- a/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_funnels_query_runner.py
@@ -363,35 +363,6 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertIn(f"holdout-{holdout.id}", result.credible_intervals)
 
     @freeze_time("2020-01-01T12:00:00Z")
-    def test_validate_event_variants_no_events(self):
-        feature_flag = self.create_feature_flag()
-        experiment = self.create_experiment(feature_flag=feature_flag)
-
-        funnels_query = FunnelsQuery(
-            series=[EventsNode(event="$pageview"), EventsNode(event="purchase")],
-            dateRange={"date_from": "2020-01-01", "date_to": "2020-01-14"},
-        )
-        experiment_query = ExperimentFunnelsQuery(
-            experiment_id=experiment.id,
-            kind="ExperimentFunnelsQuery",
-            funnels_query=funnels_query,
-        )
-
-        query_runner = ExperimentFunnelsQueryRunner(query=experiment_query, team=self.team)
-        with self.assertRaises(ValidationError) as context:
-            query_runner.calculate()
-
-        expected_errors = json.dumps(
-            {
-                ExperimentNoResultsErrorKeys.NO_EVENTS: True,
-                ExperimentNoResultsErrorKeys.NO_FLAG_INFO: True,
-                ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
-                ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: True,
-            }
-        )
-        self.assertEqual(cast(list, context.exception.detail)[0], expected_errors)
-
-    @freeze_time("2020-01-01T12:00:00Z")
     def test_validate_event_variants_no_control(self):
         feature_flag = self.create_feature_flag()
         experiment = self.create_experiment(feature_flag=feature_flag)
@@ -425,8 +396,6 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         expected_errors = json.dumps(
             {
-                ExperimentNoResultsErrorKeys.NO_EVENTS: False,
-                ExperimentNoResultsErrorKeys.NO_FLAG_INFO: False,
                 ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
                 ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: False,
             }
@@ -467,53 +436,7 @@ class TestExperimentFunnelsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         expected_errors = json.dumps(
             {
-                ExperimentNoResultsErrorKeys.NO_EVENTS: False,
-                ExperimentNoResultsErrorKeys.NO_FLAG_INFO: False,
                 ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: False,
-                ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: True,
-            }
-        )
-        self.assertEqual(cast(list, context.exception.detail)[0], expected_errors)
-
-    @freeze_time("2020-01-01T12:00:00Z")
-    def test_validate_event_variants_no_flag_info(self):
-        feature_flag = self.create_feature_flag()
-        experiment = self.create_experiment(feature_flag=feature_flag)
-
-        journeys_for(
-            {
-                "user_no_flag_1": [
-                    {"event": "$pageview", "timestamp": "2020-01-02"},
-                    {"event": "purchase", "timestamp": "2020-01-03"},
-                ],
-                "user_no_flag_2": [
-                    {"event": "$pageview", "timestamp": "2020-01-03"},
-                ],
-            },
-            self.team,
-        )
-
-        flush_persons_and_events()
-
-        funnels_query = FunnelsQuery(
-            series=[EventsNode(event="$pageview"), EventsNode(event="purchase")],
-            dateRange={"date_from": "2020-01-01", "date_to": "2020-01-14"},
-        )
-        experiment_query = ExperimentFunnelsQuery(
-            experiment_id=experiment.id,
-            kind="ExperimentFunnelsQuery",
-            funnels_query=funnels_query,
-        )
-
-        query_runner = ExperimentFunnelsQueryRunner(query=experiment_query, team=self.team)
-        with self.assertRaises(ValidationError) as context:
-            query_runner.calculate()
-
-        expected_errors = json.dumps(
-            {
-                ExperimentNoResultsErrorKeys.NO_EVENTS: False,
-                ExperimentNoResultsErrorKeys.NO_FLAG_INFO: True,
-                ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
                 ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: True,
             }
         )

--- a/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
+++ b/posthog/hogql_queries/experiments/test/test_experiment_trends_query_runner.py
@@ -2147,33 +2147,6 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(test_variant.exposure, 1.0)
 
     @freeze_time("2020-01-01T12:00:00Z")
-    def test_validate_event_variants_no_events(self):
-        feature_flag = self.create_feature_flag()
-        experiment = self.create_experiment(feature_flag=feature_flag)
-
-        count_query = TrendsQuery(series=[EventsNode(event="$pageview")])
-        experiment_query = ExperimentTrendsQuery(
-            experiment_id=experiment.id,
-            kind="ExperimentTrendsQuery",
-            count_query=count_query,
-        )
-
-        query_runner = ExperimentTrendsQueryRunner(query=experiment_query, team=self.team)
-        with self.assertRaises(ValidationError) as context:
-            query_runner.calculate()
-
-        expected_errors = json.dumps(
-            {
-                ExperimentNoResultsErrorKeys.NO_EXPOSURES: True,
-                ExperimentNoResultsErrorKeys.NO_EVENTS: True,
-                ExperimentNoResultsErrorKeys.NO_FLAG_INFO: True,
-                ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
-                ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: True,
-            }
-        )
-        self.assertEqual(cast(list, context.exception.detail)[0], expected_errors)
-
-    @freeze_time("2020-01-01T12:00:00Z")
     def test_validate_event_variants_no_control(self):
         feature_flag = self.create_feature_flag()
         experiment = self.create_experiment(feature_flag=feature_flag)
@@ -2204,8 +2177,6 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         expected_errors = json.dumps(
             {
                 ExperimentNoResultsErrorKeys.NO_EXPOSURES: True,
-                ExperimentNoResultsErrorKeys.NO_EVENTS: False,
-                ExperimentNoResultsErrorKeys.NO_FLAG_INFO: False,
                 ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
                 ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: False,
             }
@@ -2251,66 +2222,7 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         expected_errors = json.dumps(
             {
                 ExperimentNoResultsErrorKeys.NO_EXPOSURES: False,
-                ExperimentNoResultsErrorKeys.NO_EVENTS: False,
-                ExperimentNoResultsErrorKeys.NO_FLAG_INFO: False,
                 ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: False,
-                ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: True,
-            }
-        )
-        self.assertEqual(cast(list, context.exception.detail)[0], expected_errors)
-
-    @freeze_time("2020-01-01T12:00:00Z")
-    def test_validate_event_variants_no_flag_info(self):
-        feature_flag = self.create_feature_flag()
-        experiment = self.create_experiment(feature_flag=feature_flag)
-
-        journeys_for(
-            {
-                "user_no_flag_1": [
-                    {
-                        "event": "$feature_flag_called",
-                        "timestamp": "2020-01-02",
-                        "properties": {
-                            "$feature_flag": feature_flag.key,
-                            "$feature_flag_response": "control",
-                        },
-                    },
-                    {"event": "$pageview", "timestamp": "2020-01-02"},
-                ],
-                "user_no_flag_2": [
-                    {
-                        "event": "$feature_flag_called",
-                        "timestamp": "2020-01-02",
-                        "properties": {
-                            "$feature_flag": feature_flag.key,
-                            "$feature_flag_response": "control",
-                        },
-                    },
-                    {"event": "$pageview", "timestamp": "2020-01-03"},
-                ],
-            },
-            self.team,
-        )
-
-        flush_persons_and_events()
-
-        count_query = TrendsQuery(series=[EventsNode(event="$pageview")])
-        experiment_query = ExperimentTrendsQuery(
-            experiment_id=experiment.id,
-            kind="ExperimentTrendsQuery",
-            count_query=count_query,
-        )
-
-        query_runner = ExperimentTrendsQueryRunner(query=experiment_query, team=self.team)
-        with self.assertRaises(ValidationError) as context:
-            query_runner.calculate()
-
-        expected_errors = json.dumps(
-            {
-                ExperimentNoResultsErrorKeys.NO_EXPOSURES: False,
-                ExperimentNoResultsErrorKeys.NO_EVENTS: True,
-                ExperimentNoResultsErrorKeys.NO_FLAG_INFO: True,
-                ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: True,
                 ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: True,
             }
         )
@@ -2356,8 +2268,6 @@ class TestExperimentTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         expected_errors = json.dumps(
             {
                 ExperimentNoResultsErrorKeys.NO_EXPOSURES: True,
-                ExperimentNoResultsErrorKeys.NO_EVENTS: False,
-                ExperimentNoResultsErrorKeys.NO_FLAG_INFO: False,
                 ExperimentNoResultsErrorKeys.NO_CONTROL_VARIANT: False,
                 ExperimentNoResultsErrorKeys.NO_TEST_VARIANT: False,
             }


### PR DESCRIPTION
## Problem
When solving [this ticket](https://posthoghelp.zendesk.com/agent/tickets/23258), I've noticed that the "no results" diagnostics weren't working entirely correctly. This user did have the required event, just was missing the feature flag information on them. Yet, the diagnostics popup showed "Metric events not received".

I'm a bit unsure why this used to work in the old code. We did have [this filter condition](https://github.com/PostHog/posthog/blob/master/ee/clickhouse/queries/experiments/trend_experiment_result.py#L112), but the query must've returned counts for all events too (to be able to confirm their existence in the validation method). In the new HogQL implementation, this is not the case, and only the events having the feature flag variants get returned.

## Changes
Rather than fixing this, I'm proposing the following change:

- Simplify the diagnostics list, where we only let the user know when there are _no events with required variants_, as opposed to _no events whatsoever_.
- In the popup, add links to the Activity tab where the user can:
	- Verify that there are indeed no said events
	- Play with the filter to see if they're able to find any events at all

This is simplifies the checklist and lets the user verify and debug missing events in a more interactive way.

**Trends**
|Before|After|
|----|----|
|<img width="355" alt="image" src="https://github.com/user-attachments/assets/c3736afd-df45-4cd6-9612-d8d0fa9f37cf" />|<img width="363" alt="image" src="https://github.com/user-attachments/assets/80988d8d-b043-4264-8b4c-678d422f6a73" />|

**Funnels**
|Before|After|
|----|----|
|<img width="353" alt="image" src="https://github.com/user-attachments/assets/f68c92a0-fb72-4043-bca2-35b9d5acc162" />|<img width="363" alt="image" src="https://github.com/user-attachments/assets/fddaea16-fd87-41d9-ab42-a76371a5eab8" />|

- Clicking the link takes you to the activity tab where you can verify missing events:
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/de64523f-54fc-45be-b033-8ac57be01f42" />

## How did you test this code?
Manually tested that the Activity query is set up correctly for:
- Trends, default exposure
- Trends custom exposure
- Funnels