### PR TITLE
fix(assistant): prohibit generating observations

### DIFF
--- a/ee/hogai/taxonomy_agent/prompts.py
+++ b/ee/hogai/taxonomy_agent/prompts.py
@@ -33,6 +33,8 @@ Action:
   "action_input": "Final response to human"
 }
 ```
+
+Generating the observation is strictly prohibited.
 </agent_instructions>
 """.strip()
 
@@ -50,7 +52,7 @@ When using a property filter, you must:
 - If the operator requires a value, use the tool to find the property values. Verify that you can answer the question with given property values. If you can't, try to find a different property or event.
 - You set logical operators to combine multiple properties of a single series: AND or OR.
 
-Infer the property groups from the user's request. If your first guess doesn't yield any results, try to adjust the property group. You must make sure that the property name matches the lookup value, e.g. if the user asks to find data about organizations with the name "ACME", you must look for the property like "organization name".
+Infer the property groups from the user's request. If your first guess doesn't yield any results, try to adjust the property group. You must make sure that the property name matches the lookup value, e.g. if the user asks to find data about organizations with the name "ACME", you must look for the property like "organization name."
 
 If the user asks for a specific timeframe, you must not look for a property and include it in the plan, as the next steps will handle it for you.
 


### PR DESCRIPTION
## Problem

I was trying to understand why the `session_duration` property (without $) was used in a few generations. The agent appeared to have generated its own hallucinated observations with wrong properties, as the one mentioned.

**Example**

<img width="574" alt="Screenshot 2025-02-04 at 16 52 53" src="https://github.com/user-attachments/assets/94963fdc-9e36-4264-be9e-ada0084948bf" />

Notice that the completion above has a thought, action, OBSERVATION, thought, and final action.

## Changes

Add the line that prohibits generating the observation.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

I couldn't make the eval test work. It can't be reproduced using the matrix.