### PR TITLE
[SUPPORT SUPERDAY] Add bug report button to Help SidePanel

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/SidePanelSupport.tsx
@@ -13,6 +13,7 @@ import {
     IconStack,
     IconTestTube,
     IconToggle,
+    IconBug
 } from '@posthog/icons'
 import { LemonBanner, LemonButton, Link } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
@@ -306,6 +307,19 @@ export const SidePanelSupport = (): JSX.Element => {
                                             targetBlank
                                         >
                                             Request a feature
+                                        </LemonButton>
+                                    </li>
+                                    <li>
+                                        <LemonButton
+                                            type="secondary"
+                                            status="alt"
+                                            to={`https://github.com/PostHog/posthog/issues/new?&labels=bug&template=bug_report.yml&debug-info=${encodeURIComponent(
+                                                getPublicSupportSnippet(region, currentOrganization, currentTeam)
+                                            )}`}
+                                            icon={<IconBug />}
+                                            targetBlank
+                                        >
+                                            Report a bug
                                         </LemonButton>
                                     </li>
                                 </ul>


### PR DESCRIPTION
## Problem

Users may want to report a bug directly from the Help Sidepanel, but there's no way to do it currently

## Changes

Added a button that allows users to report a bug to PostHog/posthog using the bug report template: https://github.com/PostHog/posthog/issues/new?&labels=bug&template=bug_report.yml

I found the icon for the button here: https://storybook.posthog.net/?path=/story/posthog-3000-icons--alphabetical

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Issues with codespaces and not being able to spin a local env in Windows prevented me from testing, but I followed the conventions in the repository and hope to test it in the future if someone else doesn't test it first.

@abigailbramble 