### PR TITLE
chore: remove missing .env file requirement from PyCharm PostHog run config

### DIFF
--- a/.run/PostHog.run.xml
+++ b/.run/PostHog.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="PostHog" type="Python.DjangoServer" factoryName="Django server">
     <module name="posthog" />
-    <option name="ENV_FILES" value="$PROJECT_DIR$/.env" />
+    <option name="ENV_FILES" value="" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>


### PR DESCRIPTION
## Linked Issues
 - Closes https://github.com/PostHog/posthog/issues/28007

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
- The run configuration for the PostHog backend service in PyCharm fails due to the absence of the required `.env` file

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

<!-- 👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._ -->
- Removed the `.env` file requirement from the run configuration


## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->
- N/A

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
- N/A



## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (altering code without changing its external behaviour)
- [ ] Documentation change
- [x] Other


## Checklist:

- [ ] Development completed
- [ ] Comments added to code (wherever necessary)
- [ ] Documentation updated (if applicable)
- [ ] Added tests [Unit tests/Integration tests] (if required)
- [x] Tested changes locally


## Follow-up tasks (if any):

- None


## Additional Comments
- None