### PR TITLE
fix(experiments): Ensure loads when 1st metric is shared metric

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -19,7 +19,8 @@ import { ReleaseConditionsModal, ReleaseConditionsTable } from './ReleaseConditi
 import { SummaryTable } from './SummaryTable'
 
 const ResultsTab = (): JSX.Element => {
-    const { experiment, metricResults, primaryMetricsLengthWithSharedMetrics } = useValues(experimentLogic)
+    const { experiment, metricResults, firstPrimaryMetric, primaryMetricsLengthWithSharedMetrics } =
+        useValues(experimentLogic)
     const hasSomeResults = metricResults?.some((result) => result?.insight)
 
     const hasSinglePrimaryMetric = primaryMetricsLengthWithSharedMetrics === 1
@@ -43,10 +44,10 @@ const ResultsTab = (): JSX.Element => {
             )}
             <MetricsView isSecondary={false} />
             {/* Show detailed results if there's only a single primary metric */}
-            {hasSomeResults && hasSinglePrimaryMetric && (
+            {hasSomeResults && hasSinglePrimaryMetric && firstPrimaryMetric && (
                 <div>
                     <div className="pb-4">
-                        <SummaryTable metric={experiment.metrics[0]} metricIndex={0} isSecondary={false} />
+                        <SummaryTable metric={firstPrimaryMetric} metricIndex={0} isSecondary={false} />
                     </div>
                     <div className="flex justify-end">
                         <ExploreButton result={metricResults?.[0] || null} size="xsmall" />

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1738,13 +1738,12 @@ export const experimentLogic = kea<experimentLogicType>([
         firstPrimaryMetric: [
             (s) => [s.experiment],
             (experiment: Experiment): ExperimentTrendsQuery | ExperimentFunnelsQuery | undefined => {
-                const primarySharedMetrics = experiment.saved_metrics.filter(
-                    (sharedMetric) => sharedMetric.metadata.type === 'primary'
-                )
-                if (experiment.metrics.length > 0) {
+                if (experiment.metrics.length) {
                     return experiment.metrics[0]
-                } else if (primarySharedMetrics.length > 0) {
-                    return primarySharedMetrics[0].query
+                }
+                const primaryMetric = experiment.saved_metrics.find((metric) => metric.metadata.type === 'primary')
+                if (primaryMetric) {
+                    return primaryMetric.query
                 }
             },
         ],

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1735,6 +1735,19 @@ export const experimentLogic = kea<experimentLogicType>([
                 return primaryMetricsLengthWithSharedMetrics > 0
             },
         ],
+        firstPrimaryMetric: [
+            (s) => [s.experiment],
+            (experiment: Experiment): ExperimentTrendsQuery | ExperimentFunnelsQuery | undefined => {
+                const primarySharedMetrics = experiment.saved_metrics.filter(
+                    (sharedMetric) => sharedMetric.metadata.type === 'primary'
+                )
+                if (experiment.metrics.length > 0) {
+                    return experiment.metrics[0]
+                } else if (primarySharedMetrics.length > 0) {
+                    return primarySharedMetrics[0].query
+                }
+            },
+        ],
         experimentStatsVersion: [
             (s) => [s.experiment],
             (experiment: Experiment): number => {


### PR DESCRIPTION
See https://posthoghelp.zendesk.com/agent/tickets/24018 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26008)
See https://posthoghelp.zendesk.com/agent/tickets/24021 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26009)

## Changes

Ensures the experiment loads when the first metric is a shared metric.

There are some additional references to `experiment.metrics[0]`, but I'll update those in a follow-up PR.

**Before**

![CleanShot 2025-01-24 at 08 09 48@2x](https://github.com/user-attachments/assets/334c5f78-37bb-4a19-b6b4-e59fe8b45fbf)

**After**

![CleanShot 2025-01-24 at 08 08 57@2x](https://github.com/user-attachments/assets/eb068f37-3e38-401d-8c61-1fc4acc965e6)

## How did you test this code?

Visual review.
