### PR TITLE
chore(flags): tweak boolean flag usage table response values

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlag.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlag.tsx
@@ -712,7 +712,7 @@ function UsageTab({ featureFlag }: { id: string; featureFlag: FeatureFlagType })
                             ...defaultDataTableColumns(NodeKind.EventsQuery),
                             featureFlag.filters.multivariate
                                 ? 'properties.$feature_flag_response'
-                                : "if(toString(properties.$feature_flag_response) IN ['1', 'true'], 'true', 'false') -- Feature Flag Response",
+                                : "if(toString(properties.$feature_flag_response) IN ['1', 'true'], 'true', properties.$feature_flag_response) -- Feature Flag Response",
                         ],
                         event: '$feature_flag_called',
                         properties: propertyFilter,


### PR DESCRIPTION
## Problem

Context: https://posthog.slack.com/archives/C07Q2U4BH4L/p1737751112214639

Still works in both cases of `true` or a non-`true` value:

![Screenshot 2025-01-24 at 1 55 52 PM](https://github.com/user-attachments/assets/31c9780f-011d-4983-9259-c459f4467c16)

![Screenshot 2025-01-24 at 1 50 34 PM](https://github.com/user-attachments/assets/12ef9714-0c3d-4a2c-8657-69268c0bf3e4)

## Changes

Make feature flag usage tab report same value for `$feature_flag_response` as the Activity tab does

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Ran locally with events as shown above