### PR TITLE
fix(experiments): color code significance banners

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Overview.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Overview.tsx
@@ -24,7 +24,7 @@ export function WinningVariantText({
             <div className="items-center inline-flex flex-wrap">
                 <VariantTag experimentId={experimentId} variantKey={highestProbabilityVariant} />
                 <span>&nbsp;is winning with a&nbsp;</span>
-                <span className="font-semibold text-success items-center">
+                <span className="font-semibold items-center">
                     {`${(probability[highestProbabilityVariant] * 100).toFixed(2)}% probability`}&nbsp;
                 </span>
                 <span>of being best.&nbsp;</span>

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -827,7 +827,7 @@ export function DeltaChart({
                 <div className="flex justify-end">
                     <ExploreButton result={result} />
                 </div>
-                <LemonBanner type={result?.significant ? 'success' : 'warning'} className="mb-4">
+                <LemonBanner type={result?.significant ? 'success' : 'info'} className="mb-4">
                     <div className="items-center inline-flex flex-wrap">
                         <WinningVariantText result={result} experimentId={experimentId} />
                         <SignificanceText metricIndex={metricIndex} />

--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -827,7 +827,7 @@ export function DeltaChart({
                 <div className="flex justify-end">
                     <ExploreButton result={result} />
                 </div>
-                <LemonBanner type="info" className="mb-4">
+                <LemonBanner type={result?.significant ? 'success' : 'warning'} className="mb-4">
                     <div className="items-center inline-flex flex-wrap">
                         <WinningVariantText result={result} experimentId={experimentId} />
                         <SignificanceText metricIndex={metricIndex} />


### PR DESCRIPTION
## Changes

|Before|After|
|----|----|
|<img width="1197" alt="image" src="https://github.com/user-attachments/assets/bcfd108f-ddfc-4c24-91eb-c4f53c6e1f9c" />|<img width="1197" alt="image" src="https://github.com/user-attachments/assets/ceddf5ac-555e-4e9e-9550-ff1ae47e3c8d" />|

|Before|After|
|----|----|
|<img width="1196" alt="image" src="https://github.com/user-attachments/assets/03ac593b-fd57-4201-8fdf-ef8107b22623" />|<img width="1197" alt="image" src="https://github.com/user-attachments/assets/23bdd430-e132-484f-920a-ac15933b5a89" />|

## How did you test this code?
👀 