### PR TITLE
fix: enable auto commit in blobby v2

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/batch-consumer-factory.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/batch-consumer-factory.ts
@@ -37,7 +37,7 @@ export class DefaultBatchConsumerFactory implements BatchConsumerFactory {
             topic,
             eachBatch,
             callEachBatchWhenEmpty: true, // Required, as we want to flush session batches periodically
-            autoCommit: false,
+            autoCommit: true,
             autoOffsetStore: false,
             sessionTimeout: KAFKA_CONSUMER_SESSION_TIMEOUT_MS,
             maxPollIntervalMs: this.serverConfig.KAFKA_CONSUMPTION_MAX_POLL_INTERVAL_MS,

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/offset-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/kafka/offset-manager.ts
@@ -1,5 +1,6 @@
 import { TopicPartitionOffset } from 'node-rdkafka'
 
+import { status } from '../../../../utils/status'
 import { PartitionOffset } from '../types'
 
 type CommitOffsetsCallback = (offsets: TopicPartitionOffset[]) => Promise<void>
@@ -30,6 +31,10 @@ export class KafkaOffsetManager {
         }
 
         if (topicPartitionOffsets.length > 0) {
+            status.info('🔁', 'offset_manager_committing_offsets', {
+                topic: this.topic,
+                offsets: topicPartitionOffsets.map(({ partition, offset }) => ({ partition, offset })),
+            })
             await this.commitOffsets(topicPartitionOffsets)
             this.partitionOffsets.clear()
         }


### PR DESCRIPTION
## Problem

When changing to offsetStore, I forgot to reenable `autoCommit` on the Kafka consumer.

## Changes

Enables `autoCommit` on the Kafka consumer.
Adds extra log line in the offset manager, to make it visible which offsets are flushed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Will verify on the running instances.