### PR TITLE
feat: fetch team config in mr blobby v2

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -2,6 +2,7 @@ import { captureException } from '@sentry/node'
 import { CODES, features, KafkaConsumer, librdkafkaVersion, Message, TopicPartition } from 'node-rdkafka'
 
 import { KafkaProducerWrapper } from '~/src/kafka/producer'
+import { PostgresRouter } from '~/src/utils/db/postgres'
 
 import { buildIntegerMatcher } from '../../../config/config'
 import { BatchConsumer } from '../../../kafka/batch-consumer'
@@ -55,6 +56,7 @@ export class SessionRecordingIngester {
     constructor(
         private config: PluginsServerConfig,
         private consumeOverflow: boolean,
+        private postgres: PostgresRouter,
         batchConsumerFactory: BatchConsumerFactory,
         ingestionWarningProducer?: KafkaProducerWrapper
     ) {
@@ -68,7 +70,7 @@ export class SessionRecordingIngester {
         this.promiseScheduler = new PromiseScheduler()
 
         this.kafkaParser = new KafkaMessageParser(KafkaMetrics.getInstance())
-        this.teamFilter = new TeamFilter(new TeamService())
+        this.teamFilter = new TeamFilter(new TeamService(postgres))
         if (ingestionWarningProducer) {
             const captureWarning: CaptureIngestionWarningFn = async (teamId, type, details, debounce) => {
                 await captureIngestionWarning(ingestionWarningProducer, teamId, type, details, debounce)

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/teams/team-service.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/teams/team-service.ts
@@ -1,9 +1,8 @@
-import { TeamIDWithConfig } from '~/src/cdp/consumers/cdp-base.consumer'
-import { BackgroundRefresher } from '~/src/utils/background-refresher'
-import { PostgresRouter } from '~/src/utils/db/postgres'
-import { fetchTeamTokensWithRecordings } from '~/src/worker/ingestion/team-manager'
-
+import { TeamIDWithConfig } from '../../../../cdp/consumers/cdp-base.consumer'
+import { BackgroundRefresher } from '../../../../utils/background-refresher'
+import { PostgresRouter } from '../../../../utils/db/postgres'
 import { status as logger } from '../../../../utils/status'
+import { fetchTeamTokensWithRecordings } from '../../../../worker/ingestion/team-manager'
 import { Team } from './types'
 
 export class TeamService {

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/teams/team-service.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/teams/team-service.ts
@@ -1,10 +1,36 @@
+import { TeamIDWithConfig } from '~/src/cdp/consumers/cdp-base.consumer'
+import { BackgroundRefresher } from '~/src/utils/background-refresher'
+import { PostgresRouter } from '~/src/utils/db/postgres'
+import { fetchTeamTokensWithRecordings } from '~/src/worker/ingestion/team-manager'
+
+import { status as logger } from '../../../../utils/status'
 import { Team } from './types'
 
 export class TeamService {
-    constructor() {}
+    private readonly teamRefresher: BackgroundRefresher<Record<string, TeamIDWithConfig>>
 
-    public async getTeamByToken(_token: string): Promise<Team | null> {
-        // For now, just return null as we'll implement the actual team lookup later
-        return Promise.resolve(null)
+    constructor(postgres: PostgresRouter) {
+        this.teamRefresher = new BackgroundRefresher(
+            () => fetchTeamTokensWithRecordings(postgres),
+            5 * 60 * 1000, // 5 minutes
+            (e) => {
+                // We ignore the error and wait for postgres to recover
+                logger.error('Error refreshing team tokens', e)
+            }
+        )
+    }
+
+    public async getTeamByToken(token: string): Promise<Team | null> {
+        const teams = await this.teamRefresher.get()
+        const teamConfig = teams[token]
+
+        if (!teamConfig?.teamId) {
+            return null
+        }
+
+        return {
+            teamId: teamConfig.teamId,
+            consoleLogIngestionEnabled: teamConfig.consoleLogIngestionEnabled,
+        }
     }
 }

--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -493,15 +493,19 @@ export async function startPluginsServer(
         }
 
         if (capabilities.sessionRecordingBlobIngestionV2) {
+            const hub = await setupHub()
+            const postgres = hub?.postgres ?? new PostgresRouter(serverConfig)
             const batchConsumerFactory = new DefaultBatchConsumerFactory(serverConfig)
-            const ingester = new SessionRecordingIngesterV2(serverConfig, false, batchConsumerFactory)
+            const ingester = new SessionRecordingIngesterV2(serverConfig, false, postgres, batchConsumerFactory)
             await ingester.start()
             services.push(ingester.service)
         }
 
         if (capabilities.sessionRecordingBlobIngestionV2Overflow) {
+            const hub = await setupHub()
+            const postgres = hub?.postgres ?? new PostgresRouter(serverConfig)
             const batchConsumerFactory = new DefaultBatchConsumerFactory(serverConfig)
-            const ingester = new SessionRecordingIngesterV2(serverConfig, true, batchConsumerFactory)
+            const ingester = new SessionRecordingIngesterV2(serverConfig, true, postgres, batchConsumerFactory)
             await ingester.start()
             services.push(ingester.service)
         }

--- a/plugin-server/src/utils/background-refresher.ts
+++ b/plugin-server/src/utils/background-refresher.ts
@@ -7,7 +7,13 @@ export class BackgroundRefresher<T> {
     private cachedValuePromise: Promise<T> | null = null
     private lastRefreshTime = 0
 
-    constructor(private readonly refreshFunction: () => Promise<T>, private readonly maxAgeMs: number = 1000 * 60) {}
+    constructor(
+        private readonly refreshFunction: () => Promise<T>,
+        private readonly maxAgeMs: number = 1000 * 60,
+        private readonly errorHandler: (e: unknown) => void = (e) => {
+            throw e
+        }
+    ) {}
 
     public async refresh(): Promise<T> {
         if (this.cachedValuePromise) {
@@ -34,7 +40,7 @@ export class BackgroundRefresher<T> {
 
         if (Date.now() - this.lastRefreshTime > this.maxAgeMs) {
             // We trigger the refresh but we don't use it
-            void this.refresh()
+            void this.refresh().catch(this.errorHandler)
         }
 
         return this.cachedValue!

--- a/plugin-server/tests/main/ingestion-queues/session-recording-v2/teams/team-service.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording-v2/teams/team-service.test.ts
@@ -1,0 +1,142 @@
+import { TeamService } from '../../../../../src/main/ingestion-queues/session-recording-v2/teams/team-service'
+import { PostgresRouter } from '../../../../../src/utils/db/postgres'
+import { fetchTeamTokensWithRecordings } from '../../../../../src/worker/ingestion/team-manager'
+
+jest.mock('../../../../../src/worker/ingestion/team-manager')
+const mockFetchTeamTokens = fetchTeamTokensWithRecordings as jest.MockedFunction<typeof fetchTeamTokensWithRecordings>
+
+describe('TeamService', () => {
+    let teamService: TeamService
+    let mockPostgres: jest.Mocked<PostgresRouter>
+
+    beforeEach(() => {
+        jest.useFakeTimers()
+        mockPostgres = {} as jest.Mocked<PostgresRouter>
+        mockFetchTeamTokens.mockReset()
+
+        // Default mock implementation
+        mockFetchTeamTokens.mockResolvedValue({
+            'valid-token': { teamId: 1, consoleLogIngestionEnabled: true },
+            'valid-token-2': { teamId: 2, consoleLogIngestionEnabled: false },
+        })
+
+        teamService = new TeamService(mockPostgres)
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+    })
+
+    describe('getTeamByToken', () => {
+        it('should return team for valid token', async () => {
+            const team = await teamService.getTeamByToken('valid-token')
+            expect(team).toEqual({
+                teamId: 1,
+                consoleLogIngestionEnabled: true,
+            })
+        })
+
+        it('should return null for invalid token', async () => {
+            const team = await teamService.getTeamByToken('invalid-token')
+            expect(team).toBeNull()
+        })
+
+        it('should return null if teamId is missing', async () => {
+            mockFetchTeamTokens.mockResolvedValue({
+                token: { teamId: null as any, consoleLogIngestionEnabled: true },
+            })
+            const team = await teamService.getTeamByToken('token')
+            expect(team).toBeNull()
+        })
+
+        it('should cache results and not fetch again within refresh period', async () => {
+            await teamService.getTeamByToken('valid-token')
+            await teamService.getTeamByToken('valid-token-2')
+
+            // Advance time but not enough to trigger refresh
+            jest.advanceTimersByTime(4 * 60 * 1000) // 4 minutes (refresh is 5 minutes)
+
+            await teamService.getTeamByToken('valid-token')
+            await teamService.getTeamByToken('valid-token-2')
+
+            expect(mockFetchTeamTokens).toHaveBeenCalledTimes(1)
+        })
+
+        it('should refresh after max age', async () => {
+            await teamService.getTeamByToken('valid-token')
+            expect(mockFetchTeamTokens).toHaveBeenCalledTimes(1)
+
+            // Move time forward past the refresh interval
+            jest.advanceTimersByTime(5 * 60 * 1000 + 1)
+
+            // This should trigger a refresh
+            await teamService.getTeamByToken('valid-token')
+            expect(mockFetchTeamTokens).toHaveBeenCalledTimes(2)
+        })
+
+        it('should handle refresh errors and return cached data', async () => {
+            // First call succeeds
+            await teamService.getTeamByToken('valid-token')
+            expect(mockFetchTeamTokens).toHaveBeenCalledTimes(1)
+
+            // Make next refresh fail
+            mockFetchTeamTokens.mockRejectedValueOnce(new Error('Refresh failed'))
+
+            // Advance time to trigger refresh
+            jest.advanceTimersByTime(5 * 60 * 1000 + 1)
+
+            // Should still return cached data
+            const team = await teamService.getTeamByToken('valid-token')
+            expect(team).toEqual({
+                teamId: 1,
+                consoleLogIngestionEnabled: true,
+            })
+        })
+
+        it('should eventually update cache after successful refresh', async () => {
+            // Initial fetch
+            const team1 = await teamService.getTeamByToken('valid-token')
+            expect(team1?.consoleLogIngestionEnabled).toBe(true)
+
+            // Update mock data and capture the promise
+            const mockFetchPromise = Promise.resolve({
+                'valid-token': { teamId: 1, consoleLogIngestionEnabled: false },
+            })
+            mockFetchTeamTokens.mockReturnValue(mockFetchPromise)
+
+            // Advance time to trigger refresh
+            jest.advanceTimersByTime(5 * 60 * 1000 + 1)
+
+            // Wait for the new value to appear using a spinlock, don't advance time though
+            while ((await teamService.getTeamByToken('valid-token'))?.consoleLogIngestionEnabled !== false) {
+                await Promise.resolve() // Allow other promises to resolve
+            }
+
+            const team2 = await teamService.getTeamByToken('valid-token')
+            expect(team2?.consoleLogIngestionEnabled).toBe(false)
+        })
+
+        it('should eventually return null when team is removed after refresh', async () => {
+            // Initial fetch
+            const team1 = await teamService.getTeamByToken('valid-token')
+            expect(team1?.teamId).toBe(1)
+
+            // Update mock data to remove the team
+            const mockFetchPromise = Promise.resolve({
+                'valid-token-2': { teamId: 2, consoleLogIngestionEnabled: false }, // Remove valid-token
+            })
+            mockFetchTeamTokens.mockReturnValue(mockFetchPromise)
+
+            // Advance time to trigger refresh
+            jest.advanceTimersByTime(5 * 60 * 1000 + 1)
+
+            // Wait for the team to be removed using a spinlock, don't advance time though
+            while ((await teamService.getTeamByToken('valid-token')) !== null) {
+                await Promise.resolve() // Allow other promises to resolve
+            }
+
+            const team2 = await teamService.getTeamByToken('valid-token')
+            expect(team2).toBeNull()
+        })
+    })
+})


### PR DESCRIPTION
## Problem

At the moment, Mr Blobby V2 ignores all events because of the stub of the team service. We want to enable processing the events the same way as in V2.

## Changes

- Copies the logic of background team refresh from V1 into the TeamService
- Adds a background refresh error handler, so that we don't have unhandled errors

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added tests for TeamService.
