### PR TITLE
fix(experiments): Fix styling for holdout row in dark mode

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/DistributionTable.tsx
@@ -14,6 +14,7 @@ import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authoriz
 import { IconOpenInApp } from 'lib/lemon-ui/icons'
 import { featureFlagLogic, FeatureFlagLogicProps } from 'scenes/feature-flags/featureFlagLogic'
 
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { Experiment, MultivariateFlagVariant } from '~/types'
 
 import { experimentLogic } from '../experimentLogic'
@@ -134,6 +135,7 @@ export function DistributionTable(): JSX.Element {
     const { openDistributionModal } = useActions(experimentLogic)
     const { experimentId, experiment, metricResults } = useValues(experimentLogic)
     const { reportExperimentReleaseConditionsViewed } = useActions(experimentLogic)
+    const { isDarkModeOn } = useValues(themeLogic)
 
     const result = metricResults?.[0]
 
@@ -270,7 +272,13 @@ export function DistributionTable(): JSX.Element {
                 loading={false}
                 columns={columns}
                 dataSource={tableData}
-                rowClassName={(item) => (item.key === `holdout-${experiment.holdout?.id}` ? 'bg-mid' : '')}
+                rowClassName={(item) =>
+                    item.key === `holdout-${experiment.holdout?.id}`
+                        ? isDarkModeOn
+                            ? 'bg-fill-primary'
+                            : 'bg-mid'
+                        : ''
+                }
             />
         </div>
     )


### PR DESCRIPTION
## Changes

Fixes the styling for the holdout row in dark mode.

**Before**

| Light | Dark |
|--------|--------|
| ![CleanShot 2025-02-04 at 14 09 24@2x](https://github.com/user-attachments/assets/74094273-8fec-4e9c-9364-0108d2611e48) | ![CleanShot 2025-02-04 at 14 09 51@2x](https://github.com/user-attachments/assets/1d0f3029-ef72-42cf-9832-fefd99222ddf) | 

**After**

| Light | Dark |
|--------|--------|
| ![CleanShot 2025-02-04 at 14 08 57@2x](https://github.com/user-attachments/assets/9205b5a3-d5aa-46be-a596-5dcdb69abd91) | ![CleanShot 2025-02-04 at 14 08 29@2x](https://github.com/user-attachments/assets/34a3134a-9899-4586-8f4d-a77102301443) | 

## How did you test this code?

Visual review.