### PR TITLE
fix(slow-db-schema-query): Remediate slow query on full schema views for a team

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -586,7 +586,7 @@ def serialize_database(
     warehouse_schemas = (
         list(
             ExternalDataSchema.objects.exclude(deleted=True)
-            .filter(table_id__in=[table.id for table in warehouse_tables])
+            .filter(team_id=context.team_id, table_id__in=[table.id for table in warehouse_tables])
             .all()
         )
         if len(warehouse_tables) > 0


### PR DESCRIPTION
## Problem

This is a query that downloads **all** the sources, views, and nested schemas for a given PostHog organization.

Slow endpoint: https://us.posthog.com/api/environments/2/query/
```json
{
    "query": {
        "kind": "DatabaseSchemaQuery"
    }
}
```

## Changes

- Filtering by team

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

No functional change, cannot easily test perf, but this update did have a significant effect on a similar DW query.
