### PR TITLE
fix: use ping instead of nslookup

### DIFF
--- a/bin/check_hosts
+++ b/bin/check_hosts
@@ -12,7 +12,7 @@ EXPECT_HOSTS=(
 FAILED_COUNT=0
 
 for DOMAIN in "${EXPECT_HOSTS[@]}"; do
-  if ! timeout 5 nslookup "$DOMAIN" &>/dev/null; then
+  if ! ping -c 1 -W 5 "$DOMAIN" &>/dev/null; then
     echo "❌ Error: Domain '$DOMAIN' could not be resolved."
     FAILED_COUNT=$((FAILED_COUNT + 1))
   else

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -1,6 +1,6 @@
 procs:
     backend:
-        shell: 'bin/check_hosts && bin/check_kafka_clickhouse_up && ./bin/start-backend'
+        shell: 'bin/check_kafka_clickhouse_up && ./bin/start-backend'
 
     celery-worker:
         shell: 'bin/check_kafka_clickhouse_up && ./bin/start-celery worker'


### PR DESCRIPTION
## Problem

nslookup on mac happen to not work

## Changes

ping behaves quite consistently

## Does this work well for both Cloud and self-hosted?

Yes.

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
