### PR TITLE
fix: revert livestream the build to github runners

### DIFF
--- a/.github/workflows/livestream-docker-image.yml
+++ b/.github/workflows/livestream-docker-image.yml
@@ -10,12 +10,11 @@ on:
 
 jobs:
     build:
-        runs-on: depot-ubuntu-24.04
+        runs-on: ubuntu-24.04
 
         permissions:
             contents: read
             packages: write
-            id-token: write
 
         outputs:
             sha: ${{ steps.push.outputs.digest }}
@@ -41,15 +40,18 @@ jobs:
               with:
                   images: ghcr.io/posthog/posthog/livestream
 
-            - name: Set up Depot CLI
-              uses: depot/setup-action@v1
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
 
             - name: Build and push Docker image
               id: push
               if: github.ref == 'refs/heads/master'
-              uses: depot/build-push-action@v1
+              uses: docker/build-push-action@v6
               with:
-                  context: ./livestream/
+                  context: livestream/
                   file: livestream/Dockerfile
                   push: true
                   platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Problem

depot doesn't work: https://github.com/PostHog/posthog/actions/runs/12986814836/job/36214931086

## Changes

revert to github runners

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
