### PR TITLE
fix(data-warehouse): Cater for the string None too

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -108,12 +108,12 @@ def import_data_activity_sync(inputs: ImportDataActivityInputs):
         endpoints = [schema.name]
         processed_incremental_last_value = None
 
-        processed_incremental_last_value = processed_incremental_last_value = process_incremental_last_value(
+        processed_incremental_last_value = process_incremental_last_value(
             schema.sync_type_config.get("incremental_field_last_value"),
             schema.sync_type_config.get("incremental_field_type"),
         )
         if reset_pipeline is not True:
-            processed_incremental_last_value = processed_incremental_last_value = process_incremental_last_value(
+            processed_incremental_last_value = process_incremental_last_value(
                 schema.sync_type_config.get("incremental_field_last_value"),
                 schema.sync_type_config.get("incremental_field_type"),
             )

--- a/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/posthog/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -36,7 +36,7 @@ class ImportDataActivityInputs:
 
 
 def process_incremental_last_value(value: Any | None, field_type: IncrementalFieldType | None) -> Any | None:
-    if value is None or field_type is None:
+    if value is None or value == "None" or field_type is None:
         return None
 
     if field_type == IncrementalFieldType.Integer or field_type == IncrementalFieldType.Numeric:


### PR DESCRIPTION
## Problem
- Apparently we sometimes have the string `None` stored as the incremental last value instead of the actual value `None`/`null`
- https://posthog.sentry.io/issues/6162095641/events/latest/?project=4508444747956225&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=latest-event&statsPeriod=30d&stream_index=5

## Changes
- Cater for the string `"None"`
