### PR TITLE
refactor(web-analytics): Remove Web Vitals from sidebar

### DIFF
--- a/frontend/src/layout/navigation-3000/navigationLogic.tsx
+++ b/frontend/src/layout/navigation-3000/navigationLogic.tsx
@@ -482,29 +482,6 @@ export const navigation3000Logic = kea<navigation3000LogicType>([
                             label: 'Web analytics',
                             icon: <IconPieChart />,
                             to: isUsingSidebar ? undefined : urls.webAnalytics(),
-                            sideAction: featureFlags[FEATURE_FLAGS.WEB_VITALS]
-                                ? {
-                                      identifier: 'web-analytics-dropdown',
-                                      dropdown: {
-                                          overlay: (
-                                              <LemonMenuOverlay
-                                                  items={[
-                                                      {
-                                                          items: [
-                                                              {
-                                                                  label: 'Web vitals',
-                                                                  to: urls.webAnalyticsWebVitals(),
-                                                                  tag: 'beta' as const,
-                                                              },
-                                                          ],
-                                                      },
-                                                  ]}
-                                              />
-                                          ),
-                                          placement: 'bottom-end',
-                                      },
-                                  }
-                                : undefined,
                         },
                         featureFlags[FEATURE_FLAGS.LLM_OBSERVABILITY]
                             ? {


### PR DESCRIPTION
## Changes

This is too noisy and it doesn't fit the other dropdowns, let's remove them for now

See https://posthog.slack.com/archives/C011L071P8U/p1738080980717459 (internal)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Snapshots will be updated for you to see :)
