### PR TITLE
fix(breadcrumb-sources): Add contextual breadcrumb on source page 

### DIFF
--- a/frontend/src/scenes/pipeline/PipelineNode.tsx
+++ b/frontend/src/scenes/pipeline/PipelineNode.tsx
@@ -1,4 +1,4 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { NotFound } from 'lib/components/NotFound'
 import { PageHeader } from 'lib/components/PageHeader'
@@ -6,6 +6,8 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs/LemonTabs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { capitalizeFirstLetter } from 'lib/utils'
+import { useEffect } from 'react'
+import { dataWarehouseSourceSettingsLogic } from 'scenes/data-warehouse/settings/source/dataWarehouseSourceSettingsLogic'
 import { Schemas } from 'scenes/data-warehouse/settings/source/Schemas'
 import { SourceConfiguration } from 'scenes/data-warehouse/settings/source/SourceConfiguration'
 import { Syncs } from 'scenes/data-warehouse/settings/source/Syncs'
@@ -55,7 +57,17 @@ export const scene: SceneExport = {
 export function PipelineNode(params: { stage?: string; id?: string } = {}): JSX.Element {
     const { stage, id } = paramsToProps({ params })
     const { currentTab, node } = useValues(pipelineNodeLogic)
+    const { setBreadcrumbTitle } = useActions(pipelineNodeLogic)
+
+    const dataWarehouseLogic = dataWarehouseSourceSettingsLogic({ id: String(node.id) })
+    const { source } = useValues(dataWarehouseLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+
+    useEffect(() => {
+        if (source) {
+            setBreadcrumbTitle(`${source.source_type}${source.prefix.length > 0 ? ': ' : ''}${source.prefix}`)
+        }
+    }, [setBreadcrumbTitle, source])
 
     if (!stage) {
         return <NotFound object="pipeline stage" />


### PR DESCRIPTION
## Problem

We currently have no idea what source we are looking at on the source by id page because the breadcrumb title is not updated or initialized.

### Before
<img width="440" alt="image" src="https://github.com/user-attachments/assets/30967cfd-02e8-420c-8d0f-a6ab538ade77" />

### After w/prefix
<img width="548" alt="image" src="https://github.com/user-attachments/assets/cc5e1f22-33e0-4fa1-888f-40429e3e0dda" />

### After w/o prefix
<img width="472" alt="image" src="https://github.com/user-attachments/assets/25b442a9-888b-4406-80cd-fcaa07fc325e" />

## Changes
- [x] Update breadcrumb w/ prefix

## Does this work well for both Cloud and self-hosted?

Yes
