### PR TITLE
chore(web-analytics): Make the snapshot_clickhouse_queries decorator work for classes, use in web analytics

### DIFF
--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_external_clicks_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_external_clicks_table.ambr
@@ -1,0 +1,409 @@
+# serializer version: 1
+# name: TestExternalClicksTableQueryRunner.test_all_time
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestExternalClicksTableQueryRunner.test_all_time.1
+  '''
+  SELECT url AS `context.columns.url`,
+         tuple(uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))), uniqIf(filtered_person_id, 0)) AS `context.columns.visitors`,
+         tuple(sumIf(filtered_click_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))), sumIf(filtered_click_count, 0)) AS `context.columns.clicks`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_click_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '') AS url,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$autocapture'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$event_type'), ''), 'null'), '^"|"$', ''), 'click'), 0), isNotNull(url), ifNull(notEquals(url, ''), 1), ifNull(notEquals(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')), cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', ''))), isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')))
+                                                                                                                                                                                                                                                                                       or isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', '')))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1))
+     GROUP BY events.`$session_id`,
+              url)
+  GROUP BY `context.columns.url`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.clicks` DESC,
+           `context.columns.url` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestExternalClicksTableQueryRunner.test_dont_filter_test_accounts
+  '''
+  SELECT url AS `context.columns.url`,
+         tuple(uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))), uniqIf(filtered_person_id, 0)) AS `context.columns.visitors`,
+         tuple(sumIf(filtered_click_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))), sumIf(filtered_click_count, 0)) AS `context.columns.clicks`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_click_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '') AS url,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$autocapture'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$event_type'), ''), 'null'), '^"|"$', ''), 'click'), 0), isNotNull(url), ifNull(notEquals(url, ''), 1), ifNull(notEquals(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')), cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', ''))), isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')))
+                                                                                                                                                                                                                                                                                       or isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', '')))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), 1))
+     GROUP BY events.`$session_id`,
+              url)
+  GROUP BY `context.columns.url`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.clicks` DESC,
+           `context.columns.url` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestExternalClicksTableQueryRunner.test_filter_test_accounts
+  '''
+  SELECT url AS `context.columns.url`,
+         tuple(uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))), uniqIf(filtered_person_id, 0)) AS `context.columns.visitors`,
+         tuple(sumIf(filtered_click_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))), sumIf(filtered_click_count, 0)) AS `context.columns.clicks`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_click_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '') AS url,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+        FROM person
+        WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                             (SELECT person.id AS id, max(person.version) AS version
+                                                              FROM person
+                                                              WHERE equals(person.team_id, 99999)
+                                                              GROUP BY person.id
+                                                              HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$autocapture'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$event_type'), ''), 'null'), '^"|"$', ''), 'click'), 0), isNotNull(url), ifNull(notEquals(url, ''), 1), ifNull(notEquals(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')), cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', ''))), isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')))
+                                                                                                                                                                                                                                                                                       or isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', '')))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), ifNull(notILike(events__person.properties___email, '%@posthog.com%'), 1)))
+     GROUP BY events.`$session_id`,
+              url)
+  GROUP BY `context.columns.url`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.clicks` DESC,
+           `context.columns.url` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestExternalClicksTableQueryRunner.test_increase_in_users
+  '''
+  SELECT url AS `context.columns.url`,
+         tuple(uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-11 23:59:59', 6, 'UTC'))), 0))), uniqIf(filtered_person_id, 0)) AS `context.columns.visitors`,
+         tuple(sumIf(filtered_click_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-11 23:59:59', 6, 'UTC'))), 0))), sumIf(filtered_click_count, 0)) AS `context.columns.clicks`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_click_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '') AS url,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-11 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$autocapture'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$event_type'), ''), 'null'), '^"|"$', ''), 'click'), 0), isNotNull(url), ifNull(notEquals(url, ''), 1), ifNull(notEquals(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')), cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', ''))), isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')))
+                                                                                                                                                                                                                                                                                       or isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', '')))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-11 23:59:59', 6, 'UTC')))), 0), 1))
+     GROUP BY events.`$session_id`,
+              url)
+  GROUP BY `context.columns.url`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.clicks` DESC,
+           `context.columns.url` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestExternalClicksTableQueryRunner.test_no_crash_when_no_data
+  '''
+  SELECT url AS `context.columns.url`,
+         tuple(uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-08 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))), uniqIf(filtered_person_id, 0)) AS `context.columns.visitors`,
+         tuple(sumIf(filtered_click_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-08 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))), sumIf(filtered_click_count, 0)) AS `context.columns.clicks`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_click_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '') AS url,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-08 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$autocapture'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$event_type'), ''), 'null'), '^"|"$', ''), 'click'), 0), isNotNull(url), ifNull(notEquals(url, ''), 1), ifNull(notEquals(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')), cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', ''))), isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')))
+                                                                                                                                                                                                                                                                                       or isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', '')))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-08 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1))
+     GROUP BY events.`$session_id`,
+              url)
+  GROUP BY `context.columns.url`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.clicks` DESC,
+           `context.columns.url` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestExternalClicksTableQueryRunner.test_should_exclude_subdomain_under_root
+  '''
+  SELECT url AS `context.columns.url`,
+         tuple(uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))), uniqIf(filtered_person_id, 0)) AS `context.columns.visitors`,
+         tuple(sumIf(filtered_click_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))), sumIf(filtered_click_count, 0)) AS `context.columns.clicks`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_click_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '') AS url,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$autocapture'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$event_type'), ''), 'null'), '^"|"$', ''), 'click'), 0), isNotNull(url), ifNull(notEquals(url, ''), 1), ifNull(notEquals(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')), cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', ''))), isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')))
+                                                                                                                                                                                                                                                                                       or isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', '')))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), 1))
+     GROUP BY events.`$session_id`,
+              url)
+  GROUP BY `context.columns.url`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.clicks` DESC,
+           `context.columns.url` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestExternalClicksTableQueryRunner.test_should_exclude_subdomain_with_shared_root
+  '''
+  SELECT url AS `context.columns.url`,
+         tuple(uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))), uniqIf(filtered_person_id, 0)) AS `context.columns.visitors`,
+         tuple(sumIf(filtered_click_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))), sumIf(filtered_click_count, 0)) AS `context.columns.clicks`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_click_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '') AS url,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$autocapture'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$event_type'), ''), 'null'), '^"|"$', ''), 'click'), 0), isNotNull(url), ifNull(notEquals(url, ''), 1), ifNull(notEquals(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')), cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', ''))), isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')))
+                                                                                                                                                                                                                                                                                       or isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', '')))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), 1))
+     GROUP BY events.`$session_id`,
+              url)
+  GROUP BY `context.columns.url`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.clicks` DESC,
+           `context.columns.url` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestExternalClicksTableQueryRunner.test_strip_query_params
+  '''
+  SELECT url AS `context.columns.url`,
+         tuple(uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))), uniqIf(filtered_person_id, 0)) AS `context.columns.visitors`,
+         tuple(sumIf(filtered_click_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))), sumIf(filtered_click_count, 0)) AS `context.columns.clicks`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_click_count,
+            cutQueryStringAndFragment(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')) AS url,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$autocapture'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$event_type'), ''), 'null'), '^"|"$', ''), 'click'), 0), isNotNull(url), ifNull(notEquals(url, ''), 1), ifNull(notEquals(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')), cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', ''))), isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')))
+                                                                                                                                                                                                                                                                                       or isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', '')))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), 1))
+     GROUP BY events.`$session_id`,
+              url)
+  GROUP BY `context.columns.url`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.clicks` DESC,
+           `context.columns.url` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestExternalClicksTableQueryRunner.test_strip_query_params.1
+  '''
+  SELECT url AS `context.columns.url`,
+         tuple(uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))), uniqIf(filtered_person_id, 0)) AS `context.columns.visitors`,
+         tuple(sumIf(filtered_click_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))), sumIf(filtered_click_count, 0)) AS `context.columns.clicks`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_click_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '') AS url,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$autocapture'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$event_type'), ''), 'null'), '^"|"$', ''), 'click'), 0), isNotNull(url), ifNull(notEquals(url, ''), 1), ifNull(notEquals(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')), cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', ''))), isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$external_click_url'), ''), 'null'), '^"|"$', '')))
+                                                                                                                                                                                                                                                                                       or isNotNull(cutToFirstSignificantSubdomain(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$host'), ''), 'null'), '^"|"$', '')))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), 1))
+     GROUP BY events.`$session_id`,
+              url)
+  GROUP BY `context.columns.url`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.clicks` DESC,
+           `context.columns.url` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_session_attribution_explorer_query_runner.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_session_attribution_explorer_query_runner.ambr
@@ -1,0 +1,188 @@
+# serializer version: 1
+# name: TestSessionAttributionQueryRunner.test_filters
+  '''
+  SELECT count() AS `context.columns.count`,
+         sessions.`$channel_type` AS `context.columns.channel_type`,
+         topK(10)(sessions.`$entry_referring_domain`) AS `context.columns.referring_domain`,
+         sessions.`$entry_utm_source` AS `context.columns.utm_source`,
+         sessions.`$entry_utm_medium` AS `context.columns.utm_medium`,
+         topK(10)(sessions.`$entry_utm_campaign`) AS `context.columns.utm_campaign`,
+         topK(10)(nullIf(arrayStringConcat([if(isNotNull(sessions.`$entry_gclid`), 'glcid', NULL), if(isNotNull(sessions.`$entry_gad_source`), 'gad_source', NULL)], ','), '')) AS `context.columns.ad_ids`,
+         topK(10)(sessions.`$entry_current_url`) AS `context.columns.example_entry_urls`
+  FROM
+    (SELECT multiIf(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), 'cross-network'), 'Cross Network', or(ifNull(in(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), tuple('cpc', 'cpm', 'cpv', 'cpa', 'ppc', 'retargeting')), 0), startsWith(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), 'paid'), isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_gclid), 'null'), '')), isNotNull(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), ''), ''), 'null'))), coalesce(coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Paid Shopping', NULL), dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '')), 'source'))), multiIf(ifNull(equals(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), ''), ''), 'null'), '1'), 0), 'Paid Search', match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*video.*)$'), 'Paid Video', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')), 'Paid Social', 'Paid Unknown')), and(ifNull(equals(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '$direct'), 0), isNull(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null'))), or(isNull(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null'))), ifNull(in(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), tuple('(direct)', 'direct', '$direct')), 0)), not(isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')))), 'Direct', coalesce(coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Organic Shopping', NULL), dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '')), 'source'))), multiIf(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*video.*)$'), 'Organic Video', match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), 'push$'), 'Push', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')), 'Organic Social', ifNull(equals(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '$direct'), 0), 'Direct', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), '')), 'Referral', 'Unknown'))) AS `$channel_type`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), '') AS `$entry_referring_domain`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), '') AS `$entry_utm_medium`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), '') AS `$entry_utm_campaign`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_gclid), 'null'), '') AS `$entry_gclid`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), '') AS `$entry_gad_source`,
+            nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '') AS `$entry_current_url`,
+            raw_sessions.session_id_v7 AS session_id_v7
+     FROM raw_sessions
+     WHERE equals(raw_sessions.team_id, 99999)
+     GROUP BY raw_sessions.session_id_v7,
+              raw_sessions.session_id_v7) AS sessions
+  WHERE and(ifNull(equals(sessions.`$entry_utm_source`, 'source1'), 0), 1)
+  GROUP BY `context.columns.channel_type`,
+           `context.columns.utm_source`,
+           `context.columns.utm_medium`
+  ORDER BY `context.columns.count` DESC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestSessionAttributionQueryRunner.test_group_by_initial_url
+  '''
+  SELECT count() AS `context.columns.count`,
+         topK(10)(sessions.`$channel_type`) AS `context.columns.channel_type`,
+         topK(10)(sessions.`$entry_referring_domain`) AS `context.columns.referring_domain`,
+         topK(10)(sessions.`$entry_utm_source`) AS `context.columns.utm_source`,
+         topK(10)(sessions.`$entry_utm_medium`) AS `context.columns.utm_medium`,
+         topK(10)(sessions.`$entry_utm_campaign`) AS `context.columns.utm_campaign`,
+         topK(10)(nullIf(arrayStringConcat([if(isNotNull(sessions.`$entry_gclid`), 'glcid', NULL), if(isNotNull(sessions.`$entry_gad_source`), 'gad_source', NULL)], ','), '')) AS `context.columns.ad_ids`,
+         sessions.`$entry_current_url` AS `context.columns.example_entry_urls`
+  FROM
+    (SELECT multiIf(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), 'cross-network'), 'Cross Network', or(ifNull(in(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), tuple('cpc', 'cpm', 'cpv', 'cpa', 'ppc', 'retargeting')), 0), startsWith(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), 'paid'), isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_gclid), 'null'), '')), isNotNull(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), ''), ''), 'null'))), coalesce(coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Paid Shopping', NULL), dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '')), 'source'))), multiIf(ifNull(equals(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), ''), ''), 'null'), '1'), 0), 'Paid Search', match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*video.*)$'), 'Paid Video', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')), 'Paid Social', 'Paid Unknown')), and(ifNull(equals(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '$direct'), 0), isNull(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null'))), or(isNull(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null'))), ifNull(in(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), tuple('(direct)', 'direct', '$direct')), 0)), not(isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')))), 'Direct', coalesce(coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Organic Shopping', NULL), dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '')), 'source'))), multiIf(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*video.*)$'), 'Organic Video', match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), 'push$'), 'Push', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')), 'Organic Social', ifNull(equals(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '$direct'), 0), 'Direct', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), '')), 'Referral', 'Unknown'))) AS `$channel_type`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), '') AS `$entry_referring_domain`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), '') AS `$entry_utm_medium`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), '') AS `$entry_utm_campaign`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_gclid), 'null'), '') AS `$entry_gclid`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), '') AS `$entry_gad_source`,
+            nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '') AS `$entry_current_url`,
+            raw_sessions.session_id_v7 AS session_id_v7
+     FROM raw_sessions
+     WHERE equals(raw_sessions.team_id, 99999)
+     GROUP BY raw_sessions.session_id_v7,
+              raw_sessions.session_id_v7) AS sessions
+  WHERE and(1, 1)
+  GROUP BY `context.columns.example_entry_urls`
+  ORDER BY `context.columns.count` DESC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestSessionAttributionQueryRunner.test_group_by_nothing
+  '''
+  SELECT count() AS `context.columns.count`,
+         topK(10)(sessions.`$channel_type`) AS `context.columns.channel_type`,
+         topK(10)(sessions.`$entry_referring_domain`) AS `context.columns.referring_domain`,
+         topK(10)(sessions.`$entry_utm_source`) AS `context.columns.utm_source`,
+         topK(10)(sessions.`$entry_utm_medium`) AS `context.columns.utm_medium`,
+         topK(10)(sessions.`$entry_utm_campaign`) AS `context.columns.utm_campaign`,
+         topK(10)(nullIf(arrayStringConcat([if(isNotNull(sessions.`$entry_gclid`), 'glcid', NULL), if(isNotNull(sessions.`$entry_gad_source`), 'gad_source', NULL)], ','), '')) AS `context.columns.ad_ids`,
+         topK(10)(sessions.`$entry_current_url`) AS `context.columns.example_entry_urls`
+  FROM
+    (SELECT multiIf(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), 'cross-network'), 'Cross Network', or(ifNull(in(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), tuple('cpc', 'cpm', 'cpv', 'cpa', 'ppc', 'retargeting')), 0), startsWith(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), 'paid'), isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_gclid), 'null'), '')), isNotNull(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), ''), ''), 'null'))), coalesce(coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Paid Shopping', NULL), dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '')), 'source'))), multiIf(ifNull(equals(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), ''), ''), 'null'), '1'), 0), 'Paid Search', match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*video.*)$'), 'Paid Video', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')), 'Paid Social', 'Paid Unknown')), and(ifNull(equals(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '$direct'), 0), isNull(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null'))), or(isNull(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null'))), ifNull(in(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), tuple('(direct)', 'direct', '$direct')), 0)), not(isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')))), 'Direct', coalesce(coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Organic Shopping', NULL), dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '')), 'source'))), multiIf(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*video.*)$'), 'Organic Video', match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), 'push$'), 'Push', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')), 'Organic Social', ifNull(equals(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '$direct'), 0), 'Direct', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), '')), 'Referral', 'Unknown'))) AS `$channel_type`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), '') AS `$entry_referring_domain`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), '') AS `$entry_utm_medium`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), '') AS `$entry_utm_campaign`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_gclid), 'null'), '') AS `$entry_gclid`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), '') AS `$entry_gad_source`,
+            nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '') AS `$entry_current_url`,
+            raw_sessions.session_id_v7 AS session_id_v7
+     FROM raw_sessions
+     WHERE equals(raw_sessions.team_id, 99999)
+     GROUP BY raw_sessions.session_id_v7,
+              raw_sessions.session_id_v7) AS sessions
+  WHERE and(1, 1)
+  ORDER BY `context.columns.count` DESC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestSessionAttributionQueryRunner.test_group_channel_medium_source
+  '''
+  SELECT count() AS `context.columns.count`,
+         sessions.`$channel_type` AS `context.columns.channel_type`,
+         topK(10)(sessions.`$entry_referring_domain`) AS `context.columns.referring_domain`,
+         sessions.`$entry_utm_source` AS `context.columns.utm_source`,
+         sessions.`$entry_utm_medium` AS `context.columns.utm_medium`,
+         topK(10)(sessions.`$entry_utm_campaign`) AS `context.columns.utm_campaign`,
+         topK(10)(nullIf(arrayStringConcat([if(isNotNull(sessions.`$entry_gclid`), 'glcid', NULL), if(isNotNull(sessions.`$entry_gad_source`), 'gad_source', NULL)], ','), '')) AS `context.columns.ad_ids`,
+         topK(10)(sessions.`$entry_current_url`) AS `context.columns.example_entry_urls`
+  FROM
+    (SELECT multiIf(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), 'cross-network'), 'Cross Network', or(ifNull(in(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), tuple('cpc', 'cpm', 'cpv', 'cpa', 'ppc', 'retargeting')), 0), startsWith(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), 'paid'), isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_gclid), 'null'), '')), isNotNull(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), ''), ''), 'null'))), coalesce(coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Paid Shopping', NULL), dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '')), 'source'))), multiIf(ifNull(equals(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), ''), ''), 'null'), '1'), 0), 'Paid Search', match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*video.*)$'), 'Paid Video', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')), 'Paid Social', 'Paid Unknown')), and(ifNull(equals(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '$direct'), 0), isNull(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null'))), or(isNull(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null'))), ifNull(in(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), tuple('(direct)', 'direct', '$direct')), 0)), not(isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')))), 'Direct', coalesce(coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Organic Shopping', NULL), dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '')), 'source'))), multiIf(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*video.*)$'), 'Organic Video', match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), 'push$'), 'Push', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')), 'Organic Social', ifNull(equals(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '$direct'), 0), 'Direct', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), '')), 'Referral', 'Unknown'))) AS `$channel_type`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), '') AS `$entry_referring_domain`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), '') AS `$entry_utm_medium`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), '') AS `$entry_utm_campaign`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_gclid), 'null'), '') AS `$entry_gclid`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), '') AS `$entry_gad_source`,
+            nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '') AS `$entry_current_url`,
+            raw_sessions.session_id_v7 AS session_id_v7
+     FROM raw_sessions
+     WHERE equals(raw_sessions.team_id, 99999)
+     GROUP BY raw_sessions.session_id_v7,
+              raw_sessions.session_id_v7) AS sessions
+  WHERE and(1, 1)
+  GROUP BY `context.columns.channel_type`,
+           `context.columns.utm_source`,
+           `context.columns.utm_medium`
+  ORDER BY `context.columns.count` DESC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestSessionAttributionQueryRunner.test_no_crash_when_no_data
+  '''
+  SELECT count() AS `context.columns.count`,
+         topK(10)(sessions.`$channel_type`) AS `context.columns.channel_type`,
+         topK(10)(sessions.`$entry_referring_domain`) AS `context.columns.referring_domain`,
+         topK(10)(sessions.`$entry_utm_source`) AS `context.columns.utm_source`,
+         topK(10)(sessions.`$entry_utm_medium`) AS `context.columns.utm_medium`,
+         topK(10)(sessions.`$entry_utm_campaign`) AS `context.columns.utm_campaign`,
+         topK(10)(nullIf(arrayStringConcat([if(isNotNull(sessions.`$entry_gclid`), 'glcid', NULL), if(isNotNull(sessions.`$entry_gad_source`), 'gad_source', NULL)], ','), '')) AS `context.columns.ad_ids`,
+         topK(10)(sessions.`$entry_current_url`) AS `context.columns.example_entry_urls`
+  FROM
+    (SELECT multiIf(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), 'cross-network'), 'Cross Network', or(ifNull(in(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), tuple('cpc', 'cpm', 'cpv', 'cpa', 'ppc', 'retargeting')), 0), startsWith(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), 'paid'), isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_gclid), 'null'), '')), isNotNull(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), ''), ''), 'null'))), coalesce(coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Paid Shopping', NULL), dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '')), 'source'))), multiIf(ifNull(equals(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), ''), ''), 'null'), '1'), 0), 'Paid Search', match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*video.*)$'), 'Paid Video', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')), 'Paid Social', 'Paid Unknown')), and(ifNull(equals(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '$direct'), 0), isNull(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null'))), or(isNull(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null'))), ifNull(in(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), tuple('(direct)', 'direct', '$direct')), 0)), not(isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')))), 'Direct', coalesce(coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Organic Shopping', NULL), dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '')), 'source'))), multiIf(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*video.*)$'), 'Organic Video', match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), 'push$'), 'Push', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')), 'Organic Social', ifNull(equals(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '$direct'), 0), 'Direct', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), '')), 'Referral', 'Unknown'))) AS `$channel_type`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), '') AS `$entry_referring_domain`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), '') AS `$entry_utm_medium`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), '') AS `$entry_utm_campaign`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_gclid), 'null'), '') AS `$entry_gclid`,
+            nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), '') AS `$entry_gad_source`,
+            nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '') AS `$entry_current_url`,
+            raw_sessions.session_id_v7 AS session_id_v7
+     FROM raw_sessions
+     WHERE equals(raw_sessions.team_id, 99999)
+     GROUP BY raw_sessions.session_id_v7,
+              raw_sessions.session_id_v7) AS sessions
+  WHERE and(1, 1)
+  ORDER BY `context.columns.count` DESC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_goals.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_goals.ambr
@@ -1,0 +1,458 @@
+# serializer version: 1
+# name: TestWebGoalsQueryRunner.test_dont_show_deleted_actions
+  '''
+  SELECT uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))) AS current_total_people,
+         uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0))) AS previous_total_people,
+         'Contacted Sales' AS action_name_0,
+         tuple(sum(action_current_count_0), sum(action_previous_count_0)) AS action_total_0,
+         tuple(uniq(action_current_person_id_0), uniq(action_previous_person_id_0)) AS action_uniques_0,
+         'Visited Web Analytics' AS action_name_1,
+         tuple(sum(action_current_count_1), sum(action_previous_count_1)) AS action_total_1,
+         tuple(uniq(action_current_person_id_1), uniq(action_previous_person_id_1)) AS action_uniques_1
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS person_id,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_0,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_0,
+            if(ifNull(greater(action_current_count_0, 0), 0), person_id, NULL) AS action_current_person_id_0,
+            if(ifNull(greater(action_previous_count_0, 0), 0), person_id, NULL) AS action_previous_person_id_0,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_1,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_1,
+            if(ifNull(greater(action_current_count_1, 0), 0), person_id, NULL) AS action_current_person_id_1,
+            if(ifNull(greater(action_previous_count_1, 0), 0), person_id, NULL) AS action_previous_person_id_1
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), or(and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0))))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(isNotNull(events.`$session_id`), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), or(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                                                                                                                                                                                                                                                                                                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))))), 1, 1))
+     GROUP BY events.`$session_id`)
+  WHERE or(and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0)))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebGoalsQueryRunner.test_many_users_and_actions
+  '''
+  SELECT uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))) AS current_total_people,
+         uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0))) AS previous_total_people,
+         'Contacted Sales' AS action_name_0,
+         tuple(sum(action_current_count_0), sum(action_previous_count_0)) AS action_total_0,
+         tuple(uniq(action_current_person_id_0), uniq(action_previous_person_id_0)) AS action_uniques_0,
+         'Visited Web Analytics' AS action_name_1,
+         tuple(sum(action_current_count_1), sum(action_previous_count_1)) AS action_total_1,
+         tuple(uniq(action_current_person_id_1), uniq(action_previous_person_id_1)) AS action_uniques_1,
+         'Clicked Pay' AS action_name_2,
+         tuple(sum(action_current_count_2), sum(action_previous_count_2)) AS action_total_2,
+         tuple(uniq(action_current_person_id_2), uniq(action_previous_person_id_2)) AS action_uniques_2
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS person_id,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_0,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_0,
+            if(ifNull(greater(action_current_count_0, 0), 0), person_id, NULL) AS action_current_person_id_0,
+            if(ifNull(greater(action_previous_count_0, 0), 0), person_id, NULL) AS action_previous_person_id_0,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_1,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_1,
+            if(ifNull(greater(action_current_count_1, 0), 0), person_id, NULL) AS action_current_person_id_1,
+            if(ifNull(greater(action_previous_count_1, 0), 0), person_id, NULL) AS action_previous_person_id_1,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_2,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_2,
+            if(ifNull(greater(action_current_count_2, 0), 0), person_id, NULL) AS action_current_person_id_2,
+            if(ifNull(greater(action_previous_count_2, 0), 0), person_id, NULL) AS action_previous_person_id_2
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), or(and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0))))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(isNotNull(events.`$session_id`), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), or(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                                                                                                                                                                                                                                                                                                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))))), 1, 1))
+     GROUP BY events.`$session_id`)
+  WHERE or(and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0)))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebGoalsQueryRunner.test_no_comparison
+  '''
+  SELECT uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))) AS current_total_people,
+         uniqIf(person_id, 0) AS previous_total_people,
+         'Contacted Sales' AS action_name_0,
+         tuple(sum(action_current_count_0), NULL) AS action_total_0,
+         tuple(uniq(action_current_person_id_0), NULL) AS action_uniques_0,
+         'Visited Web Analytics' AS action_name_1,
+         tuple(sum(action_current_count_1), NULL) AS action_total_1,
+         tuple(uniq(action_current_person_id_1), NULL) AS action_uniques_1,
+         'Clicked Pay' AS action_name_2,
+         tuple(sum(action_current_count_2), NULL) AS action_total_2,
+         tuple(uniq(action_current_person_id_2), NULL) AS action_uniques_2
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS person_id,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_0,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), 0)) AS action_previous_count_0,
+            if(ifNull(greater(action_current_count_0, 0), 0), person_id, NULL) AS action_current_person_id_0,
+            if(ifNull(greater(action_previous_count_0, 0), 0), person_id, NULL) AS action_previous_person_id_0,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_1,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), 0)) AS action_previous_count_1,
+            if(ifNull(greater(action_current_count_1, 0), 0), person_id, NULL) AS action_current_person_id_1,
+            if(ifNull(greater(action_previous_count_1, 0), 0), person_id, NULL) AS action_previous_person_id_1,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_2,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), 0)) AS action_previous_count_2,
+            if(ifNull(greater(action_current_count_2, 0), 0), person_id, NULL) AS action_current_person_id_2,
+            if(ifNull(greater(action_previous_count_2, 0), 0), person_id, NULL) AS action_previous_person_id_2
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(isNotNull(events.`$session_id`), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), or(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                                                                                                                                                                                                                                                                                                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))), 0), 1, 1))
+     GROUP BY events.`$session_id`)
+  WHERE or(and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), 0)
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebGoalsQueryRunner.test_no_crash_when_no_data_and_some_actions
+  '''
+  SELECT uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))) AS current_total_people,
+         uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0))) AS previous_total_people,
+         'Contacted Sales' AS action_name_0,
+         tuple(sum(action_current_count_0), sum(action_previous_count_0)) AS action_total_0,
+         tuple(uniq(action_current_person_id_0), uniq(action_previous_person_id_0)) AS action_uniques_0,
+         'Visited Web Analytics' AS action_name_1,
+         tuple(sum(action_current_count_1), sum(action_previous_count_1)) AS action_total_1,
+         tuple(uniq(action_current_person_id_1), uniq(action_previous_person_id_1)) AS action_uniques_1,
+         'Clicked Pay' AS action_name_2,
+         tuple(sum(action_current_count_2), sum(action_previous_count_2)) AS action_total_2,
+         tuple(uniq(action_current_person_id_2), uniq(action_previous_person_id_2)) AS action_uniques_2
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS person_id,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_0,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_0,
+            if(ifNull(greater(action_current_count_0, 0), 0), person_id, NULL) AS action_current_person_id_0,
+            if(ifNull(greater(action_previous_count_0, 0), 0), person_id, NULL) AS action_previous_person_id_0,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_1,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_1,
+            if(ifNull(greater(action_current_count_1, 0), 0), person_id, NULL) AS action_current_person_id_1,
+            if(ifNull(greater(action_previous_count_1, 0), 0), person_id, NULL) AS action_previous_person_id_1,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_2,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_2,
+            if(ifNull(greater(action_current_count_2, 0), 0), person_id, NULL) AS action_current_person_id_2,
+            if(ifNull(greater(action_previous_count_2, 0), 0), person_id, NULL) AS action_previous_person_id_2
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), or(and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0))))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(isNotNull(events.`$session_id`), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), or(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                                                                                                                                                                                                                                                                                                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))))), 1, 1))
+     GROUP BY events.`$session_id`)
+  WHERE or(and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0)))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebGoalsQueryRunner.test_one_user_one_action
+  '''
+  SELECT uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))) AS current_total_people,
+         uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0))) AS previous_total_people,
+         'Contacted Sales' AS action_name_0,
+         tuple(sum(action_current_count_0), sum(action_previous_count_0)) AS action_total_0,
+         tuple(uniq(action_current_person_id_0), uniq(action_previous_person_id_0)) AS action_uniques_0,
+         'Visited Web Analytics' AS action_name_1,
+         tuple(sum(action_current_count_1), sum(action_previous_count_1)) AS action_total_1,
+         tuple(uniq(action_current_person_id_1), uniq(action_previous_person_id_1)) AS action_uniques_1,
+         'Clicked Pay' AS action_name_2,
+         tuple(sum(action_current_count_2), sum(action_previous_count_2)) AS action_total_2,
+         tuple(uniq(action_current_person_id_2), uniq(action_previous_person_id_2)) AS action_uniques_2
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS person_id,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_0,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_0,
+            if(ifNull(greater(action_current_count_0, 0), 0), person_id, NULL) AS action_current_person_id_0,
+            if(ifNull(greater(action_previous_count_0, 0), 0), person_id, NULL) AS action_previous_person_id_0,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_1,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_1,
+            if(ifNull(greater(action_current_count_1, 0), 0), person_id, NULL) AS action_current_person_id_1,
+            if(ifNull(greater(action_previous_count_1, 0), 0), person_id, NULL) AS action_previous_person_id_1,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_2,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_2,
+            if(ifNull(greater(action_current_count_2, 0), 0), person_id, NULL) AS action_current_person_id_2,
+            if(ifNull(greater(action_previous_count_2, 0), 0), person_id, NULL) AS action_previous_person_id_2
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), or(and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0))))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(isNotNull(events.`$session_id`), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), or(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                                                                                                                                                                                                                                                                                                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))))), 1, 1))
+     GROUP BY events.`$session_id`)
+  WHERE or(and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0)))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebGoalsQueryRunner.test_one_user_two_different_actions
+  '''
+  SELECT uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))) AS current_total_people,
+         uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0))) AS previous_total_people,
+         'Contacted Sales' AS action_name_0,
+         tuple(sum(action_current_count_0), sum(action_previous_count_0)) AS action_total_0,
+         tuple(uniq(action_current_person_id_0), uniq(action_previous_person_id_0)) AS action_uniques_0,
+         'Visited Web Analytics' AS action_name_1,
+         tuple(sum(action_current_count_1), sum(action_previous_count_1)) AS action_total_1,
+         tuple(uniq(action_current_person_id_1), uniq(action_previous_person_id_1)) AS action_uniques_1,
+         'Clicked Pay' AS action_name_2,
+         tuple(sum(action_current_count_2), sum(action_previous_count_2)) AS action_total_2,
+         tuple(uniq(action_current_person_id_2), uniq(action_previous_person_id_2)) AS action_uniques_2
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS person_id,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_0,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_0,
+            if(ifNull(greater(action_current_count_0, 0), 0), person_id, NULL) AS action_current_person_id_0,
+            if(ifNull(greater(action_previous_count_0, 0), 0), person_id, NULL) AS action_previous_person_id_0,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_1,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_1,
+            if(ifNull(greater(action_current_count_1, 0), 0), person_id, NULL) AS action_current_person_id_1,
+            if(ifNull(greater(action_previous_count_1, 0), 0), person_id, NULL) AS action_previous_person_id_1,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_2,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_2,
+            if(ifNull(greater(action_current_count_2, 0), 0), person_id, NULL) AS action_current_person_id_2,
+            if(ifNull(greater(action_previous_count_2, 0), 0), person_id, NULL) AS action_previous_person_id_2
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), or(and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0))))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(isNotNull(events.`$session_id`), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), or(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                                                                                                                                                                                                                                                                                                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))))), 1, 1))
+     GROUP BY events.`$session_id`)
+  WHERE or(and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0)))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebGoalsQueryRunner.test_one_user_two_similar_actions_across_sessions
+  '''
+  SELECT uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))) AS current_total_people,
+         uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0))) AS previous_total_people,
+         'Contacted Sales' AS action_name_0,
+         tuple(sum(action_current_count_0), sum(action_previous_count_0)) AS action_total_0,
+         tuple(uniq(action_current_person_id_0), uniq(action_previous_person_id_0)) AS action_uniques_0,
+         'Visited Web Analytics' AS action_name_1,
+         tuple(sum(action_current_count_1), sum(action_previous_count_1)) AS action_total_1,
+         tuple(uniq(action_current_person_id_1), uniq(action_previous_person_id_1)) AS action_uniques_1,
+         'Clicked Pay' AS action_name_2,
+         tuple(sum(action_current_count_2), sum(action_previous_count_2)) AS action_total_2,
+         tuple(uniq(action_current_person_id_2), uniq(action_previous_person_id_2)) AS action_uniques_2
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS person_id,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_0,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_0,
+            if(ifNull(greater(action_current_count_0, 0), 0), person_id, NULL) AS action_current_person_id_0,
+            if(ifNull(greater(action_previous_count_0, 0), 0), person_id, NULL) AS action_previous_person_id_0,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_1,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_1,
+            if(ifNull(greater(action_current_count_1, 0), 0), person_id, NULL) AS action_current_person_id_1,
+            if(ifNull(greater(action_previous_count_1, 0), 0), person_id, NULL) AS action_previous_person_id_1,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_2,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_2,
+            if(ifNull(greater(action_current_count_2, 0), 0), person_id, NULL) AS action_current_person_id_2,
+            if(ifNull(greater(action_previous_count_2, 0), 0), person_id, NULL) AS action_previous_person_id_2
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), or(and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0))))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(isNotNull(events.`$session_id`), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), or(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                                                                                                                                                                                                                                                                                                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))))), 1, 1))
+     GROUP BY events.`$session_id`)
+  WHERE or(and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0)))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebGoalsQueryRunner.test_one_users_one_action_each
+  '''
+  SELECT uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))) AS current_total_people,
+         uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0))) AS previous_total_people,
+         'Contacted Sales' AS action_name_0,
+         tuple(sum(action_current_count_0), sum(action_previous_count_0)) AS action_total_0,
+         tuple(uniq(action_current_person_id_0), uniq(action_previous_person_id_0)) AS action_uniques_0,
+         'Visited Web Analytics' AS action_name_1,
+         tuple(sum(action_current_count_1), sum(action_previous_count_1)) AS action_total_1,
+         tuple(uniq(action_current_person_id_1), uniq(action_previous_person_id_1)) AS action_uniques_1,
+         'Clicked Pay' AS action_name_2,
+         tuple(sum(action_current_count_2), sum(action_previous_count_2)) AS action_total_2,
+         tuple(uniq(action_current_person_id_2), uniq(action_previous_person_id_2)) AS action_uniques_2
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS person_id,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_0,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_0,
+            if(ifNull(greater(action_current_count_0, 0), 0), person_id, NULL) AS action_current_person_id_0,
+            if(ifNull(greater(action_previous_count_0, 0), 0), person_id, NULL) AS action_previous_person_id_0,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_1,
+            countIf(and(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_1,
+            if(ifNull(greater(action_current_count_1, 0), 0), person_id, NULL) AS action_current_person_id_1,
+            if(ifNull(greater(action_previous_count_1, 0), 0), person_id, NULL) AS action_previous_person_id_1,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))))) AS action_current_count_2,
+            countIf(and(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC')))))) AS action_previous_count_2,
+            if(ifNull(greater(action_current_count_2, 0), 0), person_id, NULL) AS action_current_person_id_2,
+            if(ifNull(greater(action_previous_count_2, 0), 0), person_id, NULL) AS action_previous_person_id_2
+     FROM events
+     LEFT JOIN
+       (SELECT min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), or(and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0))))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(isNotNull(events.`$session_id`), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), or(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Contacted Sales'), 0), events.elements_chain_texts)), and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                                                                                                                                                                                                                                                                                                                                                      and isNull('https://(app|eu|us)\\.posthog\\.com/project/\\d+/web.*'))), and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)))), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))))), 1, 1))
+     GROUP BY events.`$session_id`)
+  WHERE or(and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-11-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-08-05 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-10-31 23:59:59', 6, 'UTC'))), 0)))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0
+  '''
+# ---

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_overview.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_overview.ambr
@@ -636,6 +636,55 @@
                      max_bytes_before_external_group_by=0
   '''
 # ---
+# name: TestWebOverviewQueryRunner.test_limit_is_context_aware
+  '''
+  SELECT uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))) AS unique_users,
+         uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-28 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-30 23:59:59', 6, 'UTC'))), 0))) AS previous_unique_users,
+         sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))) AS total_filtered_pageview_count,
+         sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-28 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-30 23:59:59', 6, 'UTC'))), 0))) AS previous_filtered_pageview_count,
+         uniqIf(session_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))) AS unique_sessions,
+         uniqIf(session_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-28 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-30 23:59:59', 6, 'UTC'))), 0))) AS previous_unique_sessions,
+         avgIf(session_duration, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))) AS avg_duration_s,
+         avgIf(session_duration, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-28 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-30 23:59:59', 6, 'UTC'))), 0))) AS prev_avg_duration_s,
+         avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))) AS bounce_rate,
+         avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-28 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-30 23:59:59', 6, 'UTC'))), 0))) AS prev_bounce_rate
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS person_id,
+            events__session.session_id AS session_id,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            any(events__session.`$session_duration`) AS session_duration,
+            countIf(or(equals(events.event, '$pageview'), equals(events.event, '$screen'))) AS filtered_pageview_count,
+            any(events__session.`$is_bounce`) AS is_bounce
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))) AS `$session_duration`,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), or(and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-28 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-30 23:59:59', 6, 'UTC'))), 0))))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(isNotNull(events.`$session_id`), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-28 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-30 23:59:59', 6, 'UTC'))))), 1, 1))
+     GROUP BY session_id
+     HAVING or(and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-28 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-30 23:59:59', 6, 'UTC'))), 0))))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=600,
+                     allow_experimental_object_type=1,
+                     format_csv_allow_double_quotes=0,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0
+  '''
+# ---
 # name: TestWebOverviewQueryRunner.test_no_crash_when_no_data
   '''
   SELECT uniqIf(person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-08 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS unique_users,

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_stats_table.ambr
@@ -1,0 +1,2988 @@
+# serializer version: 1
+# name: TestWebStatsTableQueryRunner.test_all_time
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_all_time.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate.1
+  '''
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1, isNotNull(breakdown_value)))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_one_user.1
+  '''
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1, isNotNull(breakdown_value)))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_path_cleaning
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_path_cleaning.1
+  '''
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '\\/a\\/\\d+', '/a/:id'), '\\/b\\/\\d+', '/b/:id'), '\\/c\\/\\d+', '/c/:id') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1, isNotNull(breakdown_value)))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(events__session.`$entry_pathname`, '\\/a\\/\\d+', '/a/:id'), '\\/b\\/\\d+', '/b/:id'), '\\/c\\/\\d+', '/c/:id') AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_with_property
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_bounce_rate_with_property.1
+  '''
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '/a'), 0), 1, isNotNull(breakdown_value)))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '/a'), 0), 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_breakdown_channel_type_doesnt_throw
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            events__session.`$channel_type` AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT multiIf(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), 'cross-network'), 'Cross Network', or(ifNull(in(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), tuple('cpc', 'cpm', 'cpv', 'cpa', 'ppc', 'retargeting')), 0), startsWith(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), 'paid'), isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_gclid), 'null'), '')), isNotNull(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), ''), ''), 'null'))), coalesce(coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Paid Shopping', NULL), dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '')), 'source'))), multiIf(ifNull(equals(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), ''), ''), 'null'), '1'), 0), 'Paid Search', match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*video.*)$'), 'Paid Video', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')), 'Paid Social', 'Paid Unknown')), and(ifNull(equals(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '$direct'), 0), isNull(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null'))), or(isNull(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null'))), ifNull(in(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), tuple('(direct)', 'direct', '$direct')), 0)), not(isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')))), 'Direct', coalesce(coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Organic Shopping', NULL), dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '')), 'source'))), multiIf(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*video.*)$'), 'Organic Video', match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), 'push$'), 'Push', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')), 'Organic Social', ifNull(equals(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '$direct'), 0), 'Direct', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), '')), 'Referral', 'Unknown'))) AS `$channel_type`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, and(isNotNull(breakdown_value), ifNull(notEquals(breakdown_value, ''), 1))))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_cohort_test_filters
+  '''
+  
+  SELECT count(DISTINCT person_id)
+  FROM cohortpeople
+  WHERE team_id = 99999
+    AND cohort_id = 99999
+    AND version = NULL
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_cohort_test_filters.1
+  '''
+  /* cohort_calculation: */
+  SELECT count(DISTINCT person_id)
+  FROM cohortpeople
+  WHERE team_id = 99999
+    AND cohort_id = 99999
+    AND version = 0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_cohort_test_filters.2
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_cohort_test_filters.3
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), ifNull(in(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id),
+                                                                                                                                                                                                                                                                                                                                                                                                                     (SELECT cohortpeople.person_id AS person_id
+                                                                                                                                                                                                                                                                                                                                                                                                                      FROM cohortpeople
+                                                                                                                                                                                                                                                                                                                                                                                                                      WHERE and(equals(cohortpeople.team_id, 99999), equals(cohortpeople.cohort_id, 99999), equals(cohortpeople.version, 0)))), 0), isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_comparison
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-06 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-13 23:59:59', 6, 'UTC'))), 0))), uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-28 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-05 23:59:59', 6, 'UTC'))), 0)))) AS `context.columns.visitors`,
+         tuple(sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-06 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-13 23:59:59', 6, 'UTC'))), 0))), sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-28 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-05 23:59:59', 6, 'UTC'))), 0)))) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), or(and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-06 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-13 23:59:59', 6, 'UTC'))), 0)), and(ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-28 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-05 23:59:59', 6, 'UTC'))), 0))))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-06 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-13 23:59:59', 6, 'UTC')))), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-11-28 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-05 23:59:59', 6, 'UTC'))))), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_conversion_goal_no_conversions
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(conversion_count), NULL) AS `context.columns.total_conversions`,
+         tuple(uniq(conversion_person_id), NULL) AS `context.columns.unique_conversions`,
+         tuple(if(ifNull(equals(`context.columns.visitors`.1, 0), 0), NULL, divide(`context.columns.unique_conversions`.1, `context.columns.visitors`.1)), if(ifNull(equals(`context.columns.visitors`.2, 0), 0), NULL, divide(`context.columns.unique_conversions`.2, `context.columns.visitors`.2))) AS `context.columns.conversion_rate`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://www.example.com/bar'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                  and isNull('https://www.example.com/bar')))) AS conversion_count,
+            any(if(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://www.example.com/bar'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                 and isNull('https://www.example.com/bar'))), if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), NULL)) AS conversion_person_id
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://www.example.com/bar'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                                                                                                                                                                                                                                                                                                                                                                                                      and isNull('https://www.example.com/bar')))), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.total_conversions` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_conversion_goal_one_autocapture_conversion
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(conversion_count), NULL) AS `context.columns.total_conversions`,
+         tuple(uniq(conversion_person_id), NULL) AS `context.columns.unique_conversions`,
+         tuple(if(ifNull(equals(`context.columns.visitors`.1, 0), 0), NULL, divide(`context.columns.unique_conversions`.1, `context.columns.visitors`.1)), if(ifNull(equals(`context.columns.visitors`.2, 0), 0), NULL, divide(`context.columns.unique_conversions`.2, `context.columns.visitors`.2))) AS `context.columns.conversion_rate`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            events__session.`$entry_utm_source` AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts))) AS conversion_count,
+            any(if(and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts)), if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), NULL)) AS conversion_person_id
+     FROM events
+     LEFT JOIN
+       (SELECT nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), and(equals(events.event, '$autocapture'), match(events.elements_chain, '(^|;)button(\\.|$|;|:)'), arrayExists(x -> ifNull(equals(x, 'Pay $10'), 0), events.elements_chain_texts))), 1, 1))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.total_conversions` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_conversion_goal_one_custom_action_conversion
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(conversion_count), NULL) AS `context.columns.total_conversions`,
+         tuple(uniq(conversion_person_id), NULL) AS `context.columns.unique_conversions`,
+         tuple(if(ifNull(equals(`context.columns.visitors`.1, 0), 0), NULL, divide(`context.columns.unique_conversions`.1, `context.columns.visitors`.1)), if(ifNull(equals(`context.columns.visitors`.2, 0), 0), NULL, divide(`context.columns.unique_conversions`.2, `context.columns.visitors`.2))) AS `context.columns.conversion_rate`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            events__session.`$entry_utm_source` AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(equals(events.event, 'custom_event')) AS conversion_count,
+            any(if(equals(events.event, 'custom_event'), if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), NULL)) AS conversion_person_id
+     FROM events
+     LEFT JOIN
+       (SELECT nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), equals(events.event, 'custom_event')), 1, 1))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.total_conversions` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_conversion_goal_one_custom_event_conversion
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(conversion_count), NULL) AS `context.columns.total_conversions`,
+         tuple(uniq(conversion_person_id), NULL) AS `context.columns.unique_conversions`,
+         tuple(if(ifNull(equals(`context.columns.visitors`.1, 0), 0), NULL, divide(`context.columns.unique_conversions`.1, `context.columns.visitors`.1)), if(ifNull(equals(`context.columns.visitors`.2, 0), 0), NULL, divide(`context.columns.unique_conversions`.2, `context.columns.visitors`.2))) AS `context.columns.conversion_rate`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            events__session.`$entry_utm_source` AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(equals(events.event, 'custom_event')) AS conversion_count,
+            any(if(equals(events.event, 'custom_event'), if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), NULL)) AS conversion_person_id
+     FROM events
+     LEFT JOIN
+       (SELECT nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), equals(events.event, 'custom_event')), 1, 1))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.total_conversions` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_conversion_goal_one_pageview_conversion
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(conversion_count), NULL) AS `context.columns.total_conversions`,
+         tuple(uniq(conversion_person_id), NULL) AS `context.columns.unique_conversions`,
+         tuple(if(ifNull(equals(`context.columns.visitors`.1, 0), 0), NULL, divide(`context.columns.unique_conversions`.1, `context.columns.visitors`.1)), if(ifNull(equals(`context.columns.visitors`.2, 0), 0), NULL, divide(`context.columns.unique_conversions`.2, `context.columns.visitors`.2))) AS `context.columns.conversion_rate`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://www.example.com/foo'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                  and isNull('https://www.example.com/foo')))) AS conversion_count,
+            any(if(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://www.example.com/foo'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                 and isNull('https://www.example.com/foo'))), if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), NULL)) AS conversion_person_id
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://www.example.com/foo'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                                                                                                                                                                                                                                                                                                                                                                                                      and isNull('https://www.example.com/foo')))), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.total_conversions` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_conversion_goal_one_pageview_conversion.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(conversion_count), NULL) AS `context.columns.total_conversions`,
+         tuple(uniq(conversion_person_id), NULL) AS `context.columns.unique_conversions`,
+         tuple(if(ifNull(equals(`context.columns.visitors`.1, 0), 0), NULL, divide(`context.columns.unique_conversions`.1, `context.columns.visitors`.1)), if(ifNull(equals(`context.columns.visitors`.2, 0), 0), NULL, divide(`context.columns.unique_conversions`.2, `context.columns.visitors`.2))) AS `context.columns.conversion_rate`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://www.example.com/foo'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                  and isNull('https://www.example.com/foo')))) AS conversion_count,
+            any(if(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://www.example.com/foo'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                 and isNull('https://www.example.com/foo'))), if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), NULL)) AS conversion_person_id
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://www.example.com/foo'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                                                                                                                                                                                                                                                                                                                                                                                                      and isNull('https://www.example.com/foo')))), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.total_conversions` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_conversion_rate
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(conversion_count), NULL) AS `context.columns.total_conversions`,
+         tuple(uniq(conversion_person_id), NULL) AS `context.columns.unique_conversions`,
+         tuple(if(ifNull(equals(`context.columns.visitors`.1, 0), 0), NULL, divide(`context.columns.unique_conversions`.1, `context.columns.visitors`.1)), if(ifNull(equals(`context.columns.visitors`.2, 0), 0), NULL, divide(`context.columns.unique_conversions`.2, `context.columns.visitors`.2))) AS `context.columns.conversion_rate`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp,
+            countIf(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://www.example.com/foo'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                  and isNull('https://www.example.com/foo')))) AS conversion_count,
+            any(if(and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://www.example.com/foo'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                 and isNull('https://www.example.com/foo'))), if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), NULL)) AS conversion_person_id
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen'), and(equals(events.event, '$pageview'), ifNull(match(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''), 'https://www.example.com/foo'), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$current_url'), ''), 'null'), '^"|"$', ''))
+                                                                                                                                                                                                                                                                                                                                                                                                                                                      and isNull('https://www.example.com/foo')))), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.total_conversions` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_dont_filter_test_accounts
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         tuple(avg(is_bounce), NULL) AS `context.columns.bounce_rate`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            events__session.`$entry_pathname` AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_one_user
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_one_user.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         tuple(avg(is_bounce), NULL) AS `context.columns.bounce_rate`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            events__session.`$entry_pathname` AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_path_cleaning
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_path_cleaning.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         tuple(avg(is_bounce), NULL) AS `context.columns.bounce_rate`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(events__session.`$entry_pathname`, '\\/a\\/\\d+', '/a/:id'), '\\/b\\/\\d+', '/b/:id'), '\\/c\\/\\d+', '/c/:id') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_with_property
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_entry_bounce_rate_with_property.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         tuple(avg(is_bounce), NULL) AS `context.columns.bounce_rate`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            events__session.`$entry_pathname` AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '/a'), 0), isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_filter_test_accounts
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+        FROM person
+        WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                             (SELECT person.id AS id, max(person.version) AS version
+                                                              FROM person
+                                                              WHERE equals(person.team_id, 99999)
+                                                              GROUP BY person.id
+                                                              HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-03 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), ifNull(notILike(events__person.properties___email, '%@posthog.com%'), 1), isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_increase_in_users
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-11 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-11 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_increase_in_users_on_mobile
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$screen_name'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-11 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-01 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-11 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_is_not_set_filter
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_is_not_set_filter.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            events__session.`$entry_utm_source` AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-06-26 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-06-27 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-06-26 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-06-27 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'utm_source'), ''), 'null'), '^"|"$', '')), not(JSONHas(events.properties, 'utm_source'))), 1))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_language_filter
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_language_filter.1
+  '''
+  SELECT arrayElement(splitByChar('-', assumeNotNull(breakdown_value), 2), 1) AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         arrayElement(topK(1)(arrayElement(splitByChar('-', assumeNotNull(breakdown_value), 2), 2)), 1) AS `context.columns.aggregation_value`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$browser_language'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+        FROM person
+        WHERE and(equals(person.team_id, 99999), ifNull(in(tuple(person.id, person.version),
+                                                             (SELECT person.id AS id, max(person.version) AS version
+                                                              FROM person
+                                                              WHERE equals(person.team_id, 99999)
+                                                              GROUP BY person.id
+                                                              HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0)))), 0)) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), ifNull(notILike(events__person.properties___email, '%@posthog.com%'), 1), isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_limit
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_limit.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 2
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_limit.2
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_limit.3
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 3
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_crash_when_no_data
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-08 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-08 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            events__session.`$channel_type` AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT multiIf(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), 'cross-network'), 'Cross Network', or(ifNull(in(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), tuple('cpc', 'cpm', 'cpv', 'cpa', 'ppc', 'retargeting')), 0), startsWith(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), 'paid'), isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_gclid), 'null'), '')), isNotNull(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), ''), ''), 'null'))), coalesce(coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Paid Shopping', NULL), dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('channel_definition_dict', 'type_if_paid', (coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_paid', (cutToFirstSignificantSubdomain(coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '')), 'source'))), multiIf(ifNull(equals(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_gad_source), 'null'), ''), ''), 'null'), '1'), 0), 'Paid Search', match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*video.*)$'), 'Paid Video', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')), 'Paid Social', 'Paid Unknown')), and(ifNull(equals(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '$direct'), 0), isNull(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null'))), or(isNull(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null'))), ifNull(in(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), tuple('(direct)', 'direct', '$direct')), 0)), not(isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')))), 'Direct', coalesce(coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), ''), ''), 'null')), '')), 'source'))), if(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*(([^a-df-z]|^)shop|shopping).*)$'), 'Organic Shopping', NULL), dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), ''), 'medium')), coalesce(dictGetOrNull('channel_definition_dict', 'type_if_organic', (coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), ''), 'source')), dictGetOrNull('channel_definition_dict', 'type_if_organic', (cutToFirstSignificantSubdomain(coalesce(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '')), 'source'))), multiIf(match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), ''), ''), 'null')), '^(.*video.*)$'), 'Organic Video', match(lower(nullIf(nullIf(nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), ''), ''), 'null')), 'push$'), 'Push', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_fbclid), 'null'), '')), 'Organic Social', ifNull(equals(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), ''), '$direct'), 0), 'Direct', isNotNull(nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), '')), 'Referral', 'Unknown'))) AS `$channel_type`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, and(isNotNull(breakdown_value), ifNull(notEquals(breakdown_value, ''), 1))))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.2
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.3
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            events__session.`$entry_pathname` AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.4
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_no_session_id.5
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_null_in_utm_tags
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_null_in_utm_tags.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            events__session.`$entry_utm_source` AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-06-26 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-06-27 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-06-26 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-06-27 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, 1))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_filters
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_path_filters.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '\\/cleaned\\/\\d+', '/cleaned/:id'), '\\/path\\/\\d+', '/path/:id'), 'thing_a', 'thing_b'), 'thing_b', 'thing_c') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            events__session.`$entry_utm_source` AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, 1))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.2
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.3
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.4
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.5
+  '''
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC')))), 0), 1, 1, isNotNull(breakdown_value)))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.6
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_same_user_multiple_sessions.7
+  '''
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
+         tuple(scroll.average_scroll_percentage, scroll.previous_average_scroll_percentage) AS `context.columns.average_scroll_percentage`,
+         tuple(scroll.scroll_gt80_percentage, scroll.previous_scroll_gt80_percentage) AS `context.columns.scroll_gt80_percentage`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgMergeIf(average_scroll_percentage_state, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))) AS average_scroll_percentage,
+            avgMergeIf(average_scroll_percentage_state, 0) AS previous_average_scroll_percentage,
+            avgMergeIf(scroll_gt80_percentage_state, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))) AS scroll_gt80_percentage,
+            avgMergeIf(scroll_gt80_percentage_state, 0) AS previous_scroll_gt80_percentage
+     FROM
+       (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               avgState(multiIf(isNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage'), ''), 'null'), '^"|"$', ''), 'Float64')), NULL, ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage'), ''), 'null'), '^"|"$', ''), 'Float64'), 0.8), 0), 1, 0)) AS scroll_gt80_percentage_state,
+               avgState(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_scroll_percentage'), ''), 'null'), '^"|"$', ''), 'Float64')) AS average_scroll_percentage_state,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-31 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS scroll ON equals(counts.breakdown_value, scroll.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_scroll_depth_bounce_rate
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_scroll_depth_bounce_rate.1
+  '''
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
+         tuple(scroll.average_scroll_percentage, scroll.previous_average_scroll_percentage) AS `context.columns.average_scroll_percentage`,
+         tuple(scroll.scroll_gt80_percentage, scroll.previous_scroll_gt80_percentage) AS `context.columns.scroll_gt80_percentage`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgMergeIf(average_scroll_percentage_state, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS average_scroll_percentage,
+            avgMergeIf(average_scroll_percentage_state, 0) AS previous_average_scroll_percentage,
+            avgMergeIf(scroll_gt80_percentage_state, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS scroll_gt80_percentage,
+            avgMergeIf(scroll_gt80_percentage_state, 0) AS previous_scroll_gt80_percentage
+     FROM
+       (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               avgState(multiIf(isNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage'), ''), 'null'), '^"|"$', ''), 'Float64')), NULL, ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage'), ''), 'null'), '^"|"$', ''), 'Float64'), 0.8), 0), 1, 0)) AS scroll_gt80_percentage_state,
+               avgState(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_scroll_percentage'), ''), 'null'), '^"|"$', ''), 'Float64')) AS average_scroll_percentage_state,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS scroll ON equals(counts.breakdown_value, scroll.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_scroll_depth_bounce_rate_one_user
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_scroll_depth_bounce_rate_one_user.1
+  '''
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
+         tuple(scroll.average_scroll_percentage, scroll.previous_average_scroll_percentage) AS `context.columns.average_scroll_percentage`,
+         tuple(scroll.scroll_gt80_percentage, scroll.previous_scroll_gt80_percentage) AS `context.columns.scroll_gt80_percentage`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgMergeIf(average_scroll_percentage_state, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS average_scroll_percentage,
+            avgMergeIf(average_scroll_percentage_state, 0) AS previous_average_scroll_percentage,
+            avgMergeIf(scroll_gt80_percentage_state, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS scroll_gt80_percentage,
+            avgMergeIf(scroll_gt80_percentage_state, 0) AS previous_scroll_gt80_percentage
+     FROM
+       (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               avgState(multiIf(isNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage'), ''), 'null'), '^"|"$', ''), 'Float64')), NULL, ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage'), ''), 'null'), '^"|"$', ''), 'Float64'), 0.8), 0), 1, 0)) AS scroll_gt80_percentage_state,
+               avgState(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_scroll_percentage'), ''), 'null'), '^"|"$', ''), 'Float64')) AS average_scroll_percentage_state,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS scroll ON equals(counts.breakdown_value, scroll.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_scroll_depth_bounce_rate_path_cleaning
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_scroll_depth_bounce_rate_path_cleaning.1
+  '''
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
+         tuple(scroll.average_scroll_percentage, scroll.previous_average_scroll_percentage) AS `context.columns.average_scroll_percentage`,
+         tuple(scroll.scroll_gt80_percentage, scroll.previous_scroll_gt80_percentage) AS `context.columns.scroll_gt80_percentage`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '\\/a\\/\\d+', '/a/:id'), '\\/b\\/\\d+', '/b/:id'), '\\/c\\/\\d+', '/c/:id') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(events__session.`$entry_pathname`, '\\/a\\/\\d+', '/a/:id'), '\\/b\\/\\d+', '/b/:id'), '\\/c\\/\\d+', '/c/:id') AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgMergeIf(average_scroll_percentage_state, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS average_scroll_percentage,
+            avgMergeIf(average_scroll_percentage_state, 0) AS previous_average_scroll_percentage,
+            avgMergeIf(scroll_gt80_percentage_state, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS scroll_gt80_percentage,
+            avgMergeIf(scroll_gt80_percentage_state, 0) AS previous_scroll_gt80_percentage
+     FROM
+       (SELECT replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', ''), '\\/a\\/\\d+', '/a/:id'), '\\/b\\/\\d+', '/b/:id'), '\\/c\\/\\d+', '/c/:id') AS breakdown_value,
+               avgState(multiIf(isNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage'), ''), 'null'), '^"|"$', ''), 'Float64')), NULL, ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage'), ''), 'null'), '^"|"$', ''), 'Float64'), 0.8), 0), 1, 0)) AS scroll_gt80_percentage_state,
+               avgState(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_scroll_percentage'), ''), 'null'), '^"|"$', ''), 'Float64')) AS average_scroll_percentage_state,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), 1, 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS scroll ON equals(counts.breakdown_value, scroll.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_scroll_depth_bounce_rate_with_filter
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_scroll_depth_bounce_rate_with_filter.1
+  '''
+  SELECT counts.breakdown_value AS `context.columns.breakdown_value`,
+         tuple(counts.visitors, counts.previous_visitors) AS `context.columns.visitors`,
+         tuple(counts.views, counts.previous_views) AS `context.columns.views`,
+         tuple(bounce.bounce_rate, bounce.previous_bounce_rate) AS `context.columns.bounce_rate`,
+         tuple(scroll.average_scroll_percentage, scroll.previous_average_scroll_percentage) AS `context.columns.average_scroll_percentage`,
+         tuple(scroll.scroll_gt80_percentage, scroll.previous_scroll_gt80_percentage) AS `context.columns.scroll_gt80_percentage`
+  FROM
+    (SELECT breakdown_value AS breakdown_value,
+            uniqIf(filtered_person_id, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS visitors,
+            uniqIf(filtered_person_id, 0) AS previous_visitors,
+            sumIf(filtered_pageview_count, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS views,
+            sumIf(filtered_pageview_count, 0) AS previous_views
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '/a'), 0), 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS counts
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgIf(is_bounce, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS bounce_rate,
+            avgIf(is_bounce, 0) AS previous_bounce_rate
+     FROM
+       (SELECT events__session.`$entry_pathname` AS breakdown_value,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT path(nullIf(nullIf(argMinMerge(raw_sessions.entry_url), 'null'), '')) AS `$entry_pathname`,
+                  if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+                  toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '/a'), 0), 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS bounce ON equals(counts.breakdown_value, bounce.breakdown_value)
+  LEFT JOIN
+    (SELECT breakdown_value AS breakdown_value,
+            avgMergeIf(average_scroll_percentage_state, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS average_scroll_percentage,
+            avgMergeIf(average_scroll_percentage_state, 0) AS previous_average_scroll_percentage,
+            avgMergeIf(scroll_gt80_percentage_state, and(ifNull(greaterOrEquals(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(less(start_timestamp, assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))) AS scroll_gt80_percentage,
+            avgMergeIf(scroll_gt80_percentage_state, 0) AS previous_scroll_gt80_percentage
+     FROM
+       (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', '') AS breakdown_value,
+               avgState(multiIf(isNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage'), ''), 'null'), '^"|"$', ''), 'Float64')), NULL, ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_content_percentage'), ''), 'null'), '^"|"$', ''), 'Float64'), 0.8), 0), 1, 0)) AS scroll_gt80_percentage_state,
+               avgState(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_max_scroll_percentage'), ''), 'null'), '^"|"$', ''), 'Float64')) AS average_scroll_percentage_state,
+               events__session.session_id AS session_id,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC'))), 0))
+           GROUP BY raw_sessions.session_id_v7,
+                    raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+        WHERE and(equals(events.team_id, 99999), and(or(equals(events.event, '$pageview'), equals(events.event, '$pageleave'), equals(events.event, '$screen')), isNotNull(breakdown_value), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-02 12:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2023-12-15 23:59:59', 6, 'UTC')))), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$prev_pageview_pathname'), ''), 'null'), '^"|"$', ''), '/a'), 0), 1))
+        GROUP BY session_id,
+                 breakdown_value)
+     GROUP BY breakdown_value) AS scroll ON equals(counts.breakdown_value, scroll.breakdown_value)
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_source_medium_campaign
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_source_medium_campaign.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            concatWithSeparator(' / ', coalesce(events__session.`$entry_utm_source`, events__session.`$entry_referring_domain`, '(none)'), coalesce(events__session.`$entry_utm_medium`, '(none)'), coalesce(events__session.`$entry_utm_campaign`, '(none)')) AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_source), 'null'), '') AS `$entry_utm_source`,
+               nullIf(nullIf(argMinMerge(raw_sessions.initial_referring_domain), 'null'), '') AS `$entry_referring_domain`,
+               nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_medium), 'null'), '') AS `$entry_utm_medium`,
+               nullIf(nullIf(argMinMerge(raw_sessions.initial_utm_campaign), 'null'), '') AS `$entry_utm_campaign`,
+               toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-06-26 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-06-27 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-06-26 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-06-27 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_dst_change
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_dst_change.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            if(or(isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', '')), empty(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', '')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', ''), 'Etc/Unknown'), 0)), NULL, divide(minus(toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(assumeNotNull(toString(toTimeZone(events.timestamp, 'UTC'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', ''))), 6, 'UTC')), toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(assumeNotNull(toString(toTimeZone(events.timestamp, 'UTC'), 'UTC')), 6, 'UTC'))), 3600000)) AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2019-02-17 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2019-02-17 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_general
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            if(or(isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', '')), empty(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', '')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', ''), 'Etc/Unknown'), 0)), NULL, divide(minus(toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(assumeNotNull(toString(toTimeZone(events.timestamp, 'UTC'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', ''))), 6, 'UTC')), toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(assumeNotNull(toString(toTimeZone(events.timestamp, 'UTC'), 'UTC')), 6, 'UTC'))), 3600000)) AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-15 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-15 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_empty_timezone
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_empty_timezone.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            if(or(isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', '')), empty(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', '')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', ''), 'Etc/Unknown'), 0)), NULL, divide(minus(toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(assumeNotNull(toString(toTimeZone(events.timestamp, 'UTC'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', ''))), 6, 'UTC')), toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(assumeNotNull(toString(toTimeZone(events.timestamp, 'UTC'), 'UTC')), 6, 'UTC'))), 3600000)) AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2019-02-17 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2019-02-17 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone
+  '''
+  
+  SELECT timestamp
+  from events
+  WHERE team_id = 99999
+    AND timestamp > '2015-01-01'
+  order by timestamp
+  limit 1
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_timezone_filter_with_invalid_timezone.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`
+  FROM
+    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+            count() AS filtered_pageview_count,
+            if(or(isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', '')), empty(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', '')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', ''), 'Etc/Unknown'), 0)), NULL, divide(minus(toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(assumeNotNull(toString(toTimeZone(events.timestamp, 'UTC'), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$timezone'), ''), 'null'), '^"|"$', ''))), 6, 'UTC')), toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(assumeNotNull(toString(toTimeZone(events.timestamp, 'UTC'), 'UTC')), 6, 'UTC'))), 3600000)) AS breakdown_value,
+            events__session.session_id AS session_id,
+            any(events__session.`$is_bounce`) AS is_bounce,
+            min(events__session.`$start_timestamp`) AS start_timestamp
+     FROM events
+     LEFT JOIN
+       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+               if(ifNull(equals(uniqMerge(raw_sessions.pageview_uniq), 0), 0), NULL, not(or(ifNull(greater(uniqMerge(raw_sessions.pageview_uniq), 1), 0), ifNull(greater(uniqMerge(raw_sessions.autocapture_uniq), 0), 0), ifNull(greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10), 0)))) AS `$is_bounce`,
+               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+               raw_sessions.session_id_v7 AS session_id_v7
+        FROM raw_sessions
+        WHERE and(equals(raw_sessions.team_id, 99999), ifNull(greaterOrEquals(plus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), 0), ifNull(lessOrEquals(minus(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), toIntervalDay(3)), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC'))), 0))
+        GROUP BY raw_sessions.session_id_v7,
+                 raw_sessions.session_id_v7) AS events__session ON equals(toUInt128(accurateCastOrNull(events.`$session_id`, 'UUID')), events__session.session_id_v7)
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING ifNull(equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2024-07-30 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-27 23:59:59', 6, 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(breakdown_value)))
+     GROUP BY session_id,
+              breakdown_value)
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    format_csv_allow_double_quotes=0,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0
+  '''
+# ---

--- a/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_vitals_path_breakdown.ambr
+++ b/posthog/hogql_queries/web_analytics/test/__snapshots__/test_web_vitals_path_breakdown.ambr
@@ -1,0 +1,244 @@
+# serializer version: 1
+# name: TestWebVitalsPathBreakdownQueryRunner.test_data_correctly_split_between_bands
+  '''
+  SELECT band AS band,
+         path AS path,
+                 value AS value
+  FROM
+    (SELECT multiIf(ifNull(lessOrEquals(value, 100.0), 0), 'good', ifNull(lessOrEquals(value, 200.0), 0), 'needs_improvements', 'poor') AS band,
+            path AS path,
+                    value AS value
+     FROM
+       (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS path,
+               quantile(0.75)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$web_vitals_INP_value'), ''), 'null'), '^"|"$', ''), 'Float64')) AS value
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$web_vitals'), isNotNull(path), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-08 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-15 23:59:59', 6, 'UTC')))), 0), 1))
+        GROUP BY path
+        HAVING ifNull(greaterOrEquals(value, 0), 0)))
+  ORDER BY value ASC,
+           path ASC
+  LIMIT 20 BY band SETTINGS readonly=2,
+                            max_execution_time=60,
+                            allow_experimental_object_type=1,
+                            format_csv_allow_double_quotes=0,
+                            max_ast_elements=4000000,
+                            max_expanded_ast_elements=4000000,
+                            max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebVitalsPathBreakdownQueryRunner.test_limit_of_20_paths
+  '''
+  SELECT band AS band,
+         path AS path,
+                 value AS value
+  FROM
+    (SELECT multiIf(ifNull(lessOrEquals(value, 100.0), 0), 'good', ifNull(lessOrEquals(value, 200.0), 0), 'needs_improvements', 'poor') AS band,
+            path AS path,
+                    value AS value
+     FROM
+       (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS path,
+               quantile(0.75)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$web_vitals_INP_value'), ''), 'null'), '^"|"$', ''), 'Float64')) AS value
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$web_vitals'), isNotNull(path), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-08 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-15 23:59:59', 6, 'UTC')))), 0), 1))
+        GROUP BY path
+        HAVING ifNull(greaterOrEquals(value, 0), 0)))
+  ORDER BY value ASC,
+           path ASC
+  LIMIT 20 BY band SETTINGS readonly=2,
+                            max_execution_time=60,
+                            allow_experimental_object_type=1,
+                            format_csv_allow_double_quotes=0,
+                            max_ast_elements=4000000,
+                            max_expanded_ast_elements=4000000,
+                            max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebVitalsPathBreakdownQueryRunner.test_no_crash_when_no_data
+  '''
+  SELECT band AS band,
+         path AS path,
+                 value AS value
+  FROM
+    (SELECT multiIf(ifNull(lessOrEquals(value, 100.0), 0), 'good', ifNull(lessOrEquals(value, 200.0), 0), 'needs_improvements', 'poor') AS band,
+            path AS path,
+                    value AS value
+     FROM
+       (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS path,
+               quantile(0.75)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$web_vitals_INP_value'), ''), 'null'), '^"|"$', ''), 'Float64')) AS value
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$web_vitals'), isNotNull(path), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-08 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-15 23:59:59', 6, 'UTC')))), 0), 1))
+        GROUP BY path
+        HAVING ifNull(greaterOrEquals(value, 0), 0)))
+  ORDER BY value ASC,
+           path ASC
+  LIMIT 20 BY band SETTINGS readonly=2,
+                            max_execution_time=60,
+                            allow_experimental_object_type=1,
+                            format_csv_allow_double_quotes=0,
+                            max_ast_elements=4000000,
+                            max_expanded_ast_elements=4000000,
+                            max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebVitalsPathBreakdownQueryRunner.test_no_data_for_different_metric
+  '''
+  SELECT band AS band,
+         path AS path,
+                 value AS value
+  FROM
+    (SELECT multiIf(ifNull(lessOrEquals(value, 100.0), 0), 'good', ifNull(lessOrEquals(value, 200.0), 0), 'needs_improvements', 'poor') AS band,
+            path AS path,
+                    value AS value
+     FROM
+       (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS path,
+               quantile(0.75)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$web_vitals_LCP_value'), ''), 'null'), '^"|"$', ''), 'Float64')) AS value
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$web_vitals'), isNotNull(path), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-08 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-15 23:59:59', 6, 'UTC')))), 0), 1))
+        GROUP BY path
+        HAVING ifNull(greaterOrEquals(value, 0), 0)))
+  ORDER BY value ASC,
+           path ASC
+  LIMIT 20 BY band SETTINGS readonly=2,
+                            max_execution_time=60,
+                            allow_experimental_object_type=1,
+                            format_csv_allow_double_quotes=0,
+                            max_ast_elements=4000000,
+                            max_expanded_ast_elements=4000000,
+                            max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebVitalsPathBreakdownQueryRunner.test_no_data_for_different_period
+  '''
+  SELECT band AS band,
+         path AS path,
+                 value AS value
+  FROM
+    (SELECT multiIf(ifNull(lessOrEquals(value, 100.0), 0), 'good', ifNull(lessOrEquals(value, 200.0), 0), 'needs_improvements', 'poor') AS band,
+            path AS path,
+                    value AS value
+     FROM
+       (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS path,
+               quantile(0.75)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$web_vitals_INP_value'), ''), 'null'), '^"|"$', ''), 'Float64')) AS value
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$web_vitals'), isNotNull(path), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-08 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-15 23:59:59', 6, 'UTC')))), 0), 1))
+        GROUP BY path
+        HAVING ifNull(greaterOrEquals(value, 0), 0)))
+  ORDER BY value ASC,
+           path ASC
+  LIMIT 20 BY band SETTINGS readonly=2,
+                            max_execution_time=60,
+                            allow_experimental_object_type=1,
+                            format_csv_allow_double_quotes=0,
+                            max_ast_elements=4000000,
+                            max_expanded_ast_elements=4000000,
+                            max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebVitalsPathBreakdownQueryRunner.test_percentile_is_applied
+  '''
+  SELECT band AS band,
+         path AS path,
+                 value AS value
+  FROM
+    (SELECT multiIf(ifNull(lessOrEquals(value, 100.0), 0), 'good', ifNull(lessOrEquals(value, 200.0), 0), 'needs_improvements', 'poor') AS band,
+            path AS path,
+                    value AS value
+     FROM
+       (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS path,
+               quantile(0.75)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$web_vitals_INP_value'), ''), 'null'), '^"|"$', ''), 'Float64')) AS value
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$web_vitals'), isNotNull(path), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-08 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-15 23:59:59', 6, 'UTC')))), 0), 1))
+        GROUP BY path
+        HAVING ifNull(greaterOrEquals(value, 0), 0)))
+  ORDER BY value ASC,
+           path ASC
+  LIMIT 20 BY band SETTINGS readonly=2,
+                            max_execution_time=60,
+                            allow_experimental_object_type=1,
+                            format_csv_allow_double_quotes=0,
+                            max_ast_elements=4000000,
+                            max_expanded_ast_elements=4000000,
+                            max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebVitalsPathBreakdownQueryRunner.test_percentile_is_applied.1
+  '''
+  SELECT band AS band,
+         path AS path,
+                 value AS value
+  FROM
+    (SELECT multiIf(ifNull(lessOrEquals(value, 100.0), 0), 'good', ifNull(lessOrEquals(value, 200.0), 0), 'needs_improvements', 'poor') AS band,
+            path AS path,
+                    value AS value
+     FROM
+       (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS path,
+               quantile(0.9)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$web_vitals_INP_value'), ''), 'null'), '^"|"$', ''), 'Float64')) AS value
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$web_vitals'), isNotNull(path), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-08 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-15 23:59:59', 6, 'UTC')))), 0), 1))
+        GROUP BY path
+        HAVING ifNull(greaterOrEquals(value, 0), 0)))
+  ORDER BY value ASC,
+           path ASC
+  LIMIT 20 BY band SETTINGS readonly=2,
+                            max_execution_time=60,
+                            allow_experimental_object_type=1,
+                            format_csv_allow_double_quotes=0,
+                            max_ast_elements=4000000,
+                            max_expanded_ast_elements=4000000,
+                            max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebVitalsPathBreakdownQueryRunner.test_percentile_is_applied.2
+  '''
+  SELECT band AS band,
+         path AS path,
+                 value AS value
+  FROM
+    (SELECT multiIf(ifNull(lessOrEquals(value, 100.0), 0), 'good', ifNull(lessOrEquals(value, 200.0), 0), 'needs_improvements', 'poor') AS band,
+            path AS path,
+                    value AS value
+     FROM
+       (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS path,
+               quantile(0.99)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$web_vitals_INP_value'), ''), 'null'), '^"|"$', ''), 'Float64')) AS value
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$web_vitals'), isNotNull(path), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-08 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-15 23:59:59', 6, 'UTC')))), 0), 1))
+        GROUP BY path
+        HAVING ifNull(greaterOrEquals(value, 0), 0)))
+  ORDER BY value ASC,
+           path ASC
+  LIMIT 20 BY band SETTINGS readonly=2,
+                            max_execution_time=60,
+                            allow_experimental_object_type=1,
+                            format_csv_allow_double_quotes=0,
+                            max_ast_elements=4000000,
+                            max_expanded_ast_elements=4000000,
+                            max_bytes_before_external_group_by=0
+  '''
+# ---
+# name: TestWebVitalsPathBreakdownQueryRunner.test_properties_are_applied
+  '''
+  SELECT band AS band,
+         path AS path,
+                 value AS value
+  FROM
+    (SELECT multiIf(ifNull(lessOrEquals(value, 100.0), 0), 'good', ifNull(lessOrEquals(value, 200.0), 0), 'needs_improvements', 'poor') AS band,
+            path AS path,
+                    value AS value
+     FROM
+       (SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', '') AS path,
+               quantile(0.75)(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$web_vitals_INP_value'), ''), 'null'), '^"|"$', ''), 'Float64')) AS value
+        FROM events
+        WHERE and(equals(events.team_id, 99999), and(equals(events.event, '$web_vitals'), isNotNull(path), or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-08 00:00:00', 6, 'UTC'))), less(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(parseDateTime64BestEffortOrNull('2025-01-15 23:59:59', 6, 'UTC')))), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$pathname'), ''), 'null'), '^"|"$', ''), '/path1'), 0)))
+        GROUP BY path
+        HAVING ifNull(greaterOrEquals(value, 0), 0)))
+  ORDER BY value ASC,
+           path ASC
+  LIMIT 20 BY band SETTINGS readonly=2,
+                            max_execution_time=60,
+                            allow_experimental_object_type=1,
+                            format_csv_allow_double_quotes=0,
+                            max_ast_elements=4000000,
+                            max_expanded_ast_elements=4000000,
+                            max_bytes_before_external_group_by=0
+  '''
+# ---

--- a/posthog/hogql_queries/web_analytics/test/test_external_clicks_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_external_clicks_table.py
@@ -15,9 +15,11 @@ from posthog.test.base import (
     ClickhouseTestMixin,
     _create_event,
     _create_person,
+    snapshot_clickhouse_queries,
 )
 
 
+@snapshot_clickhouse_queries
 class TestExternalClicksTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
     def _create_events(self, data, event="$autocapture"):
         person_result = []

--- a/posthog/hogql_queries/web_analytics/test/test_session_attribution_explorer_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/test/test_session_attribution_explorer_query_runner.py
@@ -16,13 +16,10 @@ from posthog.schema import (
     SessionPropertyFilter,
     PropertyOperator,
 )
-from posthog.test.base import (
-    APIBaseTest,
-    ClickhouseTestMixin,
-    _create_event,
-)
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, snapshot_clickhouse_queries
 
 
+@snapshot_clickhouse_queries
 class TestSessionAttributionQueryRunner(ClickhouseTestMixin, APIBaseTest):
     def _create_session(
         self, url=None, source=None, medium=None, campaign=None, gclid=None, gad_source=None, referring_domain="$direct"

--- a/posthog/hogql_queries/web_analytics/test/test_web_analytics_query_runner.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_analytics_query_runner.py
@@ -20,9 +20,11 @@ from posthog.test.base import (
     ClickhouseTestMixin,
     _create_event,
     _create_person,
+    snapshot_clickhouse_queries,
 )
 
 
+@snapshot_clickhouse_queries
 class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
     def _create_events(self, data, event="$pageview"):
         person_result = []

--- a/posthog/hogql_queries/web_analytics/test/test_web_goals.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_goals.py
@@ -17,9 +17,11 @@ from posthog.test.base import (
     ClickhouseTestMixin,
     _create_event,
     _create_person,
+    snapshot_clickhouse_queries,
 )
 
 
+@snapshot_clickhouse_queries
 class TestWebGoalsQueryRunner(ClickhouseTestMixin, APIBaseTest):
     TIMESTAMP = "2024-12-01"
 

--- a/posthog/hogql_queries/web_analytics/test/test_web_overview.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_overview.py
@@ -29,6 +29,7 @@ from posthog.test.base import (
 )
 
 
+@snapshot_clickhouse_queries
 class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
     def _create_events(self, data, event="$pageview"):
         person_result = []
@@ -109,7 +110,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         WebOverviewQueryResponse.model_validate(response)
         return response
 
-    @snapshot_clickhouse_queries
     def test_no_crash_when_no_data(self):
         results = self._run_web_overview_query(
             "2023-12-08",
@@ -152,7 +152,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
             "conversion rate",
         ]
 
-    @snapshot_clickhouse_queries
     def test_increase_in_users(self):
         s1a = str(uuid7("2023-12-02"))
         s1b = str(uuid7("2023-12-12"))
@@ -200,7 +199,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(0, bounce.previous)
         self.assertEqual(None, bounce.changeFromPreviousPct)
 
-    @snapshot_clickhouse_queries
     def test_increase_in_users_using_mobile(self):
         s1a = str(uuid7("2023-12-02"))
         s1b = str(uuid7("2023-12-12"))
@@ -250,7 +248,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(0, bounce.previous)
         self.assertEqual(None, bounce.changeFromPreviousPct)
 
-    @snapshot_clickhouse_queries
     def test_all_time(self):
         s1a = str(uuid7("2023-12-02"))
         s1b = str(uuid7("2023-12-12"))
@@ -298,7 +295,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(None, bounce.previous)
         self.assertEqual(None, bounce.changeFromPreviousPct)
 
-    @snapshot_clickhouse_queries
     def test_comparison(self):
         s1a = str(uuid7("2023-12-02"))
         s1b = str(uuid7("2023-12-12"))
@@ -346,7 +342,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(0, bounce.previous)
         self.assertEqual(None, bounce.changeFromPreviousPct)
 
-    @snapshot_clickhouse_queries
     def test_filter_test_accounts(self):
         s1 = str(uuid7("2023-12-02"))
         # Create 1 test account
@@ -370,7 +365,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual("bounce rate", bounce.key)
         self.assertEqual(None, bounce.value)
 
-    @snapshot_clickhouse_queries
     def test_dont_filter_test_accounts(self):
         s1 = str(uuid7("2023-12-02"))
         # Create 1 test account
@@ -381,7 +375,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         visitors = results[0]
         self.assertEqual(1, visitors.value)
 
-    @snapshot_clickhouse_queries
     def test_correctly_counts_pageviews_in_long_running_session(self):
         # this test is important when using the v1 sessions table as the raw sessions table will have 3 entries, one per day
         s1 = str(uuid7("2023-12-01"))
@@ -405,7 +398,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         sessions = results[2]
         self.assertEqual(1, sessions.value)
 
-    @snapshot_clickhouse_queries
     def test_conversion_goal_no_conversions(self):
         s1 = str(uuid7("2023-12-01"))
         self._create_events(
@@ -440,7 +432,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         conversion_rate = results[3]
         assert conversion_rate.value == 0
 
-    @snapshot_clickhouse_queries
     def test_conversion_goal_one_pageview_conversion(self):
         s1 = str(uuid7("2023-12-01"))
         self._create_events(
@@ -475,7 +466,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         conversion_rate = results[3]
         assert conversion_rate.value == 100
 
-    @snapshot_clickhouse_queries
     def test_conversion_goal_one_custom_event_conversion(self):
         s1 = str(uuid7("2023-12-01"))
         self._create_events(
@@ -499,7 +489,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         conversion_rate = results[3]
         assert conversion_rate.value == 100
 
-    @snapshot_clickhouse_queries
     def test_conversion_goal_one_custom_action_conversion(self):
         s1 = str(uuid7("2023-12-01"))
         self._create_events(
@@ -533,7 +522,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         conversion_rate = results[3]
         assert conversion_rate.value == 100
 
-    @snapshot_clickhouse_queries
     def test_conversion_goal_one_autocapture_conversion(self):
         s1 = str(uuid7("2023-12-01"))
         self._create_events(
@@ -569,7 +557,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         conversion_rate = results[3]
         assert conversion_rate.value == 100
 
-    @snapshot_clickhouse_queries
     def test_conversion_rate(self):
         s1 = str(uuid7("2023-12-01"))
         s2 = str(uuid7("2023-12-01"))
@@ -621,7 +608,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         conversion_rate = results[3]
         self.assertAlmostEqual(conversion_rate.value, 100 * 2 / 3)
 
-    @snapshot_clickhouse_queries
     def test_revenue(self):
         s1 = str(uuid7("2023-12-02"))
 
@@ -655,7 +641,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert revenue.kind == "currency"
         assert revenue.value == 100
 
-    @snapshot_clickhouse_queries
     def test_revenue_multiple_events(self):
         s1 = str(uuid7("2023-12-02"))
         s2 = str(uuid7("2023-12-02"))
@@ -701,7 +686,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert revenue.kind == "currency"
         assert revenue.value == 150
 
-    @snapshot_clickhouse_queries
     def test_revenue_no_config(self):
         s1 = str(uuid7("2023-12-02"))
 
@@ -717,7 +701,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert revenue.kind == "currency"
         assert revenue.value is None
 
-    @snapshot_clickhouse_queries
     def test_revenue_conversion_event(self):
         s1 = str(uuid7("2023-12-02"))
 
@@ -750,7 +733,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert revenue.kind == "currency"
         assert revenue.value == 100
 
-    @snapshot_clickhouse_queries
     def test_revenue_conversion_event_with_multiple_revenue_events(self):
         s1 = str(uuid7("2023-12-02"))
         s2 = str(uuid7("2023-12-02"))
@@ -783,7 +765,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert revenue.kind == "currency"
         assert revenue.value == 100
 
-    @snapshot_clickhouse_queries
     def test_revenue_conversion_no_config(self):
         s1 = str(uuid7("2023-12-02"))
 
@@ -801,7 +782,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert revenue.kind == "currency"
         assert revenue.value is None
 
-    @snapshot_clickhouse_queries
     def test_no_revenue_when_event_conversion_goal_set_but_include_revenue_disabled(self):
         s1 = str(uuid7("2023-12-01"))
 
@@ -821,7 +801,6 @@ class TestWebOverviewQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         assert len(results) == 4
 
-    @snapshot_clickhouse_queries
     def test_no_revenue_when_action_conversion_goal_set_but_include_revenue_disabled(self):
         s1 = str(uuid7("2023-12-01"))
 

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -24,9 +24,11 @@ from posthog.test.base import (
     _create_event,
     _create_person,
     flush_persons_and_events,
+    snapshot_clickhouse_queries,
 )
 
 
+@snapshot_clickhouse_queries
 class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
     def _create_events(self, data, event="$pageview"):
         person_result = []

--- a/posthog/hogql_queries/web_analytics/test/test_web_vitals_path_breakdown.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_vitals_path_breakdown.py
@@ -14,9 +14,11 @@ from posthog.test.base import (
     ClickhouseTestMixin,
     _create_event,
     flush_persons_and_events,
+    snapshot_clickhouse_queries,
 )
 
 
+@snapshot_clickhouse_queries
 class TestWebVitalsPathBreakdownQueryRunner(ClickhouseTestMixin, APIBaseTest):
     def _create_events(self, data, metric: WebVitalsMetric = WebVitalsMetric.INP):
         for distinct_id, timestamps in data:


### PR DESCRIPTION
## Problem

We're missing snapshots tests

## Changes

Add snapshot tests. Be a bit clever so I don't need to copy the decorator once per test

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
It is tests