### PR TITLE
fix: only rate limit password changes on the user api

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -847,6 +847,11 @@ class TestUserAPI(APIBaseTest):
             response = self.client.patch("/api/users/@me/", {"current_password": "wrong", "password": "12345678"})
         self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
 
+    def test_no_ratelimit_for_updates_that_are_not_password_changes(self):
+        for _ in range(10):
+            response = self.client.patch("/api/users/@me/", {"organization_name": "new name"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     # DELETING USER
 
     def test_deleting_current_user_is_not_supported(self):

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -314,6 +314,11 @@ class UserAuthenticationThrottle(UserOrEmailRateThrottle):
         # only throttle non-GET requests
         if request.method == "GET":
             return True
+
+        # only throttle if attempting to change current password
+        if "current_password" not in request.data:
+            return True
+
         return super().allow_request(request, view)
 
 


### PR DESCRIPTION
## Problem

We are currently rate limiting all user updates to 5/minute, this causes issues when a user changes their notification preferences, or performs any action that sends updates quickly

## Changes

Scopes the rate limiting on the user api to only cover password change requests, which was it's original purpose.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added a test for checking that the rate limit is not reached for an update request, along with the existing check that it is reached for password change requests.
