### PR TITLE
fix(batch-exports): Account for empty filters

### DIFF
--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -569,7 +569,7 @@ class Producer:
 
         extra_query_parameters = parameters.pop("extra_query_parameters", {}) or {}
 
-        if filters is not None:
+        if filters is not None and len(filters) > 0:
             filters_str, extra_query_parameters = await database_sync_to_async(compose_filters_clause)(
                 filters, team_id=team_id, values=extra_query_parameters
             )


### PR DESCRIPTION
## Problem

Empty filters are rendered as `and()` which is not valid SQL. This only happens if I set filters on a batch export and later clear them.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Ignore `[]` filters.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
