### PR TITLE
fix: Fix migration names

### DIFF
--- a/plugin-server/src/cdp/legacy-plugins/_transformations/posthog-filter-out-plugin/template.ts
+++ b/plugin-server/src/cdp/legacy-plugins/_transformations/posthog-filter-out-plugin/template.ts
@@ -15,7 +15,7 @@ export const template: HogFunctionTemplate = {
             key: 'filters',
             templating: false,
             label: 'Filters to apply',
-            type: 'string',
+            type: 'json',
             description: 'A JSON file containing an array of filters to apply. See the README for more information.',
             required: false,
         },

--- a/plugin-server/src/cdp/legacy-plugins/index.ts
+++ b/plugin-server/src/cdp/legacy-plugins/index.ts
@@ -55,15 +55,15 @@ export const DESTINATION_PLUGINS_BY_ID = {
 export const DEPRECATED_TRANSFORMATION_PLUGINS_BY_ID = {
     [dropEventsOnPropertyPlugin.id]: dropEventsOnPropertyPlugin,
     [flattenPropertiesPlugin.id]: flattenPropertiesPlugin,
+    [phShotgunProcessEventApp.id]: phShotgunProcessEventApp,
     [pluginAdvancedGeoip.id]: pluginAdvancedGeoip,
+    [posthogNetdataEventProcessingPlugin.id]: posthogNetdataEventProcessingPlugin,
     [pluginStonlyCleanCampaignName.id]: pluginStonlyCleanCampaignName,
     [pluginStonlyUtmExtractor.id]: pluginStonlyUtmExtractor,
-    [posthogAppUnduplicator.id]: posthogAppUnduplicator,
     [pluginPosthogAnonymization.id]: pluginPosthogAnonymization,
+    [posthogAppUnduplicator.id]: posthogAppUnduplicator,
     [posthogPluginGeoip.id]: posthogPluginGeoip,
     [posthogRouteCensorPlugin.id]: posthogRouteCensorPlugin,
-    [posthogNetdataEventProcessingPlugin.id]: posthogNetdataEventProcessingPlugin,
-    [phShotgunProcessEventApp.id]: phShotgunProcessEventApp,
     [posthogSnowplowRefererParser.id]: posthogSnowplowRefererParser,
 }
 

--- a/plugin-server/src/cdp/templates/index.ts
+++ b/plugin-server/src/cdp/templates/index.ts
@@ -7,6 +7,7 @@ import { template as pluginAdvancedGeoipTemplate } from '../legacy-plugins/_tran
 import { template as posthogNetdataEventProcessingPluginTemplate } from '../legacy-plugins/_transformations/plugin-netdata-event-processing/template'
 import { template as pluginStonlyCleanCampaignNameTemplate } from '../legacy-plugins/_transformations/Plugin-Stonly-Clean-Campaign-Name/template'
 import { template as pluginStonlyUtmExtractorTemplate } from '../legacy-plugins/_transformations/plugin-stonly-UTM-Extractor/template'
+import { template as pluginPosthogAnonymizationTemplate } from '../legacy-plugins/_transformations/posthog-anonymization/template'
 import { template as posthogAppUnduplicatorTemplate } from '../legacy-plugins/_transformations/posthog-app-unduplicator/template'
 import { template as posthogAppUrlParametersToEventPropertiesTemplate } from '../legacy-plugins/_transformations/posthog-app-url-parameters-to-event-properties/template'
 import { template as posthogFilterOutTemplate } from '../legacy-plugins/_transformations/posthog-filter-out-plugin/template'
@@ -53,6 +54,7 @@ export const HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS_DEPRECATED: HogFunctionTempl
     posthogPluginGeoipTemplate,
     posthogSnowplowRefererParserTemplate,
     posthogRouteCensorPluginTemplate,
+    pluginPosthogAnonymizationTemplate,
 ]
 
 export const HOG_FUNCTION_TEMPLATES: HogFunctionTemplate[] = [

--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -68,6 +68,12 @@ def migrate_legacy_plugins(dry_run=True, team_ids=None, test_mode=True, kind=str
         plugin_id = url.replace("inline://", "").replace("https://github.com/PostHog/", "")
         plugin_name = plugin_config["plugin__name"]
 
+        # Inline plugins are named slightly differently so we fix it here
+        if plugin_id == "semver-flattener":
+            plugin_id = "semver-flattener-plugin"
+        if plugin_id == "user-agent":
+            plugin_id = "user-agent-plugin"
+
         if test_mode:
             plugin_name = f"[CDP-TEST-HIDDEN] {plugin_name}"
 


### PR DESCRIPTION
## Problem

Found an issue with inline plugins being named slightly differently to the remote version


## Changes

* Quick hack fix for them

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
