### PR TITLE
fix: playlist keys are unexpectedly un-unique

### DIFF
--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -159,7 +159,7 @@ export function Group(): JSX.Element {
                                 ) : (
                                     <div className="SessionRecordingPlaylistHeightWrapper">
                                         <SessionRecordingsPlaylist
-                                            logicKey="groups-recordings"
+                                            logicKey={`groups-recordings-${groupKey}-${groupTypeIndex}`}
                                             updateSearchParams
                                             filters={{
                                                 duration: [

--- a/frontend/src/scenes/persons/PersonScene.tsx
+++ b/frontend/src/scenes/persons/PersonScene.tsx
@@ -239,7 +239,11 @@ export function PersonScene(): JSX.Element | null {
                                     </div>
                                 ) : null}
                                 <div className="SessionRecordingPlaylistHeightWrapper">
-                                    <SessionRecordingsPlaylist personUUID={person.uuid} updateSearchParams />
+                                    <SessionRecordingsPlaylist
+                                        logicKey={`person-scene-${person.uuid}`}
+                                        personUUID={person.uuid}
+                                        updateSearchParams
+                                    />
                                 </div>
                             </>
                         ),


### PR DESCRIPTION
We made playlists remember their filters in https://github.com/PostHog/posthog/pull/27839 but it turns out not all instances of playlist logics had unique keys...

That meant for those non-unique playlist instances (notably in groups) filters would not be those expected :/

Let's uniquify them

https://posthoghelp.zendesk.com/agent/tickets/24150 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26104)
