### PR TITLE
feat(experiments): Remove blocking results load animation

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -10,7 +10,7 @@ import { MetricSourceModal } from '../Metrics/MetricSourceModal'
 import { SharedMetricModal } from '../Metrics/SharedMetricModal'
 import { MetricsView } from '../MetricsView/MetricsView'
 import { VariantDeltaTimeseries } from '../MetricsView/VariantDeltaTimeseries'
-import { ExperimentLoadingAnimation, ExploreButton, LoadingState, PageHeaderCustom, ResultsQuery } from './components'
+import { ExploreButton, LoadingState, PageHeaderCustom, ResultsQuery } from './components'
 import { CumulativeExposuresChart } from './CumulativeExposuresChart'
 import { DataCollection } from './DataCollection'
 import { DistributionModal, DistributionTable } from './DistributionTable'
@@ -20,15 +20,20 @@ import { ReleaseConditionsModal, ReleaseConditionsTable } from './ReleaseConditi
 import { SummaryTable } from './SummaryTable'
 
 const ResultsTab = (): JSX.Element => {
-    const { experiment, metricResults, firstPrimaryMetric, primaryMetricsLengthWithSharedMetrics } =
-        useValues(experimentLogic)
+    const {
+        experiment,
+        metricResults,
+        firstPrimaryMetric,
+        primaryMetricsLengthWithSharedMetrics,
+        metricResultsLoading,
+    } = useValues(experimentLogic)
     const hasSomeResults = metricResults?.some((result) => result?.insight)
 
     const hasSinglePrimaryMetric = primaryMetricsLengthWithSharedMetrics === 1
 
     return (
         <>
-            {!hasSomeResults && (
+            {!hasSomeResults && !metricResultsLoading && (
                 <>
                     {experiment.type === 'web' ? (
                         <WebExperimentImplementationDetails experiment={experiment} />
@@ -76,8 +81,7 @@ const VariantsTab = (): JSX.Element => {
 }
 
 export function ExperimentView(): JSX.Element {
-    const { experimentLoading, metricResultsLoading, secondaryMetricResultsLoading, experimentId, tabKey } =
-        useValues(experimentLogic)
+    const { experimentLoading, experimentId, tabKey } = useValues(experimentLogic)
 
     const { setTabKey } = useActions(experimentLogic)
 
@@ -90,33 +94,28 @@ export function ExperimentView(): JSX.Element {
                 ) : (
                     <>
                         <Info />
-                        {metricResultsLoading || secondaryMetricResultsLoading ? (
-                            <ExperimentLoadingAnimation />
-                        ) : (
-                            <>
-                                <div className="xl:flex">
-                                    <div className="w-1/2 mt-8 xl:mt-0">
-                                        <DataCollection />
-                                    </div>
-                                </div>
-                                <LemonTabs
-                                    activeKey={tabKey}
-                                    onChange={(key) => setTabKey(key)}
-                                    tabs={[
-                                        {
-                                            key: 'results',
-                                            label: 'Results',
-                                            content: <ResultsTab />,
-                                        },
-                                        {
-                                            key: 'variants',
-                                            label: 'Variants',
-                                            content: <VariantsTab />,
-                                        },
-                                    ]}
-                                />
-                            </>
-                        )}
+                        <div className="xl:flex">
+                            <div className="w-1/2 mt-8 xl:mt-0">
+                                <DataCollection />
+                            </div>
+                        </div>
+                        <LemonTabs
+                            activeKey={tabKey}
+                            onChange={(key) => setTabKey(key)}
+                            tabs={[
+                                {
+                                    key: 'results',
+                                    label: 'Results',
+                                    content: <ResultsTab />,
+                                },
+                                {
+                                    key: 'variants',
+                                    label: 'Variants',
+                                    content: <VariantsTab />,
+                                },
+                            ]}
+                        />
+
                         <MetricSourceModal experimentId={experimentId} isSecondary={true} />
                         <MetricSourceModal experimentId={experimentId} isSecondary={false} />
 

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -17,8 +17,7 @@ import { ExperimentDates } from './ExperimentDates'
 
 export function Info(): JSX.Element {
     const { experiment, featureFlags, metricResults } = useValues(experimentLogic)
-    const { updateExperiment, setExperimentStatsVersion, loadMetricResults, loadSecondaryMetricResults } =
-        useActions(experimentLogic)
+    const { updateExperiment, setExperimentStatsVersion, refreshExperimentResults } = useActions(experimentLogic)
 
     const { created_by } = experiment
 
@@ -119,8 +118,7 @@ export function Info(): JSX.Element {
                                         type="secondary"
                                         size="xsmall"
                                         onClick={() => {
-                                            loadMetricResults(true)
-                                            loadSecondaryMetricResults(true)
+                                            refreshExperimentResults(true)
                                         }}
                                         data-attr="refresh-experiment"
                                         icon={<IconRefresh />}

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -201,7 +201,7 @@ export function DeltaChart({
         return () => {
             resizeObserver.disconnect()
         }
-    }, [])
+    }, [result])
 
     return (
         <div className="rounded bg-[var(--bg-table)]">

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -718,7 +718,7 @@ export const experimentLogic = kea<experimentLogicType>([
             actions.updateExperiment({ archived: true })
             values.experiment && actions.reportExperimentArchived(values.experiment)
         },
-        refreshExperimentResults: async (forceRefresh) => {
+        refreshExperimentResults: async ({ forceRefresh }) => {
             actions.loadMetricResultsSuccess([])
             actions.loadSecondaryMetricResultsSuccess([])
             actions.loadMetricResults(forceRefresh)

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -159,6 +159,7 @@ export const experimentLogic = kea<experimentLogicType>([
         setEditExperiment: (editing: boolean) => ({ editing }),
         setFlagImplementationWarning: (warning: boolean) => ({ warning }),
         setExposureAndSampleSize: (exposure: number, sampleSize: number) => ({ exposure, sampleSize }),
+        refreshExperimentResults: (forceRefresh?: boolean) => ({ forceRefresh }),
         updateExperimentGoal: true,
         updateExperimentCollectionGoal: true,
         changeExperimentStartDate: (startDate: string) => ({ startDate }),
@@ -682,8 +683,7 @@ export const experimentLogic = kea<experimentLogicType>([
             experiment && actions.reportExperimentViewed(experiment, duration)
 
             if (experiment?.start_date) {
-                actions.loadMetricResults()
-                actions.loadSecondaryMetricResults()
+                actions.refreshExperimentResults()
             }
         },
         launchExperiment: async () => {
@@ -699,8 +699,7 @@ export const experimentLogic = kea<experimentLogicType>([
             actions.updateExperiment({ stats_config: { version } })
             await breakpoint(100)
             if (values.experiment?.start_date) {
-                actions.loadMetricResults(true)
-                actions.loadSecondaryMetricResults(true)
+                actions.refreshExperimentResults(true)
             }
         },
         endExperiment: async () => {
@@ -718,6 +717,12 @@ export const experimentLogic = kea<experimentLogicType>([
         archiveExperiment: async () => {
             actions.updateExperiment({ archived: true })
             values.experiment && actions.reportExperimentArchived(values.experiment)
+        },
+        refreshExperimentResults: async (forceRefresh) => {
+            actions.loadMetricResultsSuccess([])
+            actions.loadSecondaryMetricResultsSuccess([])
+            actions.loadMetricResults(forceRefresh)
+            actions.loadSecondaryMetricResults(forceRefresh)
         },
         updateExperimentGoal: async () => {
             // Reset MDE to the recommended setting
@@ -763,8 +768,7 @@ export const experimentLogic = kea<experimentLogicType>([
             actions.updateExperiments(experiment)
             if (experiment.start_date) {
                 const forceRefresh = payload?.start_date !== undefined
-                actions.loadMetricResults(forceRefresh)
-                actions.loadSecondaryMetricResults(forceRefresh)
+                actions.refreshExperimentResults(forceRefresh)
             }
         },
         setExperiment: async ({ experiment }) => {


### PR DESCRIPTION
See https://posthog.slack.com/archives/C07PXH2GTGV/p1738179059221599

> When adding a secondary result, all results have to recalculate and it takes 2 minutes for each and so much waiting. This seems super unnecessary.

## Changes

* Removes `<ExperimentLoadingAnimation />` from displaying when experiment results are loading.
* Prevents `<ExperimentImplementationDetails experiment={experiment} />` from displaying until results have loaded, to prevent it from displaying and then disappearing.
* Introduces `refreshExperimentResults()` so we can null out the stale results while the new results are loading.

I didn't think it would be this simple, but seems to work in my testing.

**Before**

![CleanShot 2025-01-29 at 15 21 31](https://github.com/user-attachments/assets/291f736a-5f77-4395-a802-1b394b12ac42)

**After**

![CleanShot 2025-01-29 at 15 20 32](https://github.com/user-attachments/assets/c1ee26da-5b3c-4777-bbbc-b03443d3ece6)

## How did you test this code?

Manual testing. To more easily evaluate, apply this diff locally:

```diff
diff --git a/frontend/src/scenes/experiments/experimentLogic.tsx b/frontend/src/scenes/experiments/experimentLogic.tsx
index 8daf9df7de..84de49bc81 100644
--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -1051,7 +1051,8 @@ export const experimentLogic = kea<experimentLogicType>([
             null as (CachedExperimentTrendsQueryResponse | CachedExperimentFunnelsQueryResponse | null)[] | null,
             {
                 loadMetricResults: async (
-                    refresh?: boolean
+                    refresh?: boolean,
+                    breakpoint?: BreakPointFunction
                 ): Promise<(CachedExperimentTrendsQueryResponse | CachedExperimentFunnelsQueryResponse | null)[]> => {
                     let metrics = values.experiment?.metrics
                     const sharedMetrics = values.experiment?.saved_metrics
@@ -1070,6 +1071,8 @@ export const experimentLogic = kea<experimentLogicType>([
                                 }
                                 const response = await performQuery(queryWithExperimentId, undefined, refresh)
 
+                                await breakpoint(5000)
+
                                 return {
                                     ...response,
                                     fakeInsightId: Math.random().toString(36).substring(2, 15),
@@ -1103,7 +1106,8 @@ export const experimentLogic = kea<experimentLogicType>([
             null as (CachedExperimentTrendsQueryResponse | CachedExperimentFunnelsQueryResponse | null)[] | null,
             {
                 loadSecondaryMetricResults: async (
-                    refresh?: boolean
+                    refresh?: boolean,
+                    breakpoint?: BreakPointFunction
                 ): Promise<(CachedExperimentTrendsQueryResponse | CachedExperimentFunnelsQueryResponse | null)[]> => {
                     let metrics = values.experiment?.metrics_secondary
                     const sharedMetrics = values.experiment?.saved_metrics
@@ -1122,6 +1126,8 @@ export const experimentLogic = kea<experimentLogicType>([
                                 }
                                 const response = await performQuery(queryWithExperimentId, undefined, refresh)
 
+                                await breakpoint(5000)
+
                                 return {
                                     ...response,
                                     fakeInsightId: Math.random().toString(36).substring(2, 15),

```