### PR TITLE
feat(web-analytics): Add conversion revenue graph

### DIFF
--- a/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
+++ b/frontend/src/queries/nodes/WebOverview/WebOverview.tsx
@@ -2,6 +2,7 @@ import { IconTrending } from '@posthog/icons'
 import { LemonSkeleton } from '@posthog/lemon-ui'
 import { useValues } from 'kea'
 import { getColorVar } from 'lib/colors'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconTrendingDown, IconTrendingFlat } from 'lib/lemon-ui/icons'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
@@ -46,7 +47,10 @@ export function WebOverview(props: {
 
     const samplingRate = webOverviewQueryResponse?.samplingRate
 
-    const numSkeletons = props.query.conversionGoal ? 4 : 5
+    let numSkeletons = props.query.conversionGoal ? 4 : 5
+    if (useFeatureFlag('WEB_REVENUE_TRACKING')) {
+        numSkeletons += 1
+    }
 
     return (
         <>

--- a/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
+++ b/frontend/src/scenes/web-analytics/webAnalyticsLogic.tsx
@@ -180,7 +180,7 @@ export enum GraphsTab {
     TOTAL_CONVERSIONS = 'TOTAL_CONVERSIONS',
     CONVERSION_RATE = 'CONVERSION_RATE',
     REVENUE_EVENTS = 'REVENUE_EVENTS',
-    REVENUE_CONVERSION = 'REVENUE_CONVERSION',
+    CONVERSION_REVENUE = 'CONVERSION_REVENUE',
 }
 
 export enum SourceTab {
@@ -706,6 +706,11 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                           }))
                         : []
 
+                const conversionRevenueSeries =
+                    conversionGoal && 'customEventName' in conversionGoal && includeRevenue
+                        ? revenueEventsSeries.filter((e) => e.event === conversionGoal.customEventName)
+                        : []
+
                 const createInsightProps = (tile: TileId, tab?: string): InsightLogicProps => {
                     return {
                         dashboardItemId: getDashboardItemId(tile, tab, false),
@@ -948,23 +953,23 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                           sessionsSeries,
                                       ])
                                     : null,
-                                !conversionGoal &&
-                                    revenueEventsSeries?.length &&
-                                    createGraphsTrendsTab(
-                                        GraphsTab.REVENUE_EVENTS,
-                                        'Revenue',
-                                        'Revenue',
-                                        revenueEventsSeries,
-                                        {
-                                            display:
-                                                revenueEventsSeries.length > 1
-                                                    ? ChartDisplayType.ActionsAreaGraph
-                                                    : ChartDisplayType.ActionsLineGraph,
-                                        },
-                                        {
-                                            compareFilter: revenueEventsSeries.length > 1 ? undefined : compareFilter,
-                                        }
-                                    ),
+                                !conversionGoal && revenueEventsSeries?.length
+                                    ? createGraphsTrendsTab(
+                                          GraphsTab.REVENUE_EVENTS,
+                                          'Revenue',
+                                          'Revenue',
+                                          revenueEventsSeries,
+                                          {
+                                              display:
+                                                  revenueEventsSeries.length > 1
+                                                      ? ChartDisplayType.ActionsAreaGraph
+                                                      : ChartDisplayType.ActionsLineGraph,
+                                          },
+                                          {
+                                              compareFilter: revenueEventsSeries.length > 1 ? undefined : compareFilter,
+                                          }
+                                      )
+                                    : null,
                                 conversionGoal && uniqueConversionsSeries
                                     ? createGraphsTrendsTab(
                                           GraphsTab.UNIQUE_CONVERSIONS,
@@ -991,6 +996,14 @@ export const webAnalyticsLogic = kea<webAnalyticsLogicType>([
                                               formula: 'A / B',
                                               aggregationAxisFormat: 'percentage_scaled',
                                           }
+                                      )
+                                    : null,
+                                conversionGoal && conversionRevenueSeries.length
+                                    ? createGraphsTrendsTab(
+                                          GraphsTab.CONVERSION_REVENUE,
+                                          'Conversion revenue',
+                                          'Conversion revenue',
+                                          conversionRevenueSeries
                                       )
                                     : null,
                             ] as (TabsTileTab | null)[]


### PR DESCRIPTION
## Problem

We didn't show a revenue graph when there was a conversion event

## Changes
<img width="995" alt="Screenshot 2025-01-28 at 14 28 07" src="https://github.com/user-attachments/assets/00e11ea0-d78f-4207-bb6c-3811963a8819" />


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
Local dev, took this screenshot
