### PR TITLE
fix: Turn off hog transformations by default

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -154,7 +154,8 @@
                 "WORKER_CONCURRENCY": "2",
                 "OBJECT_STORAGE_ENABLED": "True",
                 "HOG_HOOK_URL": "http://localhost:3300/hoghook",
-                "PLUGIN_SERVER_MODE": "all-v2"
+                "PLUGIN_SERVER_MODE": "all-v2",
+                "HOG_TRANSFORMATIONS_ENABLED": "True"
             },
             "presentation": {
                 "group": "main"

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -224,7 +224,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         SESSION_RECORDING_MAX_BATCH_AGE_MS: 10 * 1000, // 10 seconds
 
         // Hog Transformations (Alpha)
-        HOG_TRANSFORMATIONS_ENABLED: true,
+        HOG_TRANSFORMATIONS_ENABLED: false,
 
         // Cookieless
         COOKIELESS_FORCE_STATELESS_MODE: false,


### PR DESCRIPTION
## Problem

Default should't have been true...

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
