### PR TITLE
chore: only activate flox if installed

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,5 @@
-if [ -z "${FLOX_VERSION}" ]; then # Don't activate if already activated
-    flox activate
+if command -v flox >/dev/null 2>&1; then # Only activate flox if installed
+    if [ -z "${FLOX_VERSION}" ]; then # Don't activate if already activated
+        flox activate
+    fi
 fi


### PR DESCRIPTION
## Problem
Users with direnv installed but not flox get's an error as flox tries to activate

## Changes
only activate flox if installed
