### PR TITLE
fix: no longer persist Survey editing state

### DIFF
--- a/frontend/src/scenes/surveys/Survey.tsx
+++ b/frontend/src/scenes/surveys/Survey.tsx
@@ -6,6 +6,7 @@ import { FlagSelector } from 'lib/components/FlagSelector'
 import { NotFound } from 'lib/components/NotFound'
 import { PageHeader } from 'lib/components/PageHeader'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { useEffect } from 'react'
 import { featureFlagLogic } from 'scenes/feature-flags/featureFlagLogic'
 import { FeatureFlagReleaseConditions } from 'scenes/feature-flags/FeatureFlagReleaseConditions'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -27,7 +28,14 @@ export const scene: SceneExport = {
 }
 
 export function SurveyComponent({ id }: { id?: string } = {}): JSX.Element {
+    const { editingSurvey } = useActions(surveyLogic)
     const { isEditingSurvey, surveyMissing } = useValues(surveyLogic)
+
+    useEffect(() => {
+        return () => {
+            editingSurvey(false)
+        }
+    }, [editingSurvey])
 
     if (surveyMissing) {
         return <NotFound object="survey" />


### PR DESCRIPTION
## Problem

Paper cut on Survey editing flow: no longer persist Survey editing state if you navigate to another page and then click on the Survey again.

## Does this work well for both Cloud and self-hosted?

N/A

## How did you test this code?

Tested locally:

1. Click on edit survey
2. Navigate back to Surveys page
3. Click on the survey again
4. Check if editing form is not shown

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
