### PR TITLE
fix: Add missing app singleton setting

### DIFF
--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -63,6 +63,7 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
             return {
                 mmdb: true,
                 ingestionOverflow: true,
+                appManagementSingleton: true,
                 ...sharedCapabilities,
             }
         case PluginServerMode.ingestion_historical:

--- a/plugin-server/src/capabilities.ts
+++ b/plugin-server/src/capabilities.ts
@@ -63,7 +63,6 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
             return {
                 mmdb: true,
                 ingestionOverflow: true,
-                appManagementSingleton: true,
                 ...sharedCapabilities,
             }
         case PluginServerMode.ingestion_historical:
@@ -150,6 +149,8 @@ export function getPluginServerCapabilities(config: PluginsServerConfig): Plugin
         case PluginServerMode.cdp_api:
             return {
                 cdpApi: true,
+                // NOTE: This is temporary until we have removed plugins
+                appManagementSingleton: true,
                 ...sharedCapabilities,
             }
         // This is only for functional tests, which time out if all capabilities are used


### PR DESCRIPTION
## Problem

There is a special setting that generates the capabilities for plugins.

At least one service needs to have this and we no longer have the scheduler which does this...

## Changes

* Adds it to the cdp api 

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
