### PR TITLE
chore(data-warehouse): Add tracking events to new source onboarding

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
+++ b/frontend/src/scenes/data-warehouse/new/NewSourceWizard.tsx
@@ -3,6 +3,7 @@ import { useActions, useValues } from 'kea'
 import { PageHeader } from 'lib/components/PageHeader'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import posthog from 'posthog-js'
 import { useCallback } from 'react'
 import { SceneExport } from 'scenes/sceneTypes'
 
@@ -130,6 +131,8 @@ function FirstStep(): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
 
     const onClick = (sourceConfig: SourceConfig): void => {
+        posthog.capture('new source selected', { sourceType: sourceConfig.name })
+
         if (sourceConfig.name == 'Hubspot') {
             window.open(addToHubspotButtonUrl() as string)
         } else {

--- a/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/sourceWizardLogic.tsx
@@ -1117,6 +1117,11 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                 return
             }
 
+            posthog.capture('new source onSubmit', {
+                currentStep: values.currentStep,
+                sourceType: values.selectedConnector?.name,
+            })
+
             if (values.currentStep === 2 && values.selectedConnector?.name) {
                 actions.submitSourceConnectionDetails()
             } else if (values.currentStep === 2 && values.isManualLinkFormVisible) {


### PR DESCRIPTION
## Changes
- Add tracking calls during the new source wizard 
- So that I can build out some dashboarding to track new source conversion rates per source type