### PR TITLE
fix: livestream: disable compression in promhttp handler

### DIFF
--- a/livestream/main.go
+++ b/livestream/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"log"
 	"net/http"
 	"time"
@@ -103,7 +104,11 @@ func main() {
 	// Routes
 	e.GET("/", index)
 
-	e.GET("/metrics", echo.WrapHandler(promhttp.Handler()))
+	// For details why promhttp.Handler won't work: https://github.com/prometheus/client_golang/issues/622
+	e.GET("/metrics", echo.WrapHandler(promhttp.InstrumentMetricHandler(
+		prometheus.DefaultRegisterer,
+		promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{DisableCompression: true}),
+	)))
 
 	e.GET("/served", servedHandler(stats))
 

--- a/livestream/main.go
+++ b/livestream/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"log"
 	"net/http"
 	"time"
@@ -11,6 +10,7 @@ import (
 	"github.com/labstack/echo-contrib/echoprometheus"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/viper"
 )


### PR DESCRIPTION
## Problem

livestream: promhttp and echo compression was on.

## Changes

disable compression on promhttp level

## Does this work well for both Cloud and self-hosted?

yes

## How did you test this code?

local run and test