### PR TITLE
feat: add a reporting async deletes table for auditability

### DIFF
--- a/dags/tests/test_deletes.py
+++ b/dags/tests/test_deletes.py
@@ -112,3 +112,8 @@ def test_full_job(cluster: ClickhouseCluster):
     assert not any(cluster.map_all_hosts(table.exists).result().values())
     deletes_dict = PendingDeletesDictionary(source=table)
     assert not any(cluster.map_all_hosts(deletes_dict.exists).result().values())
+    report_table = PendingPersonEventDeletesTable(timestamp=timestamp, is_reporting=True)
+    assert all(cluster.map_all_hosts(report_table.exists).result().values())
+
+    # clean up the reporting table
+    cluster.map_all_hosts(report_table.drop).result()


### PR DESCRIPTION
## Problem

Right now there is not way to audit directly that deletes were completed on CH.

## Changes

This ETLs the async deletes queue with history to Clickhouse as the final step so that we can audit deletes in reporting

<img width="668" alt="image" src="https://github.com/user-attachments/assets/d6b5de71-1914-448b-8e27-69aa811f25aa" />


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
