### PR TITLE
fix(insight-variables): don't always add all variables

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
@@ -60,6 +60,7 @@ export const variablesLogic = kea<variablesLogicType>([
         }),
         setEditorQuery: (query: string) => ({ query }),
         updateSourceQuery: true,
+        resetVariables: true,
     })),
     propsChanged(({ props, actions }, oldProps) => {
         if (oldProps.queryInput !== props.queryInput) {
@@ -102,6 +103,9 @@ export const variablesLogic = kea<variablesLogicType>([
                     }
 
                     return stateCopy
+                },
+                resetVariables: () => {
+                    return []
                 },
             },
         ],
@@ -191,6 +195,11 @@ export const variablesLogic = kea<variablesLogicType>([
         editorQuery: (query: string) => {
             const queryVariableMatches = getVariablesFromQuery(query)
 
+            if (!queryVariableMatches.length) {
+                actions.resetVariables()
+                return
+            }
+
             queryVariableMatches?.forEach((match) => {
                 if (match === null) {
                     return
@@ -212,10 +221,16 @@ export const variablesLogic = kea<variablesLogicType>([
                 return
             }
 
+            const queryVariableMatches = getVariablesFromQuery(query.source.query)
+
             const variables = Object.values(query.source.variables ?? {})
 
             if (variables.length) {
-                actions.addVariables(variables)
+                variables.forEach((variable) => {
+                    if (queryVariableMatches.includes(variable.code_name)) {
+                        actions.addVariable(variable)
+                    }
+                })
             }
         },
     })),


### PR DESCRIPTION
## Problem

- all variables will showup even when there are none for the query

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- change the parsing such that variables will be hidden if there are none used
- on load of a query scene, the queries that are relevant to the query will be visible

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
