### PR TITLE
fix(experiments): Update references to first primary metric

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/DataCollection.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DataCollection.tsx
@@ -21,11 +21,12 @@ export function DataCollection(): JSX.Element {
         funnelResultsPersonsTotal,
         actualRunningTime,
         minimumDetectableEffect,
+        firstPrimaryMetric,
     } = useValues(experimentLogic)
 
     const { openExperimentCollectionGoalModal } = useActions(experimentLogic)
 
-    const metricType = getMetricType(experiment.metrics[0])
+    const metricType = getMetricType(firstPrimaryMetric)
 
     const recommendedRunningTime = experiment?.parameters?.recommended_running_time || 1
     const recommendedSampleSize = experiment?.parameters?.recommended_sample_size || 100
@@ -172,8 +173,8 @@ export function DataCollection(): JSX.Element {
 export function DataCollectionGoalModal({ experimentId }: { experimentId: Experiment['id'] }): JSX.Element {
     const {
         isExperimentCollectionGoalModalOpen,
-        experiment,
         getMetricType,
+        firstPrimaryMetric,
         trendMetricInsightLoading,
         funnelMetricInsightLoading,
     } = useValues(experimentLogic({ experimentId }))
@@ -181,7 +182,7 @@ export function DataCollectionGoalModal({ experimentId }: { experimentId: Experi
         useActions(experimentLogic({ experimentId }))
 
     const isInsightLoading =
-        getMetricType(experiment.metrics[0]) === InsightType.TRENDS
+        getMetricType(firstPrimaryMetric) === InsightType.TRENDS
             ? trendMetricInsightLoading
             : funnelMetricInsightLoading
 

--- a/frontend/src/scenes/experiments/ExperimentView/DataCollectionCalculator.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DataCollectionCalculator.tsx
@@ -107,12 +107,12 @@ function TrendCalculation({ experimentId }: ExperimentCalculatorProps): JSX.Elem
 }
 
 export function DataCollectionCalculator({ experimentId }: ExperimentCalculatorProps): JSX.Element {
-    const { getMetricType, minimumDetectableEffect, experiment, conversionMetrics } = useValues(
+    const { getMetricType, firstPrimaryMetric, minimumDetectableEffect, experiment, conversionMetrics } = useValues(
         experimentLogic({ experimentId })
     )
     const { setExperiment } = useActions(experimentLogic({ experimentId }))
 
-    const metricType = getMetricType(experiment.metrics[0])
+    const metricType = getMetricType(firstPrimaryMetric)
 
     // :KLUDGE: need these to mount the Query component to load the insight */
     const insightLogicInstance = insightLogic({
@@ -126,8 +126,8 @@ export function DataCollectionCalculator({ experimentId }: ExperimentCalculatorP
             kind: NodeKind.InsightVizNode,
             source:
                 metricType === InsightType.FUNNELS
-                    ? (experiment.metrics[0] as ExperimentFunnelsQuery).funnels_query
-                    : (experiment.metrics[0] as ExperimentTrendsQuery).count_query,
+                    ? (firstPrimaryMetric as ExperimentFunnelsQuery).funnels_query
+                    : (firstPrimaryMetric as ExperimentTrendsQuery).count_query,
         }
     }
 
@@ -217,7 +217,7 @@ export function DataCollectionCalculator({ experimentId }: ExperimentCalculatorP
                         The calculations are based on the events received in the last 14 days. This event count may
                         differ from what was considered in earlier estimates.
                     </LemonBanner>
-                    {getMetricType(experiment.metrics[0]) === InsightType.TRENDS ? (
+                    {getMetricType(firstPrimaryMetric) === InsightType.TRENDS ? (
                         <TrendCalculation experimentId={experimentId} />
                     ) : (
                         <FunnelCalculation experimentId={experimentId} />

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1495,8 +1495,8 @@ export const experimentLogic = kea<experimentLogicType>([
                 },
         ],
         getIndexForVariant: [
-            (s) => [s.experiment, s.getMetricType, s.firstPrimaryMetric],
-            (experiment, getMetricType, firstPrimaryMetric) =>
+            (s) => [s.getMetricType, s.firstPrimaryMetric],
+            (getMetricType, firstPrimaryMetric) =>
                 (
                     metricResult: CachedExperimentTrendsQueryResponse | CachedExperimentFunnelsQueryResponse | null,
                     variant: string


### PR DESCRIPTION
Follow up from https://github.com/PostHog/posthog/pull/27866

## Changes

Replaces references to `experiment.metrics[0]` with `firstPrimaryMetric`, to accommodate a shared metric as the first primary metric. Doing so ensures the data collection and MDE components display something.

It's a bit wonky to have `getMetricType` default to funnel when `metric` is undefined, but that's the current behavior and I don't want to refactor further right now.

Related https://github.com/PostHog/posthog/issues/26933

**Before**

![CleanShot 2025-01-28 at 08 10 38@2x](https://github.com/user-attachments/assets/0f5ff6f0-bf27-4f08-8895-47e1b420c79e)

**After**

![CleanShot 2025-01-28 at 08 10 11@2x](https://github.com/user-attachments/assets/be1f5a53-fd46-4dfb-a08f-65411aaea864)

## How did you test this code?

Manual review.