### PR TITLE
chore(data-warehouse): Remove references to V2_PIPELINE_ENABLED_TEAM_IDS

### DIFF
--- a/posthog/settings/data_warehouse.py
+++ b/posthog/settings/data_warehouse.py
@@ -1,5 +1,4 @@
 import os
-from posthog.settings.utils import get_list
 
 AIRBYTE_API_KEY = os.getenv("AIRBYTE_API_KEY", None)
 AIRBYTE_BUCKET_REGION = os.getenv("AIRBYTE_BUCKET_REGION", None)
@@ -10,5 +9,3 @@ AIRBYTE_BUCKET_DOMAIN = os.getenv("AIRBYTE_BUCKET_DOMAIN", None)
 BUCKET_URL = os.getenv("BUCKET_URL", None)
 AIRBYTE_BUCKET_NAME = os.getenv("AIRBYTE_BUCKET_NAME", None)
 BUCKET = "test-pipeline"
-
-V2_PIPELINE_ENABLED_TEAM_IDS = get_list(os.getenv("V2_PIPELINE_ENABLED_TEAM_IDS", ""))

--- a/posthog/temporal/data_imports/util.py
+++ b/posthog/temporal/data_imports/util.py
@@ -38,7 +38,3 @@ def is_posthog_team(team_id: int) -> bool:
 
     region = get_from_env("CLOUD_DEPLOYMENT", optional=True)
     return (region == "EU" and team_id == 1) or (region == "US" and team_id == 2)
-
-
-def is_enabled_for_team(team_id: int) -> bool:
-    return str(team_id) in settings.V2_PIPELINE_ENABLED_TEAM_IDS


### PR DESCRIPTION
## Changes
- `V2_PIPELINE_ENABLED_TEAM_IDS` is useless now that the new pipeline has been released
- Its being removed from charts too - https://github.com/PostHog/charts/pull/3166