### PR TITLE
fix(sources-perf): Adding query perf updates for external_data_source

### DIFF
--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -265,18 +265,22 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 "created_by",
                 Prefetch(
                     "jobs",
-                    queryset=ExternalDataJob.objects.filter(status="Completed").order_by("-created_at"),
+                    queryset=ExternalDataJob.objects.filter(status="Completed", team_id=self.team_id).order_by(
+                        "-created_at"
+                    )[:1],
                     to_attr="ordered_jobs",
                 ),
                 Prefetch(
                     "schemas",
-                    queryset=ExternalDataSchema.objects.exclude(deleted=True)
+                    queryset=ExternalDataSchema.objects.filter(team_id=self.team_id)
+                    .exclude(deleted=True)
                     .select_related("table__credential", "table__external_data_source")
                     .order_by("name"),
                 ),
                 Prefetch(
                     "schemas",
-                    queryset=ExternalDataSchema.objects.exclude(deleted=True)
+                    queryset=ExternalDataSchema.objects.filter(team_id=self.team_id)
+                    .exclude(deleted=True)
                     .filter(should_sync=True)
                     .select_related("source", "table__credential", "table__external_data_source"),
                     to_attr="active_schemas",

--- a/posthog/warehouse/models/external_data_source.py
+++ b/posthog/warehouse/models/external_data_source.py
@@ -79,8 +79,8 @@ class ExternalDataSource(CreatedMetaFields, UpdatedMetaFields, UUIDModel, Delete
         from posthog.warehouse.models.external_data_schema import ExternalDataSchema
 
         for schema in (
-            ExternalDataSchema.objects.exclude(deleted=True)
-            .filter(team_id=self.team.pk, source_id=self.id, should_sync=True)
+            ExternalDataSchema.objects.filter(team_id=self.team.pk, source_id=self.id, should_sync=True)
+            .exclude(deleted=True)
             .all()
         ):
             try:


### PR DESCRIPTION
## Problem

We currently have 14+ second queries on `external_data_sources` for some users. I'm not 100% sure that this will indeed fix all the query perf issues here, but it seems to be a good place for us to start.

<img width="1082" alt="image" src="https://github.com/user-attachments/assets/6a167386-0fd4-49e9-a29b-a0f93a10e312" />

## Changes

- Update prefetch queries to filter by the team
- As far as I can tell, we only need the most recent job, so I reduced the result set of the prefetch to 1... It looks like the ORM doesn't support `.limit(1)` type syntax, so the gain here may be limited.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Looked at the join sequence needed to extract the DW data out of the DB layer with Metabase and then at the ORM handling for get and list implementations.
The query works, but it's hard to test in the local env w/o all of the other data present.
