### PR TITLE
fix: stop writing nulls to postgres

### DIFF
--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -192,7 +192,7 @@ where
 
 // Postgres doesn't like nulls in strings, so we replace them with uFFFD.
 pub fn sanitize_string(s: String) -> String {
-    s.replace("\u0000", "\uFFFD").replace('\0', '\u{FFFD}')
+    s.replace("\\u0000", "\\uFFFD")
 }
 
 #[cfg(test)]

--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -192,7 +192,7 @@ where
 
 // Postgres doesn't like nulls in strings, so we replace them with uFFFD.
 pub fn sanitize_string(s: String) -> String {
-    s.replace("\\u0000", "\\uFFFD")
+    s.replace("\u0000", "\uFFFD").replace('\0', '\u{FFFD}')
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

Context https://posthog.slack.com/archives/C07CR2K1H6G/p1737966128865249

## Changes

Postgres does not handle null characters very well so we need to rewrite them.

Emulating how we do this elsewhere e.g. Rust webhooks
https://github.com/PostHog/posthog/blob/b2c120a63f044214ad385259af3d268cbf4122af/rust/hook-api/src/handlers/webhook.rs#L222-L225
