### PR TITLE
fix: adds default value for survey feedback button appearance

### DIFF
--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -43,6 +43,9 @@ export const defaultSurveyAppearance = {
     displayThankYouMessage: true,
     thankYouMessageHeader: 'Thank you for your feedback!',
     position: 'right',
+    widgetType: 'tab' as const,
+    widgetLabel: 'Feedback',
+    widgetColor: 'black',
 }
 
 export const defaultSurveyFieldValues = {

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -1332,6 +1332,19 @@ function sanitizeQuestions(surveyPayload: Partial<Survey>): Partial<Survey> {
     const sanitizedThankYouHeader = sanitizeHTML(surveyPayload.appearance?.thankYouMessageHeader || '')
     const sanitizedThankYouDescription = sanitizeHTML(surveyPayload.appearance?.thankYouMessageDescription || '')
 
+    const appearance = {
+        ...surveyPayload.appearance,
+        ...(sanitizedThankYouHeader && { thankYouMessageHeader: sanitizedThankYouHeader }),
+        ...(sanitizedThankYouDescription && { thankYouMessageDescription: sanitizedThankYouDescription }),
+    }
+
+    // Remove widget-specific fields if survey type is not Widget
+    if (surveyPayload.type !== 'widget') {
+        delete appearance.widgetType
+        delete appearance.widgetLabel
+        delete appearance.widgetColor
+    }
+
     return {
         ...surveyPayload,
         questions: surveyPayload.questions?.map((rawQuestion) => {
@@ -1341,10 +1354,6 @@ function sanitizeQuestions(surveyPayload: Partial<Survey>): Partial<Survey> {
                 question: sanitizeHTML(rawQuestion.question || ''),
             }
         }),
-        appearance: {
-            ...surveyPayload.appearance,
-            ...(sanitizedThankYouHeader && { thankYouMessageHeader: sanitizedThankYouHeader }),
-            ...(sanitizedThankYouDescription && { thankYouMessageDescription: sanitizedThankYouDescription }),
-        },
+        appearance,
     }
 }


### PR DESCRIPTION
adds default appearance values for Survey feedback button.

otherwise, if you select "Feedback button", but don't do any changes to the Appearances tab, the button doesn't show up.

## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

1. create survey with feedback button
2. dont do any appearance changes
3. check if button is shown
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
