### PR TITLE
chore: bump posthoganalytics

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -69,7 +69,7 @@ pandas==2.2.0
 paramiko==3.4.0
 Pillow==10.2.0
 pdpyras==5.2.0
-posthoganalytics~=3.9.3
+posthoganalytics~=3.11.0
 psutil==6.0.0
 psycopg2-binary==2.9.7
 pymssql==2.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -568,7 +568,7 @@ pluggy==1.5.0
     # via dlt
 ply==3.11
     # via jsonpath-ng
-posthoganalytics==3.9.3
+posthoganalytics==3.11.0
     # via -r requirements.in
 prometheus-client==0.14.1
     # via django-prometheus


### PR DESCRIPTION
## Problem

LLM Observability now supports LangChain's spans, so let's dogfood it.

## Changes

Bump `posthoganalytics` to `3.11.0`.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

N/A