### PR TITLE
feat: handle node frames

### DIFF
--- a/rust/cymbal/src/frames/resolver.rs
+++ b/rust/cymbal/src/frames/resolver.rs
@@ -152,14 +152,14 @@ mod test {
         // We're going to pretend out stack consists exclusively of JS frames whose source
         // we have locally
         test_stack.retain(|s| {
-            let RawFrame::JavaScript(s) = s else {
+            let RawFrame::JavaScriptWeb(s) = s else {
                 return false;
             };
             s.source_url.as_ref().unwrap().contains(CHUNK_PATH)
         });
 
         for frame in test_stack.iter_mut() {
-            let RawFrame::JavaScript(frame) = frame else {
+            let RawFrame::JavaScriptWeb(frame) = frame else {
                 panic!("Expected a JavaScript frame")
             };
             // Our test data contains our /actual/ source urls - we need to swap that to localhost

--- a/rust/cymbal/src/langs/mod.rs
+++ b/rust/cymbal/src/langs/mod.rs
@@ -1,2 +1,3 @@
 pub mod js;
+pub mod node;
 pub mod python;

--- a/rust/cymbal/src/langs/node.rs
+++ b/rust/cymbal/src/langs/node.rs
@@ -1,0 +1,87 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha512};
+
+use crate::frames::{Context, ContextLine, Frame};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RawNodeFrame {
+    pub filename: String,    // The relative path of the file the context line is in
+    pub function: String,    // The name of the function the exception came from
+    pub lineno: Option<u32>, // The line number of the context line
+    pub colno: Option<u32>,  // The column number of the context line
+    pub module: Option<String>, // The python-import style module name the function is in
+    // Default to false as sometimes not present on library code
+    #[serde(default)]
+    pub in_app: bool, // Whether the frame is in the user's code
+    pub context_line: Option<String>, // The line of code the exception came from
+    #[serde(default)]
+    pub pre_context: Vec<String>, // The lines of code before the context line
+    #[serde(default)]
+    pub post_context: Vec<String>, // The lines of code after the context line
+}
+
+impl RawNodeFrame {
+    pub fn frame_id(&self) -> String {
+        let mut hasher = Sha512::new();
+        self.context_line
+            .as_ref()
+            .inspect(|c| hasher.update(c.as_bytes()));
+        hasher.update(self.filename.as_bytes());
+        hasher.update(self.function.as_bytes());
+        hasher.update(self.lineno.unwrap_or_default().to_be_bytes());
+        self.module
+            .as_ref()
+            .inspect(|m| hasher.update(m.as_bytes()));
+        self.pre_context
+            .iter()
+            .chain(self.post_context.iter())
+            .for_each(|line| {
+                hasher.update(line.as_bytes());
+            });
+        format!("{:x}", hasher.finalize())
+    }
+
+    pub fn get_context(&self) -> Option<Context> {
+        let context_line = self.context_line.as_ref()?;
+        let lineno = self.lineno?;
+
+        let line = ContextLine::new(lineno, context_line);
+
+        let before = self
+            .pre_context
+            .iter()
+            .enumerate()
+            .map(|(i, line)| ContextLine::new(lineno - i as u32 - 1, line.clone()))
+            .collect();
+        let after = self
+            .post_context
+            .iter()
+            .enumerate()
+            .map(|(i, line)| ContextLine::new(lineno + i as u32 + 1, line.clone()))
+            .collect();
+        Some(Context {
+            before,
+            line,
+            after,
+        })
+    }
+}
+
+impl From<&RawNodeFrame> for Frame {
+    fn from(raw: &RawNodeFrame) -> Self {
+        Frame {
+            raw_id: String::new(),
+            mangled_name: raw.function.clone(),
+            line: raw.lineno,
+            column: None,
+            source: Some(raw.filename.clone()),
+            in_app: raw.in_app,
+            resolved_name: Some(raw.function.clone()),
+            lang: "javascript".to_string(),
+            resolved: true,
+            resolve_failure: None,
+            junk_drawer: None,
+            context: raw.get_context(),
+        }
+    }
+}

--- a/rust/cymbal/src/types/mod.rs
+++ b/rust/cymbal/src/types/mod.rs
@@ -207,7 +207,7 @@ mod test {
             panic!("Expected a Raw stacktrace")
         };
         assert_eq!(frames.len(), 2);
-        let RawFrame::JavaScript(frame) = &frames[0] else {
+        let RawFrame::JavaScriptWeb(frame) = &frames[0] else {
             panic!("Expected a JavaScript frame")
         };
 
@@ -220,7 +220,7 @@ mod test {
         assert_eq!(frame.location.as_ref().unwrap().line, 64);
         assert_eq!(frame.location.as_ref().unwrap().column, 25112);
 
-        let RawFrame::JavaScript(frame) = &frames[1] else {
+        let RawFrame::JavaScriptWeb(frame) = &frames[1] else {
             panic!("Expected a JavaScript frame")
         };
         assert_eq!(

--- a/rust/cymbal/tests/resolve.rs
+++ b/rust/cymbal/tests/resolve.rs
@@ -46,14 +46,14 @@ async fn end_to_end_resolver_test() {
     // We're going to pretend out stack consists exclusively of JS frames whose source
     // we have locally
     test_stack.retain(|s| {
-        let RawFrame::JavaScript(s) = s else {
+        let RawFrame::JavaScriptWeb(s) = s else {
             panic!("Expected a JavaScript frame")
         };
         s.source_url.as_ref().unwrap().contains(CHUNK_PATH)
     });
 
     for frame in test_stack.iter_mut() {
-        let RawFrame::JavaScript(frame) = frame else {
+        let RawFrame::JavaScriptWeb(frame) = frame else {
             panic!("Expected a JavaScript frame")
         };
         // Our test data contains our /actual/ source urls - we need to swap that to localhost

--- a/rust/cymbal/tests/static/node_err_props.json
+++ b/rust/cymbal/tests/static/node_err_props.json
@@ -1,0 +1,73 @@
+{
+    "$exception_list": [
+        {
+            "type": "Error",
+            "value": "My first Sentry error!",
+            "stacktrace": {
+                "frames": [
+                    {
+                        "filename": "node:_http_common",
+                        "module": "node:_http_common",
+                        "function": "HTTPParser.parserOnHeadersComplete",
+                        "lineno": 119,
+                        "colno": 17,
+                        "in_app": false,
+                        "platform": "node:javascript"
+                    },
+                    {
+                        "filename": "node:_http_server",
+                        "module": "node:_http_server",
+                        "function": "parserOnIncoming",
+                        "lineno": 1131,
+                        "colno": 12,
+                        "in_app": false,
+                        "platform": "node:javascript"
+                    },
+                    {
+                        "filename": "node:events",
+                        "module": "node:events",
+                        "function": "Server.emit",
+                        "lineno": 517,
+                        "colno": 28,
+                        "in_app": false,
+                        "platform": "node:javascript"
+                    },
+                    {
+                        "filename": "/Users/david/Desktop/example/server.ts",
+                        "module": "server.ts",
+                        "function": "Server.?",
+                        "lineno": 27,
+                        "colno": 9,
+                        "in_app": true,
+                        "platform": "node:javascript",
+                        "pre_context": [
+                            "});",
+                            "",
+                            "posthog.debug();",
+                            "",
+                            "const server = createServer((req, res) => {",
+                            "  res.writeHead(200, { \"Content-Type\": \"text/plain\" });",
+                            "  posthog.capture({ event: \"Test event\", distinctId: \"test\" });"
+                        ],
+                        "context_line": "  throw new Error(\"My first Sentry error!\");",
+                        "post_context": [
+                            "  res.end(\"Hello World!\\n\");",
+                            "});",
+                            "// starts a simple http server locally on port 3000",
+                            "server.listen(8020, \"127.0.0.1\", () => {",
+                            "  console.log(\"Listening on 127.0.0.1:8020\");",
+                            "});"
+                        ]
+                    }
+                ],
+                "type": "raw"
+            },
+            "mechanism": {
+                "type": "onuncaughtexception",
+                "handled": false
+            }
+        }
+    ],
+    "$lib": "posthog-node",
+    "$lib_version": "4.4.1"
+}

--- a/rust/cymbal/tests/static/node_err_props.json
+++ b/rust/cymbal/tests/static/node_err_props.json
@@ -49,7 +49,7 @@
                             "  res.writeHead(200, { \"Content-Type\": \"text/plain\" });",
                             "  posthog.capture({ event: \"Test event\", distinctId: \"test\" });"
                         ],
-                        "context_line": "  throw new Error(\"My first Sentry error!\");",
+                        "context_line": "  throw new Error(\"My first PostHog error!\");",
                         "post_context": [
                             "  res.end(\"Hello World!\\n\");",
                             "});",

--- a/rust/cymbal/tests/static/node_err_props.json
+++ b/rust/cymbal/tests/static/node_err_props.json
@@ -2,7 +2,7 @@
     "$exception_list": [
         {
             "type": "Error",
-            "value": "My first Sentry error!",
+            "value": "My first PostHog error!",
             "stacktrace": {
                 "frames": [
                     {

--- a/rust/cymbal/tests/static/python_err_props.json
+++ b/rust/cymbal/tests/static/python_err_props.json
@@ -722,8 +722,6 @@
             }
         }
     ],
-    "$exception_message": "[Errno 111] Connection refused",
-    "$exception_type": "ConnectionRefusedError",
     "$plugins_failed": [],
     "$geoip_disable": true,
     "$lib_version__patch": 6,

--- a/rust/cymbal/tests/types.rs
+++ b/rust/cymbal/tests/types.rs
@@ -54,3 +54,30 @@ fn python_exceptions() {
 
     assert_eq!(frames.len(), 31);
 }
+
+#[test]
+fn node_exceptions() {
+    let props: RawErrProps =
+        serde_json::from_str(include_str!("./static/node_err_props.json")).unwrap();
+
+    let frames = props
+        .exception_list
+        .into_iter()
+        .map(|e| e.stack.unwrap())
+        .flat_map(|t| {
+            let Stacktrace::Raw { frames } = t else {
+                panic!("Expected a Raw stacktrace")
+            };
+            frames
+        })
+        .map(|f| {
+            let RawFrame::JavaScriptNode(f) = f else {
+                panic!("Expected a Node frame")
+            };
+            let f: Frame = (&f).into();
+            f
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(frames.len(), 4);
+}


### PR DESCRIPTION
## Problem

Related to https://github.com/PostHog/posthog-js-lite/pull/366

## Changes

- Add new node frame type
- Funnily enough the context can be added clientside so Node is more similar to Python than it is Javascript
- I fear that won't be the case if the JS is minified. Wonder if that is ever the case?

Will leave it up to you @oliverb123 as to how we want to structure things. Should there only be a single raw frame type or is that a conflation of types?

## How did you test this code?

Copied the message from Kafka to make the test