### PR TITLE
fix(web-analytics): Fix flaky web analytics tests

### DIFF
--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -138,28 +138,29 @@ class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
         filter_test_accounts: Optional[bool] = False,
         bounce_rate_mode: Optional[BounceRatePageViewMode] = BounceRatePageViewMode.COUNT_PAGEVIEWS,
     ):
-        modifiers = HogQLQueryModifiers(
-            sessionTableVersion=session_table_version, bounceRatePageViewMode=bounce_rate_mode
-        )
-        query = WebStatsTableQuery(
-            dateRange=DateRange(date_from=date_from, date_to=date_to),
-            properties=properties or [],
-            breakdownBy=breakdown_by,
-            limit=limit,
-            doPathCleaning=bool(path_cleaning_filters),
-            includeBounceRate=include_bounce_rate,
-            includeScrollDepth=include_scroll_depth,
-            compareFilter=compare_filter,
-            conversionGoal=ActionConversionGoal(actionId=action.id)
-            if action
-            else CustomEventConversionGoal(customEventName=custom_event)
-            if custom_event
-            else None,
-            filterTestAccounts=filter_test_accounts,
-        )
-        self.team.path_cleaning_filters = path_cleaning_filters or []
-        runner = WebStatsTableQueryRunner(team=self.team, query=query, modifiers=modifiers)
-        return runner.calculate()
+        with freeze_time(self.QUERY_TIMESTAMP):
+            modifiers = HogQLQueryModifiers(
+                sessionTableVersion=session_table_version, bounceRatePageViewMode=bounce_rate_mode
+            )
+            query = WebStatsTableQuery(
+                dateRange=DateRange(date_from=date_from, date_to=date_to),
+                properties=properties or [],
+                breakdownBy=breakdown_by,
+                limit=limit,
+                doPathCleaning=bool(path_cleaning_filters),
+                includeBounceRate=include_bounce_rate,
+                includeScrollDepth=include_scroll_depth,
+                compareFilter=compare_filter,
+                conversionGoal=ActionConversionGoal(actionId=action.id)
+                if action
+                else CustomEventConversionGoal(customEventName=custom_event)
+                if custom_event
+                else None,
+                filterTestAccounts=filter_test_accounts,
+            )
+            self.team.path_cleaning_filters = path_cleaning_filters or []
+            runner = WebStatsTableQueryRunner(team=self.team, query=query, modifiers=modifiers)
+            return runner.calculate()
 
     def test_no_crash_when_no_data(self):
         results = self._run_web_stats_table_query(

--- a/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_stats_table.py
@@ -30,6 +30,8 @@ from posthog.test.base import (
 
 @snapshot_clickhouse_queries
 class TestWebStatsTableQueryRunner(ClickhouseTestMixin, APIBaseTest):
+    QUERY_TIMESTAMP = "2025-01-29"
+
     def _create_events(self, data, event="$pageview"):
         person_result = []
         for id, timestamps in data:

--- a/posthog/hogql_queries/web_analytics/test/test_web_vitals_path_breakdown.py
+++ b/posthog/hogql_queries/web_analytics/test/test_web_vitals_path_breakdown.py
@@ -17,9 +17,13 @@ from posthog.test.base import (
     snapshot_clickhouse_queries,
 )
 
+from freezegun import freeze_time
+
 
 @snapshot_clickhouse_queries
 class TestWebVitalsPathBreakdownQueryRunner(ClickhouseTestMixin, APIBaseTest):
+    QUERY_TIMESTAMP = "2025-01-29"
+
     def _create_events(self, data, metric: WebVitalsMetric = WebVitalsMetric.INP):
         for distinct_id, timestamps in data:
             for timestamp, path, value in timestamps:
@@ -45,16 +49,17 @@ class TestWebVitalsPathBreakdownQueryRunner(ClickhouseTestMixin, APIBaseTest):
         percentile: PropertyMathType = PropertyMathType.P75,
         properties=None,
     ):
-        query = WebVitalsPathBreakdownQuery(
-            dateRange=DateRange(date_from=date_from, date_to=date_to),
-            metric=metric,
-            percentile=percentile,
-            thresholds=thresholds,
-            properties=properties or [],
-        )
+        with freeze_time(self.QUERY_TIMESTAMP):
+            query = WebVitalsPathBreakdownQuery(
+                dateRange=DateRange(date_from=date_from, date_to=date_to),
+                metric=metric,
+                percentile=percentile,
+                thresholds=thresholds,
+                properties=properties or [],
+            )
 
-        runner = WebVitalsPathBreakdownQueryRunner(team=self.team, query=query)
-        return runner.calculate()
+            runner = WebVitalsPathBreakdownQueryRunner(team=self.team, query=query)
+            return runner.calculate()
 
     def test_no_crash_when_no_data(self):
         results = self._run_web_vitals_path_breakdown_query(


### PR DESCRIPTION
## Problem
Tests are flaky, the snapshots include the current date

## Changes

Use freezegun to use the same timestamp each time
## Does this work well for both Cloud and self-hosted?

n/a

## How did you test this code?

It is tests