### PR TITLE
feat(web-analytics): Track product intent from web analytics to insights

### DIFF
--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -14,6 +14,7 @@ import { PostHogComDocsURL } from 'lib/lemon-ui/Link/Link'
 import { Popover } from 'lib/lemon-ui/Popover'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { isNotNil } from 'lib/utils'
+import { addProductIntentForCrossSell, ProductIntentContext } from 'lib/utils/product-intents'
 import React, { useState } from 'react'
 import { WebAnalyticsErrorTrackingTile } from 'scenes/web-analytics/tiles/WebAnalyticsErrorTracking'
 import { WebAnalyticsRecordingsTile } from 'scenes/web-analytics/tiles/WebAnalyticsRecordings'
@@ -35,7 +36,7 @@ import { navigationLogic } from '~/layout/navigation/navigationLogic'
 import { dataNodeCollectionLogic } from '~/queries/nodes/DataNode/dataNodeCollectionLogic'
 import { ReloadAll } from '~/queries/nodes/DataNode/Reload'
 import { QuerySchema } from '~/queries/schema'
-import { PropertyMathType } from '~/types'
+import { ProductKey, PropertyMathType } from '~/types'
 
 import { WebAnalyticsLiveUserCount } from './WebAnalyticsLiveUserCount'
 
@@ -136,6 +137,13 @@ const QueryTileItem = ({ tile }: { tile: QueryTile }): JSX.Element => {
                 icon={<IconOpenInNew />}
                 size="small"
                 type="secondary"
+                onClick={() => {
+                    void addProductIntentForCrossSell({
+                        from: ProductKey.WEB_ANALYTICS,
+                        to: ProductKey.PRODUCT_ANALYTICS,
+                        intent_context: ProductIntentContext.WEB_ANALYTICS_INSIGHT,
+                    })
+                }}
             >
                 Open as new Insight
             </LemonButton>
@@ -267,6 +275,13 @@ export const WebTabs = ({
                 icon={<IconOpenInNew />}
                 size="small"
                 type="secondary"
+                onClick={() => {
+                    void addProductIntentForCrossSell({
+                        from: ProductKey.WEB_ANALYTICS,
+                        to: ProductKey.PRODUCT_ANALYTICS,
+                        intent_context: ProductIntentContext.WEB_ANALYTICS_INSIGHT,
+                    })
+                }}
             >
                 Open as new Insight
             </LemonButton>

--- a/frontend/src/scenes/web-analytics/WebAnalyticsModal.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsModal.tsx
@@ -3,10 +3,13 @@ import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
+import { addProductIntentForCrossSell, ProductIntentContext } from 'lib/utils/product-intents'
 import { urls } from 'scenes/urls'
 import { WebQuery } from 'scenes/web-analytics/tiles/WebAnalyticsTile'
 import { webAnalyticsLogic } from 'scenes/web-analytics/webAnalyticsLogic'
 import { WebPropertyFilters } from 'scenes/web-analytics/WebPropertyFilters'
+
+import { ProductKey } from '~/types'
 
 export const WebAnalyticsModal = (): JSX.Element | null => {
     const {
@@ -53,6 +56,13 @@ export const WebAnalyticsModal = (): JSX.Element | null => {
                             icon={<IconOpenInNew />}
                             size="small"
                             type="secondary"
+                            onClick={() => {
+                                void addProductIntentForCrossSell({
+                                    from: ProductKey.WEB_ANALYTICS,
+                                    to: ProductKey.PRODUCT_ANALYTICS,
+                                    intent_context: ProductIntentContext.WEB_ANALYTICS_INSIGHT,
+                                })
+                            }}
                         >
                             Open as new Insight
                         </LemonButton>


### PR DESCRIPTION
## Problem

We're missing some cross-sell tracking

## Changes
Track our `Open as new Insight` buttons that open product analytics

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Opened this locally with posthog debug, saw the events in the console
