### PR TITLE
fix: Use alias in distributed events recent query

### DIFF
--- a/posthog/temporal/batch_exports/sql.py
+++ b/posthog/temporal/batch_exports/sql.py
@@ -164,7 +164,7 @@ FROM (
         AND (length({exclude_events}::Array(String)) = 0 OR event NOT IN {exclude_events}::Array(String))
     ORDER BY
         _inserted_at, event
-)
+) AS events
 FORMAT ArrowStream
 SETTINGS
     optimize_aggregation_in_order=1,


### PR DESCRIPTION
## Problem

Batch exports subqueries need to be aliased as `events` to allow users to select custom fields.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Set an alias to subquery in new distributed_events_recent query.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
