### PR TITLE
fix: no more crashes on empty message.

### DIFF
--- a/livestream/kafka.go
+++ b/livestream/kafka.go
@@ -83,6 +83,7 @@ func (c *PostHogKafkaConsumer) Consume() {
 		if err != nil {
 			log.Printf("Error consuming message: %v", err)
 			sentry.CaptureException(err)
+			continue
 		}
 
 		var wrapperMessage PostHogEventWrapper


### PR DESCRIPTION
## Problem

livestream is crashing on timeout

## Changes

handle timeout and no message to parse properly

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

yes.

