### PR TITLE
fix(funnels): show correct tooltip according to step reference

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarVertical/StepLegend.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarVertical/StepLegend.tsx
@@ -11,7 +11,7 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { getActionFilterFromFunnelStep } from 'scenes/insights/views/Funnels/funnelStepTableUtils'
 import { userLogic } from 'scenes/userLogic'
 
-import { AvailableFeature, ChartParams, FunnelStepWithConversionMetrics } from '~/types'
+import { AvailableFeature, ChartParams, FunnelStepReference, FunnelStepWithConversionMetrics } from '~/types'
 
 import { funnelPersonsModalLogic } from '../funnelPersonsModalLogic'
 import { FunnelStepMore } from '../FunnelStepMore'
@@ -25,7 +25,7 @@ type StepLegendProps = {
 
 export function StepLegend({ step, stepIndex, showTime, showPersonsModal }: StepLegendProps): JSX.Element {
     const { insightProps } = useValues(insightLogic)
-    const { aggregationTargetLabel } = useValues(funnelDataLogic(insightProps))
+    const { aggregationTargetLabel, funnelsFilter } = useValues(funnelDataLogic(insightProps))
     const { canOpenPersonModal, isInExperimentContext } = useValues(funnelPersonsModalLogic(insightProps))
     const { openPersonsModalForStep } = useActions(funnelPersonsModalLogic(insightProps))
     const { hasAvailableFeature } = useValues(userLogic)
@@ -74,7 +74,11 @@ export function StepLegend({ step, stepIndex, showTime, showPersonsModal }: Step
                         <>
                             {capitalizeFirstLetter(aggregationTargetLabel.plural)} who completed this step,
                             <br />
-                            with conversion rate relative to the first step
+                            with conversion rate relative to the{' '}
+                            {funnelsFilter?.funnelStepReference === FunnelStepReference.previous
+                                ? 'previous'
+                                : 'first'}{' '}
+                            step
                         </>
                     }
                     placement="right"


### PR DESCRIPTION
## Problem
https://posthoghelp.zendesk.com/agent/tickets/23831 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/25889)

## Changes
Shows tooltip according to funnel step reference
<img width="544" alt="image" src="https://github.com/user-attachments/assets/8339a4e7-2e7f-4b06-a904-3c8b2a6771af" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
👀
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
