### PR TITLE
fix: hide inspector button if not used

### DIFF
--- a/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/SessionRecordingPlayer.tsx
@@ -70,6 +70,7 @@ export function SessionRecordingPlayer(props: SessionRecordingPlayerProps): JSX.
         matchingEventsMatchType,
         sessionRecordingData,
         autoPlay,
+        noInspector,
         playlistLogic,
         mode,
         playerRef,

--- a/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
+++ b/frontend/src/scenes/session-recordings/player/controller/PlayerController.tsx
@@ -175,6 +175,10 @@ function InspectDOM(): JSX.Element {
 }
 
 function PlayerBottomSettings(): JSX.Element {
+    const {
+        logicProps: { noInspector },
+    } = useValues(sessionRecordingPlayerLogic)
+
     return (
         <SettingsBar border="top" className="justify-between">
             <div className="flex flex-row gap-0.5">
@@ -183,7 +187,7 @@ function PlayerBottomSettings(): JSX.Element {
                 <SetPlaybackSpeed />
                 <SetTimeFormat />
             </div>
-            <InspectDOM />
+            {noInspector ? null : <InspectDOM />}
         </SettingsBar>
     )
 }

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -86,6 +86,7 @@ export interface SessionRecordingPlayerLogicProps extends SessionRecordingDataLo
     matchingEventsMatchType?: MatchingEventsMatchType
     playlistLogic?: BuiltLogic<sessionRecordingsPlaylistLogicType>
     autoPlay?: boolean
+    noInspector?: boolean
     mode?: SessionRecordingPlayerMode
     playerRef?: RefObject<HTMLDivElement>
     pinned?: boolean


### PR DESCRIPTION
## Problem

The 'Inspect DOM' button is still visible even if the `noInspector` prop is set on the `SessionRecordingPlayer`
