### PR TITLE
fix(insight-variables): dashboard too many calls

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Variables/variablesLogic.ts
@@ -146,7 +146,10 @@ export const variablesLogic = kea<variablesLogicType>([
     }),
     listeners(({ props, values, actions }) => ({
         addVariable: () => {
-            actions.updateSourceQuery()
+            // dashboard items handle source query separately
+            if (!props.readOnly) {
+                actions.updateSourceQuery()
+            }
         },
         removeVariable: () => {
             actions.updateSourceQuery()


### PR DESCRIPTION
## Problem

- variables logic calls load data which overrides dashboard item control of loading the insight

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- don't update source query from variables logic when in read only mode

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
