### PR TITLE
fix(editor-3001): conditional formatting spacing

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/ConditionalFormatting/ConditionalFormattingTab.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/ConditionalFormatting/ConditionalFormattingTab.tsx
@@ -36,7 +36,7 @@ export const ConditionalFormattingTab = (): JSX.Element => {
         useActions(dataVisualizationLogic)
 
     return (
-        <div className="flex flex-col w-full ConditionalFormattingTab">
+        <div className="flex flex-col ConditionalFormattingTab">
             <p>You can add rules to make the cells in the table change color if they meet certain conditions.</p>
 
             {conditionalFormattingRules.length > 0 && (

--- a/frontend/src/queries/nodes/DataVisualization/Components/SideBar.scss
+++ b/frontend/src/queries/nodes/DataVisualization/Components/SideBar.scss
@@ -8,7 +8,6 @@
     .SideBar {
         min-width: 18rem;
         max-width: 18rem;
-        min-height: var(--viz-min-height);
         border-radius: var(--radius);
 
         .LemonInput.LemonInput--medium {

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -270,7 +270,7 @@ function InternalDataTableVisualization(
     }
 
     return (
-        <div className="h-full hide-scrollbar flex flex-1 gap-2">
+        <div className="DataVisualization h-full hide-scrollbar flex flex-1 gap-2">
             <div className="relative w-full flex flex-col gap-4 flex-1">
                 <div className="flex flex-1 flex-row gap-4 overflow-scroll hide-scrollbar">
                     {isChartSettingsPanelOpen && (


### PR DESCRIPTION
## Problem

- when porting the component to the new editor there was a missing style
![CleanShot 2025-01-28 at 16 24 58@2x](https://github.com/user-attachments/assets/4ade5ce1-3ab8-4897-9c24-354e5447406f)

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- restore missing style
![CleanShot 2025-01-28 at 16 24 31@2x](https://github.com/user-attachments/assets/13215494-d750-41f4-8244-ad26eea60100)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
