### PR TITLE
feat: Support providing a configurable limit to squash job

### DIFF
--- a/dags/person_overrides.py
+++ b/dags/person_overrides.py
@@ -72,7 +72,7 @@ class PersonOverridesSnapshotTable:
         [[count]] = client.execute(f"SELECT count() FROM {self.qualified_name}")
         assert count == 0
 
-        limit_clause = "LIMIT {limit}" if limit else ""
+        limit_clause = f"LIMIT {limit}" if limit else ""
 
         client.execute(
             f"""

--- a/dags/person_overrides.py
+++ b/dags/person_overrides.py
@@ -36,7 +36,6 @@ class ClickhouseClusterResource(dagster.ConfigurableResource):
 @dataclass
 class PersonOverridesSnapshotTable:
     id: uuid.UUID
-    timestamp: str
 
     @property
     def name(self) -> str:
@@ -66,7 +65,7 @@ class PersonOverridesSnapshotTable:
     def drop(self, client: Client) -> None:
         client.execute(f"DROP TABLE IF EXISTS {self.qualified_name} SYNC")
 
-    def populate(self, client: Client, limit: int | None = None) -> None:
+    def populate(self, client: Client, timestamp: str, limit: int | None = None) -> None:
         # NOTE: this is theoretically subject to replication lag and accuracy of this result is not a guarantee
         # this could optionally support truncate as a config option if necessary to reset the table state, or
         # force an optimize after insertion to compact the table before dictionary insertion (if that's even needed)
@@ -84,7 +83,7 @@ class PersonOverridesSnapshotTable:
             GROUP BY team_id, distinct_id
             {limit_clause}
             """,
-            {"timestamp": self.timestamp},
+            {"timestamp": timestamp},
         )
 
     def sync(self, client: Client) -> None:
@@ -207,7 +206,18 @@ class PersonOverridesSnapshotDictionary:
 # Snapshot Table Management
 
 
-class SnapshotTableConfig(dagster.Config):
+@dagster.op
+def create_snapshot_table(
+    context: dagster.OpExecutionContext,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+) -> PersonOverridesSnapshotTable:
+    """Create the snapshot table on all hosts in the cluster."""
+    table = PersonOverridesSnapshotTable(id=uuid.UUID(context.run.run_id))
+    cluster.map_all_hosts(table.create).result()
+    return table
+
+
+class PopulateSnapshotTableConfig(dagster.Config):
     """
     Configuration for creating and populating the initial snapshot table.
     """
@@ -218,30 +228,20 @@ class SnapshotTableConfig(dagster.Config):
         "the past that there is no reasonable likelihood that events or overrides prior to this time have not yet been "
         "written to the database and replicated to all hosts in the cluster."
     )
-
-
-@dagster.op
-def create_snapshot_table(
-    context: dagster.OpExecutionContext,
-    cluster: dagster.ResourceParam[ClickhouseCluster],
-    config: SnapshotTableConfig,
-) -> PersonOverridesSnapshotTable:
-    """Create the snapshot table on all hosts in the cluster."""
-    table = PersonOverridesSnapshotTable(
-        id=uuid.UUID(context.run.run_id),
-        timestamp=config.timestamp,
+    limit: int | None = pydantic.Field(
+        description="The number of rows to include in the snapshot. If provided, this can be used to limit the total "
+        "amount of memory consumed by the squash process during execution."
     )
-    cluster.map_all_hosts(table.create).result()
-    return table
 
 
 @dagster.op
 def populate_snapshot_table(
     cluster: dagster.ResourceParam[ClickhouseCluster],
     table: PersonOverridesSnapshotTable,
+    config: PopulateSnapshotTableConfig,
 ) -> PersonOverridesSnapshotTable:
     """Fill the snapshot data with the selected overrides based on the configuration timestamp."""
-    cluster.any_host(table.populate).result()
+    cluster.any_host(partial(table.populate, timestamp=config.timestamp, limit=config.limit)).result()
     return table
 
 

--- a/dags_test/test_person_overrides.py
+++ b/dags_test/test_person_overrides.py
@@ -76,12 +76,37 @@ def test_full_job(cluster: ClickhouseCluster):
     }
     assert cluster.any_host(get_distinct_ids_with_overrides).result() == {"c", "d", "e", "z"}
 
-    result = squash_person_overrides.execute_in_process(
+    # run with limit
+    limited_run_result = squash_person_overrides.execute_in_process(
+        run_config=dagster.RunConfig(
+            {populate_snapshot_table.name: PopulateSnapshotTableConfig(timestamp=timestamp.isoformat(), limit=2)}
+        ),
+        resources={"cluster": cluster},
+    )
+
+    # ensure we cleaned up after ourselves
+    table = PersonOverridesSnapshotTable(UUID(limited_run_result.dagster_run.run_id))
+    dictionary = PersonOverridesSnapshotDictionary(table)
+    assert not any(cluster.map_all_hosts(table.exists).result().values())
+    assert not any(cluster.map_all_hosts(dictionary.exists).result().values())
+
+    remaining_overrides = cluster.any_host(get_distinct_ids_with_overrides).result()
+    assert len(remaining_overrides) == 2  # one candidate discarded due to limit, one out of timestamp range
+    assert "z" in remaining_overrides  # outside of timestamp range
+
+    # run without limit to handle the remaining item(s)
+    full_run_result = squash_person_overrides.execute_in_process(
         run_config=dagster.RunConfig(
             {populate_snapshot_table.name: PopulateSnapshotTableConfig(timestamp=timestamp.isoformat())}
         ),
         resources={"cluster": cluster},
     )
+
+    # ensure we cleaned up after ourselves again
+    table = PersonOverridesSnapshotTable(UUID(full_run_result.dagster_run.run_id))
+    dictionary = PersonOverridesSnapshotDictionary(table)
+    assert not any(cluster.map_all_hosts(table.exists).result().values())
+    assert not any(cluster.map_all_hosts(dictionary.exists).result().values())
 
     # check postconditions
     assert cluster.any_host(get_distinct_ids_on_events_by_person).result() == {
@@ -90,9 +115,3 @@ def test_full_job(cluster: ClickhouseCluster):
         UUID(int=100): {"z"},
     }
     assert cluster.any_host(get_distinct_ids_with_overrides).result() == {"z"}
-
-    # ensure we cleaned up after ourselves
-    table = PersonOverridesSnapshotTable(UUID(result.dagster_run.run_id))
-    dictionary = PersonOverridesSnapshotDictionary(table)
-    assert not any(cluster.map_all_hosts(table.exists).result().values())
-    assert not any(cluster.map_all_hosts(dictionary.exists).result().values())


### PR DESCRIPTION
## Problem

In cases where the overrides table holds a very large number of records, the dictionary that is required to perform the mutation may not be able to be loaded due to memory limits. This is especially likely on cluster architectures that use a large number of small machines (in contrast with a small number of large machines) as they are more likely to be resource constrained.

## Changes

- Adds the ability to pass a limit to the snapshot populate step
- Cleans up some existing configuration: the timestamp is only used in the populate step, so didn't need to be bound to the snapshot table object - this keeps all the configuration colocated

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added test