### PR TITLE
feat: measure commit latency

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -303,13 +303,12 @@ export class SessionRecordingIngester {
     }
 
     private async commitOffsets(offsets: TopicPartitionOffset[]): Promise<void> {
-        await new Promise<void>((resolve, reject) => {
-            try {
+        await runInstrumentedFunction({
+            statsKey: `recordingingesterv2.handleEachBatch.flush.commitOffsets`,
+            func: async () => {
                 this.batchConsumer!.consumer.commitSync(offsets)
-                resolve()
-            } catch (error) {
-                reject(error)
-            }
+                return Promise.resolve()
+            },
         })
     }
 }


### PR DESCRIPTION
## Problem

Flushing the data (even though we discard it) seems to be very slow and we don't know whether it's writing the data or comitting of the offsets. 

## Changes

Added instrumentation to the commit offset function.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Will check it on the Grafana dashboards.