### PR TITLE
fix(cdp): Testing of new destination

### DIFF
--- a/plugin-server/src/cdp/cdp-api.ts
+++ b/plugin-server/src/cdp/cdp-api.ts
@@ -137,6 +137,7 @@ export class CdpApi {
             const compoundConfiguration: HogFunctionType = {
                 ...(hogFunction ?? {}),
                 ...(configuration ?? {}),
+                team_id: team.id,
             }
 
             await this.hogFunctionManager.enrichWithIntegrations([compoundConfiguration])


### PR DESCRIPTION
## Problem

The team ID was missing which stops the enrichment from working

## Changes

* Adds it in

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

* Manually checked it works - will add proper testing at some point...
