### PR TITLE
feat: Add info icon to Web Vitals navbar

### DIFF
--- a/frontend/src/queries/nodes/WebVitals/WebVitals.tsx
+++ b/frontend/src/queries/nodes/WebVitals/WebVitals.tsx
@@ -7,7 +7,7 @@ import { AnyResponseType, WebVitalsQuery, WebVitalsQueryResponse } from '~/queri
 import { QueryContext } from '~/queries/types'
 
 import { dataNodeLogic } from '../DataNode/dataNodeLogic'
-import { getMetric, LONG_METRIC_NAME } from './definitions'
+import { getMetric } from './definitions'
 import { WebVitalsContent } from './WebVitalsContent'
 import { WebVitalsTab } from './WebVitalsTab'
 
@@ -58,28 +58,24 @@ export function WebVitals(props: {
             <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 cursor-pointer border-b divide-y sm:divide-y-2 xl:divide-y-0 divide-x-0 sm:divide-x xl:divide-x-2">
                 <WebVitalsTab
                     metric="INP"
-                    label={LONG_METRIC_NAME.INP}
                     value={INP}
                     isActive={webVitalsTab === 'INP'}
                     setTab={() => setWebVitalsTab('INP')}
                 />
                 <WebVitalsTab
                     metric="LCP"
-                    label={LONG_METRIC_NAME.LCP}
                     value={LCP}
                     isActive={webVitalsTab === 'LCP'}
                     setTab={() => setWebVitalsTab('LCP')}
                 />
                 <WebVitalsTab
                     metric="FCP"
-                    label={LONG_METRIC_NAME.FCP}
                     value={FCP}
                     isActive={webVitalsTab === 'FCP'}
                     setTab={() => setWebVitalsTab('FCP')}
                 />
                 <WebVitalsTab
                     metric="CLS"
-                    label={LONG_METRIC_NAME.CLS}
                     value={CLS}
                     isActive={webVitalsTab === 'CLS'}
                     setTab={() => setWebVitalsTab('CLS')}

--- a/frontend/src/queries/nodes/WebVitals/WebVitalsTab.tsx
+++ b/frontend/src/queries/nodes/WebVitals/WebVitalsTab.tsx
@@ -1,24 +1,25 @@
 import './WebVitalsTab.scss'
 
+import { IconInfo } from '@posthog/icons'
 import { LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 import clsx from 'clsx'
 
 import { WebVitalsMetric } from '~/queries/schema'
 
-import { getThresholdColor, getValueWithUnit } from './definitions'
+import { getThresholdColor, getValueWithUnit, LONG_METRIC_NAME, METRIC_DESCRIPTION } from './definitions'
 import { WebVitalsProgressBar } from './WebVitalsProgressBar'
 
 type WebVitalsTabProps = {
     value: number | undefined
-    label: string
     metric: WebVitalsMetric
     isActive: boolean
     setTab?: () => void
 }
 
-export function WebVitalsTab({ value, label, metric, isActive, setTab }: WebVitalsTabProps): JSX.Element {
-    const { value: parsedValue, unit } = getValueWithUnit(value, metric)
+export function WebVitalsTab({ value, metric, isActive, setTab }: WebVitalsTabProps): JSX.Element {
+    const label = LONG_METRIC_NAME[metric]
 
+    const { value: parsedValue, unit } = getValueWithUnit(value, metric)
     const thresholdColor = getThresholdColor(value, metric)
 
     return (
@@ -27,7 +28,12 @@ export function WebVitalsTab({ value, label, metric, isActive, setTab }: WebVita
             className="WebVitals__WebVitalsTab flex flex-1 flex-row sm:flex-col justify-around sm:justify-start items-center sm:items-start p-4"
             data-active={isActive ? 'true' : 'false'}
         >
-            <span className="text-sm hidden sm:block">{label}</span>
+            <div className="text-sm hidden sm:flex w-full flex-row justify-between">
+                <span>{label}</span>
+                <Tooltip title={METRIC_DESCRIPTION[metric]}>
+                    <IconInfo />
+                </Tooltip>
+            </div>
             <span className="text-sm block sm:hidden">
                 <Tooltip title={label}>{metric}</Tooltip>
             </span>


### PR DESCRIPTION
We're now explaining what each of the Web Vitals metrics stand for at the navbar level, people don't need to click on them to see the results

This was heard from 2 customers when asked for feedback

![image](https://github.com/user-attachments/assets/3f97cbe5-6e43-4974-a536-bad3cfedc32a)
