### PR TITLE
fix(editor-3001): objects stringified in data grid

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -89,7 +89,12 @@ export function OutputPane(): JSX.Element {
         return response?.results?.map((row: any[]) => {
             const rowObject: Record<string, any> = {}
             response.columns.forEach((column: string, i: number) => {
-                rowObject[column] = row[i]
+                // Handling objects here as other viz methods can accept objects. Data grid does not for now
+                if (typeof row[i] === 'object' && row[i] !== null) {
+                    rowObject[column] = JSON.stringify(row[i])
+                } else {
+                    rowObject[column] = row[i]
+                }
             })
             return rowObject
         })


### PR DESCRIPTION
## Problem

- actual objects will break data grid

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- for display purposes stringify for now

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
