### PR TITLE
chore(flags): upgrade decide debug logs to warn level

### DIFF
--- a/posthog/api/decide.py
+++ b/posthog/api/decide.py
@@ -253,7 +253,7 @@ def get_decide(request: HttpRequest):
     is_request_sampled_for_logging = random() < settings.DECIDE_REQUEST_LOGGING_SAMPLING_RATE
     if team:
         if is_request_sampled_for_logging:
-            logger.info(
+            logger.warn(
                 "DECIDE_REQUEST_STARTED",
                 team_id=team.id,
                 distinct_id=data.get("distinct_id", None),
@@ -337,7 +337,7 @@ def get_decide(request: HttpRequest):
             ).inc()
 
             if is_request_sampled_for_logging:
-                logger.info(
+                logger.warn(
                     "DECIDE_REQUEST_SUCCEEDED",
                     team_id=team.id,
                     distinct_id=distinct_id,


### PR DESCRIPTION
## Problem

After [looking into which logs make it to Loki](https://posthog.slack.com/archives/C02E3BKC78F/p1737655768827389) (and digging myself to no avail), I've decide to upgrade these to warns as a band-aid to get better viz on decide requests for now.

I've noticed that decide's app-level warn logs make it to Loki, so this seems like it'll work: https://grafana.prod-us.posthog.dev/a/grafana-lokiexplore-app/explore/service/posthog/logs?patterns=%5B%5D&from=now-15m&to=now&var-ds=P8E80F9AEF21F6940&var-filters=service_name%7C%3D%7Cposthog&var-filters=container%7C%3D%7Cposthog-decide&var-fields=&var-levels=&var-metadata=&var-patterns=&var-lineFilterV2=&var-lineFilters=&timezone=browser&urlColumns=%5B%5D&visualizationType=%22logs%22&displayedFields=%5B%5D&sortOrder=%22Descending%22&wrapLogMessage=false

## Changes

info -> warn

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

n/a