### PR TITLE
feat(web-analytics): Improve revenue formatting

### DIFF
--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -148,6 +148,19 @@ const formatUnit = (x: number, options?: { precise?: boolean }): string => {
     return humanFriendlyLargeNumber(x)
 }
 
+const getCurrencySymbol = (currency: string): { symbol: string; isPrefix: boolean } => {
+    const formatter = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: currency,
+    })
+    const parts = formatter.formatToParts(0)
+    const symbol = parts.find((part) => part.type === 'currency')?.value
+
+    const isPrefix = symbol ? parts[0].type === 'currency' : true
+
+    return { symbol: symbol ?? currency, isPrefix }
+}
+
 const formatItem = (
     value: number | undefined,
     kind: WebOverviewItemKind,
@@ -160,9 +173,10 @@ const formatItem = (
     } else if (kind === 'duration_s') {
         return humanFriendlyDuration(value, { secondsPrecision: 3 })
     } else if (kind === 'currency') {
-        return new Intl.NumberFormat(undefined, { style: 'currency', currency: options?.currency ?? 'USD' }).format(
-            value
-        )
+        const { symbol, isPrefix } = getCurrencySymbol(options?.currency ?? 'USD')
+        return `${isPrefix ? symbol : ''}${formatUnit(value, { precise: options?.precise })}${
+            isPrefix ? '' : ' ' + symbol
+        }`
     }
     return formatUnit(value, options)
 }


### PR DESCRIPTION
## Problem

Right now we do this
![image](https://github.com/user-attachments/assets/8dcd4092-0b7f-4ace-b7af-9d32d9471aa3)


## Changes
Instead do this

![image](https://github.com/user-attachments/assets/ed881573-e6e1-4480-9bc0-b5c340827652)
![image](https://github.com/user-attachments/assets/40fa3fa5-6ffc-4d21-8d59-f2802008a82c)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Took these screenshots :D
