### PR TITLE
fix: typo for feature flags

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -511,17 +511,19 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                             overlay={
                                                 <>
                                                     {featureFlags[FEATURE_FLAGS.FEATURE_FLAG_COHORT_CREATION] && (
-                                                        <LemonButton
-                                                            loading={newCohortLoading}
-                                                            onClick={() => {
-                                                                createStaticCohort()
-                                                            }}
-                                                            fullWidth
-                                                        >
-                                                            Create Cohort
-                                                        </LemonButton>
+                                                        <>
+                                                            <LemonButton
+                                                                loading={newCohortLoading}
+                                                                onClick={() => {
+                                                                    createStaticCohort()
+                                                                }}
+                                                                fullWidth
+                                                            >
+                                                                Create Cohort
+                                                            </LemonButton>
+                                                            <LemonDivider />
+                                                        </>
                                                     )}
-                                                    <LemonDivider />
                                                     <LemonButton
                                                         data-attr={
                                                             featureFlag.deleted
@@ -545,8 +547,9 @@ export function FeatureFlag({ id }: { id?: string } = {}): JSX.Element {
                                                                 : null
                                                         }
                                                     >
-                                                        <span>{featureFlag.deleted ? 'Restore' : 'Delete'}</span>{' '}
-                                                        <span>feature flag</span>
+                                                        <span>
+                                                            {featureFlag.deleted ? 'Restore' : 'Delete'} feature flag
+                                                        </span>
                                                     </LemonButton>
                                                 </>
                                             }


### PR DESCRIPTION
## Problem

typos were present

## Changes

typos are not present

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Looked at it
