### PR TITLE
chore: persist staged events for deletion in dag

### DIFF
--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -88,13 +88,9 @@ class PendingPersonEventDeletesTable:
         return f"{settings.CLICKHOUSE_DATABASE}.{self.table_name}"
 
     @property
-    def dictionary_name(self) -> str:
-        return f"{self.table_name}_dict"
-
-    @property
     def create_table_query(self) -> str:
         return f"""
-            CREATE TABLE IF NOT EXISTS {self.table_name} ON CLUSTER '{self.cluster}'
+            CREATE TABLE IF NOT EXISTS {self.qualified_name} ON CLUSTER '{self.cluster}'
             (
                 team_id Int64,
                 deletion_type Int8,
@@ -108,7 +104,7 @@ class PendingPersonEventDeletesTable:
 
     @property
     def drop_table_query(self) -> str:
-        return f"DROP TABLE IF EXISTS {self.table_name} ON CLUSTER '{self.cluster}'"
+        return f"DROP TABLE IF EXISTS {self.qualified_name} ON CLUSTER '{self.cluster}'"
 
     def create(self, client: Client) -> None:
         client.execute(self.create_table_query)
@@ -130,21 +126,101 @@ class PendingPersonEventDeletesTable:
             VALUES
         """
 
-    @property
-    def person_event_delete_mutation_runner(self) -> MutationRunner:
-        return MutationRunner(
-            EVENTS_DATA_TABLE(),
+    def checksum(self, client: Client):
+        results = client.execute(
             f"""
-            DELETE FROM {EVENTS_DATA_TABLE()} WHERE (uuid, event, team_id, person_id, timestamp) IN (
-                SELECT e.uuid, e.event, e.team_id, e.person_id, e.timestamp
+            SELECT groupBitXor(row_checksum) AS table_checksum
+            FROM (SELECT cityHash64(*) AS row_checksum FROM {self.qualified_name} ORDER BY team_id, deletion_type, key, created_at)
+            """
+        )
+        [[checksum]] = results
+        return checksum
+
+
+@dataclass
+class PendingEventDeletesTable:
+    """
+    Represents a temporary table storing pending event deletions.
+    """
+
+    timestamp: datetime
+    team_id: int | None = None
+    cluster: str = settings.CLICKHOUSE_CLUSTER
+    pending_person_deletions_qualified_name: str = (
+        f"{settings.CLICKHOUSE_DATABASE}.pending_person_deletes_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    )
+
+    @property
+    def timestamp_isoformat(self) -> str:
+        return self.timestamp.isoformat()
+
+    @property
+    def clickhouse_timestamp(self) -> str:
+        return self.timestamp.strftime("%Y%m%d_%H%M%S")
+
+    @property
+    def table_name(self) -> str:
+        return f"pending_event_deletes_{self.clickhouse_timestamp}"
+
+    @property
+    def qualified_name(self):
+        return f"{settings.CLICKHOUSE_DATABASE}.{self.table_name}"
+
+    @property
+    def create_table_query(self) -> str:
+        return f"""
+            CREATE TABLE IF NOT EXISTS {self.qualified_name} ON CLUSTER '{self.cluster}'
+            (
+                uuid UUID,
+                event String,
+                team_id Int64,
+                person_id UUID,
+                timestamp DateTime
+            )
+            ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/noshard/{self.table_name}', '{{shard}}-{{replica}}')
+            ORDER BY (team_id, event, person_id, timestamp)
+        """
+
+    @property
+    def drop_table_query(self) -> str:
+        return f"DROP TABLE IF EXISTS {self.qualified_name} ON CLUSTER '{self.cluster}'"
+
+    def create(self, client: Client) -> None:
+        client.execute(self.create_table_query)
+
+    def drop(self, client: Client) -> None:
+        client.execute(self.drop_table_query)
+
+    def exists(self, client: Client) -> bool:
+        result = client.execute(
+            f"SELECT count() FROM system.tables WHERE database = %(database)s AND name = %(table_name)s",
+            {"database": settings.CLICKHOUSE_DATABASE, "table_name": self.table_name},
+        )
+        return bool(result[0][0]) if result else False
+
+    @property
+    def populate_query(self) -> str:
+        return f"""
+            INSERT INTO {self.qualified_name} (uuid, event, team_id, person_id, timestamp)
+            SELECT e.uuid, e.event, e.team_id, e.person_id, e.timestamp
                 FROM {settings.CLICKHOUSE_DATABASE}.{EVENTS_DATA_TABLE()} e
-                INNER JOIN {self.qualified_name} d
+                INNER JOIN {self.pending_person_deletions_qualified_name} d
                 ON e.team_id = d.team_id
                 AND toString(e.person_id) = d.key
                 WHERE
                     e.timestamp < d.created_at
                     AND d.delete_verified_at IS NULL
                     AND d.deletion_type = '1'
+        """
+
+    @property
+    def person_event_delete_mutation_runner(self) -> MutationRunner:
+        return MutationRunner(
+            EVENTS_DATA_TABLE(),
+            f"""
+            DELETE FROM {EVENTS_DATA_TABLE()} WHERE (uuid, event, team_id, person_id, timestamp) IN (
+                SELECT uuid, event, team_id, person_id, timestamp
+                FROM {self.qualified_name}
             )
             """,
             {},
@@ -162,7 +238,7 @@ class PendingPersonEventDeletesTable:
 
 
 @op
-def create_pending_deletes_table(
+def create_pending_person_deletions_table(
     config: DeleteConfig,
     cluster: ResourceParam[ClickhouseCluster],
 ) -> PendingPersonEventDeletesTable:
@@ -178,23 +254,23 @@ def create_pending_deletes_table(
 
 @op
 def load_pending_person_deletions(
-    context: OpExecutionContext, create_pending_deletes_table: PendingPersonEventDeletesTable
+    context: OpExecutionContext, create_pending_person_deletions_table: PendingPersonEventDeletesTable
 ) -> PendingPersonEventDeletesTable:
     """Query postgres using django ORM to get pending person deletions and insert directly into ClickHouse."""
 
-    if not create_pending_deletes_table.team_id:
+    if not create_pending_person_deletions_table.team_id:
         # Use Django's queryset iterator for memory efficiency
         pending_deletions = AsyncDeletion.objects.filter(
             deletion_type=DeletionType.Person,
             delete_verified_at__isnull=True,
-            created_at__lte=create_pending_deletes_table.timestamp,
+            created_at__lte=create_pending_person_deletions_table.timestamp,
         ).iterator()
     else:
         pending_deletions = AsyncDeletion.objects.filter(
             deletion_type=DeletionType.Person,
-            team_id=create_pending_deletes_table.team_id,
+            team_id=create_pending_person_deletions_table.team_id,
             delete_verified_at__isnull=True,
-            created_at__lte=create_pending_deletes_table.timestamp,
+            created_at__lte=create_pending_person_deletions_table.timestamp,
         ).iterator()
 
     # Process and insert in chunks
@@ -222,7 +298,7 @@ def load_pending_person_deletions(
 
         if len(current_chunk) >= chunk_size:
             client.execute(
-                create_pending_deletes_table.populate_query,
+                create_pending_person_deletions_table.populate_query,
                 current_chunk,
             )
             total_rows += len(current_chunk)
@@ -231,7 +307,7 @@ def load_pending_person_deletions(
     # Insert any remaining records
     if current_chunk:
         client.execute(
-            create_pending_deletes_table.populate_query,
+            create_pending_person_deletions_table.populate_query,
             current_chunk,
         )
         total_rows += len(current_chunk)
@@ -239,23 +315,64 @@ def load_pending_person_deletions(
     context.add_output_metadata(
         {
             "total_rows": MetadataValue.int(total_rows),
-            "table_name": MetadataValue.text(create_pending_deletes_table.table_name),
+            "table_name": MetadataValue.text(create_pending_person_deletions_table.table_name),
         }
     )
-    return create_pending_deletes_table
+    return create_pending_person_deletions_table
+
+
+@op
+def create_pending_event_deletes_table(
+    config: DeleteConfig,
+    create_pending_person_deletions_table: PendingPersonEventDeletesTable,
+    cluster: ResourceParam[ClickhouseCluster],
+) -> PendingEventDeletesTable:
+    """Create a merge tree table in ClickHouse to store pending event deletions."""
+    table = PendingEventDeletesTable(
+        timestamp=create_pending_person_deletions_table.timestamp,
+        cluster=settings.CLICKHOUSE_CLUSTER,
+        pending_person_deletions_qualified_name=create_pending_person_deletions_table.qualified_name,
+    )
+
+    cluster.any_host(table.create).result()
+    return table
+
+
+@op
+def load_pending_event_deletes(
+    context: OpExecutionContext,
+    create_pending_event_deletes_table: PendingEventDeletesTable,
+    create_pending_person_deletions_table: PendingPersonEventDeletesTable,
+    cluster: ResourceParam[ClickhouseCluster],
+) -> PendingEventDeletesTable:
+    """Query postgres using django ORM to get pending event deletions and insert directly into ClickHouse."""
+
+    # Wait for the table to be fully replicated
+    def sync_replica(client: Client):
+        client.execute(f"SYSTEM SYNC REPLICA {create_pending_person_deletions_table.qualified_name} STRICT")
+
+    cluster.map_hosts_by_role(sync_replica, NodeRole.WORKER).result()
+
+    # Load pending event deletions
+    def load_pending_event_deletions(client: Client):
+        client.execute(create_pending_event_deletes_table.populate_query)
+
+    cluster.any_host_by_role(load_pending_event_deletions, NodeRole.WORKER).result()
+
+    return create_pending_event_deletes_table
 
 
 @op
 def delete_person_events(
     context: OpExecutionContext,
     cluster: ResourceParam[ClickhouseCluster],
-    load_pending_person_deletions: PendingPersonEventDeletesTable,
-) -> tuple[PendingPersonEventDeletesTable, ShardMutations]:
+    load_pending_event_deletions: PendingEventDeletesTable,
+) -> tuple[PendingEventDeletesTable, ShardMutations]:
     """Delete events from sharded_events table for persons pending deletion."""
 
     # Wait for the table to be fully replicated
     def sync_replica(client: Client):
-        client.execute(f"SYSTEM SYNC REPLICA {load_pending_person_deletions.qualified_name} STRICT")
+        client.execute(f"SYSTEM SYNC REPLICA {load_pending_event_deletions.qualified_name} STRICT")
 
     cluster.map_hosts_by_role(sync_replica, NodeRole.WORKER).result()
 
@@ -263,7 +380,7 @@ def delete_person_events(
         result = client.execute(
             f"""
             SELECT count()
-            FROM {load_pending_person_deletions.qualified_name}
+            FROM {load_pending_event_deletions.qualified_name}
             """
         )
         return result[0][0] if result else 0
@@ -272,7 +389,7 @@ def delete_person_events(
 
     if count_result == 0:
         context.add_output_metadata({"events_deleted": MetadataValue.int(0), "message": "No pending deletions found"})
-        return (load_pending_person_deletions, {})
+        return (load_pending_event_deletions, {})
 
     context.add_output_metadata(
         {
@@ -283,32 +400,33 @@ def delete_person_events(
     shard_mutations = {
         host.shard_num: mutation
         for host, mutation in (
-            cluster.map_one_host_per_shard(load_pending_person_deletions.person_event_delete_mutation_runner.enqueue)
+            cluster.map_one_host_per_shard(load_pending_event_deletions.person_event_delete_mutation_runner.enqueue)
             .result()
             .items()
         )
     }
-    return (load_pending_person_deletions, shard_mutations)
+    return (load_pending_event_deletions, shard_mutations)
 
 
 @op
 def wait_for_delete_mutations(
     context: OpExecutionContext,
     cluster: ResourceParam[ClickhouseCluster],
-    delete_person_events: tuple[PendingPersonEventDeletesTable, ShardMutations],
-) -> PendingPersonEventDeletesTable:
-    pending_person_deletions, shard_mutations = delete_person_events
+    delete_person_events: tuple[PendingEventDeletesTable, ShardMutations],
+) -> PendingEventDeletesTable:
+    pending_event_deletions, shard_mutations = delete_person_events
 
     cluster.map_all_hosts_in_shards({shard: mutation.wait for shard, mutation in shard_mutations.items()}).result()
 
-    return pending_person_deletions
+    return pending_event_deletions
 
 
 @op
 def cleanup_delete_assets(
     cluster: ResourceParam[ClickhouseCluster],
     config: DeleteConfig,
-    create_pending_deletes_table: PendingPersonEventDeletesTable,
+    create_pending_person_deletions_table: PendingPersonEventDeletesTable,
+    create_pending_event_deletes_table: PendingEventDeletesTable,
     wait_for_delete_mutations: PendingPersonEventDeletesTable,
 ) -> bool:
     """Clean up temporary tables and mark deletions as verified."""
@@ -318,21 +436,22 @@ def cleanup_delete_assets(
         config.log.info("Skipping cleanup as cleanup is disabled")
         return True
 
-    cluster.any_host(create_pending_deletes_table.drop).result()
+    cluster.any_host_by_role(create_pending_person_deletions_table.drop, NodeRole.WORKER).result()
+    cluster.any_host_by_role(create_pending_event_deletes_table.drop, NodeRole.WORKER).result()
 
     # Mark deletions as verified in Django
-    if not create_pending_deletes_table.team_id:
+    if not create_pending_person_deletions_table.team_id:
         AsyncDeletion.objects.filter(
             deletion_type=DeletionType.Person,
             delete_verified_at__isnull=True,
-            created_at__lte=create_pending_deletes_table.timestamp,
+            created_at__lte=create_pending_person_deletions_table.timestamp,
         ).update(delete_verified_at=datetime.now())
     else:
         AsyncDeletion.objects.filter(
             deletion_type=DeletionType.Person,
-            team_id=create_pending_deletes_table.team_id,
+            team_id=create_pending_person_deletions_table.team_id,
             delete_verified_at__isnull=True,
-            created_at__lte=create_pending_deletes_table.timestamp,
+            created_at__lte=create_pending_person_deletions_table.timestamp,
         ).update(delete_verified_at=datetime.now())
 
     return True
@@ -341,8 +460,10 @@ def cleanup_delete_assets(
 @job
 def deletes_job():
     """Job that handles deletion of person events."""
-    table = create_pending_deletes_table()
-    loaded_table = load_pending_person_deletions(table)
-    delete_events = delete_person_events(loaded_table)
+    person_table = create_pending_person_deletions_table()
+    event_table = create_pending_event_deletes_table(person_table)
+    loaded_person_table = load_pending_person_deletions(person_table)
+    loaded_event_table = load_pending_event_deletes(loaded_person_table)
+    delete_events = delete_person_events(loaded_event_table)
     waited_table = wait_for_delete_mutations(delete_events)
-    cleanup_delete_assets(table, waited_table)
+    cleanup_delete_assets(person_table, event_table, waited_table)

--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -146,9 +146,7 @@ class PendingEventDeletesTable:
     timestamp: datetime
     team_id: int | None = None
     cluster: str = settings.CLICKHOUSE_CLUSTER
-    pending_person_deletions_qualified_name: str = (
-        f"{settings.CLICKHOUSE_DATABASE}.pending_person_deletes_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-    )
+    pending_person_deletions_qualified_name: str = ""
 
     @property
     def timestamp_isoformat(self) -> str:
@@ -210,7 +208,7 @@ class PendingEventDeletesTable:
                 WHERE
                     e.timestamp < d.created_at
                     AND d.delete_verified_at IS NULL
-                    AND d.deletion_type = '1'
+                    AND d.deletion_type = 1
         """
 
     @property
@@ -428,7 +426,7 @@ def cleanup_delete_assets(
     config: DeleteConfig,
     create_pending_person_deletions_table: PendingPersonEventDeletesTable,
     create_pending_event_deletes_table: PendingEventDeletesTable,
-    wait_for_delete_mutations: PendingPersonEventDeletesTable,
+    wait_for_delete_mutations: PendingEventDeletesTable,
 ) -> bool:
     """Clean up temporary tables and mark deletions as verified."""
     # Drop the dictionary and table using the table object


### PR DESCRIPTION
## Problem

Calculating the events to delete is quite expensive - let's persist it and reference it

## Changes

persist and reference staged deletes

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
