### PR TITLE
chore: split coordinator node setup for local development

### DIFF
--- a/docker-compose.dev-coordinator.yml
+++ b/docker-compose.dev-coordinator.yml
@@ -1,5 +1,5 @@
 #
-# docker-compose file used ONLY for local development.
+# docker-compose file used ONLY for local development using a coordinator topology in ClickHouse.
 # For more info, see:
 # https://posthog.com/handbook/engineering/developing-locally
 #
@@ -69,7 +69,7 @@ services:
             - ./posthog/idl:/idl
             - ./docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
             - ./docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
-            - ./docker/clickhouse/config.d/default.xml:/etc/clickhouse-server/config.d/default.xml
+            - ./docker/clickhouse/config.d/data_node.xml:/etc/clickhouse-server/config.d/data_node.xml
             - ./docker/clickhouse/users-dev.xml:/etc/clickhouse-server/users.xml
             - ./docker/clickhouse/user_defined_function.xml:/etc/clickhouse-server/user_defined_function.xml
             - ./posthog/user_scripts:/var/lib/clickhouse/user_scripts
@@ -78,6 +78,23 @@ services:
         depends_on:
             - kafka
             - zookeeper
+
+    clickhouse-coordinator:
+        hostname: clickhouse-coordinator
+        <<: *clickhouse
+        volumes:
+            # this new entrypoint file is to fix a bug detailed here https://github.com/ClickHouse/ClickHouse/pull/59991
+            # revert this when we upgrade clickhouse
+            - ./docker/clickhouse/entrypoint.sh:/entrypoint.sh
+            - ./posthog/idl:/idl
+            - ./docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+            - ./docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
+            - ./docker/clickhouse/config.d/coordinator.xml:/etc/clickhouse-server/config.d/coordinator.xml
+            - ./docker/clickhouse/users-dev.xml:/etc/clickhouse-server/users.xml
+            - ./docker/clickhouse/user_defined_function.xml:/etc/clickhouse-server/user_defined_function.xml
+            - ./posthog/user_scripts:/var/lib/clickhouse/user_scripts
+        ports:
+            - '9001:9001'
 
     zookeeper:
         extends:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,7 +51,7 @@ services:
         ports:
             - '5555:5555'
 
-    clickhouse: &clickhouse
+    clickhouse:
         extends:
             file: docker-compose.base.yml
             service: clickhouse


### PR DESCRIPTION
## Problem

The new coordinator setup can cause some trouble when trying to run migrations or end-to-end tests locally. Also, it slightly differs from the hobby deployment, so we can introduce issues without noticing them because it's not a 1:1 setup.

## Changes

Leave the development docker stack as it was before introducing the coordinator node, and create a new stack to test coordinator migrations.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Running locally migrations on both setups.
