### PR TITLE
fix: link to replay setting in web analytics

### DIFF
--- a/frontend/src/scenes/web-analytics/tiles/WebAnalyticsRecordings.tsx
+++ b/frontend/src/scenes/web-analytics/tiles/WebAnalyticsRecordings.tsx
@@ -30,7 +30,7 @@ export function WebAnalyticsRecordingsTile({ tile }: { tile: ReplayTile }): JSX.
               title: 'Recordings are not enabled for this project',
               description: 'Once recordings are enabled, new recordings will display here.',
               buttonText: 'Enable recordings',
-              buttonTo: urls.settings('project-replay'),
+              buttonTo: urls.settings('project-replay', 'replay'),
           }
         : webAnalyticsFilters.length > 0
         ? {


### PR DESCRIPTION
## Problem

For some reason `buttonTo` is maintaining scroll position, which means the previous link was going somewhere random in the page, was a bit confusing.

## Changes

Link to setting

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Clicked it
