### PR TITLE
fix: increase the receive_timeout to 24 hours for delete job

### DIFF
--- a/dags/deletes.py
+++ b/dags/deletes.py
@@ -62,7 +62,7 @@ class DeleteConfig(Config):
     )
     max_execution_time: int = pydantic.Field(
         default=0,
-        description="The maximum amount of time to wait for any step to complete before considering the operation "
+        description="The maximum amount of time to wait for the dictionary load to complete before considering the operation "
         "a failure, or 0 to wait an unlimited amount of time.",
     )
     max_memory_usage: int = pydantic.Field(

--- a/dags/tests/test_deletes.py
+++ b/dags/tests/test_deletes.py
@@ -78,13 +78,7 @@ def test_full_job(cluster: ClickhouseCluster):
 
     # Run the deletion job
     deletes_job.execute_in_process(
-        run_config={
-            "ops": {
-                "create_pending_person_deletions_table": {
-                    "config": {"timestamp": timestamp.isoformat(), "lightweight_deletes_sync": 1}
-                }
-            }
-        },
+        run_config={"ops": {"create_pending_person_deletions_table": {"config": {"timestamp": timestamp.isoformat()}}}},
         resources={"cluster": cluster},
     )
 


### PR DESCRIPTION
## Problem

We timeout waiting for lightweight deletes to finish on CH deleting events

## Changes

This will basically just let the job wait for the delete event to finish (should always finish in 24 hours) - if the workflow is killed it will pick up from the `waiting on mutation` node anyways so just lean into that

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
