### PR TITLE
feat(experiments): Auto-apply date+breakdown when creating dash

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -42,6 +42,7 @@ import {
 import {
     Breadcrumb,
     BreakdownAttributionType,
+    BreakdownType,
     ChartDisplayType,
     CohortType,
     CountPerActorMathType,
@@ -937,6 +938,15 @@ export const experimentLogic = kea<experimentLogicType>([
                     {
                         name: 'Experiment: ' + values.experiment.name,
                         description: `Dashboard for [${experimentUrl}](${experimentUrl})`,
+                        filters: {
+                            date_from: values.experiment.start_date,
+                            date_to: values.experiment.end_date,
+                            properties: [],
+                            breakdown_filter: {
+                                breakdown: '$feature/' + values.experiment.feature_flag_key,
+                                breakdown_type: 'event' as BreakdownType,
+                            },
+                        },
                     } as Partial<DashboardType>
                 )
 


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/26934#issuecomment-2604838411

## Changes

Automatically applies the experiment dates as a filter and feature flag as a breakdown when creating a dashboard:

https://github.com/user-attachments/assets/c3583470-cfaf-4b81-b301-f9f774cb61e6

## How did you test this code?

👀 