### PR TITLE
chore: move cohort calculation to longrunning queue

### DIFF
--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -76,7 +76,7 @@ from posthog.tasks.calculate_cohort import (
     calculate_cohort_from_list,
     insert_cohort_from_feature_flag,
     insert_cohort_from_insight_filter,
-    update_cohort,
+    increment_version_and_enqueue_calculate_cohort,
     insert_cohort_from_query,
 )
 from posthog.utils import format_query_params_absolute_url
@@ -161,7 +161,7 @@ class CohortSerializer(serializers.ModelSerializer):
         elif cohort.query is not None:
             raise ValidationError("Cannot create a dynamic cohort with a query. Set is_static to true.")
         else:
-            update_cohort(cohort, initiating_user=request.user)
+            increment_version_and_enqueue_calculate_cohort(cohort, initiating_user=request.user)
 
         report_user_action(request.user, "cohort created", cohort.get_analytics_metadata())
         return cohort
@@ -274,9 +274,9 @@ class CohortSerializer(serializers.ModelSerializer):
                 if request.FILES.get("csv"):
                     self._calculate_static_by_csv(request.FILES["csv"], cohort)
                 else:
-                    update_cohort(cohort, initiating_user=request.user)
+                    increment_version_and_enqueue_calculate_cohort(cohort, initiating_user=request.user)
             else:
-                update_cohort(cohort, initiating_user=request.user)
+                increment_version_and_enqueue_calculate_cohort(cohort, initiating_user=request.user)
 
         report_user_action(
             request.user,

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -580,11 +580,11 @@ def monitoring_check_clickhouse_schema_drift() -> None:
     check_clickhouse_schema_drift()
 
 
-@shared_task(ignore_result=True, queue=CeleryQueue.LONG_RUNNING.value)
+@shared_task(ignore_result=True)
 def calculate_cohort(parallel_count: int) -> None:
-    from posthog.tasks.calculate_cohort import calculate_cohorts
+    from posthog.tasks.calculate_cohort import enqueue_cohorts_to_calculate
 
-    calculate_cohorts(parallel_count)
+    enqueue_cohorts_to_calculate(parallel_count)
 
 
 class Polling:

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -67,8 +67,8 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
             people = Person.objects.filter(cohort__id=cohort.pk)
             self.assertEqual(people.count(), 1)
 
-        @patch("posthog.tasks.calculate_cohort.update_cohort")
-        def test_exponential_backoff(self, patch_update_cohort: MagicMock) -> None:
+        @patch("posthog.tasks.calculate_cohort.increment_version_and_enqueue_calculate_cohort")
+        def test_exponential_backoff(self, patch_increment_version_and_enqueue_calculate_cohort: MagicMock) -> None:
             # Exponential backoff
             Cohort.objects.create(
                 last_calculation=timezone.now() - relativedelta(minutes=MAX_AGE_MINUTES + 1),
@@ -89,6 +89,6 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
                 team_id=self.team.pk,
             )
             enqueue_cohorts_to_calculate(5)
-            self.assertEqual(patch_update_cohort.call_count, 2)
+            self.assertEqual(patch_increment_version_and_enqueue_calculate_cohort.call_count, 2)
 
     return TestCalculateCohort

--- a/posthog/tasks/test/test_calculate_cohort.py
+++ b/posthog/tasks/test/test_calculate_cohort.py
@@ -7,7 +7,7 @@ from freezegun import freeze_time
 
 from posthog.models.cohort import Cohort
 from posthog.models.person import Person
-from posthog.tasks.calculate_cohort import calculate_cohort_from_list, calculate_cohorts, MAX_AGE_MINUTES
+from posthog.tasks.calculate_cohort import calculate_cohort_from_list, enqueue_cohorts_to_calculate, MAX_AGE_MINUTES
 from posthog.test.base import APIBaseTest
 
 
@@ -88,7 +88,7 @@ def calculate_cohort_test_factory(event_factory: Callable, person_factory: Calla
                 errors_calculating=1,
                 team_id=self.team.pk,
             )
-            calculate_cohorts(5)
+            enqueue_cohorts_to_calculate(5)
             self.assertEqual(patch_update_cohort.call_count, 2)
 
     return TestCalculateCohort


### PR DESCRIPTION
## Problem

currently cohort calculation was on the default queue, while the cohort enqueue process was on longrunning. this is backwards.

## Changes

switch these

also renamed some stuff to make it clearer

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Didn't!
