### PR TITLE
chore: send dict credentials on delete dict creation

### DIFF
--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -176,7 +176,7 @@ class PendingDeletesDictionary:
                 created_at DateTime,
             )
             PRIMARY KEY team_id, key
-            SOURCE(CLICKHOUSE(DB %(database)s TABLE %(table)s))
+            SOURCE(CLICKHOUSE(DB %(database)s TABLE %(table)s PASSWORD %(password)s))
             LAYOUT(COMPLEX_KEY_HASHED(SHARDS {shards}))
             LIFETIME(0)
             SETTINGS(max_execution_time={max_execution_time}, max_memory_usage={max_memory_usage})
@@ -184,6 +184,7 @@ class PendingDeletesDictionary:
             {
                 "database": settings.CLICKHOUSE_DATABASE,
                 "table": self.source.table_name,
+                "password": settings.CLICKHOUSE_PASSWORD,
             },
         )
 


### PR DESCRIPTION
## Problem

dictionary still requires credentials in prod?

## Changes

This works fine locally, going to have to investigate settings to change to disable needing this in prod

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
