### PR TITLE
chore: remove team_id from extended prometheus metrics

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -21,7 +21,6 @@ from django.utils.cache import add_never_cache_headers
 from django_prometheus.middleware import (
     Metrics,
     PrometheusAfterMiddleware,
-    PrometheusBeforeMiddleware,
 )
 from rest_framework import status
 from statshog.defaults.django import statsd

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -442,7 +442,6 @@ class CaptureMiddleware:
         # reconciles the old style middleware with the new style middleware.
         for middleware_class in (
             CorsMiddleware,
-            PrometheusAfterMiddlewareWithTeamIds,
         ):
             try:
                 # Some middlewares raise MiddlewareNotUsed if they are not

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -568,8 +568,6 @@ PROMETHEUS_EXTENDED_METRICS = [
 
 class CustomPrometheusMetrics(Metrics):
     def register_metric(self, metric_cls, name, documentation, labelnames=(), **kwargs):
-        if name in PROMETHEUS_EXTENDED_METRICS:
-            labelnames.extend([LABEL_TEAM_ID])
         return super().register_metric(metric_cls, name, documentation, labelnames=labelnames, **kwargs)
 
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -33,7 +33,6 @@ from posthog.clickhouse.client.execute import clickhouse_query_counter
 from posthog.clickhouse.query_tagging import QueryCounter, reset_query_tags, tag_queries
 from posthog.cloud_utils import is_cloud
 from posthog.exceptions import generate_exception_response
-from posthog.metrics import LABEL_TEAM_ID
 from posthog.models import Action, Cohort, Dashboard, FeatureFlag, Insight, Notebook, User, Team
 from posthog.rate_limit import DecideRateThrottle
 from posthog.settings import SITE_URL, DEBUG, PROJECT_SWITCHING_TOKEN_ALLOWLIST

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -571,31 +571,6 @@ class CustomPrometheusMetrics(Metrics):
         return super().register_metric(metric_cls, name, documentation, labelnames=labelnames, **kwargs)
 
 
-class PrometheusBeforeMiddlewareWithTeamIds(PrometheusBeforeMiddleware):
-    metrics_cls = CustomPrometheusMetrics
-
-
-class PrometheusAfterMiddlewareWithTeamIds(PrometheusAfterMiddleware):
-    metrics_cls = CustomPrometheusMetrics
-
-    def label_metric(self, metric, request, response=None, **labels):
-        new_labels = labels
-        if metric._name in PROMETHEUS_EXTENDED_METRICS:
-            team_id = None
-            if request and getattr(request, "user", None) and request.user.is_authenticated:
-                if request.resolver_match.kwargs.get("parent_lookup_team_id"):
-                    team_id = request.resolver_match.kwargs["parent_lookup_team_id"]
-                    if team_id == "@current":
-                        if hasattr(request.user, "current_team_id"):
-                            team_id = request.user.current_team_id
-                        else:
-                            team_id = None
-
-            new_labels = {LABEL_TEAM_ID: team_id}
-            new_labels.update(labels)
-        return super().label_metric(metric, request, response=response, **new_labels)
-
-
 class PostHogTokenCookieMiddleware(SessionMiddleware):
     """
     Adds two secure cookies to enable auto-filling the current project token on the docs.

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -442,6 +442,7 @@ class CaptureMiddleware:
         # reconciles the old style middleware with the new style middleware.
         for middleware_class in (
             CorsMiddleware,
+            PrometheusAfterMiddleware,
         ):
             try:
                 # Some middlewares raise MiddlewareNotUsed if they are not

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -92,7 +92,6 @@ INSTALLED_APPS = [
 
 
 MIDDLEWARE = [
-    "posthog.middleware.PrometheusBeforeMiddlewareWithTeamIds",
     "posthog.gzip_middleware.ScopedGZipMiddleware",
     "posthog.middleware.per_request_logging_context_middleware",
     "django_structlog.middlewares.RequestMiddleware",
@@ -122,7 +121,6 @@ MIDDLEWARE = [
     "axes.middleware.AxesMiddleware",
     "posthog.middleware.AutoProjectMiddleware",
     "posthog.middleware.CHQueries",
-    "posthog.middleware.PrometheusAfterMiddlewareWithTeamIds",
     "posthog.middleware.PostHogTokenCookieMiddleware",
 ]
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -92,7 +92,7 @@ INSTALLED_APPS = [
 
 
 MIDDLEWARE = [
-    "posthog.middleware.PrometheusBeforeMiddleware",
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "posthog.gzip_middleware.ScopedGZipMiddleware",
     "posthog.middleware.per_request_logging_context_middleware",
     "django_structlog.middlewares.RequestMiddleware",
@@ -122,7 +122,7 @@ MIDDLEWARE = [
     "axes.middleware.AxesMiddleware",
     "posthog.middleware.AutoProjectMiddleware",
     "posthog.middleware.CHQueries",
-    "posthog.middleware.PrometheusAfterMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
     "posthog.middleware.PostHogTokenCookieMiddleware",
 ]
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -92,6 +92,7 @@ INSTALLED_APPS = [
 
 
 MIDDLEWARE = [
+    "posthog.middleware.PrometheusBeforeMiddleware",
     "posthog.gzip_middleware.ScopedGZipMiddleware",
     "posthog.middleware.per_request_logging_context_middleware",
     "django_structlog.middlewares.RequestMiddleware",
@@ -121,6 +122,7 @@ MIDDLEWARE = [
     "axes.middleware.AxesMiddleware",
     "posthog.middleware.AutoProjectMiddleware",
     "posthog.middleware.CHQueries",
+    "posthog.middleware.PrometheusAfterMiddleware",
     "posthog.middleware.PostHogTokenCookieMiddleware",
 ]
 


### PR DESCRIPTION
## Problem
these metrics are super high cardinality due to team_id, and growing

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
