### PR TITLE
feat: add node roles to del dag

### DIFF
--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -160,7 +160,10 @@ class ClickhouseCluster:
         Execute the callable once for any host with the given node role.
         """
         with ThreadPoolExecutor() as executor:
-            host = next(host for host in self.__hosts if host.host_cluster_role == node_role.value.lower())
+            try:
+                host = next(host for host in self.__hosts if host.host_cluster_role == node_role.value.lower())
+            except StopIteration:
+                raise ValueError(f"No hosts found with role {node_role.value}")
             return executor.submit(self.__get_task_function(host, fn))
 
     def map_all_hosts(self, fn: Callable[[Client], T], concurrency: int | None = None) -> FuturesMap[HostInfo, T]:

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -155,6 +155,14 @@ class ClickhouseCluster:
             host = self.__hosts[0]
             return executor.submit(self.__get_task_function(host, fn))
 
+    def any_host_by_role(self, fn: Callable[[Client], T], node_role: NodeRole) -> Future[T]:
+        """
+        Execute the callable once for any host with the given node role.
+        """
+        with ThreadPoolExecutor() as executor:
+            host = next(host for host in self.__hosts if host.host_cluster_role == node_role.value.lower())
+            return executor.submit(self.__get_task_function(host, fn))
+
     def map_all_hosts(self, fn: Callable[[Client], T], concurrency: int | None = None) -> FuturesMap[HostInfo, T]:
         """
         Execute the callable once for each host in the cluster.


### PR DESCRIPTION
## Problem

We have Node roles now, let's use them to target where we are running certain queries in delete dag

## Changes

added a few functions I'm sure greptile will see :eyes:

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
