### PR TITLE
fix(experiments): Always allow refresh once started

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -98,7 +98,7 @@ export function Info(): JSX.Element {
 
                 <div className="w-1/2 flex flex-col justify-end">
                     <div className="ml-auto inline-flex space-x-8">
-                        {lastRefresh && (
+                        {experiment.start_date && (
                             <div className="block">
                                 <div className="text-xs font-semibold uppercase tracking-wide">Last refreshed</div>
                                 <div className="inline-flex space-x-2">


### PR DESCRIPTION
Follow up from https://github.com/PostHog/posthog/pull/27586

## Changes

Always lets an experiment be refreshed once its started, not just when there are some existing results.

**Before (missing when no results)**

![CleanShot 2025-01-24 at 07 51 26@2x](https://github.com/user-attachments/assets/6ddf00a8-ceb4-4049-b97e-c945ea5b74a3)

**After (present when no results)**

![CleanShot 2025-01-24 at 07 50 57@2x](https://github.com/user-attachments/assets/fe317370-ca8d-4632-be34-3c5fc1279df7)

## How did you test this code?

Manual review.