### PR TITLE
fix(experiments): Restores border color on delta charts

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -143,7 +143,7 @@ export function DeltaChart({
     const { isDarkModeOn } = useValues(themeLogic)
     const COLORS = {
         TICK_TEXT_COLOR: 'var(--text-secondary-3000)',
-        BOUNDARY_LINES: 'var(--accent-primary)',
+        BOUNDARY_LINES: 'var(--border-primary)',
         ZERO_LINE: 'var(--border-bold)',
         BAR_NEGATIVE: isDarkModeOn ? '#c32f45' : '#f84257',
         BAR_POSITIVE: isDarkModeOn ? '#12a461' : '#36cd6f',


### PR DESCRIPTION
## Changes

**Before**

![CleanShot 2025-01-23 at 14 07 47@2x](https://github.com/user-attachments/assets/2441f398-a529-4f82-84e1-ab64ea8a7214)

**After**

![CleanShot 2025-01-23 at 14 07 22@2x](https://github.com/user-attachments/assets/53e363f8-5681-416a-ac03-c7720caf28b5)


## How did you test this code?

👀 