### PR TITLE
chore: use setting to grab the dagster s3 bucket per env

### DIFF
--- a/dags/definitions.py
+++ b/dags/definitions.py
@@ -15,7 +15,9 @@ env = "local" if settings.DEBUG else "prod"
 resources_by_env = {
     "prod": {
         "cluster": ClickhouseClusterResource.configure_at_launch(),
-        "io_manager": s3_pickle_io_manager.configured({"s3_bucket": "posthog-dags", "s3_prefix": "dag-storage"}),
+        "io_manager": s3_pickle_io_manager.configured(
+            {"s3_bucket": settings.DAGSTER_S3_BUCKET, "s3_prefix": "dag-storage"}
+        ),
         "s3": s3_resource,
     },
     "local": {

--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -24,6 +24,7 @@ from posthog.settings.access import *
 from posthog.settings.async_migrations import *
 from posthog.settings.celery import *
 from posthog.settings.data_stores import *
+from posthog.settings.dagster import *
 from posthog.settings.demo import *
 from posthog.settings.dynamic_settings import *
 from posthog.settings.ee import *

--- a/posthog/settings/dagster.py
+++ b/posthog/settings/dagster.py
@@ -1,3 +1,3 @@
 import os
 
-DAGSTER_S3_BUCKET = os.getenv("DAGSTER_S3_BUCKET")
+DAGSTER_S3_BUCKET = os.getenv("DAGSTER_S3_BUCKET", "posthog-dags")

--- a/posthog/settings/dagster.py
+++ b/posthog/settings/dagster.py
@@ -1,0 +1,3 @@
+import os
+
+DAGSTER_S3_BUCKET = os.getenv("DAGSTER_S3_BUCKET")


### PR DESCRIPTION
## Problem

We don't have a way to pass dagster s3 bucket for each env 

## Changes

create the setting and pass that to dagster boot

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
