### PR TITLE
fix(insights): add event listeners for canvas context errors

### DIFF
--- a/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
+++ b/frontend/src/scenes/insights/views/LineGraph/LineGraph.tsx
@@ -1,5 +1,6 @@
 import 'chartjs-adapter-dayjs-3'
 
+import * as Sentry from '@sentry/react'
 import { LegendOptions } from 'chart.js'
 import { DeepPartial } from 'chart.js/dist/types/utils'
 import annotationPlugin from 'chartjs-plugin-annotation'
@@ -315,6 +316,28 @@ export function LineGraph_({
         return () => {
             const tooltipEl = document.getElementById('InsightTooltipWrapper')
             tooltipEl?.remove()
+        }
+    }, [])
+
+    // Add event listeners to canvas
+    useEffect(() => {
+        const canvas = canvasRef.current
+
+        if (canvas) {
+            const handleEvent = (event: Event): void => {
+                console.error(event)
+                Sentry.captureException(event)
+            }
+
+            canvas.addEventListener('contextlost', handleEvent)
+            canvas.addEventListener('webglcontextcreationerror', handleEvent)
+            canvas.addEventListener('webglcontextlost', handleEvent)
+
+            return () => {
+                canvas.removeEventListener('contextlost', handleEvent)
+                canvas.removeEventListener('webglcontextcreationerror', handleEvent)
+                canvas.removeEventListener('webglcontextlost', handleEvent)
+            }
         }
     }, [])
 


### PR DESCRIPTION
## Problem

We have [a customer](https://posthoghelp.zendesk.com/agent/tickets/22958) that is experiencing issues loading insights on dashboads with large amounts of data.

## Changes

I noticed the "sad face" icon from Chrome on canvas elements, indicating a problem with the canvas context. This PR aims to capture these problems in Sentry.

## How did you test this code?

Errors should pop up in Sentry