### PR TITLE
chore: do not output logs on console for ClickHouse

### DIFF
--- a/docker/clickhouse/config.xml
+++ b/docker/clickhouse/config.xml
@@ -12,7 +12,6 @@
         <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
         <size>1000M</size>
         <count>10</count>
-        <console>1</console>
     </logger>
 
     <http_port>8123</http_port>


### PR DESCRIPTION
## Problem

CH container is flooded by the logs because of a setting change.

## Changes

Revert this to its previous state.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes.
