### PR TITLE
chore: do not use path in metric labels if response code is 404 not found.

### DIFF
--- a/livestream/main.go
+++ b/livestream/main.go
@@ -94,7 +94,8 @@ func main() {
 	e.Use(middleware.GzipWithConfig(middleware.GzipConfig{
 		Level: 9, // Set compression level to maximum
 	}))
-	e.Use(echoprometheus.NewMiddleware("livestream"))
+	e.Use(echoprometheus.NewMiddlewareWithConfig(
+		echoprometheus.MiddlewareConfig{DoNotUseRequestPathFor404: true, Subsystem: "livestream"}))
 
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins: []string{"*"},


### PR DESCRIPTION
## Problem

Path was used in metrics despite 404 response.

## Changes

Disable using path for 404 responses.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

run locally
