### PR TITLE
fix: Replace the right list with a tuple this time

### DIFF
--- a/posthog/temporal/delete_persons/delete_persons_workflow.py
+++ b/posthog/temporal/delete_persons/delete_persons_workflow.py
@@ -63,7 +63,7 @@ async def mogrify_delete_queries_activity(inputs: MogrifyDeleteQueriesActivityIn
         logger = get_internal_logger()
 
         select_query = SELECT_QUERY.format(
-            person_ids_filter=f"AND id IN {inputs.person_ids}" if tuple(inputs.person_ids) else ""
+            person_ids_filter=f"AND id IN {tuple(inputs.person_ids)}" if inputs.person_ids else ""
         )
         delete_query_person_distinct_ids = DELETE_QUERY_PERSON_DISTINCT_IDS.format(select_query=select_query)
         delete_query_person_override = DELETE_QUERY_PERSON_OVERRIDE.format(select_query=select_query)
@@ -116,7 +116,7 @@ async def delete_persons_activity(inputs: DeletePersonsActivityInputs) -> tuple[
         logger = get_internal_logger()
 
         select_query = SELECT_QUERY.format(
-            person_ids_filter=f"AND id IN {inputs.person_ids}" if tuple(inputs.person_ids) else ""
+            person_ids_filter=f"AND id IN {tuple(inputs.person_ids)}" if inputs.person_ids else ""
         )
         delete_query_person_distinct_ids = DELETE_QUERY_PERSON_DISTINCT_IDS.format(select_query=select_query)
         delete_query_person_override = DELETE_QUERY_PERSON_OVERRIDE.format(select_query=select_query)


### PR DESCRIPTION
## Problem

#28080 was right in spirit, but I mistakenly replaced a different list by a tuple instead of the one going into the query. Maybe this workflow should have unit tests.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Replace the right list for a tuple this time.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
