### PR TITLE
fix: Hog function comparison

### DIFF
--- a/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
@@ -47,14 +47,9 @@ export const compareEvents = (pluginEvent: PluginEvent, hogEvent: PluginEvent): 
 export async function compareToHogTransformStep(
     hogTransformer: HogTransformerService | null,
     prePluginsEvent: PluginEvent,
-    postPluginsEvent: PluginEvent | null,
-    samplePercentage?: number
+    postPluginsEvent: PluginEvent | null
 ): Promise<void> {
     if (!hogTransformer) {
-        return
-    }
-
-    if (!samplePercentage || Math.random() > samplePercentage) {
         return
     }
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
@@ -17,6 +17,9 @@ export const counterHogTransformationDiff = new Counter({
     labelNames: ['outcome'], // either same or diff
 })
 
+// We don't care about plugin only properties
+const IGNORE_PROPERTIES = ['$plugins_failed', '$plugins_succeeded']
+
 export const compareEvents = (pluginEvent: PluginEvent, hogEvent: PluginEvent): Diff[] => {
     // Comparing objects is expensive so we will do this instead by iterating over the keys we care about
 
@@ -33,6 +36,10 @@ export const compareEvents = (pluginEvent: PluginEvent, hogEvent: PluginEvent): 
     const diffs: Diff[] = []
     // Compare each property individually
     pluginProperties.forEach((property) => {
+        if (IGNORE_PROPERTIES.includes(property)) {
+            return
+        }
+
         const pluginValue = pluginEvent.properties?.[property]
         const hogValue = hogEvent.properties?.[property]
 

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -239,7 +239,7 @@ export class EventPipelineRunner {
             const shouldCompareToHogFunctions =
                 this.hogTransformer &&
                 (!this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE ||
-                    Math.random() > this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE)
+                    Math.random() < this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE)
 
             if (!shouldCompareToHogFunctions) {
                 clonedSourceEvent = cloneObject(postCookielessEvent)

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -234,13 +234,18 @@ export class EventPipelineRunner {
 
         // Setup a cloned event so we can compare the post-plugins event to the pre-plugins event
         let clonedSourceEvent: PluginEvent | null = null
-        const shouldCompareToHogFunctions =
-            this.hogTransformer &&
-            (!this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE ||
-                Math.random() > this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE)
 
-        if (!shouldCompareToHogFunctions) {
-            clonedSourceEvent = cloneObject(postCookielessEvent)
+        try {
+            const shouldCompareToHogFunctions =
+                this.hogTransformer &&
+                (!this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE ||
+                    Math.random() > this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE)
+
+            if (!shouldCompareToHogFunctions) {
+                clonedSourceEvent = cloneObject(postCookielessEvent)
+            }
+        } catch (error) {
+            status.error('🔔', 'Error cloning event for hog transform comparison', { error })
         }
 
         const processedEvent = await this.runStep(pluginsProcessEventStep, [this, postCookielessEvent], event.team_id)

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -10,6 +10,7 @@ import { DependencyUnavailableError } from '../../../utils/db/error'
 import { timeoutGuard } from '../../../utils/db/utils'
 import { normalizeProcessPerson } from '../../../utils/event'
 import { status } from '../../../utils/status'
+import { cloneObject } from '../../../utils/utils'
 import { EventsProcessor } from '../process-event'
 import { captureIngestionWarning, generateEventDeadLetterQueueMessage } from '../utils'
 import { compareToHogTransformStep } from './compareToHogTransformStep'
@@ -32,7 +33,6 @@ import { prepareEventStep } from './prepareEventStep'
 import { processPersonsStep } from './processPersonsStep'
 import { produceExceptionSymbolificationEventStep } from './produceExceptionSymbolificationEventStep'
 import { transformEventStep } from './transformEventStep'
-
 export type EventPipelineResult = {
     // Promises that the batch handler should await on before committing offsets,
     // contains the Kafka producer ACKs and message promises, to avoid blocking after every message.
@@ -232,18 +232,26 @@ export class EventPipelineRunner {
             return this.registerLastStep('cookielessServerHashStep', [event], kafkaAcks)
         }
 
+        // Setup a cloned event so we can compare the post-plugins event to the pre-plugins event
+        let clonedSourceEvent: PluginEvent | null = null
+        const shouldCompareToHogFunctions =
+            this.hogTransformer &&
+            (!this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE ||
+                Math.random() > this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE)
+
+        if (!shouldCompareToHogFunctions) {
+            clonedSourceEvent = cloneObject(postCookielessEvent)
+        }
+
         const processedEvent = await this.runStep(pluginsProcessEventStep, [this, postCookielessEvent], event.team_id)
 
-        // NOTE: We don't use the step process here as we don't want it to interfere with other metrics
-        try {
-            await compareToHogTransformStep(
-                this.hogTransformer,
-                postCookielessEvent,
-                processedEvent,
-                this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE
-            )
-        } catch (error) {
-            status.error('🔔', 'Error comparing to hog transform', { error })
+        if (clonedSourceEvent) {
+            // NOTE: We don't use the step process here as we don't want it to interfere with other metrics
+            try {
+                await compareToHogTransformStep(this.hogTransformer, clonedSourceEvent, processedEvent)
+            } catch (error) {
+                status.error('🔔', 'Error comparing to hog transform', { error })
+            }
         }
 
         if (processedEvent == null) {

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -237,9 +237,7 @@ export class EventPipelineRunner {
 
         try {
             const shouldCompareToHogFunctions =
-                this.hogTransformer &&
-                (!this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE ||
-                    Math.random() < this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE)
+                this.hogTransformer && Math.random() < (this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE ?? 0)
 
             if (!shouldCompareToHogFunctions) {
                 clonedSourceEvent = cloneObject(postCookielessEvent)

--- a/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/runner.ts
@@ -239,7 +239,7 @@ export class EventPipelineRunner {
             const shouldCompareToHogFunctions =
                 this.hogTransformer && Math.random() < (this.hub.HOG_TRANSFORMATIONS_COMPARISON_PERCENTAGE ?? 0)
 
-            if (!shouldCompareToHogFunctions) {
+            if (shouldCompareToHogFunctions) {
                 clonedSourceEvent = cloneObject(postCookielessEvent)
             }
         } catch (error) {


### PR DESCRIPTION
## Problem

The plugins modify the properties in place making a comparison impossible.

## Changes

* Modify the comparer to first clone the object before running plugins
* Ignore the plugin specific properties

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
