### PR TITLE
fix: do not open a connection on every migration operation

### DIFF
--- a/posthog/clickhouse/client/migration_tools.py
+++ b/posthog/clickhouse/client/migration_tools.py
@@ -8,14 +8,14 @@ from posthog.settings.data_stores import CLICKHOUSE_MIGRATIONS_CLUSTER
 
 logger = logging.getLogger("migrations")
 
+cluster = get_cluster(cluster=CLICKHOUSE_MIGRATIONS_CLUSTER)
 
-def run_sql_with_exceptions(sql: str, settings=None, node_role: NodeRole = NodeRole.WORKER):
+
+def run_sql_with_exceptions(sql: str, node_role: NodeRole = NodeRole.WORKER):
     """
     migrations.RunSQL does not raise exceptions, so we need to wrap it in a function that does.
     node_role is set to WORKER by default to keep compatibility with the old migrations.
     """
-
-    cluster = get_cluster(client_settings=settings, cluster=CLICKHOUSE_MIGRATIONS_CLUSTER)
 
     def run_migration():
         if node_role == NodeRole.ALL:


### PR DESCRIPTION
## Problem

We are opening a new connection on every call to `run_sql_with_exceptions`, so we can hit the limit when we apply all the migrations.

## Changes

Call the `get_cluster` just once so it creates a single pool.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Running locally
