### PR TITLE
feat(web-analytics): Add setting for tracking revenue from custom events

### DIFF
--- a/frontend/src/lib/api.mock.ts
+++ b/frontend/src/lib/api.mock.ts
@@ -94,6 +94,7 @@ export const MOCK_DEFAULT_TEAM: TeamType = {
     live_events_token: '123',
     capture_dead_clicks: false,
     human_friendly_comparison_periods: false,
+    revenue_tracking_config: { events: [] },
     flags_persistence_default: false,
 }
 

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -195,7 +195,6 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getValue: (eventDefinition: Record<string, any>) =>
                             // Use the property's "name" when available, or "value" if a local option
                             'id' in eventDefinition ? eventDefinition.name : eventDefinition.value,
-                        excludedProperties: excludedProperties[TaxonomicFilterGroupType.Events],
                         ...eventTaxonomicGroupProps,
                     },
                     {

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -195,6 +195,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         getValue: (eventDefinition: Record<string, any>) =>
                             // Use the property's "name" when available, or "value" if a local option
                             'id' in eventDefinition ? eventDefinition.name : eventDefinition.value,
+                        excludedProperties: excludedProperties[TaxonomicFilterGroupType.Events],
                         ...eventTaxonomicGroupProps,
                     },
                     {

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -236,6 +236,7 @@ export const FEATURE_FLAGS = {
     REPLAY_FLAGS_FILTERS: 'replay-flags-filters', // owner: @pauldambra #team-replay
     REPLAY_LANDING_PAGE: 'replay-landing-page', // owner :#team-replay
     WEB_VITALS: 'web-vitals', // owner: @rafaeelaudibert #team-web-analytics
+    WEB_REVENUE_TRACKING: 'web-revenue-tracking', // owner: @robbie-c #team-web-analytics
     LLM_OBSERVABILITY: 'llm-observability', // owner: #team-ai-product-manager
     ONBOARDING_SESSION_REPLAY_SEPERATE_STEP: 'onboarding-session-replay-separate-step', // owner: @joshsny #team-growth
 } as const

--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -1210,6 +1210,17 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
             label: 'Initial Person Info',
             description: 'posthog-js initial person information. used in the $set_once flow',
         },
+        revenue: {
+            label: 'Revenue',
+            description:
+                'The revenue associated with the event. By default, this is in USD, but the currency property can be used to specify a different currency.',
+            examples: [10.0],
+        },
+        currency: {
+            label: 'Currency',
+            description: 'The currency code associated with the event.',
+            examples: ['USD', 'EUR', 'GBP', 'CAD'],
+        },
         // web vitals properties
         $web_vitals_enabled_server_side: {
             label: 'Web vitals enabled server side',

--- a/frontend/src/lib/utils.tsx
+++ b/frontend/src/lib/utils.tsx
@@ -1936,3 +1936,7 @@ export function debounce<F extends (...args: Parameters<F>) => ReturnType<F>>(
         timeout = setTimeout(() => func(...args), waitFor)
     }
 }
+
+export function interleaveArray<T1, T2>(arr: T1[], separator: T2): (T1 | T2)[] {
+    return arr.flatMap((item, index, _arr) => (_arr.length - 1 !== index ? [item, separator] : [item]))
+}

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -8,6 +8,7 @@ import { DeadClicksAutocaptureSettings } from 'scenes/settings/environment/DeadC
 import { PersonsJoinMode } from 'scenes/settings/environment/PersonsJoinMode'
 import { PersonsOnEvents } from 'scenes/settings/environment/PersonsOnEvents'
 import { ReplayTriggers } from 'scenes/settings/environment/ReplayTriggers'
+import { RevenueEventsSettings } from 'scenes/settings/environment/RevenueEventsSettings'
 import { SessionsTableVersion } from 'scenes/settings/environment/SessionsTableVersion'
 
 import { Realm } from '~/types'
@@ -247,6 +248,11 @@ export const SETTINGS_MAP: SettingSection[] = [
                 title: 'Bounce rate page view mode',
                 component: <BounceRatePageViewModeSetting />,
                 flag: 'SETTINGS_BOUNCE_RATE_PAGE_VIEW_MODE',
+            },
+            {
+                id: 'web-revenue-events',
+                title: 'Revenue tracking',
+                component: <RevenueEventsSettings />,
             },
         ],
     },

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -253,6 +253,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'web-revenue-events',
                 title: 'Revenue tracking',
                 component: <RevenueEventsSettings />,
+                flag: 'WEB_REVENUE_TRACKING',
             },
         ],
     },

--- a/frontend/src/scenes/settings/environment/RevenueEventsSettings.tsx
+++ b/frontend/src/scenes/settings/environment/RevenueEventsSettings.tsx
@@ -1,0 +1,94 @@
+import { IconTrash } from '@posthog/icons'
+import { useActions, useValues } from 'kea'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { useCallback } from 'react'
+import { revenueEventsSettingsLogic } from 'scenes/settings/environment/revenueEventsSettingsLogic'
+
+import { RevenueTrackingEventItem } from '~/types'
+
+export function RevenueEventsSettings(): JSX.Element {
+    const { saveDisabledReason, events } = useValues(revenueEventsSettingsLogic)
+    const { addEvent, deleteEvent, updatePropertyName, saveChanges } = useActions(revenueEventsSettingsLogic)
+
+    const renderPropertyColumn = useCallback(
+        (_, item: RevenueTrackingEventItem) => {
+            return (
+                <TaxonomicPopover
+                    groupType={TaxonomicFilterGroupType.EventProperties}
+                    onChange={(newPropertyName) => updatePropertyName(item.eventName, newPropertyName)}
+                    value={item.revenueProperty}
+                    placeholder="Choose event property"
+                    excludedProperties={{}}
+                    showNumericalPropsOnly={true}
+                    disabledReason={
+                        item.eventName === '$pageview' || item.eventName === '$autocapture'
+                            ? 'Built-in events must use revenue'
+                            : undefined
+                    }
+                />
+            )
+        },
+        [updatePropertyName]
+    )
+
+    return (
+        <div className="space-y-4">
+            <div>
+                <p>
+                    Add events to revenue tracking in web analytics. The events here will be added to the total revenue
+                    shown.
+                </p>
+                <p>Pageview and autocapture events are always included.</p>
+            </div>
+            <LemonTable<RevenueTrackingEventItem>
+                columns={[
+                    { key: 'eventName', title: 'Event name', dataIndex: 'eventName' },
+                    {
+                        key: 'revenueProperty',
+                        title: 'Revenue property',
+                        dataIndex: 'revenueProperty',
+                        render: renderPropertyColumn,
+                    },
+                    {
+                        key: 'delete',
+                        title: '',
+                        render: (_, item) =>
+                            item.eventName === '$pageview' || item.eventName === '$autocapture' ? null : (
+                                <LemonButton
+                                    type="secondary"
+                                    onClick={() => deleteEvent(item.eventName)}
+                                    icon={<IconTrash />}
+                                >
+                                    Delete
+                                </LemonButton>
+                            ),
+                    },
+                ]}
+                dataSource={[
+                    { eventName: '$pageview', revenueProperty: 'revenue' },
+                    { eventName: '$autocapture', revenueProperty: 'revenue' },
+                    ...events,
+                ]}
+                rowKey={(item) => item.eventName}
+            />
+
+            <TaxonomicPopover
+                groupType={TaxonomicFilterGroupType.CustomEvents}
+                onChange={addEvent}
+                value={undefined}
+                placeholder="Choose custom events to add"
+                excludedProperties={{
+                    [TaxonomicFilterGroupType.CustomEvents]: [null, ...events.map((item) => item.eventName)],
+                }}
+            />
+            <div className="mt-4">
+                <LemonButton type="primary" onClick={saveChanges} disabledReason={saveDisabledReason}>
+                    Save
+                </LemonButton>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/settings/environment/RevenueEventsSettings.tsx
+++ b/frontend/src/scenes/settings/environment/RevenueEventsSettings.tsx
@@ -11,7 +11,7 @@ import { RevenueTrackingEventItem } from '~/types'
 
 export function RevenueEventsSettings(): JSX.Element {
     const { saveDisabledReason, events } = useValues(revenueEventsSettingsLogic)
-    const { addEvent, deleteEvent, updatePropertyName, saveChanges } = useActions(revenueEventsSettingsLogic)
+    const { addEvent, deleteEvent, updatePropertyName, save } = useActions(revenueEventsSettingsLogic)
 
     const renderPropertyColumn = useCallback(
         (_, item: RevenueTrackingEventItem) => {
@@ -37,11 +37,7 @@ export function RevenueEventsSettings(): JSX.Element {
     return (
         <div className="space-y-4">
             <div>
-                <p>
-                    Add events to revenue tracking in web analytics. The events here will be added to the total revenue
-                    shown.
-                </p>
-                <p>Pageview and autocapture events are always included.</p>
+                <p>Add revenue tracking for Custom events in Web analytics</p>
             </div>
             <LemonTable<RevenueTrackingEventItem>
                 columns={[
@@ -55,23 +51,18 @@ export function RevenueEventsSettings(): JSX.Element {
                     {
                         key: 'delete',
                         title: '',
-                        render: (_, item) =>
-                            item.eventName === '$pageview' || item.eventName === '$autocapture' ? null : (
-                                <LemonButton
-                                    type="secondary"
-                                    onClick={() => deleteEvent(item.eventName)}
-                                    icon={<IconTrash />}
-                                >
-                                    Delete
-                                </LemonButton>
-                            ),
+                        render: (_, item) => (
+                            <LemonButton
+                                type="secondary"
+                                onClick={() => deleteEvent(item.eventName)}
+                                icon={<IconTrash />}
+                            >
+                                Delete
+                            </LemonButton>
+                        ),
                     },
                 ]}
-                dataSource={[
-                    { eventName: '$pageview', revenueProperty: 'revenue' },
-                    { eventName: '$autocapture', revenueProperty: 'revenue' },
-                    ...events,
-                ]}
+                dataSource={events}
                 rowKey={(item) => item.eventName}
             />
 
@@ -85,7 +76,7 @@ export function RevenueEventsSettings(): JSX.Element {
                 }}
             />
             <div className="mt-4">
-                <LemonButton type="primary" onClick={saveChanges} disabledReason={saveDisabledReason}>
+                <LemonButton type="primary" onClick={save} disabledReason={saveDisabledReason}>
                     Save
                 </LemonButton>
             </div>

--- a/frontend/src/scenes/settings/environment/revenueEventsSettingsLogic.ts
+++ b/frontend/src/scenes/settings/environment/revenueEventsSettingsLogic.ts
@@ -1,0 +1,92 @@
+import { actions, connect, kea, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { objectsEqual } from 'lib/utils'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { RevenueTrackingConfig, RevenueTrackingEventItem } from '~/types'
+
+import type { revenueEventsSettingsLogicType } from './revenueEventsSettingsLogicType'
+
+export const revenueEventsSettingsLogic = kea<revenueEventsSettingsLogicType>([
+    connect({ values: [teamLogic, ['currentTeam']], actions: [teamLogic, ['updateCurrentTeam']] }),
+    path(['scenes', 'settings', 'environment', 'revenueEventsSettingsLogic']),
+    actions({
+        addEvent: (eventName: string) => ({ eventName }),
+        deleteEvent: (eventName: string) => ({ eventName }),
+        updatePropertyName: (eventName: string, revenueProperty: string) => ({ eventName, revenueProperty }),
+    }),
+    reducers(({ values }) => ({
+        revenueTrackingConfig: [
+            null as RevenueTrackingConfig | null,
+            {
+                addEvent: (state, { eventName }) => {
+                    if (
+                        !state ||
+                        !eventName ||
+                        typeof eventName !== 'string' ||
+                        eventName == '$pageview' ||
+                        eventName == '$autocapture'
+                    ) {
+                        return state
+                    }
+                    const existingEvents = new Set(state.events.map((item: RevenueTrackingEventItem) => item.eventName))
+                    if (!existingEvents.has(eventName)) {
+                        return { ...state, events: [...state.events, { eventName, revenueProperty: 'revenue' }] }
+                    }
+                    return state
+                },
+                deleteEvent: (state, { eventName }) => {
+                    if (!state) {
+                        return state
+                    }
+                    return { ...state, events: state.events.filter((item) => item.eventName !== eventName) }
+                },
+                updatePropertyName: (state, { eventName, revenueProperty }) => {
+                    if (!state) {
+                        return state
+                    }
+                    return {
+                        ...state,
+                        events: state.events.map((item) => {
+                            if (item.eventName === eventName) {
+                                return { ...item, revenueProperty }
+                            }
+                            return item
+                        }),
+                    }
+                },
+            },
+        ],
+        savedRevenueTrackingConfig: [
+            values.currentTeam?.revenue_tracking_config || {},
+            {
+                saveChanges: (_, team) => team.revenue_tracking_config || {},
+            },
+        ],
+    })),
+    selectors({
+        events: [(s) => [s.revenueTrackingConfig], (revenueTrackingConfig) => revenueTrackingConfig?.events || []],
+        saveDisabledReason: [
+            (s) => [s.revenueTrackingConfig, s.savedRevenueTrackingConfig],
+            (config, savedConfig): string | null => {
+                if (!config) {
+                    return 'Loading...'
+                }
+                if (objectsEqual(config, savedConfig)) {
+                    return 'No changes to save'
+                }
+                return null
+            },
+        ],
+    }),
+    loaders(({ values, actions }) => ({
+        saveChanges: {
+            save: () => {
+                if (values.saveDisabledReason) {
+                    return
+                }
+                return actions.updateCurrentTeam({ revenue_tracking_config: values.revenueTrackingConfig })
+            },
+        },
+    })),
+])

--- a/frontend/src/scenes/settings/organization/VerifiedDomains/__snapshots__/verifiedDomainsLogic.test.ts.snap
+++ b/frontend/src/scenes/settings/organization/VerifiedDomains/__snapshots__/verifiedDomainsLogic.test.ts.snap
@@ -96,6 +96,9 @@ exports[`verifiedDomainsLogic values has proper defaults 1`] = `
         "recording_domains": [
           "https://recordings.posthog.com/",
         ],
+        "revenue_tracking_config": {
+          "events": [],
+        },
         "session_recording_linked_flag": null,
         "session_recording_minimum_duration_milliseconds": null,
         "session_recording_network_payload_capture_config": {

--- a/frontend/src/scenes/settings/types.ts
+++ b/frontend/src/scenes/settings/types.ts
@@ -115,6 +115,7 @@ export type SettingId =
     | 'channel-type'
     | 'cookieless-server-hash-mode'
     | 'user-groups'
+    | 'web-revenue-events'
 
 type FeatureFlagKey = keyof typeof FEATURE_FLAGS
 

--- a/frontend/src/scenes/teamActivityDescriber.tsx
+++ b/frontend/src/scenes/teamActivityDescriber.tsx
@@ -10,7 +10,7 @@ import {
 import { SentenceList } from 'lib/components/ActivityLog/SentenceList'
 import PropertyFiltersDisplay from 'lib/components/PropertyFilters/components/PropertyFiltersDisplay'
 import { Link } from 'lib/lemon-ui/Link'
-import { interleaveArray, isNotNil, isObject, pluralize } from 'lib/utils'
+import { isNotNil, isObject, pluralize } from 'lib/utils'
 import { urls } from 'scenes/urls'
 
 import { ActivityScope, RevenueTrackingEventItem, TeamSurveyConfigType, TeamType } from '~/types'
@@ -381,41 +381,39 @@ const teamActionsMapping: Record<
         const removedEvents = beforeEventNames?.filter((event) => !afterEventNames?.includes(event))
         const modifiedEvents = afterEventNames?.filter((event) => beforeEventNames?.includes(event))
 
+        const changes = [
+            addedEvents?.length
+                ? `added ${addedEvents.length} ${pluralize(
+                      addedEvents.length,
+                      'event',
+                      'events',
+                      true
+                  )} (${addedEvents.join(', ')})`
+                : null,
+            removedEvents?.length
+                ? `removed ${removedEvents.length} ${pluralize(
+                      removedEvents.length,
+                      'event',
+                      'events',
+                      true
+                  )} (${removedEvents.join(', ')})`
+                : null,
+            modifiedEvents?.length
+                ? `modified ${modifiedEvents.length} ${pluralize(
+                      modifiedEvents.length,
+                      'event',
+                      'events',
+                      true
+                  )} (${modifiedEvents.join(', ')})`
+                : null,
+        ].filter(isNotNil)
+
+        if (!changes.length) {
+            return null
+        }
+
         return {
-            description: [
-                <>
-                    {interleaveArray(
-                        [
-                            'Updated revenue tracking config: ',
-                            addedEvents?.length
-                                ? `added ${addedEvents.length} ${pluralize(
-                                      addedEvents.length,
-                                      'event',
-                                      'events',
-                                      true
-                                  )} (${addedEvents.join(', ')})`
-                                : null,
-                            removedEvents?.length
-                                ? `removed ${removedEvents.length} ${pluralize(
-                                      removedEvents.length,
-                                      'event',
-                                      'events',
-                                      true
-                                  )} (${removedEvents.join(', ')})`
-                                : null,
-                            modifiedEvents?.length
-                                ? `modified ${modifiedEvents.length} ${pluralize(
-                                      modifiedEvents.length,
-                                      'event',
-                                      'events',
-                                      true
-                                  )} (${modifiedEvents.join(', ')})`
-                                : null,
-                        ].filter(isNotNil),
-                        ', '
-                    )}
-                </>,
-            ],
+            description: [<>Updated revenue tracking config: {changes.join(', ')}</>],
         }
     },
 

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -14,6 +14,7 @@ import { getDefaultInterval, isNotNil, objectsEqual, updateDatesWithInterval } f
 import { isDefinitionStale } from 'lib/utils/definitions'
 import { errorTrackingQuery } from 'scenes/error-tracking/queries'
 import { Scene } from 'scenes/sceneTypes'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { hogqlQuery } from '~/queries/query'
@@ -178,6 +179,8 @@ export enum GraphsTab {
     UNIQUE_CONVERSIONS = 'UNIQUE_CONVERSIONS',
     TOTAL_CONVERSIONS = 'TOTAL_CONVERSIONS',
     CONVERSION_RATE = 'CONVERSION_RATE',
+    REVENUE_EVENTS = 'REVENUE_EVENTS',
+    REVENUE_CONVERSION = 'REVENUE_CONVERSION',
 }
 
 export enum SourceTab {
@@ -263,7 +266,7 @@ const persistConfig = { persist: true, prefix: `${teamId}__` }
 export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
     path(['scenes', 'webAnalytics', 'webAnalyticsSceneLogic']),
     connect(() => ({
-        values: [featureFlagLogic, ['featureFlags']],
+        values: [featureFlagLogic, ['featureFlags'], teamLogic, ['currentTeam']],
     })),
     actions({
         setWebAnalyticsFilters: (webAnalyticsFilters: WebAnalyticsPropertyFilters) => ({ webAnalyticsFilters }),
@@ -618,6 +621,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                 s.filters,
                 () => values.featureFlags,
                 () => values.isGreaterThanMd,
+                () => values.currentTeam,
             ],
             (
                 productTab,
@@ -633,7 +637,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     webVitalsTab,
                 },
                 featureFlags,
-                isGreaterThanMd
+                isGreaterThanMd,
+                currentTeam
             ): WebAnalyticsTile[] => {
                 const dateRange = { date_from: dateFrom, date_to: dateTo }
                 const sampling = { enabled: false, forceSamplingRate: { numerator: 1, denominator: 10 } }
@@ -684,6 +689,20 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                       }
                     : undefined
 
+                const includeRevenue = !!featureFlags[FEATURE_FLAGS.WEB_REVENUE_TRACKING]
+
+                const revenueEventsSeries: EventsNode[] | undefined =
+                    includeRevenue && currentTeam?.revenue_tracking_config
+                        ? currentTeam.revenue_tracking_config.events.map((e) => ({
+                              math: PropertyMathType.Sum,
+                              name: e.eventName,
+                              event: e.eventName,
+                              kind: NodeKind.EventsNode,
+                              custom_name: e.eventName,
+                              math_property: e.revenueProperty,
+                          }))
+                        : undefined
+
                 const createInsightProps = (tile: TileId, tab?: string): InsightLogicProps => {
                     return {
                         dashboardItemId: getDashboardItemId(tile, tab, false),
@@ -697,7 +716,8 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                     title: string,
                     linkText: string,
                     series: AnyEntityNode[],
-                    trendsFilter?: Partial<TrendsFilter>
+                    trendsFilter?: Partial<TrendsFilter>,
+                    trendsQueryProperties?: Partial<TrendsQuery>
                 ): TabsTileTab => ({
                     id,
                     title,
@@ -719,6 +739,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                 ? conversionGoal
                                 : undefined,
                             properties: webAnalyticsFilters,
+                            ...trendsQueryProperties,
                         },
                         hidePersonsModal: true,
                         embedded: true,
@@ -927,6 +948,23 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                           sessionsSeries,
                                       ])
                                     : null,
+                                !conversionGoal &&
+                                    revenueEventsSeries?.length &&
+                                    createGraphsTrendsTab(
+                                        GraphsTab.REVENUE_EVENTS,
+                                        'Revenue',
+                                        'Revenue',
+                                        revenueEventsSeries,
+                                        {
+                                            display:
+                                                revenueEventsSeries.length > 1
+                                                    ? ChartDisplayType.ActionsAreaGraph
+                                                    : ChartDisplayType.ActionsLineGraph,
+                                        },
+                                        {
+                                            compareFilter: revenueEventsSeries.length > 1 ? undefined : compareFilter,
+                                        }
+                                    ),
                                 conversionGoal && uniqueConversionsSeries
                                     ? createGraphsTrendsTab(
                                           GraphsTab.UNIQUE_CONVERSIONS,

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -691,7 +691,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
 
                 const includeRevenue = !!featureFlags[FEATURE_FLAGS.WEB_REVENUE_TRACKING]
 
-                const revenueEventsSeries: EventsNode[] | undefined =
+                const revenueEventsSeries: EventsNode[] =
                     includeRevenue && currentTeam?.revenue_tracking_config
                         ? currentTeam.revenue_tracking_config.events.map((e) => ({
                               math: PropertyMathType.Sum,
@@ -701,7 +701,7 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                               custom_name: e.eventName,
                               math_property: e.revenueProperty,
                           }))
-                        : undefined
+                        : []
 
                 const createInsightProps = (tile: TileId, tab?: string): InsightLogicProps => {
                     return {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -563,6 +563,7 @@ export interface TeamType extends TeamBasicType {
     live_events_token: string
     cookieless_server_hash_mode?: CookielessServerHashMode
     human_friendly_comparison_periods: boolean
+    revenue_tracking_config: RevenueTrackingConfig
 
     /** Effective access level of the user in this specific team. Null if user has no access. */
     effective_membership_level: OrganizationMembershipLevel | null
@@ -4845,6 +4846,15 @@ export enum CookielessServerHashMode {
     Disabled = 0,
     Stateless = 1,
     Stateful = 2,
+}
+
+export interface RevenueTrackingEventItem {
+    eventName: string
+    revenueProperty: string
+}
+
+export interface RevenueTrackingConfig {
+    events: RevenueTrackingEventItem[]
 }
 
 /**

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -219,6 +219,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
             "capture_dead_clicks",
             "user_access_level",
             "default_data_theme",
+            "revenue_tracking_config",
         )
         read_only_fields = (
             "id",


### PR DESCRIPTION
## Problem

See https://github.com/PostHog/product-internal/pull/684

## Changes
This is just a very small part of the above RFC, all it does is add an extra graph tab to the web analytics dashboard, based on any custom revenue events.

The idea behind this is to track the revenue from our merch store on posthog.com

On local dev
<img width="1248" alt="Screenshot 2025-01-24 at 15 01 44" src="https://github.com/user-attachments/assets/3ab75670-f005-41dc-be36-eb488656b345" />

<img width="967" alt="Screenshot 2025-01-24 at 15 02 22" src="https://github.com/user-attachments/assets/baed0ab8-60e8-4477-ae2e-6f93c9b29e3f" />

The settings UI is not final so not looking for design feedback just now

In a future PR:
* handle pageviews and autocaptures
* add a revenue stat to the WebOverviewQuery

## Does this work 

well for both Cloud and self-hosted?

Yes

## How did you test this code?

UI snapshots should update
