### PR TITLE
fix: livestream upgrade actions for a build

### DIFF
--- a/.github/workflows/livestream-docker-image.yml
+++ b/.github/workflows/livestream-docker-image.yml
@@ -41,15 +41,15 @@ jobs:
                   images: ghcr.io/posthog/posthog/livestream
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v2
+              uses: docker/setup-buildx-action@v3
 
             - name: Set up QEMU
-              uses: docker/setup-qemu-action@v2
+              uses: docker/setup-qemu-action@v3
 
             - name: Build and push Docker image
               id: push
               if: github.ref == 'refs/heads/master'
-              uses: docker/build-push-action@v5
+              uses: docker/build-push-action@v6
               with:
                   context: livestream/
                   file: livestream/Dockerfile

--- a/.github/workflows/livestream-docker-image.yml
+++ b/.github/workflows/livestream-docker-image.yml
@@ -15,6 +15,7 @@ jobs:
         permissions:
             contents: read
             packages: write
+            id-token: write
 
         outputs:
             sha: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/livestream-docker-image.yml
+++ b/.github/workflows/livestream-docker-image.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
     build:
-        runs-on: ubuntu-24.04
+        runs-on: depot-ubuntu-24.04
 
         permissions:
             contents: read
@@ -40,18 +40,15 @@ jobs:
               with:
                   images: ghcr.io/posthog/posthog/livestream
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
+            - name: Set up Depot CLI
+              uses: depot/setup-action@v1
 
             - name: Build and push Docker image
               id: push
               if: github.ref == 'refs/heads/master'
-              uses: docker/build-push-action@v6
+              uses: depot/build-push-action@v1
               with:
-                  context: livestream/
+                  context: ./livestream/
                   file: livestream/Dockerfile
                   push: true
                   platforms: linux/amd64,linux/arm64

--- a/livestream/Dockerfile
+++ b/livestream/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 as builder
+FROM golang:1.23 AS builder
 WORKDIR /code
 COPY go.sum go.mod ./
 RUN go mod download -x

--- a/livestream/Dockerfile
+++ b/livestream/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     ( curl -s -L "https://mmdbcdn.posthog.net/" --http1.1 | brotli --decompress --output=/GeoLite2-City.mmdb ) && \
     chmod -R 755 /GeoLite2-City.mmdb
 
-FROM ubuntu
+FROM ubuntu:24.04
 COPY --from=builder /livestream /GeoLite2-City.mmdb /
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates


### PR DESCRIPTION
## Problem

A new livestream docker image is failing to build

## Changes

Bump actions to new versions

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
