### PR TITLE
fix: Ensure pubsub listeners work without piscina

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -39,8 +39,12 @@ import { GroupTypeManager } from '../worker/ingestion/group-type-manager'
 import { OrganizationManager } from '../worker/ingestion/organization-manager'
 import { TeamManager } from '../worker/ingestion/team-manager'
 import Piscina, { makePiscina as defaultMakePiscina } from '../worker/piscina'
+import { loadSchedule } from '../worker/plugins/loadSchedule'
+import { teardownPlugins } from '../worker/plugins/teardown'
 import { RustyHook } from '../worker/rusty-hook'
+import { reloadPlugins } from '../worker/tasks'
 import { syncInlinePlugins } from '../worker/vm/inline/inline'
+import { populatePluginCapabilities } from '../worker/vm/lazy'
 import { GraphileWorker } from './graphile-worker/graphile-worker'
 import { loadPluginSchedule } from './graphile-worker/schedule'
 import { startGraphileWorker } from './graphile-worker/worker-setup'
@@ -132,11 +136,12 @@ export async function startPluginsServer(
             posthog.shutdownAsync(),
         ])
 
-        if (piscina) {
-            await stopPiscina(piscina)
-        }
-
         if (serverInstance.hub) {
+            // Wait *up to* 5 seconds to shut down VMs.
+            await Promise.race([teardownPlugins(serverInstance.hub), delay(5000)])
+            // Wait 2 seconds to flush the last queues and caches
+            await Promise.all([serverInstance.hub?.kafkaProducer.flush(), delay(2000)])
+
             await closeHub(serverInstance.hub)
         }
     }
@@ -424,23 +429,20 @@ export async function startPluginsServer(
             pubSub = new PubSub(hub, {
                 [hub.PLUGINS_RELOAD_PUBSUB_CHANNEL]: async () => {
                     status.info('⚡', 'Reloading plugins!')
-                    await piscina?.broadcastTask({ task: 'reloadPlugins' })
+                    await reloadPlugins(hub)
 
                     if (hub?.capabilities.pluginScheduledTasks && piscina) {
-                        await piscina.broadcastTask({ task: 'reloadSchedule' })
+                        await loadSchedule(hub)
                         hub.pluginSchedule = await loadPluginSchedule(piscina)
                     }
                 },
-                'reset-available-product-features-cache': async (message) => {
-                    await piscina?.broadcastTask({
-                        task: 'resetAvailableProductFeaturesCache',
-                        args: JSON.parse(message),
-                    })
+                'reset-available-product-features-cache': (message) => {
+                    hub.organizationManager.resetAvailableProductFeaturesCache(JSON.parse(message).organization_id)
                 },
                 'populate-plugin-capabilities': async (message) => {
                     // We need this to be done in only once
-                    if (hub?.capabilities.appManagementSingleton && piscina) {
-                        await piscina?.broadcastTask({ task: 'populatePluginCapabilities', args: JSON.parse(message) })
+                    if (hub?.capabilities.appManagementSingleton) {
+                        await populatePluginCapabilities(hub, Number(JSON.parse(message).plugin_id))
                     }
                 },
             })
@@ -605,13 +607,6 @@ const startPreflightSchedules = (hub: Hub) => {
             jsonSerialize: false,
         })
     })
-}
-
-export async function stopPiscina(piscina: Piscina): Promise<void> {
-    // Wait *up to* 5 seconds to shut down VMs.
-    await Promise.race([piscina.broadcastTask({ task: 'teardownPlugins' }), delay(5000)])
-    // Wait 2 seconds to flush the last queues and caches
-    await Promise.all([piscina.broadcastTask({ task: 'flushKafkaMessages' }), delay(2000)])
 }
 
 const kafkaProtocolErrors = new Counter({

--- a/plugin-server/src/worker/tasks.ts
+++ b/plugin-server/src/worker/tasks.ts
@@ -4,11 +4,8 @@ import { EnqueuedPluginJob, Hub, PluginTaskType } from '../types'
 import { retryIfRetriable } from '../utils/retries'
 import { status } from '../utils/status'
 import { sleep } from '../utils/utils'
-import { loadSchedule } from './plugins/loadSchedule'
 import { runPluginTask, runProcessEvent } from './plugins/run'
 import { setupPlugins } from './plugins/setup'
-import { teardownPlugins } from './plugins/teardown'
-import { populatePluginCapabilities } from './vm/lazy'
 
 type TaskRunner = (hub: Hub, args: any) => Promise<any> | any
 
@@ -19,6 +16,45 @@ let RELOAD_PLUGINS_PROMISE: Promise<void> | undefined
 // `false` it means the promise is still sleeping for jitter, and so concurrent requests can know
 // that a reload will start in the future.
 let RELOAD_PLUGINS_PROMISE_STARTED = false
+
+export const reloadPlugins = async (hub: Hub) => {
+    if (RELOAD_PLUGINS_PROMISE && !RELOAD_PLUGINS_PROMISE_STARTED) {
+        // A reload is already scheduled and hasn't started yet. When it starts it will load the
+        // state of plugins after this reload request was issued, so we're done here.
+        return
+    }
+
+    if (RELOAD_PLUGINS_PROMISE && RELOAD_PLUGINS_PROMISE_STARTED) {
+        // A reload was in progress, we need to wait for it to finish and then we can schedule a
+        // new one (or a concurrent request will beat us to it after also waiting here, which is
+        // fine!).
+        await RELOAD_PLUGINS_PROMISE
+    }
+
+    if (!RELOAD_PLUGINS_PROMISE) {
+        // No reload is in progress, schedule one. If multiple concurrent requests got in line
+        // above, we only need one to schedule the reload here.
+
+        RELOAD_PLUGINS_PROMISE = (async () => {
+            // Jitter the reload time to avoid all workers reloading at the same time.
+            const jitterMs = Math.random() * hub.RELOAD_PLUGIN_JITTER_MAX_MS
+            status.info('💤', `Sleeping for ${jitterMs}ms to jitter reloadPlugins`)
+            await sleep(jitterMs)
+
+            RELOAD_PLUGINS_PROMISE_STARTED = true
+            try {
+                const tries = 3
+                const retrySleepMs = 5000
+                await retryIfRetriable(async () => await setupPlugins(hub), tries, retrySleepMs)
+            } finally {
+                RELOAD_PLUGINS_PROMISE = undefined
+                RELOAD_PLUGINS_PROMISE_STARTED = false
+            }
+        })()
+
+        await RELOAD_PLUGINS_PROMISE
+    }
+}
 
 export const workerTasks: Record<string, TaskRunner> = {
     runPluginJob: (hub, { job }: { job: EnqueuedPluginJob }) => {
@@ -38,59 +74,6 @@ export const workerTasks: Record<string, TaskRunner> = {
     },
     pluginScheduleReady: (hub) => {
         return hub.pluginSchedule !== null
-    },
-    reloadPlugins: async (hub) => {
-        if (RELOAD_PLUGINS_PROMISE && !RELOAD_PLUGINS_PROMISE_STARTED) {
-            // A reload is already scheduled and hasn't started yet. When it starts it will load the
-            // state of plugins after this reload request was issued, so we're done here.
-            return
-        }
-
-        if (RELOAD_PLUGINS_PROMISE && RELOAD_PLUGINS_PROMISE_STARTED) {
-            // A reload was in progress, we need to wait for it to finish and then we can schedule a
-            // new one (or a concurrent request will beat us to it after also waiting here, which is
-            // fine!).
-            await RELOAD_PLUGINS_PROMISE
-        }
-
-        if (!RELOAD_PLUGINS_PROMISE) {
-            // No reload is in progress, schedule one. If multiple concurrent requests got in line
-            // above, we only need one to schedule the reload here.
-
-            RELOAD_PLUGINS_PROMISE = (async () => {
-                // Jitter the reload time to avoid all workers reloading at the same time.
-                const jitterMs = Math.random() * hub.RELOAD_PLUGIN_JITTER_MAX_MS
-                status.info('💤', `Sleeping for ${jitterMs}ms to jitter reloadPlugins`)
-                await sleep(jitterMs)
-
-                RELOAD_PLUGINS_PROMISE_STARTED = true
-                try {
-                    const tries = 3
-                    const retrySleepMs = 5000
-                    await retryIfRetriable(async () => await setupPlugins(hub), tries, retrySleepMs)
-                } finally {
-                    RELOAD_PLUGINS_PROMISE = undefined
-                    RELOAD_PLUGINS_PROMISE_STARTED = false
-                }
-            })()
-
-            await RELOAD_PLUGINS_PROMISE
-        }
-    },
-    reloadSchedule: async (hub) => {
-        await loadSchedule(hub)
-    },
-    teardownPlugins: async (hub) => {
-        await teardownPlugins(hub)
-    },
-    flushKafkaMessages: async (hub) => {
-        await hub.kafkaProducer.flush()
-    },
-    resetAvailableProductFeaturesCache: (hub, args: { organization_id: string }) => {
-        hub.organizationManager.resetAvailableProductFeaturesCache(args.organization_id)
-    },
-    populatePluginCapabilities: async (hub, args: { plugin_id: string }) => {
-        await populatePluginCapabilities(hub, Number(args.plugin_id))
     },
     // Exported only for tests
     _testsRunProcessEvent: async (hub, args: { event: PluginEvent }) => {


### PR DESCRIPTION
## Problem

Piscina is the old worker thing that we used for doing jobs and things. It isn't actively used but the code is splattered throughout so it hasn't been possible to remove it.

The new IngestionConsumer doesn't set up piscina as it doesn't need it anymore, **however** this means we lose a couple of things, in particular the reload listeners.

## Changes

* To fix this I just removed it from piscina listeners and instead call the functions directly

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
