### PR TITLE
refactor: store offsets like in v1

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/consumer.ts
@@ -306,7 +306,7 @@ export class SessionRecordingIngester {
         await runInstrumentedFunction({
             statsKey: `recordingingesterv2.handleEachBatch.flush.commitOffsets`,
             func: async () => {
-                this.batchConsumer!.consumer.commitSync(offsets)
+                this.batchConsumer!.consumer.offsetsStore(offsets)
                 return Promise.resolve()
             },
         })


### PR DESCRIPTION
## Problem

Committing offsets using `commitSync` seems to be extremely slow quite often and causes the consumers to be kicked out of the group.

## Changes

Changed to the `offsetsStore` method to make it in line with Mr Blobby V1.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Will check the metrics on Grafana dashboards to compare the latency.