### PR TITLE
feat: schedule squash job and then sensor the delete job off squash job success

### DIFF
--- a/dags/definitions.py
+++ b/dags/definitions.py
@@ -1,4 +1,11 @@
-from dagster import Definitions, load_assets_from_modules, ScheduleDefinition
+from dagster import (
+    Definitions,
+    load_assets_from_modules,
+    run_status_sensor,
+    ScheduleDefinition,
+    RunRequest,
+    DagsterRunStatus,
+)
 from dagster_aws.s3.io_manager import s3_pickle_io_manager
 from dagster_aws.s3.resources import s3_resource
 from dagster import fs_io_manager
@@ -9,14 +16,9 @@ from .person_overrides import ClickhouseClusterResource, squash_person_overrides
 
 all_assets = load_assets_from_modules([ch_examples, orm_examples])
 
-# Schedule to run deletes at 10 PM on Saturdays
-deletes_schedule = ScheduleDefinition(
-    job=deletes.deletes_job,
-    cron_schedule="0 22 * * 6",  # At 22:00 (10 PM) on Saturday
-    execution_timezone="UTC",
-    name="deletes_schedule",
-)
+
 env = "local" if settings.DEBUG else "prod"
+
 
 # Define resources for different environments
 resources_by_env = {
@@ -33,12 +35,31 @@ resources_by_env = {
     },
 }
 
+
 # Get resources for current environment, fallback to local if env not found
 resources = resources_by_env.get(env, resources_by_env["local"])
+
+
+# Schedule to run squash at 10 PM on Saturdays
+squash_schedule = ScheduleDefinition(
+    job=squash_person_overrides,
+    cron_schedule="0 22 * * 6",  # At 22:00 (10 PM) on Saturday
+    execution_timezone="UTC",
+    name="squash_person_overrides_schedule",
+)
+
+
+@run_status_sensor(
+    run_status=DagsterRunStatus.SUCCESS, monitored_jobs=[squash_person_overrides], request_job=deletes.deletes_job
+)
+def run_deletes_after_squash(context):
+    return RunRequest(run_key=None)
+
 
 defs = Definitions(
     assets=all_assets,
     jobs=[squash_person_overrides, deletes.deletes_job],
-    schedules=[deletes_schedule],
+    schedules=[squash_schedule],
+    sensors=[run_deletes_after_squash],
     resources=resources,
 )

--- a/dags/person_overrides.py
+++ b/dags/person_overrides.py
@@ -198,7 +198,7 @@ class PersonOverridesSnapshotDictionary:
         return MutationRunner(
             PERSON_DISTINCT_ID_OVERRIDES_TABLE,
             f"""
-            DELETE WHERE
+            DELETE FROM {PERSON_DISTINCT_ID_OVERRIDES_TABLE} WHERE
                 isNotNull(dictGetOrNull(%(name)s, 'version', (team_id, distinct_id)) as snapshot_version)
                 AND snapshot_version >= version
             """,

--- a/dags/person_overrides.py
+++ b/dags/person_overrides.py
@@ -1,3 +1,4 @@
+import datetime
 import time
 import uuid
 from dataclasses import dataclass
@@ -229,11 +230,13 @@ class PopulateSnapshotTableConfig(dagster.Config):
         description="The upper bound (non-inclusive) timestamp used when selecting person overrides to be squashed. The "
         "value can be provided in any format that is can be parsed by ClickHouse. This value should be far enough in "
         "the past that there is no reasonable likelihood that events or overrides prior to this time have not yet been "
-        "written to the database and replicated to all hosts in the cluster."
+        "written to the database and replicated to all hosts in the cluster.",
+        default=(datetime.datetime.now() - datetime.timedelta(days=2)).strftime("%Y-%m-%d %H:%M:%S"),
     )
     limit: int | None = pydantic.Field(
         description="The number of rows to include in the snapshot. If provided, this can be used to limit the total "
-        "amount of memory consumed by the squash process during execution."
+        "amount of memory consumed by the squash process during execution.",
+        default=None,
     )
 
 


### PR DESCRIPTION
## Problem

Currently these jobs are not really scheduled right.

## Changes

**Added defaults for the squash job!**

Schedule the jobs such that the squash job runs first and upon success it sensor triggers the delete job

<img width="2465" alt="image" src="https://github.com/user-attachments/assets/af2dbe2e-bfd0-485d-b318-9bc05617d035" />

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Integration tests and ran locally!
