### PR TITLE
chore: track sdk selection in onboarding

### DIFF
--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -56,6 +56,7 @@ import {
     RecordingReportLoadTimes,
     RecordingUniversalFilters,
     Resource,
+    type SDK,
     SessionPlayerData,
     SessionRecordingType,
     SessionRecordingUsageType,
@@ -532,6 +533,7 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportCommandBarActionSearch: (query: string) => ({ query }),
         reportCommandBarActionResultExecuted: (resultDisplay) => ({ resultDisplay }),
         reportBillingCTAShown: true,
+        reportSDKSelected: (sdk: SDK) => ({ sdk }),
     }),
     listeners(({ values }) => ({
         reportBillingCTAShown: () => {
@@ -1282,6 +1284,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportSubscribedDuringOnboarding: ({ productKey }) => {
             posthog.capture('subscribed during onboarding', {
                 product_key: productKey,
+            })
+        },
+        reportSDKSelected: ({ sdk }) => {
+            posthog.capture('sdk selected', {
+                sdk: sdk.key,
             })
         },
         // command bar

--- a/frontend/src/scenes/onboarding/sdks/SDKs.tsx
+++ b/frontend/src/scenes/onboarding/sdks/SDKs.tsx
@@ -40,7 +40,7 @@ export function SDKs({
 }): JSX.Element {
     const { loadCurrentTeam } = useActions(teamLogic)
     const { currentTeam } = useValues(teamLogic)
-    const { setSourceFilter, setSelectedSDK, setAvailableSDKInstructionsMap, setShowSideBySide, setPanel } =
+    const { setSourceFilter, selectSDK, setAvailableSDKInstructionsMap, setShowSideBySide, setPanel } =
         useActions(sdksLogic)
     const { sourceFilter, sdks, selectedSDK, sourceOptions, showSourceOptionsSelect, showSideBySide, panel } =
         useValues(sdksLogic)
@@ -103,7 +103,7 @@ export function SDKs({
                             <LemonButton
                                 data-attr={`onboarding-sdk-${sdk.key}`}
                                 active={selectedSDK?.key === sdk.key}
-                                onClick={selectedSDK?.key !== sdk.key ? () => setSelectedSDK(sdk) : undefined}
+                                onClick={selectedSDK?.key !== sdk.key ? () => selectSDK(sdk) : undefined}
                                 fullWidth
                                 icon={
                                     typeof sdk.image === 'string' ? (

--- a/frontend/src/scenes/onboarding/sdks/sdksLogic.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdksLogic.tsx
@@ -5,6 +5,7 @@ import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonSelectOptions } from 'lib/lemon-ui/LemonSelect/LemonSelect'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { liveEventsTableLogic } from 'scenes/activity/live/liveEventsTableLogic'
 import { userLogic } from 'scenes/userLogic'
 
@@ -63,6 +64,7 @@ export const sdksLogic = kea<sdksLogicType>([
             userLogic,
             ['user', 'isUserNonTechnical'],
         ],
+        actions: [eventUsageLogic, ['reportSDKSelected']],
     }),
     actions({
         setSourceFilter: (sourceFilter: string | null) => ({ sourceFilter }),
@@ -76,6 +78,7 @@ export const sdksLogic = kea<sdksLogicType>([
         setPanel: (panel: 'instructions' | 'options') => ({ panel }),
         setHasSnippetEvents: (hasSnippetEvents: boolean) => ({ hasSnippetEvents }),
         setSnippetHosts: (snippetHosts: string[]) => ({ snippetHosts }),
+        selectSDK: (sdk: SDK) => ({ sdk }),
     }),
     reducers({
         sourceFilter: [
@@ -248,6 +251,10 @@ export const sdksLogic = kea<sdksLogicType>([
             if (values.showSideBySide && !values.selectedSDK) {
                 actions.setSelectedSDK(values.sdks?.[0] || null)
             }
+        },
+        selectSDK: ({ sdk }) => {
+            actions.setSelectedSDK(sdk)
+            actions.reportSDKSelected(sdk)
         },
     })),
     events(({ actions }) => ({


### PR DESCRIPTION
## Problem

We want to be able to understand which SDKs have the most interest and understand which ones cause installation problems.

## Changes

Add tracking for sdk selection

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Tested locally that it tracks the event with the correct property
