### PR TITLE
fix: Ensure overflow events are written to consume kafka

### DIFF
--- a/plugin-server/src/kafka/producer.ts
+++ b/plugin-server/src/kafka/producer.ts
@@ -41,8 +41,8 @@ export class KafkaProducerWrapper {
     /** Kafka producer used for syncing Postgres and ClickHouse person data. */
     public producer: HighLevelProducer
 
-    static async create(config: PluginsServerConfig) {
-        const globalConfig = createRdConnectionConfigFromEnvVars(config, 'producer')
+    static async create(config: PluginsServerConfig, mode: 'producer' | 'consumer' = 'producer') {
+        const globalConfig = createRdConnectionConfigFromEnvVars(config, mode)
         const producer = new HighLevelProducer({
             ...globalConfig,
             // milliseconds to wait after the most recently added message before sending a batch. The


### PR DESCRIPTION
## Problem

It's a little confusing but when we have different kafkas for producing and consuming, we want to produce overflow events to the _consume_ kafka.

## Changes

* Adds a separate producer for exactly that

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
