### PR TITLE
fix(flags): prevent error when editing flag which lacks payloads

### DIFF
--- a/frontend/src/scenes/feature-flags/activityDescriptions.tsx
+++ b/frontend/src/scenes/feature-flags/activityDescriptions.tsx
@@ -62,7 +62,7 @@ const featureFlagActionsMapping: Record<
             } else {
                 filtersAfter.payloads &&
                     Object.keys(filtersAfter.payloads).forEach((key: string) => {
-                        const changedPayload = filtersAfter.payloads[key]?.toString() || null
+                        const changedPayload = filtersAfter.payloads?.[key]?.toString() || null
                         changes.push(<SentenceList listParts={[changedPayload]} prefix="changed payload to" />)
                     })
 
@@ -145,7 +145,7 @@ const featureFlagActionsMapping: Record<
         if (isMultivariateFlag) {
             filtersAfter.payloads &&
                 Object.keys(filtersAfter.payloads).forEach((key: string) => {
-                    const changedPayload = filtersAfter.payloads[key]?.toString() || null
+                    const changedPayload = filtersAfter.payloads?.[key]?.toString() || null
                     changes.push(
                         <SentenceList
                             listParts={[

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -322,7 +322,7 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                             ValidationErrorType
                         >[],
                         payloads: {
-                            true: validatePayloadRequired(filters?.payloads['true'], is_remote_configuration),
+                            true: validatePayloadRequired(filters?.payloads?.['true'], is_remote_configuration),
                         } as unknown as DeepPartialMap<Record<string, JsonType>, ValidationErrorType> | undefined,
                         // Forced cast necessary to prevent Kea's typechecking from raising "Type instantiation
                         // is excessively deep and possibly infinite" error

--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -129,7 +129,7 @@ export function validateFeatureFlagKey(key: string): string | undefined {
         : undefined
 }
 
-function validatePayloadRequired(payload: JsonType, is_remote_configuration: boolean): string | undefined {
+function validatePayloadRequired(is_remote_configuration: boolean, payload?: JsonType): string | undefined {
     if (!is_remote_configuration) {
         return undefined
     }
@@ -322,9 +322,9 @@ export const featureFlagLogic = kea<featureFlagLogicType>([
                             ValidationErrorType
                         >[],
                         payloads: {
-                            true: validatePayloadRequired(filters?.payloads?.['true'], is_remote_configuration),
-                        } as unknown as DeepPartialMap<Record<string, JsonType>, ValidationErrorType> | undefined,
-                        // Forced cast necessary to prevent Kea's typechecking from raising "Type instantiation
+                            true: validatePayloadRequired(is_remote_configuration, filters?.payloads?.['true']),
+                        } as any,
+                        // Forced any cast necessary to prevent Kea's typechecking from raising "Type instantiation
                         // is excessively deep and possibly infinite" error
                     },
                 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2958,7 +2958,7 @@ export interface FeatureFlagFilters {
     groups: FeatureFlagGroupType[]
     multivariate: MultivariateFlagOptions | null
     aggregation_group_type_index?: integer | null
-    payloads: Record<string, JsonType>
+    payloads?: Record<string, JsonType>
     super_groups?: FeatureFlagGroupType[]
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2956,7 +2956,7 @@ export interface MultivariateFlagOptions {
 
 export interface FeatureFlagFilters {
     groups: FeatureFlagGroupType[]
-    multivariate: MultivariateFlagOptions | null
+    multivariate?: MultivariateFlagOptions | null
     aggregation_group_type_index?: integer | null
     payloads?: Record<string, JsonType>
     super_groups?: FeatureFlagGroupType[]


### PR DESCRIPTION
## Problem

Resolves https://posthog.sentry.io/issues/6252759400/?notification_uuid=fffdfac1-f174-411b-be1f-904496a409a6&project=1899813&referrer=assigned_activity-email

Repro case: flags generated for an early access feature do not have `payloads` in their filters json blob:

<img width="378" alt="Screenshot 2025-01-28 at 1 41 13 PM" src="https://github.com/user-attachments/assets/9f5622b3-c8a9-4e60-8fdb-44123053cc3e" />


## Changes

- Fix known bug that caused sentry error above
- Make `payloads` and `multivariate` optional in TS types to prevent more bugs in future


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Repro'd sentry error and validated fix prevents React error boundary
