### PR TITLE
fix(no-code experiments): UI polish (1)

### DIFF
--- a/frontend/src/toolbar/experiments/ExperimentsEditingToolbarMenu.tsx
+++ b/frontend/src/toolbar/experiments/ExperimentsEditingToolbarMenu.tsx
@@ -5,6 +5,7 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonCollapse } from 'lib/lemon-ui/LemonCollapse'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { useEffect, useMemo } from 'react'
 
 import { ToolbarMenu } from '~/toolbar/bar/ToolbarMenu'
@@ -65,12 +66,14 @@ export const ExperimentsEditingToolbarMenu = (): JSX.Element => {
                     </div>
                 </ToolbarMenu.Header>
                 <ToolbarMenu.Body>
-                    <div>
-                        <div className="flex w-full m-1">
+                    <div className="space-y-6 p-2">
+                        <div className="flex w-full">
                             {selectedExperimentId === 'new' ? (
-                                <>
+                                <div className="w-full">
+                                    <LemonLabel>Name</LemonLabel>
                                     <LemonInput
-                                        placeholder="Enter experiment name"
+                                        className="w-2/3"
+                                        placeholder="Example: Pricing page conversion"
                                         onChange={(newName: string) => {
                                             experimentForm.name = newName
                                             setExperimentFormValue('name', experimentForm.name)
@@ -78,56 +81,58 @@ export const ExperimentsEditingToolbarMenu = (): JSX.Element => {
                                         value={experimentForm.name}
                                         status={experimentFormErrors.name ? 'danger' : 'default'}
                                     />
-                                </>
+                                </div>
                             ) : (
                                 <h4 className="col-span-2">{experimentForm.name}</h4>
                             )}
                         </div>
-                        <Group name="variants">
-                            <div>
-                                <LemonCollapse
-                                    size="medium"
-                                    activeKey={selectedVariant}
-                                    onChange={(variant) => {
-                                        if (variant) {
-                                            selectVariant(variant)
-                                            applyVariant(selectedVariant, variant)
-                                        }
-                                    }}
-                                    panels={Object.keys(experimentForm.variants || {})
-                                        .sort((a, b) => (b === 'control' ? 0 : a.localeCompare(b)))
-                                        .map((variant) => {
-                                            return {
-                                                key: variant,
-                                                header: <WebExperimentVariantHeader variant={variant} />,
-                                                content:
-                                                    variant == 'control' ? (
-                                                        <span className="m-2">
-                                                            {' '}
-                                                            The control variant represents your page in its original
-                                                            state.{' '}
-                                                        </span>
-                                                    ) : (
-                                                        <WebExperimentVariant variant={variant} />
-                                                    ),
+                        <div>
+                            <div className="flex items-center justify-between mb-2">
+                                <label className="LemonLabel">Variants</label>
+                                {addVariantAvailable && (
+                                    <LemonButton
+                                        type="secondary"
+                                        size="xsmall"
+                                        icon={<IconPlus />}
+                                        onClick={addNewVariant}
+                                    >
+                                        Add variant
+                                    </LemonButton>
+                                )}
+                            </div>
+                            <Group name="variants">
+                                <div>
+                                    <LemonCollapse
+                                        size="medium"
+                                        activeKey={selectedVariant}
+                                        onChange={(variant) => {
+                                            if (variant) {
+                                                selectVariant(variant)
+                                                applyVariant(selectedVariant, variant)
                                             }
-                                        })}
-                                />
-                            </div>
-                        </Group>
-                        {addVariantAvailable && (
-                            <div className="grid grid-cols-3 mt-2 mb-1">
-                                <LemonButton
-                                    type="secondary"
-                                    size="small"
-                                    className="col-span-1"
-                                    sideIcon={<IconPlus />}
-                                    onClick={addNewVariant}
-                                >
-                                    Add variant
-                                </LemonButton>
-                            </div>
-                        )}
+                                        }}
+                                        panels={Object.keys(experimentForm.variants || {})
+                                            .sort((a, b) => (b === 'control' ? 0 : a.localeCompare(b)))
+                                            .map((variant) => {
+                                                return {
+                                                    key: variant,
+                                                    header: <WebExperimentVariantHeader variant={variant} />,
+                                                    content:
+                                                        variant == 'control' ? (
+                                                            <span className="m-2">
+                                                                {' '}
+                                                                The control variant represents your page in its original
+                                                                state.{' '}
+                                                            </span>
+                                                        ) : (
+                                                            <WebExperimentVariant variant={variant} />
+                                                        ),
+                                                }
+                                            })}
+                                    />
+                                </div>
+                            </Group>
+                        </div>
                     </div>
                 </ToolbarMenu.Body>
                 <ToolbarMenu.Footer>

--- a/frontend/src/toolbar/experiments/ExperimentsEditingToolbarMenu.tsx
+++ b/frontend/src/toolbar/experiments/ExperimentsEditingToolbarMenu.tsx
@@ -66,7 +66,7 @@ export const ExperimentsEditingToolbarMenu = (): JSX.Element => {
                     </div>
                 </ToolbarMenu.Header>
                 <ToolbarMenu.Body>
-                    <div className="space-y-6 p-2 h-full">
+                    <div className="space-y-6 p-2">
                         <div className="flex w-full">
                             {selectedExperimentId === 'new' ? (
                                 <div className="w-full">

--- a/frontend/src/toolbar/experiments/ExperimentsEditingToolbarMenu.tsx
+++ b/frontend/src/toolbar/experiments/ExperimentsEditingToolbarMenu.tsx
@@ -66,7 +66,7 @@ export const ExperimentsEditingToolbarMenu = (): JSX.Element => {
                     </div>
                 </ToolbarMenu.Header>
                 <ToolbarMenu.Body>
-                    <div className="space-y-6 p-2">
+                    <div className="space-y-6 p-2 h-full">
                         <div className="flex w-full">
                             {selectedExperimentId === 'new' ? (
                                 <div className="w-full">
@@ -88,7 +88,7 @@ export const ExperimentsEditingToolbarMenu = (): JSX.Element => {
                         </div>
                         <div>
                             <div className="flex items-center justify-between mb-2">
-                                <label className="LemonLabel">Variants</label>
+                                <LemonLabel>Variants</LemonLabel>
                                 {addVariantAvailable && (
                                     <LemonButton
                                         type="secondary"

--- a/frontend/src/toolbar/experiments/WebExperimentVariant.tsx
+++ b/frontend/src/toolbar/experiments/WebExperimentVariant.tsx
@@ -1,4 +1,5 @@
 import { IconPlus } from '@posthog/icons'
+import { LemonLabel } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonCollapse } from 'lib/lemon-ui/LemonCollapse'
@@ -18,71 +19,78 @@ export function WebExperimentVariant({ variant }: WebExperimentVariantProps): JS
     const [localTentativeValue, setLocalTentativeValue] = useState(variant)
     const { addNewElement, setExperimentFormValue } = useActions(experimentsTabLogic)
     return (
-        <div className="flex flex-col">
+        <div className="space-y-4">
             {selectedExperimentId === 'new' && experimentForm.variants && experimentForm.variants[variant].is_new && (
-                <LemonInput
-                    key="variant-name-small"
-                    className="mb-2"
-                    value={localTentativeValue}
-                    onChange={(newName) => {
-                        setLocalTentativeValue(newName)
-                    }}
-                    onBlur={(e) => {
-                        e.stopPropagation()
-                        if (experimentForm.variants && localTentativeValue !== variant) {
-                            const webVariant = experimentForm.variants[variant]
-                            if (webVariant) {
-                                experimentForm.variants[localTentativeValue] = webVariant
-                                delete experimentForm.variants[variant]
-                                setExperimentFormValue('variants', experimentForm.variants)
+                <div>
+                    <LemonLabel>Variant name</LemonLabel>
+                    <LemonInput
+                        key="variant-name-small"
+                        className="mb-2"
+                        value={localTentativeValue}
+                        onChange={(newName) => {
+                            setLocalTentativeValue(newName)
+                        }}
+                        onBlur={(e) => {
+                            e.stopPropagation()
+                            if (experimentForm.variants && localTentativeValue !== variant) {
+                                const webVariant = experimentForm.variants[variant]
+                                if (webVariant) {
+                                    experimentForm.variants[localTentativeValue] = webVariant
+                                    delete experimentForm.variants[variant]
+                                    setExperimentFormValue('variants', experimentForm.variants)
+                                }
                             }
-                        }
-                    }}
-                    placeholder="Variant name"
-                />
+                        }}
+                        placeholder={`Example: "test-1"`}
+                    />
+                </div>
             )}
             {experimentForm?.variants &&
             experimentForm?.variants[variant] &&
             experimentForm?.variants[variant].transforms &&
             experimentForm?.variants[variant].transforms?.length > 0 ? (
-                <LemonCollapse
-                    size="small"
-                    activeKey={experimentForm?.variants[variant].transforms.length === 1 ? 0 : undefined}
-                    panels={experimentForm?.variants[variant].transforms.map((transform, tIndex) => {
-                        return {
-                            key: tIndex,
-                            header: (
-                                <WebExperimentTransformHeader
-                                    variant={variant}
-                                    transformIndex={tIndex}
-                                    transform={transform}
-                                />
-                            ),
-                            content: (
-                                <WebExperimentTransformField tIndex={tIndex} variant={variant} transform={transform} />
-                            ),
-                        }
-                    })}
-                />
+                <div>
+                    <div className="flex items-center justify-between mb-2">
+                        <LemonLabel>Transformations</LemonLabel>
+                        <LemonButton
+                            type="secondary"
+                            size="xsmall"
+                            icon={<IconPlus />}
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                addNewElement(variant)
+                            }}
+                        >
+                            Add transformation
+                        </LemonButton>
+                    </div>
+                    <LemonCollapse
+                        size="small"
+                        activeKey={experimentForm?.variants[variant].transforms.length === 1 ? 0 : undefined}
+                        panels={experimentForm?.variants[variant].transforms.map((transform, tIndex) => {
+                            return {
+                                key: tIndex,
+                                header: (
+                                    <WebExperimentTransformHeader
+                                        variant={variant}
+                                        transformIndex={tIndex}
+                                        transform={transform}
+                                    />
+                                ),
+                                content: (
+                                    <WebExperimentTransformField
+                                        tIndex={tIndex}
+                                        variant={variant}
+                                        transform={transform}
+                                    />
+                                ),
+                            }
+                        })}
+                    />
+                </div>
             ) : (
                 <span className="m-2"> This experiment variant doesn't modify any elements. </span>
             )}
-
-            <div className="grid grid-cols-3 gap-2 m-1">
-                <LemonButton
-                    icon={<IconPlus />}
-                    type="secondary"
-                    size="small"
-                    className="col-span-1"
-                    onClick={(e) => {
-                        e.stopPropagation()
-                        addNewElement(variant)
-                    }}
-                >
-                    Add element
-                </LemonButton>
-                <div className="col-span-1" />
-            </div>
         </div>
     )
 }

--- a/frontend/src/toolbar/experiments/WebExperimentVariantHeader.tsx
+++ b/frontend/src/toolbar/experiments/WebExperimentVariantHeader.tsx
@@ -10,39 +10,44 @@ interface WebExperimentVariantHeaderProps {
 }
 
 export function WebExperimentVariantHeader({ variant }: WebExperimentVariantHeaderProps): JSX.Element {
-    const { experimentForm, removeVariantAvailable } = useValues(experimentsTabLogic)
+    const { experimentForm, removeVariantAvailable, selectedVariant } = useValues(experimentsTabLogic)
     const { removeVariant } = useActions(experimentsTabLogic)
     return (
-        <div className="flex w-full gap-4 items-center">
-            <div className="flex-1">
+        <div className="flex w-full items-center justify-between">
+            <div className="flex items-center gap-2">
                 <h2>{variant}</h2>
+                {selectedVariant === variant && (
+                    <LemonTag className="px-1 py-0.5 font-semibold" size="small" type="success">
+                        Currently applied
+                    </LemonTag>
+                )}
             </div>
-            <div className="shrink">
-                <LemonTag className="p-2" type="success">
+            <div className="flex items-center gap-2">
+                <LemonTag className="px-1 py-0.5 font-semibold" size="small" type="muted">
                     <span>
-                        {'rollout :' +
-                            (experimentForm.variants && experimentForm.variants[variant]
+                        {`Rollout: ${
+                            experimentForm.variants && experimentForm.variants[variant]
                                 ? experimentForm.variants[variant].rollout_percentage!
                                 : 0
-                            ).toString()}
+                        } %`}
                     </span>
                 </LemonTag>
+                <div>
+                    {removeVariantAvailable && (
+                        <LemonButton
+                            icon={<IconTrash />}
+                            size="small"
+                            className="shrink"
+                            noPadding
+                            status="danger"
+                            onClick={(e) => {
+                                e.stopPropagation()
+                                removeVariant(variant)
+                            }}
+                        />
+                    )}
+                </div>
             </div>
-            {removeVariantAvailable ? (
-                <LemonButton
-                    icon={<IconTrash />}
-                    size="small"
-                    className="shrink"
-                    noPadding
-                    status="danger"
-                    onClick={(e) => {
-                        e.stopPropagation()
-                        removeVariant(variant)
-                    }}
-                />
-            ) : (
-                <span className="size-5 inline-block" />
-            )}
         </div>
     )
 }

--- a/frontend/src/toolbar/experiments/WebExperimentVariantHeader.tsx
+++ b/frontend/src/toolbar/experiments/WebExperimentVariantHeader.tsx
@@ -27,26 +27,24 @@ export function WebExperimentVariantHeader({ variant }: WebExperimentVariantHead
                     <span>
                         {`Rollout: ${
                             experimentForm.variants && experimentForm.variants[variant]
-                                ? experimentForm.variants[variant].rollout_percentage!
+                                ? experimentForm.variants[variant].rollout_percentage ?? 0
                                 : 0
                         } %`}
                     </span>
                 </LemonTag>
-                <div>
-                    {removeVariantAvailable && (
-                        <LemonButton
-                            icon={<IconTrash />}
-                            size="small"
-                            className="shrink"
-                            noPadding
-                            status="danger"
-                            onClick={(e) => {
-                                e.stopPropagation()
-                                removeVariant(variant)
-                            }}
-                        />
-                    )}
-                </div>
+                {removeVariantAvailable && (
+                    <LemonButton
+                        icon={<IconTrash />}
+                        size="small"
+                        className="shrink"
+                        noPadding
+                        status="danger"
+                        onClick={(e) => {
+                            e.stopPropagation()
+                            removeVariant(variant)
+                        }}
+                    />
+                )}
             </div>
         </div>
     )


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/26936

## Changes
First pass at polishing the no-code UI.

- Added input labels
- Added "Currently applied" variant tag
- Improved visual hierarchy of "Add" buttons
- Fixed padding/margins

|Before|After|
|----|----|
|<img width="479" alt="image" src="https://github.com/user-attachments/assets/2d8b89b0-f6d1-411e-af4c-6796ab4c1fcc" />|<img width="478" alt="image" src="https://github.com/user-attachments/assets/9176dcb6-c3f0-49a5-ba6c-1b712d64409a" />|

## How did you test this code?
👀 