### PR TITLE
chore(groups): Make team empty state snippet more obvious

### DIFF
--- a/frontend/src/scenes/groups/Groups.tsx
+++ b/frontend/src/scenes/groups/Groups.tsx
@@ -115,7 +115,7 @@ export function Groups({ groupTypeIndex }: { groupTypeIndex: number }): JSX.Elem
                             </Link>
                         </LemonBanner>
                         <CodeSnippet language={Language.JavaScript} wrap>
-                            {`posthog.group('${singular}', 'id:5', {\n` +
+                            {`posthog.group('${singular}', your_${singular}_id, {\n` +
                                 `    name: 'Awesome ${singular}',\n` +
                                 '    value: 11\n' +
                                 '});'}


### PR DESCRIPTION
## Problem

I haven't looked but i think id:5 was a little confusing for people. Make clearer they should just pass id here

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
