### PR TITLE
fix: Use correct parameter in delete_persons

### DIFF
--- a/posthog/temporal/delete_persons/delete_persons_workflow.py
+++ b/posthog/temporal/delete_persons/delete_persons_workflow.py
@@ -17,7 +17,7 @@ from posthog.temporal.common.logger import get_internal_logger
 SELECT_QUERY = """
     SELECT id
     FROM posthog_person
-    WHERE team_id=%(team_id)s {person_id_filter}
+    WHERE team_id=%(team_id)s {person_ids_filter}
     ORDER BY id ASC
     LIMIT %(limit)s
 """


### PR DESCRIPTION
## Problem

`delete-persons` workflow has a bug in string formatting: key is `person_id_filter` when it should be `person_ids_filter` (notice the plural of "ids")

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Use the right key.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
