### PR TITLE
fix(cdp): Setup piscina for new ingester

### DIFF
--- a/plugin-server/src/main/pluginsServer.ts
+++ b/plugin-server/src/main/pluginsServer.ts
@@ -303,6 +303,8 @@ export async function startPluginsServer(
                     INGESTION_CONSUMER_CONSUME_TOPIC: consumerOption.topic,
                     INGESTION_CONSUMER_GROUP_ID: consumerOption.group_id,
                 }
+                piscina = piscina ?? (await makePiscina(serverConfig, hub))
+
                 const consumer = new IngestionConsumer(modifiedHub)
                 await consumer.start()
                 services.push(consumer.service)
@@ -310,6 +312,9 @@ export async function startPluginsServer(
         } else {
             if (capabilities.ingestionV2) {
                 const hub = await setupHub()
+                // NOTE: Piscina is only needed whilst we have legacy plugins running. Once we have all
+                // moved to hog functions we can remove this.
+                piscina = piscina ?? (await makePiscina(serverConfig, hub))
                 const consumer = new IngestionConsumer(hub)
                 await consumer.start()
                 services.push(consumer.service)


### PR DESCRIPTION
## Problem

More messy code means that the piscina setup also covers things like initial plugins setup... This is just a real mess to look after so I'm simplifying it by just setting up piscina anyways...

## Changes

* Adds piscina to the ingestion consumer setup

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
