### PR TITLE
perf: WIP Cache parsing of static hogql queries

### DIFF
--- a/.run/PostHog.run.xml
+++ b/.run/PostHog.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="PostHog" type="Python.DjangoServer" factoryName="Django server">
     <module name="posthog" />
-    <option name="ENV_FILES" value="" />
+    <option name="ENV_FILES" value="$PROJECT_DIR$/.env" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>

--- a/.run/PostHog.run.xml
+++ b/.run/PostHog.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="PostHog" type="Python.DjangoServer" factoryName="Django server">
     <module name="posthog" />
-    <option name="ENV_FILES" value="$PROJECT_DIR$/.env" />
+    <option name="ENV_FILES" value="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>

--- a/posthog/cache_utils.py
+++ b/posthog/cache_utils.py
@@ -83,6 +83,10 @@ def lru_cache_ignore_args(ignore_args: set[str], maxsize=128):
     """
     A decorator for an LRU cache that ignores specific arguments when caching.
 
+    Uses the functools.lru_cache decorator under the hood.
+
+    The ignored args MUST be passed as keyword arguments.
+
     :param ignore_args: Set of argument names to ignore for caching.
     :param maxsize: Maximum size of the LRU cache.
     """
@@ -94,9 +98,7 @@ def lru_cache_ignore_args(ignore_args: set[str], maxsize=128):
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            # Rebuild the kwargs excluding ignored arguments
             filtered_kwargs = {k: v for k, v in kwargs.items() if k not in ignore_args}
-            # Rebuild args and kwargs for the cache key
             return cached_function(*args, **filtered_kwargs)
 
         return wrapper

--- a/posthog/hogql/database/schema/channel_type.py
+++ b/posthog/hogql/database/schema/channel_type.py
@@ -1,11 +1,10 @@
 from dataclasses import dataclass
-from functools import cache
 from typing import Optional, Union
 
 
 from posthog.hogql import ast
 from posthog.hogql.database.models import ExpressionField
-from posthog.hogql.parser import parse_expr, parse_expr_static
+from posthog.hogql.parser import parse_expr_static
 from posthog.hogql.timings import HogQLTimings
 from posthog.schema import (
     CustomChannelRule,
@@ -321,13 +320,6 @@ def create_channel_type_expr(
         )
     else:
         return builtin_rules
-
-
-@cache
-def _initial_default_channel_rules_expr():
-    # This logic is referenced in our docs https://posthog.com/docs/data/channel-type, be sure to update both if you
-    # update either.
-    return parse_expr()
 
 
 def wrap_with_null_if_empty(expr: ast.Expr) -> ast.Expr:

--- a/posthog/hogql_queries/web_analytics/stats_table.py
+++ b/posthog/hogql_queries/web_analytics/stats_table.py
@@ -2,7 +2,7 @@ from typing import Union
 
 from posthog.hogql import ast
 from posthog.hogql.constants import LimitContext
-from posthog.hogql.parser import parse_select, parse_expr
+from posthog.hogql.parser import parse_expr, parse_select_static
 from posthog.hogql.property import (
     property_to_expr,
     get_property_operator,
@@ -124,7 +124,7 @@ class WebStatsTableQueryRunner(WebAnalyticsQueryRunner):
 
     def to_path_scroll_bounce_query(self) -> ast.SelectQuery:
         with self.timings.measure("stats_table_bounce_query"):
-            query = parse_select(
+            query = parse_select_static(
                 """
 SELECT
     counts.breakdown_value AS "context.columns.breakdown_value",
@@ -240,7 +240,7 @@ ORDER BY "context.columns.visitors" DESC,
             raise NotImplementedError("Bounce rate is only supported for page breakdowns")
 
         with self.timings.measure("stats_table_scroll_query"):
-            query = parse_select(
+            query = parse_select_static(
                 """
 SELECT
     counts.breakdown_value AS "context.columns.breakdown_value",
@@ -317,7 +317,7 @@ ORDER BY "context.columns.visitors" DESC,
         return query
 
     def _main_inner_query(self, breakdown):
-        query = parse_select(
+        query = parse_select_static(
             """
 SELECT
     any(person_id) AS filtered_person_id,

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -5,6 +5,7 @@ import datetime
 import datetime as dt
 import gzip
 import hashlib
+import inspect
 import json
 import os
 import re
@@ -1499,3 +1500,14 @@ def get_from_dict_or_attr(obj: Any, key: str):
         return getattr(obj, key, None)
     else:
         raise AttributeError(f"Object {obj} has no key {key}")
+
+
+def is_constant_in_current_stack(value: str):
+    """Determine if a value is a static string literal anywhere in the current stack."""
+    for frame_info in inspect.stack():
+        frame = frame_info.frame
+        # Get all constants from the code object in the frame
+        code_context = frame.f_code.co_consts
+        if value in code_context:
+            return True
+    return False

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -1503,10 +1503,14 @@ def get_from_dict_or_attr(obj: Any, key: str):
 
 
 def is_constant_in_current_stack(value: str):
-    """Determine if a value is a static string literal anywhere in the current stack."""
+    """
+    Go back through the current stack, and look for a given value in its constants.
+
+    This can be used as an imperfect signal whether the given argument is a constant (i.e. a static string),
+    though obviously there are cases where a false negative is possible.
+    """
     for frame_info in inspect.stack():
         frame = frame_info.frame
-        # Get all constants from the code object in the frame
         code_context = frame.f_code.co_consts
         if value in code_context:
             return True


### PR DESCRIPTION
WIP WIP WIP WIP WIP WIP

## Problem

We have a lot of static query strings that we parse, which could be cached. Some of these queries strings take hundreds of ms to parse.

## Changes

WIP WIP WIP WIP WIP WIP

This is a rough proof of concept, I just wanted to use a PR to demonstrate the approach and get feedback.

To use this in prod would involve writing some tests, and changing many more of our static queries to use it.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

WIP WIP WIP WIP WIP WIP
