### PR TITLE
fix(filters): duplicated row should show up below

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
@@ -278,6 +278,7 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
             const previousLength = values.localFilters.length
             const newLength = previousLength + 1
             const order = filter.order ?? values.localFilters[previousLength - 1].order
+
             const newFilters = [...values.localFilters]
             for (const _filter of newFilters) {
                 // Because duplicate filters are inserted within the current filters we need to move over the remaining filers
@@ -285,12 +286,13 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
                     _filter.order = _filter.order + 1
                 }
             }
-            newFilters.splice(order, 0, {
+            newFilters.splice(order + 1, 0, {
                 ...filter,
                 uuid: uuid(),
                 custom_name: undefined,
                 order: order + 1,
             } as LocalFilter)
+
             actions.setFilters(newFilters)
             actions.setEntityFilterVisibility(order + 1, values.entityFilterVisible[order])
             eventUsageLogic.actions.reportInsightFilterAdded(newLength, GraphSeriesAddedSource.Duplicate)

--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
@@ -278,7 +278,6 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
             const previousLength = values.localFilters.length
             const newLength = previousLength + 1
             const order = filter.order ?? values.localFilters[previousLength - 1].order
-
             const newFilters = [...values.localFilters]
             for (const _filter of newFilters) {
                 // Because duplicate filters are inserted within the current filters we need to move over the remaining filers
@@ -292,7 +291,6 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
                 custom_name: undefined,
                 order: order + 1,
             } as LocalFilter)
-
             actions.setFilters(newFilters)
             actions.setEntityFilterVisibility(order + 1, values.entityFilterVisible[order])
             eventUsageLogic.actions.reportInsightFilterAdded(newLength, GraphSeriesAddedSource.Duplicate)


### PR DESCRIPTION
## Problem
https://posthog.slack.com/archives/C0450KBMQBS/p1737709475448639
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Duplicating a filter adds the new one below
<img width="574" alt="image" src="https://github.com/user-attachments/assets/eda0a5ba-f5c2-4d72-ae95-b93a9441de06" />
<img width="572" alt="image" src="https://github.com/user-attachments/assets/1a7227f1-efa1-47ee-8832-3de7f83770aa" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Tested locally
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
