### PR TITLE
chore(BI): Format the goal line figure

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -201,7 +201,9 @@ export const LineGraph = (): JSX.Element => {
                         if (ctx.chart.options.plugins?.annotation?.annotations) {
                             const annotations = ctx.chart.options.plugins.annotation.annotations as Record<string, any>
                             if (annotations[`line${curIndex}`]) {
-                                annotations[`line${curIndex}`].label.content = `${cur.label}: ${cur.value}`
+                                annotations[`line${curIndex}`].label.content = `${
+                                    cur.label
+                                }: ${cur.value.toLocaleString()}`
                                 // Hide the external tooltip element
                                 const tooltipEl = document.getElementById('InsightTooltipWrapper')
 


### PR DESCRIPTION
## Problem
- Goal line figures in BI aren't formatted with commas, making them hard to read
- [From here](https://posthog.slack.com/archives/C019RAX2XBN/p1738233391540739)

## Changes
- Added formatting! 

<img width="483" alt="image" src="https://github.com/user-attachments/assets/8c936a37-0bc8-47e6-953a-d46c27e7b4f3" />


## Does this work well for both Cloud and self-hosted?
I presume so

## How did you test this code?
See screenshot 