### PR TITLE
fix(tab-rename): Fix tab rename

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/QueryTabs.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryTabs.tsx
@@ -58,8 +58,8 @@ function QueryTabComponent({ model, active, onClear, onClick, onRename }: QueryT
         <div
             onClick={() => onClick?.(model)}
             className={clsx(
-                'space-y-px rounded-t p-1 flex flex-row items-center gap-1 hover:bg-[var(--bg-light)] cursor-pointer',
-                active ? 'bg-[var(--bg-light)] border-t border-l border-r' : 'bg-bg-3000',
+                'space-y-px rounded-t p-1 flex border-b-2 border-transparent flex-row items-center gap-1 hover:bg-[var(--bg-light)] cursor-pointer',
+                active ? 'bg-[var(--bg-light)] border-b-2 border-brand-yellow' : 'bg-bg-3000',
                 onClear ? 'pl-3 pr-2' : 'px-3'
             )}
         >

--- a/frontend/src/scenes/data-warehouse/editor/QueryTabs.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryTabs.tsx
@@ -47,7 +47,7 @@ function QueryTabComponent({ model, active, onClear, onClick, onRename }: QueryT
 
     useEffect(() => {
         setTabName(model.view?.name || model.name || NEW_QUERY)
-    }, [model])
+    }, [model.view?.name])
 
     const handleRename = (): void => {
         setIsEditing(false)


### PR DESCRIPTION
## Problem
Tab renaming is not working correctly for the SQL editor.

This also updates the tab style to not "grow" on selection.
<img width="1146" alt="image" src="https://github.com/user-attachments/assets/2291722b-9c0e-4751-9601-0cc89ad9a594" />

<img width="1197" alt="image" src="https://github.com/user-attachments/assets/02e3c991-fd0e-443a-9251-2d596628a8c7" />


## Changes
- [x] Restrict hook

## Does this work well for both Cloud and self-hosted?
Yes

## How did you test this code?
It works now.
