### PR TITLE
fix(assistant): omit feature flags

### DIFF
--- a/posthog/hogql_queries/ai/event_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/event_taxonomy_query_runner.py
@@ -102,6 +102,8 @@ class EventTaxonomyQueryRunner(TaxonomyCacheMixin, QueryRunner):
             r"\$sent_at",
             # privacy-related
             r"\$ip",
+            # feature flags and experiments
+            r"\$feature\/",
             # flatten-properties-plugin
             "__",
             # other metadata

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_event_taxonomy_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_event_taxonomy_query_runner.ambr
@@ -13,7 +13,7 @@
      LIMIT 100) ARRAY
   JOIN (kv).1 AS key,
        (kv).2 AS value
-  WHERE not(match(key, '(\\$set|\\$time|\\$set_once|\\$sent_at|\\$ip|__|phjs|survey_dismissed|survey_responded|partial_filter_chosen|changed_action|window-id|changed_event|partial_filter)'))
+  WHERE not(match(key, '(\\$set|\\$time|\\$set_once|\\$sent_at|\\$ip|\\$feature\\/|__|phjs|survey_dismissed|survey_responded|partial_filter_chosen|changed_action|window-id|changed_event|partial_filter)'))
   GROUP BY key
   ORDER BY total_count DESC
   LIMIT 500 SETTINGS readonly=2,

--- a/posthog/hogql_queries/ai/test/test_event_taxonomy_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_event_taxonomy_query_runner.py
@@ -444,3 +444,33 @@ class TestEventTaxonomyQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(response.results[0].property, "prop")
         self.assertEqual(response.results[0].sample_count, 3)
         self.assertEqual(len(response.results[0].sample_values), 1)
+
+    def test_feature_flags_properties_are_omitted(self):
+        _create_person(
+            distinct_ids=["person1"],
+            properties={"email": "person1@example.com"},
+            team=self.team,
+        )
+        _create_event(
+            event="event1",
+            distinct_id="person1",
+            properties={"$feature/ai": "1"},
+            team=self.team,
+        )
+        _create_event(
+            event="event1",
+            distinct_id="person2",
+            properties={"prop": "2"},
+            team=self.team,
+        )
+        _create_event(
+            event="event1",
+            distinct_id="person2",
+            properties={"prop": "3", "$feature/dashboard": "0"},
+            team=self.team,
+        )
+
+        response = EventTaxonomyQueryRunner(team=self.team, query=EventTaxonomyQuery(event="event1")).calculate()
+        self.assertEqual(len(response.results), 1)
+        self.assertEqual(response.results[0].property, "prop")
+        self.assertEqual(response.results[0].sample_count, 2)


### PR DESCRIPTION
## Problem

Feature flags on events are not useful for the assistant. We need to find a better way to handle them. Until then, let's disable their output.

## Changes

Filter out feature flags.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Manual testing, unit tests
