### PR TITLE
fix(assistant): compress trends aggregated values

### DIFF
--- a/ee/hogai/summarizer/format.py
+++ b/ee/hogai/summarizer/format.py
@@ -125,7 +125,7 @@ def _extract_series_label(series: dict) -> str:
 def _format_trends_aggregated_values(results: list[dict]) -> str:
     # Get dates and series labels
     result = results[0]
-    dates = result["action"].get("days") or []
+    dates = result.get("action", {}).get("days") or []
     if len(dates) == 0:
         range = "All time"
     else:

--- a/ee/hogai/summarizer/format.py
+++ b/ee/hogai/summarizer/format.py
@@ -122,10 +122,38 @@ def _extract_series_label(series: dict) -> str:
     return _replace_breakdown_labels(name)
 
 
-def _format_trends_results(results: list[dict]) -> str:
+def _format_trends_aggregated_values(results: list[dict]) -> str:
+    # Get dates and series labels
+    result = results[0]
+    dates = result["action"].get("days") or []
+    if len(dates) == 0:
+        range = "All time"
+    else:
+        range = f"{dates[0]} to {dates[-1]}"
+
+    series_labels = []
+    for series in results:
+        label = f"Aggregated value for {_extract_series_label(series)}"
+        series_labels.append(label)
+
+    # Build header row
+    matrix: list[list[str]] = []
+    header = ["Date range", *series_labels]
+    matrix.append(header)
+
+    row = [range]
+    for series in results:
+        row.append(_format_number(series["aggregated_value"]))
+    matrix.append(row)
+
+    return _format_matrix(matrix)
+
+
+def _format_trends_non_aggregated_values(results: list[dict]) -> str:
     # Get dates and series labels
     result = results[0]
     dates = result["days"]
+
     series_labels = []
     for series in results:
         label = _extract_series_label(series)
@@ -140,11 +168,21 @@ def _format_trends_results(results: list[dict]) -> str:
     # Build data rows
     for i, date in enumerate(dates):
         row = [_strip_datetime_seconds(date)]
-        for result in results:
-            row.append(_format_number(result["data"][i]))
+        for series in results:
+            row.append(_format_number(series["data"][i]))
         matrix.append(row)
 
     return _format_matrix(matrix)
+
+
+def _format_trends_results(results: list[dict]) -> str:
+    # Get dates and series labels
+    result = results[0]
+    aggregation_applied = result.get("aggregated_value") is not None
+    if aggregation_applied:
+        return _format_trends_aggregated_values(results)
+    else:
+        return _format_trends_non_aggregated_values(results)
 
 
 def compress_and_format_trends_results(results: list[dict]) -> str:

--- a/ee/hogai/summarizer/test/test_format.py
+++ b/ee/hogai/summarizer/test/test_format.py
@@ -373,3 +373,81 @@ class TestCompression(BaseTest):
             "2025-01-23 00:00|0|100%|0%\n"
             "2025-01-24 00:00|0|100%",
         )
+
+    def test_trends_aggregated_value(self):
+        results = [
+            {
+                "data": [],
+                "days": [],
+                "count": 0,
+                "aggregated_value": 993,
+                "label": "$pageview",
+                "action": {
+                    "days": ["2025-01-20", "2025-01-21", "2025-01-22"],
+                },
+            }
+        ]
+        self.assertEqual(
+            compress_and_format_trends_results(results),
+            "Date range|Aggregated value for $pageview\n2025-01-20 to 2025-01-22|993",
+        )
+
+    def test_trends_aggregated_values(self):
+        results = [
+            {
+                "data": [],
+                "days": [],
+                "count": 0,
+                "aggregated_value": 993,
+                "label": "$pageview",
+                "action": {
+                    "days": ["2025-01-20", "2025-01-21", "2025-01-22"],
+                },
+            },
+            {
+                "data": [],
+                "days": [],
+                "count": 0,
+                "aggregated_value": 1000,
+                "label": "$pageleave",
+                "action": {
+                    "days": ["2025-01-20", "2025-01-21", "2025-01-22"],
+                },
+            },
+        ]
+        self.assertEqual(
+            compress_and_format_trends_results(results),
+            "Date range|Aggregated value for $pageview|Aggregated value for $pageleave\n2025-01-20 to 2025-01-22|993|1000",
+        )
+
+    def test_trends_aggregated_values_with_comparison(self):
+        results = [
+            {
+                "data": [],
+                "days": [],
+                "count": 0,
+                "aggregated_value": 993,
+                "label": "$pageview",
+                "action": {
+                    "days": ["2025-01-17", "2025-01-18", "2025-01-19"],
+                },
+                "compare": True,
+                "compare_label": Compare.PREVIOUS,
+            },
+            {
+                "data": [],
+                "days": [],
+                "count": 0,
+                "aggregated_value": 1000,
+                "label": "$pageview",
+                "action": {
+                    "days": ["2025-01-20", "2025-01-21", "2025-01-22"],
+                },
+                "compare": True,
+                "compare_label": Compare.CURRENT,
+            },
+        ]
+        self.assertEqual(
+            compress_and_format_trends_results(results),
+            "Previous period:\nDate range|Aggregated value for $pageview\n2025-01-17 to 2025-01-19|993\n\nCurrent period:\nDate range|Aggregated value for $pageview\n2025-01-20 to 2025-01-22|1000",
+        )


### PR DESCRIPTION
## Problem

The summarizer doesn't compress trends insights with aggregated values.

## Changes

- Detect if a trends insight has an aggregated value.
- Compress series with the aggregated value.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Unit tests