### PR TITLE
feat: allow to set name for a HogQLQuery /query request.

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -7762,6 +7762,11 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
+                "name": {
+                    "description": "Client provided name of the query",
+                    "maxLength": 64,
+                    "type": "string"
+                },
                 "query": {
                     "type": "object"
                 },
@@ -7776,7 +7781,7 @@
                     "additionalProperties": {
                         "$ref": "#/definitions/HogQLVariable"
                     },
-                    "description": "Variables to be subsituted into the query",
+                    "description": "Variables to be substituted into the query",
                     "type": "object"
                 }
             },
@@ -8025,6 +8030,11 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
+                "name": {
+                    "description": "Client provided name of the query",
+                    "maxLength": 64,
+                    "type": "string"
+                },
                 "query": {
                     "type": "string"
                 },
@@ -8039,7 +8049,7 @@
                     "additionalProperties": {
                         "$ref": "#/definitions/HogQLVariable"
                     },
-                    "description": "Variables to be subsituted into the query",
+                    "description": "Variables to be substituted into the query",
                     "type": "object"
                 }
             },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -8025,6 +8025,11 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
+                "name": {
+                    "description": "Client provided name of the query",
+                    "maxLength": 64,
+                    "type": "string"
+                },
                 "query": {
                     "type": "string"
                 },
@@ -8041,11 +8046,6 @@
                     },
                     "description": "Variables to be substituted into the query",
                     "type": "object"
-                },
-                "name": {
-                    "description": "Client provided name of the query",
-                    "type": "string",
-                    "maxLength": 64
                 }
             },
             "required": ["kind", "query"],

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -8025,11 +8025,6 @@
                     "$ref": "#/definitions/HogQLQueryModifiers",
                     "description": "Modifiers used when performing the query"
                 },
-                "name": {
-                    "description": "Client provided name of the query",
-                    "maxLength": 64,
-                    "type": "string"
-                },
                 "query": {
                     "type": "string"
                 },
@@ -8044,7 +8039,7 @@
                     "additionalProperties": {
                         "$ref": "#/definitions/HogQLVariable"
                     },
-                    "description": "Variables to be substituted into the query",
+                    "description": "Variables to be subsituted into the query",
                     "type": "object"
                 }
             },

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -8039,8 +8039,13 @@
                     "additionalProperties": {
                         "$ref": "#/definitions/HogQLVariable"
                     },
-                    "description": "Variables to be subsituted into the query",
+                    "description": "Variables to be substituted into the query",
                     "type": "object"
+                },
+                "name": {
+                    "description": "Client provided name of the query",
+                    "type": "string",
+                    "maxLength": 64
                 }
             },
             "required": ["kind", "query"],

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -7764,7 +7764,6 @@
                 },
                 "name": {
                     "description": "Client provided name of the query",
-                    "maxLength": 64,
                     "type": "string"
                 },
                 "query": {
@@ -8032,7 +8031,6 @@
                 },
                 "name": {
                     "description": "Client provided name of the query",
-                    "maxLength": 64,
                     "type": "string"
                 },
                 "query": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -304,9 +304,7 @@ export interface HogQLQuery extends DataNode<HogQLQueryResponse> {
     values?: Record<string, any>
     /** @deprecated use modifiers.debug instead */
     explain?: boolean
-    /** Client provided name of the query
-     * @maxLength 64
-     */
+    /** Client provided name of the query */
     name?: string
 }
 

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -298,12 +298,16 @@ export interface HogQLQuery extends DataNode<HogQLQueryResponse> {
     kind: NodeKind.HogQLQuery
     query: string
     filters?: HogQLFilters
-    /** Variables to be subsituted into the query */
+    /** Variables to be substituted into the query */
     variables?: Record<string, HogQLVariable>
     /** Constant values that can be referenced with the {placeholder} syntax in the query */
     values?: Record<string, any>
     /** @deprecated use modifiers.debug instead */
     explain?: boolean
+    /** Client provided name of the query
+     * @maxLength 64
+     */
+    name?: string
 }
 
 export interface HogQLASTQuery extends Omit<HogQLQuery, 'query' | 'kind'> {

--- a/posthog/hogql/database/schema/query_log.py
+++ b/posthog/hogql/database/schema/query_log.py
@@ -19,6 +19,7 @@ QUERY_LOG_FIELDS: dict[str, FieldOrTable] = {
     "query": StringDatabaseField(name="query"),  #
     "query_start_time": DateTimeDatabaseField(name="event_time"),  #
     "query_duration_ms": FloatDatabaseField(name="query_duration_ms"),  #
+    "hogql_name": StringDatabaseField(name="hogql_name"),
     "created_by": IntegerDatabaseField(name="created_by"),
     "read_rows": IntegerDatabaseField(name="read_rows"),
     "read_bytes": IntegerDatabaseField(name="read_bytes"),
@@ -41,6 +42,7 @@ STRING_FIELDS = {
     "query_id": ["client_query_id"],
     "query": ["query", "query"],
     "kind": ["query", "kind"],
+    "hogql_name": ["query", "name"],
 }
 INT_FIELDS = {"created_by": ["user_id"]}
 

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -1793,6 +1793,16 @@
                   "table": null,
                   "type": "float"
               },
+              "hogql_name": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "hogql_name",
+                  "id": null,
+                  "name": "hogql_name",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
+              },
               "created_by": {
                   "chain": null,
                   "fields": null,
@@ -3627,6 +3637,16 @@
                   "schema_valid": true,
                   "table": null,
                   "type": "float"
+              },
+              "hogql_name": {
+                  "chain": null,
+                  "fields": null,
+                  "hogql_value": "hogql_name",
+                  "id": null,
+                  "name": "hogql_name",
+                  "schema_valid": true,
+                  "table": null,
+                  "type": "string"
               },
               "created_by": {
                   "chain": null,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum, StrEnum
 from typing import Any, Literal, Optional, Union
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel, constr
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel
 
 
 class SchemaRoot(RootModel[Any]):
@@ -6202,7 +6202,7 @@ class HogQLASTQuery(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    name: Optional[constr(max_length=64)] = Field(default=None, description="Client provided name of the query")
+    name: Optional[str] = Field(default=None, description="Client provided name of the query")
     query: dict[str, Any]
     response: Optional[HogQLQueryResponse] = None
     values: Optional[dict[str, Any]] = Field(
@@ -6223,7 +6223,7 @@ class HogQLQuery(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    name: Optional[constr(max_length=64)] = Field(default=None, description="Client provided name of the query")
+    name: Optional[str] = Field(default=None, description="Client provided name of the query")
     query: str
     response: Optional[HogQLQueryResponse] = None
     values: Optional[dict[str, Any]] = Field(

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -6222,6 +6222,7 @@ class HogQLQuery(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    name: Optional[constr(max_length=64)] = Field(default=None, description="Client provided name of the query")
     query: str
     response: Optional[HogQLQueryResponse] = None
     values: Optional[dict[str, Any]] = Field(
@@ -6230,7 +6231,6 @@ class HogQLQuery(BaseModel):
     variables: Optional[dict[str, HogQLVariable]] = Field(
         default=None, description="Variables to be substituted into the query"
     )
-    name: Optional[constr(max_length=64)] = Field(default=None, description="Client provided name of the query")
 
 
 class InsightActorsQueryOptionsResponse(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum, StrEnum
 from typing import Any, Literal, Optional, Union
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel, constr
 
 
 class SchemaRoot(RootModel[Any]):
@@ -6230,9 +6230,7 @@ class HogQLQuery(BaseModel):
     variables: Optional[dict[str, HogQLVariable]] = Field(
         default=None, description="Variables to be substituted into the query"
     )
-    name: Optional[str] = Field(
-        default=None, alias="name", max_length=64, description="Client provided name of the query."
-    )
+    name: Optional[constr(max_length=64)] = Field(default=None, description="Client provided name of the query")
 
 
 class InsightActorsQueryOptionsResponse(BaseModel):

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum, StrEnum
 from typing import Any, Literal, Optional, Union
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel, constr
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel
 
 
 class SchemaRoot(RootModel[Any]):
@@ -6222,14 +6222,13 @@ class HogQLQuery(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
-    name: Optional[constr(max_length=64)] = Field(default=None, description="Client provided name of the query")
     query: str
     response: Optional[HogQLQueryResponse] = None
     values: Optional[dict[str, Any]] = Field(
         default=None, description="Constant values that can be referenced with the {placeholder} syntax in the query"
     )
     variables: Optional[dict[str, HogQLVariable]] = Field(
-        default=None, description="Variables to be substituted into the query"
+        default=None, description="Variables to be subsituted into the query"
     )
 
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -6228,7 +6228,10 @@ class HogQLQuery(BaseModel):
         default=None, description="Constant values that can be referenced with the {placeholder} syntax in the query"
     )
     variables: Optional[dict[str, HogQLVariable]] = Field(
-        default=None, description="Variables to be subsituted into the query"
+        default=None, description="Variables to be substituted into the query"
+    )
+    name: Optional[str] = Field(
+        default=None, alias="name", max_length=64, description="Client provided name of the query."
     )
 
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum, StrEnum
 from typing import Any, Literal, Optional, Union
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel, constr
 
 
 class SchemaRoot(RootModel[Any]):
@@ -6202,13 +6202,14 @@ class HogQLASTQuery(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    name: Optional[constr(max_length=64)] = Field(default=None, description="Client provided name of the query")
     query: dict[str, Any]
     response: Optional[HogQLQueryResponse] = None
     values: Optional[dict[str, Any]] = Field(
         default=None, description="Constant values that can be referenced with the {placeholder} syntax in the query"
     )
     variables: Optional[dict[str, HogQLVariable]] = Field(
-        default=None, description="Variables to be subsituted into the query"
+        default=None, description="Variables to be substituted into the query"
     )
 
 
@@ -6222,13 +6223,14 @@ class HogQLQuery(BaseModel):
     modifiers: Optional[HogQLQueryModifiers] = Field(
         default=None, description="Modifiers used when performing the query"
     )
+    name: Optional[constr(max_length=64)] = Field(default=None, description="Client provided name of the query")
     query: str
     response: Optional[HogQLQueryResponse] = None
     values: Optional[dict[str, Any]] = Field(
         default=None, description="Constant values that can be referenced with the {placeholder} syntax in the query"
     )
     variables: Optional[dict[str, HogQLVariable]] = Field(
-        default=None, description="Variables to be subsituted into the query"
+        default=None, description="Variables to be substituted into the query"
     )
 
 


### PR DESCRIPTION
## Problem

Allow API customers to name their queries. One should be able to get all queries and group them by name from query_log table.

## Changes

Add a name to HogQLQuery model. Expose the name as `hogql_name` in `query_log` table.

![image](https://github.com/user-attachments/assets/e955f526-30a3-47ce-93c8-f4845c444e66)

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

Test query.
