### PR TITLE
feat(cdp): show metrics frequency for transformations

### DIFF
--- a/frontend/src/scenes/pipeline/destinations/Destinations.tsx
+++ b/frontend/src/scenes/pipeline/destinations/Destinations.tsx
@@ -108,7 +108,7 @@ export function DestinationsTable({
     const { resetFilters } = useActions(destinationsFiltersLogic({ types }))
 
     const showMetricsHistory = types.includes('destination') || types.includes('transformation')
-    const showFrequency = types.includes('destination')
+    const showFrequencyInterval = types.includes('destination')
     const simpleName =
         types.includes('destination') || types.includes('site_destination')
             ? 'destination'
@@ -232,7 +232,7 @@ export function DestinationsTable({
                             )
                         },
                     },
-                    ...(showFrequency
+                    ...(showFrequencyInterval
                         ? [
                               {
                                   title: 'Frequency',

--- a/frontend/src/scenes/pipeline/destinations/Destinations.tsx
+++ b/frontend/src/scenes/pipeline/destinations/Destinations.tsx
@@ -107,7 +107,8 @@ export function DestinationsTable({
     const { toggleNode, deleteNode, openReorderTransformationsModal } = useActions(pipelineDestinationsLogic({ types }))
     const { resetFilters } = useActions(destinationsFiltersLogic({ types }))
 
-    const showFrequencyHistory = types.includes('destination')
+    const showMetricsHistory = types.includes('destination') || types.includes('transformation')
+    const showFrequency = types.includes('destination')
     const simpleName =
         types.includes('destination') || types.includes('site_destination')
             ? 'destination'
@@ -231,7 +232,7 @@ export function DestinationsTable({
                             )
                         },
                     },
-                    ...(showFrequencyHistory
+                    ...(showFrequency
                         ? [
                               {
                                   title: 'Frequency',
@@ -242,7 +243,7 @@ export function DestinationsTable({
                               } as LemonTableColumn<Destination | Transformation | SiteApp, any>,
                           ]
                         : []),
-                    ...(showFrequencyHistory
+                    ...(showMetricsHistory
                         ? [
                               {
                                   title: 'Last 7 days',


### PR DESCRIPTION
## Problem

- metrics frequency was not displayed for transformations

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes



<img width="1019" alt="Screenshot 2025-02-03 at 15 12 58" src="https://github.com/user-attachments/assets/ee4cc7a4-d8cd-44c0-bb62-bba1f9d1a1e5" />


- display metrics frequency for transformations

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
