### PR TITLE
chore(data-warehouse): Temp skip deltalake compact and vacuuming

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -1,9 +1,7 @@
 import gc
 import time
 from typing import Any
-import os
 import pyarrow as pa
-import subprocess
 from dlt.sources import DltSource, DltResource
 import deltalake as deltalake
 from posthog.temporal.common.logger import FilteringBoundLogger
@@ -159,26 +157,28 @@ class PipelineNonDLT:
             self._logger.debug("No deltalake table, not continuing with post-run ops")
             return
 
-        self._logger.debug("Spawning new process for deltatable compact and vacuuming")
-        try:
-            process = subprocess.Popen(
-                [
-                    "python",
-                    f"{os.getcwd()}/posthog/temporal/data_imports/pipelines/pipeline/delta_table_subprocess.py",
-                    "--table_uri",
-                    self._delta_table_helper._get_delta_table_uri(),
-                ],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                close_fds=True,
-            )
-            stdout, stderr = process.communicate()
+        self._logger.debug("SKIPPING deltatable compact and vacuuming")
 
-            if process.returncode != 0:
-                raise Exception(f"Delta subprocess failed: {stderr.decode()}")
-        finally:
-            if process.poll() is not None:
-                process.kill()
+        # self._logger.debug("Spawning new process for deltatable compact and vacuuming")
+        # try:
+        #     process = subprocess.Popen(
+        #         [
+        #             "python",
+        #             f"{os.getcwd()}/posthog/temporal/data_imports/pipelines/pipeline/delta_table_subprocess.py",
+        #             "--table_uri",
+        #             self._delta_table_helper._get_delta_table_uri(),
+        #         ],
+        #         stdout=subprocess.PIPE,
+        #         stderr=subprocess.PIPE,
+        #         close_fds=True,
+        #     )
+        #     stdout, stderr = process.communicate()
+
+        #     if process.returncode != 0:
+        #         raise Exception(f"Delta subprocess failed: {stderr.decode()}")
+        # finally:
+        #     if process.poll() is not None:
+        #         process.kill()
 
         file_uris = delta_table.file_uris()
         self._logger.debug(f"Preparing S3 files - total parquet files: {len(file_uris)}")


### PR DESCRIPTION
## Problem
- Memory is an issue... see [here](https://posthog.slack.com/archives/C019RAX2XBN/p1738232129326629)

## Changes
- Lets reaffirm our previous suspicions that deltalake compact/vacuuming is the culprit here 
- Disabling this for a few hours won't harm table performance considering we have `retention_hours=24` set up on the vacuuming and compaction can be done at any point
