### PR TITLE
fix: send the correct io_manager resource for the env in Dag

### DIFF
--- a/dags/definitions.py
+++ b/dags/definitions.py
@@ -40,8 +40,5 @@ defs = Definitions(
     assets=all_assets,
     jobs=[squash_person_overrides, deletes.deletes_job],
     schedules=[deletes_schedule],
-    resources={
-        "cluster": ClickhouseClusterResource.configure_at_launch(),
-        "io_manager": resources["io_manager"],
-    },
+    resources=resources,
 )

--- a/dags/definitions.py
+++ b/dags/definitions.py
@@ -42,5 +42,6 @@ defs = Definitions(
     schedules=[deletes_schedule],
     resources={
         "cluster": ClickhouseClusterResource.configure_at_launch(),
+        "io_manager": resources["io_manager"],
     },
 )


### PR DESCRIPTION
## Problem

We shouldn't be using vanilla io manager in prod

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
