### PR TITLE
feat: add session metrics to blobby v2

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/metrics.ts
@@ -16,6 +16,11 @@ export class SessionBatchMetrics {
         help: 'Number of individual events that have been flushed',
     })
 
+    private static readonly bytesWritten = new Counter({
+        name: 'recording_blob_ingestion_v2_bytes_written_total',
+        help: 'Number of bytes written to storage',
+    })
+
     public static incrementBatchesFlushed(): void {
         this.batchesFlushed.inc()
     }
@@ -26,5 +31,9 @@ export class SessionBatchMetrics {
 
     public static incrementEventsFlushed(count: number = 1): void {
         this.eventsFlushed.inc(count)
+    }
+
+    public static incrementBytesWritten(bytes: number): void {
+        this.bytesWritten.inc(bytes)
     }
 }

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/metrics.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/metrics.ts
@@ -1,0 +1,30 @@
+import { Counter } from 'prom-client'
+
+export class SessionBatchMetrics {
+    private static readonly batchesFlushed = new Counter({
+        name: 'recording_blob_ingestion_v2_batches_flushed_total',
+        help: 'Number of session recording batches that have been flushed',
+    })
+
+    private static readonly sessionsFlushed = new Counter({
+        name: 'recording_blob_ingestion_v2_sessions_flushed_total',
+        help: 'Number of individual sessions that have been flushed',
+    })
+
+    private static readonly eventsFlushed = new Counter({
+        name: 'recording_blob_ingestion_v2_events_flushed_total',
+        help: 'Number of individual events that have been flushed',
+    })
+
+    public static incrementBatchesFlushed(): void {
+        this.batchesFlushed.inc()
+    }
+
+    public static incrementSessionsFlushed(count: number = 1): void {
+        this.sessionsFlushed.inc(count)
+    }
+
+    public static incrementEventsFlushed(count: number = 1): void {
+        this.eventsFlushed.inc(count)
+    }
+}

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/recorder.ts
@@ -2,6 +2,11 @@ import { Writable } from 'stream'
 
 import { ParsedMessageData } from '../kafka/types'
 
+interface WriteResult {
+    eventCount: number
+    bytesWritten: number
+}
+
 export class SessionRecorder {
     private chunks: string[] = []
     private size: number = 0
@@ -21,15 +26,19 @@ export class SessionRecorder {
         return bytesWritten
     }
 
-    public async dump(stream: Writable): Promise<number> {
+    public async write(stream: Writable): Promise<WriteResult> {
         let eventCount = 0
+        let bytesWritten = 0
+
         for (const chunk of this.chunks) {
             if (!stream.write(chunk)) {
                 // Handle backpressure
                 await new Promise((resolve) => stream.once('drain', resolve))
             }
             eventCount++
+            bytesWritten += Buffer.byteLength(chunk)
         }
-        return eventCount
+
+        return { eventCount, bytesWritten }
     }
 }

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/recorder.ts
@@ -21,12 +21,15 @@ export class SessionRecorder {
         return bytesWritten
     }
 
-    public async dump(stream: Writable): Promise<void> {
+    public async dump(stream: Writable): Promise<number> {
+        let eventCount = 0
         for (const chunk of this.chunks) {
             if (!stream.write(chunk)) {
                 // Handle backpressure
                 await new Promise((resolve) => stream.once('drain', resolve))
             }
+            eventCount++
         }
+        return eventCount
     }
 }

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-manager.ts
@@ -38,13 +38,10 @@ export class SessionBatchManager {
         })
     }
 
-    public async flushIfNeeded(): Promise<void> {
-        return this.queue.add(async () => {
-            const timeSinceLastFlush = Date.now() - this.lastFlushTime
-            if (this.currentBatch.size >= this.maxBatchSizeBytes || timeSinceLastFlush >= this.maxBatchAgeMs) {
-                await this.rotateBatch()
-            }
-        })
+    public shouldFlush(): boolean {
+        const batchSize = this.currentBatch.size
+        const batchAge = Date.now() - this.lastFlushTime
+        return batchSize >= this.maxBatchSizeBytes || batchAge >= this.maxBatchAgeMs
     }
 
     public async discardPartitions(partitions: number[]): Promise<void> {

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
@@ -1,6 +1,7 @@
 import { Writable } from 'stream'
 
 import { MessageWithTeam } from '../teams/types'
+import { SessionBatchMetrics } from './metrics'
 import { SessionRecorder } from './recorder'
 
 export interface StreamWithFinish {
@@ -63,15 +64,25 @@ export class SessionBatchRecorder implements SessionBatchRecorderInterface {
     public async flush(): Promise<void> {
         const { stream, finish } = await this.writer.open()
 
+        let totalEvents = 0
+        let totalSessions = 0
+
         // Flush sessions grouped by partition
         for (const sessions of this.partitionSessions.values()) {
             for (const recorder of sessions.values()) {
-                await recorder.dump(stream)
+                const eventCount = await recorder.dump(stream)
+                totalEvents += eventCount
             }
+            totalSessions += sessions.size
         }
 
         stream.end()
         await finish()
+
+        // Update metrics
+        SessionBatchMetrics.incrementBatchesFlushed()
+        SessionBatchMetrics.incrementSessionsFlushed(totalSessions)
+        SessionBatchMetrics.incrementEventsFlushed(totalEvents)
 
         // Clear sessions, partition sizes, and total size after successful flush
         this.partitionSessions.clear()

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
@@ -66,12 +66,14 @@ export class SessionBatchRecorder implements SessionBatchRecorderInterface {
 
         let totalEvents = 0
         let totalSessions = 0
+        let totalBytes = 0
 
         // Flush sessions grouped by partition
         for (const sessions of this.partitionSessions.values()) {
             for (const recorder of sessions.values()) {
-                const eventCount = await recorder.dump(stream)
+                const { eventCount, bytesWritten } = await recorder.write(stream)
                 totalEvents += eventCount
+                totalBytes += bytesWritten
             }
             totalSessions += sessions.size
         }
@@ -83,6 +85,7 @@ export class SessionBatchRecorder implements SessionBatchRecorderInterface {
         SessionBatchMetrics.incrementBatchesFlushed()
         SessionBatchMetrics.incrementSessionsFlushed(totalSessions)
         SessionBatchMetrics.incrementEventsFlushed(totalEvents)
+        SessionBatchMetrics.incrementBytesWritten(totalBytes)
 
         // Clear sessions, partition sizes, and total size after successful flush
         this.partitionSessions.clear()

--- a/plugin-server/tests/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
+++ b/plugin-server/tests/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
@@ -38,6 +38,7 @@ jest.mock('../../../../../src/main/ingestion-queues/session-recording-v2/session
         incrementBatchesFlushed: jest.fn(),
         incrementSessionsFlushed: jest.fn(),
         incrementEventsFlushed: jest.fn(),
+        incrementBytesWritten: jest.fn(),
     },
 }))
 
@@ -64,6 +65,7 @@ describe('SessionBatchRecorder', () => {
         jest.mocked(SessionBatchMetrics.incrementBatchesFlushed).mockClear()
         jest.mocked(SessionBatchMetrics.incrementSessionsFlushed).mockClear()
         jest.mocked(SessionBatchMetrics.incrementEventsFlushed).mockClear()
+        jest.mocked(SessionBatchMetrics.incrementBytesWritten).mockClear()
     })
 
     const createMessage = (
@@ -118,7 +120,7 @@ describe('SessionBatchRecorder', () => {
         })
     }
 
-    describe('recording and flushing', () => {
+    describe('recording and writing', () => {
         it('should process and flush a single session', async () => {
             const message = createMessage('session1', [
                 {


### PR DESCRIPTION
## Problem

In order to decide how to develop Mr Blobby V2, we want to gather some metrics around the new batching algorithm. We want to track how often batches are written, how many sessions and events are in each batch, and how much time writing a batch takes.

## Changes

Adds a bunch of metrics in `session-recording-v2`:

- Number of session recording batches that have been flushed
- Number of individual sessions that have been flushed
- Number of individual events that have been flushed
- Number of bytes written to storage

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Unit tests.