### PR TITLE
chore: Simplify redis error handling and use custom error class

### DIFF
--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -202,14 +202,14 @@ export class DB {
     ): Promise<T> {
         return instrumentQuery(operationName, tag, async () => {
             let client: Redis.Redis
-            const timeout = timeoutGuard(`${operationName} delayed. Waiting over 30 sec to get key.`, logContext)
+            const timeout = timeoutGuard(`${operationName} delayed. Waiting over 30 sec.`, logContext)
             try {
                 client = await this.redisPool.acquire()
             } catch (error) {
                 throw new RedisOperationError('Failed to acquire redis client from pool', error)
             }
 
-            // Don't use nested try/catch/finally for this, are there are 2 potential errors that could be thrown
+            // Don't use a single try/catch/finally for this, are there are 2 potential errors that could be thrown
             // (error and cleanup) and we want to be explicit about which one we choose, rather than relying on
             // "what happens when you throw in a finally block"
             // We explicitly want to throw the error from the operation if there is one, prioritising it over any errors

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -274,7 +274,7 @@ export class DB {
     public redisGetBuffer(key: string, tag: string): Promise<Buffer | null> {
         return this.instrumentRedisQuery('query.redisGetBuffer', tag, { key }, async (client) => {
             return await tryTwice(
-                async () => await client!.getBuffer(key),
+                async () => await client.getBuffer(key),
                 `Waited 5 sec to get redis key: ${key}, retrying once!`
             )
         })

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -63,6 +63,7 @@ import {
     UUIDT,
 } from '../utils'
 import { OrganizationPluginsAccessLevel } from './../../types'
+import { RedisOperationError } from './error'
 import { personUpdateVersionMismatchCounter, pluginLogEntryCounter } from './metrics'
 import { PostgresRouter, PostgresUse, TransactionClient } from './postgres'
 import {
@@ -193,6 +194,55 @@ export class DB {
 
     // Redis
 
+    private instrumentRedisQuery<T>(
+        operationName: string,
+        tag: string | undefined,
+        logContext: Record<string, string | string[] | number>,
+        runQuery: (client: Redis.Redis) => Promise<T>
+    ): Promise<T> {
+        return instrumentQuery(operationName, tag, async () => {
+            let client: Redis.Redis
+            const timeout = timeoutGuard(`${operationName} delayed. Waiting over 30 sec to get key.`, logContext)
+            try {
+                client = await this.redisPool.acquire()
+            } catch (error) {
+                throw new RedisOperationError('Failed to acquire redis client from pool', error)
+            }
+
+            // Don't use nested try/catch/finally for this, are there are 2 potential errors that could be thrown
+            // (error and cleanup) and we want to be explicit about which one we choose, rather than relying on
+            // "what happens when you throw in a finally block"
+            // We explicitly want to throw the error from the operation if there is one, prioritising it over any errors
+            // from the cleanup
+            let operationResult: { value: T } | { error: Error }
+            let cleanupError: Error | undefined
+
+            try {
+                operationResult = { value: await runQuery(client) }
+            } catch (error) {
+                operationResult = { error }
+            }
+
+            try {
+                clearTimeout(timeout)
+                await this.redisPool.release(client)
+            } catch (error) {
+                cleanupError = error
+            }
+
+            if ('error' in operationResult) {
+                throw new RedisOperationError(
+                    `${operationName} failed for ${JSON.stringify(logContext)}`,
+                    operationResult.error
+                )
+            }
+            if (cleanupError) {
+                throw new RedisOperationError('Failed to release redis client from pool', cleanupError)
+            }
+            return operationResult.value
+        })
+    }
+
     public redisGet<T = unknown>(
         key: string,
         defaultValue: T,
@@ -200,10 +250,7 @@ export class DB {
         options: CacheOptions = {}
     ): Promise<T | null> {
         const { jsonSerialize = true } = options
-
-        return instrumentQuery('query.redisGet', tag, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('Getting redis key delayed. Waiting over 30 sec to get key.', { key })
+        return this.instrumentRedisQuery('query.redisGet', tag, { key }, async (client) => {
             try {
                 const value = await tryTwice(
                     async () => await client.get(key),
@@ -220,26 +267,16 @@ export class DB {
                 } else {
                     throw error
                 }
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
             }
         })
     }
 
     public redisGetBuffer(key: string, tag: string): Promise<Buffer | null> {
-        return instrumentQuery('query.redisGetBuffer', tag, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('Getting redis key delayed. Waiting over 30 sec to get key.', { key })
-            try {
-                return await tryTwice(
-                    async () => await client.getBuffer(key),
-                    `Waited 5 sec to get redis key: ${key}, retrying once!`
-                )
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
-            }
+        return this.instrumentRedisQuery('query.redisGetBuffer', tag, { key }, async (client) => {
+            return await tryTwice(
+                async () => await client!.getBuffer(key),
+                `Waited 5 sec to get redis key: ${key}, retrying once!`
+            )
         })
     }
 
@@ -252,36 +289,22 @@ export class DB {
     ): Promise<void> {
         const { jsonSerialize = true } = options
 
-        return instrumentQuery('query.redisSet', tag, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('Setting redis key delayed. Waiting over 30 sec to set key', { key })
-            try {
-                const serializedValue = jsonSerialize ? JSON.stringify(value) : (value as string)
-                if (ttlSeconds) {
-                    await client.set(key, serializedValue, 'EX', ttlSeconds)
-                } else {
-                    await client.set(key, serializedValue)
-                }
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
+        return this.instrumentRedisQuery('query.redisSet', tag, { key }, async (client) => {
+            const serializedValue = jsonSerialize ? JSON.stringify(value) : (value as string)
+            if (ttlSeconds) {
+                await client.set(key, serializedValue, 'EX', ttlSeconds)
+            } else {
+                await client.set(key, serializedValue)
             }
         })
     }
 
     public redisSetBuffer(key: string, value: Buffer, tag: string, ttlSeconds?: number): Promise<void> {
-        return instrumentQuery('query.redisSetBuffer', tag, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('Setting redis key delayed. Waiting over 30 sec to set key', { key })
-            try {
-                if (ttlSeconds) {
-                    await client.setBuffer(key, value, 'EX', ttlSeconds)
-                } else {
-                    await client.setBuffer(key, value)
-                }
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
+        return this.instrumentRedisQuery('query.redisSetBuffer', tag, { key }, async (client) => {
+            if (ttlSeconds) {
+                await client.setBuffer(key, value, 'EX', ttlSeconds)
+            } else {
+                await client.setBuffer(key, value)
             }
         })
     }
@@ -295,19 +318,12 @@ export class DB {
     ): Promise<'OK' | null> {
         const { jsonSerialize = true } = options
 
-        return instrumentQuery('query.redisSetNX', tag, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('Setting redis key delayed. Waiting over 30 sec to set key (NX)', { key })
-            try {
-                const serializedValue = jsonSerialize ? JSON.stringify(value) : (value as string)
-                if (ttlSeconds) {
-                    return await client.set(key, serializedValue, 'EX', ttlSeconds, 'NX')
-                } else {
-                    return await client.set(key, serializedValue, 'NX')
-                }
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
+        return this.instrumentRedisQuery('query.redisSetNX', tag, { key }, async (client) => {
+            const serializedValue = jsonSerialize ? JSON.stringify(value) : (value as string)
+            if (ttlSeconds) {
+                return await client.set(key, serializedValue, 'EX', ttlSeconds, 'NX')
+            } else {
+                return await client.set(key, serializedValue, 'NX')
             }
         })
     }
@@ -315,205 +331,127 @@ export class DB {
     public redisSetMulti(kv: Array<[string, unknown]>, ttlSeconds?: number, options: CacheOptions = {}): Promise<void> {
         const { jsonSerialize = true } = options
 
-        return instrumentQuery('query.redisSet', undefined, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('Setting redis key delayed. Waiting over 30 sec to set keys', {
-                keys: kv.map((x) => x[0]),
-            })
-            try {
-                let pipeline = client.multi()
-                for (const [key, value] of kv) {
-                    const serializedValue = jsonSerialize ? JSON.stringify(value) : (value as string)
-                    if (ttlSeconds) {
-                        pipeline = pipeline.set(key, serializedValue, 'EX', ttlSeconds)
-                    } else {
-                        pipeline = pipeline.set(key, serializedValue)
-                    }
+        return this.instrumentRedisQuery('query.redisSet', undefined, { keys: kv.map((x) => x[0]) }, async (client) => {
+            let pipeline = client.multi()
+            for (const [key, value] of kv) {
+                const serializedValue = jsonSerialize ? JSON.stringify(value) : (value as string)
+                if (ttlSeconds) {
+                    pipeline = pipeline.set(key, serializedValue, 'EX', ttlSeconds)
+                } else {
+                    pipeline = pipeline.set(key, serializedValue)
                 }
-                await pipeline.exec()
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
             }
+            await pipeline.exec()
         })
     }
 
     public redisIncr(key: string): Promise<number> {
-        return instrumentQuery('query.redisIncr', undefined, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('Incrementing redis key delayed. Waiting over 30 sec to incr key', { key })
-            try {
-                return await client.incr(key)
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
-            }
+        return this.instrumentRedisQuery('query.redisIncr', undefined, { key }, async (client) => {
+            return await client.incr(key)
         })
     }
 
     public redisExpire(key: string, ttlSeconds: number): Promise<boolean> {
-        return instrumentQuery('query.redisExpire', undefined, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('Expiring redis key delayed. Waiting over 30 sec to expire key', { key })
-            try {
-                return (await client.expire(key, ttlSeconds)) === 1
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
-            }
+        return this.instrumentRedisQuery('query.redisExpire', undefined, { key }, async (client) => {
+            return (await client.expire(key, ttlSeconds)) === 1
         })
     }
 
     public redisLPush(key: string, value: unknown, options: CacheOptions = {}): Promise<number> {
         const { jsonSerialize = true } = options
 
-        return instrumentQuery('query.redisLPush', undefined, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('LPushing redis key delayed. Waiting over 30 sec to lpush key', { key })
-            try {
-                const serializedValue = jsonSerialize ? JSON.stringify(value) : (value as string | string[])
-                return await client.lpush(key, serializedValue)
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
-            }
+        return this.instrumentRedisQuery('query.redisLPush', undefined, { key }, async (client) => {
+            const serializedValue = jsonSerialize ? JSON.stringify(value) : (value as string | string[])
+            return await client.lpush(key, serializedValue)
         })
     }
 
-    public redisLRange(key: string, startIndex: number, endIndex: number): Promise<string[]> {
-        return instrumentQuery('query.redisLRange', undefined, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('LRANGE delayed. Waiting over 30 sec to perform LRANGE', {
-                key,
-                startIndex,
-                endIndex,
-            })
-            try {
-                return await client.lrange(key, startIndex, endIndex)
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
-            }
+    public redisLRange(key: string, startIndex: number, endIndex: number, tag?: string): Promise<string[]> {
+        return this.instrumentRedisQuery('query.redisLRange', tag, { key, startIndex, endIndex }, async (client) => {
+            return await client.lrange(key, startIndex, endIndex)
         })
     }
 
     public redisLLen(key: string): Promise<number> {
-        return instrumentQuery('query.redisLLen', undefined, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('LLEN delayed. Waiting over 30 sec to perform LLEN', {
-                key,
-            })
-            try {
-                return await client.llen(key)
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
-            }
+        return this.instrumentRedisQuery('query.redisLLen', undefined, { key }, async (client) => {
+            return await client.llen(key)
         })
     }
 
     public redisBRPop(key1: string, key2: string): Promise<[string, string]> {
-        return instrumentQuery('query.redisBRPop', undefined, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('BRPoping redis key delayed. Waiting over 30 sec to brpop keys', {
-                key1,
-                key2,
-            })
-            try {
-                return await client.brpop(key1, key2)
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
-            }
+        return this.instrumentRedisQuery('query.redisBRPop', undefined, { key1, key2 }, async (client) => {
+            return await client.brpop(key1, key2)
         })
     }
 
     public redisLRem(key: string, count: number, elementKey: string): Promise<number> {
-        return instrumentQuery('query.redisLRem', undefined, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('LREM delayed. Waiting over 30 sec to perform LREM', {
+        return this.instrumentRedisQuery(
+            'query.redisLRem',
+            undefined,
+            {
                 key,
                 count,
                 elementKey,
-            })
-            try {
+            },
+            async (client) => {
                 return await client.lrem(key, count, elementKey)
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
             }
-        })
+        )
     }
 
     public redisLPop(key: string, count: number): Promise<string[]> {
-        return instrumentQuery('query.redisLPop', undefined, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('LPOP delayed. Waiting over 30 sec to perform LPOP', {
+        return this.instrumentRedisQuery(
+            'query.redisLPop',
+            undefined,
+            {
                 key,
                 count,
-            })
-            try {
+            },
+            async (client) => {
                 return await client.lpop(key, count)
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
             }
-        })
+        )
     }
 
     public redisSAddAndSCard(key: string, value: Redis.ValueType, ttlSeconds?: number): Promise<number> {
-        return instrumentQuery('query.redisSAddAndSCard', undefined, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('SADD+SCARD delayed. Waiting over 30 sec to perform SADD+SCARD', {
-                key,
-                value,
-            })
-            try {
-                const multi = client.multi()
-                multi.sadd(key, value)
-                if (ttlSeconds) {
-                    multi.expire(key, ttlSeconds)
-                }
-                multi.scard(key)
-                const results = await multi.exec()
-                const scardResult = ttlSeconds ? results[2] : results[1]
-                return scardResult[1]
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
+        return this.instrumentRedisQuery('query.redisSAddAndSCard', undefined, { key }, async (client) => {
+            const multi = client.multi()
+            multi.sadd(key, value)
+            if (ttlSeconds) {
+                multi.expire(key, ttlSeconds)
             }
+            multi.scard(key)
+            const results = await multi.exec()
+            const scardResult = ttlSeconds ? results[2] : results[1]
+            return scardResult[1]
         })
     }
 
     public redisSCard(key: string): Promise<number> {
-        return instrumentQuery('query.redisSCard', undefined, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('SCARD delayed. Waiting over 30 sec to perform SCARD', {
+        return this.instrumentRedisQuery(
+            'query.redisSCard',
+            undefined,
+            {
                 key,
-            })
-            try {
+            },
+            async (client) => {
                 return await client.scard(key)
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
             }
-        })
+        )
     }
 
     public redisPublish(channel: string, message: string): Promise<number> {
-        return instrumentQuery('query.redisPublish', undefined, async () => {
-            const client = await this.redisPool.acquire()
-            const timeout = timeoutGuard('Publish delayed. Waiting over 30 sec to perform Publish', {
+        return this.instrumentRedisQuery(
+            'query.redisPublish',
+            undefined,
+            {
                 channel,
                 message,
-            })
-            try {
+            },
+            async (client) => {
                 return await client.publish(channel, message)
-            } finally {
-                clearTimeout(timeout)
-                await this.redisPool.release(client)
             }
-        })
+        )
     }
 
     private toPerson(row: RawPerson): InternalPerson {

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -209,9 +209,9 @@ export class DB {
                 throw new RedisOperationError('Failed to acquire redis client from pool', error)
             }
 
-            // Don't use a single try/catch/finally for this, are there are 2 potential errors that could be thrown
+            // Don't use a single try/catch/finally for this, as there are 2 potential errors that could be thrown
             // (error and cleanup) and we want to be explicit about which one we choose, rather than relying on
-            // "what happens when you throw in a finally block"
+            // "what happens when you throw in a finally block".
             // We explicitly want to throw the error from the operation if there is one, prioritising it over any errors
             // from the cleanup
             let operationResult: { value: T } | { error: Error }

--- a/plugin-server/src/utils/db/db.ts
+++ b/plugin-server/src/utils/db/db.ts
@@ -233,7 +233,8 @@ export class DB {
             if ('error' in operationResult) {
                 throw new RedisOperationError(
                     `${operationName} failed for ${JSON.stringify(logContext)}`,
-                    operationResult.error
+                    operationResult.error,
+                    logContext
                 )
             }
             if (cleanupError) {

--- a/plugin-server/src/utils/db/error.ts
+++ b/plugin-server/src/utils/db/error.ts
@@ -26,13 +26,14 @@ export class MessageSizeTooLarge extends Error {
 }
 
 export class RedisOperationError extends Error {
-    constructor(message: string, error: Error) {
+    constructor(message: string, error: Error, logContext?: Record<string, any>) {
         super(message)
         this.name = 'RedisOperationError'
         this.error = error
+        this.logContext = logContext
     }
     readonly error: Error
-    readonly isRetriable = false
+    readonly logContext?: Record<string, any>
 }
 
 export async function processError(

--- a/plugin-server/src/utils/db/error.ts
+++ b/plugin-server/src/utils/db/error.ts
@@ -25,6 +25,16 @@ export class MessageSizeTooLarge extends Error {
     readonly isRetriable = false
 }
 
+export class RedisOperationError extends Error {
+    constructor(message: string, error: Error) {
+        super(message)
+        this.name = 'RedisOperationError'
+        this.error = error
+    }
+    readonly error: Error
+    readonly isRetriable = false
+}
+
 export async function processError(
     server: Hub,
     pluginConfig: PluginConfig | null,


### PR DESCRIPTION
## Problem

In my cookieless PR, I want to explicitly count when any errors are due to Redis errors. At the moment, our redis operations don't return a known error class, and IORedis doesn't do this by default.

## Changes

In this PR, I simplified our Redis operation code. Now, a shared wrapper function handles metrics and cleanup, and the operations themselves are much simpler. All errors that are thrown inside our Redis code use the RedisOperationError class and so can be detected by any code that uses it.

I also fixed a situation where the cleanup code could throw inside a `finally` block, which was not ideal.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Added some tests for the wrapper, and of course our existing tests still pass without changes.