### PR TITLE
chore(bi): goal line visibility

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -193,6 +193,13 @@ export const LineGraph = (): JSX.Element => {
                             const annotations = ctx.chart.options.plugins.annotation.annotations as Record<string, any>
                             if (annotations[`line${curIndex}`]) {
                                 annotations[`line${curIndex}`].label.content = `${cur.label}: ${cur.value}`
+                                // Hide the external tooltip element
+                                const tooltipEl = document.getElementById('InsightTooltipWrapper')
+
+                                if (tooltipEl) {
+                                    tooltipEl.style.display = 'none'
+                                }
+
                                 ctx.chart.update()
                             }
                         }
@@ -202,6 +209,13 @@ export const LineGraph = (): JSX.Element => {
                             const annotations = ctx.chart.options.plugins.annotation.annotations as Record<string, any>
                             if (annotations[`line${curIndex}`]) {
                                 annotations[`line${curIndex}`].label.content = cur.label
+
+                                // Show the external tooltip element
+                                const tooltipEl = document.getElementById('InsightTooltipWrapper')
+                                if (tooltipEl) {
+                                    tooltipEl.style.display = 'block'
+                                }
+
                                 ctx.chart.update()
                             }
                         }


### PR DESCRIPTION
## Problem

- goalline isn't visible behind tooltip

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- show goalline only on hover

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
