### PR TITLE
chore(data-warehouse): Format the rows synced figure on the syncs tab

### DIFF
--- a/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/source/Syncs.tsx
@@ -44,7 +44,7 @@ export const Syncs = ({ id }: SyncsProps): JSX.Element => {
                 {
                     title: 'Rows synced',
                     render: (_, job) => {
-                        return job.rows_synced
+                        return job.rows_synced.toLocaleString()
                     },
                 },
                 {


### PR DESCRIPTION
## Changes
- Format the "rows synced" column on the syncs tab when viewing a warehouse source

**Before:**
<img width="668" alt="image" src="https://github.com/user-attachments/assets/49af4f9d-2d0b-4948-80d3-04a1d0544894" />
