### PR TITLE
fix: nulls in cymbal

### DIFF
--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -190,9 +190,9 @@ where
     Ok(fingerprinted.to_output(issue_override.issue_id))
 }
 
-// Postgres doesn't like nulls in strings, so we replace them with uFFFD.
+// Postgres doesn't like nulls (u0000) in strings, so we replace them with uFFFD.
 pub fn sanitize_string(s: String) -> String {
-    s.replace("\\u0000", "\\uFFFD")
+    s.replace('\u{0000}', "\u{FFFD}")
 }
 
 #[cfg(test)]

--- a/rust/cymbal/src/issue_resolution.rs
+++ b/rust/cymbal/src/issue_resolution.rs
@@ -201,7 +201,7 @@ mod test {
 
     #[test]
     fn it_replaces_null_characters() {
-        let content = sanitize_string("\\u0000 is not valid JSON".to_string());
-        assert_eq!(content, "\\uFFFD is not valid JSON");
+        let content = sanitize_string("\u{0000} is not valid JSON".to_string());
+        assert_eq!(content, "� is not valid JSON");
     }
 }


### PR DESCRIPTION
## Problem

Follow on from https://github.com/PostHog/posthog/pull/28029

## Changes

Capture null bytes correctly. Using property defs as an example this time

https://github.com/PostHog/posthog/blob/d8d77045429803576e6bf171ac3f93956dea4bc0/rust/property-defs-rs/src/types.rs#L357-L359

## How did you test this code?

Produced the problematic message in production on my local Kafka. Didn't crash once I made this change