### PR TITLE
fix(experiments): fix violin gradients

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/DeltaChart.tsx
@@ -477,7 +477,9 @@ export function DeltaChart({
                                                 <>
                                                     <defs>
                                                         <linearGradient
-                                                            id={`gradient-${metricIndex}-${variant.key}`}
+                                                            id={`gradient-${metricIndex}-${variant.key}-${
+                                                                isSecondary ? 'secondary' : 'primary'
+                                                            }`}
                                                             x1="0"
                                                             x2="1"
                                                             y1="0"
@@ -513,7 +515,9 @@ export function DeltaChart({
                                                     </defs>
                                                     <path
                                                         d={generateViolinPath(x1, x2, y, BAR_HEIGHT)}
-                                                        fill={`url(#gradient-${metricIndex}-${variant.key})`}
+                                                        fill={`url(#gradient-${metricIndex}-${variant.key}-${
+                                                            isSecondary ? 'secondary' : 'primary'
+                                                        })`}
                                                     />
                                                 </>
                                             )}


### PR DESCRIPTION
## Problem
In the secondary metrics view, the violin gradient color offset is off. This is because there's a conflict in the gradient ID.

## Changes
Added an extra parameter to the gradient ID to distinguish between primary and secondary metrics.

|Before|After|
|----|----|
|<img width="1180" alt="image" src="https://github.com/user-attachments/assets/21083b30-91e1-4265-8df2-bed259a58fd5" />|<img width="1181" alt="image" src="https://github.com/user-attachments/assets/54de813b-4b30-4a32-b947-56a4b45faa41" />|	

## How did you test this code?
👀 