### PR TITLE
fix(data-warehouse): SQL sources ORDER BY is missing

### DIFF
--- a/posthog/temporal/data_imports/pipelines/sql_database/helpers.py
+++ b/posthog/temporal/data_imports/pipelines/sql_database/helpers.py
@@ -102,8 +102,9 @@ class TableLoader:
             if self.end_value is not None:
                 query = query.where(filter_op_end(self.cursor_column, self.end_value))
 
-        # generate order by from declared row order
-        order_by = None
+        # generate order by from declared row order - default to asc
+        order_by = self.cursor_column.asc()
+
         if (self.row_order == "asc" and last_value_func is max) or (
             self.row_order == "desc" and last_value_func is min
         ):


### PR DESCRIPTION
## Problem
- `Customer 1`'s table was syncing weirdly, checked the logs and the last incremental value was all over the place - very inconsistent
- Turns out we don't actually have a `ORDER BY` clause in the SQL query when importing from a SQL source 🤯 

## Changes
Make sure there's a default order by 

## Does this work well for both Cloud and self-hosted?
Aye

## How did you test this code?
Tested locally - gonna see if I can recreate this in a test too 