### PR TITLE
fix(bi): add goal line value on hover

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -188,10 +188,28 @@ export const LineGraph = (): JSX.Element => {
                     },
                     scaleID: hasLeftYAxis ? 'yLeft' : 'yRight',
                     value: cur.value,
+                    enter: (ctx) => {
+                        if (ctx.chart.options.plugins?.annotation?.annotations) {
+                            const annotations = ctx.chart.options.plugins.annotation.annotations as Record<string, any>
+                            if (annotations[`line${curIndex}`]) {
+                                annotations[`line${curIndex}`].label.content = `${cur.label}: ${cur.value}`
+                                ctx.chart.update()
+                            }
+                        }
+                    },
+                    leave: (ctx) => {
+                        if (ctx.chart.options.plugins?.annotation?.annotations) {
+                            const annotations = ctx.chart.options.plugins.annotation.annotations as Record<string, any>
+                            if (annotations[`line${curIndex}`]) {
+                                annotations[`line${curIndex}`].label.content = cur.label
+                                ctx.chart.update()
+                            }
+                        }
+                    },
                 }
 
                 acc.annotations[`line${curIndex}`] = {
-                    type: 'line',
+                    type: 'line' as const,
                     ...line,
                 }
 


### PR DESCRIPTION
## Problem

- no goal line values

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- show goalline value on hover
![CleanShot 2025-01-24 at 14 04 27](https://github.com/user-attachments/assets/4b858a94-fe01-4cd8-8a23-bd7eeb41dceb)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
