### PR TITLE
feat(web-analytics): Set unique conversions graph when adding conversions goal

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -383,6 +383,12 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
             {
                 setGraphsTab: (_, { tab }) => tab,
                 togglePropertyFilter: (oldTab, { tabChange }) => tabChange?.graphsTab || oldTab,
+                setConversionGoal: (oldTab, { conversionGoal }) => {
+                    if (conversionGoal) {
+                        return GraphsTab.UNIQUE_CONVERSIONS
+                    }
+                    return oldTab
+                },
             },
         ],
         _sourceTab: [


### PR DESCRIPTION
## Problem

Feature request from @andyvan-ph https://posthog.slack.com/archives/C05LJK1N3CP/p1737543233335339

## Changes

When adding or changing a conversion goal, set the tab to Unique Visitors

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran locally
Added a conversion goal
Observed that the unique conversions graph was active
