### PR TITLE
chore: improve generation of experiment flag key

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentForm.tsx
@@ -18,9 +18,8 @@ const ExperimentFormFields = (): JSX.Element => {
     const { experiment, groupTypes, aggregationLabel } = useValues(experimentLogic)
     const { addVariant, removeExperimentGroup, setExperiment, createExperiment, setExperimentType } =
         useActions(experimentLogic)
-    const { webExperimentsAvailable } = useValues(experimentsLogic)
+    const { webExperimentsAvailable, unavailableFeatureFlagKeys } = useValues(experimentsLogic)
     const { groupsAccessStatus } = useValues(groupsAccessLogic)
-    const { takenKeys } = useValues(experimentsLogic)
 
     return (
         <div>
@@ -40,14 +39,14 @@ const ExperimentFormFields = (): JSX.Element => {
                                 <LemonButton
                                     type="secondary"
                                     size="xsmall"
-                                    tooltip={
-                                        experiment.name
-                                            ? 'Generate a key from the experiment name'
-                                            : 'Fill out the experiment name first.'
-                                    }
+                                    disabledReason={experiment.name ? undefined : 'Fill out the experiment name first.'}
+                                    tooltip={experiment.name ? 'Generate a key from the experiment name' : undefined}
                                     onClick={() => {
                                         setExperiment({
-                                            feature_flag_key: generateFeatureFlagKey(experiment.name, takenKeys),
+                                            feature_flag_key: generateFeatureFlagKey(
+                                                experiment.name,
+                                                unavailableFeatureFlagKeys
+                                            ),
                                         })
                                     }}
                                 >
@@ -294,7 +293,7 @@ export function ExperimentForm(): JSX.Element {
     )
 }
 
-const generateFeatureFlagKey = (name: string, takenKeys: string[]): string => {
+const generateFeatureFlagKey = (name: string, unavailableFeatureFlagKeys: Set<string>): string => {
     const baseKey = name
         .toLowerCase()
         .replace(/[^A-Za-z0-9-_]+/g, '-')
@@ -303,7 +302,8 @@ const generateFeatureFlagKey = (name: string, takenKeys: string[]): string => {
 
     let key = baseKey
     let counter = 1
-    while (takenKeys.includes(key)) {
+
+    while (unavailableFeatureFlagKeys.has(key)) {
         key = `${baseKey}-${counter}`
         counter++
     }


### PR DESCRIPTION
## Problem

We were only using experiments to dedupe, might as well include recent flags also to avoid collisions when generating the key.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Add in first page of feature flags to improve deduplication of generated flag key in experiments
- Disable generation when no name is entered

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran locally and tested creating a few flags.
