### PR TITLE
feat: try snappy compression for session recording v2

### DIFF
--- a/plugin-server/package.json
+++ b/plugin-server/package.json
@@ -92,6 +92,7 @@
         "prom-client": "^14.2.0",
         "re2": "^1.20.3",
         "safe-stable-stringify": "^2.4.0",
+        "snappy": "^7.2.2",
         "tail": "^2.2.6",
         "tldts": "^6.1.57",
         "uuid": "^9.0.1",

--- a/plugin-server/pnpm-lock.yaml
+++ b/plugin-server/pnpm-lock.yaml
@@ -160,6 +160,9 @@ dependencies:
   safe-stable-stringify:
     specifier: ^2.4.0
     version: 2.4.3
+  snappy:
+    specifier: ^7.2.2
+    version: 7.2.2
   tail:
     specifier: ^2.2.6
     version: 2.2.6
@@ -2899,6 +2902,123 @@ packages:
       ip6addr: 0.2.5
       maxmind: 4.3.11
     dev: false
+
+  /@napi-rs/snappy-android-arm-eabi@7.2.2:
+    resolution: {integrity: sha512-H7DuVkPCK5BlAr1NfSU8bDEN7gYs+R78pSHhDng83QxRnCLmVIZk33ymmIwurmoA1HrdTxbkbuNl+lMvNqnytw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/snappy-android-arm64@7.2.2:
+    resolution: {integrity: sha512-2R/A3qok+nGtpVK8oUMcrIi5OMDckGYNoBLFyli3zp8w6IArPRfg1yOfVUcHvpUDTo9T7LOS1fXgMOoC796eQw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/snappy-darwin-arm64@7.2.2:
+    resolution: {integrity: sha512-USgArHbfrmdbuq33bD5ssbkPIoT7YCXCRLmZpDS6dMDrx+iM7eD2BecNbOOo7/v1eu6TRmQ0xOzeQ6I/9FIi5g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/snappy-darwin-x64@7.2.2:
+    resolution: {integrity: sha512-0APDu8iO5iT0IJKblk2lH0VpWSl9zOZndZKnBYIc+ei1npw2L5QvuErFOTeTdHBtzvUHASB+9bvgaWnQo4PvTQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/snappy-freebsd-x64@7.2.2:
+    resolution: {integrity: sha512-mRTCJsuzy0o/B0Hnp9CwNB5V6cOJ4wedDTWEthsdKHSsQlO7WU9W1yP7H3Qv3Ccp/ZfMyrmG98Ad7u7lG58WXA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/snappy-linux-arm-gnueabihf@7.2.2:
+    resolution: {integrity: sha512-v1uzm8+6uYjasBPcFkv90VLZ+WhLzr/tnfkZ/iD9mHYiULqkqpRuC8zvc3FZaJy5wLQE9zTDkTJN1IvUcZ+Vcg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/snappy-linux-arm64-gnu@7.2.2:
+    resolution: {integrity: sha512-LrEMa5pBScs4GXWOn6ZYXfQ72IzoolZw5txqUHVGs8eK4g1HR9HTHhb2oY5ySNaKakG5sOgMsb1rwaEnjhChmQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/snappy-linux-arm64-musl@7.2.2:
+    resolution: {integrity: sha512-3orWZo9hUpGQcB+3aTLW7UFDqNCQfbr0+MvV67x8nMNYj5eAeUtMmUE/HxLznHO4eZ1qSqiTwLbVx05/Socdlw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/snappy-linux-x64-gnu@7.2.2:
+    resolution: {integrity: sha512-jZt8Jit/HHDcavt80zxEkDpH+R1Ic0ssiVCoueASzMXa7vwPJeF4ZxZyqUw4qeSy7n8UUExomu8G8ZbP6VKhgw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/snappy-linux-x64-musl@7.2.2:
+    resolution: {integrity: sha512-Dh96IXgcZrV39a+Tej/owcd9vr5ihiZ3KRix11rr1v0MWtVb61+H1GXXlz6+Zcx9y8jM1NmOuiIuJwkV4vZ4WA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/snappy-win32-arm64-msvc@7.2.2:
+    resolution: {integrity: sha512-9No0b3xGbHSWv2wtLEn3MO76Yopn1U2TdemZpCaEgOGccz1V+a/1d16Piz3ofSmnA13HGFz3h9NwZH9EOaIgYA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/snappy-win32-ia32-msvc@7.2.2:
+    resolution: {integrity: sha512-QiGe+0G86J74Qz1JcHtBwM3OYdTni1hX1PFyLRo3HhQUSpmi13Bzc1En7APn+6Pvo7gkrcy81dObGLDSxFAkQQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/snappy-win32-x64-msvc@7.2.2:
+    resolution: {integrity: sha512-a43cyx1nK0daw6BZxVcvDEXxKMFLSBSDTAhsFD0VqSKcC7MGUBMaqyoWUcMiI7LBSz4bxUmxDWKfCYzpEmeb3w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3:
     resolution: {integrity: sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==}
@@ -10083,6 +10203,25 @@ packages:
   /smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+    dev: false
+
+  /snappy@7.2.2:
+    resolution: {integrity: sha512-iADMq1kY0v3vJmGTuKcFWSXt15qYUz7wFkArOrsSg0IFfI3nJqIJvK2/ZbEIndg7erIJLtAVX2nSOqPz7DcwbA==}
+    engines: {node: '>= 10'}
+    optionalDependencies:
+      '@napi-rs/snappy-android-arm-eabi': 7.2.2
+      '@napi-rs/snappy-android-arm64': 7.2.2
+      '@napi-rs/snappy-darwin-arm64': 7.2.2
+      '@napi-rs/snappy-darwin-x64': 7.2.2
+      '@napi-rs/snappy-freebsd-x64': 7.2.2
+      '@napi-rs/snappy-linux-arm-gnueabihf': 7.2.2
+      '@napi-rs/snappy-linux-arm64-gnu': 7.2.2
+      '@napi-rs/snappy-linux-arm64-musl': 7.2.2
+      '@napi-rs/snappy-linux-x64-gnu': 7.2.2
+      '@napi-rs/snappy-linux-x64-musl': 7.2.2
+      '@napi-rs/snappy-win32-arm64-msvc': 7.2.2
+      '@napi-rs/snappy-win32-ia32-msvc': 7.2.2
+      '@napi-rs/snappy-win32-x64-msvc': 7.2.2
     dev: false
 
   /snappyjs@0.6.1:

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-manager.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-manager.ts
@@ -27,7 +27,7 @@ export interface SessionBatchManagerConfig {
  * Each flush creates a new session batch file:
  * ```
  * Session Batch File 1 (flushed)
- * ├── Gzipped Session Recording Block 1
+ * ├── Compressed Session Recording Block 1
  * │   └── JSONL Session Recording Block
  * │       ├── [windowId, event1]
  * │       ├── [windowId, event2]
@@ -35,14 +35,14 @@ export interface SessionBatchManagerConfig {
  * └── ...
  *
  * Session Batch File 2 (flushed)
- * ├── Gzipped Session Recording Block 1
+ * ├── Compressed Session Recording Block 1
  * │   └── JSONL Session Recording Block
  * │       ├── [windowId, event1]
  * │       └── ...
  * └── ...
  *
  * Session Batch File 3 (current, returned to consumer)
- * ├── Gzipped Session Recording Block 1
+ * ├── Compressed Session Recording Block 1
  * │   └── JSONL Session Recording Block
  * │       ├── [windowId, event1]
  * │       └── ... (still recording)

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
@@ -6,7 +6,7 @@ import { MessageWithTeam } from '../teams/types'
 import { SessionBatchMetrics } from './metrics'
 import { SessionBatchFileWriter } from './session-batch-file-writer'
 import { SessionBatchRecorder } from './session-batch-recorder'
-import { EndResult, SessionRecorder } from './session-recorder'
+import { EndResult, SnappySessionRecorder } from './snappy-session-recorder'
 
 // RRWeb event type constants
 const enum EventType {
@@ -32,7 +32,7 @@ interface MessageMetadata {
     rawSize?: number
 }
 
-export class SessionRecorderMock {
+export class SnappySessionRecorderMock {
     private chunks: Buffer[] = []
     private size: number = 0
 
@@ -72,8 +72,8 @@ jest.mock('./metrics', () => ({
 }))
 
 jest.mock('./blackhole-session-batch-writer')
-jest.mock('./session-recorder', () => ({
-    SessionRecorder: jest.fn().mockImplementation(() => new SessionRecorderMock()),
+jest.mock('./snappy-session-recorder', () => ({
+    SnappySessionRecorder: jest.fn().mockImplementation(() => new SnappySessionRecorderMock()),
 }))
 
 describe('SessionBatchRecorder', () => {
@@ -94,7 +94,9 @@ describe('SessionBatchRecorder', () => {
     beforeEach(() => {
         jest.clearAllMocks()
 
-        jest.mocked(SessionRecorder).mockImplementation(() => new SessionRecorderMock() as unknown as SessionRecorder)
+        jest.mocked(SnappySessionRecorder).mockImplementation(
+            () => new SnappySessionRecorderMock() as unknown as SnappySessionRecorder
+        )
 
         const openMock = createOpenMock()
         mockNewBatch = openMock.openMock
@@ -722,12 +724,12 @@ describe('SessionBatchRecorder', () => {
                 },
             ]
 
-            jest.mocked(SessionRecorder).mockImplementation(
+            jest.mocked(SnappySessionRecorder).mockImplementation(
                 () =>
                     ({
                         recordMessage: jest.fn().mockReturnValue(1),
                         end: () => Promise.reject(new Error('Stream read error')),
-                    } as unknown as SessionRecorder)
+                    } as unknown as SnappySessionRecorder)
             )
 
             recorder.record(createMessage('session', events))

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
@@ -3,7 +3,7 @@ import { KafkaOffsetManager } from '../kafka/offset-manager'
 import { MessageWithTeam } from '../teams/types'
 import { SessionBatchMetrics } from './metrics'
 import { SessionBatchFileWriter } from './session-batch-file-writer'
-import { SessionRecorder } from './session-recorder'
+import { SnappySessionRecorder } from './snappy-session-recorder'
 
 /**
  * Manages the recording of a batch of session recordings:
@@ -19,12 +19,12 @@ import { SessionRecorder } from './session-recorder'
  * └── ... (previous batch)
  *
  * Session Batch File 2 <── One SessionBatchRecorder corresponds to one batch file
- * ├── Gzipped Session Recording Block 1
+ * ├── Compressed Session Recording Block 1
  * │   └── JSONL Session Recording Block
  * │       ├── [windowId, event1]
  * │       ├── [windowId, event2]
  * │       └── ...
- * ├── Gzipped Session Recording Block 2
+ * ├── Compressed Session Recording Block 2
  * │   └── JSONL Session Recording Block
  * │       ├── [windowId, event1]
  * │       └── ...
@@ -44,7 +44,7 @@ import { SessionRecorder } from './session-recorder'
  * as only the relevant session block needs to be retrieved and decompressed.
  */
 export class SessionBatchRecorder {
-    private readonly partitionSessions = new Map<number, Map<string, SessionRecorder>>()
+    private readonly partitionSessions = new Map<number, Map<string, SnappySessionRecorder>>()
     private readonly partitionSizes = new Map<number, number>()
     private _size: number = 0
 
@@ -69,7 +69,7 @@ export class SessionBatchRecorder {
 
         const sessions = this.partitionSessions.get(partition)!
         if (!sessions.has(sessionId)) {
-            sessions.set(sessionId, new SessionRecorder())
+            sessions.set(sessionId, new SnappySessionRecorder())
         }
 
         const recorder = sessions.get(sessionId)!

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.test.ts
@@ -1,0 +1,185 @@
+import snappy from 'snappy'
+
+import { ParsedMessageData } from '../kafka/types'
+import { SnappySessionRecorder } from './snappy-session-recorder'
+
+// RRWeb event type constants
+const enum EventType {
+    DomContentLoaded = 0,
+    Load = 1,
+    FullSnapshot = 2,
+    IncrementalSnapshot = 3,
+    Meta = 4,
+    Custom = 5,
+}
+
+describe('SnappySessionRecorder', () => {
+    let recorder: SnappySessionRecorder
+
+    beforeEach(() => {
+        recorder = new SnappySessionRecorder()
+    })
+
+    const createMessage = (windowId: string, events: any[]): ParsedMessageData => ({
+        distinct_id: 'distinct_id',
+        session_id: 'session_id',
+        eventsByWindowId: {
+            [windowId]: events,
+        },
+        eventsRange: {
+            start: events[0]?.timestamp || 0,
+            end: events[events.length - 1]?.timestamp || 0,
+        },
+        metadata: {
+            partition: 1,
+            topic: 'test',
+            offset: 0,
+            timestamp: 0,
+            rawSize: 0,
+        },
+    })
+
+    const readSnappyBuffer = async (buffer: Buffer): Promise<any[]> => {
+        const decompressed = await snappy.uncompress(buffer)
+        return decompressed
+            .toString()
+            .trim()
+            .split('\n')
+            .map((line) => line.trim())
+            .filter(Boolean)
+            .map((line) => JSON.parse(line))
+    }
+
+    describe('recordMessage', () => {
+        it('should record events in snappy-compressed JSONL format', async () => {
+            const events = [
+                {
+                    type: EventType.FullSnapshot,
+                    timestamp: 1000,
+                    data: {
+                        source: 1,
+                        adds: [{ parentId: 1, nextId: 2, node: { tag: 'div', attrs: { class: 'test' } } }],
+                    },
+                },
+                {
+                    type: EventType.IncrementalSnapshot,
+                    timestamp: 2000,
+                    data: { source: 2, texts: [{ id: 1, value: 'Updated text' }] },
+                },
+            ]
+            const message = createMessage('window1', events)
+
+            const rawBytesWritten = recorder.recordMessage(message)
+            expect(rawBytesWritten).toBeGreaterThan(0)
+
+            const { buffer, eventCount } = await recorder.end()
+            const lines = await readSnappyBuffer(buffer)
+
+            expect(lines).toEqual([
+                ['window1', events[0]],
+                ['window1', events[1]],
+            ])
+            expect(eventCount).toBe(2)
+        })
+
+        it('should handle multiple windows with multiple events', async () => {
+            const events = {
+                window1: [
+                    {
+                        type: EventType.Meta,
+                        timestamp: 1000,
+                        data: { href: 'https://example.com', width: 1024, height: 768 },
+                    },
+                    {
+                        type: EventType.FullSnapshot,
+                        timestamp: 1500,
+                        data: {
+                            source: 1,
+                            adds: [{ parentId: 1, nextId: null, node: { tag: 'h1', attrs: { id: 'title' } } }],
+                        },
+                    },
+                ],
+                window2: [
+                    {
+                        type: EventType.Custom,
+                        timestamp: 2000,
+                        data: { tag: 'user-interaction', payload: { type: 'click', target: '#submit-btn' } },
+                    },
+                    {
+                        type: EventType.IncrementalSnapshot,
+                        timestamp: 2500,
+                        data: { source: 3, mousemove: [{ x: 100, y: 200, id: 1 }] },
+                    },
+                ],
+            }
+            const message: ParsedMessageData = {
+                ...createMessage('', []),
+                eventsByWindowId: events,
+            }
+
+            recorder.recordMessage(message)
+            const { buffer, eventCount } = await recorder.end()
+            const lines = await readSnappyBuffer(buffer)
+
+            expect(lines).toEqual([
+                ['window1', events.window1[0]],
+                ['window1', events.window1[1]],
+                ['window2', events.window2[0]],
+                ['window2', events.window2[1]],
+            ])
+            expect(eventCount).toBe(4)
+        })
+
+        it('should handle empty events array', async () => {
+            const message = createMessage('window1', [])
+            recorder.recordMessage(message)
+
+            const { buffer, eventCount } = await recorder.end()
+            const lines = await readSnappyBuffer(buffer)
+
+            expect(lines).toEqual([])
+            expect(eventCount).toBe(0)
+        })
+
+        it('should handle large amounts of data', async () => {
+            const events = Array.from({ length: 10000 }, (_, i) => ({
+                type: EventType.Custom,
+                timestamp: i * 100,
+                data: { value: 'x'.repeat(1000) },
+            }))
+
+            // Split events into 100 messages of 100 events each
+            for (let i = 0; i < events.length; i += 100) {
+                const messageEvents = events.slice(i, i + 100)
+                const message = createMessage('window1', messageEvents)
+                recorder.recordMessage(message)
+            }
+
+            const { buffer, eventCount } = await recorder.end()
+            const lines = await readSnappyBuffer(buffer)
+
+            expect(lines.length).toBe(10000)
+            expect(eventCount).toBe(10000)
+
+            // Verify first and last events
+            expect(lines[0]).toEqual(['window1', events[0]])
+            expect(lines[lines.length - 1]).toEqual(['window1', events[events.length - 1]])
+        })
+
+        it('should throw error when recording after end', async () => {
+            const message = createMessage('window1', [{ type: EventType.Custom, timestamp: 1000, data: {} }])
+            recorder.recordMessage(message)
+            await recorder.end()
+
+            expect(() => recorder.recordMessage(message)).toThrow('Cannot record message after end() has been called')
+        })
+
+        it('should throw error when calling end multiple times', async () => {
+            const message = createMessage('window1', [{ type: EventType.Custom, timestamp: 1000, data: {} }])
+            recorder.recordMessage(message)
+            await recorder.end()
+
+            await expect(recorder.end()).rejects.toThrow('end() has already been called')
+        })
+    })
+})

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.ts
@@ -1,0 +1,91 @@
+import snappy from 'snappy'
+
+import { ParsedMessageData } from '../kafka/types'
+
+export interface EndResult {
+    /** The complete compressed session block */
+    buffer: Buffer
+    /** Number of events in the session block */
+    eventCount: number
+}
+
+/**
+ * Records events for a single session recording using Snappy compression
+ *
+ * Buffers events and provides them as a snappy-compressed session recording block that can be
+ * stored in a session batch file. The session recording block can be read as an independent unit.
+ *
+ * ```
+ * Session Batch File
+ * ├── Snappy Session Recording Block 1 <── One SessionRecorder corresponds to one block
+ * │   └── JSONL Session Recording Block
+ * │       ├── [windowId, event1]
+ * │       ├── [windowId, event2]
+ * │       └── ...
+ * ├── Snappy Session Recording Block 2
+ * │   └── JSONL Session Recording Block
+ * │       ├── [windowId, event1]
+ * │       └── ...
+ * └── ...
+ * ```
+ *
+ * The session block format (after decompression) is a sequence of newline-delimited JSON records.
+ * Each record is an array of [windowId, event].
+ */
+export class SnappySessionRecorder {
+    private readonly uncompressedChunks: Buffer[] = []
+    private eventCount: number = 0
+    private rawBytesWritten: number = 0
+    private ended = false
+
+    /**
+     * Records a message containing events for this session
+     * Events are buffered until end() is called
+     *
+     * @param message - Message containing events for one or more windows
+     * @returns Number of raw bytes written (before compression)
+     * @throws If called after end()
+     */
+    public recordMessage(message: ParsedMessageData): number {
+        if (this.ended) {
+            throw new Error('Cannot record message after end() has been called')
+        }
+
+        let rawBytesWritten = 0
+
+        Object.entries(message.eventsByWindowId).forEach(([windowId, events]) => {
+            events.forEach((event) => {
+                const serializedLine = JSON.stringify([windowId, event]) + '\n'
+                const chunk = Buffer.from(serializedLine)
+                this.uncompressedChunks.push(chunk)
+                rawBytesWritten += chunk.length
+                this.eventCount++
+            })
+        })
+
+        this.rawBytesWritten += rawBytesWritten
+        return rawBytesWritten
+    }
+
+    /**
+     * Finalizes and returns the compressed session block
+     *
+     * @returns The complete compressed session block and event count
+     * @throws If called more than once
+     */
+    public async end(): Promise<EndResult> {
+        if (this.ended) {
+            throw new Error('end() has already been called')
+        }
+        this.ended = true
+
+        // Buffer.concat typings are missing the signature with Buffer[]
+        const uncompressedBuffer = Buffer.concat(this.uncompressedChunks as any)
+        const buffer = await snappy.compress(uncompressedBuffer)
+
+        return {
+            buffer,
+            eventCount: this.eventCount,
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Adding gzip roughly doubled the CPU consumption of Mr Blobby V2 pods. This means that we have to run twice as many pods for given amount of traffic, which then makes us flush twice as many batches to S3 to maintain the same processing delay in session replay. Ideally we would like to run as few processes as possible to keep the amount of write requests to S3 as low as possible.

## Changes

- Implements a new session recorder that uses Snappy, which is know for lower CPU consumption and not much worse compression ratios
- Switches the session batch recorders to use the snappy session recorder

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

- Unit tests
- Will gather performance metrics on production
