### PR TITLE
feat: S3 fallback for event capture

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -114,7 +114,7 @@ jobs:
             - name: Setup dependencies
               if: needs.changes.outputs.rust == 'true' && matrix.package == 'others'
               run: |
-                  docker compose up kafka redis db echo_server -d --wait
+                  docker compose up kafka redis db echo_server objectstorage -d --wait
                   docker compose up setup_test_db
                   echo "127.0.0.1 kafka" | sudo tee -a /etc/hosts
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN pnpm build
 #
 # ---------------------------------------------------------
 #
-FROM ghcr.io/posthog/rust-node-container:bookworm_rust_1.80.1-node_18.19.1 AS plugin-server-build
+FROM ghcr.io/posthog/rust-node-container:bookworm_rust_1.82-node_18.19.1 AS plugin-server-build
 
 # Compile and install system dependencies
 RUN apt-get update && \

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -77,10 +77,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "anyhow"
@@ -394,9 +437,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "1.5.9"
+version = "1.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6448cfb224dd6a9b9ac734f58622dd0d4751f3589f3b777345745f46b2eb14"
+checksum = "dc47e70fc35d054c8fcd296d47a61711f043ac80534a10b4f741904f81e73a90"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -436,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.4.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10d5c055aa540164d9561a0e2e74ad30f0dcf7393c3a92f6733ddf9c5762468"
+checksum = "bee7643696e7fdd74c10f9eb42848a87fe469d35eae9c3323f80aa98f350baac"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -462,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.58.0"
+version = "1.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0656a79cf5e6ab0d4bb2465cd750a7a2fd7ea26c062183ed94225f5782e22365"
+checksum = "705cb534fb7b620f540d2fac268d378918dc67d25b173f67edcab3851fe19392"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -496,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.47.0"
+version = "1.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8776850becacbd3a82a4737a9375ddb5c6832a51379f24443a98e61513f852c"
+checksum = "12e057fdcb8842de9b83592a70f5b4da0ee10bc0ad278247da1425a742a444d7"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -518,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.48.0"
+version = "1.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0007b5b8004547133319b6c4e87193eee2a0bcb3e4c18c75d09febe9dab7b383"
+checksum = "a120ade4a44691b3c5c2ff2fa61b14ed331fdc218397f61ab48d66593012ae2a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -540,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.47.0"
+version = "1.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fffaa356e7f1c725908b75136d53207fa714e348f365671df14e95a60530ad3"
+checksum = "115fd4fb663817ed595a5ee4f1649d7aacd861d47462323cb37576ce89271b93"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -563,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.5"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5619742a0d8f253be760bfbb8e8e8368c69e3587e4637af5754e488a611499b1"
+checksum = "690118821e46967b3c4501d67d7d52dd75106a9c54cf36cefa1985cedbe94e05"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -592,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.1"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+checksum = "fa59d1327d8b5053c54bf2eaae63bf629ba9e904434d0835a28ed3c0ed0a614e"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -603,15 +646,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.13"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1a71073fca26775c8b5189175ea8863afb1c9ea2cceb02a5de5ad9dfbaa795"
+checksum = "f2f45a1c384d7a393026bc5f5c177105aa9fa68e4749653b985707ac27d77295"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
  "crc32c",
  "crc32fast",
+ "crc64fast-nvme",
  "hex",
  "http 0.2.11",
  "http-body 0.4.6",
@@ -624,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.5"
+version = "0.60.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef7d0a272725f87e51ba2bf89f8c21e4df61b9e49ae1ac367a6d69916ef7c90"
+checksum = "8b18559a41e0c909b77625adf2b8c50de480a8041e5e4a3f5f7d177db70abc5a"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -635,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.11"
+version = "0.60.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -656,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.60.7"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+checksum = "623a51127f24c30776c8b374295f2df78d92517386f77ba30773f15a30ce1422"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -675,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.3"
+version = "1.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be28bd063fa91fd871d131fc8b68d7cd4c5fa0869bea68daca50dcb1cbd76be2"
+checksum = "865f7050bbc7107a6c98a397a9fcd9413690c27fa718446967cf03b2d3ac517e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -702,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e086682a53d3aa241192aa110fa8dfce98f2f5ac2ead0de84d41582c7e8fdb96"
+checksum = "92165296a47a812b267b4f41032ff8069ab7ff783696d217f0994a0d7ab585cd"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -719,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.8"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c9cdc179e6afbf5d391ab08c85eac817b51c87e1892a5edb5f7bbdc64314b4"
+checksum = "a28f6feb647fb5e0d5b50f0472c19a7db9462b74e2fec01bb0b44eedcc834e97"
 dependencies = [
  "base64-simd 0.8.0",
  "bytes",
@@ -754,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.3"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5221b91b3e441e6675310829fd8984801b772cb1546ef6c0e54dec9f1ac13fef"
+checksum = "b0df5a18c4f951c645300d365fec53a61418bcf4650f604f85fe2a665bfaa0c2"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1129,11 +1173,14 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "async-trait",
+ "aws-config",
+ "aws-sdk-s3",
  "axum 0.7.5",
  "axum-client-ip",
  "axum-test-helper",
  "base64 0.22.0",
  "bytes",
+ "chrono",
  "common-alloc",
  "common-types",
  "envconfig",
@@ -1163,6 +1210,25 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "cbindgen"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
+dependencies = [
+ "clap",
+ "heck 0.4.1",
+ "indexmap 2.7.1",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.89",
+ "tempfile",
+ "toml",
 ]
 
 [[package]]
@@ -1198,6 +1264,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
 name = "cmake"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1298,12 @@ checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "combine"
@@ -1352,6 +1451,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crc64fast-nvme"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5e2ee08013e3f228d6d2394116c4549a6df77708442c62d887d83f68ef2ee37"
+dependencies = [
+ "cbindgen",
+ "crc",
 ]
 
 [[package]]
@@ -2353,7 +2462,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.11",
- "indexmap 2.2.2",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2372,7 +2481,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 1.1.0",
- "indexmap 2.2.2",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2831,6 +2940,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2838,12 +3065,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -2876,12 +3114,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "serde",
 ]
 
@@ -2931,6 +3169,12 @@ dependencies = [
  "quote",
  "syn 2.0.89",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "iter-read"
@@ -2992,7 +3236,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adfdc25288ccb82b33c3aa3f14587fd920b825690f3c4f8c5385b1d8998e9a40"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.7.1",
  "sourcemap 8.0.1",
  "swc_common",
  "swc_ecma_parser",
@@ -3139,6 +3383,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3258,7 +3508,7 @@ dependencies = [
  "hyper 1.3.1",
  "hyper-tls",
  "hyper-util",
- "indexmap 2.2.2",
+ "indexmap 2.7.1",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -3833,7 +4083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.2",
+ "indexmap 2.7.1",
 ]
 
 [[package]]
@@ -4067,7 +4317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -4860,6 +5110,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5148,7 +5407,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "hashlink",
  "hex",
- "indexmap 2.2.2",
+ "indexmap 2.7.1",
  "log",
  "memchr",
  "native-tls",
@@ -5609,7 +5868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7dd2fb720ae89293253b60cd701c3a1de556a3b54ec9170ca2098789a994b1"
 dependencies = [
  "flate2",
- "indexmap 2.2.2",
+ "indexmap 2.7.1",
  "serde",
  "serde_json",
  "symbolic-common",
@@ -5677,6 +5936,17 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
 
 [[package]]
 name = "system-configuration"
@@ -5832,6 +6102,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5932,10 +6212,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.5"
+name = "toml"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.22",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -5943,9 +6238,22 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.7.1",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.37",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap 2.7.1",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.25",
 ]
 
 [[package]]
@@ -6194,9 +6502,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -6208,6 +6516,24 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -6375,7 +6701,7 @@ dependencies = [
  "ahash",
  "bitflags 2.6.0",
  "hashbrown 0.14.5",
- "indexmap 2.2.2",
+ "indexmap 2.7.1",
  "semver 1.0.23",
  "serde",
 ]
@@ -6604,6 +6930,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6624,6 +6959,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6637,6 +6984,30 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -6656,6 +7027,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+ "synstructure",
 ]
 
 [[package]]
@@ -6679,6 +7071,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "zip"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6689,7 +7103,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.2.2",
+ "indexmap 2.7.1",
  "memchr",
  "thiserror",
  "zopfli",

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/lukemathwalker/cargo-chef:latest-rust-1.80.1-bookworm AS chef
+FROM docker.io/lukemathwalker/cargo-chef:latest-rust-1.82-bookworm AS chef
 ARG BIN
 WORKDIR /app
 

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -43,6 +43,9 @@ tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
+aws-config = "1.5.15"
+aws-sdk-s3 = "1.65.0"
+chrono.workspace = true
 
 [dev-dependencies]
 assert-json-diff = { workspace = true }

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -43,9 +43,9 @@ tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
-aws-config = "1.5.15"
-aws-sdk-s3 = "1.65.0"
-chrono.workspace = true
+aws-config = { workspace = true }
+aws-sdk-s3 = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 assert-json-diff = { workspace = true }

--- a/rust/capture/src/api.rs
+++ b/rust/capture/src/api.rs
@@ -18,12 +18,12 @@ pub struct CaptureResponse {
     pub quota_limited: Option<Vec<String>>,
 }
 
-#[derive(Error, Debug)]
+#[derive(Clone, Error, Debug, PartialEq)]
 pub enum CaptureError {
     #[error("failed to decode request: {0}")]
     RequestDecodingError(String),
     #[error("failed to parse request: {0}")]
-    RequestParsingError(#[from] serde_json::Error),
+    RequestParsingError(String),
 
     #[error("request holds no event")]
     EmptyBatch,
@@ -61,6 +61,12 @@ pub enum CaptureError {
 
     #[error("rate limited")]
     RateLimited,
+}
+
+impl From<serde_json::Error> for CaptureError {
+    fn from(e: serde_json::Error) -> Self {
+        CaptureError::RequestParsingError(e.to_string())
+    }
 }
 
 impl IntoResponse for CaptureError {

--- a/rust/capture/src/api.rs
+++ b/rust/capture/src/api.rs
@@ -18,7 +18,7 @@ pub struct CaptureResponse {
     pub quota_limited: Option<Vec<String>>,
 }
 
-#[derive(Clone, Error, Debug, PartialEq)]
+#[derive(Clone, Error, Debug)]
 pub enum CaptureError {
     #[error("failed to decode request: {0}")]
     RequestDecodingError(String),

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -61,6 +61,55 @@ pub struct Config {
     pub capture_mode: CaptureMode,
 
     pub concurrency_limit: Option<usize>,
+
+    #[envconfig(default = "false")]
+    pub s3_fallback_enabled: bool,
+    pub s3_fallback_bucket: Option<String>,
+    pub s3_fallback_endpoint: Option<String>,
+}
+
+impl Config {
+    pub fn from_env() -> Self {
+        Self {
+            print_sink: false,
+            address: "127.0.0.1:3000".parse().unwrap(),
+            redis_url: String::new(),
+            otel_url: None,
+            overflow_enabled: false,
+            overflow_per_second_limit: NonZeroU32::new(100).unwrap(),
+            overflow_burst_limit: NonZeroU32::new(1000).unwrap(),
+            overflow_forced_keys: None,
+            dropped_keys: None,
+            kafka: KafkaConfig {
+                kafka_producer_linger_ms: 20,
+                kafka_producer_queue_mib: 400,
+                kafka_message_timeout_ms: 20000,
+                kafka_producer_message_max_bytes: 1000000,
+                kafka_compression_codec: String::new(),
+                kafka_hosts: String::new(),
+                kafka_topic: String::new(),
+                kafka_historical_topic: String::new(),
+                kafka_client_ingestion_warning_topic: String::new(),
+                kafka_exceptions_topic: String::new(),
+                kafka_heatmaps_topic: String::new(),
+                kafka_replay_overflow_topic: String::new(),
+                kafka_tls: false,
+                kafka_client_id: String::new(),
+                kafka_metadata_max_age_ms: 60000,
+                kafka_producer_max_retries: 2,
+                kafka_producer_acks: String::new(),
+            },
+            otel_sampling_rate: 1.0,
+            otel_service_name: String::new(),
+            export_prometheus: true,
+            redis_key_prefix: None,
+            capture_mode: CaptureMode::Events,
+            concurrency_limit: None,
+            s3_fallback_enabled: false,
+            s3_fallback_bucket: None,
+            s3_fallback_endpoint: None,
+        }
+    }
 }
 
 #[derive(Envconfig, Clone)]

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -1,6 +1,7 @@
 use std::{net::SocketAddr, num::NonZeroU32};
 
 use envconfig::Envconfig;
+use health::HealthStrategy;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum CaptureMode {
@@ -66,6 +67,9 @@ pub struct Config {
     pub s3_fallback_enabled: bool,
     pub s3_fallback_bucket: Option<String>,
     pub s3_fallback_endpoint: Option<String>,
+
+    #[envconfig(default = "ALL")]
+    pub healthcheck_strategy: HealthStrategy
 }
 
 impl Config {
@@ -108,6 +112,7 @@ impl Config {
             s3_fallback_enabled: false,
             s3_fallback_bucket: None,
             s3_fallback_endpoint: None,
+            healthcheck_strategy: HealthStrategy::All,
         }
     }
 }

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -72,7 +72,7 @@ pub struct Config {
     pub s3_fallback_prefix: String,
 
     #[envconfig(default = "ALL")]
-    pub healthcheck_strategy: HealthStrategy
+    pub healthcheck_strategy: HealthStrategy,
 }
 
 impl Config {

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -68,6 +68,9 @@ pub struct Config {
     pub s3_fallback_bucket: Option<String>,
     pub s3_fallback_endpoint: Option<String>,
 
+    #[envconfig(default = "")]
+    pub s3_fallback_prefix: String,
+
     #[envconfig(default = "ALL")]
     pub healthcheck_strategy: HealthStrategy
 }
@@ -112,6 +115,7 @@ impl Config {
             s3_fallback_enabled: false,
             s3_fallback_bucket: None,
             s3_fallback_endpoint: None,
+            s3_fallback_prefix: String::new(),
             healthcheck_strategy: HealthStrategy::All,
         }
     }

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -75,52 +75,6 @@ pub struct Config {
     pub healthcheck_strategy: HealthStrategy,
 }
 
-impl Config {
-    pub fn from_env() -> Self {
-        Self {
-            print_sink: false,
-            address: "127.0.0.1:3000".parse().unwrap(),
-            redis_url: String::new(),
-            otel_url: None,
-            overflow_enabled: false,
-            overflow_per_second_limit: NonZeroU32::new(100).unwrap(),
-            overflow_burst_limit: NonZeroU32::new(1000).unwrap(),
-            overflow_forced_keys: None,
-            dropped_keys: None,
-            kafka: KafkaConfig {
-                kafka_producer_linger_ms: 20,
-                kafka_producer_queue_mib: 400,
-                kafka_message_timeout_ms: 20000,
-                kafka_producer_message_max_bytes: 1000000,
-                kafka_compression_codec: String::new(),
-                kafka_hosts: String::new(),
-                kafka_topic: String::new(),
-                kafka_historical_topic: String::new(),
-                kafka_client_ingestion_warning_topic: String::new(),
-                kafka_exceptions_topic: String::new(),
-                kafka_heatmaps_topic: String::new(),
-                kafka_replay_overflow_topic: String::new(),
-                kafka_tls: false,
-                kafka_client_id: String::new(),
-                kafka_metadata_max_age_ms: 60000,
-                kafka_producer_max_retries: 2,
-                kafka_producer_acks: String::new(),
-            },
-            otel_sampling_rate: 1.0,
-            otel_service_name: String::new(),
-            export_prometheus: true,
-            redis_key_prefix: None,
-            capture_mode: CaptureMode::Events,
-            concurrency_limit: None,
-            s3_fallback_enabled: false,
-            s3_fallback_bucket: None,
-            s3_fallback_endpoint: None,
-            s3_fallback_prefix: String::new(),
-            healthcheck_strategy: HealthStrategy::All,
-        }
-    }
-}
-
 #[derive(Envconfig, Clone)]
 pub struct KafkaConfig {
     #[envconfig(default = "20")]

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -22,58 +22,14 @@ use crate::sinks::fallback::FallbackSink;
 use crate::sinks::kafka::KafkaSink;
 use crate::sinks::print::PrintSink;
 use crate::sinks::s3::S3Sink;
+use crate::sinks::Event;
 
-pub async fn serve<F>(config: Config, listener: TcpListener, shutdown: F)
-where
-    F: Future<Output = ()> + Send + 'static,
-{
-    let liveness = HealthRegistry::new("liveness");
-
-    let redis_client =
-        Arc::new(RedisClient::new(config.redis_url).expect("failed to create redis client"));
-
-    let replay_overflow_limiter = match config.capture_mode {
-        CaptureMode::Recordings => Some(
-            RedisLimiter::new(
-                Duration::seconds(5),
-                redis_client.clone(),
-                OVERFLOW_LIMITER_CACHE_KEY.to_string(),
-                config.redis_key_prefix.clone(),
-                QuotaResource::Replay,
-            )
-            .expect("failed to start replay overflow limiter"),
-        ),
-        _ => None,
-    };
-
-    let billing_limiter = RedisLimiter::new(
-        Duration::seconds(5),
-        redis_client.clone(),
-        QUOTA_LIMITER_CACHE_KEY.to_string(),
-        config.redis_key_prefix,
-        match config.capture_mode {
-            CaptureMode::Events => QuotaResource::Events,
-            CaptureMode::Recordings => QuotaResource::Recordings,
-        },
-    )
-    .expect("failed to create billing limiter");
-
-    let token_dropper = config
-        .dropped_keys
-        .map(|k| TokenDropper::new(&k))
-        .unwrap_or_default();
-
-    // In Recordings capture mode, we unpack a batch of events, and then pack them back up into
-    // a big blob and send to kafka all at once - so we should abort unpacking a batch if the data
-    // size crosses the kafka limit. In the Events mode, we can unpack the batch and send each
-    // event individually, so we should instead allow for some small multiple of our max compressed
-    // body size to be unpacked. If a single event is still too big, we'll drop it at kafka send time.
-    let event_max_bytes = match config.capture_mode {
-        CaptureMode::Events => BATCH_BODY_SIZE * 5, // To allow for some compression ratio, but still have a limit of 100MB.
-        CaptureMode::Recordings => config.kafka.kafka_producer_message_max_bytes as usize,
-    };
-
-    let app = if config.print_sink {
+async fn create_sink(
+    config: &Config,
+    redis_client: Arc<RedisClient>,
+    liveness: &HealthRegistry,
+) -> anyhow::Result<Box<dyn Event + Send + Sync>> {
+    if config.print_sink {
         // Print sink is only used for local debug, don't allow a container with it to run on prod
         liveness
             .register("print_sink".to_string(), Duration::seconds(30))
@@ -81,18 +37,7 @@ where
             .report_status(ComponentStatus::Unhealthy)
             .await;
 
-        router::router(
-            crate::time::SystemTime {},
-            liveness,
-            PrintSink {},
-            redis_client,
-            billing_limiter,
-            token_dropper,
-            config.export_prometheus,
-            config.capture_mode,
-            config.concurrency_limit,
-            event_max_bytes,
-        )
+        Ok(Box::new(PrintSink {}))
     } else {
         let sink_liveness = liveness
             .register("rdkafka".to_string(), Duration::seconds(30))
@@ -104,7 +49,7 @@ where
                 let partition = OverflowLimiter::new(
                     config.overflow_per_second_limit,
                     config.overflow_burst_limit,
-                    config.overflow_forced_keys,
+                    config.overflow_forced_keys.clone(),
                 );
                 if config.export_prometheus {
                     let partition = partition.clone();
@@ -122,8 +67,23 @@ where
                 Some(partition)
             }
         };
+
+        let replay_overflow_limiter = match config.capture_mode {
+            CaptureMode::Recordings => Some(
+                RedisLimiter::new(
+                    Duration::seconds(5),
+                    redis_client.clone(),
+                    OVERFLOW_LIMITER_CACHE_KEY.to_string(),
+                    config.redis_key_prefix.clone(),
+                    QuotaResource::Replay,
+                )
+                .expect("failed to start replay overflow limiter"),
+            ),
+            _ => None,
+        };
+
         let kafka_sink = KafkaSink::new(
-            config.kafka,
+            config.kafka.clone(),
             sink_liveness,
             partition,
             replay_overflow_limiter,
@@ -138,45 +98,73 @@ where
             let s3_sink = S3Sink::new(
                 config
                     .s3_fallback_bucket
+                    .clone()
                     .expect("S3 bucket required when fallback enabled"),
-                config.s3_fallback_endpoint,
+                config.s3_fallback_endpoint.clone(),
                 sink_liveness,
             )
             .await
             .expect("failed to create S3 sink");
 
-            let fallback_sink = FallbackSink::new(kafka_sink, s3_sink);
-
-            router::router(
-                crate::time::SystemTime {},
-                liveness,
-                fallback_sink,
-                redis_client,
-                billing_limiter,
-                token_dropper,
-                config.export_prometheus,
-                config.capture_mode,
-                config.concurrency_limit,
-                event_max_bytes,
-            )
+            Ok(Box::new(FallbackSink::new(kafka_sink, s3_sink)))
         } else {
-            router::router(
-                crate::time::SystemTime {},
-                liveness,
-                kafka_sink,
-                redis_client,
-                billing_limiter,
-                token_dropper,
-                config.export_prometheus,
-                config.capture_mode,
-                config.concurrency_limit,
-                event_max_bytes,
-            )
+            Ok(Box::new(kafka_sink))
         }
+    }
+}
+
+pub async fn serve<F>(config: Config, listener: TcpListener, shutdown: F)
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let liveness = HealthRegistry::new("liveness");
+
+    let redis_client =
+        Arc::new(RedisClient::new(config.redis_url.clone()).expect("failed to create redis client"));
+
+    let billing_limiter = RedisLimiter::new(
+        Duration::seconds(5),
+        redis_client.clone(),
+        QUOTA_LIMITER_CACHE_KEY.to_string(),
+        config.redis_key_prefix.clone(),
+        match config.capture_mode {
+            CaptureMode::Events => QuotaResource::Events,
+            CaptureMode::Recordings => QuotaResource::Recordings,
+        },
+    )
+    .expect("failed to create billing limiter");
+
+    let token_dropper = config
+        .dropped_keys.clone()
+        .map(|k| TokenDropper::new(&k))
+        .unwrap_or_default();
+
+    // In Recordings capture mode, we unpack a batch of events, and then pack them back up into
+    // a big blob and send to kafka all at once - so we should abort unpacking a batch if the data
+    // size crosses the kafka limit. In the Events mode, we can unpack the batch and send each
+    // event individually, so we should instead allow for some small multiple of our max compressed
+    // body size to be unpacked. If a single event is still too big, we'll drop it at kafka send time.
+    let event_max_bytes = match config.capture_mode {
+        CaptureMode::Events => BATCH_BODY_SIZE * 5,
+        CaptureMode::Recordings => config.kafka.kafka_producer_message_max_bytes as usize,
     };
 
+    let sink = create_sink(&config, redis_client.clone(), &liveness).await.expect("failed to create sink");
+
+    let app = router::router(
+        crate::time::SystemTime {},
+        liveness,
+        sink,
+        redis_client,
+        billing_limiter,
+        token_dropper,
+        config.export_prometheus,
+        config.capture_mode,
+        config.concurrency_limit,
+        event_max_bytes,
+    );
+
     // run our app with hyper
-    // `axum::Server` is a re-export of `hyper::Server`
     tracing::info!("listening on {:?}", listener.local_addr().unwrap());
     axum::serve(
         listener,

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -88,7 +88,7 @@ async fn create_sink(
             partition,
             replay_overflow_limiter,
         )
-        .expect("failed to start Kafka sink");
+        .await.expect("failed to start Kafka sink");
 
         if config.s3_fallback_enabled {
             let sink_liveness = liveness

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -106,7 +106,12 @@ async fn create_sink(
             .await
             .expect("failed to create S3 sink");
 
-            Ok(Box::new(FallbackSink::new(kafka_sink, s3_sink)))
+            Ok(Box::new(FallbackSink::new_with_health(
+                kafka_sink,
+                s3_sink,
+                liveness.clone(),
+                "rdkafka".to_string(),
+            )))
         } else {
             Ok(Box::new(kafka_sink))
         }

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -117,7 +117,7 @@ pub async fn serve<F>(config: Config, listener: TcpListener, shutdown: F)
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    let liveness = HealthRegistry::new("liveness");
+    let liveness = HealthRegistry::new_with_strategy("liveness", config.healthcheck_strategy.clone());
 
     let redis_client =
         Arc::new(RedisClient::new(config.redis_url.clone()).expect("failed to create redis client"));

--- a/rust/capture/src/server.rs
+++ b/rust/capture/src/server.rs
@@ -100,6 +100,7 @@ async fn create_sink(
                     .s3_fallback_bucket
                     .clone()
                     .expect("S3 bucket required when fallback enabled"),
+                config.s3_fallback_prefix.clone(),
                 config.s3_fallback_endpoint.clone(),
                 sink_liveness,
             )

--- a/rust/capture/src/sinks/fallback.rs
+++ b/rust/capture/src/sinks/fallback.rs
@@ -230,16 +230,16 @@ mod tests {
 
         // Should fail over to print sink
 
-        assert_eq!(
+        assert!(matches!(
             fallback_sink.send(event.clone()).await,
             Err(CaptureError::RetryableSinkError)
-        );
+        ));
 
         // Test batch
         let batch = vec![event.clone(), event.clone()];
-        assert_eq!(
+        assert!(matches!(
             fallback_sink.send_batch(batch).await,
             Err(CaptureError::RetryableSinkError)
-        );
+        ));
     }
 }

--- a/rust/capture/src/sinks/fallback.rs
+++ b/rust/capture/src/sinks/fallback.rs
@@ -34,13 +34,25 @@ impl FallbackSink {
             shutdown_tx: None,
         }
     }
-    pub fn new_with_health<P, F>(primary: P, fallback: F, health_registry: HealthRegistry, primary_component_name: String) -> Self
+    pub fn new_with_health<P, F>(
+        primary: P,
+        fallback: F,
+        health_registry: HealthRegistry,
+        primary_component_name: String,
+    ) -> Self
     where
         P: Event + Send + Sync + 'static,
         F: Event + Send + Sync + 'static,
     {
-        if !health_registry.get_status().components.contains_key(&primary_component_name) {
-            panic!("health registry does not contain primary component {}", primary_component_name)
+        if !health_registry
+            .get_status()
+            .components
+            .contains_key(&primary_component_name)
+        {
+            panic!(
+                "health registry does not contain primary component {}",
+                primary_component_name
+            )
         }
 
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
@@ -95,9 +107,7 @@ impl Event for FallbackSink {
                     counter!("capture_fallback_sink_failovers_total").increment(1);
                     self.fallback.send(event).await
                 }
-                Err(e) => {
-                    Err(e)
-                }
+                Err(e) => Err(e),
             }
         } else {
             error!("Primary sink unhealthy, falling back");
@@ -116,9 +126,7 @@ impl Event for FallbackSink {
                     counter!("capture_fallback_sink_failovers_total").increment(1);
                     self.fallback.send_batch(events).await
                 }
-                Err(e) => {
-                    Err(e)
-                }
+                Err(e) => Err(e),
             }
         } else {
             error!("Primary sink unhealthy, falling back");

--- a/rust/capture/src/sinks/fallback.rs
+++ b/rust/capture/src/sinks/fallback.rs
@@ -1,0 +1,154 @@
+use crate::api::CaptureError;
+use crate::sinks::Event;
+use crate::v0_request::ProcessedEvent;
+use async_trait::async_trait;
+use metrics::counter;
+use std::sync::Arc;
+use tracing::instrument;
+use tracing::log::error;
+
+#[derive(Clone)]
+pub struct FallbackSink {
+    primary: Arc<Box<dyn Event + Send + Sync + 'static>>,
+    fallback: Arc<Box<dyn Event + Send + Sync + 'static>>,
+}
+
+impl FallbackSink {
+    pub fn new<P, F>(primary: P, fallback: F) -> Self
+    where
+        P: Event + Send + Sync + 'static,
+        F: Event + Send + Sync + 'static,
+    {
+        Self {
+            primary: Arc::new(Box::new(primary)),
+            fallback: Arc::new(Box::new(fallback)),
+        }
+    }
+}
+
+#[async_trait]
+impl Event for FallbackSink {
+    #[instrument(skip_all)]
+    async fn send(&self, event: ProcessedEvent) -> Result<(), CaptureError> {
+        match self.primary.send(event.clone()).await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                error!("Primary sink failed, falling back: {}", e);
+                counter!("capture_fallback_sink_failovers_total").increment(1);
+                self.fallback.send(event).await
+            }
+        }
+    }
+
+    #[instrument(skip_all)]
+    async fn send_batch(&self, events: Vec<ProcessedEvent>) -> Result<(), CaptureError> {
+        match self.primary.send_batch(events.clone()).await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                error!("Primary sink failed, falling back: {}", e);
+                counter!("capture_fallback_sink_failovers_total").increment(1);
+                self.fallback.send_batch(events).await
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sinks::print::PrintSink;
+    use crate::utils::uuid_v7;
+    use crate::v0_request::{DataType, ProcessedEventMetadata};
+    use common_types::CapturedEvent;
+
+    #[derive(Clone)]
+    pub struct FailSink {}
+
+    // sink that always fails for testing fallback
+    #[async_trait]
+    impl Event for FailSink {
+        async fn send(&self, _event: ProcessedEvent) -> Result<(), CaptureError> {
+            Err(CaptureError::EventTooBig)
+        }
+        async fn send_batch(&self, _events: Vec<ProcessedEvent>) -> Result<(), CaptureError> {
+            Err(CaptureError::EventTooBig)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fallback_sink() {
+        let fail_sink = FailSink {};
+        let print_sink = PrintSink {};
+
+        let fallback_sink = FallbackSink::new(fail_sink, print_sink);
+
+        // Create test event
+        let event = ProcessedEvent {
+            event: CapturedEvent {
+                uuid: uuid_v7(),
+                distinct_id: "test_id".to_string(),
+                ip: "127.0.0.1".to_string(),
+                data: "test data".to_string(),
+                now: "2024-01-01T00:00:00Z".to_string(),
+                sent_at: None,
+                token: "test_token".to_string(),
+                is_cookieless_mode: false,
+            },
+            metadata: ProcessedEventMetadata {
+                data_type: DataType::AnalyticsMain,
+                session_id: None,
+            },
+        };
+
+        // Should fail over to print sink
+        fallback_sink
+            .send(event.clone())
+            .await
+            .expect("Failed to send event");
+
+        // Test batch
+        let batch = vec![event.clone(), event.clone()];
+        fallback_sink
+            .send_batch(batch)
+            .await
+            .expect("Failed to send batch");
+    }
+
+    #[tokio::test]
+    async fn test_fallback_sink_fail() {
+        let fail_sink = FailSink {};
+        let fallback_sink = FallbackSink::new(fail_sink.clone(), fail_sink);
+
+        // Create test event
+        let event = ProcessedEvent {
+            event: CapturedEvent {
+                uuid: uuid_v7(),
+                distinct_id: "test_id".to_string(),
+                ip: "127.0.0.1".to_string(),
+                data: "test data".to_string(),
+                now: "2024-01-01T00:00:00Z".to_string(),
+                sent_at: None,
+                token: "test_token".to_string(),
+                is_cookieless_mode: false,
+            },
+            metadata: ProcessedEventMetadata {
+                data_type: DataType::AnalyticsMain,
+                session_id: None,
+            },
+        };
+
+        // Should fail over to print sink
+
+        assert_eq!(
+            fallback_sink.send(event.clone()).await,
+            Err(CaptureError::EventTooBig)
+        );
+
+        // Test batch
+        let batch = vec![event.clone(), event.clone()];
+        assert_eq!(
+            fallback_sink.send_batch(batch).await,
+            Err(CaptureError::EventTooBig)
+        );
+    }
+}

--- a/rust/capture/src/sinks/fallback.rs
+++ b/rust/capture/src/sinks/fallback.rs
@@ -8,7 +8,7 @@ use tokio::task;
 use tokio::time::sleep;
 
 use async_trait::async_trait;
-use metrics::counter;
+use metrics::{counter, gauge};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tracing::instrument;
@@ -76,8 +76,10 @@ impl FallbackSink {
                         let was_healthy = thread_healthy.load(Ordering::Relaxed);
                         if was_healthy && !is_healthy {
                             error!("primary sink has become unhealthy");
+                            gauge!("capture_primary_sink_health").set(0.0);
                         } else if !was_healthy && is_healthy {
                             warn!("primary sink has recovered");
+                            gauge!("capture_primary_sink_health").set(1.0);
                         }
                         thread_healthy.store(is_healthy, Ordering::Relaxed);
                     }

--- a/rust/capture/src/sinks/fallback.rs
+++ b/rust/capture/src/sinks/fallback.rs
@@ -1,16 +1,24 @@
 use crate::api::CaptureError;
 use crate::sinks::Event;
 use crate::v0_request::ProcessedEvent;
+use health::HealthRegistry;
+use std::time::Duration;
+use tokio::sync::oneshot;
+use tokio::task;
+use tokio::time::sleep;
+
 use async_trait::async_trait;
 use metrics::counter;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tracing::instrument;
 use tracing::log::error;
 
-#[derive(Clone)]
 pub struct FallbackSink {
     primary: Arc<Box<dyn Event + Send + Sync + 'static>>,
     fallback: Arc<Box<dyn Event + Send + Sync + 'static>>,
+    primary_is_healthy: Arc<AtomicBool>,
+    shutdown_tx: Option<oneshot::Sender<()>>,
 }
 
 impl FallbackSink {
@@ -22,6 +30,49 @@ impl FallbackSink {
         Self {
             primary: Arc::new(Box::new(primary)),
             fallback: Arc::new(Box::new(fallback)),
+            primary_is_healthy: Arc::new(AtomicBool::new(true)),
+            shutdown_tx: None,
+        }
+    }
+    pub fn new_with_health<P, F>(primary: P, fallback: F, health_registry: HealthRegistry, primary_component_name: String) -> Self
+    where
+        P: Event + Send + Sync + 'static,
+        F: Event + Send + Sync + 'static,
+    {
+        if !health_registry.get_status().components.contains_key(&primary_component_name) {
+            panic!("health registry does not contain primary component {}", primary_component_name)
+        }
+
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+        let primary_is_healthy = Arc::new(AtomicBool::new(true));
+        let thread_healthy = primary_is_healthy.clone();
+
+        // Asynchronously update primary health status every 10 seconds
+        // this means if the primary starts failing we'll stop trying to send to it until it recovers.
+        task::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = sleep(Duration::from_millis(10000)) => {
+                        let is_healthy = health_registry
+                            .get_status()
+                            .components
+                            .get(&primary_component_name)
+                            .unwrap()
+                            .is_healthy();
+                        thread_healthy.store(is_healthy, Ordering::Relaxed);
+                    }
+                    _ = &mut shutdown_rx => {
+                        break;
+                    }
+                }
+            }
+        });
+
+        Self {
+            primary: Arc::new(Box::new(primary)),
+            fallback: Arc::new(Box::new(fallback)),
+            primary_is_healthy,
+            shutdown_tx: Some(shutdown_tx),
         }
     }
 }
@@ -30,25 +81,45 @@ impl FallbackSink {
 impl Event for FallbackSink {
     #[instrument(skip_all)]
     async fn send(&self, event: ProcessedEvent) -> Result<(), CaptureError> {
-        match self.primary.send(event.clone()).await {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                error!("Primary sink failed, falling back: {}", e);
-                counter!("capture_fallback_sink_failovers_total").increment(1);
-                self.fallback.send(event).await
+        if self.primary_is_healthy.load(Ordering::Relaxed) {
+            match self.primary.send(event.clone()).await {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    error!("Primary sink failed, falling back: {}", e);
+                    counter!("capture_fallback_sink_failovers_total").increment(1);
+                    self.fallback.send(event).await
+                }
             }
+        } else {
+            error!("Primary sink unhealthy, falling back");
+            counter!("capture_fallback_sink_failovers_total").increment(1);
+            self.fallback.send(event).await
         }
     }
 
     #[instrument(skip_all)]
     async fn send_batch(&self, events: Vec<ProcessedEvent>) -> Result<(), CaptureError> {
-        match self.primary.send_batch(events.clone()).await {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                error!("Primary sink failed, falling back: {}", e);
-                counter!("capture_fallback_sink_failovers_total").increment(1);
-                self.fallback.send_batch(events).await
+        if self.primary_is_healthy.load(Ordering::Relaxed) {
+            match self.primary.send_batch(events.clone()).await {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    error!("Primary sink failed, falling back: {}", e);
+                    counter!("capture_fallback_sink_failovers_total").increment(1);
+                    self.fallback.send_batch(events).await
+                }
             }
+        } else {
+            error!("Primary sink unhealthy, falling back");
+            counter!("capture_fallback_sink_failovers_total").increment(1);
+            self.fallback.send_batch(events).await
+        }
+    }
+}
+
+impl Drop for FallbackSink {
+    fn drop(&mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            drop(shutdown_tx);
         }
     }
 }
@@ -141,14 +212,14 @@ mod tests {
 
         assert_eq!(
             fallback_sink.send(event.clone()).await,
-            Err(CaptureError::EventTooBig)
+            Err(CaptureError::RetryableSinkError)
         );
 
         // Test batch
         let batch = vec![event.clone(), event.clone()];
         assert_eq!(
             fallback_sink.send_batch(batch).await,
-            Err(CaptureError::EventTooBig)
+            Err(CaptureError::RetryableSinkError)
         );
     }
 }

--- a/rust/capture/src/sinks/fallback.rs
+++ b/rust/capture/src/sinks/fallback.rs
@@ -21,6 +21,8 @@ pub struct FallbackSink {
     shutdown_tx: Option<oneshot::Sender<()>>,
 }
 
+// FallbackSink attempts to send events to the primary sink, and if it fails, it will send events to the fallback sink.
+// Optionally pass in a health registry to stop attempting to send events to the primary sink if it becomes unhealthy.
 impl FallbackSink {
     pub fn new<P, F>(primary: P, fallback: F) -> Self
     where

--- a/rust/capture/src/sinks/fallback.rs
+++ b/rust/capture/src/sinks/fallback.rs
@@ -112,7 +112,6 @@ impl Event for FallbackSink {
                 Err(e) => Err(e),
             }
         } else {
-            error!("Primary sink unhealthy, falling back");
             counter!("capture_fallback_sink_failovers_total").increment(1);
             self.fallback.send(event).await
         }
@@ -131,7 +130,6 @@ impl Event for FallbackSink {
                 Err(e) => Err(e),
             }
         } else {
-            error!("Primary sink unhealthy, falling back");
             counter!("capture_fallback_sink_failovers_total").increment(1);
             self.fallback.send_batch(events).await
         }

--- a/rust/capture/src/sinks/fallback.rs
+++ b/rust/capture/src/sinks/fallback.rs
@@ -71,8 +71,8 @@ impl FallbackSink {
                             .get_status()
                             .components
                             .get(&primary_component_name)
-                            .unwrap()
-                            .is_healthy();
+                            .map(|c| c.is_healthy())
+                            .unwrap_or(false);
                         let was_healthy = thread_healthy.load(Ordering::Relaxed);
                         if was_healthy && !is_healthy {
                             error!("primary sink has become unhealthy");

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -27,8 +27,8 @@ struct KafkaContext {
 impl rdkafka::ClientContext for KafkaContext {
     fn stats(&self, stats: rdkafka::Statistics) {
         // Signal liveness, as the main rdkafka loop is running and calling us
-        // If rx_bytes is zero we've had no communication from the brokers so are probably not healthy
-        if stats.rx_bytes > 0 {
+        let brokers_up = stats.brokers.values().any(|broker| broker.state == "UP");
+        if brokers_up {
             self.liveness.report_healthy_blocking();
         }
 
@@ -173,14 +173,20 @@ impl KafkaSink {
 
         debug!("rdkafka configuration: {:?}", client_config);
         let producer: FutureProducer<KafkaContext> =
-            client_config.create_with_context(KafkaContext { liveness: liveness.clone() })?;
+            client_config.create_with_context(KafkaContext {
+                liveness: liveness.clone(),
+            })?;
 
         // Ping the cluster to make sure we can reach brokers, fail after 10 seconds
         // Note: we don't error if we fail to connect as there may be other sinks that report healthy
-        if producer.client().fetch_metadata(
-            Some("__consumer_offsets"),
-            Timeout::After(Duration::new(10, 0)),
-        ).is_ok() {
+        if producer
+            .client()
+            .fetch_metadata(
+                Some("__consumer_offsets"),
+                Timeout::After(Duration::new(10, 0)),
+            )
+            .is_ok()
+        {
             liveness.report_healthy().await;
             info!("connected to Kafka brokers");
         };
@@ -417,7 +423,9 @@ mod tests {
             kafka_producer_max_retries: 2,
             kafka_producer_acks: "all".to_string(),
         };
-        let sink = KafkaSink::new(config, handle, limiter, None).await.expect("failed to create sink");
+        let sink = KafkaSink::new(config, handle, limiter, None)
+            .await
+            .expect("failed to create sink");
         (cluster, sink)
     }
 

--- a/rust/capture/src/sinks/mod.rs
+++ b/rust/capture/src/sinks/mod.rs
@@ -12,4 +12,15 @@ pub trait Event {
     async fn send_batch(&self, events: Vec<ProcessedEvent>) -> Result<(), CaptureError>;
 }
 
+#[async_trait]
+impl<T: Event + ?Sized + Send + Sync> Event for Box<T> {
+    async fn send(&self, event: ProcessedEvent) -> Result<(), CaptureError> {
+        (**self).send(event).await
+    }
+
+    async fn send_batch(&self, events: Vec<ProcessedEvent>) -> Result<(), CaptureError> {
+        (**self).send_batch(events).await
+    }
+}
+
 pub use fallback::FallbackSink;

--- a/rust/capture/src/sinks/mod.rs
+++ b/rust/capture/src/sinks/mod.rs
@@ -2,11 +2,14 @@ use async_trait::async_trait;
 
 use crate::{api::CaptureError, v0_request::ProcessedEvent};
 
+pub mod fallback;
 pub mod kafka;
 pub mod print;
-
+pub mod s3;
 #[async_trait]
 pub trait Event {
     async fn send(&self, event: ProcessedEvent) -> Result<(), CaptureError>;
     async fn send_batch(&self, events: Vec<ProcessedEvent>) -> Result<(), CaptureError>;
 }
+
+pub use fallback::FallbackSink;

--- a/rust/capture/src/sinks/s3.rs
+++ b/rust/capture/src/sinks/s3.rs
@@ -2,14 +2,10 @@ use crate::v0_request::ProcessedEvent;
 use async_trait::async_trait;
 use aws_sdk_s3::config::Builder;
 use aws_sdk_s3::Client as S3Client;
-use bytes::BytesMut;
 use chrono::{DateTime, Datelike, Timelike, Utc};
-use flate2::write::GzEncoder;
-use flate2::Compression;
 use health::HealthHandle;
 use metrics::{counter, histogram};
 use std::env;
-use std::io::Write;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::sync::broadcast;
@@ -39,9 +35,9 @@ pub struct S3Sink {
 }
 
 struct EventBuffer {
-    events: Vec<ProcessedEvent>,
+    event_bytes: Vec<u8>,
+    event_count: usize,
     time_elapsed: Instant,
-    total_size: usize,
     tx: Sender<Result<(), CaptureError>>,
 }
 
@@ -50,11 +46,19 @@ impl EventBuffer {
         let (tx, _) = broadcast::channel(32);
 
         Self {
-            events: Vec::new(),
+            event_bytes: Vec::new(),
+            event_count: 0,
             time_elapsed: Instant::now(),
-            total_size: 0,
             tx,
         }
+    }
+
+    fn add_event(&mut self, event: ProcessedEvent) -> Result<(), CaptureError> {
+        let json = serde_json::to_string(&event.event)?;
+        self.event_bytes.extend_from_slice(json.as_bytes());
+        self.event_bytes.push(b'\n');
+        self.event_count += 1;
+        Ok(())
     }
 }
 
@@ -101,8 +105,8 @@ impl S3Sink {
                 tokio::select! {
                     _ = sleep(Duration::from_millis(10)) => {
                         let mut buffer = s3sink.buffer.lock().await;
-                        let should_flush = !buffer.events.is_empty()
-                         && (buffer.total_size >= MAX_BUFFER_SIZE ||
+                        let should_flush = !buffer.event_bytes.is_empty()
+                         && (buffer.event_bytes.len() >= MAX_BUFFER_SIZE ||
                             buffer.time_elapsed.elapsed() >= FLUSH_INTERVAL);
 
                         if should_flush {
@@ -128,7 +132,7 @@ impl S3Sink {
                     _ = &mut shutdown_rx => {
                         // Final flush on shutdown
                         let mut buffer = s3sink.buffer.lock().await;
-                        if !buffer.events.is_empty() {
+                        if !buffer.event_bytes.is_empty() {
                             let result = s3sink.flush_buffer(&mut buffer).await;
                             drop(buffer.tx.send(result));
                         }
@@ -164,8 +168,8 @@ impl S3Sink {
 
     async fn flush_buffer(&self, buffer: &mut EventBuffer) -> Result<(), CaptureError> {
         let start = Instant::now();
-        let events_count = buffer.events.len();
-        let batch_size = buffer.total_size;
+        let events_count = buffer.event_count;
+        let batch_size = buffer.event_bytes.len();
 
         match self.do_flush(buffer).await {
             Ok(_) => {
@@ -200,7 +204,7 @@ impl S3Sink {
     }
 
     async fn try_flush(&self, buffer: &mut EventBuffer) -> Result<(), CaptureError> {
-        if buffer.events.is_empty() {
+        if buffer.event_bytes.is_empty() {
             return Ok(());
         }
 
@@ -218,40 +222,33 @@ impl S3Sink {
             hostname
         );
 
-        let mut data = BytesMut::new();
-        for event in &buffer.events {
-            let json = serde_json::to_string(&event.event)?;
-            data.extend_from_slice(json.as_bytes());
-            data.extend_from_slice(b"\n");
-        }
-
-        let compressed = self.compress_events(&data)?;
-        let data = BytesMut::from(&compressed[..]);
-
         debug!(
             "Flushing {} events to S3 path: {}",
-            buffer.events.len(),
+            buffer.event_count,
             path
         );
+
+        let event_count = buffer.event_count;
+        let written_bytes = buffer.event_bytes.len();
+
+        // take the event_bytes - this will implicitly reset to a new Vec
+        let event_bytes = std::mem::take(&mut buffer.event_bytes);
+        buffer.event_count = 0;
+        buffer.time_elapsed = Instant::now();
 
         match self
             .client
             .put_object()
             .bucket(&self.bucket)
             .key(&path)
-            .body(data.freeze().into())
+            .body(event_bytes.into())
             .send()
             .await
         {
             Ok(_) => {
-                let count = buffer.events.len();
-                counter!("capture_s3_events_written_total").increment(count as u64);
-                counter!("capture_s3_bytes_written_total").increment(buffer.total_size as u64);
-                histogram!("capture_s3_batch_size").record(count as f64);
-
-                // Reset buffer
-                buffer.events.clear();
-
+                counter!("capture_s3_events_written_total").increment(event_count as u64);
+                counter!("capture_s3_bytes_written_total").increment(written_bytes as u64);
+                histogram!("capture_s3_batch_size").record(event_count as f64);
                 self.liveness.report_healthy().await;
                 Ok(())
             }
@@ -262,25 +259,12 @@ impl S3Sink {
             }
         }
     }
-
-    fn compress_events(&self, data: &[u8]) -> Result<Vec<u8>, CaptureError> {
-        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        encoder.write_all(data).map_err(|e| {
-            error!("Failed to compress events: {}", e);
-            CaptureError::NonRetryableSinkError
-        })?;
-        encoder.finish().map_err(|e| {
-            error!("Failed to finish compression: {}", e);
-            CaptureError::NonRetryableSinkError
-        })
-    }
 }
 
 impl Drop for S3Sink {
     fn drop(&mut self) {
         if let Some(shutdown) = self.shutdown.take() {
-            // we don't actually need to send on the channel, dropping works
-            drop(shutdown);
+            let _ = shutdown.send(());
         }
     }
 }
@@ -290,8 +274,7 @@ impl Event for S3Sink {
     #[instrument(skip_all)]
     async fn send(&self, event: ProcessedEvent) -> Result<(), CaptureError> {
         let mut buffer = self.buffer.lock().await;
-        buffer.total_size += event.event.data.len();
-        buffer.events.push(event);
+        buffer.add_event(event)?;
         let mut rx = buffer.tx.subscribe();
         drop(buffer);
         rx.recv()
@@ -303,8 +286,7 @@ impl Event for S3Sink {
     async fn send_batch(&self, events: Vec<ProcessedEvent>) -> Result<(), CaptureError> {
         let mut buffer = self.buffer.lock().await;
         for event in events {
-            buffer.total_size += event.event.data.len();
-            buffer.events.push(event);
+            buffer.add_event(event)?;
         }
         let mut rx = buffer.tx.subscribe();
         drop(buffer);

--- a/rust/capture/src/sinks/s3.rs
+++ b/rust/capture/src/sinks/s3.rs
@@ -2,7 +2,7 @@ use crate::v0_request::ProcessedEvent;
 use async_trait::async_trait;
 use aws_sdk_s3::config::Builder;
 use aws_sdk_s3::Client as S3Client;
-use chrono::{DateTime, Datelike, Timelike, Utc};
+use chrono::{DateTime, Datelike, Utc};
 use health::HealthHandle;
 use metrics::{counter, histogram};
 use std::env;
@@ -214,12 +214,11 @@ impl Inner {
 
         let now: DateTime<Utc> = SystemTime::now().into();
         let path = format!(
-            "{}year={}/month={:02}/day={:02}/hour={:02}/events_{}_{}.json.gz",
+            "{}{}/{:02}/{:02}/events_{}_{}.jsonl.gz",
             self.prefix,
             now.year(),
             now.month(),
             now.day(),
-            now.hour(),
             now.timestamp_millis(),
             hostname
         );

--- a/rust/capture/src/sinks/s3.rs
+++ b/rust/capture/src/sinks/s3.rs
@@ -29,11 +29,11 @@ struct Inner {
     bucket: String,
     prefix: String,
     buffer: Arc<Mutex<EventBuffer>>,
-    liveness: HealthHandle
+    liveness: HealthHandle,
 }
 
 pub struct S3Sink {
-    inner: Arc<Inner>
+    inner: Arc<Inner>,
 }
 
 struct EventBuffer {
@@ -65,10 +65,8 @@ impl EventBuffer {
 
     fn should_flush(&self) -> bool {
         !self.event_bytes.is_empty()
-            && (
-                self.event_bytes.len() >= MAX_BUFFER_SIZE
-             || self.time_elapsed.elapsed() >= FLUSH_INTERVAL
-            )
+            && (self.event_bytes.len() >= MAX_BUFFER_SIZE
+                || self.time_elapsed.elapsed() >= FLUSH_INTERVAL)
     }
 }
 
@@ -102,7 +100,7 @@ impl S3Sink {
             bucket,
             prefix,
             buffer,
-            liveness
+            liveness,
         });
 
         // Do initial healthcheck
@@ -225,8 +223,7 @@ impl Inner {
 
         debug!(
             "Flushing {} events to S3 path: {}",
-            buffer.event_count,
-            path
+            buffer.event_count, path
         );
 
         let event_count = buffer.event_count;

--- a/rust/capture/src/sinks/s3.rs
+++ b/rust/capture/src/sinks/s3.rs
@@ -144,12 +144,15 @@ impl S3Sink {
 
     async fn healthcheck(&self) {
         // Verify bucket exists and is accessible
-        match self.client.head_bucket().bucket(&self.bucket).send().await {
-            Ok(_) => {
-                self.liveness.report_healthy().await;
-            }
-            Err(_) => {
-            }
+        if self
+            .client
+            .head_bucket()
+            .bucket(&self.bucket)
+            .send()
+            .await
+            .is_ok()
+        {
+            self.liveness.report_healthy().await;
         };
     }
 

--- a/rust/capture/src/sinks/s3.rs
+++ b/rust/capture/src/sinks/s3.rs
@@ -294,7 +294,9 @@ impl Event for S3Sink {
         buffer.events.push(event);
         let mut rx = buffer.tx.subscribe();
         drop(buffer);
-        rx.recv().await.map_err(|_| CaptureError::NonRetryableSinkError)?
+        rx.recv()
+            .await
+            .map_err(|_| CaptureError::NonRetryableSinkError)?
     }
 
     #[instrument(skip_all)]
@@ -306,7 +308,9 @@ impl Event for S3Sink {
         }
         let mut rx = buffer.tx.subscribe();
         drop(buffer);
-        rx.recv().await.map_err(|_| CaptureError::NonRetryableSinkError)?
+        rx.recv()
+            .await
+            .map_err(|_| CaptureError::NonRetryableSinkError)?
     }
 }
 

--- a/rust/capture/src/sinks/s3.rs
+++ b/rust/capture/src/sinks/s3.rs
@@ -244,11 +244,10 @@ impl S3Sink {
             .send()
             .await
         {
-            Ok(response) => {
+            Ok(_) => {
                 let count = buffer.events.len();
                 counter!("capture_s3_events_written_total").increment(count as u64);
-                counter!("capture_s3_bytes_written_total")
-                    .increment(u64::try_from(response.size.unwrap_or(0)).unwrap_or(0));
+                counter!("capture_s3_bytes_written_total").increment(buffer.total_size as u64);
                 histogram!("capture_s3_batch_size").record(count as f64);
 
                 // Reset buffer

--- a/rust/capture/src/sinks/s3.rs
+++ b/rust/capture/src/sinks/s3.rs
@@ -1,0 +1,375 @@
+use crate::v0_request::ProcessedEvent;
+use async_trait::async_trait;
+use aws_sdk_s3::config::Builder;
+use aws_sdk_s3::error::ProvideErrorMetadata;
+use aws_sdk_s3::Client as S3Client;
+use bytes::BytesMut;
+use chrono::{DateTime, Datelike, Timelike, Utc};
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use health::HealthHandle;
+use metrics::{counter, histogram};
+use std::env;
+use std::io::Write;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+use tokio::sync::broadcast;
+use tokio::sync::broadcast::Sender;
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
+use tokio::task;
+use tokio::time::sleep;
+use tokio::time::Instant;
+use tracing::instrument;
+use tracing::log::{debug, error, info};
+
+use crate::api::CaptureError;
+use crate::sinks::Event;
+
+const FLUSH_INTERVAL: Duration = Duration::from_secs(1);
+const MAX_BUFFER_SIZE: usize = 4 * 1024 * 1024; // 4MB
+
+pub struct S3Sink {
+    client: S3Client,
+    bucket: String,
+    buffer: Arc<Mutex<EventBuffer>>,
+    liveness: HealthHandle,
+    shutdown: Option<oneshot::Sender<()>>,
+}
+
+struct EventBuffer {
+    events: Vec<ProcessedEvent>,
+    time_elapsed: Instant,
+    total_size: usize,
+    tx: Sender<Result<(), CaptureError>>,
+}
+
+impl EventBuffer {
+    fn new() -> Self {
+        let (tx, _) = broadcast::channel(32);
+
+        Self {
+            events: Vec::new(),
+            time_elapsed: Instant::now(),
+            total_size: 0,
+            tx,
+        }
+    }
+}
+
+impl S3Sink {
+    pub async fn new(
+        bucket: String,
+        s3_endpoint: Option<String>,
+        liveness: HealthHandle,
+    ) -> anyhow::Result<S3Sink> {
+        info!("Initializing S3 sink with bucket: {}", bucket);
+
+        // Load base config
+        let mut config_loader = aws_config::defaults(aws_config::BehaviorVersion::latest());
+
+        if let Some(s3_endpoint) = s3_endpoint.clone() {
+            config_loader = config_loader.endpoint_url(s3_endpoint);
+        }
+
+        let mut config = Builder::from(&config_loader.load().await);
+        if s3_endpoint.is_some() {
+            // custom s3 endpoints need force_path_style set
+            config = config.force_path_style(true);
+        }
+
+        let client = S3Client::from_conf(config.build());
+        // Verify bucket exists and is accessible
+        match client.head_bucket().bucket(&bucket).send().await {
+            Ok(_) => {
+                info!("Successfully connected to S3 bucket");
+            }
+            Err(err) => {
+                error!("Failed to connect to S3 bucket: {:?}", err.code());
+                return Err(anyhow::anyhow!("Failed to connect to S3: {:?}", err));
+            }
+        }
+
+        let buffer = Arc::new(Mutex::new(EventBuffer::new()));
+
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+        let s3sink = S3Sink {
+            client: client.clone(),
+            bucket: bucket.clone(),
+            buffer: buffer.clone(),
+            liveness: liveness.clone(),
+            shutdown: None,
+        };
+
+        // Spawn background task with shutdown handling
+        task::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = sleep(Duration::from_millis(10)) => {
+                        let mut buffer = s3sink.buffer.lock().await;
+                        let should_flush = !buffer.events.is_empty()
+                         && (buffer.total_size >= MAX_BUFFER_SIZE ||
+                            buffer.time_elapsed.elapsed() >= FLUSH_INTERVAL);
+
+                        if should_flush {
+                            let mut old_buffer = {
+                                // Replace the current buffer with a brand-new one.
+                                std::mem::replace(&mut *buffer, EventBuffer::new())
+                            };
+
+                            let result = s3sink.flush_buffer(&mut old_buffer).await;
+                            drop(old_buffer.tx.send(result));
+                        }
+                    }
+                    _ = &mut shutdown_rx => {
+                        // Final flush on shutdown
+                        let mut buffer = s3sink.buffer.lock().await;
+                        if !buffer.events.is_empty() {
+                            let mut old_buffer = std::mem::replace(&mut *buffer, EventBuffer::new());
+                            let result = s3sink.flush_buffer(&mut old_buffer).await;
+                            drop(old_buffer.tx.send(result));
+                        }
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(S3Sink {
+            client,
+            bucket,
+            buffer,
+            liveness,
+            shutdown: Some(shutdown_tx),
+        })
+    }
+
+    async fn flush_buffer(&self, buffer: &mut EventBuffer) -> Result<(), CaptureError> {
+        let start = Instant::now();
+        let events_count = buffer.events.len();
+        let batch_size = buffer.total_size;
+
+        match self.do_flush(buffer).await {
+            Ok(_) => {
+                let duration = start.elapsed();
+                histogram!("capture_s3_flush_duration_ms").record(duration.as_millis() as f64);
+                histogram!("capture_s3_batch_size_events").record(events_count as f64);
+                histogram!("capture_s3_batch_size_bytes").record(batch_size as f64);
+                Ok(())
+            }
+            Err(e) => {
+                counter!("capture_s3_flush_errors_total", "error" => e.to_string()).increment(1);
+                Err(e)
+            }
+        }
+    }
+
+    async fn do_flush(&self, buffer: &mut EventBuffer) -> Result<(), CaptureError> {
+        let mut retries = 3;
+        let mut last_error = None;
+
+        while retries > 0 {
+            match self.try_flush(buffer).await {
+                Ok(_) => return Ok(()),
+                Err(e) => {
+                    last_error = Some(e);
+                    retries -= 1;
+                    if retries > 0 {
+                        sleep(Duration::from_millis(100 * (4 - retries))).await;
+                    }
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or(CaptureError::RetryableSinkError))
+    }
+
+    async fn try_flush(&self, buffer: &mut EventBuffer) -> Result<(), CaptureError> {
+        if buffer.events.is_empty() {
+            return Ok(());
+        }
+
+        let hostname = env::var("HOSTNAME").unwrap_or("unknown".to_string());
+
+        let now: DateTime<Utc> = SystemTime::now().into();
+        let path = format!(
+            "year={}/month={:02}/day={:02}/hour={:02}/events_{}_{}.json.gz",
+            now.year(),
+            now.month(),
+            now.day(),
+            now.hour(),
+            hostname,
+            now.timestamp_millis()
+        );
+
+        let mut data = BytesMut::new();
+        for event in &buffer.events {
+            let json = serde_json::to_string(&event.event)?;
+            data.extend_from_slice(json.as_bytes());
+            data.extend_from_slice(b"\n");
+        }
+
+        let compressed = self.compress_events(&data)?;
+        let data = BytesMut::from(&compressed[..]);
+
+        debug!(
+            "Flushing {} events to S3 path: {}",
+            buffer.events.len(),
+            path
+        );
+
+        match self
+            .client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(&path)
+            .body(data.freeze().into())
+            .send()
+            .await
+        {
+            Ok(response) => {
+                let count = buffer.events.len();
+                counter!("capture_s3_events_written_total").increment(count as u64);
+                counter!("capture_s3_bytes_written_total")
+                    .increment(u64::try_from(response.size.unwrap_or(0)).unwrap_or(0));
+                histogram!("capture_s3_batch_size").record(count as f64);
+
+                // Reset buffer
+                buffer.events.clear();
+
+                self.liveness.report_healthy().await;
+                Ok(())
+            }
+            Err(err) => {
+                error!("Failed to write to S3: {}", err);
+                counter!("capture_s3_write_errors_total").increment(1);
+                Err(CaptureError::RetryableSinkError)
+            }
+        }
+    }
+
+    fn compress_events(&self, data: &[u8]) -> Result<Vec<u8>, CaptureError> {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).map_err(|e| {
+            error!("Failed to compress events: {}", e);
+            CaptureError::NonRetryableSinkError
+        })?;
+        encoder.finish().map_err(|e| {
+            error!("Failed to finish compression: {}", e);
+            CaptureError::NonRetryableSinkError
+        })
+    }
+}
+
+impl Drop for S3Sink {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            drop(shutdown); // Signal background task to stop
+        }
+    }
+}
+
+#[async_trait]
+impl Event for S3Sink {
+    #[instrument(skip_all)]
+    async fn send(&self, event: ProcessedEvent) -> Result<(), CaptureError> {
+        let mut buffer = self.buffer.lock().await;
+        buffer.total_size += event.event.data.len();
+        buffer.events.push(event);
+        let mut rx = buffer.tx.subscribe();
+        drop(buffer);
+        rx.recv().await.map_err(|_| CaptureError::NonRetryableSinkError)?
+    }
+
+    #[instrument(skip_all)]
+    async fn send_batch(&self, events: Vec<ProcessedEvent>) -> Result<(), CaptureError> {
+        let mut buffer = self.buffer.lock().await;
+        for event in events {
+            buffer.total_size += event.event.data.len();
+            buffer.events.push(event);
+        }
+        let mut rx = buffer.tx.subscribe();
+        drop(buffer);
+        rx.recv().await.map_err(|_| CaptureError::NonRetryableSinkError)?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::uuid_v7;
+    use crate::v0_request::{DataType, ProcessedEventMetadata};
+    use common_types::CapturedEvent;
+    use health::HealthRegistry;
+    use time::Duration as TimeDuration;
+
+    async fn setup_test_sink() -> S3Sink {
+        let registry = HealthRegistry::new("test");
+        let handle = registry
+            .register("s3".to_string(), TimeDuration::seconds(30))
+            .await;
+
+        // Use environment variables for test configuration
+        env::set_var("AWS_ACCESS_KEY_ID", "object_storage_root_user");
+        env::set_var("AWS_SECRET_ACCESS_KEY", "object_storage_root_password");
+
+        S3Sink::new(
+            "capture".to_string(),
+            Some("http://localhost:19000".to_string()),
+            handle,
+        )
+        .await
+        .expect("Failed to create S3 sink")
+    }
+
+    fn create_test_event() -> ProcessedEvent {
+        ProcessedEvent {
+            event: CapturedEvent {
+                uuid: uuid_v7(),
+                distinct_id: "test_id".to_string(),
+                ip: "127.0.0.1".to_string(),
+                data: "test data".to_string(),
+                now: "2024-01-01T00:00:00Z".to_string(),
+                sent_at: None,
+                token: "test_token".to_string(),
+                is_cookieless_mode: false,
+            },
+            metadata: ProcessedEventMetadata {
+                data_type: DataType::AnalyticsMain,
+                session_id: None,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_basic_functionality() {
+        let sink = setup_test_sink().await;
+
+        // Test single event
+        let event = create_test_event();
+        sink.send(event.clone())
+            .await
+            .expect("Failed to send event");
+
+        // Test batch
+        let batch = vec![event.clone(), event.clone()];
+        sink.send_batch(batch).await.expect("Failed to send batch");
+    }
+
+    #[tokio::test]
+    async fn test_large_event() {
+        let sink = setup_test_sink().await;
+
+        // Create event that will exceed MAX_BUFFER_SIZE
+        let large_data = "x".repeat(MAX_BUFFER_SIZE + 1000);
+        let event = ProcessedEvent {
+            event: CapturedEvent {
+                data: large_data,
+                ..create_test_event().event
+            },
+            metadata: create_test_event().metadata,
+        };
+
+        sink.send(event).await.expect("Failed to send large event");
+    }
+}

--- a/rust/capture/src/sinks/s3.rs
+++ b/rust/capture/src/sinks/s3.rs
@@ -129,12 +129,12 @@ impl S3Sink {
                                 // Replace the current buffer with a brand-new one.
                                 std::mem::replace(&mut *buffer, EventBuffer::new())
                             };
-
+                            // drop the old buffer so the lock is freed and we can keep writing
+                            drop(buffer);
                             let result = inner.flush_buffer(&mut old_buffer).await;
                             if result.is_ok() {
                                 last_healthcheck = Instant::now();
                             }
-                            // drop the old buffer so the lock is freed and we can keep writing
                             drop(old_buffer.tx.send(result));
                         }
 

--- a/rust/capture/src/test_endpoint.rs
+++ b/rust/capture/src/test_endpoint.rs
@@ -220,6 +220,6 @@ pub fn from_bytes(bytes: Bytes, limit: usize, comp: String) -> Result<RawRequest
 
     match serde_json::from_str::<RawRequest>(&payload) {
         Ok(res) => Ok(res),
-        Err(e) => Err(CaptureError::RequestParsingError(e)),
+        Err(e) => Err(CaptureError::RequestParsingError(e.to_string())),
     }
 }

--- a/rust/capture/src/token.rs
+++ b/rust/capture/src/token.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 
 /// Validate that a token is the correct shape
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum InvalidTokenReason {
     Empty,
 

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -25,12 +25,12 @@ use tokio::sync::Notify;
 use tokio::time::timeout;
 use tracing::{debug, warn};
 
-use health::HealthStrategy;
 use capture::config::{CaptureMode, Config, KafkaConfig};
 use capture::limiters::redis::{
     QuotaResource, OVERFLOW_LIMITER_CACHE_KEY, QUOTA_LIMITER_CACHE_KEY,
 };
 use capture::server::serve;
+use health::HealthStrategy;
 
 pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     print_sink: false,

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -66,6 +66,9 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     redis_key_prefix: None,
     capture_mode: CaptureMode::Events,
     concurrency_limit: None,
+    s3_fallback_enabled: false,
+    s3_fallback_bucket: None,
+    s3_fallback_endpoint: None,
 });
 
 static TRACING_INIT: Once = Once::new();
@@ -107,7 +110,10 @@ impl ServerHandle {
     }
 
     pub async fn capture_events<T: Into<reqwest::Body>>(&self, body: T) -> reqwest::Response {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(3000))
+            .build()
+            .unwrap();
         client
             .post(format!("http://{:?}/i/v0/e", self.addr))
             .body(body)
@@ -117,7 +123,10 @@ impl ServerHandle {
     }
 
     pub async fn capture_to_batch<T: Into<reqwest::Body>>(&self, body: T) -> reqwest::Response {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(3000))
+            .build()
+            .unwrap();
         client
             .post(format!("http://{:?}/batch", self.addr))
             .body(body)
@@ -127,7 +136,10 @@ impl ServerHandle {
     }
 
     pub async fn capture_recording<T: Into<reqwest::Body>>(&self, body: T) -> reqwest::Response {
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(3000))
+            .build()
+            .unwrap();
         client
             .post(format!("http://{:?}/s/", self.addr))
             .body(body)
@@ -158,6 +170,7 @@ impl EphemeralTopic {
             DEFAULT_CONFIG.kafka.kafka_hosts.clone(),
         );
         config.set("debug", "all");
+        config.set("socket.timeout.ms", "5000");
 
         // TODO: check for name collision?
         let topic_name = random_string("events_", 16);

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -70,6 +70,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     s3_fallback_enabled: false,
     s3_fallback_bucket: None,
     s3_fallback_endpoint: None,
+    s3_fallback_prefix: String::new(),
     healthcheck_strategy: HealthStrategy::All,
 });
 

--- a/rust/capture/tests/common.rs
+++ b/rust/capture/tests/common.rs
@@ -25,6 +25,7 @@ use tokio::sync::Notify;
 use tokio::time::timeout;
 use tracing::{debug, warn};
 
+use health::HealthStrategy;
 use capture::config::{CaptureMode, Config, KafkaConfig};
 use capture::limiters::redis::{
     QuotaResource, OVERFLOW_LIMITER_CACHE_KEY, QUOTA_LIMITER_CACHE_KEY,
@@ -69,6 +70,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     s3_fallback_enabled: false,
     s3_fallback_bucket: None,
     s3_fallback_endpoint: None,
+    healthcheck_strategy: HealthStrategy::All,
 });
 
 static TRACING_INIT: Once = Once::new();

--- a/rust/common/health/src/lib.rs
+++ b/rust/common/health/src/lib.rs
@@ -58,6 +58,17 @@ pub enum ComponentStatus {
     /// Automatically set when the HealthyUntil deadline is reached
     Stalled,
 }
+
+impl ComponentStatus {
+    /// Returns true if the component is currently healthy (i.e., has a valid HealthyUntil status)
+    pub fn is_healthy(&self) -> bool {
+        match self {
+            ComponentStatus::HealthyUntil(until) => until.gt(&time::OffsetDateTime::now_utc()),
+            _ => false,
+        }
+    }
+}
+
 struct HealthMessage {
     component: String,
     status: ComponentStatus,

--- a/rust/common/health/src/lib.rs
+++ b/rust/common/health/src/lib.rs
@@ -63,6 +63,7 @@ struct HealthMessage {
     status: ComponentStatus,
 }
 
+#[derive(Clone)]
 pub struct HealthHandle {
     component: String,
     deadline: Duration,

--- a/rust/common/health/src/lib.rs
+++ b/rust/common/health/src/lib.rs
@@ -111,18 +111,44 @@ impl HealthHandle {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum HealthStrategy {
+    /// All components must be healthy for the registry to be healthy
+    All,
+    /// At least one component must be healthy for the registry to be healthy
+    Any,
+}
+
+impl std::str::FromStr for HealthStrategy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_ref() {
+            "all" => Ok(HealthStrategy::All),
+            "any" => Ok(HealthStrategy::Any),
+            _ => Err(format!("Unknown Health Strategy: {s}, must be ALL or ANY")),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct HealthRegistry {
     name: String,
+    strategy: HealthStrategy,
     components: Arc<RwLock<HashMap<String, ComponentStatus>>>,
     sender: mpsc::Sender<HealthMessage>,
 }
 
 impl HealthRegistry {
     pub fn new(name: &str) -> Self {
+        Self::new_with_strategy(name, HealthStrategy::All)
+    }
+
+    pub fn new_with_strategy(name: &str, strategy: HealthStrategy) -> Self {
         let (tx, mut rx) = mpsc::channel::<HealthMessage>(16);
         let registry = Self {
             name: name.to_owned(),
+            strategy,
             components: Default::default(),
             sender: tx,
         };
@@ -172,7 +198,10 @@ impl HealthRegistry {
             .expect("poisoned HeathRegistry mutex");
 
         let result = HealthStatus {
-            healthy: !components.is_empty(), // unhealthy if no component has registered yet
+            // unhealthy if no component has registered yet or if we're using the "Any" strategy
+            // "All" defaults to true and is set to false if any healthcheck fails
+            // "Any" defaults to false and is set to true if any healthcheck passes
+            healthy: !components.is_empty() && self.strategy == HealthStrategy::All,
             components: Default::default(),
         };
         let now = time::OffsetDateTime::now_utc();
@@ -183,16 +212,23 @@ impl HealthRegistry {
                 match status {
                     ComponentStatus::HealthyUntil(until) => {
                         if until.gt(&now) {
+                            if self.strategy == HealthStrategy::Any {
+                                result.healthy = true;
+                            }
                             _ = result.components.insert(name.clone(), status.clone())
                         } else {
-                            result.healthy = false;
+                            if self.strategy == HealthStrategy::All {
+                                result.healthy = false;
+                            }
                             _ = result
                                 .components
                                 .insert(name.clone(), ComponentStatus::Stalled)
                         }
                     }
                     _ => {
-                        result.healthy = false;
+                        if self.strategy == HealthStrategy::All {
+                            result.healthy = false;
+                        }
                         _ = result.components.insert(name.clone(), status.clone())
                     }
                 }
@@ -208,7 +244,7 @@ impl HealthRegistry {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ComponentStatus, HealthRegistry, HealthStatus};
+    use crate::{ComponentStatus, HealthRegistry, HealthStatus, HealthStrategy};
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
     use std::ops::{Add, Sub};
@@ -350,5 +386,53 @@ mod tests {
         }
         .into_response();
         assert_eq!(ok.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn any_strategy() {
+        let registry = HealthRegistry::new_with_strategy("liveness", HealthStrategy::Any);
+        let handle1 = registry
+            .register("one".to_string(), Duration::seconds(30))
+            .await;
+        let handle2 = registry
+            .register("two".to_string(), Duration::seconds(30))
+            .await;
+        assert_or_retry(|| registry.get_status().components.len() == 2).await;
+
+        // Initially unhealthy with Any strategy
+        assert!(!registry.get_status().healthy);
+
+        // First component going healthy is enough in Any strategy
+        handle1.report_healthy().await;
+        assert_or_retry(|| registry.get_status().healthy).await;
+
+        // Still healthy even if second component is unhealthy
+        handle2.report_status(ComponentStatus::Unhealthy).await;
+        assert_or_retry(|| registry.get_status().healthy).await;
+
+        // Becomes unhealthy only when all components are unhealthy
+        handle1.report_status(ComponentStatus::Unhealthy).await;
+        assert_or_retry(|| !registry.get_status().healthy).await;
+    }
+
+    #[tokio::test]
+    async fn health_strategy_from_str() {
+        assert_eq!(
+            "ALL".parse::<HealthStrategy>().unwrap(),
+            HealthStrategy::All
+        );
+        assert_eq!(
+            "ANY".parse::<HealthStrategy>().unwrap(),
+            HealthStrategy::Any
+        );
+        assert_eq!(
+            "all".parse::<HealthStrategy>().unwrap(),
+            HealthStrategy::All
+        );
+        assert_eq!(
+            "any".parse::<HealthStrategy>().unwrap(),
+            HealthStrategy::Any
+        );
+        assert!("invalid".parse::<HealthStrategy>().is_err());
     }
 }

--- a/rust/docker-compose.yml
+++ b/rust/docker-compose.yml
@@ -37,6 +37,18 @@ services:
             timeout: 10s
             retries: 10
 
+    objectstorage:
+        image: minio/minio:RELEASE.2025-01-20T14-49-07Z
+        restart: on-failure
+        ports:
+            - '19000:19000'
+            - '19001:19001'
+        environment:
+            MINIO_ROOT_USER: object_storage_root_user
+            MINIO_ROOT_PASSWORD: object_storage_root_password
+        entrypoint: sh
+        command: -c 'mkdir -p /data/capture && minio server --address ":19000" --console-address ":19001" /data' # create the 'capture' bucket before starting the service
+
     kafka-ui:
         image: provectuslabs/kafka-ui:latest
         profiles: ['ui']


### PR DESCRIPTION
## Problem

We currently have a major single point of failure for event capture: Kafka

If Kafka (or warpstream) goes down we start losing 100% of new captured events. Implement a fallback where events are sent to S3 if kafka fails, so we can reingest them once kafka is back up

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

ran on 100% production traffic mirrored to warpstream, shut down warpstream agents and observed it fallback to s3