### PR TITLE
fix: do not use cluster ports for cluster client - use defaults

### DIFF
--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -265,7 +265,7 @@ def get_cluster(
 ) -> ClickhouseCluster:
     extra_hosts = []
     for host_config in map(copy, CLICKHOUSE_PER_TEAM_SETTINGS.values()):
-        extra_hosts.append(ConnectionInfo(host_config.pop("host"), None))
+        extra_hosts.append(ConnectionInfo(host_config.pop("host")))
         assert len(host_config) == 0, f"unexpected values: {host_config!r}"
     return ClickhouseCluster(
         default_client(), extra_hosts=extra_hosts, logger=logger, client_settings=client_settings, cluster=cluster

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -62,10 +62,9 @@ class FuturesMap(dict[K, Future[V]]):
 
 class ConnectionInfo(NamedTuple):
     address: str
-    port: int | None
 
     def make_pool(self, client_settings: Mapping[str, str] | None = None) -> ChPool:
-        return _make_ch_pool(host=self.address, port=self.port, settings=client_settings)
+        return _make_ch_pool(host=self.address, settings=client_settings)
 
 
 class HostInfo(NamedTuple):
@@ -92,17 +91,16 @@ class ClickhouseCluster:
             logger = logging.getLogger(__name__)
 
         self.__hosts = [
-            HostInfo(ConnectionInfo(host_address, port), shard_num, replica_num, host_cluster_type, host_cluster_role)
+            HostInfo(ConnectionInfo(host_address), shard_num, replica_num, host_cluster_type, host_cluster_role)
             for (
                 host_address,
-                port,
                 shard_num,
                 replica_num,
                 host_cluster_type,
                 host_cluster_role,
             ) in bootstrap_client.execute(
                 """
-                SELECT host_address, port, shard_num, replica_num, getMacro('hostClusterType') as host_cluster_type, getMacro('hostClusterRole') as host_cluster_role
+                SELECT host_address, shard_num, replica_num, getMacro('hostClusterType') as host_cluster_type, getMacro('hostClusterRole') as host_cluster_role
                 FROM clusterAllReplicas(%(name)s, system.clusters)
                 WHERE name = %(name)s and is_local
                 ORDER BY shard_num, replica_num

--- a/posthog/clickhouse/test/test_cluster.py
+++ b/posthog/clickhouse/test/test_cluster.py
@@ -80,10 +80,10 @@ def test_map_hosts_by_role() -> None:
     bootstrap_client_mock = Mock()
     bootstrap_client_mock.execute = Mock()
     bootstrap_client_mock.execute.return_value = [
-        ("host1", "9000", "1", "1", "online", "worker"),
-        ("host2", "9000", "1", "2", "online", "worker"),
-        ("host3", "9000", "1", "3", "online", "worker"),
-        ("host4", "9000", "1", "4", "online", "coordinator"),
+        ("host1", "1", "1", "online", "worker"),
+        ("host2", "1", "2", "online", "worker"),
+        ("host3", "1", "3", "online", "worker"),
+        ("host4", "1", "4", "online", "coordinator"),
     ]
 
     cluster = ClickhouseCluster(bootstrap_client_mock)


### PR DESCRIPTION
## Problem

Ports configured in the `remote_servers` block do not represent the ports that clients should be connecting with

## Changes

Use the default ports based on TLS or no TLS

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
