### PR TITLE
fix(flags): handle b64 encoded traffic to new `/flags` endpoint

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18818,7 +18818,7 @@ packages:
       react: '>=15'
     dependencies:
       react: 18.2.0
-      unlayer-types: 1.202.0
+      unlayer-types: 1.199.0
     dev: false
 
   /react-error-boundary@3.1.4(react@18.2.0):
@@ -21429,8 +21429,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  /unlayer-types@1.202.0:
-    resolution: {integrity: sha512-m84X+APYWPOl7QUDxPeiB2eUQSgWx4HeE3zyX1BhTTRI9NEki8Z0BB7hvP+Ddqg2utr5L6oJnBHc6vj9rPPtmw==}
+  /unlayer-types@1.199.0:
+    resolution: {integrity: sha512-ZBHpty2RkDc4BygHqw18ZwNrTvX31Rf10NY4SuncdqYkEj6wqHoNZiVoIhObQJrhPskT1mYdL8CTgLsSq42SeQ==}
     dev: false
 
   /unpipe@1.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18818,7 +18818,7 @@ packages:
       react: '>=15'
     dependencies:
       react: 18.2.0
-      unlayer-types: 1.199.0
+      unlayer-types: 1.202.0
     dev: false
 
   /react-error-boundary@3.1.4(react@18.2.0):
@@ -21429,8 +21429,8 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
 
-  /unlayer-types@1.199.0:
-    resolution: {integrity: sha512-ZBHpty2RkDc4BygHqw18ZwNrTvX31Rf10NY4SuncdqYkEj6wqHoNZiVoIhObQJrhPskT1mYdL8CTgLsSq42SeQ==}
+  /unlayer-types@1.202.0:
+    resolution: {integrity: sha512-m84X+APYWPOl7QUDxPeiB2eUQSgWx4HeE3zyX1BhTTRI9NEki8Z0BB7hvP+Ddqg2utr5L6oJnBHc6vj9rPPtmw==}
     dev: false
 
   /unpipe@1.0.0:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1973,6 +1973,7 @@ dependencies = [
  "serde",
  "serde-pickle",
  "serde_json",
+ "serde_urlencoded",
  "sha1",
  "sqlx",
  "strum",
@@ -1982,6 +1983,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
 ]
 

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -44,6 +44,8 @@ tower-http = { workspace = true }
 derive_builder = "0.20.1"
 petgraph = "0.6.5"
 moka = { workspace = true }
+serde_urlencoded = "0.7.1"
+urlencoding = "2.1.3"
 
 [lints]
 workspace = true

--- a/rust/feature-flags/Cargo.toml
+++ b/rust/feature-flags/Cargo.toml
@@ -44,7 +44,7 @@ tower-http = { workspace = true }
 derive_builder = "0.20.1"
 petgraph = "0.6.5"
 moka = { workspace = true }
-serde_urlencoded = "0.7.1"
+serde_urlencoded = { workspace = true }
 urlencoding = "2.1.3"
 
 [lints]

--- a/rust/feature-flags/src/api/endpoint.rs
+++ b/rust/feature-flags/src/api/endpoint.rs
@@ -35,18 +35,19 @@ use tracing::instrument;
 pub async fn flags(
     state: State<router::State>,
     InsecureClientIp(ip): InsecureClientIp,
-    meta: Query<FlagsQueryParams>,
+    Query(query_params): Query<FlagsQueryParams>,
     headers: HeaderMap,
     method: Method,
     path: MatchedPath,
     body: Bytes,
 ) -> Result<Json<FlagsResponse>, FlagError> {
-    record_request_metadata(&headers, &method, &path, &ip, &meta);
+    record_request_metadata(&headers, &method, &path, &ip, &Query(query_params.clone()));
 
     let context = RequestContext {
         state,
         ip,
         headers,
+        meta: query_params,
         body,
     };
 
@@ -69,9 +70,7 @@ fn record_request_metadata(
     let user_agent = headers
         .get("user-agent")
         .map_or("unknown", |v| v.to_str().unwrap_or("unknown"));
-    let content_encoding = headers
-        .get("content-encoding")
-        .map_or("unknown", |v| v.to_str().unwrap_or("unknown"));
+    let content_encoding = meta.compression.as_ref().map_or("none", |c| c.as_str());
     let content_type = headers
         .get("content-type")
         .map_or("unknown", |v| v.to_str().unwrap_or("unknown"));
@@ -92,4 +91,66 @@ fn record_request_metadata(
     tracing::Span::current().record("path", path.as_str().trim_end_matches('/'));
     tracing::Span::current().record("ip", ip.to_string());
     tracing::Span::current().record("sent_at", meta.sent_at.unwrap_or(0).to_string());
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::api::request_handler::Compression;
+
+    use super::*;
+    use axum::{
+        body::Body,
+        extract::{FromRequest, Request},
+        http::Uri,
+    };
+
+    #[tokio::test]
+    async fn test_query_param_extraction() {
+        // Test case 1: Full query string
+        let uri = Uri::from_static(
+            "http://localhost:3001/flags/?v=3&compression=base64&ver=1.211.0&_=1738006794028",
+        );
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let Query(params) = Query::<FlagsQueryParams>::from_request(req, &())
+            .await
+            .unwrap();
+
+        assert_eq!(params.version, Some("3".to_string()));
+        assert_eq!(params.lib_version, Some("1.211.0".to_string()));
+        assert_eq!(params.sent_at, Some(1738006794028));
+        assert!(matches!(params.compression, Some(Compression::Base64)));
+
+        // Test case 2: Partial query string
+        let uri = Uri::from_static("http://localhost:3001/flags/?v=3&compression=gzip");
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let Query(params) = Query::<FlagsQueryParams>::from_request(req, &())
+            .await
+            .unwrap();
+
+        assert_eq!(params.version, Some("3".to_string()));
+        assert!(matches!(params.compression, Some(Compression::Gzip)));
+        assert_eq!(params.lib_version, None);
+        assert_eq!(params.sent_at, None);
+
+        // Test case 3: Empty query string
+        let uri = Uri::from_static("http://localhost:3001/flags/");
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let Query(params) = Query::<FlagsQueryParams>::from_request(req, &())
+            .await
+            .unwrap();
+
+        assert_eq!(params.version, None);
+        assert_eq!(params.compression, None);
+        assert_eq!(params.lib_version, None);
+        assert_eq!(params.sent_at, None);
+
+        // Test case 4: Invalid compression type
+        let uri = Uri::from_static("http://localhost:3001/flags/?compression=invalid");
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let Query(params) = Query::<FlagsQueryParams>::from_request(req, &())
+            .await
+            .unwrap();
+
+        assert!(matches!(params.compression, Some(Compression::Unsupported)));
+    }
 }

--- a/rust/feature-flags/src/api/test_endpoint.rs
+++ b/rust/feature-flags/src/api/test_endpoint.rs
@@ -44,7 +44,7 @@ pub async fn test_black_hole(
     metrics::counter!(CONTENT_HEADER_TYPE, "type" => content_type.to_string()).increment(1);
 
     // Attempt to decode the request using the handler's decode_request function
-    let request = match decode_request(&headers, body) {
+    let request = match decode_request(&headers, body, &meta) {
         Ok(req) => req,
         Err(e) => {
             error!("failed to decode request: {}", e);


### PR DESCRIPTION
## Problem

Initially I wasn't sure I'd support it, and I'm still happy migrating all new SDK traffic to use gzip/plaintext, but keeping this behavior makes it way the heck easier to test against existing SDK traffic (since we send requests to `/decide` using base64 encoded traffic by default).

## Changes

Supports `application/x-www-form-urlencoded` requests to the `/flags` endpoint.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

New test for the endpoint, confirmed it worked when I changed posthog-js locally to hit `/flags` instead of `/decide`.
