### PR TITLE
fix(editor-3001): make sure view name stays synced to tab

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/QueryTabs.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryTabs.tsx
@@ -1,7 +1,7 @@
 import { IconPlus, IconX } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 import clsx from 'clsx'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import AutoTab from './AutoTab'
 import { NEW_QUERY, QueryTab } from './multitabEditorLogic'
@@ -44,6 +44,10 @@ interface QueryTabProps {
 function QueryTabComponent({ model, active, onClear, onClick, onRename }: QueryTabProps): JSX.Element {
     const [tabName, setTabName] = useState(() => model.name || NEW_QUERY)
     const [isEditing, setIsEditing] = useState(false)
+
+    useEffect(() => {
+        setTabName(model.view?.name || model.name || NEW_QUERY)
+    }, [model])
 
     const handleRename = (): void => {
         setIsEditing(false)

--- a/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/multitabEditorLogic.tsx
@@ -361,7 +361,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
                 return {
                     query: props.monaco?.editor.getModel(model.uri)?.getValue() || '',
                     path: model.uri.path.split('/').pop(),
-                    name: model.name || NEW_QUERY,
+                    name: model.view?.name || model.name || NEW_QUERY,
                     view: model.view,
                 }
             })
@@ -426,6 +426,7 @@ export const multitabEditorLogic = kea<multitabEditorLogicType>([
             const types = logic.values.response?.types ?? []
 
             await dataWarehouseViewsLogic.asyncActions.createDataWarehouseSavedQuery({ name, query, types })
+            actions.updateState()
         },
         saveAsInsight: async () => {
             LemonDialog.openForm({


### PR DESCRIPTION
## Problem

- when you save a view, the name doesn't become the tab name

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- make sure it does

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
