### PR TITLE
feat(LLM-Observability): New Error UI

### DIFF
--- a/products/llm_observability/frontend/ConversationDisplay/MetadataHeader.tsx
+++ b/products/llm_observability/frontend/ConversationDisplay/MetadataHeader.tsx
@@ -23,7 +23,7 @@ export function MetadataHeader({
 }): JSX.Element {
     return (
         <div className={classNames('flex flex-wrap gap-2', className)}>
-            {isError && <LemonTag type="warning">Error</LemonTag>}
+            {isError && <LemonTag type="danger">Error</LemonTag>}
             {typeof latency === 'number' && (
                 <MetadataTag label="Latency">{`${Math.round(latency * 10e2) / 10e2} s of latency`}</MetadataTag>
             )}

--- a/products/llm_observability/frontend/LLMInputOutput.tsx
+++ b/products/llm_observability/frontend/LLMInputOutput.tsx
@@ -1,4 +1,5 @@
 import { IconArrowDown, IconArrowUp } from 'lib/lemon-ui/icons'
+import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 
 export function LLMInputOutput({
     inputDisplay,
@@ -14,17 +15,20 @@ export function LLMInputOutput({
     bordered?: boolean
 }): JSX.Element {
     return (
-        <div className={bordered ? 'bg-bg-light rounded-lg border p-2' : undefined}>
-            <h4 className="flex items-center gap-x-1.5 text-xs font-semibold mb-2">
-                <IconArrowUp className="text-base" />
-                {inputHeading}
-            </h4>
-            {inputDisplay}
-            <h4 className="flex items-center gap-x-1.5 text-xs font-semibold my-2">
-                <IconArrowDown className="text-base" />
-                {outputHeading}
-            </h4>
-            {outputDisplay}
-        </div>
+        <>
+            <LemonDivider className="my-3" />
+            <div className={bordered ? 'bg-bg-light rounded-lg border p-2' : undefined}>
+                <h4 className="flex items-center gap-x-1.5 text-xs font-semibold mb-2">
+                    <IconArrowUp className="text-base" />
+                    {inputHeading}
+                </h4>
+                {inputDisplay}
+                <h4 className="flex items-center gap-x-1.5 text-xs font-semibold my-2">
+                    <IconArrowDown className="text-base" />
+                    {outputHeading}
+                </h4>
+                {outputDisplay}
+            </div>
+        </>
     )
 }

--- a/products/llm_observability/frontend/LLMObservabilityTraceScene.tsx
+++ b/products/llm_observability/frontend/LLMObservabilityTraceScene.tsx
@@ -211,7 +211,7 @@ const TreeNode = React.memo(function TraceNode({
 
     const children = [
         isLLMTraceEvent(item) && item.properties.$ai_is_error && (
-            <LemonTag key="error-tag" type="warning">
+            <LemonTag key="error-tag" type="danger">
                 Error
             </LemonTag>
         ),
@@ -375,9 +375,9 @@ function EventContent({ event }: { event: LLMTrace | LLMTraceEvent | null }): JS
                             <ConversationMessagesDisplay
                                 input={event.properties.$ai_input}
                                 output={
-                                    event.properties.$ai_output_choices ??
-                                    event.properties.$ai_output ??
-                                    event.properties.$ai_error
+                                    event.properties.$ai_is_error
+                                        ? event.properties.$ai_error
+                                        : event.properties.$ai_output_choices ?? event.properties.$ai_output
                                 }
                                 httpStatus={event.properties.$ai_http_status}
                                 raisedError={event.properties.$ai_is_error}

--- a/products/llm_observability/frontend/LLMObservabilityTraceScene.tsx
+++ b/products/llm_observability/frontend/LLMObservabilityTraceScene.tsx
@@ -303,6 +303,11 @@ function EventContentDisplay({
     output: unknown
     raisedError?: boolean
 }): JSX.Element {
+    if (!input && !output) {
+        // If we have no data here we should not render anything
+        // In future plan to point docs to show how to add custom trace events
+        return <></>
+    }
     return (
         <LLMInputOutput
             inputDisplay={
@@ -365,7 +370,6 @@ function EventContent({ event }: { event: LLMTrace | LLMTraceEvent | null }): JS
                         )}
                         {isLLMTraceEvent(event) && <ParametersHeader eventProperties={event.properties} />}
                     </header>
-                    <LemonDivider className="my-3" />
                     {isLLMTraceEvent(event) ? (
                         event.event === '$ai_generation' ? (
                             <ConversationMessagesDisplay


### PR DESCRIPTION
<img width="1379" alt="Screenshot 2025-01-28 at 5 22 23 PM" src="https://github.com/user-attachments/assets/64529dda-d0e6-40d4-a748-dcbaae263bbf" />
<img width="1381" alt="Screenshot 2025-01-28 at 5 27 14 PM" src="https://github.com/user-attachments/assets/76eb8511-deb3-488a-b66b-629c8ec07c57" />

New Error UI for LLM Observability

Testing done manually 