### PR TITLE
fix(data-warehouse): Set the last incremental value to none on reset

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -71,6 +71,7 @@ class PipelineNonDLT:
                 self._delta_table_helper.reset_table()
 
                 self._schema.sync_type_config.pop("reset_pipeline", None)
+                self._schema.sync_type_config.pop("incremental_field_last_value", None)
                 self._schema.save()
 
             for item in self._resource:


### PR DESCRIPTION
## Changes
- We ignore the last incremental value when `reset_pipeline` is true, but for cleanness sake, I'd rather the value was reset to None in the DB