### PR TITLE
fix(devex): update devcontainer netcat

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update \
     # Add in useful db debugging tools
     "postgresql-client=13+*" \
     # needed for posthog to run
-    netcat brotli curl \
+    netcat-openbsd brotli curl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
## Problem

Master is failing: https://github.com/PostHog/posthog/actions/runs/12931027680/job/36063938035

Reason: debian upgrade in the dockerfile, and now the dev container can't be built.

```
2.253 Package netcat is a virtual package provided by:
2.253   netcat-openbsd 1.219-1
2.253   netcat-traditional 1.10-47
```

## Changes

[Choose](https://askubuntu.com/questions/346869/what-are-the-differences-between-netcat-traditional-and-netcat-openbsd) `netcat-openbsd`.

## How did you test this code?

CI