### PR TITLE
chore(llm-observability): dogfood traces

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -67,7 +67,7 @@ pandas==2.2.0
 paramiko==3.4.0
 Pillow==10.2.0
 pdpyras==5.2.0
-posthoganalytics~=3.8.4
+posthoganalytics~=3.9.3
 psutil==6.0.0
 psycopg2-binary==2.9.7
 pymssql==2.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -564,7 +564,7 @@ pluggy==1.5.0
     # via dlt
 ply==3.11
     # via jsonpath-ng
-posthoganalytics==3.8.4
+posthoganalytics==3.9.3
     # via -r requirements.in
 prometheus-client==0.14.1
     # via django-prometheus


### PR DESCRIPTION
## Problem

The Python SDK now supports traces. Let's dogfood them.

## Changes

- Bump the `posthoganalytics` version.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

N/A
