### PR TITLE
feat(cdp): add execution order to function creation

### DIFF
--- a/plugin-server/src/cdp/templates/test/test-helpers.ts
+++ b/plugin-server/src/cdp/templates/test/test-helpers.ts
@@ -157,6 +157,7 @@ export class TemplateTester {
             team_id: 1,
             enabled: true,
             mappings: this.template.mappings || null,
+            created_at: '2024-01-01T00:00:00Z',
         }
 
         const globalsWithInputs = buildGlobalsWithInputs(globals, hogFunction.inputs)


### PR DESCRIPTION
## Problem

we need to add automatic execution_order assignment for transformations

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Modified `HogFunctionSerializer.create()` to automatically set `execution_order` for transformation type functions
- The first transformation gets `execution_order = 1`, and subsequent transformations increment from there
- We always take the highest execution_order and increment it by one
- Non-transformation functions are unaffected and keep their `execution_order` as `Null`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- Added test `test_transformation_type_gets_execution_order_automatically` to verify:
  - First transformation gets `execution_order = 1`
  - Second transformation gets `execution_order = 2` 
  - Non-transformation functions don't get an `execution_order`

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
