### PR TITLE
chore: remove hogql

### DIFF
--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -264,16 +264,16 @@ class Cohort(models.Model):
             # Jan 29 2025 - Temporarily commented out because of celery load issues
             return
 
-            try:
-                fn()
-            except Exception:
-                logger.exception(
-                    "cohort_hogql_calculation_failed",
-                    id=self.pk,
-                    current_version=self.version,
-                    new_version=pending_version,
-                    exc_info=True,
-                )
+            # try:
+            #     fn()
+            # except Exception:
+            #     logger.exception(
+            #         "cohort_hogql_calculation_failed",
+            #         id=self.pk,
+            #         current_version=self.version,
+            #         new_version=pending_version,
+            #         exc_info=True,
+            #     )
 
     def insert_users_by_list(self, items: list[str], *, team_id: Optional[int] = None) -> None:
         """

--- a/posthog/models/cohort/cohort.py
+++ b/posthog/models/cohort/cohort.py
@@ -261,6 +261,9 @@ class Cohort(models.Model):
                 fn()
                 return
 
+            # Jan 29 2025 - Temporarily commented out because of celery load issues
+            return
+
             try:
                 fn()
             except Exception:


### PR DESCRIPTION
Celery queues having some load issues with clickhouse. Remove the hogql extra cohort calculations for now.