### PR TITLE
feat(gcs-import-error-avoidance): GCS error avoidence

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/DataWarehouseTableForm.tsx
+++ b/frontend/src/scenes/data-warehouse/new/DataWarehouseTableForm.tsx
@@ -82,15 +82,6 @@ export function DatawarehouseTableForm(): JSX.Element {
                     />
                 </LemonField>
                 <div className="text-muted text-xs mb-4">
-                    {provider === 'google-cloud' && (
-                        <div className="mb-1">
-                            Google Cloud links must start with <strong>https://storage.googleapis.com</strong> to be
-                            interoperable across blob storage providers. Learn more{' '}
-                            <Link target="_new" to="https://cloud.google.com/storage/docs/interoperability">
-                                here
-                            </Link>
-                        </div>
-                    )}
                     You can use <strong>*</strong> to select multiple files.
                 </div>
                 <LemonField name="format" label="File format" className="w-max mb-4">

--- a/frontend/src/scenes/data-warehouse/new/DataWarehouseTableForm.tsx
+++ b/frontend/src/scenes/data-warehouse/new/DataWarehouseTableForm.tsx
@@ -82,6 +82,15 @@ export function DatawarehouseTableForm(): JSX.Element {
                     />
                 </LemonField>
                 <div className="text-muted text-xs mb-4">
+                    {provider === 'google-cloud' && (
+                        <div className="mb-1">
+                            Google Cloud links must start with <strong>https://storage.googleapis.com</strong> to be
+                            interoperable across blob storage providers. Learn more{' '}
+                            <Link target="_new" to="https://cloud.google.com/storage/docs/interoperability">
+                                here
+                            </Link>
+                        </div>
+                    )}
                     You can use <strong>*</strong> to select multiple files.
                 </div>
                 <LemonField name="format" label="File format" className="w-max mb-4">

--- a/frontend/src/scenes/data-warehouse/new/dataWarehouseTableLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/dataWarehouseTableLogic.tsx
@@ -99,6 +99,13 @@ export const dataWarehouseTableLogic = kea<dataWarehouseTableLogicType>([
                     }
                 }
 
+                if (url_pattern?.startsWith('https://storage.cloud.google.com')) {
+                    return {
+                        url_pattern:
+                            'Google Cloud links must start with "https://storage.googleapis.com". Please update your URL pattern.',
+                    }
+                }
+
                 return {
                     name: !name && 'Please enter a name.',
                     url_pattern: !url_pattern && 'Please enter a url pattern.',


### PR DESCRIPTION
## Problem
Google Cloud storage links need to be different than what the bucket indicates to be interoperable across blob storage providers.

<img width="667" alt="image" src="https://github.com/user-attachments/assets/ca3f1d7e-7b65-4cc0-8e88-68e64b99105c" />


## Changes

- [x] Add message/link to explain why
- [x] Add validation 

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Tested with correct and incorrect GCS link and works as expected.
