### PR TITLE
chore: Add no typegen config for vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,17 @@
             "skipFiles": ["${workspaceFolder}/node_modules/kea-typegen/**/*.js"]
         },
         {
+            "name": "Frontend (no typegen)",
+            "command": "pnpm start-http",
+            "request": "launch",
+            "type": "node-terminal",
+            "cwd": "${workspaceFolder}",
+            "presentation": {
+                "group": "main"
+            },
+            "skipFiles": ["${workspaceFolder}/node_modules/kea-typegen/**/*.js"]
+        },
+        {
             "name": "Frontend (https)",
             "command": "pnpm start",
             "request": "launch",


### PR DESCRIPTION
I run typegen on a separate terminal window because I wanna look at the errors, so I want a custom container where that's not running by default