### PR TITLE
feat(experiments): Add "Stats Engine" to the experiment info

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -31,8 +31,8 @@ export function Info(): JSX.Element {
 
     return (
         <div>
-            <div className="flex">
-                <div className="w-1/2 inline-flex space-x-8">
+            <div className="flex flex-wrap justify-between gap-4">
+                <div className="inline-flex space-x-8">
                     <div className="block" data-attr="experiment-status">
                         <div className="text-xs font-semibold uppercase tracking-wide">Status</div>
                         <StatusTag experiment={experiment} />
@@ -101,8 +101,8 @@ export function Info(): JSX.Element {
                     )}
                 </div>
 
-                <div className="w-1/2 flex flex-col justify-end">
-                    <div className="ml-auto inline-flex space-x-8">
+                <div className="flex flex-col">
+                    <div className="inline-flex space-x-8">
                         {experiment.start_date && (
                             <div className="block">
                                 <div className="text-xs font-semibold uppercase tracking-wide">Last refreshed</div>

--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -71,6 +71,12 @@ export function Info(): JSX.Element {
                             </Link>
                         </div>
                     )}
+                    <div className="block">
+                        <div className="text-xs font-semibold uppercase tracking-wide">
+                            <span>Stats Engine</span>
+                        </div>
+                        <div className="flex gap-1">Bayesian</div>
+                    </div>
                     {featureFlags[FEATURE_FLAGS.EXPERIMENT_STATS_V2] && (
                         <div className="block">
                             <div className="text-xs font-semibold uppercase tracking-wide">


### PR DESCRIPTION
## Changes

Adds a new "Stats Engine" element to the experiment info:

![CleanShot 2025-02-04 at 15 33 55@2x](https://github.com/user-attachments/assets/5c8a60b0-74b8-416e-af18-2c1a95baf2e6)

Also prevents collision for info elements:

**Before**

https://github.com/user-attachments/assets/69f32679-4def-401f-ac39-d0414ff363be

**After**

https://github.com/user-attachments/assets/81c720d2-a768-4a87-960d-5e889cf36f7b

## How did you test this code?

Manual review.