### PR TITLE
fix(experiments): fix diagnostics URL for "no exposures"

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/NoResultEmptyState.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/NoResultEmptyState.tsx
@@ -39,9 +39,11 @@ export function NoResultEmptyState({ error, metric }: { error: any; metric: any 
         }
 
         const metricType = getMetricType(metric)
+        const hasMissingExposure = errorCode === ResultErrorCode.NO_EXPOSURES
+
         const requiredEvent =
             metricType === InsightType.TRENDS
-                ? errorCode === ResultErrorCode.NO_EXPOSURES
+                ? hasMissingExposure
                     ? metric.exposure_query?.series[0]?.event || '$feature_flag_called'
                     : metric.count_query?.series[0]?.event
                 : metric.funnels_query?.series[0]?.event
@@ -58,15 +60,24 @@ export function NoResultEmptyState({ error, metric }: { error: any; metric: any 
                 properties: [
                     {
                         key: `$feature/${experiment.feature_flag?.key}`,
-                        value:
-                            errorCode === ResultErrorCode.NO_EXPOSURES
-                                ? variants.map((variant) => variant.key)
-                                : errorCode === ResultErrorCode.NO_CONTROL_VARIANT
-                                ? ['control']
-                                : variants.slice(1).map((variant) => variant.key),
+                        value: hasMissingExposure
+                            ? variants.map((variant) => variant.key)
+                            : errorCode === ResultErrorCode.NO_CONTROL_VARIANT
+                            ? ['control']
+                            : variants.slice(1).map((variant) => variant.key),
                         operator: 'exact',
                         type: 'event',
                     },
+                    ...(hasMissingExposure
+                        ? [
+                              {
+                                  key: '$feature_flag',
+                                  value: [experiment.feature_flag?.key],
+                                  operator: 'exact',
+                                  type: 'event',
+                              },
+                          ]
+                        : []),
                 ],
                 filterTestAccounts: metric.count_query?.filter_test_accounts,
             },


### PR DESCRIPTION
## Problem

1. Click on the "Exposure events not received" in the diagnostics tooltip, which takes you to the Activity view.

![image](https://github.com/user-attachments/assets/345523e4-c822-40d6-b391-a9675fd71e41)

2. In the Activity view, there are some `feature_flag_called` events present, even though they shouldn't be. This is because the filter shows all `$feature_flag_called` events, and not just those belonging to the experiment.

![image](https://github.com/user-attachments/assets/8d36db57-c3f1-46b0-8451-2ed13e97c7e9)

## Changes
Add the missing filter condition which correctly filters the `$feature_flag_called events`. This replicates the filter from the [Trends query runner](https://github.com/PostHog/posthog/blob/master/posthog/hogql_queries/experiments/experiment_trends_query_runner.py#L230-L235).

|Before|After|
|----|----|
|![image](https://github.com/user-attachments/assets/6efb04d4-bc6b-4002-9fe4-03f3c831289e)|![image](https://github.com/user-attachments/assets/21e11838-a46f-444b-af2a-e0b8eb010514)|

## How did you test this code?
👀 