### PR TITLE
chore: use lightweight deletes for squash job cleanup in overrides table

### DIFF
--- a/dags/person_overrides.py
+++ b/dags/person_overrides.py
@@ -198,7 +198,7 @@ class PersonOverridesSnapshotDictionary:
         return MutationRunner(
             PERSON_DISTINCT_ID_OVERRIDES_TABLE,
             f"""
-            DELETE WHERE
+            DELETE FROM {PERSON_DISTINCT_ID_OVERRIDES_TABLE} WHERE
                 isNotNull(dictGetOrNull(%(name)s, 'version', (team_id, distinct_id)) as snapshot_version)
                 AND snapshot_version >= version
             """,


### PR DESCRIPTION
## Problem

No real problem, just an optimization.

## Changes

use lightweight deletes on the overrides table

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Integration tests!
