### PR TITLE
fix(assistant): memory collection bugs

### DIFF
--- a/ee/hogai/eval/tests/test_eval_memory.py
+++ b/ee/hogai/eval/tests/test_eval_memory.py
@@ -182,3 +182,16 @@ def test_memory_collector_does_not_answer_to_user(call_node):
     query = "What is a unicorn product?"
     actual_output = call_node(query)
     assert actual_output is None
+
+
+def test_saves_explicitly_requested_information(call_node):
+    query = "Remember that I like to view the pageview trend broken down by a country."
+    actual_output = call_node(query)
+
+    test_case = LLMTestCase(
+        input=query,
+        expected_tools=["core_memory_append"],
+        actual_output=actual_output.content,
+        tools_called=[tool["name"] for tool in actual_output.tool_calls],
+    )
+    assert_test(test_case, [ToolCorrectnessMetric()])

--- a/ee/hogai/eval/tests/test_eval_memory.py
+++ b/ee/hogai/eval/tests/test_eval_memory.py
@@ -176,3 +176,9 @@ def test_parallel_calls(call_node):
         tools_called=[tool[0]["name"], tool[1]["name"]],
     )
     assert_test(test_case, [ToolCorrectnessMetric()])
+
+
+def test_memory_collector_does_not_answer_to_user(call_node):
+    query = "What is a unicorn product?"
+    actual_output = call_node(query)
+    assert actual_output is None

--- a/ee/hogai/memory/nodes.py
+++ b/ee/hogai/memory/nodes.py
@@ -27,6 +27,7 @@ from ee.hogai.memory.prompts import (
     INITIALIZE_CORE_MEMORY_WITH_URL_PROMPT,
     INITIALIZE_CORE_MEMORY_WITH_URL_USER_PROMPT,
     MEMORY_COLLECTOR_PROMPT,
+    MEMORY_COLLECTOR_WITH_VISUALIZATION_PROMPT,
     SCRAPING_CONFIRMATION_MESSAGE,
     SCRAPING_INITIAL_MESSAGE,
     SCRAPING_MEMORY_SAVED_MESSAGE,
@@ -51,6 +52,7 @@ from posthog.schema import (
     CachedEventTaxonomyQueryResponse,
     EventTaxonomyQuery,
     HumanMessage,
+    VisualizationMessage,
 )
 
 
@@ -323,7 +325,9 @@ class MemoryCollectorNode(AssistantNode):
     def _construct_messages(self, state: AssistantState) -> list[BaseMessage]:
         node_messages = state.memory_collection_messages or []
 
-        filtered_messages = filter_messages(state.messages, entity_filter=(HumanMessage, AssistantMessage))
+        filtered_messages = filter_messages(
+            state.messages, entity_filter=(HumanMessage, AssistantMessage, VisualizationMessage)
+        )
         conversation: list[BaseMessage] = []
 
         for message in filtered_messages:
@@ -331,8 +335,19 @@ class MemoryCollectorNode(AssistantNode):
                 conversation.append(LangchainHumanMessage(content=message.content, id=message.id))
             elif isinstance(message, AssistantMessage):
                 conversation.append(LangchainAIMessage(content=message.content, id=message.id))
+            elif isinstance(message, VisualizationMessage) and message.answer:
+                conversation += ChatPromptTemplate.from_messages(
+                    [
+                        ("assistant", MEMORY_COLLECTOR_WITH_VISUALIZATION_PROMPT),
+                    ],
+                    template_format="mustache",
+                ).format_messages(
+                    schema=message.answer.model_dump_json(exclude_unset=True, exclude_none=True),
+                )
 
-        return [*conversation, *node_messages]
+        # Trim messages to keep only last 10 messages.
+        messages = [*conversation[-10:], *node_messages]
+        return messages
 
 
 class MemoryCollectorToolsNode(AssistantNode):

--- a/ee/hogai/memory/nodes.py
+++ b/ee/hogai/memory/nodes.py
@@ -255,7 +255,7 @@ class MemoryInitializerInterruptNode(AssistantNode):
 
     @property
     def _model(self):
-        return ChatOpenAI(model="gpt-4o-mini", temperature=0, disable_streaming=True)
+        return ChatOpenAI(model="gpt-4o-mini", temperature=0, disable_streaming=True, stop_sequences=["[Done]"])
 
     def _format_memory(self, memory: str) -> str:
         """

--- a/ee/hogai/memory/prompts.py
+++ b/ee/hogai/memory/prompts.py
@@ -90,6 +90,10 @@ Here is the initial core memory about the user's product:
 {{core_memory}}
 </product_core_memory>
 
+<basic_functions>
+When you send a message, treat its content as your private inner dialogue that represents your thought process. Use it for planning or personal reflection, as it can reveal your reasoning, introspection, and growth during interactions. Do not answer to the user. They won't see your message, as it's your inner monologue. Remember, always keep this monologue brief—under 40 words—and do not share it with the user.
+</basic_functions>
+
 <responsibilities>
 Your responsibilities include:
 1. Analyzing new information provided by users.
@@ -108,7 +112,7 @@ Memory Types to Collect:
 
 <instructions>
 When new information is provided, follow these steps:
-1. Analyze the information inside <information_processing> tags:
+1. Analyze the information:
    - Determine if the information is relevant and which memory type it belongs to.
    - If relevant, formulate a clear, factual statement based on the information.
    - Consider the implications of this new information on existing memory.
@@ -162,4 +166,11 @@ The arguments of the tool call are invalid and raised a Pydantic validation erro
 {{validation_error_message}}
 
 Fix the error and return the correct response.
-"""
+""".strip()
+
+MEMORY_COLLECTOR_WITH_VISUALIZATION_PROMPT = """
+I previously generated an insight with the following JSON schema:
+```json
+{{{schema}}}
+```
+""".strip()

--- a/ee/hogai/memory/prompts.py
+++ b/ee/hogai/memory/prompts.py
@@ -115,7 +115,7 @@ When new information is provided, follow these steps:
    - Decide whether to append this new information or replace existing information in the core memory, providing reasoning for your decision.
    - Keep reasoning short and concise under 50 words.
 2. If relevant, update the core memory using the 'core_memory_append' or 'core_memory_replace' function as appropriate.
-3. Output "[Done]" when you have finished processing the information.
+3. Output "[Done]" when you have finished processing the information. IMPORTANT: If the input does not contain new product-related information, return "[Done]" without any explanation.
 
 Ignore phrases that:
 - Are too vague or generic without specific details (e.g., "pageview trend").
@@ -148,6 +148,7 @@ Do not return anything from the custom few shot example prompts provided above.
 - All users have their personal event and property taxonomy. Manage your memory to capture specifics of their taxonomy.
 - Infer broader implications from specific statements when appropriate.
 - Reformulate user inputs into clear, factual statements about the product or company.
+- Save information the user explicitly asked to save using indicative verbs like "remember," "save," "note," etc.
 - Do not use markdown or add notes.
 - Today's date is {{date}}.
 </remember>

--- a/ee/hogai/memory/prompts.py
+++ b/ee/hogai/memory/prompts.py
@@ -152,7 +152,7 @@ Do not return anything from the custom few shot example prompts provided above.
 - All users have their personal event and property taxonomy. Manage your memory to capture specifics of their taxonomy.
 - Infer broader implications from specific statements when appropriate.
 - Reformulate user inputs into clear, factual statements about the product or company.
-- Save information the user explicitly asked to save using indicative verbs like "remember," "save," "note," etc.
+- Save information the user explicitly asked to save using indicative verbs like "remember," "save," "note," etc even if it's not relevant to the product or company.
 - Do not use markdown or add notes.
 - Today's date is {{date}}.
 </remember>


### PR DESCRIPTION
## Problem

The assistant now collects the memory in background, but this process is not perfect:
- The node is too verbose.
- The node answers on user questions, but it should not.
- The node doesn't respect hint verbs like "remember" to save the information. In addition, it should save any information prompted, but if it's not related to the company or product, it skips it.

## Changes

- Clarify prompt.
- Add more eval tests.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Evals and manual testing