### PR TITLE
feat(experiments): Add primary and secondary metric explanation

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/MetricsView.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/MetricsView.tsx
@@ -259,8 +259,15 @@ export function MetricsView({ isSecondary }: { isSecondary?: boolean }): JSX.Ele
                 <div className="border rounded bg-bg-light pt-6 pb-8 text-muted mt-2">
                     <div className="flex flex-col items-center mx-auto space-y-3">
                         <IconAreaChart fontSize="30" />
-                        <div className="text-sm text-center text-balance">
-                            Add up to {MAX_PRIMARY_METRICS} {isSecondary ? 'secondary' : 'primary'} metrics.
+                        <div className="text-sm text-center text-balance max-w-sm">
+                            <p>
+                                Add up to {MAX_PRIMARY_METRICS} {isSecondary ? 'secondary' : 'primary'} metrics.
+                            </p>
+                            <p>
+                                {isSecondary
+                                    ? 'Secondary metrics provide additional context and help detect unintended side effects.'
+                                    : 'Primary metrics represent the main goal of the experiment and directly measure if your hypothesis was successful.'}
+                            </p>
                         </div>
                         {isSecondary ? <AddSecondaryMetric /> : <AddPrimaryMetric />}
                     </div>


### PR DESCRIPTION
## Changes

Adds an explanation of primary and secondary metrics to the new experiment UI

**Before**

![CleanShot 2025-01-31 at 12 24 41@2x](https://github.com/user-attachments/assets/a48738a8-714a-490b-9277-139add2367ca)

**After**

![CleanShot 2025-01-31 at 12 24 01@2x](https://github.com/user-attachments/assets/a82db02e-7042-477c-8257-3e1735d98e09)

## How did you test this code?

Visual review