### PR TITLE
fix(data-warehouse): Use SSH if available when getting row counts

### DIFF
--- a/posthog/warehouse/api/external_data_source.py
+++ b/posthog/warehouse/api/external_data_source.py
@@ -1084,7 +1084,10 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 filtered_results = [
                     (table_name, filter_postgres_incremental_fields(columns)) for table_name, columns in result.items()
                 ]
-                rows = get_postgres_row_count(host, port, database, user, password, schema)
+                try:
+                    rows = get_postgres_row_count(host, port, database, user, password, schema, ssh_tunnel)
+                except:
+                    pass
 
             elif source_type == ExternalDataSource.Type.MYSQL:
                 filtered_results = [

--- a/posthog/warehouse/models/external_data_schema.py
+++ b/posthog/warehouse/models/external_data_schema.py
@@ -304,46 +304,56 @@ def filter_postgres_incremental_fields(columns: list[tuple[str, str]]) -> list[t
 
 
 def get_postgres_row_count(
-    host: str, port: str, database: str, user: str, password: str, schema: str
+    host: str, port: str, database: str, user: str, password: str, schema: str, ssh_tunnel: SSHTunnel
 ) -> dict[str, int]:
-    connection = psycopg2.connect(
-        host=host,
-        port=port,
-        dbname=database,
-        user=user,
-        password=password,
-        sslmode="prefer",
-        connect_timeout=5,
-        sslrootcert="/tmp/no.txt",
-        sslcert="/tmp/no.txt",
-        sslkey="/tmp/no.txt",
-    )
+    def get_row_count(postgres_host: str, postgres_port: int):
+        connection = psycopg2.connect(
+            host=postgres_host,
+            port=postgres_port,
+            dbname=database,
+            user=user,
+            password=password,
+            sslmode="prefer",
+            connect_timeout=5,
+            sslrootcert="/tmp/no.txt",
+            sslcert="/tmp/no.txt",
+            sslkey="/tmp/no.txt",
+        )
 
-    try:
-        with connection.cursor() as cursor:
-            cursor.execute(
-                "SELECT tablename as table_name FROM pg_tables WHERE schemaname = %(schema)s",
-                {"schema": schema},
-            )
-            tables = cursor.fetchall()
-
-            if not tables:
-                return {}
-
-            counts = [
-                sql.SQL("SELECT {table_name} AS table_name, COUNT(*) AS row_count FROM {schema}.{table}").format(
-                    table_name=sql.Literal(table[0]), schema=sql.Identifier(schema), table=sql.Identifier(table[0])
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT tablename as table_name FROM pg_tables WHERE schemaname = %(schema)s",
+                    {"schema": schema},
                 )
-                for table in tables
-            ]
+                tables = cursor.fetchall()
 
-            union_counts = sql.SQL(" UNION ALL ").join(counts)
-            cursor.execute(union_counts)
-            row_count_result = cursor.fetchall()
-            row_counts = {row[0]: row[1] for row in row_count_result}
-        return row_counts
-    finally:
-        connection.close()
+                if not tables:
+                    return {}
+
+                counts = [
+                    sql.SQL("SELECT {table_name} AS table_name, COUNT(*) AS row_count FROM {schema}.{table}").format(
+                        table_name=sql.Literal(table[0]), schema=sql.Identifier(schema), table=sql.Identifier(table[0])
+                    )
+                    for table in tables
+                ]
+
+                union_counts = sql.SQL(" UNION ALL ").join(counts)
+                cursor.execute(union_counts)
+                row_count_result = cursor.fetchall()
+                row_counts = {row[0]: row[1] for row in row_count_result}
+            return row_counts
+        finally:
+            connection.close()
+
+    if ssh_tunnel.enabled:
+        with ssh_tunnel.get_tunnel(host, int(port)) as tunnel:
+            if tunnel is None:
+                raise Exception("Can't open tunnel to SSH server")
+
+            return get_row_count(tunnel.local_bind_host, tunnel.local_bind_port)
+
+    return get_row_count(host, int(port))
 
 
 def get_postgres_schemas(


### PR DESCRIPTION
## Problem
- If a user wants to use SSH tunneling with their postgres source, then the `database_schema` endpoint fails because getting row_counts didn't cater for users using a SSH tunnel

## Changes
- Use the ssh tunnel if there exists one
- Wrap getting row counts in an empty try/except - connection errors are handled when we request schemas

## Does this work well for both Cloud and self-hosted?
Yep

## How did you test this code?
Tested with a postgres behind a SSH server