### PR TITLE
feat(llm-observability): display metrics and user feedback in trace

### DIFF
--- a/products/llm_observability/frontend/LLMObservabilityTraceScene.tsx
+++ b/products/llm_observability/frontend/LLMObservabilityTraceScene.tsx
@@ -442,7 +442,7 @@ function TraceMetricsTable(): JSX.Element | null {
                     {
                         title: 'Value',
                         key: 'value',
-                        render: (_, { value }) => <span>{value || '–'}</span>,
+                        render: (_, { value }) => <span>{value ?? '–'}</span>,
                         width: '60%',
                     },
                 ]}

--- a/products/llm_observability/frontend/LLMObservabilityTraceScene.tsx
+++ b/products/llm_observability/frontend/LLMObservabilityTraceScene.tsx
@@ -1,12 +1,12 @@
-import { IconAIText, IconReceipt } from '@posthog/icons'
-import { LemonDivider, LemonTag, LemonTagProps, Link, SpinnerOverlay, Tooltip } from '@posthog/lemon-ui'
+import { IconAIText, IconMessage, IconReceipt } from '@posthog/icons'
+import { LemonDivider, LemonTable, LemonTag, LemonTagProps, Link, SpinnerOverlay, Tooltip } from '@posthog/lemon-ui'
 import classNames from 'classnames'
 import clsx from 'clsx'
 import { BindLogic, useValues } from 'kea'
 import { JSONViewer } from 'lib/components/JSONViewer'
 import { NotFound } from 'lib/components/NotFound'
 import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
-import { isObject, pluralize } from 'lib/utils'
+import { identifierToHuman, isObject, pluralize } from 'lib/utils'
 import { cn } from 'lib/utils/css-classes'
 import React, { useState } from 'react'
 import { InsightEmptyState, InsightErrorState } from 'scenes/insights/EmptyStates'
@@ -337,7 +337,7 @@ function EventContentDisplay({
     )
 }
 
-function EventContent({ event }: { event: LLMTrace | LLMTraceEvent | null }): JSX.Element {
+const EventContent = React.memo(({ event }: { event: LLMTrace | LLMTraceEvent | null }): JSX.Element => {
     return (
         <div className="flex-1 bg-bg-light max-h-fit border rounded flex flex-col border-border p-4 overflow-y-auto">
             {!event ? (
@@ -390,13 +390,17 @@ function EventContent({ event }: { event: LLMTrace | LLMTraceEvent | null }): JS
                             />
                         )
                     ) : (
-                        <EventContentDisplay input={event.inputState} output={event.outputState} />
+                        <>
+                            <TraceMetricsTable />
+                            <EventContentDisplay input={event.inputState} output={event.outputState} />
+                        </>
                     )}
                 </>
             )}
         </div>
     )
-}
+})
+EventContent.displayName = 'EventContent'
 
 function EventTypeTag({ event, size }: { event: LLMTrace | LLMTraceEvent; size?: LemonTagProps['size'] }): JSX.Element {
     let eventType = 'trace'
@@ -411,5 +415,39 @@ function EventTypeTag({ event, size }: { event: LLMTrace | LLMTraceEvent; size?:
         >
             {eventType}
         </LemonTag>
+    )
+}
+
+function TraceMetricsTable(): JSX.Element | null {
+    const { metricsAndFeedbackEvents } = useValues(llmObservabilityTraceDataLogic)
+
+    if (!metricsAndFeedbackEvents?.length) {
+        return null
+    }
+
+    return (
+        <div className="mb-3">
+            <h4 className="flex items-center gap-x-1.5 text-xs font-semibold mb-2">
+                <IconMessage className="text-base" />
+                Metrics and user feedback
+            </h4>
+            <LemonTable
+                columns={[
+                    {
+                        title: 'Metric',
+                        key: 'metric',
+                        render: (_, { metric }) => <span>{identifierToHuman(metric)}</span>,
+                        width: '40%',
+                    },
+                    {
+                        title: 'Value',
+                        key: 'value',
+                        render: (_, { value }) => <span>{value || '–'}</span>,
+                        width: '60%',
+                    },
+                ]}
+                dataSource={metricsAndFeedbackEvents}
+            />
+        </div>
     )
 }

--- a/products/llm_observability/frontend/llmObservabilityTraceDataLogic.ts
+++ b/products/llm_observability/frontend/llmObservabilityTraceDataLogic.ts
@@ -66,6 +66,15 @@ export const llmObservabilityTraceDataLogic = kea<llmObservabilityTraceDataLogic
             (trace): LLMTraceEvent[] | undefined =>
                 trace?.events.filter((event) => event.event === '$ai_feedback' && event.properties.$ai_feedback_text),
         ],
+        metricsAndFeedbackEvents: [
+            (s) => [s.metricEvents, s.feedbackEvents],
+            (metricEvents, feedbackEvents): { metric: string; value: any }[] =>
+                [...(metricEvents ?? []), ...(feedbackEvents ?? [])].map((event) => ({
+                    metric:
+                        event.event === '$ai_metric' ? event.properties.$ai_metric_name ?? 'Metric' : 'User feedback',
+                    value: event.properties.$ai_metric_value ?? event.properties.$ai_feedback_text,
+                })),
+        ],
         event: [
             (s, p) => [p.traceId, s.eventId, s.trace, s.showableEvents],
             (traceId, eventId, trace, showableEvents): LLMTrace | LLMTraceEvent | null => {


### PR DESCRIPTION
## Problem

Metrics and feedback are currently only visible as tags with tooltips. It's inconvenient when you have multiple metrics or want to read feedback.

## Changes

- Display metrics and user feedback in the trace overview component.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manual testing
