### PR TITLE
fix(retention): fix background color for the retention modal

### DIFF
--- a/frontend/src/scenes/retention/RetentionModal.tsx
+++ b/frontend/src/scenes/retention/RetentionModal.tsx
@@ -30,9 +30,11 @@ export function RetentionModal(): JSX.Element | null {
     const { aggregationTargetLabel, selectedInterval, exploreUrl, actorsQuery } = useValues(
         retentionModalLogic(insightProps)
     )
+    const { theme } = useValues(retentionModalLogic(insightProps))
     const { closeModal } = useActions(retentionModalLogic(insightProps))
     const { startExport } = useActions(exportsLogic)
 
+    const backgroundColor = theme?.['preset-1'] || '#000000' // Default to black if no color found
     const dataTableNodeQuery: DataTableNode | undefined = actorsQuery
         ? {
               kind: NodeKind.DataTableNode,
@@ -107,7 +109,15 @@ export function RetentionModal(): JSX.Element | null {
                     <span>No {aggregationTargetLabel.plural} during this period.</span>
                 ) : (
                     <>
-                        <table className="RetentionTable RetentionTable--non-interactive">
+                        <table
+                            className="RetentionTable RetentionTable--non-interactive"
+                            // eslint-disable-next-line react/forbid-dom-props
+                            style={
+                                {
+                                    '--retention-table-color': backgroundColor,
+                                } as React.CSSProperties
+                            }
+                        >
                             <tbody>
                                 <tr>
                                     <th>{capitalizeFirstLetter(aggregationTargetLabel.singular)}</th>

--- a/frontend/src/scenes/retention/retentionModalLogic.ts
+++ b/frontend/src/scenes/retention/retentionModalLogic.ts
@@ -22,7 +22,7 @@ export const retentionModalLogic = kea<retentionModalLogicType>([
     connect((props: InsightLogicProps) => ({
         values: [
             insightVizDataLogic(props),
-            ['querySource', 'retentionFilter'],
+            ['querySource', 'retentionFilter', 'theme'],
             groupsModel,
             ['aggregationLabel'],
             featureFlagLogic,


### PR DESCRIPTION
## Problem

https://github.com/PostHog/posthog/pull/27642 broke the retention modal

## Changes

This PR adds the missing CSS var to the retention modal table as well.

## How did you test this code?

👀 

<img width="1389" alt="Screenshot 2025-01-22 at 12 56 56" src="https://github.com/user-attachments/assets/52ca7e61-7b64-449e-b59d-314949486b73" />
