### PR TITLE
fix: dark mode in replay onboarding

### DIFF
--- a/frontend/src/scenes/onboarding/OnboardingSessionReplayConfiguration.tsx
+++ b/frontend/src/scenes/onboarding/OnboardingSessionReplayConfiguration.tsx
@@ -28,7 +28,7 @@ export function OnboardingSessionReplayConfiguration({ stepKey }: { stepKey: Onb
                 <div className="hidden md:block flex-shrink-0">
                     <FilmCameraHog className="w-36 h-auto" />
                 </div>
-                <div className="flex-1 border border-gray-200 rounded-lg bg-white p-4">
+                <div className="flex-1 border border-gray-200 rounded-lg bg-bg-light dark:bg-bg-depth p-4">
                     <h4 className="text-lg font-semibold mb-2">Why enable Session Replay?</h4>
                     <ul className="space-y-2 text-muted">
                         <li>


### PR DESCRIPTION
## Problem

Dark mode was impossible to see for this step

## Changes

<img width="842" alt="Screenshot 2025-02-04 at 22 12 47" src="https://github.com/user-attachments/assets/f8a7b0ba-5bc3-4725-9e9d-f7287b56c24a" />


## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Looked at it, dark and light.
