### PR TITLE
fix: fix the profile bubbles class name overwrite

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivityMetalytics.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivityMetalytics.tsx
@@ -52,12 +52,11 @@ export function SidePanelActivityMetalytics(): JSX.Element {
 
                 <Tooltip title={`The most recent 30 users who have viewed ${humanizedScope}.`} placement="top">
                     <div className="flex-1 p-4 border rounded bg-bg-light min-w-40">
-                        <div className="text-sm text-muted">Recent viewers (30 days)</div>
+                        <div className="text-sm text-muted mb-2">Recent viewers (30 days)</div>
                         {recentUsersLoading ? (
                             <Spinner />
                         ) : (
                             <ProfileBubbles
-                                className="mt-2"
                                 people={recentUserMembers.map((member) => ({
                                     email: member.user.email,
                                     name: member.user.first_name,

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivityMetalytics.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/SidePanelActivityMetalytics.tsx
@@ -52,11 +52,12 @@ export function SidePanelActivityMetalytics(): JSX.Element {
 
                 <Tooltip title={`The most recent 30 users who have viewed ${humanizedScope}.`} placement="top">
                     <div className="flex-1 p-4 border rounded bg-bg-light min-w-40">
-                        <div className="text-sm text-muted mb-2">Recent viewers (30 days)</div>
+                        <div className="text-sm text-muted">Recent viewers (30 days)</div>
                         {recentUsersLoading ? (
                             <Spinner />
-                        ) : (
+                        ) : recentUserMembers.length > 0 ? (
                             <ProfileBubbles
+                                className="mt-2"
                                 people={recentUserMembers.map((member) => ({
                                     email: member.user.email,
                                     name: member.user.first_name,
@@ -64,6 +65,8 @@ export function SidePanelActivityMetalytics(): JSX.Element {
                                 }))}
                                 limit={3}
                             />
+                        ) : (
+                            <div className="text-sm mt-2">No recent viewers</div>
                         )}
                     </div>
                 </Tooltip>

--- a/frontend/src/lib/lemon-ui/ProfilePicture/ProfileBubbles.tsx
+++ b/frontend/src/lib/lemon-ui/ProfilePicture/ProfileBubbles.tsx
@@ -7,6 +7,7 @@ export interface ProfileBubblesProps extends React.HTMLProps<HTMLDivElement> {
     people: { email: string; name?: string; title?: string }[]
     tooltip?: string
     limit?: number
+    className?: string
 }
 
 /** Bubbles are a compact way of listing PostHog users – usually in a collaborative context, such as dashboard collaborators. */

--- a/frontend/src/lib/lemon-ui/ProfilePicture/ProfileBubbles.tsx
+++ b/frontend/src/lib/lemon-ui/ProfilePicture/ProfileBubbles.tsx
@@ -10,7 +10,13 @@ export interface ProfileBubblesProps extends React.HTMLProps<HTMLDivElement> {
 }
 
 /** Bubbles are a compact way of listing PostHog users – usually in a collaborative context, such as dashboard collaborators. */
-export function ProfileBubbles({ people, tooltip, limit = 6, ...divProps }: ProfileBubblesProps): JSX.Element {
+export function ProfileBubbles({
+    people,
+    tooltip,
+    limit = 6,
+    className,
+    ...divProps
+}: ProfileBubblesProps): JSX.Element {
     const overflowing = people.length > limit
 
     let shownPeople: ProfileBubblesProps['people'] = people
@@ -25,7 +31,7 @@ export function ProfileBubbles({ people, tooltip, limit = 6, ...divProps }: Prof
 
     return (
         <Tooltip title={tooltip}>
-            <div className={clsx('ProfileBubbles', !!divProps.onClick && 'cursor-pointer')} {...divProps}>
+            <div className={clsx('ProfileBubbles', !!divProps.onClick && 'cursor-pointer', className)} {...divProps}>
                 {shownPeople.map(({ email, name, title }, index) => (
                     <ProfilePicture
                         key={email}


### PR DESCRIPTION
## Changes

Metalytics profile bubbles aren't flex-ing because the `className` props is being overwritten.

<img width="173" alt="Screenshot 2025-01-27 at 10 36 40 AM" src="https://github.com/user-attachments/assets/b81ca8b1-70e2-4288-9a2b-0837253425b8" />

This PR is also added a no viewers case

<img width="256" alt="Screenshot 2025-01-27 at 10 41 16 AM" src="https://github.com/user-attachments/assets/18b59590-caa8-46b6-8a32-fddc3539ff77" />

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

## How did you test this code?

Manually
