### PR TITLE
feat: Hog transformation comparer

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -155,7 +155,8 @@
                 "OBJECT_STORAGE_ENABLED": "True",
                 "HOG_HOOK_URL": "http://localhost:3300/hoghook",
                 "PLUGIN_SERVER_MODE": "all-v2",
-                "HOG_TRANSFORMATIONS_ENABLED": "True"
+                "HOG_TRANSFORMATIONS_ENABLED": "True",
+                "HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE": "1"
             },
             "presentation": {
                 "group": "main"

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
@@ -126,7 +126,7 @@ function DictionaryField({ onChange, value }: { onChange?: (value: any) => void;
                     />
 
                     <HogFunctionTemplateInput
-                        className="flex-2 overflow-hidden"
+                        className="overflow-hidden flex-2"
                         value={val}
                         language="hogTemplate"
                         onChange={(val) => {
@@ -230,7 +230,7 @@ function HogFunctionInputSchemaControls({
 
     return (
         <div className="flex flex-col gap-2">
-            <div className="flex-1 flex items-center gap-2 flex-wrap">
+            <div className="flex flex-wrap items-center flex-1 gap-2">
                 <LemonSelect
                     size="small"
                     options={typeList.map((type) => ({
@@ -263,7 +263,7 @@ function HogFunctionInputSchemaControls({
                     Done
                 </LemonButton>
             </div>
-            <div className="flex-1 flex gap-2 flex-wrap">
+            <div className="flex flex-wrap flex-1 gap-2">
                 <LemonField.Pure label="Display label">
                     <LemonInput
                         className="min-w-60"
@@ -371,7 +371,8 @@ export function HogFunctionInputWithSchema({
         }
     }, [showSource])
 
-    const supportsTemplating = ['string', 'json', 'dictionary', 'email'].includes(schema.type)
+    const supportsTemplating =
+        ['string', 'json', 'dictionary', 'email'].includes(schema.type) && schema.templating !== false
     const supportsSecrets = 'type' in configuration // no secrets for mapping inputs
 
     return (
@@ -422,7 +423,7 @@ export function HogFunctionInputWithSchema({
                                             to="https://posthog.com/docs/cdp/destinations/customizing-destinations#customizing-payload"
                                             sideIcon={<IconInfo />}
                                             noPadding
-                                            className=" opacity-0 group-hover:opacity-100 p-1 transition-opacity"
+                                            className="p-1 transition-opacity opacity-0 group-hover:opacity-100"
                                         >
                                             Supports templating
                                         </LemonButton>
@@ -437,8 +438,8 @@ export function HogFunctionInputWithSchema({
                                     )}
                                 </div>
                                 {value?.secret ? (
-                                    <div className="border border-dashed rounded p-1 flex gap-2 items-center">
-                                        <span className="flex-1 text-muted-alt italic p-1">
+                                    <div className="flex items-center gap-2 p-1 border border-dashed rounded">
+                                        <span className="flex-1 p-1 italic text-muted-alt">
                                             This value is secret and is not displayed here.
                                         </span>
                                         <LemonButton
@@ -463,7 +464,7 @@ export function HogFunctionInputWithSchema({
                     }}
                 </LemonField>
             ) : (
-                <div className="border rounded p-2 border-dashed space-y-4">
+                <div className="p-2 space-y-4 border border-dashed rounded">
                     <HogFunctionInputSchemaControls
                         value={schema}
                         onChange={onSchemaChange}

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionInputs.tsx
@@ -113,7 +113,15 @@ function HogFunctionTemplateInput(
     return <CodeEditorInline {...props} globals={globalsWithInputs} />
 }
 
-function DictionaryField({ onChange, value }: { onChange?: (value: any) => void; value: any }): JSX.Element {
+function DictionaryField({
+    onChange,
+    value,
+    templating,
+}: {
+    onChange?: (value: any) => void
+    value: any
+    templating: boolean
+}): JSX.Element {
     const [entries, setEntries] = useState<[string, string][]>(Object.entries(value ?? {}))
 
     useEffect(() => {
@@ -146,6 +154,7 @@ function DictionaryField({ onChange, value }: { onChange?: (value: any) => void;
                             newEntries[index] = [newEntries[index][0], val ?? '']
                             setEntries(newEntries)
                         }}
+                        templating={templating}
                     />
 
                     <LemonButton

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4596,6 +4596,7 @@ export type HogFunctionInputSchemaType = {
     required?: boolean
     default?: any
     secret?: boolean
+    templating?: boolean
     description?: string
     integration?: string
     integration_key?: string

--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
@@ -9,7 +9,7 @@ import { template as defaultTemplate } from '../../../src/cdp/templates/_transfo
 import { template as geoipTemplate } from '../../../src/cdp/templates/_transformations/geoip/geoip.template'
 import { compileHog } from '../../../src/cdp/templates/compiler'
 import { createHogFunction, insertHogFunction } from '../../../tests/cdp/fixtures'
-import { createTeam, getFirstTeam, resetTestDatabase } from '../../../tests/helpers/sql'
+import { getFirstTeam, resetTestDatabase } from '../../../tests/helpers/sql'
 import { Hub } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
 import { HogFunctionTemplate } from '../templates/types'

--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
@@ -9,7 +9,7 @@ import { template as defaultTemplate } from '../../../src/cdp/templates/_transfo
 import { template as geoipTemplate } from '../../../src/cdp/templates/_transformations/geoip/geoip.template'
 import { compileHog } from '../../../src/cdp/templates/compiler'
 import { createHogFunction, insertHogFunction } from '../../../tests/cdp/fixtures'
-import { createTeam, resetTestDatabase } from '../../../tests/helpers/sql'
+import { createTeam, getFirstTeam, resetTestDatabase } from '../../../tests/helpers/sql'
 import { Hub } from '../../types'
 import { closeHub, createHub } from '../../utils/db/hub'
 import { HogFunctionTemplate } from '../templates/types'
@@ -51,8 +51,8 @@ describe('HogTransformer', () => {
         await resetTestDatabase()
 
         // Create a team first before inserting hog functions
-        const team = await hub.db.fetchTeam(2)
-        teamId = await createTeam(hub.db.postgres, team!.organization_id)
+        const team = await getFirstTeam(hub)
+        teamId = team.id
 
         hub.mmdb = Reader.openBuffer(brotliDecompressSync(mmdbBrotliContents))
         hogTransformer = new HogTransformerService(hub)
@@ -444,7 +444,7 @@ describe('HogTransformer', () => {
                     "$ip": "89.160.20.129",
                   },
                   "site_url": "http://localhost",
-                  "team_id": 386116330,
+                  "team_id": 2,
                   "timestamp": "2024-01-01T00:00:00Z",
                   "uuid": "event-id",
                 }

--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.test.ts
@@ -425,15 +425,7 @@ describe('HogTransformer', () => {
             const event: PluginEvent = createPluginEvent({ event: 'drop-me', team_id: teamId })
             const result = await hogTransformer.transformEvent(event)
             expect(executeSpy).toHaveBeenCalledTimes(1)
-            expect(result).toMatchInlineSnapshot(`
-                {
-                  "event": null,
-                  "messagePromises": [
-                    Promise {},
-                    Promise {},
-                  ],
-                }
-            `)
+            expect(result.event).toMatchInlineSnapshot(`null`)
         })
 
         it('handles legacy plugin transformation to keep events', async () => {
@@ -441,26 +433,20 @@ describe('HogTransformer', () => {
             const result = await hogTransformer.transformEvent(event)
 
             expect(executeSpy).toHaveBeenCalledTimes(1)
-            expect(result).toMatchInlineSnapshot(`
+            expect(result.event).toMatchInlineSnapshot(`
                 {
-                  "event": {
-                    "distinct_id": "distinct-id",
-                    "event": "keep-me",
-                    "ip": "89.160.20.129",
-                    "now": "2024-06-07T12:00:00.000Z",
-                    "properties": {
-                      "$current_url": "https://example.com",
-                      "$ip": "89.160.20.129",
-                    },
-                    "site_url": "http://localhost",
-                    "team_id": ${teamId},
-                    "timestamp": "2024-01-01T00:00:00Z",
-                    "uuid": "event-id",
+                  "distinct_id": "distinct-id",
+                  "event": "keep-me",
+                  "ip": "89.160.20.129",
+                  "now": "2024-06-07T12:00:00.000Z",
+                  "properties": {
+                    "$current_url": "https://example.com",
+                    "$ip": "89.160.20.129",
                   },
-                  "messagePromises": [
-                    Promise {},
-                    Promise {},
-                  ],
+                  "site_url": "http://localhost",
+                  "team_id": 386116330,
+                  "timestamp": "2024-01-01T00:00:00Z",
+                  "uuid": "event-id",
                 }
             `)
         })

--- a/plugin-server/src/cdp/legacy-plugins/_transformations/downsampling-plugin/template.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_transformations/downsampling-plugin/template.ts
@@ -16,6 +16,7 @@ export const template: HogFunctionTemplate = {
             label: '% of events to keep',
             default: '100',
             required: false,
+            templating: false,
         },
         {
             type: 'choice',
@@ -27,6 +28,7 @@ export const template: HogFunctionTemplate = {
             ],
             default: 'Distinct ID aware sampling',
             required: false,
+            templating: false,
         },
     ],
 }

--- a/plugin-server/src/cdp/legacy-plugins/_transformations/language-url-splitter-app/template.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_transformations/language-url-splitter-app/template.ts
@@ -17,6 +17,7 @@ export const template: HogFunctionTemplate = {
             default: '^/([a-z]{2})(?=/|#|\\?|$)',
             description: 'Ininitalized with `const regexp = new RegExp($pattern)`',
             required: true,
+            templating: false,
         },
         {
             key: 'matchGroup',
@@ -25,6 +26,7 @@ export const template: HogFunctionTemplate = {
             default: '1',
             description: 'Used in: `const value = regexp.match($pathname)[$matchGroup]`',
             required: true,
+            templating: false,
         },
         {
             key: 'property',
@@ -33,6 +35,7 @@ export const template: HogFunctionTemplate = {
             default: 'locale',
             description: 'Name of the event property we will store the matched value in',
             required: true,
+            templating: false,
         },
         {
             key: 'replacePattern',
@@ -41,6 +44,7 @@ export const template: HogFunctionTemplate = {
             default: '^(/[a-z]{2})(/|(?=/|#|\\?|$))',
             description: 'Initialized with `new RegExp($pattern)`, leave empty to disable path cleanup.',
             required: true,
+            templating: false,
         },
         {
             key: 'replaceKey',
@@ -49,6 +53,7 @@ export const template: HogFunctionTemplate = {
             default: '$pathname',
             description: 'Where to store the updated path. Keep as `$pathname` to override.',
             required: true,
+            templating: false,
         },
         {
             key: 'replaceValue',
@@ -57,6 +62,7 @@ export const template: HogFunctionTemplate = {
             default: '/',
             description: '`properties[key] = $pathname.replace(pattern, value)`',
             required: true,
+            templating: false,
         },
     ],
 }

--- a/plugin-server/src/cdp/legacy-plugins/_transformations/posthog-app-url-parameters-to-event-properties/template.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_transformations/posthog-app-url-parameters-to-event-properties/template.ts
@@ -12,6 +12,7 @@ export const template: HogFunctionTemplate = {
     inputs_schema: [
         {
             key: 'parameters',
+            templating: false,
             label: 'URL query parameters to convert',
             type: 'string',
             default: '',
@@ -20,6 +21,7 @@ export const template: HogFunctionTemplate = {
         },
         {
             key: 'prefix',
+            templating: false,
             label: 'Prefix',
             type: 'string',
             default: '',
@@ -28,6 +30,7 @@ export const template: HogFunctionTemplate = {
         },
         {
             key: 'suffix',
+            templating: false,
             label: 'Suffix',
             type: 'string',
             default: '',
@@ -36,6 +39,7 @@ export const template: HogFunctionTemplate = {
         },
         {
             key: 'ignoreCase',
+            templating: false,
             label: 'Ignore the case of URL parameters',
             type: 'choice',
             choices: [
@@ -48,6 +52,7 @@ export const template: HogFunctionTemplate = {
         },
         {
             key: 'setAsUserProperties',
+            templating: false,
             label: 'Add to user properties',
             type: 'choice',
             choices: [
@@ -59,6 +64,7 @@ export const template: HogFunctionTemplate = {
         },
         {
             key: 'setAsInitialUserProperties',
+            templating: false,
             label: 'Add to user initial properties',
             type: 'choice',
             choices: [
@@ -71,6 +77,7 @@ export const template: HogFunctionTemplate = {
         },
         {
             key: 'alwaysJson',
+            templating: false,
             label: 'Always JSON stringify the property data',
             type: 'choice',
             choices: [

--- a/plugin-server/src/cdp/legacy-plugins/_transformations/posthog-filter-out-plugin/template.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_transformations/posthog-filter-out-plugin/template.ts
@@ -12,6 +12,7 @@ export const template: HogFunctionTemplate = {
     inputs_schema: [
         {
             key: 'filters',
+            templating: false,
             label: 'Filters to apply',
             type: 'string',
             description: 'A JSON file containing an array of filters to apply. See the README for more information.',
@@ -19,6 +20,7 @@ export const template: HogFunctionTemplate = {
         },
         {
             key: 'eventsToDrop',
+            templating: false,
             label: 'Events to filter out',
             type: 'string',
             description: 'A comma-separated list of event names to filter out (e.g. $pageview,$autocapture)',
@@ -26,6 +28,7 @@ export const template: HogFunctionTemplate = {
         },
         {
             key: 'keepUndefinedProperties',
+            templating: false,
             label: 'Keep event if any of the filtered properties are undefined?',
             type: 'choice',
             choices: [

--- a/plugin-server/src/cdp/legacy-plugins/_transformations/property-filter-plugin/template.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_transformations/property-filter-plugin/template.ts
@@ -12,6 +12,7 @@ export const template: HogFunctionTemplate = {
     inputs_schema: [
         {
             key: 'properties',
+            templating: false,
             label: 'Properties to filter out',
             type: 'string',
             description: 'A comma-separated list of properties to filter out (e.g. $ip, $current_url)',

--- a/plugin-server/src/cdp/legacy-plugins/_transformations/semver-flattener-plugin/template.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_transformations/semver-flattener-plugin/template.ts
@@ -12,6 +12,7 @@ export const template: HogFunctionTemplate = {
     inputs_schema: [
         {
             key: 'properties',
+            templating: false,
             label: 'comma separated properties to explode version number from',
             type: 'string',
             description: 'my_version_number,app_version',

--- a/plugin-server/src/cdp/legacy-plugins/_transformations/taxonomy-plugin/template.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_transformations/taxonomy-plugin/template.ts
@@ -12,6 +12,7 @@ export const template: HogFunctionTemplate = {
     inputs_schema: [
         {
             key: 'defaultNamingConvention',
+            templating: false,
             label: 'Select your default naming pattern',
             type: 'choice',
             choices: [

--- a/plugin-server/src/cdp/legacy-plugins/_transformations/user-agent-plugin/template.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_transformations/user-agent-plugin/template.ts
@@ -13,6 +13,7 @@ export const template: HogFunctionTemplate = {
     inputs_schema: [
         {
             key: 'overrideUserAgentDetails',
+            templating: false,
             label: 'Can override existing browser related properties of event?',
             type: 'string',
             description:
@@ -22,6 +23,7 @@ export const template: HogFunctionTemplate = {
         },
         {
             key: 'enableSegmentAnalyticsJs',
+            templating: false,
             label: 'Automatically read segment_userAgent property, automatically sent by Segment via analytics.js?',
             type: 'choice',
             description:
@@ -35,6 +37,7 @@ export const template: HogFunctionTemplate = {
         },
         {
             key: 'debugMode',
+            templating: false,
             type: 'choice',
             description: 'Enable debug mode to log when the plugin is unable to extract values from the user agent',
             choices: [

--- a/plugin-server/src/cdp/types.ts
+++ b/plugin-server/src/cdp/types.ts
@@ -271,6 +271,7 @@ export type HogFunctionInputSchemaType = {
     requires_field?: string
     integration_field?: string
     requiredScopes?: string
+    templating?: boolean
 }
 
 export type HogFunctionTypeType =

--- a/plugin-server/src/config/config.ts
+++ b/plugin-server/src/config/config.ts
@@ -225,6 +225,7 @@ export function getDefaultConfig(): PluginsServerConfig {
 
         // Hog Transformations (Alpha)
         HOG_TRANSFORMATIONS_ENABLED: false,
+        HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE: 0,
 
         // Cookieless
         COOKIELESS_FORCE_STATELESS_MODE: false,

--- a/plugin-server/src/types.ts
+++ b/plugin-server/src/types.ts
@@ -323,6 +323,7 @@ export interface PluginsServerConfig extends CdpConfig, IngestionConsumerConfig 
 
     // HOG Transformations (Alpha feature)
     HOG_TRANSFORMATIONS_ENABLED: boolean
+    HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE: number | undefined
 
     SESSION_RECORDING_MAX_BATCH_SIZE_KB: number | undefined
     SESSION_RECORDING_MAX_BATCH_AGE_MS: number | undefined

--- a/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
@@ -48,6 +48,8 @@ export const compareEvents = (pluginEvent: PluginEvent, hogEvent: PluginEvent): 
     if (diffProperties.length > 0) {
         return { key: 'properties', plugins: diffProperties.join(','), hog: diffProperties.join(',') }
     }
+
+    return null
 }
 
 export async function compareToHogTransformStep(

--- a/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
@@ -87,7 +87,7 @@ export async function compareToHogTransformStep(
 
         const diff = compareEvents(postPluginsEvent, hogEvent)
         if (diff) {
-            status.warn('⚠️', 'Hog transformation produced an event but the plugin did not', {
+            status.warn('⚠️', 'Hog transformation was different from plugin', {
                 team_id: prePluginsEvent.team_id,
                 diff,
             })

--- a/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
@@ -1,0 +1,94 @@
+import { PluginEvent } from '@posthog/plugin-scaffold'
+import { Counter } from 'prom-client'
+
+import { cloneObject } from '~/src/utils/utils'
+
+import { HogTransformerService } from '../../../cdp/hog-transformations/hog-transformer.service'
+import { status } from '../../../utils/status'
+
+type Diff = {
+    key: string
+    plugins: string
+    hog: string
+}
+
+export const counterHogTransformationDiff = new Counter({
+    name: 'hog_transformation_diff',
+    help: 'Whether the hog transformations produced the same event as the plugin',
+    labelNames: ['outcome'], // either same or diff
+})
+
+export const compareEvents = (pluginEvent: PluginEvent, hogEvent: PluginEvent): Diff | null => {
+    // Comparing objects is expensive so we will do this instead by iterating over the keys we care about
+
+    if (pluginEvent.event !== hogEvent.event) {
+        return { key: 'event', plugins: pluginEvent.event, hog: hogEvent.event }
+    }
+
+    if (pluginEvent.distinct_id !== hogEvent.distinct_id) {
+        return { key: 'distinct_id', plugins: pluginEvent.distinct_id, hog: hogEvent.distinct_id }
+    }
+
+    const pluginProperties = Object.keys(pluginEvent.properties ?? {}).sort()
+    const hogProperties = Object.keys(hogEvent.properties ?? {}).sort()
+
+    // Loosely compare the two events by comparing the properties
+    if (pluginProperties.length !== hogProperties.length) {
+        return { key: 'properties', plugins: pluginProperties.join(','), hog: hogProperties.join(',') }
+    }
+
+    // Compare each property individually
+    const diffProperties = pluginProperties.filter((property) => {
+        const pluginValue = pluginEvent.properties?.[property]
+        const hogValue = hogEvent.properties?.[property]
+
+        return JSON.stringify(pluginValue) === JSON.stringify(hogValue)
+    })
+
+    if (diffProperties.length > 0) {
+        return { key: 'properties', plugins: diffProperties.join(','), hog: diffProperties.join(',') }
+    }
+}
+
+export async function compareToHogTransformStep(
+    hogTransformer: HogTransformerService | null,
+    prePluginsEvent: PluginEvent,
+    postPluginsEvent: PluginEvent | null
+): Promise<void> {
+    if (!hogTransformer) {
+        return
+    }
+
+    try {
+        // TRICKY: We
+        const clonedEvent = cloneObject(prePluginsEvent)
+        const result = await hogTransformer.transformEvent(clonedEvent)
+        const hogEvent = result.event
+
+        if (!hogEvent || !postPluginsEvent) {
+            if (!hogEvent && !postPluginsEvent) {
+                counterHogTransformationDiff.inc({ outcome: 'same' })
+            } else if (!hogEvent && postPluginsEvent) {
+                status.warn('⚠️', 'Hog transformation produced no event but the plugin did')
+                counterHogTransformationDiff.inc({ outcome: 'diff' })
+            } else if (hogEvent && !postPluginsEvent) {
+                status.warn('⚠️', 'Hog transformation produced an event but the plugin did not')
+                counterHogTransformationDiff.inc({ outcome: 'diff' })
+            }
+            return
+        }
+
+        const diff = compareEvents(postPluginsEvent, hogEvent)
+        if (diff) {
+            status.warn('⚠️', 'Hog transformation produced an event but the plugin did not', {
+                team_id: prePluginsEvent.team_id,
+                diff,
+            })
+            counterHogTransformationDiff.inc({ outcome: 'diff' })
+        } else {
+            counterHogTransformationDiff.inc({ outcome: 'same' })
+        }
+    } catch (error) {
+        status.error('Error occured when comparing plugin event to hog transform', error)
+    }
+}

--- a/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
@@ -53,14 +53,19 @@ export const compareEvents = (pluginEvent: PluginEvent, hogEvent: PluginEvent): 
 export async function compareToHogTransformStep(
     hogTransformer: HogTransformerService | null,
     prePluginsEvent: PluginEvent,
-    postPluginsEvent: PluginEvent | null
+    postPluginsEvent: PluginEvent | null,
+    samplePercentage?: number
 ): Promise<void> {
     if (!hogTransformer) {
         return
     }
 
+    if (!samplePercentage || Math.random() > samplePercentage) {
+        return
+    }
+
     try {
-        // TRICKY: We
+        // TRICKY: We really want to make sure that the other event is unaffected
         const clonedEvent = cloneObject(prePluginsEvent)
         const result = await hogTransformer.transformEvent(clonedEvent)
         const hogEvent = result.event

--- a/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
@@ -1,10 +1,9 @@
 import { PluginEvent } from '@posthog/plugin-scaffold'
 import { Counter } from 'prom-client'
 
-import { cloneObject } from '~/src/utils/utils'
-
 import { HogTransformerService } from '../../../cdp/hog-transformations/hog-transformer.service'
 import { status } from '../../../utils/status'
+import { cloneObject } from '../../../utils/utils'
 
 type Diff = {
     key: string

--- a/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
@@ -90,6 +90,6 @@ export async function compareToHogTransformStep(
             counterHogTransformationDiff.inc({ outcome: 'same' })
         }
     } catch (error) {
-        status.error('Error occured when comparing plugin event to hog transform', error)
+        status.error('Error occurred when comparing plugin event to hog transform', error)
     }
 }

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -234,16 +234,17 @@ export class EventPipelineRunner {
 
         const processedEvent = await this.runStep(pluginsProcessEventStep, [this, postCookielessEvent], event.team_id)
 
-        await this.runStep(
-            compareToHogTransformStep,
-            [
+        // NOTE: We don't use the step process here as we don't want it to interfere with other metrics
+        try {
+            await compareToHogTransformStep(
                 this.hogTransformer,
                 postCookielessEvent,
                 processedEvent,
-                this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE,
-            ],
-            event.team_id
-        )
+                this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE
+            )
+        } catch (error) {
+            status.error('🔔', 'Error comparing to hog transform', { error })
+        }
 
         if (processedEvent == null) {
             // A plugin dropped the event.

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -64,7 +64,7 @@ export class EventPipelineRunner {
         this.hub = hub
         this.originalEvent = event
         this.eventsProcessor = new EventsProcessor(hub)
-        this.hogTransformer = hub.HOG_TRANSFORMATIONS_ENABLED ? hogTransformer : null
+        this.hogTransformer = hogTransformer
     }
 
     isEventDisallowed(event: PipelineEvent): boolean {
@@ -236,7 +236,12 @@ export class EventPipelineRunner {
 
         await this.runStep(
             compareToHogTransformStep,
-            [this.hogTransformer, postCookielessEvent, processedEvent],
+            [
+                this.hogTransformer,
+                postCookielessEvent,
+                processedEvent,
+                this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE,
+            ],
             event.team_id
         )
 
@@ -247,7 +252,7 @@ export class EventPipelineRunner {
 
         const { event: transformedEvent, messagePromises } = await this.runStep(
             transformEventStep,
-            [processedEvent, this.hogTransformer],
+            [processedEvent, this.hub.HOG_TRANSFORMATIONS_ENABLED ? this.hogTransformer : null],
             event.team_id
         )
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/transformEventStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/transformEventStep.ts
@@ -7,7 +7,7 @@ export async function transformEventStep(
     hogTransformer: HogTransformerService | null
 ): Promise<TransformationResult> {
     if (!hogTransformer) {
-        return { event, messagePromises: [] }
+        return { event, invocationResults: [], messagePromises: [] }
     }
-    return hogTransformer.transformEvent(event)
+    return hogTransformer.transformEventAndProduceMessages(event)
 }

--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -112,7 +112,6 @@ def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True, kind=str
                     }
                     for choice in schema["choices"]
                 ]
-                input_schema["type"] = "string"
             elif schema["type"] == "attachment":
                 input_schema["secret"] = schema["key"] == "googleCloudKeyJson"
                 input_schema["type"] = "json"
@@ -152,6 +151,7 @@ def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True, kind=str
             "inputs": inputs,
             "inputs_schema": inputs_schema,
             "enabled": True,
+            "hog": "return event",
             "icon_url": icon_url,
         }
 

--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -40,8 +40,6 @@ def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True, kind=str
     else:
         raise ValueError(f"Invalid kind: {kind}")
 
-    print(legacy_plugins.query, legacy_plugins.count())
-
     if team_ids:
         legacy_plugins = legacy_plugins.filter(team_id__in=team_ids)
 

--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -9,11 +9,6 @@ from django.db.models import Q
 
 # python manage.py migrate_plugins_to_hog_functions --dry-run --test-mode
 
-"""
-from posthog.models.hog_functions.hog_function import HogFunction
-HogFunction.objects.filter(type="transformation", name__contains="CDP-TEST-HIDDEN").delete()
-"""
-
 
 def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True, kind=str):
     # Get all legacy plugin_configs that are active with their attachments and global values

--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -298,7 +298,7 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
         # This should ignore X since it's not defined.
         # So no error, but A has no real dependencies that matter.
         inputs_schema = [
-            {"key": "A", "type": "string", "required": True, "hog": False},
+            {"key": "A", "type": "string", "required": True, "templating": False},
         ]
         inputs = {
             "A": {"value": "{inputs.X} + A"},

--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -292,3 +292,19 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
         validated = validate_inputs(inputs_schema, inputs)
         # Only A is present, so A=0
         assert validated["A"]["order"] == 0
+
+    def test_validate_inputs_no_bytcode_if_not_hog(self):
+        # A depends on a non-existing input X
+        # This should ignore X since it's not defined.
+        # So no error, but A has no real dependencies that matter.
+        inputs_schema = [
+            {"key": "A", "type": "string", "required": True, "hog": False},
+        ]
+        inputs = {
+            "A": {"value": "{inputs.X} + A"},
+        }
+
+        validated = validate_inputs(inputs_schema, inputs)
+        assert validated["A"].get("bytecode") is None
+        assert validated["A"].get("transpiled") is None
+        assert validated["A"].get("value") == "{inputs.X} + A"

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -92,7 +92,7 @@ class InputsSchemaItemSerializer(serializers.Serializer):
     integration_field = serializers.CharField(required=False)
     requiredScopes = serializers.CharField(required=False)
     # Indicates if hog templating should be used for this input
-    hog = serializers.BooleanField(required=False, default=True)
+    templating = serializers.BooleanField(required=False, default=True)
 
     # TODO Validate choices if type=choice
 
@@ -149,7 +149,7 @@ class InputsItemSerializer(serializers.Serializer):
                 raise serializers.ValidationError({"inputs": {name: f"Either 'text' or 'html' is required."}})
 
         try:
-            if value and schema.get("hog"):
+            if value and schema.get("templating"):
                 # If we have a value and hog templating is enabled, we need to transpile the value
                 if item_type in ["string", "dictionary", "json", "email"]:
                     if item_type == "email" and isinstance(value, dict):

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -91,6 +91,8 @@ class InputsSchemaItemSerializer(serializers.Serializer):
     requires_field = serializers.CharField(required=False)
     integration_field = serializers.CharField(required=False)
     requiredScopes = serializers.CharField(required=False)
+    # Indicates if hog templating should be used for this input
+    hog = serializers.BooleanField(required=False, default=True)
 
     # TODO Validate choices if type=choice
 
@@ -106,7 +108,6 @@ class AnyInputField(serializers.Field):
 class InputsItemSerializer(serializers.Serializer):
     value = AnyInputField(required=False)
     bytecode = serializers.ListField(required=False, read_only=True)
-    # input_deps = serializers.ListField(required=False)
     order = serializers.IntegerField(required=False)
     transpiled = serializers.JSONField(required=False)
 
@@ -148,7 +149,8 @@ class InputsItemSerializer(serializers.Serializer):
                 raise serializers.ValidationError({"inputs": {name: f"Either 'text' or 'html' is required."}})
 
         try:
-            if value:
+            if value and schema.get("hog"):
+                # If we have a value and hog templating is enabled, we need to transpile the value
                 if item_type in ["string", "dictionary", "json", "email"]:
                     if item_type == "email" and isinstance(value, dict):
                         # We want to exclude the "design" property

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -92,7 +92,7 @@ class InputsSchemaItemSerializer(serializers.Serializer):
     integration_field = serializers.CharField(required=False)
     requiredScopes = serializers.CharField(required=False)
     # Indicates if hog templating should be used for this input
-    templating = serializers.BooleanField(required=False, default=True)
+    templating = serializers.BooleanField(required=False)
 
     # TODO Validate choices if type=choice
 
@@ -149,7 +149,7 @@ class InputsItemSerializer(serializers.Serializer):
                 raise serializers.ValidationError({"inputs": {name: f"Either 'text' or 'html' is required."}})
 
         try:
-            if value and schema.get("templating"):
+            if value and schema.get("templating", True):
                 # If we have a value and hog templating is enabled, we need to transpile the value
                 if item_type in ["string", "dictionary", "json", "email"]:
                     if item_type == "email" and isinstance(value, dict):

--- a/posthog/management/commands/migrate_plugins_to_hog_functions.py
+++ b/posthog/management/commands/migrate_plugins_to_hog_functions.py
@@ -16,12 +16,18 @@ class Command(BaseCommand):
         parser.add_argument(
             "--test-mode", action="store_true", help="Whether to just copy as a test function rather than migrate"
         )
+        parser.add_argument(
+            "--kind",
+            type=str,
+            help="Whether to migrate destinations or transformations",
+            choices=["destination", "transformation"],
+        )
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
         team_ids = options["team_ids"]
         test_mode = options["test_mode"]
-
+        kind = options["kind"]
         print("Migrating plugins to hog functions", options)  # noqa: T201
 
-        migrate_legacy_plugins(dry_run=dry_run, team_ids=team_ids, test_mode=test_mode)
+        migrate_legacy_plugins(dry_run=dry_run, team_ids=team_ids, test_mode=test_mode, kind=kind)


### PR DESCRIPTION
## Problem

We want to safely roll out the migration to hog functions but the question is - how?

## Changes

- [x] Adds a comparer step that compares the plugin transforms to the hog version
- [x] Adds a migration script to migrate all plugin ones over to hog ones
- [x] Adds an env var for sampling this so we don't hit the ingestion pipeline too hard
- [x] Fixes the migrator to work for transformations as well
- [x] Fixes the UI so that we have a way of saying an input doesn't support templating (so that hog bytecode isn't generated)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
