### PR TITLE
fix: default for live events hosts

### DIFF
--- a/frontend/src/scenes/activity/live/liveEventsTableLogic.tsx
+++ b/frontend/src/scenes/activity/live/liveEventsTableLogic.tsx
@@ -96,7 +96,7 @@ export const liveEventsTableLogic = kea<liveEventsTableLogicType>([
                     if (!state.includes(eventHost)) {
                         return [...state, eventHost]
                     }
-                    return state
+                    return state ?? []
                 },
             },
         ],


### PR DESCRIPTION
## Problem

`eventsHosts` is `undefined` which causes an error when trying to iterate over it.

## Changes

Default it's value to an empty array (existing default)

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Repro'd the bug before, confirmed fix after.
