### PR TITLE
fix(data-warehouse): Dont read last incremental value when the pipeline is being reset

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -101,24 +101,26 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
         )
 
         endpoints = [schema.name]
+        processed_incremental_last_value = None
 
-        if settings.TEMPORAL_TASK_QUEUE == DATA_WAREHOUSE_TASK_QUEUE_V2:
-            # Get the V2 last value, if it's not set yet (e.g. the first run), then fallback to the V1 value
-            processed_incremental_last_value = process_incremental_last_value(
-                schema.sync_type_config.get("incremental_field_last_value_v2"),
-                schema.sync_type_config.get("incremental_field_type"),
-            )
+        if reset_pipeline is not True:
+            if settings.TEMPORAL_TASK_QUEUE == DATA_WAREHOUSE_TASK_QUEUE_V2:
+                # Get the V2 last value, if it's not set yet (e.g. the first run), then fallback to the V1 value
+                processed_incremental_last_value = process_incremental_last_value(
+                    schema.sync_type_config.get("incremental_field_last_value_v2"),
+                    schema.sync_type_config.get("incremental_field_type"),
+                )
 
-            if processed_incremental_last_value is None:
+                if processed_incremental_last_value is None:
+                    processed_incremental_last_value = process_incremental_last_value(
+                        schema.sync_type_config.get("incremental_field_last_value"),
+                        schema.sync_type_config.get("incremental_field_type"),
+                    )
+            else:
                 processed_incremental_last_value = process_incremental_last_value(
                     schema.sync_type_config.get("incremental_field_last_value"),
                     schema.sync_type_config.get("incremental_field_type"),
                 )
-        else:
-            processed_incremental_last_value = process_incremental_last_value(
-                schema.sync_type_config.get("incremental_field_last_value"),
-                schema.sync_type_config.get("incremental_field_type"),
-            )
 
         if schema.is_incremental:
             logger.debug(f"Incremental last value being used is: {processed_incremental_last_value}")

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -94,6 +94,9 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
         assert schema is not None
         reset_pipeline = schema.sync_type_config.get("reset_pipeline", False) is True
 
+        logger.debug(f"schema.sync_type_config = {schema.sync_type_config}")
+        logger.debug(f"reset_pipeline = {reset_pipeline}")
+
         schema = (
             ExternalDataSchema.objects.prefetch_related("source")
             .exclude(deleted=True)


### PR DESCRIPTION
## Changes
- When resetting the pipeline, don't use the stored `last_incremental_value` - instead use `None` to ensure all values are read from the source