### PR TITLE
feat: Be more tolerant of mutations not being immediately visible after scheduling

### DIFF
--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -276,7 +276,7 @@ class MutationRunner:
                 return task
             time.sleep(1.0)
 
-        raise Exception(f"unable to find running mutation after {time.time()-start:0.2f}s!")
+        raise Exception(f"unable to find mutation after {time.time()-start:0.2f}s!")
 
     @property
     def is_lightweight_delete(self) -> bool:

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -269,10 +269,14 @@ class MutationRunner:
                 self.parameters,
             )
 
-        task = self.find(client)
-        assert task is not None
+        # mutations are not always immediately visible, so give it a bit of time to show up
+        start = time.time()
+        for _ in range(5):
+            if task := self.find(client):
+                return task
+            time.sleep(1.0)
 
-        return task
+        raise Exception(f"unable to find running mutation after {time.time()-start:0.2f}s!")
 
     @property
     def is_lightweight_delete(self) -> bool:


### PR DESCRIPTION
## Problem

It seems like sometimes mutations are not immediately available to be found in `system.mutations` after they are submitted.

## Changes

Gives them a little bit of time to show up in the system table before assuming there is a problem.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

👀 