### PR TITLE
fix: exclude plugin-server tests from build

### DIFF
--- a/plugin-server/tsconfig.json
+++ b/plugin-server/tsconfig.json
@@ -24,5 +24,5 @@
         }
     },
     "include": ["src"],
-    "exclude": ["node_modules", "dist", "bin"]
+    "exclude": ["node_modules", "dist", "bin", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Problem

Some mocks can cause build failures due to the differences between the regular TS builds and the Jest environment.

## Changes

Excludes *.test.ts files in plugin server from the build.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Verified locally.