### PR TITLE
fix(table-visualization): Fix table crash on large datasets for SQL editor

### DIFF
--- a/frontend/src/layout/navigation-3000/components/SidebarList.tsx
+++ b/frontend/src/layout/navigation-3000/components/SidebarList.tsx
@@ -298,7 +298,7 @@ function SidebarListItem({ item, validateName, active, style }: SidebarListItemP
         content = <SidebarListItemAccordion category={item} />
     } else if (isItemClickable(item)) {
         content = (
-            <li
+            <div
                 className="SidebarListItem__button"
                 onClick={item.onClick}
                 // eslint-disable-next-line react/forbid-dom-props
@@ -306,7 +306,7 @@ function SidebarListItem({ item, validateName, active, style }: SidebarListItemP
             >
                 {item.icon && <div className="SidebarListItem__icon">{item.icon}</div>}
                 <h5 className="SidebarListItem__name">{item.name}</h5>
-            </li>
+            </div>
         )
     } else if (!save || (!isItemTentative(item) && newName === null)) {
         if (isItemTentative(item)) {
@@ -556,7 +556,7 @@ function SidebarListItemAccordion({ category }: { category: ListItemAccordion })
     const isExpanded = !(keyString in listItemAccordionCollapseMapping) || !listItemAccordionCollapseMapping[keyString]
 
     return (
-        <li className="SidebarListItemAccordion" role="region" aria-expanded={isExpanded}>
+        <div className="SidebarListItemAccordion" role="region" aria-expanded={isExpanded}>
             <div
                 id={`sidebar-list-item-accordion-${keyString}`}
                 className="SidebarListItemAccordion__header"
@@ -577,6 +577,6 @@ function SidebarListItemAccordion({ category }: { category: ListItemAccordion })
                     )}
                 </h4>
             </div>
-        </li>
+        </div>
     )
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -98,31 +98,30 @@ export const Table = (props: TableProps): JSX.Element => {
     )
 
     return (
-        <div className="relative w-full flex flex-col gap-4 flex-1 h-full">
-            <LemonTable
-                dataSource={tabularData}
-                columns={tableColumns}
-                loading={responseLoading}
-                emptyState={
-                    responseError ? (
-                        <InsightErrorState
-                            query={props.query}
-                            excludeDetail
-                            title={
-                                queryCancelled
-                                    ? 'The query was cancelled'
-                                    : response && 'error' in response
-                                    ? (response as any).error
-                                    : responseError
-                            }
-                        />
-                    ) : (
-                        <InsightEmptyState heading="There are no matching rows for this query" detail="" />
-                    )
-                }
-                footer={tabularData.length > 0 ? <LoadNext query={props.query} /> : null}
-                rowClassName="DataVizRow"
-            />
-        </div>
+        <LemonTable
+            dataSource={tabularData}
+            columns={tableColumns}
+            loading={responseLoading}
+            pagination={{ pageSize: 100 }}
+            emptyState={
+                responseError ? (
+                    <InsightErrorState
+                        query={props.query}
+                        excludeDetail
+                        title={
+                            queryCancelled
+                                ? 'The query was cancelled'
+                                : response && 'error' in response
+                                ? (response as any).error
+                                : responseError
+                        }
+                    />
+                ) : (
+                    <InsightEmptyState heading="There are no matching rows for this query" detail="" />
+                )
+            }
+            footer={tabularData.length > 0 ? <LoadNext query={props.query} /> : null}
+            rowClassName="DataVizRow"
+        />
     )
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -8,7 +8,6 @@ import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { DataVisualizationNode, HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 
-import { LoadNext } from '../../DataNode/LoadNext'
 import { renderColumn } from '../../DataTable/renderColumn'
 import { renderColumnMeta } from '../../DataTable/renderColumnMeta'
 import { convertTableValue, dataVisualizationLogic, TableDataCell } from '../dataVisualizationLogic'
@@ -120,7 +119,6 @@ export const Table = (props: TableProps): JSX.Element => {
                     <InsightEmptyState heading="There are no matching rows for this query" detail="" />
                 )
             }
-            footer={tabularData.length > 0 ? <LoadNext query={props.query} /> : null}
             rowClassName="DataVizRow"
         />
     )


### PR DESCRIPTION
## Problem

We crashed the entire webapp without paging our table. 😨 

<img width="1109" alt="image" src="https://github.com/user-attachments/assets/a32f8e0f-0618-4f14-ac53-5f2a4ce8d217" />


## Changes

- Page the table, removed a DOM layer that didn't seem to be helping us in a meaningful way.
- Transitioned list elements that were nested and throwing DOM nesting exceptions.

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
The app does not crash.

> Note: Suboptimal state exists with paging and constrained table, but that's a battle for another workflow.
