### PR TITLE
feat: Make nodejs based CDP templates available to django

### DIFF
--- a/plugin-server/.gitignore
+++ b/plugin-server/.gitignore
@@ -9,3 +9,5 @@ tmp
 *.0x
 coverage/
 .tmp/
+
+cdp-templates.json

--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -30,7 +30,8 @@
         "services:clean": "cd .. && docker compose -f docker-compose.dev.yml rm -v",
         "services": "pnpm services:stop && pnpm services:clean && pnpm services:start",
         "build:cyclotron": "cd ../rust/cyclotron-node && pnpm run package",
-        "pnpm:devPreinstall": "pnpm run build:cyclotron"
+        "pnpm:devPreinstall": "pnpm run build:cyclotron",
+        "cdp:templates": "NODE_ENV=dev BASE_DIR=.. node -r @swc-node/register src/scripts/generate-cdp-templates.ts"
     },
     "graphile-worker": {
         "maxContiguousErrors": 300

--- a/plugin-server/src/cdp/templates/index.ts
+++ b/plugin-server/src/cdp/templates/index.ts
@@ -1,0 +1,8 @@
+import { template as webhookTemplate } from './_destinations/webhook/webhook.template'
+import { template as defaultTemplate } from './_transformations/default/default.template'
+import { template as geoipTemplate } from './_transformations/geoip/geoip.template'
+
+export const DESTINATION_TEMPLATES = [webhookTemplate]
+export const TRANSFORMATION_TEMPLATES = [geoipTemplate, defaultTemplate]
+
+export const ALL_TEMPLATES = [...DESTINATION_TEMPLATES, ...TRANSFORMATION_TEMPLATES]

--- a/plugin-server/src/scripts/generate-cdp-templates.ts
+++ b/plugin-server/src/scripts/generate-cdp-templates.ts
@@ -1,0 +1,8 @@
+import fs from 'fs'
+import path from 'path'
+
+import { ALL_TEMPLATES } from '../cdp/templates'
+
+const destination = path.join(__dirname, '..', '..', 'cdp-templates.json')
+
+fs.writeFileSync(destination, JSON.stringify(ALL_TEMPLATES, null, 2))


### PR DESCRIPTION
## Problem

We are slowly moving templates over to nodejs. This makes those templates available in both sides


## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
