### PR TITLE
fix: Rename ids of plugins to match remote

### DIFF
--- a/plugin-server/src/cdp/consumers/__snapshots__/cdp-cyclotron-plugins-worker.test.ts.snap
+++ b/plugin-server/src/cdp/consumers/__snapshots__/cdp-cyclotron-plugins-worker.test.ts.snap
@@ -23,7 +23,7 @@ exports[`CdpCyclotronWorkerPlugins onEvent should handle and collect errors 3`] 
       "level": "debug",
       "log_source": "hog_function",
       "log_source_id": "<REPLACED-UUID-2>",
-      "message": "Executing plugin intercom",
+      "message": "Executing plugin posthog-intercom-plugin",
       "team_id": 2,
       "timestamp": "2025-01-01 00:00:00.000",
     },
@@ -44,11 +44,11 @@ exports[`CdpCyclotronWorkerPlugins onEvent should handle and collect errors 3`] 
 ]
 `;
 
-exports[`CdpCyclotronWorkerPlugins smoke tests should run the plugin: { name: 'customer-io', plugin: [Object] } 1`] = `
+exports[`CdpCyclotronWorkerPlugins smoke tests should run the plugin: { name: 'customerio-plugin', plugin: [Object] } 1`] = `
 [
   {
     "level": "debug",
-    "message": "Executing plugin customer-io",
+    "message": "Executing plugin customerio-plugin",
   },
   {
     "level": "info",
@@ -73,11 +73,11 @@ exports[`CdpCyclotronWorkerPlugins smoke tests should run the plugin: { name: 'c
 ]
 `;
 
-exports[`CdpCyclotronWorkerPlugins smoke tests should run the plugin: { name: 'intercom', plugin: [Object] } 1`] = `
+exports[`CdpCyclotronWorkerPlugins smoke tests should run the plugin: { name: 'posthog-intercom-plugin', plugin: [Object] } 1`] = `
 [
   {
     "level": "debug",
-    "message": "Executing plugin intercom",
+    "message": "Executing plugin posthog-intercom-plugin",
   },
   {
     "level": "info",

--- a/plugin-server/src/cdp/legacy-plugins/customerio/index.ts
+++ b/plugin-server/src/cdp/legacy-plugins/customerio/index.ts
@@ -256,7 +256,7 @@ function getEmailFromEvent(event: ProcessedPluginEvent): string | null {
 }
 
 export const customerioPlugin: LegacyPlugin = {
-    id: 'customer-io',
+    id: 'customerio-plugin',
     metadata: metadata as any,
     setupPlugin: setupPlugin as any,
     onEvent,

--- a/plugin-server/src/cdp/legacy-plugins/intercom/index.ts
+++ b/plugin-server/src/cdp/legacy-plugins/intercom/index.ts
@@ -190,7 +190,7 @@ function getTimestamp(meta: IntercomMeta, event: ProcessedPluginEvent): number {
 }
 
 export const intercomPlugin: LegacyPlugin = {
-    id: 'intercom',
+    id: 'posthog-intercom-plugin',
     metadata: metadata as any,
     onEvent,
     setupPlugin: () => Promise.resolve(),

--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -121,7 +121,7 @@ def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True):
         team = teams_by_id[plugin_config["team_id"]]
         serializer_context = {"team": team, "get_team": (lambda t=team: t)}
 
-        icon_url = plugin_config["plugin_icon"]
+        icon_url = plugin_config["plugin__icon"]
 
         if not icon_url:
             icon_url = f"https://raw.githubusercontent.com/PostHog/{plugin_id}/main/logo.png"

--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -121,6 +121,11 @@ def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True):
         team = teams_by_id[plugin_config["team_id"]]
         serializer_context = {"team": team, "get_team": (lambda t=team: t)}
 
+        icon_url = plugin_config["plugin_icon"]
+
+        if not icon_url:
+            icon_url = f"https://raw.githubusercontent.com/PostHog/{plugin_id}/main/logo.png"
+
         data = {
             "template_id": f"plugin-{plugin_id}",
             "type": "destination",


### PR DESCRIPTION
## Problem

The IDs of our plugins need to be the same as the remote git repo.

## Changes

* Fixes this for the ones we have so far
* Will see if there is a way of enforcing this later...


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
