### PR TITLE
feat(cdp): google ads: add orderId field

### DIFF
--- a/posthog/cdp/templates/google_ads/template_google_ads.py
+++ b/posthog/cdp/templates/google_ads/template_google_ads.py
@@ -33,6 +33,9 @@ if (not empty(inputs.conversionValue)) {
 if (not empty(inputs.currencyCode)) {
     body.conversions[1].currency_code := inputs.currencyCode
 }
+if (not empty(inputs.orderId)) {
+    body.conversions[1].order_id := inputs.orderId
+}
 
 let res := fetch(f'https://googleads.googleapis.com/v18/customers/{replaceAll(inputs.customerId, '-', '')}:uploadClickConversions', {
     'method': 'POST',
@@ -112,6 +115,15 @@ if (res.status >= 400) {
             "type": "string",
             "label": "Currency code",
             "description": "Currency associated with the conversion value. This is the ISO 4217 3-character currency code. For example: USD, EUR.",
+            "default": "",
+            "secret": False,
+            "required": False,
+        },
+        {
+            "key": "orderId",
+            "type": "string",
+            "label": "Order ID",
+            "description": "The order ID associated with the conversion. An order id can only be used for one conversion per conversion action.",
             "default": "",
             "secret": False,
             "required": False,


### PR DESCRIPTION
## Changes

- allow deduplication through the `order_id` parameter

## Context

https://posthoghelp.zendesk.com/agent/tickets/22988 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/27145)
