### PR TITLE
fix: delete_persons_workflow logger should be async

### DIFF
--- a/posthog/temporal/delete_persons/delete_persons_workflow.py
+++ b/posthog/temporal/delete_persons/delete_persons_workflow.py
@@ -126,7 +126,9 @@ async def delete_persons_activity(inputs: DeletePersonsActivityInputs) -> tuple[
         conn = await psycopg.AsyncConnection.connect(settings.DATABASE_URL)
         async with conn:
             async with conn.cursor() as cursor:
-                await logger.ainfo("Deleting batch %d of {batches} (%d rows)", inputs.batch_number, inputs.batch_size)
+                await logger.ainfo(
+                    "Deleting batch %d of %d (%d rows)", inputs.batch_number, inputs.batches, inputs.batch_size
+                )
 
                 await cursor.execute(
                     delete_query_person_distinct_ids,

--- a/posthog/temporal/delete_persons/delete_persons_workflow.py
+++ b/posthog/temporal/delete_persons/delete_persons_workflow.py
@@ -150,7 +150,7 @@ async def delete_persons_activity(inputs: DeletePersonsActivityInputs) -> tuple[
                     delete_query_person,
                     {"team_id": inputs.team_id, "limit": inputs.batch_size, "person_ids": inputs.person_ids},
                 )
-                await logger.info("Deleted %d persons", cursor.rowcount)
+                await logger.ainfo("Deleted %d persons", cursor.rowcount)
 
                 should_continue = True
                 if cursor.rowcount < inputs.batch_size:


### PR DESCRIPTION
## Problem

Right at the final delete query, one of the logger calls is not using the async method.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Swap `info` for `ainfo`.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
