### PR TITLE
refactor: compute session batch metadata

### DIFF
--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-format.integration.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-format.integration.test.ts
@@ -1,3 +1,29 @@
+/**
+ * Integration tests for the session recording batch file format
+ *
+ * The batch file format is a sequence of independently-readable session blocks:
+ * ```
+ * Session Batch File
+ * ├── Snappy Session Recording Block 1
+ * │   └── JSONL Session Recording Block
+ * │       ├── [windowId, event1]
+ * │       ├── [windowId, event2]
+ * │       └── ...
+ * ├── Snappy Session Recording Block 2
+ * │   └── JSONL Session Recording Block
+ * │       ├── [windowId, event1]
+ * │       └── ...
+ * └── ...
+ * ```
+ *
+ * Each session block:
+ * - Contains all events for one session recording
+ * - Is compressed independently with Snappy
+ * - Can be read in isolation using the block metadata (offset and length)
+ * - Contains newline-delimited JSON records after decompression
+ * - Each record is an array of [windowId, event]
+ */
+
 import snappy from 'snappy'
 import { PassThrough } from 'stream'
 

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-format.integration.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-file-format.integration.test.ts
@@ -1,0 +1,141 @@
+import snappy from 'snappy'
+import { PassThrough } from 'stream'
+
+import { KafkaOffsetManager } from '../kafka/offset-manager'
+import { MessageWithTeam } from '../teams/types'
+import { SessionBatchFileWriter } from './session-batch-file-writer'
+import { SessionBatchRecorder, SessionBlockMetadata } from './session-batch-recorder'
+
+const enum EventType {
+    FullSnapshot = 2,
+    IncrementalSnapshot = 3,
+    Meta = 4,
+}
+
+describe('session recording integration', () => {
+    let recorder: SessionBatchRecorder
+    let mockOffsetManager: jest.Mocked<KafkaOffsetManager>
+    let mockWriter: jest.Mocked<SessionBatchFileWriter>
+    let mockStream: PassThrough
+    let mockFinish: jest.Mock
+
+    beforeEach(() => {
+        mockStream = new PassThrough()
+        mockFinish = jest.fn().mockResolvedValue(undefined)
+        mockWriter = {
+            newBatch: jest.fn().mockReturnValue({ stream: mockStream, finish: mockFinish }),
+        } as unknown as jest.Mocked<SessionBatchFileWriter>
+
+        mockOffsetManager = {
+            trackOffset: jest.fn(),
+            discardPartition: jest.fn(),
+            commit: jest.fn(),
+        } as unknown as jest.Mocked<KafkaOffsetManager>
+
+        recorder = new SessionBatchRecorder(mockOffsetManager, mockWriter)
+    })
+
+    const createMessage = (
+        sessionId: string,
+        teamId: number,
+        events: { type: EventType; data: any }[]
+    ): MessageWithTeam => ({
+        team: {
+            teamId,
+            consoleLogIngestionEnabled: false,
+        },
+        message: {
+            distinct_id: 'distinct_id',
+            session_id: sessionId,
+            eventsByWindowId: {
+                window1: events.map((event, index) => ({
+                    ...event,
+                    timestamp: 1000 + index * 1000,
+                })),
+            },
+            eventsRange: {
+                start: 1000,
+                end: 1000 + (events.length - 1) * 1000,
+            },
+            metadata: {
+                partition: 1,
+                topic: 'test',
+                offset: 0,
+                timestamp: 0,
+                rawSize: 0,
+            },
+        },
+    })
+
+    const readSessionFromBatch = async (
+        batchBuffer: Buffer,
+        blockMetadata: SessionBlockMetadata
+    ): Promise<[string, any][]> => {
+        const sessionBuffer = batchBuffer.subarray(
+            blockMetadata.blockStartOffset,
+            blockMetadata.blockStartOffset + blockMetadata.blockLength
+        )
+        const decompressed = await snappy.uncompress(sessionBuffer)
+        return decompressed
+            .toString()
+            .trim()
+            .split('\n')
+            .map((line) => JSON.parse(line))
+    }
+
+    it('should correctly record and read back multiple sessions', async () => {
+        const messages = [
+            createMessage('session1', 42, [
+                { type: EventType.FullSnapshot, data: { source: 1, snapshot: { html: '<div>1</div>' } } },
+                { type: EventType.IncrementalSnapshot, data: { source: 2, mutations: [{ id: 1 }] } },
+            ]),
+            createMessage('session2', 787, [
+                { type: EventType.Meta, data: { href: 'https://example.com', width: 1024, height: 768 } },
+                { type: EventType.FullSnapshot, data: { source: 1, snapshot: { html: '<div>2</div>' } } },
+            ]),
+            createMessage('session3', 123, [
+                { type: EventType.FullSnapshot, data: { source: 1, snapshot: { html: '<div>3</div>' } } },
+                { type: EventType.IncrementalSnapshot, data: { source: 3, mousemove: [{ x: 100, y: 200 }] } },
+                { type: EventType.Meta, data: { href: 'https://example.com/page2' } },
+            ]),
+        ]
+
+        // Record all messages
+        messages.forEach((message) => recorder.record(message))
+
+        // Collect the output stream data
+        const streamDataPromise = new Promise<Buffer>((resolve) => {
+            const chunks: Buffer[] = []
+            mockStream.on('data', (chunk) => chunks.push(chunk))
+            mockStream.on('end', () => resolve(Buffer.concat(chunks)))
+        })
+
+        // Flush and get metadata
+        const metadata = await recorder.flush()
+        const batchBuffer = await streamDataPromise
+
+        // Verify we got all sessions
+        expect(metadata).toHaveLength(3)
+        expect(new Set(metadata.map((block) => block.sessionId))).toEqual(new Set(['session1', 'session2', 'session3']))
+
+        // Read and verify each session's data
+        for (const block of metadata) {
+            const events = await readSessionFromBatch(batchBuffer, block)
+            const originalMessage = messages.find((m) => m.message.session_id === block.sessionId)!
+            const originalEvents = originalMessage.message.eventsByWindowId.window1
+
+            expect(block.teamId).toBe(originalMessage.team.teamId)
+            expect(events).toHaveLength(originalEvents.length)
+
+            events.forEach(([windowId, event], index) => {
+                expect(windowId).toBe('window1')
+                expect(event.type).toBe(originalEvents[index].type)
+                expect(event.data).toEqual(originalEvents[index].data)
+            })
+        }
+
+        // Verify the batch was properly finalized
+        expect(mockFinish).toHaveBeenCalled()
+        expect(mockOffsetManager.commit).toHaveBeenCalled()
+    })
+})

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
@@ -123,10 +123,11 @@ describe('SessionBatchRecorder', () => {
     const createMessage = (
         sessionId: string,
         events: RRWebEvent[],
-        metadata: MessageMetadata = {}
+        metadata: MessageMetadata = {},
+        teamId: number = 1
     ): MessageWithTeam => ({
         team: {
-            teamId: 1,
+            teamId,
             consoleLogIngestionEnabled: false,
         },
         message: {
@@ -803,6 +804,103 @@ describe('SessionBatchRecorder', () => {
             await expect(recorder.flush()).rejects.toThrow('Stream write error')
             expect(mockFinish).not.toHaveBeenCalled()
             expect(mockOffsetManager.commit).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('block metadata', () => {
+        it('should track correct metadata for multiple sessions', async () => {
+            const messages = [
+                createMessage(
+                    'session1',
+                    [
+                        {
+                            type: EventType.FullSnapshot,
+                            timestamp: 1000,
+                            data: { source: 1, adds: [{ parentId: 1, nextId: 2, node: { tag: 'div' } }] },
+                        },
+                    ],
+                    undefined,
+                    42
+                ),
+                createMessage(
+                    'session2',
+                    [
+                        {
+                            type: EventType.Meta,
+                            timestamp: 1500,
+                            data: { href: 'https://example.com', width: 1024, height: 768 },
+                        },
+                    ],
+                    undefined,
+                    787
+                ),
+                createMessage(
+                    'session3',
+                    [
+                        {
+                            type: EventType.IncrementalSnapshot,
+                            timestamp: 2000,
+                            data: { source: 2, texts: [{ id: 1, value: 'Updated text' }] },
+                        },
+                    ],
+                    undefined,
+                    123
+                ),
+            ]
+
+            // Create individual recorders and get their buffers
+            const recorder1 = new SnappySessionRecorderMock('session1', 42)
+            const recorder2 = new SnappySessionRecorderMock('session2', 787)
+            const recorder3 = new SnappySessionRecorderMock('session3', 123)
+
+            recorder1.recordMessage(messages[0].message)
+            recorder2.recordMessage(messages[1].message)
+            recorder3.recordMessage(messages[2].message)
+
+            const buffer1 = recorder1.end().buffer
+            const buffer2 = recorder2.end().buffer
+            const buffer3 = recorder3.end().buffer
+
+            const expectedBuffers = {
+                session1: buffer1,
+                session2: buffer2,
+                session3: buffer3,
+            }
+
+            // Record messages in the batch recorder
+            messages.forEach((message) => recorder.record(message))
+
+            const streamOutputPromise = captureOutput(mockStream)
+            const metadata = await recorder.flush()
+            const streamOutput = await streamOutputPromise
+
+            // Verify we got metadata for all three sessions
+            expect(metadata).toHaveLength(3)
+
+            // Verify all expected sessions are present
+            const sessionIds = new Set(metadata.map((block) => block.sessionId))
+            expect(sessionIds).toEqual(new Set(['session1', 'session2', 'session3']))
+
+            // Verify that each session has a block with correct data
+            metadata.forEach((block) => {
+                const expectedBuffer = expectedBuffers[block.sessionId as keyof typeof expectedBuffers]
+                const blockData = streamOutput.slice(block.blockStartOffset, block.blockStartOffset + block.blockLength)
+
+                const expectedTeamId = {
+                    session1: 42,
+                    session2: 787,
+                    session3: 123,
+                }[block.sessionId as keyof typeof expectedBuffers]
+
+                expect(block.teamId).toBe(expectedTeamId)
+                expect(block.blockLength).toBe(expectedBuffer.length)
+                expect(Buffer.from(blockData)).toEqual(expectedBuffer)
+            })
+
+            // Verify total length matches
+            const totalLength = Buffer.from(streamOutput).length
+            const expectedTotalLength = Object.values(expectedBuffers).reduce((sum, buf) => sum + buf.length, 0)
+            expect(totalLength).toBe(expectedTotalLength)
         })
     })
 })

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.test.ts
@@ -33,6 +33,8 @@ interface MessageMetadata {
 }
 
 export class SnappySessionRecorderMock {
+    constructor(private readonly sessionId: string, private readonly teamId: number) {}
+
     private chunks: Buffer[] = []
     private size: number = 0
 
@@ -73,7 +75,9 @@ jest.mock('./metrics', () => ({
 
 jest.mock('./blackhole-session-batch-writer')
 jest.mock('./snappy-session-recorder', () => ({
-    SnappySessionRecorder: jest.fn().mockImplementation(() => new SnappySessionRecorderMock()),
+    SnappySessionRecorder: jest
+        .fn()
+        .mockImplementation((sessionId: string, teamId: number) => new SnappySessionRecorderMock(sessionId, teamId)),
 }))
 
 describe('SessionBatchRecorder', () => {
@@ -95,7 +99,8 @@ describe('SessionBatchRecorder', () => {
         jest.clearAllMocks()
 
         jest.mocked(SnappySessionRecorder).mockImplementation(
-            () => new SnappySessionRecorderMock() as unknown as SnappySessionRecorder
+            (sessionId: string, teamId: number) =>
+                new SnappySessionRecorderMock(sessionId, teamId) as unknown as SnappySessionRecorder
         )
 
         const openMock = createOpenMock()

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
@@ -61,6 +61,7 @@ export class SessionBatchRecorder {
     public record(message: MessageWithTeam): number {
         const { partition } = message.message.metadata
         const sessionId = message.message.session_id
+        const teamId = message.team.teamId
 
         if (!this.partitionSessions.has(partition)) {
             this.partitionSessions.set(partition, new Map())
@@ -69,7 +70,7 @@ export class SessionBatchRecorder {
 
         const sessions = this.partitionSessions.get(partition)!
         if (!sessions.has(sessionId)) {
-            sessions.set(sessionId, new SnappySessionRecorder())
+            sessions.set(sessionId, new SnappySessionRecorder(sessionId, teamId))
         }
 
         const recorder = sessions.get(sessionId)!

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/session-batch-recorder.ts
@@ -43,6 +43,14 @@ import { SnappySessionRecorder } from './snappy-session-recorder'
  * This format allows efficient access to individual session recordings within a batch,
  * as only the relevant session block needs to be retrieved and decompressed.
  */
+
+export interface SessionBlockMetadata {
+    sessionId: string
+    teamId: number
+    blockStartOffset: number
+    blockLength: number
+}
+
 export class SessionBatchRecorder {
     private readonly partitionSessions = new Map<number, Map<string, SnappySessionRecorder>>()
     private readonly partitionSizes = new Map<number, number>()
@@ -69,7 +77,18 @@ export class SessionBatchRecorder {
         }
 
         const sessions = this.partitionSessions.get(partition)!
-        if (!sessions.has(sessionId)) {
+        const existingRecorder = sessions.get(sessionId)
+
+        if (existingRecorder) {
+            if (existingRecorder.teamId !== teamId) {
+                status.warn('🔁', 'session_batch_recorder_team_id_mismatch', {
+                    sessionId,
+                    existingTeamId: existingRecorder.teamId,
+                    newTeamId: teamId,
+                })
+                return 0
+            }
+        } else {
             sessions.set(sessionId, new SnappySessionRecorder(sessionId, teamId))
         }
 
@@ -118,13 +137,15 @@ export class SessionBatchRecorder {
      *
      * @throws If the flush operation fails
      */
-    public async flush(): Promise<void> {
+    public async flush(): Promise<SessionBlockMetadata[]> {
         status.info('🔁', 'session_batch_recorder_flushing', {
             partitions: this.partitionSessions.size,
             totalSize: this._size,
         })
 
         const { stream: outputStream, finish } = this.writer.newBatch()
+        const blockMetadata: SessionBlockMetadata[] = []
+        let currentOffset = 0
 
         let totalEvents = 0
         let totalSessions = 0
@@ -139,6 +160,15 @@ export class SessionBatchRecorder {
             for (const sessions of this.partitionSessions.values()) {
                 for (const recorder of sessions.values()) {
                     const { buffer, eventCount } = await recorder.end()
+
+                    // Track block metadata
+                    blockMetadata.push({
+                        sessionId: recorder.sessionId,
+                        teamId: recorder.teamId,
+                        blockStartOffset: currentOffset,
+                        blockLength: buffer.length,
+                    })
+                    currentOffset += buffer.length
 
                     // Write and handle backpressure, but also watch for errors
                     const canWriteMore = outputStream.write(buffer)
@@ -177,6 +207,8 @@ export class SessionBatchRecorder {
                 totalSessions,
                 totalBytes,
             })
+
+            return blockMetadata
         } catch (error) {
             // Log error and cleanup
             status.error('🔁', 'session_batch_recorder_flush_error', {

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.test.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.test.ts
@@ -17,7 +17,7 @@ describe('SnappySessionRecorder', () => {
     let recorder: SnappySessionRecorder
 
     beforeEach(() => {
-        recorder = new SnappySessionRecorder()
+        recorder = new SnappySessionRecorder('test_session_id', 1)
     })
 
     const createMessage = (windowId: string, events: any[]): ParsedMessageData => ({

--- a/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.ts
+++ b/plugin-server/src/main/ingestion-queues/session-recording-v2/sessions/snappy-session-recorder.ts
@@ -38,6 +38,8 @@ export class SnappySessionRecorder {
     private rawBytesWritten: number = 0
     private ended = false
 
+    constructor(public readonly sessionId: string, public readonly teamId: number) {}
+
     /**
      * Records a message containing events for this session
      * Events are buffered until end() is called


### PR DESCRIPTION
## Problem

We can write compressed session batch files to S3, but we can't read them. In order to be able to read that, we need to record where each session is stored in the file.

## Changes

- Session batch recorder now returns an array of metadata for each session block
- Implemented an integration test that creates a session batch in the final format and verifies that it can be read

In another PR, we'll add a way to store that metadata (e.g. in Clickhouse), so that another service can retrieve the session blocks from S3.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Added unit tests and one integration test.