### PR TITLE
fix(data-warehouse): Set column after editing the column from a struct

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/utils.py
@@ -101,6 +101,7 @@ def _evolve_pyarrow_schema(table: pa.Table, delta_schema: deltalake.Schema | Non
         if pa.types.is_struct(column.type) or pa.types.is_list(column.type):
             json_column = pa.array([json.dumps(row.as_py()) if row.as_py() is not None else None for row in column])
             table = table.set_column(table.schema.get_field_index(column_name), column_name, json_column)
+            column = table.column(column_name)
 
         # Normalize column names
         normalized_column_name = normalize_column_name(column_name)


### PR DESCRIPTION
## Problem
- When updating a struct in pyarrows to be a json string instead, we weren't re-setting the `column` var with the newly updated array of data
- fixes https://posthog.sentry.io/issues/6192269190/?project=4508444747956225&query=SchemaMismatchError&referrer=issue-stream&statsPeriod=30d&stream_index=0

## Changes
Set it 