### PR TITLE
chore: livestream proper 401 status code

### DIFF
--- a/livestream/README.md
+++ b/livestream/README.md
@@ -18,7 +18,7 @@ Hog 3000 powers live event stream on PostHog: https://us.posthog.com/project/0/a
    - `geo` - return only coordinates guessed based on IP,
  - `/debug` - dummy html for SSE testing,
  - `/debug/sse/` - backend for `/debug` generating a server side events,
- - `/metrics` - exposes metrcis in Prometheus format
+ - `/metrics` - exposes metrics in Prometheus format
  
 ## Installing
 

--- a/livestream/jwt.go
+++ b/livestream/jwt.go
@@ -3,6 +3,8 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/labstack/echo/v4"
+	"net/http"
 	"strings"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -10,6 +12,19 @@ import (
 )
 
 const ExpectedScope = "posthog:livestream"
+
+func getAuth(header http.Header) (jwt.MapClaims, error) {
+	authHeader := header.Get("Authorization")
+	if authHeader == "" {
+		return nil, echo.NewHTTPError(http.StatusUnauthorized, "authorization header is required")
+	}
+
+	claims, err := decodeAuthToken(authHeader)
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusUnauthorized, err)
+	}
+	return claims, nil
+}
 
 func decodeAuthToken(authHeader string) (jwt.MapClaims, error) {
 	// split the token

--- a/livestream/jwt.go
+++ b/livestream/jwt.go
@@ -3,11 +3,11 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/labstack/echo/v4"
 	"net/http"
 	"strings"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v4"
 	"github.com/spf13/viper"
 )
 

--- a/livestream/main.go
+++ b/livestream/main.go
@@ -118,12 +118,7 @@ func main() {
 	e.GET("/events", streamEventsHandler(e.Logger, subChan, filter))
 
 	e.GET("/jwt", func(c echo.Context) error {
-		authHeader := c.Request().Header.Get("Authorization")
-		if authHeader == "" {
-			return errors.New("authorization header is required")
-		}
-
-		claims, err := decodeAuthToken(authHeader)
+		claims, err := getAuth(c.Request().Header)
 		if err != nil {
 			return err
 		}

--- a/livestream/served.go
+++ b/livestream/served.go
@@ -39,12 +39,7 @@ func statsHandler(stats *Stats) func(c echo.Context) error {
 			Error          string `json:"error,omitempty"`
 		}
 
-		authHeader := c.Request().Header.Get("Authorization")
-		if authHeader == "" {
-			return errors.New("authorization header is required")
-		}
-
-		claims, err := decodeAuthToken(authHeader)
+		claims, err := getAuth(c.Request().Header)
 		if err != nil {
 			return err
 		}
@@ -82,12 +77,7 @@ func streamEventsHandler(log echo.Logger, subChan chan Subscription, filter *Fil
 		if strings.ToLower(geo) == "true" || geo == "1" {
 			geoOnly = true
 		} else {
-			authHeader := c.Request().Header.Get("Authorization")
-			if authHeader == "" {
-				return errors.New("authorization header is required")
-			}
-
-			claims, err := decodeAuthToken(authHeader)
+			claims, err := getAuth(c.Request().Header)
 			if err != nil {
 				return err
 			}

--- a/livestream/served.go
+++ b/livestream/served.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -85,7 +84,7 @@ func streamEventsHandler(log echo.Logger, subChan chan Subscription, filter *Fil
 			token = fmt.Sprint(claims["api_token"])
 
 			if teamId == "" {
-				return errors.New("teamId is required unless geo=true")
+				return echo.NewHTTPError(http.StatusBadRequest, "teamId is required unless geo=true")
 			}
 		}
 


### PR DESCRIPTION
## Problem

livestream returns http response code 500 for unauthorized requests, polluting our metrics.

## Changes

Return 401 status code when appropriate.

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

run locally
