### PR TITLE
feat(early-access): Add quick links when >= 5

### DIFF
--- a/frontend/src/layout/FeaturePreviews/FeaturePreviews.tsx
+++ b/frontend/src/layout/FeaturePreviews/FeaturePreviews.tsx
@@ -19,12 +19,37 @@ export function FeaturePreviews(): JSX.Element {
                 earlyAccessFeatures.length === 0 && 'items-center justify-center'
             )}
         >
+            {earlyAccessFeatures.length > 4 && (
+                <div className="mb-4">
+                    <h4 className="font-semibold mb-0">Jump to:</h4>
+                    <ul className="list-disc pl-4">
+                        {earlyAccessFeatures.map(
+                            (feature) =>
+                                feature.flagKey && (
+                                    <li key={`nav-${feature.flagKey}`}>
+                                        <Link
+                                            onClick={(e) => {
+                                                e.preventDefault()
+                                                document
+                                                    .getElementById(`feature-preview-${feature.flagKey}`)
+                                                    ?.scrollIntoView({ behavior: 'smooth' })
+                                            }}
+                                        >
+                                            {feature.name}
+                                        </Link>
+                                    </li>
+                                )
+                        )}
+                    </ul>
+                    <LemonDivider className="my-4" />
+                </div>
+            )}
             {earlyAccessFeatures.map((feature, i) => {
                 if (!feature.flagKey) {
                     return false
                 }
                 return (
-                    <div key={feature.flagKey}>
+                    <div key={feature.flagKey} id={`feature-preview-${feature.flagKey}`}>
                         {i > 0 && <LemonDivider className="my-4" />}
                         <FeaturePreview key={feature.flagKey} feature={feature} />
                     </div>


### PR DESCRIPTION
## Problem

When a project has lots of early access features, the panel can get quite long and it can be difficult to find the older early access features.

From https://app.buildbetter.app/calls/268777?t=737.325

## Changes

Adds "Jump to" links to the early access features panel when there are five or more early access features:

https://github.com/user-attachments/assets/82116554-5016-4a87-9877-1f5976c2fd9d

Less than five drops the quick links:

![CleanShot 2025-01-24 at 13 26 12@2x](https://github.com/user-attachments/assets/4b3cc28e-f172-46b2-bbff-7a3749240579)

## How did you test this code?

Manual review.
