### PR TITLE
fix(experiments): Allow standard trends query on data warehouse

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_trends_data_warehouse_query.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_data_warehouse_query.py
@@ -344,6 +344,43 @@ class TestTrendsDataWarehouseQuery(ClickhouseTestMixin, BaseTest):
         assert response.results[3][1] == [0, 0, 0, 1, 0, 0, 0]
         assert response.results[3][2] == "d"
 
+    def test_trends_breakdown_with_events_join_experiments_optimized(self):
+        table_name = self.create_parquet_file()
+
+        DataWarehouseJoin.objects.create(
+            team=self.team,
+            source_table_name=table_name,
+            source_table_key="prop_1",
+            joining_table_name="events",
+            joining_table_key="distinct_id",
+            field_name="events",
+            configuration={"experiments_optimized": True, "experiments_timestamp_key": "created"},
+        )
+
+        trends_query = TrendsQuery(
+            kind="TrendsQuery",
+            dateRange=DateRange(date_from="2023-01-01"),
+            series=[
+                DataWarehouseNode(
+                    id=table_name,
+                    table_name=table_name,
+                    id_field="id",
+                    distinct_id_field="prop_1",
+                    timestamp_field="created",
+                )
+            ],
+            filterTestAccounts=True,
+            interval="day",
+            trendsFilter=TrendsFilter(display=ChartDisplayType.ACTIONS_LINE_GRAPH),
+        )
+
+        with freeze_time("2023-01-07"):
+            response = self.get_response(trends_query=trends_query)
+
+        assert response.columns is not None
+        assert set(response.columns).issubset({"date", "total"})
+        assert response.results[0][1] == [1, 1, 1, 1, 0, 0, 0]
+
     @snapshot_clickhouse_queries
     def test_trends_breakdown_on_view(self):
         from posthog.warehouse.models import DataWarehouseSavedQuery

--- a/posthog/warehouse/models/join.py
+++ b/posthog/warehouse/models/join.py
@@ -149,6 +149,7 @@ class DataWarehouseJoin(CreatedMetaFields, UUIDModel, DeletedMetaFields):
                         )
                         for name, chain in {
                             **join_to_add.fields_accessed,
+                            "event": ["event"],
                             "timestamp": ["timestamp"],
                             "distinct_id": ["distinct_id"],
                             "properties": ["properties"],


### PR DESCRIPTION
See https://posthog.slack.com/archives/C07PXH2GTGV/p1738246944407899
Related https://github.com/PostHog/posthog/issues/27012

## Problem

Conditions:
* Data warehouse table has `events` table as `ASOF LEFT JOIN`.
* "Filter out internal and test users" includes an event property filter.

Outcome:

```
>       raise ResolutionError(f"Field {name} not found on query with alias {self.alias}")
E       posthog.hogql.errors.ResolutionError: Field event not found on query with alias e__events

posthog/hogql/ast.py:356: ResolutionError
```

## Changes

Always includes `events.event` as an accessed property so this clause works as expected:

https://github.com/PostHog/posthog/blob/797672560de5f7007d6b881dfbf2d17fab98d059/posthog/warehouse/models/join.py#L181-L185

## How did you test this code?

Tests should pass. I also verified that a trends insight loaded as expected for me (previously failed).