### PR TITLE
fix: dont show ai data table if no events sent

### DIFF
--- a/products/llm_observability/frontend/LLMObservabilityScene.tsx
+++ b/products/llm_observability/frontend/LLMObservabilityScene.tsx
@@ -85,10 +85,6 @@ const IngestionStatusCheck = (): JSX.Element | null => {
                 </Link>{' '}
                 (otherwise it'll be a little empty!)
             </p>
-            <p>
-                To get cost information, you'll also{' '}
-                <Link to="/pipeline/new/transformation">need to enable the "AI Costs" transformation.</Link>
-            </p>
         </LemonBanner>
     )
 }

--- a/products/llm_observability/frontend/LLMObservabilityScene.tsx
+++ b/products/llm_observability/frontend/LLMObservabilityScene.tsx
@@ -1,3 +1,4 @@
+import { IconArchive } from '@posthog/icons'
 import { LemonBanner, LemonTabs, Link } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
@@ -122,8 +123,25 @@ function LLMObservabilityGenerations(): JSX.Element {
     )
 }
 
+function LLMObservabilityNoEvents(): JSX.Element {
+    return (
+        <div className="w-full flex flex-col items-center justify-center">
+            <div className="flex flex-col items-center justify-center max-w-md w-full">
+                <IconArchive className="text-5xl mb-2 text-muted-alt" />
+                <h2 className="text-xl leading-tight">We haven't detected any LLM generations yet</h2>
+                <p className="text-sm text-center text-balance">
+                    To use the LLM Observability product, please{' '}
+                    <Link to="https://posthog.com/docs/ai-engineering/observability">
+                        instrument your LLM calls with the PostHog SDK
+                    </Link>{' '}
+                </p>
+            </div>
+        </div>
+    )
+}
+
 export function LLMObservabilityScene(): JSX.Element {
-    const { activeTab } = useValues(llmObservabilityLogic)
+    const { activeTab, hasSentAiGenerationEvent } = useValues(llmObservabilityLogic)
     const { searchParams } = useValues(router)
 
     return (
@@ -141,13 +159,17 @@ export function LLMObservabilityScene(): JSX.Element {
                     {
                         key: 'traces',
                         label: 'Traces',
-                        content: <LLMObservabilityTraces />,
+                        content: hasSentAiGenerationEvent ? <LLMObservabilityTraces /> : <LLMObservabilityNoEvents />,
                         link: combineUrl(urls.llmObservabilityTraces(), searchParams).url,
                     },
                     {
                         key: 'generations',
                         label: 'Generations',
-                        content: <LLMObservabilityGenerations />,
+                        content: hasSentAiGenerationEvent ? (
+                            <LLMObservabilityGenerations />
+                        ) : (
+                            <LLMObservabilityNoEvents />
+                        ),
                         link: combineUrl(urls.llmObservabilityGenerations(), searchParams).url,
                     },
                 ]}


### PR DESCRIPTION
Some people are seeing errors on the generatinos tab if no events have been sent yet. If no events have been sent we should point people to docs and not hit the query


<img width="1378" alt="Screenshot 2025-01-29 at 3 40 42 PM" src="https://github.com/user-attachments/assets/81b18d7f-f464-4e65-a6f4-57d6d0c52469" />
