### PR TITLE
fix: allow direct event property filtering

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFilters.tsx
@@ -38,6 +38,7 @@ export const RecordingsUniversalFilters = ({
     const taxonomicGroupTypes = [
         TaxonomicFilterGroupType.Replay,
         TaxonomicFilterGroupType.Events,
+        TaxonomicFilterGroupType.EventProperties,
         TaxonomicFilterGroupType.Actions,
         TaxonomicFilterGroupType.Cohorts,
         TaxonomicFilterGroupType.PersonProperties,


### PR DESCRIPTION
it is definitely going to be slower to filter by event properties without specifying an event for some accounts

but right now this is confusing everyone (me included)

so let's let people pick event properties and then we can later add some nice affordances to help them make those filters faster

we measure listing API speed so we can assert on the impact of this

<img width="1017" alt="Screenshot 2025-01-27 at 19 34 54" src="https://github.com/user-attachments/assets/318764d5-f133-497b-aa16-ccd3a593d554" />
<img width="819" alt="Screenshot 2025-01-27 at 19 35 02" src="https://github.com/user-attachments/assets/f04e92f5-e14f-4aea-8a6a-181809e5172f" />

