### PR TITLE
fix: Person ids input should be list[int]

### DIFF
--- a/posthog/temporal/delete_persons/delete_persons_workflow.py
+++ b/posthog/temporal/delete_persons/delete_persons_workflow.py
@@ -52,7 +52,7 @@ class MogrifyDeleteQueriesActivityInputs:
     """Inputs for the `mogrify_delete_queries_activity`."""
 
     team_id: int
-    person_ids: list[str] = dataclasses.field(default_factory=list)
+    person_ids: list[int] = dataclasses.field(default_factory=list)
     batch_size: int = 1000
 
 
@@ -103,7 +103,7 @@ class DeletePersonsActivityInputs:
     """Inputs for the `delete_persons_activity`."""
 
     team_id: int
-    person_ids: list[str] = dataclasses.field(default_factory=list)
+    person_ids: list[int] = dataclasses.field(default_factory=list)
     batch_number: int = 1
     batches: int = 1
     batch_size: int = 1000
@@ -165,7 +165,7 @@ class DeletePersonsWorkflowInputs:
     """Inputs for the `DeletePersonsWorkflow`."""
 
     team_id: int
-    person_ids: list[str] = dataclasses.field(default_factory=list)
+    person_ids: list[int] = dataclasses.field(default_factory=list)
     batches: int = 1
     batch_size: int = 1000
 


### PR DESCRIPTION
## Problem

More errors coming up from testing: This time, I've realized person ids are ints (bigint in postgresql), not strings. Temporal is pretty strict about inputs, so we can't just pass ints.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Update input to delete-persons to be `list[int]`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
