### PR TITLE
fix: Plugin Hog function migrator

### DIFF
--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -21,6 +21,7 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.cdp.filters import compile_filters_bytecode, compile_filters_expr
 from posthog.cdp.services.icons import CDPIconsService
 from posthog.cdp.templates import HOG_FUNCTION_TEMPLATES_BY_ID
+from posthog.cdp.templates._internal.template_legacy_plugin import create_legacy_plugin_template
 from posthog.cdp.validation import compile_hog, generate_template_bytecode, validate_inputs, validate_inputs_schema
 from posthog.cdp.site_functions import get_transpiled_function
 from posthog.constants import AvailableFeature
@@ -155,7 +156,11 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         is_create = self.context.get("view") and self.context["view"].action == "create"
 
         template_id = attrs.get("template_id", instance.template_id if instance else None)
-        template = HOG_FUNCTION_TEMPLATES_BY_ID.get(template_id, None)
+
+        if template_id and template_id.startswith("plugin-"):
+            template = create_legacy_plugin_template(template_id)
+        else:
+            template = HOG_FUNCTION_TEMPLATES_BY_ID.get(template_id, None)
 
         if not has_addon:
             # In this case they are only allowed to create or update the function with free templates

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -156,11 +156,10 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         is_create = self.context.get("view") and self.context["view"].action == "create"
 
         template_id = attrs.get("template_id", instance.template_id if instance else None)
+        template = HOG_FUNCTION_TEMPLATES_BY_ID.get(template_id, None)
 
         if template_id and template_id.startswith("plugin-"):
             template = create_legacy_plugin_template(template_id)
-        else:
-            template = HOG_FUNCTION_TEMPLATES_BY_ID.get(template_id, None)
 
         if not has_addon:
             # In this case they are only allowed to create or update the function with free templates

--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -42,12 +42,12 @@ def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True):
     plugin_configs_without_addon = []
 
     for plugin_config in legacy_plugins:
-        print(
+        print(  # noqa: T201
             "Migrating plugin",
             plugin_config["id"],
             plugin_config["plugin__name"],
             plugin_config["plugin__capabilities"],
-        )  # noqa: T201
+        )
 
         methods = plugin_config["plugin__capabilities"].get("methods", [])
 

--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -139,9 +139,7 @@ def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True):
         has_addon = team.organization.is_feature_available(AvailableFeature.DATA_PIPELINES)
 
         if not has_addon:
-            print("Found a team without the required addon!", team.id, plugin_config["id"])  # noqa: T201
             plugin_configs_without_addon.append(plugin_config["id"])
-            continue
 
         serializer = HogFunctionSerializer(
             data=data,

--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -1,33 +1,69 @@
+import json
 from posthog.api.hog_function import HogFunctionSerializer
+from posthog.constants import AvailableFeature
 from posthog.models.hog_functions.hog_function import HogFunction
 from posthog.models.plugin import PluginAttachment, PluginConfig
+from posthog.models.team.team import Team
+from django.db.models import Q
+
+# python manage.py migrate_plugins_to_hog_functions --dry-run --test-mode
 
 
 def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True):
     # Get all legacy plugin_configs that are active with their attachments and global values
-    legacy_plugins = PluginConfig.objects.select_related("plugin").filter(enabled=True)
+    # Plugins are huge (JS and assets) so we only grab the bits we really need
+    legacy_plugins = (
+        PluginConfig.objects.values(
+            "id",
+            "config",
+            "team_id",
+            "plugin__name",
+            "plugin__url",
+            "plugin__capabilities",
+            "plugin__config_schema",
+            "plugin__icon",
+        )
+        .filter(enabled=True)
+        .filter(
+            Q(plugin__capabilities__methods__contains=["onEvent"])
+            | Q(plugin__capabilities__methods__contains=["composeWebhook"])
+        )
+        # always filter out geoip as we are not migrating it this way
+        .exclude(plugin__name="GeoIP")
+    )
 
     if team_ids:
         legacy_plugins = legacy_plugins.filter(team_id__in=team_ids)
 
+    teams = Team.objects.filter(id__in=legacy_plugins.values_list("team_id", flat=True).distinct())
+    teams_by_id = {team.id: team for team in teams}
+
     hog_functions = []
+    plugin_configs_without_addon = []
 
     for plugin_config in legacy_plugins:
-        methods = plugin_config.plugin.capabilities.get("methods", [])
+        print(
+            "Migrating plugin",
+            plugin_config["id"],
+            plugin_config["plugin__name"],
+            plugin_config["plugin__capabilities"],
+        )  # noqa: T201
 
-        if "onEvent" not in methods or "composeWebhook" not in methods:
-            print("Skipping plugin", plugin_config.plugin.name, "as it doesn't have onEvent or composeWebhook")  # noqa: T201
+        methods = plugin_config["plugin__capabilities"].get("methods", [])
+
+        if "onEvent" not in methods and "composeWebhook" not in methods:
+            print("Skipping plugin", plugin_config["plugin__name"], "as it doesn't have onEvent or composeWebhook")  # noqa: T201
             continue
 
         print("Attempting to migrate plugin", plugin_config)  # noqa: T201
-        url: str = plugin_config.plugin.url or ""
+        url: str = plugin_config["plugin__url"] or ""
 
         if not url:
-            print("Skipping plugin", plugin_config.plugin.name, "as it doesn't have a url")  # noqa: T201
+            print("Skipping plugin", plugin_config["plugin__name"], "as it doesn't have a url")  # noqa: T201
             continue
 
         plugin_id = url.replace("inline://", "").replace("https://github.com/PostHog/", "")
-        plugin_name = plugin_config.plugin.name
+        plugin_name = plugin_config["plugin__name"]
 
         if test_mode:
             plugin_name = f"[CDP-TEST-HIDDEN] {plugin_name}"
@@ -37,7 +73,7 @@ def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True):
 
         # Iterate over the plugin config to build the inputs
 
-        for schema in plugin_config.plugin.config_schema:
+        for schema in plugin_config["plugin__config_schema"]:
             if not schema.get("key"):
                 continue
 
@@ -48,11 +84,15 @@ def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True):
                 "key": schema["key"],
                 "type": schema["type"],
                 "label": schema.get("name", schema["key"]),
-                "description": schema.get("hint", ""),
                 "secret": schema.get("secret", False),
                 "required": schema.get("required", False),
-                "default": schema.get("default", None),
             }
+
+            if schema.get("default"):
+                input_schema["default"] = schema["default"]
+
+            if schema.get("hint"):
+                input_schema["description"] = schema["hint"]
 
             if schema["type"] == "choice":
                 input_schema["choices"] = [
@@ -64,20 +104,22 @@ def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True):
                 ]
                 input_schema["type"] = "string"
             elif schema["type"] == "attachment":
+                input_schema["secret"] = True
                 input_schema["type"] = "string"
 
             inputs_schema.append(input_schema)
 
-        for key, value in plugin_config.config.items():
+        for key, value in plugin_config["config"].items():
             inputs[key] = {"value": value}
 
         # Load all attachments for this plugin config
-        attachments = PluginAttachment.objects.filter(plugin_config=plugin_config)
+        attachments = PluginAttachment.objects.filter(plugin_config_id=plugin_config["id"])
 
         for attachment in attachments:
             inputs[attachment.key] = {"value": attachment.parse_contents()}
 
-        serializer_context = {"team": plugin_config.team, "get_team": (lambda config=plugin_config: config.team)}
+        team = teams_by_id[plugin_config["team_id"]]
+        serializer_context = {"team": team, "get_team": (lambda t=team: t)}
 
         data = {
             "template_id": f"plugin-{plugin_id}",
@@ -88,10 +130,18 @@ def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True):
             "inputs": inputs,
             "inputs_schema": inputs_schema,
             "enabled": True,
-            "icon_url": plugin_config.plugin.icon,
+            "icon_url": plugin_config["plugin__icon"],
         }
 
         print("Attempting to create hog function...")  # noqa: T201
+        print(json.dumps(data, indent=2))  # noqa: T201
+
+        has_addon = team.organization.is_feature_available(AvailableFeature.DATA_PIPELINES)
+
+        if not has_addon:
+            print("Found a team without the required addon!", team.id, plugin_config["id"])  # noqa: T201
+            plugin_configs_without_addon.append(plugin_config["id"])
+            continue
 
         serializer = HogFunctionSerializer(
             data=data,
@@ -101,6 +151,9 @@ def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True):
         hog_functions.append(HogFunction(**serializer.validated_data))
 
     print(hog_functions)  # noqa: T201
+
+    if plugin_configs_without_addon:
+        print("Found plugin configs without the required addon!", plugin_configs_without_addon)  # noqa: T201
 
     if not hog_functions:
         print("No hog functions to create")  # noqa: T201
@@ -116,7 +169,9 @@ def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True):
     if not test_mode:
         print("Disabling old plugins")  # noqa: T201
         # Disable the old plugins
-        PluginConfig.objects.filter(id__in=[plugin_config.id for plugin_config in legacy_plugins]).update(enabled=False)
+        PluginConfig.objects.filter(id__in=[plugin_config["id"] for plugin_config in legacy_plugins]).update(
+            enabled=False
+        )
 
     print("Done")  # noqa: T201
 

--- a/posthog/cdp/templates/_internal/template_legacy_plugin.py
+++ b/posthog/cdp/templates/_internal/template_legacy_plugin.py
@@ -3,7 +3,7 @@ from posthog.cdp.templates.hog_function_template import HogFunctionTemplate
 
 def create_legacy_plugin_template(template_id: str) -> HogFunctionTemplate:
     return HogFunctionTemplate(
-        status="alpha",
+        status="free",  # NOTE: This is "free" in the sense that we use it to bypass needing the addon
         type="destination",
         id=f"{template_id}",
         name=f"Legacy plugin {template_id}",

--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -281,10 +281,7 @@ class PluginAttachment(models.Model):
             return None
 
         try:
-            if self.content_type == "application/json":
-                return json.loads(contents)
-
-            if self.content_type == "text/plain":
+            if self.content_type == "application/json" or self.content_type == "text/plain":
                 return contents.decode("utf-8")
             return None
         except Exception:

--- a/posthog/models/plugin.py
+++ b/posthog/models/plugin.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 import os
 import subprocess
 from dataclasses import dataclass


### PR DESCRIPTION
## Problem

* Tried this out and immediately crashed hard due to OOM
* Also noticed that some legacy plugins have orgs without the required addon so we need to bypass this logic to get it to work

## Changes

* Reworks the migration script to be loading as little info as possible
* Logs out teams in this special case without the addon
* Corrects some of the ways fields were loaded

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
