### PR TITLE
fix(experiments): Apply correct filters to "View recordings"

### DIFF
--- a/frontend/src/mocks/fixtures/api/experiments/_metric_funnel_events.json
+++ b/frontend/src/mocks/fixtures/api/experiments/_metric_funnel_events.json
@@ -1,0 +1,30 @@
+{
+    "kind": "ExperimentFunnelsQuery",
+    "funnels_query": {
+        "kind": "FunnelsQuery",
+        "series": [
+            {
+                "kind": "EventsNode",
+                "name": "[jan-16-running] seen",
+                "event": "[jan-16-running] seen"
+            },
+            {
+                "kind": "EventsNode",
+                "name": "[jan-16-running] payment",
+                "event": "[jan-16-running] payment"
+            }
+        ],
+        "dateRange": {
+            "date_to": "2025-01-16T23:59",
+            "date_from": "2025-01-02T13:54",
+            "explicitDate": true
+        },
+        "funnelsFilter": {
+            "layout": "horizontal",
+            "funnelVizType": "steps",
+            "funnelWindowInterval": 14,
+            "funnelWindowIntervalUnit": "day"
+        },
+        "filterTestAccounts": true
+    }
+}

--- a/frontend/src/mocks/fixtures/api/experiments/_metric_trend_action.json
+++ b/frontend/src/mocks/fixtures/api/experiments/_metric_trend_action.json
@@ -1,0 +1,24 @@
+{
+    "kind": "ExperimentTrendsQuery",
+    "count_query": {
+        "kind": "TrendsQuery",
+        "series": [
+            {
+                "kind": "ActionsNode",
+                "id": 8,
+                "name": "jan-16-running payment action",
+                "math": "total"
+            }
+        ],
+        "interval": "day",
+        "dateRange": {
+            "date_to": "2025-01-16T23:59",
+            "date_from": "2025-01-02T13:54",
+            "explicitDate": true
+        },
+        "trendsFilter": {
+            "display": "ActionsLineGraph"
+        },
+        "filterTestAccounts": true
+    }
+}

--- a/frontend/src/mocks/fixtures/api/experiments/_metric_trend_custom_exposure.json
+++ b/frontend/src/mocks/fixtures/api/experiments/_metric_trend_custom_exposure.json
@@ -1,0 +1,45 @@
+{
+    "kind": "ExperimentTrendsQuery",
+    "count_query": {
+        "kind": "TrendsQuery",
+        "series": [
+            {
+                "kind": "EventsNode",
+                "math": "total",
+                "name": "[jan-16-running] event one",
+                "event": "[jan-16-running] event one"
+            }
+        ],
+        "interval": "day",
+        "dateRange": {
+            "date_to": "2025-01-16T23:59",
+            "date_from": "2025-01-02T13:54",
+            "explicitDate": true
+        },
+        "trendsFilter": {
+            "display": "ActionsLineGraph"
+        },
+        "filterTestAccounts": true
+    },
+    "exposure_query": {
+        "kind": "TrendsQuery",
+        "series": [
+            {
+                "kind": "EventsNode",
+                "math": "dau",
+                "name": "[jan-16-running] event zero",
+                "event": "[jan-16-running] event zero"
+            }
+        ],
+        "interval": "day",
+        "dateRange": {
+            "date_to": "2025-01-23T23:59",
+            "date_from": "2025-01-09T15:10",
+            "explicitDate": true
+        },
+        "trendsFilter": {
+            "display": "ActionsLineGraph"
+        },
+        "filterTestAccounts": true
+    }
+}

--- a/frontend/src/mocks/fixtures/api/experiments/_metric_trend_feature_flag_called.json
+++ b/frontend/src/mocks/fixtures/api/experiments/_metric_trend_feature_flag_called.json
@@ -1,0 +1,24 @@
+{
+    "kind": "ExperimentTrendsQuery",
+    "count_query": {
+        "kind": "TrendsQuery",
+        "series": [
+            {
+                "kind": "EventsNode",
+                "math": "total",
+                "name": "[jan-16-running] event one",
+                "event": "[jan-16-running] event one"
+            }
+        ],
+        "interval": "day",
+        "dateRange": {
+            "date_to": "2025-01-16T23:59",
+            "date_from": "2025-01-02T13:54",
+            "explicitDate": true
+        },
+        "trendsFilter": {
+            "display": "ActionsLineGraph"
+        },
+        "filterTestAccounts": true
+    }
+}

--- a/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
@@ -308,11 +308,13 @@ export function SummaryTable({
         render: function Key(_, item): JSX.Element {
             const variantKey = item.key
 
+            const filters = getViewRecordingFilters(metric, experiment.feature_flag_key, variantKey)
             return (
                 <LemonButton
                     size="xsmall"
                     icon={<IconRewindPlay />}
                     tooltip="Watch recordings of people who were exposed to this variant."
+                    disabledReason={filters.length === 0 ? 'Unable to identify recordings for this metric' : undefined}
                     type="secondary"
                     onClick={() => {
                         const filterGroup: Partial<RecordingUniversalFilters> = {
@@ -321,11 +323,7 @@ export function SummaryTable({
                                 values: [
                                     {
                                         type: FilterLogicalOperator.And,
-                                        values: getViewRecordingFilters(
-                                            metric,
-                                            experiment.feature_flag_key,
-                                            variantKey
-                                        ),
+                                        values: filters,
                                     },
                                 ],
                             },

--- a/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SummaryTable.tsx
@@ -12,15 +12,13 @@ import { ExperimentFunnelsQuery, ExperimentTrendsQuery } from '~/queries/schema'
 import {
     FilterLogicalOperator,
     InsightType,
-    PropertyFilterType,
-    PropertyOperator,
     RecordingUniversalFilters,
     ReplayTabs,
     TrendExperimentVariant,
-    UniversalFiltersGroupValue,
 } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
+import { getViewRecordingFilters } from '../utils'
 import { VariantTag } from './components'
 
 export function SummaryTable({
@@ -309,6 +307,7 @@ export function SummaryTable({
         title: '',
         render: function Key(_, item): JSX.Element {
             const variantKey = item.key
+
             return (
                 <LemonButton
                     size="xsmall"
@@ -316,47 +315,17 @@ export function SummaryTable({
                     tooltip="Watch recordings of people who were exposed to this variant."
                     type="secondary"
                     onClick={() => {
-                        const filters: UniversalFiltersGroupValue[] = [
-                            {
-                                id: '$feature_flag_called',
-                                name: '$feature_flag_called',
-                                type: 'events',
-                                properties: [
-                                    {
-                                        key: `$feature/${experiment.feature_flag_key}`,
-                                        type: PropertyFilterType.Event,
-                                        value: [variantKey],
-                                        operator: PropertyOperator.Exact,
-                                    },
-                                    {
-                                        key: `$feature/${experiment.feature_flag_key}`,
-                                        type: PropertyFilterType.Event,
-                                        value: 'is_set',
-                                        operator: PropertyOperator.IsSet,
-                                    },
-                                    {
-                                        key: '$feature_flag',
-                                        type: PropertyFilterType.Event,
-                                        value: experiment.feature_flag_key,
-                                        operator: PropertyOperator.Exact,
-                                    },
-                                ],
-                            },
-                        ]
-                        if (experiment.filters.insight === InsightType.FUNNELS) {
-                            if (experiment.filters?.events?.[0]) {
-                                filters.push(experiment.filters.events[0])
-                            } else if (experiment.filters?.actions?.[0]) {
-                                filters.push(experiment.filters.actions[0])
-                            }
-                        }
                         const filterGroup: Partial<RecordingUniversalFilters> = {
                             filter_group: {
                                 type: FilterLogicalOperator.And,
                                 values: [
                                     {
                                         type: FilterLogicalOperator.And,
-                                        values: filters,
+                                        values: getViewRecordingFilters(
+                                            metric,
+                                            experiment.feature_flag_key,
+                                            variantKey
+                                        ),
                                     },
                                 ],
                             },

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -1,4 +1,5 @@
 import metricFunnelEventsJson from '~/mocks/fixtures/api/experiments/_metric_funnel_events.json'
+import metricTrendActionJson from '~/mocks/fixtures/api/experiments/_metric_trend_action.json'
 import metricTrendCustomExposureJson from '~/mocks/fixtures/api/experiments/_metric_trend_custom_exposure.json'
 import metricTrendFeatureFlagCalledJson from '~/mocks/fixtures/api/experiments/_metric_trend_feature_flag_called.json'
 import { ExperimentFunnelsQuery, ExperimentTrendsQuery } from '~/queries/schema/schema-general'
@@ -351,6 +352,35 @@ describe('getViewRecordingFilters', () => {
                         operator: PropertyOperator.Exact,
                     },
                 ],
+            },
+        ])
+    })
+    it('returns the correct filters for a trend metric with an action', () => {
+        const filters = getViewRecordingFilters(metricTrendActionJson as ExperimentTrendsQuery, featureFlagKey, 'test')
+        expect(filters).toEqual([
+            {
+                id: '$feature_flag_called',
+                name: '$feature_flag_called',
+                type: 'events',
+                properties: [
+                    {
+                        key: '$feature_flag_response',
+                        type: PropertyFilterType.Event,
+                        value: ['test'],
+                        operator: PropertyOperator.Exact,
+                    },
+                    {
+                        key: '$feature_flag',
+                        type: PropertyFilterType.Event,
+                        value: 'jan-16-running',
+                        operator: PropertyOperator.Exact,
+                    },
+                ],
+            },
+            {
+                id: 8,
+                name: 'jan-16-running payment action',
+                type: 'actions',
             },
         ])
     })

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -1,7 +1,10 @@
-import { EntityType, FeatureFlagFilters, InsightType } from '~/types'
+import metricFunnelEventsJson from '~/mocks/fixtures/api/experiments/_metric_funnel_events.json'
+import metricTrendFeatureFlagCalledJson from '~/mocks/fixtures/api/experiments/_metric_trend_feature_flag_called.json'
+import { ExperimentFunnelsQuery, ExperimentTrendsQuery } from '~/queries/schema/schema-general'
+import { EntityType, FeatureFlagFilters, InsightType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { getNiceTickValues } from './MetricsView/MetricsView'
-import { getMinimumDetectableEffect, transformFiltersForWinningVariant } from './utils'
+import { getMinimumDetectableEffect, getViewRecordingFilters, transformFiltersForWinningVariant } from './utils'
 
 describe('utils', () => {
     it('Funnel experiment returns correct MDE', async () => {
@@ -233,5 +236,86 @@ describe('getNiceTickValues', () => {
 
         // Larger values
         expect(getNiceTickValues(8.5)).toEqual([-10, -8, -6, -4, -2, 0, 2, 4, 6, 8, 10])
+    })
+})
+
+describe('getViewRecordingFilters', () => {
+    const featureFlagKey = 'jan-16-running'
+
+    it('returns the correct filters for a funnel metric', () => {
+        const filters = getViewRecordingFilters(
+            metricFunnelEventsJson as ExperimentFunnelsQuery,
+            featureFlagKey,
+            'control'
+        )
+        expect(filters).toEqual([
+            {
+                id: '[jan-16-running] seen',
+                name: '[jan-16-running] seen',
+                type: 'events',
+                properties: [
+                    {
+                        key: `$feature/${featureFlagKey}`,
+                        type: PropertyFilterType.Event,
+                        value: ['control'],
+                        operator: PropertyOperator.Exact,
+                    },
+                ],
+            },
+            {
+                id: '[jan-16-running] payment',
+                name: '[jan-16-running] payment',
+                type: 'events',
+                properties: [
+                    {
+                        key: `$feature/${featureFlagKey}`,
+                        type: PropertyFilterType.Event,
+                        value: ['control'],
+                        operator: PropertyOperator.Exact,
+                    },
+                ],
+            },
+        ])
+    })
+    it('returns the correct filters for a trend metric', () => {
+        const filters = getViewRecordingFilters(
+            metricTrendFeatureFlagCalledJson as ExperimentTrendsQuery,
+            featureFlagKey,
+            'test'
+        )
+        expect(filters).toEqual([
+            {
+                id: '$feature_flag_called',
+                name: '$feature_flag_called',
+                type: 'events',
+                properties: [
+                    {
+                        key: '$feature_flag_response',
+                        type: PropertyFilterType.Event,
+                        value: ['test'],
+                        operator: PropertyOperator.Exact,
+                    },
+                    {
+                        key: '$feature_flag',
+                        type: PropertyFilterType.Event,
+                        value: 'jan-16-running',
+                        operator: PropertyOperator.Exact,
+                    },
+                ],
+            },
+            {
+                id: '[jan-16-running] event one',
+                name: '[jan-16-running] event one',
+                type: 'events',
+                properties: [
+                    {
+                        key: `$feature/${featureFlagKey}`,
+                        type: PropertyFilterType.Event,
+                        value: ['test'],
+                        operator: PropertyOperator.Exact,
+                    },
+                ],
+            },
+        ])
     })
 })

--- a/frontend/src/scenes/experiments/utils.test.ts
+++ b/frontend/src/scenes/experiments/utils.test.ts
@@ -1,4 +1,5 @@
 import metricFunnelEventsJson from '~/mocks/fixtures/api/experiments/_metric_funnel_events.json'
+import metricTrendCustomExposureJson from '~/mocks/fixtures/api/experiments/_metric_trend_custom_exposure.json'
 import metricTrendFeatureFlagCalledJson from '~/mocks/fixtures/api/experiments/_metric_trend_feature_flag_called.json'
 import { ExperimentFunnelsQuery, ExperimentTrendsQuery } from '~/queries/schema/schema-general'
 import { EntityType, FeatureFlagFilters, InsightType, PropertyFilterType, PropertyOperator } from '~/types'
@@ -299,6 +300,41 @@ describe('getViewRecordingFilters', () => {
                         key: '$feature_flag',
                         type: PropertyFilterType.Event,
                         value: 'jan-16-running',
+                        operator: PropertyOperator.Exact,
+                    },
+                ],
+            },
+            {
+                id: '[jan-16-running] event one',
+                name: '[jan-16-running] event one',
+                type: 'events',
+                properties: [
+                    {
+                        key: `$feature/${featureFlagKey}`,
+                        type: PropertyFilterType.Event,
+                        value: ['test'],
+                        operator: PropertyOperator.Exact,
+                    },
+                ],
+            },
+        ])
+    })
+    it('returns the correct filters for a trend metric with custom exposure', () => {
+        const filters = getViewRecordingFilters(
+            metricTrendCustomExposureJson as ExperimentTrendsQuery,
+            featureFlagKey,
+            'test'
+        )
+        expect(filters).toEqual([
+            {
+                id: '[jan-16-running] event zero',
+                name: '[jan-16-running] event zero',
+                type: 'events',
+                properties: [
+                    {
+                        key: `$feature/${featureFlagKey}`,
+                        type: PropertyFilterType.Event,
+                        value: ['test'],
                         operator: PropertyOperator.Exact,
                     },
                 ],

--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -107,27 +107,43 @@ export function getViewRecordingFilters(
     variantKey: string
 ): UniversalFiltersGroupValue[] {
     const filters: UniversalFiltersGroupValue[] = []
-    // TODO support custom exposure events and actions
+    // TODO support actions
     if (metric.kind === NodeKind.ExperimentTrendsQuery) {
-        filters.push({
-            id: '$feature_flag_called',
-            name: '$feature_flag_called',
-            type: 'events',
-            properties: [
-                {
-                    key: `$feature_flag_response`,
-                    type: PropertyFilterType.Event,
-                    value: [variantKey],
-                    operator: PropertyOperator.Exact,
-                },
-                {
-                    key: '$feature_flag',
-                    type: PropertyFilterType.Event,
-                    value: featureFlagKey,
-                    operator: PropertyOperator.Exact,
-                },
-            ],
-        })
+        if (metric.exposure_query) {
+            filters.push({
+                id: (metric.exposure_query.series[0] as EventsNode).event as string,
+                name: (metric.exposure_query.series[0] as EventsNode).event as string,
+                type: 'events',
+                properties: [
+                    {
+                        key: `$feature/${featureFlagKey}`,
+                        type: PropertyFilterType.Event,
+                        value: [variantKey],
+                        operator: PropertyOperator.Exact,
+                    },
+                ],
+            })
+        } else {
+            filters.push({
+                id: '$feature_flag_called',
+                name: '$feature_flag_called',
+                type: 'events',
+                properties: [
+                    {
+                        key: `$feature_flag_response`,
+                        type: PropertyFilterType.Event,
+                        value: [variantKey],
+                        operator: PropertyOperator.Exact,
+                    },
+                    {
+                        key: '$feature_flag',
+                        type: PropertyFilterType.Event,
+                        value: featureFlagKey,
+                        operator: PropertyOperator.Exact,
+                    },
+                ],
+            })
+        }
         filters.push({
             id: (metric.count_query.series[0] as EventsNode).event as string,
             name: (metric.count_query.series[0] as EventsNode).event as string,


### PR DESCRIPTION
See https://posthog.slack.com/archives/C087ZBJBZ7C/p1737128365755459

Also reported in a direct email:
> I’ve been running another no-code experiment on PostHog. The recordings show that not everyone is seeing the variant I set, even when I filter based on the experiment and variant. For example, if my control is ABC and the variant is CBA, the recordings for CBA sometimes show the control instead. This makes me question the accuracy of the stats... Is this a bug or user error on my part?

## Changes

Introduces a `getViewRecordingFilters()` function with tests to generate the various permutations of filters based on the metric. Note: the screencasts are solely to show the filters being applied; I don't actually have any recordings because I generated the events synthetically.

If no filters could be identified, then the button will be disabled:

![CleanShot 2025-01-23 at 15 48 16@2x](https://github.com/user-attachments/assets/0ce2a003-5cd8-4007-b25c-640031c15c22)

**Funnel with events**

https://github.com/user-attachments/assets/60972a9a-cfb6-469f-9c73-9f1c0935bb64

**Funnel with action**

https://github.com/user-attachments/assets/66c3662e-25b4-4912-b49e-eec062021c2e

**Trend with default exposure**

https://github.com/user-attachments/assets/bdb211f5-4910-411b-a116-36ae14c009a7

## How did you test this code?

Tests should pass + manual review.