### PR TITLE
perf(batch-exports): Use `distributed_events_recent` if backfill is within last 6 days

### DIFF
--- a/posthog/batch_exports/service.py
+++ b/posthog/batch_exports/service.py
@@ -938,12 +938,12 @@ class BatchExportInsertInputs:
     exclude_events: list[str] | None = None
     include_events: list[str] | None = None
     run_id: str | None = None
-    # TODO: Remove after updating existing batch exports to use backfill_details
-    is_backfill: bool = False
     backfill_details: BackfillDetails | None = None
     batch_export_model: BatchExportModel | None = None
     # TODO: Remove after updating existing batch exports
     batch_export_schema: BatchExportSchema | None = None
+    # TODO: Remove after updating existing batch exports to use backfill_details
+    is_backfill: bool = False
 
     def get_is_backfill(self) -> bool:
         """Needed for backwards compatibility with existing batch exports.

--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -65,10 +65,3 @@ CLICKHOUSE_MAX_BLOCK_SIZE_OVERRIDES: dict[int, int] = dict(
     [map(int, o.split(":")) for o in os.getenv("CLICKHOUSE_MAX_BLOCK_SIZE_OVERRIDES", "").split(",") if o]  # type: ignore
 )
 CLICKHOUSE_OFFLINE_5MIN_CLUSTER_HOST: str | None = os.getenv("CLICKHOUSE_OFFLINE_5MIN_CLUSTER_HOST", None)
-
-# What percentage of teams should use distributed_events_recent for batch exports (should be a value from 0 to 1 and we
-# only support increments of 0.1)
-# TODO - remove this once migration is complete
-BATCH_EXPORT_DISTRIBUTED_EVENTS_RECENT_ROLLOUT: float = get_from_env(
-    "BATCH_EXPORT_DISTRIBUTED_EVENTS_RECENT_ROLLOUT", 0.0, type_cast=float
-)

--- a/posthog/temporal/batch_exports/backfill_batch_export.py
+++ b/posthog/temporal/batch_exports/backfill_batch_export.py
@@ -15,14 +15,18 @@ from asgiref.sync import sync_to_async
 from django.conf import settings
 
 from posthog.batch_exports.models import BatchExportBackfill
-from posthog.batch_exports.service import BackfillBatchExportInputs, unpause_batch_export
-from posthog.temporal.common.base import PostHogWorkflow
+from posthog.batch_exports.service import (
+    BackfillBatchExportInputs,
+    BackfillDetails,
+    unpause_batch_export,
+)
 from posthog.temporal.batch_exports.batch_exports import (
     CreateBatchExportBackfillInputs,
     UpdateBatchExportBackfillStatusInputs,
     create_batch_export_backfill_model,
     update_batch_export_backfill_model_status,
 )
+from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.client import connect
 from posthog.temporal.common.heartbeat import Heartbeater
 
@@ -83,6 +87,7 @@ class BackfillScheduleInputs:
     end_at: str | None
     frequency_seconds: float
     start_delay: float = 5.0
+    backfill_id: str | None = None
 
 
 def get_utcnow():
@@ -236,8 +241,12 @@ async def backfill_schedule(inputs: BackfillScheduleInputs) -> None:
             ]
 
             args = await client.data_converter.decode(schedule_action.args)
-            args[0]["is_backfill"] = True
-            args[0]["is_earliest_backfill"] = start_at is None
+            args[0]["backfill_details"] = BackfillDetails(
+                backfill_id=inputs.backfill_id,
+                is_earliest_backfill=start_at is None,
+                start_at=inputs.start_at,
+                end_at=inputs.end_at,
+            )
 
             await asyncio.sleep(inputs.start_delay)
 
@@ -388,6 +397,7 @@ class BackfillBatchExportWorkflow(PostHogWorkflow):
             end_at=inputs.end_at,
             frequency_seconds=frequency_seconds,
             start_delay=inputs.start_delay,
+            backfill_id=backfill_id,
         )
         try:
             await temporalio.workflow.execute_activity(

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -316,7 +316,7 @@ async def iter_records_from_model_view(
             query_template = SELECT_FROM_EVENTS_VIEW_RECENT
         # for other batch exports that should use `events_recent` we use the `distributed_events_recent` table
         # which is a distributed table that sits in front of the `events_recent` table
-        elif use_distributed_events_recent_table(is_backfill=is_backfill, team_id=team_id):
+        elif use_distributed_events_recent_table(is_backfill=is_backfill, backfill_details=backfill_details):
             query_template = SELECT_FROM_DISTRIBUTED_EVENTS_RECENT
         elif str(team_id) in settings.UNCONSTRAINED_TIMESTAMP_TEAM_IDS:
             query_template = SELECT_FROM_EVENTS_VIEW_UNBOUNDED
@@ -510,7 +510,7 @@ def iter_records(
         query = SELECT_FROM_EVENTS_VIEW_RECENT
     # for other batch exports that should use `events_recent` we use the `distributed_events_recent` table
     # which is a distributed table that sits in front of the `events_recent` table
-    elif use_distributed_events_recent_table(is_backfill=is_backfill, team_id=team_id):
+    elif use_distributed_events_recent_table(is_backfill=is_backfill, backfill_details=backfill_details):
         query = SELECT_FROM_DISTRIBUTED_EVENTS_RECENT
     elif str(team_id) in settings.UNCONSTRAINED_TIMESTAMP_TEAM_IDS:
         query = SELECT_FROM_EVENTS_VIEW_UNBOUNDED

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -316,7 +316,9 @@ async def iter_records_from_model_view(
             query_template = SELECT_FROM_EVENTS_VIEW_RECENT
         # for other batch exports that should use `events_recent` we use the `distributed_events_recent` table
         # which is a distributed table that sits in front of the `events_recent` table
-        elif use_distributed_events_recent_table(is_backfill=is_backfill, backfill_details=backfill_details):
+        elif use_distributed_events_recent_table(
+            is_backfill=is_backfill, backfill_details=backfill_details, data_interval_start=start_at
+        ):
             query_template = SELECT_FROM_DISTRIBUTED_EVENTS_RECENT
         elif str(team_id) in settings.UNCONSTRAINED_TIMESTAMP_TEAM_IDS:
             query_template = SELECT_FROM_EVENTS_VIEW_UNBOUNDED
@@ -510,7 +512,9 @@ def iter_records(
         query = SELECT_FROM_EVENTS_VIEW_RECENT
     # for other batch exports that should use `events_recent` we use the `distributed_events_recent` table
     # which is a distributed table that sits in front of the `events_recent` table
-    elif use_distributed_events_recent_table(is_backfill=is_backfill, backfill_details=backfill_details):
+    elif use_distributed_events_recent_table(
+        is_backfill=is_backfill, backfill_details=backfill_details, data_interval_start=start_at
+    ):
         query = SELECT_FROM_DISTRIBUTED_EVENTS_RECENT
     elif str(team_id) in settings.UNCONSTRAINED_TIMESTAMP_TEAM_IDS:
         query = SELECT_FROM_EVENTS_VIEW_UNBOUNDED

--- a/posthog/temporal/batch_exports/batch_exports.py
+++ b/posthog/temporal/batch_exports/batch_exports.py
@@ -180,11 +180,11 @@ async def iter_model_records(
     interval_start: str | None,
     interval_end: str,
     destination_default_fields: list[BatchExportField] | None = None,
+    backfill_details: BackfillDetails | None = None,
     # TODO - remove this once all batch exports are using the latest schema
     use_latest_schema: bool = False,
     # TODO: this can be removed once all backfill inputs are migrated
     is_backfill: bool = False,
-    backfill_details: BackfillDetails | None = None,
     **parameters,
 ) -> AsyncRecordsGenerator:
     # TODO: this can be simplified once all backfill inputs are migrated

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -16,7 +16,6 @@ from temporalio.common import RetryPolicy
 
 from posthog.batch_exports.models import BatchExportRun
 from posthog.batch_exports.service import (
-    BackfillDetails,
     BatchExportField,
     BatchExportInsertInputs,
     BatchExportModel,
@@ -660,6 +659,7 @@ async def insert_into_bigquery_activity(inputs: BigQueryInsertInputs) -> Records
             queue=queue,
             model_name=model_name,
             is_backfill=inputs.get_is_backfill(),
+            backfill_details=inputs.backfill_details,
             team_id=inputs.team_id,
             full_range=full_range,
             done_ranges=done_ranges,
@@ -845,12 +845,8 @@ class BigQueryBatchExportWorkflow(PostHogWorkflow):
             include_events=inputs.include_events,
             use_json_type=inputs.use_json_type,
             run_id=run_id,
-            backfill_details=BackfillDetails(
-                backfill_id=inputs.backfill_details.backfill_id if inputs.backfill_details else None,
-                is_earliest_backfill=is_earliest_backfill,
-                start_at=inputs.backfill_details.start_at if inputs.backfill_details else None,
-                end_at=inputs.backfill_details.end_at if inputs.backfill_details else None,
-            ),
+            backfill_details=inputs.backfill_details,
+            is_backfill=is_backfill,
             batch_export_model=inputs.batch_export_model,
             # TODO: Remove after updating existing batch exports.
             batch_export_schema=inputs.batch_export_schema,

--- a/posthog/temporal/batch_exports/bigquery_batch_export.py
+++ b/posthog/temporal/batch_exports/bigquery_batch_export.py
@@ -17,6 +17,7 @@ from temporalio.common import RetryPolicy
 from posthog.batch_exports.models import BatchExportRun
 from posthog.batch_exports.service import (
     BatchExportField,
+    BatchExportInsertInputs,
     BatchExportModel,
     BatchExportSchema,
     BigQueryBatchExportInputs,
@@ -137,11 +138,10 @@ class BigQueryHeartbeatDetails(BatchExportRangeHeartbeatDetails):
     pass
 
 
-@dataclasses.dataclass
-class BigQueryInsertInputs:
+@dataclasses.dataclass(kw_only=True)
+class BigQueryInsertInputs(BatchExportInsertInputs):
     """Inputs for BigQuery."""
 
-    team_id: int
     project_id: str
     dataset_id: str
     table_id: str
@@ -149,16 +149,7 @@ class BigQueryInsertInputs:
     private_key_id: str
     token_uri: str
     client_email: str
-    data_interval_start: str | None
-    data_interval_end: str
-    exclude_events: list[str] | None = None
-    include_events: list[str] | None = None
     use_json_type: bool = False
-    run_id: str | None = None
-    is_backfill: bool = False
-    batch_export_model: BatchExportModel | None = None
-    # TODO: Remove after updating existing batch exports
-    batch_export_schema: BatchExportSchema | None = None
 
 
 class BigQueryQuotaExceededError(Exception):

--- a/posthog/temporal/batch_exports/http_batch_export.py
+++ b/posthog/temporal/batch_exports/http_batch_export.py
@@ -10,7 +10,6 @@ from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
 from posthog.batch_exports.service import (
-    BackfillDetails,
     BatchExportField,
     BatchExportInsertInputs,
     HttpBatchExportInputs,
@@ -356,12 +355,8 @@ class HttpBatchExportWorkflow(PostHogWorkflow):
             include_events=inputs.include_events,
             batch_export_schema=inputs.batch_export_schema,
             run_id=run_id,
-            backfill_details=BackfillDetails(
-                backfill_id=inputs.backfill_details.backfill_id if inputs.backfill_details else None,
-                is_earliest_backfill=is_earliest_backfill,
-                start_at=inputs.backfill_details.start_at if inputs.backfill_details else None,
-                end_at=inputs.backfill_details.end_at if inputs.backfill_details else None,
-            ),
+            backfill_details=inputs.backfill_details,
+            is_backfill=is_backfill,
             batch_export_model=inputs.batch_export_model,
         )
 

--- a/posthog/temporal/batch_exports/http_batch_export.py
+++ b/posthog/temporal/batch_exports/http_batch_export.py
@@ -11,8 +11,7 @@ from temporalio.common import RetryPolicy
 
 from posthog.batch_exports.service import (
     BatchExportField,
-    BatchExportModel,
-    BatchExportSchema,
+    BatchExportInsertInputs,
     HttpBatchExportInputs,
 )
 from posthog.models import BatchExportRun
@@ -94,21 +93,12 @@ class HeartbeatDetails:
         return HeartbeatDetails(last_uploaded_timestamp)
 
 
-@dataclasses.dataclass
-class HttpInsertInputs:
+@dataclasses.dataclass(kw_only=True)
+class HttpInsertInputs(BatchExportInsertInputs):
     """Inputs for HTTP insert activity."""
 
-    team_id: int
     url: str
     token: str
-    data_interval_start: str | None
-    data_interval_end: str
-    exclude_events: list[str] | None = None
-    include_events: list[str] | None = None
-    run_id: str | None = None
-    is_backfill: bool = False
-    batch_export_model: BatchExportModel | None = None
-    batch_export_schema: BatchExportSchema | None = None
 
 
 async def maybe_resume_from_heartbeat(inputs: HttpInsertInputs) -> str | None:

--- a/posthog/temporal/batch_exports/noop.py
+++ b/posthog/temporal/batch_exports/noop.py
@@ -6,14 +6,14 @@ from typing import Any
 
 from temporalio import activity, workflow
 
-from posthog.batch_exports.service import NoOpInputs
+from posthog.batch_exports.service import BackfillDetails, NoOpInputs
 from posthog.temporal.common.base import PostHogWorkflow
 
 
 @dataclass
 class NoopActivityArgs:
     arg: str
-    is_backfill: bool = False
+    backfill_details: BackfillDetails | None = None
 
 
 @activity.defn
@@ -40,7 +40,7 @@ class NoOpWorkflow(PostHogWorkflow):
         workflow.logger.info(f"Running workflow with parameter {inputs.arg}")
         result = await workflow.execute_activity(
             noop_activity,
-            NoopActivityArgs(inputs.arg, inputs.is_backfill),
+            NoopActivityArgs(inputs.arg, inputs.backfill_details),
             start_to_close_timeout=timedelta(seconds=60),
             schedule_to_close_timeout=timedelta(minutes=5),
         )

--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -16,7 +16,6 @@ from temporalio.common import RetryPolicy
 
 from posthog.batch_exports.models import BatchExportRun
 from posthog.batch_exports.service import (
-    BackfillDetails,
     BatchExportField,
     BatchExportInsertInputs,
     BatchExportModel,
@@ -608,6 +607,7 @@ async def insert_into_postgres_activity(inputs: PostgresInsertInputs) -> Records
             queue=queue,
             model_name=model_name,
             is_backfill=inputs.get_is_backfill(),
+            backfill_details=inputs.backfill_details,
             team_id=inputs.team_id,
             full_range=full_range,
             done_ranges=done_ranges,
@@ -811,12 +811,8 @@ class PostgresBatchExportWorkflow(PostHogWorkflow):
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
             run_id=run_id,
-            backfill_details=BackfillDetails(
-                backfill_id=inputs.backfill_details.backfill_id if inputs.backfill_details else None,
-                is_earliest_backfill=is_earliest_backfill,
-                start_at=inputs.backfill_details.start_at if inputs.backfill_details else None,
-                end_at=inputs.backfill_details.end_at if inputs.backfill_details else None,
-            ),
+            backfill_details=inputs.backfill_details,
+            is_backfill=is_backfill,
             batch_export_model=inputs.batch_export_model,
             batch_export_schema=inputs.batch_export_schema,
         )

--- a/posthog/temporal/batch_exports/postgres_batch_export.py
+++ b/posthog/temporal/batch_exports/postgres_batch_export.py
@@ -17,6 +17,7 @@ from temporalio.common import RetryPolicy
 from posthog.batch_exports.models import BatchExportRun
 from posthog.batch_exports.service import (
     BatchExportField,
+    BatchExportInsertInputs,
     BatchExportModel,
     BatchExportSchema,
     PostgresBatchExportInputs,
@@ -68,27 +69,18 @@ class MissingPrimaryKeyError(Exception):
         super().__init__(f"An operation could not be completed as '{table}' is missing a primary key on {primary_key}")
 
 
-@dataclasses.dataclass
-class PostgresInsertInputs:
-    """Inputs for Postgres insert activity."""
+@dataclasses.dataclass(kw_only=True)
+class PostgresInsertInputs(BatchExportInsertInputs):
+    """Inputs for Postgres."""
 
-    team_id: int
     user: str
     password: str
     host: str
-    database: str
-    table_name: str
-    data_interval_start: str | None
-    data_interval_end: str
-    has_self_signed_cert: bool = False
-    schema: str = "public"
     port: int = 5432
-    exclude_events: list[str] | None = None
-    include_events: list[str] | None = None
-    run_id: str | None = None
-    is_backfill: bool = False
-    batch_export_model: BatchExportModel | None = None
-    batch_export_schema: BatchExportSchema | None = None
+    database: str
+    schema: str = "public"
+    table_name: str
+    has_self_signed_cert: bool = False
 
 
 class PostgreSQLClient:

--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -313,7 +313,7 @@ class RedshiftConsumer(Consumer):
         self.heartbeat_details.track_done_range(last_date_range, self.data_interval_start)
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(kw_only=True)
 class RedshiftInsertInputs(PostgresInsertInputs):
     """Inputs for Redshift insert activity.
 

--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -14,7 +14,6 @@ from temporalio.common import RetryPolicy
 
 from posthog.batch_exports.models import BatchExportRun
 from posthog.batch_exports.service import (
-    BackfillDetails,
     BatchExportField,
     BatchExportModel,
     BatchExportSchema,
@@ -398,6 +397,7 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs) -> Records
             queue=queue,
             model_name=model_name,
             is_backfill=inputs.get_is_backfill(),
+            backfill_details=inputs.backfill_details,
             team_id=inputs.team_id,
             full_range=full_range,
             done_ranges=done_ranges,
@@ -591,12 +591,8 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
             include_events=inputs.include_events,
             properties_data_type=inputs.properties_data_type,
             run_id=run_id,
-            backfill_details=BackfillDetails(
-                backfill_id=inputs.backfill_details.backfill_id if inputs.backfill_details else None,
-                is_earliest_backfill=is_earliest_backfill,
-                start_at=inputs.backfill_details.start_at if inputs.backfill_details else None,
-                end_at=inputs.backfill_details.end_at if inputs.backfill_details else None,
-            ),
+            backfill_details=inputs.backfill_details,
+            is_backfill=is_backfill,
             batch_export_model=inputs.batch_export_model,
             batch_export_schema=inputs.batch_export_schema,
         )

--- a/posthog/temporal/batch_exports/redshift_batch_export.py
+++ b/posthog/temporal/batch_exports/redshift_batch_export.py
@@ -14,6 +14,7 @@ from temporalio.common import RetryPolicy
 
 from posthog.batch_exports.models import BatchExportRun
 from posthog.batch_exports.service import (
+    BackfillDetails,
     BatchExportField,
     BatchExportModel,
     BatchExportSchema,
@@ -396,7 +397,7 @@ async def insert_into_redshift_activity(inputs: RedshiftInsertInputs) -> Records
         producer_task = await producer.start(
             queue=queue,
             model_name=model_name,
-            is_backfill=inputs.is_backfill,
+            is_backfill=inputs.get_is_backfill(),
             team_id=inputs.team_id,
             full_range=full_range,
             done_ranges=done_ranges,
@@ -541,8 +542,10 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
     @workflow.run
     async def run(self, inputs: RedshiftBatchExportInputs):
         """Workflow implementation to export data to Redshift."""
+        is_backfill = inputs.get_is_backfill()
+        is_earliest_backfill = inputs.get_is_earliest_backfill()
         data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
-        should_backfill_from_beginning = inputs.is_backfill and inputs.is_earliest_backfill
+        should_backfill_from_beginning = is_backfill and is_earliest_backfill
 
         start_batch_export_run_inputs = StartBatchExportRunInputs(
             team_id=inputs.team_id,
@@ -551,7 +554,7 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
             data_interval_end=data_interval_end.isoformat(),
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
-            is_backfill=inputs.is_backfill,
+            backfill_id=inputs.backfill_details.backfill_id if inputs.backfill_details else None,
         )
         run_id = await workflow.execute_activity(
             start_batch_export_run,
@@ -588,7 +591,12 @@ class RedshiftBatchExportWorkflow(PostHogWorkflow):
             include_events=inputs.include_events,
             properties_data_type=inputs.properties_data_type,
             run_id=run_id,
-            is_backfill=inputs.is_backfill,
+            backfill_details=BackfillDetails(
+                backfill_id=inputs.backfill_details.backfill_id if inputs.backfill_details else None,
+                is_earliest_backfill=is_earliest_backfill,
+                start_at=inputs.backfill_details.start_at if inputs.backfill_details else None,
+                end_at=inputs.backfill_details.end_at if inputs.backfill_details else None,
+            ),
             batch_export_model=inputs.batch_export_model,
             batch_export_schema=inputs.batch_export_schema,
         )

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -18,7 +18,6 @@ from temporalio.common import RetryPolicy
 
 from posthog.batch_exports.models import BatchExportRun
 from posthog.batch_exports.service import (
-    BackfillDetails,
     BatchExportField,
     BatchExportInsertInputs,
     BatchExportModel,
@@ -769,6 +768,7 @@ async def insert_into_s3_activity(inputs: S3InsertInputs) -> RecordsCompleted:
             queue=queue,
             model_name=model_name,
             is_backfill=inputs.get_is_backfill(),
+            backfill_details=inputs.backfill_details,
             team_id=inputs.team_id,
             full_range=full_range,
             done_ranges=done_ranges,
@@ -886,12 +886,8 @@ class S3BatchExportWorkflow(PostHogWorkflow):
             file_format=inputs.file_format,
             max_file_size_mb=inputs.max_file_size_mb,
             run_id=run_id,
-            backfill_details=BackfillDetails(
-                backfill_id=inputs.backfill_details.backfill_id if inputs.backfill_details else None,
-                is_earliest_backfill=is_earliest_backfill,
-                start_at=inputs.backfill_details.start_at if inputs.backfill_details else None,
-                end_at=inputs.backfill_details.end_at if inputs.backfill_details else None,
-            ),
+            backfill_details=inputs.backfill_details,
+            is_backfill=is_backfill,
             batch_export_model=inputs.batch_export_model,
             # TODO: Remove after updating existing batch exports.
             batch_export_schema=inputs.batch_export_schema,

--- a/posthog/temporal/batch_exports/s3_batch_export.py
+++ b/posthog/temporal/batch_exports/s3_batch_export.py
@@ -19,6 +19,7 @@ from temporalio.common import RetryPolicy
 from posthog.batch_exports.models import BatchExportRun
 from posthog.batch_exports.service import (
     BatchExportField,
+    BatchExportInsertInputs,
     BatchExportModel,
     BatchExportSchema,
     S3BatchExportInputs,
@@ -91,8 +92,8 @@ COMPRESSION_EXTENSIONS = {
 }
 
 
-@dataclasses.dataclass
-class S3InsertInputs:
+@dataclasses.dataclass(kw_only=True)
+class S3InsertInputs(BatchExportInsertInputs):
     """Inputs for S3 exports."""
 
     # TODO: do _not_ store credentials in temporal inputs. It makes it very hard
@@ -102,25 +103,15 @@ class S3InsertInputs:
     bucket_name: str
     region: str
     prefix: str
-    team_id: int
-    data_interval_start: str | None
-    data_interval_end: str
     aws_access_key_id: str | None = None
     aws_secret_access_key: str | None = None
     compression: str | None = None
-    exclude_events: list[str] | None = None
-    include_events: list[str] | None = None
     encryption: str | None = None
     kms_key_id: str | None = None
     endpoint_url: str | None = None
     # TODO: In Python 3.11, this could be a enum.StrEnum.
     file_format: str = "JSONLines"
     max_file_size_mb: int | None = None
-    run_id: str | None = None
-    is_backfill: bool = False
-    batch_export_model: BatchExportModel | None = None
-    # TODO: Remove after updating existing batch exports
-    batch_export_schema: BatchExportSchema | None = None
 
 
 def get_allowed_template_variables(inputs) -> dict[str, str]:

--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -21,7 +21,6 @@ from temporalio.common import RetryPolicy
 
 from posthog.batch_exports.models import BatchExportRun
 from posthog.batch_exports.service import (
-    BackfillDetails,
     BatchExportField,
     BatchExportInsertInputs,
     BatchExportModel,
@@ -767,6 +766,7 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs) -> Recor
             queue=queue,
             model_name=model_name,
             is_backfill=inputs.get_is_backfill(),
+            backfill_details=inputs.backfill_details,
             team_id=inputs.team_id,
             full_range=full_range,
             done_ranges=done_ranges,
@@ -944,12 +944,8 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
             run_id=run_id,
-            backfill_details=BackfillDetails(
-                backfill_id=inputs.backfill_details.backfill_id if inputs.backfill_details else None,
-                is_earliest_backfill=is_earliest_backfill,
-                start_at=inputs.backfill_details.start_at if inputs.backfill_details else None,
-                end_at=inputs.backfill_details.end_at if inputs.backfill_details else None,
-            ),
+            backfill_details=inputs.backfill_details,
+            is_backfill=is_backfill,
             batch_export_model=inputs.batch_export_model,
             batch_export_schema=inputs.batch_export_schema,
         )

--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -21,6 +21,7 @@ from temporalio.common import RetryPolicy
 
 from posthog.batch_exports.models import BatchExportRun
 from posthog.batch_exports.service import (
+    BackfillDetails,
     BatchExportField,
     BatchExportInsertInputs,
     BatchExportModel,
@@ -765,7 +766,7 @@ async def insert_into_snowflake_activity(inputs: SnowflakeInsertInputs) -> Recor
         producer_task = await producer.start(
             queue=queue,
             model_name=model_name,
-            is_backfill=inputs.is_backfill,
+            is_backfill=inputs.get_is_backfill(),
             team_id=inputs.team_id,
             full_range=full_range,
             done_ranges=done_ranges,
@@ -892,8 +893,10 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
     @workflow.run
     async def run(self, inputs: SnowflakeBatchExportInputs):
         """Workflow implementation to export data to Snowflake table."""
+        is_backfill = inputs.get_is_backfill()
+        is_earliest_backfill = inputs.get_is_earliest_backfill()
         data_interval_start, data_interval_end = get_data_interval(inputs.interval, inputs.data_interval_end)
-        should_backfill_from_beginning = inputs.is_backfill and inputs.is_earliest_backfill
+        should_backfill_from_beginning = is_backfill and is_earliest_backfill
 
         start_batch_export_run_inputs = StartBatchExportRunInputs(
             team_id=inputs.team_id,
@@ -902,7 +905,7 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
             data_interval_end=data_interval_end.isoformat(),
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
-            is_backfill=inputs.is_backfill,
+            backfill_id=inputs.backfill_details.backfill_id if inputs.backfill_details else None,
         )
         run_id = await workflow.execute_activity(
             start_batch_export_run,
@@ -941,7 +944,12 @@ class SnowflakeBatchExportWorkflow(PostHogWorkflow):
             exclude_events=inputs.exclude_events,
             include_events=inputs.include_events,
             run_id=run_id,
-            is_backfill=inputs.is_backfill,
+            backfill_details=BackfillDetails(
+                backfill_id=inputs.backfill_details.backfill_id if inputs.backfill_details else None,
+                is_earliest_backfill=is_earliest_backfill,
+                start_at=inputs.backfill_details.start_at if inputs.backfill_details else None,
+                end_at=inputs.backfill_details.end_at if inputs.backfill_details else None,
+            ),
             batch_export_model=inputs.batch_export_model,
             batch_export_schema=inputs.batch_export_schema,
         )

--- a/posthog/temporal/batch_exports/snowflake_batch_export.py
+++ b/posthog/temporal/batch_exports/snowflake_batch_export.py
@@ -22,6 +22,7 @@ from temporalio.common import RetryPolicy
 from posthog.batch_exports.models import BatchExportRun
 from posthog.batch_exports.service import (
     BatchExportField,
+    BatchExportInsertInputs,
     BatchExportModel,
     BatchExportSchema,
     SnowflakeBatchExportInputs,
@@ -133,34 +134,25 @@ class SnowflakeHeartbeatDetails(BatchExportRangeHeartbeatDetails):
     pass
 
 
-@dataclasses.dataclass
-class SnowflakeInsertInputs:
+@dataclasses.dataclass(kw_only=True)
+class SnowflakeInsertInputs(BatchExportInsertInputs):
     """Inputs for Snowflake."""
 
     # TODO: do _not_ store credentials in temporal inputs. It makes it very hard
     # to keep track of where credentials are being stored and increases the
     # attach surface for credential leaks.
 
-    team_id: int
     user: str
     account: str
     database: str
     warehouse: str
     schema: str
     table_name: str
-    data_interval_start: str | None
-    data_interval_end: str
     authentication_type: str = "password"
     password: str | None = None
     private_key: str | None = None
     private_key_passphrase: str | None = None
     role: str | None = None
-    exclude_events: list[str] | None = None
-    include_events: list[str] | None = None
-    run_id: str | None = None
-    is_backfill: bool = False
-    batch_export_model: BatchExportModel | None = None
-    batch_export_schema: BatchExportSchema | None = None
 
 
 SnowflakeField = tuple[str, str]

--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -516,19 +516,23 @@ def is_5_min_batch_export(full_range: tuple[dt.datetime | None, dt.datetime]) ->
     return False
 
 
-def use_distributed_events_recent_table(is_backfill: bool, team_id: int) -> bool:
-    if is_backfill:
-        return False
+def use_distributed_events_recent_table(is_backfill: bool, backfill_details: BackfillDetails | None) -> bool:
+    """We should use the distributed_events_recent table if it's not a backfill (backfill_details is None) or the
+    backfill is within the last 6 days.
 
-    events_recent_rollout: float = settings.BATCH_EXPORT_DISTRIBUTED_EVENTS_RECENT_ROLLOUT
-    # sanity check
-    if events_recent_rollout < 0:
-        events_recent_rollout = 0
-    elif events_recent_rollout > 1:
-        events_recent_rollout = 1
+    The events_recent table, and by extension, the distributed_events_recent table, only have event data from the last 7
+    days (we use 6 days to give some buffer).
+    """
 
-    bucket = team_id % 10
-    return bucket < events_recent_rollout * 10
+    if not is_backfill:
+        return True
+
+    backfill_start_at = None
+    if backfill_details and backfill_details.start_at:
+        backfill_start_at = dt.datetime.fromisoformat(backfill_details.start_at)
+    if backfill_start_at and backfill_start_at > (dt.datetime.now(tz=dt.UTC) - dt.timedelta(days=6)):
+        return True
+    return False
 
 
 class Producer:
@@ -614,7 +618,7 @@ class Producer:
                 query_template = SELECT_FROM_EVENTS_VIEW_RECENT
             # for other batch exports that should use `events_recent` we use the `distributed_events_recent` table
             # which is a distributed table that sits in front of the `events_recent` table
-            elif use_distributed_events_recent_table(is_backfill=is_backfill, team_id=team_id):
+            elif use_distributed_events_recent_table(is_backfill=is_backfill, backfill_details=backfill_details):
                 self.logger.info("Using distributed_events_recent table for batch export")
                 query_template = SELECT_FROM_DISTRIBUTED_EVENTS_RECENT
             elif str(team_id) in settings.UNCONSTRAINED_TIMESTAMP_TEAM_IDS:

--- a/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
+++ b/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
@@ -227,6 +227,7 @@ async def test_backfill_schedule_activity(activity_environment, temporal_worker,
     """Test backfill_schedule activity schedules all backfill runs."""
     start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
     end_at = dt.datetime(2023, 1, 1, 0, 10, 0, tzinfo=dt.UTC)
+    backfill_id = str(uuid.uuid4())
 
     desc = await temporal_schedule.describe()
     inputs = BackfillScheduleInputs(
@@ -235,6 +236,7 @@ async def test_backfill_schedule_activity(activity_environment, temporal_worker,
         end_at=end_at.isoformat(),
         start_delay=1.0,
         frequency_seconds=desc.schedule.spec.intervals[0].every.total_seconds(),
+        backfill_id=backfill_id,
     )
 
     await activity_environment.run(backfill_schedule, inputs)
@@ -267,13 +269,23 @@ async def test_backfill_schedule_activity(activity_environment, temporal_worker,
                 args = await workflow.data_converter.decode(
                     event.workflow_execution_started_event_attributes.input.payloads
                 )
-                assert args[0]["is_backfill"] is True
+                assert args[0]["backfill_details"] == {
+                    "backfill_id": backfill_id,
+                    "start_at": start_at.isoformat(),
+                    "end_at": end_at.isoformat(),
+                    "is_earliest_backfill": False,
+                }
             elif event.event_type == 10:
                 # 10 is EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
                 args = await workflow.data_converter.decode(
                     event.activity_task_scheduled_event_attributes.input.payloads
                 )
-                assert args[0]["is_backfill"] is True
+                assert args[0]["backfill_details"] == {
+                    "backfill_id": backfill_id,
+                    "start_at": start_at.isoformat(),
+                    "end_at": end_at.isoformat(),
+                    "is_earliest_backfill": False,
+                }
 
 
 @pytest.mark.django_db(transaction=True)
@@ -281,7 +293,6 @@ async def test_backfill_batch_export_workflow(temporal_worker, temporal_schedule
     """Test BackfillBatchExportWorkflow executes all backfill runs and updates model."""
     start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
     end_at = dt.datetime(2023, 1, 1, 0, 10, 0, tzinfo=dt.UTC)
-
     desc = await temporal_schedule.describe()
 
     workflow_id = str(uuid.uuid4())
@@ -321,6 +332,7 @@ async def test_backfill_batch_export_workflow(temporal_worker, temporal_schedule
 
     assert len(workflows) == expected
 
+    event_backfill_ids = []
     for workflow in workflows:
         handle = temporal_client.get_workflow_handle(workflow.id)
         history = await handle.fetch_history()
@@ -331,13 +343,19 @@ async def test_backfill_batch_export_workflow(temporal_worker, temporal_schedule
                 args = await workflow.data_converter.decode(
                     event.workflow_execution_started_event_attributes.input.payloads
                 )
-                assert args[0]["is_backfill"] is True
+                event_backfill_ids.append(args[0]["backfill_details"]["backfill_id"])
+                assert args[0]["backfill_details"]["start_at"] == start_at.isoformat()
+                assert args[0]["backfill_details"]["end_at"] == end_at.isoformat()
+                assert args[0]["backfill_details"]["is_earliest_backfill"] is False
             elif event.event_type == 10:
                 # 10 is EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
                 args = await workflow.data_converter.decode(
                     event.activity_task_scheduled_event_attributes.input.payloads
                 )
-                assert args[0]["is_backfill"] is True
+                event_backfill_ids.append(args[0]["backfill_details"]["backfill_id"])
+                assert args[0]["backfill_details"]["start_at"] == start_at.isoformat()
+                assert args[0]["backfill_details"]["end_at"] == end_at.isoformat()
+                assert args[0]["backfill_details"]["is_earliest_backfill"] is False
 
     backfills = await afetch_batch_export_backfills(batch_export_id=desc.id)
 
@@ -346,6 +364,9 @@ async def test_backfill_batch_export_workflow(temporal_worker, temporal_schedule
     backfill = backfills.pop()
     assert backfill.status == "Completed"
     assert backfill.finished_at is not None
+
+    for backfill_id in event_backfill_ids:
+        assert backfill_id == str(backfill.id)
 
 
 @pytest.mark.django_db(transaction=True)
@@ -360,7 +381,6 @@ async def test_backfill_batch_export_workflow_no_end_at(
 
     start_at = dt.datetime(2023, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
     end_at = None
-
     desc = await temporal_schedule.describe()
 
     workflow_id = str(uuid.uuid4())
@@ -403,6 +423,7 @@ async def test_backfill_batch_export_workflow_no_end_at(
 
     assert len(workflows) == expected
 
+    event_backfill_ids = []
     for workflow in workflows:
         handle = temporal_client.get_workflow_handle(workflow.id)
         history = await handle.fetch_history()
@@ -413,13 +434,19 @@ async def test_backfill_batch_export_workflow_no_end_at(
                 args = await workflow.data_converter.decode(
                     event.workflow_execution_started_event_attributes.input.payloads
                 )
-                assert args[0]["is_backfill"] is True
+                event_backfill_ids.append(args[0]["backfill_details"]["backfill_id"])
+                assert args[0]["backfill_details"]["start_at"] == start_at.isoformat()
+                assert args[0]["backfill_details"]["end_at"] is None
+                assert args[0]["backfill_details"]["is_earliest_backfill"] is False
             elif event.event_type == 10:
                 # 10 is EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
                 args = await workflow.data_converter.decode(
                     event.activity_task_scheduled_event_attributes.input.payloads
                 )
-                assert args[0]["is_backfill"] is True
+                event_backfill_ids.append(args[0]["backfill_details"]["backfill_id"])
+                assert args[0]["backfill_details"]["start_at"] == start_at.isoformat()
+                assert args[0]["backfill_details"]["end_at"] is None
+                assert args[0]["backfill_details"]["is_earliest_backfill"] is False
 
     backfills = await afetch_batch_export_backfills(batch_export_id=desc.id)
 
@@ -428,6 +455,9 @@ async def test_backfill_batch_export_workflow_no_end_at(
     backfill = backfills.pop()
     assert backfill.status == "Completed"
     assert backfill.finished_at is not None
+
+    for backfill_id in event_backfill_ids:
+        assert backfill_id == str(backfill.id)
 
     batch_export = await afetch_batch_export(desc.id)
     assert batch_export.paused is False
@@ -807,7 +837,6 @@ async def test_backfill_batch_export_workflow_no_start_at(temporal_worker, tempo
     """Test BackfillBatchExportWorkflow executes all backfill runs and updates model."""
     start_at = None
     end_at = dt.datetime(2023, 1, 1, 0, 10, 0, tzinfo=dt.UTC)
-
     desc = await temporal_schedule.describe()
 
     workflow_id = str(uuid.uuid4())
@@ -847,6 +876,7 @@ async def test_backfill_batch_export_workflow_no_start_at(temporal_worker, tempo
 
     assert len(workflows) == expected
 
+    event_backfill_ids = []
     for workflow in workflows:
         handle = temporal_client.get_workflow_handle(workflow.id)
         history = await handle.fetch_history()
@@ -857,13 +887,19 @@ async def test_backfill_batch_export_workflow_no_start_at(temporal_worker, tempo
                 args = await workflow.data_converter.decode(
                     event.workflow_execution_started_event_attributes.input.payloads
                 )
-                assert args[0]["is_backfill"] is True
+                event_backfill_ids.append(args[0]["backfill_details"]["backfill_id"])
+                assert args[0]["backfill_details"]["start_at"] is None
+                assert args[0]["backfill_details"]["end_at"] == end_at.isoformat()
+                assert args[0]["backfill_details"]["is_earliest_backfill"] is True
             elif event.event_type == 10:
                 # 10 is EVENT_TYPE_ACTIVITY_TASK_SCHEDULED
                 args = await workflow.data_converter.decode(
                     event.activity_task_scheduled_event_attributes.input.payloads
                 )
-                assert args[0]["is_backfill"] is True
+                event_backfill_ids.append(args[0]["backfill_details"]["backfill_id"])
+                assert args[0]["backfill_details"]["start_at"] is None
+                assert args[0]["backfill_details"]["end_at"] == end_at.isoformat()
+                assert args[0]["backfill_details"]["is_earliest_backfill"] is True
 
     backfills = await afetch_batch_export_backfills(batch_export_id=desc.id)
 
@@ -872,6 +908,9 @@ async def test_backfill_batch_export_workflow_no_start_at(temporal_worker, tempo
     backfill = backfills.pop()
     assert backfill.status == "Completed"
     assert backfill.finished_at is not None
+
+    for backfill_id in event_backfill_ids:
+        assert backfill_id == str(backfill.id)
 
 
 @pytest.mark.parametrize(

--- a/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
+++ b/posthog/temporal/tests/batch_exports/test_backfill_batch_export.py
@@ -595,6 +595,7 @@ async def test_backfill_batch_export_workflow_is_cancelled_on_repeated_failures(
             end_time=end_at,
             count=10,
             inserted_at=d,
+            table="sharded_events",
         )
 
     inputs = BackfillBatchExportInputs(

--- a/posthog/temporal/tests/batch_exports/test_batch_exports.py
+++ b/posthog/temporal/tests/batch_exports/test_batch_exports.py
@@ -268,7 +268,7 @@ async def test_iter_records_with_single_field_and_alias(clickhouse_client, field
             client=clickhouse_client,
             model=BatchExportModel(name="events", schema={"fields": [field], "values": {}}),
             team_id=team_id,
-            is_backfill=False,
+            backfill_details=None,
             interval_start=data_interval_start.isoformat(),
             interval_end=data_interval_end.isoformat(),
         )

--- a/posthog/temporal/tests/batch_exports/test_batch_exports.py
+++ b/posthog/temporal/tests/batch_exports/test_batch_exports.py
@@ -205,6 +205,7 @@ async def test_iter_records_ignores_timestamp_predicates(clickhouse_client):
         duplicate=True,
         person_properties={"$browser": "Chrome", "$os": "Mac OS X"},
         inserted_at=inserted_at,
+        table="sharded_events",
     )
 
     records = [

--- a/posthog/temporal/tests/batch_exports/test_batch_exports.py
+++ b/posthog/temporal/tests/batch_exports/test_batch_exports.py
@@ -342,7 +342,7 @@ async def test_iter_records_can_flatten_properties(clickhouse_client):
 
 
 async def test_iter_records_uses_extra_query_parameters(clickhouse_client):
-    """Test iter_records can flatten properties as indicated by a field expression."""
+    """Test iter_records can use extra query parameters"""
     team_id = randint(1, 1000000)
     data_interval_end = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
     data_interval_start = data_interval_end - dt.timedelta(hours=1)

--- a/posthog/temporal/tests/batch_exports/test_batch_exports.py
+++ b/posthog/temporal/tests/batch_exports/test_batch_exports.py
@@ -52,8 +52,8 @@ def assert_records_match_events(records, events):
 async def test_iter_records(clickhouse_client):
     """Test the rows returned by iter_records."""
     team_id = randint(1, 1000000)
-    data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:31:00.000000+00:00")
-    data_interval_start = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
+    data_interval_end = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    data_interval_start = data_interval_end - dt.timedelta(hours=1)
 
     (events, _, _) = await generate_test_events_in_clickhouse(
         client=clickhouse_client,
@@ -84,8 +84,8 @@ async def test_iter_records(clickhouse_client):
 async def test_iter_records_handles_duplicates(clickhouse_client):
     """Test the rows returned by iter_records are de-duplicated."""
     team_id = randint(1, 1000000)
-    data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:31:00.000000+00:00")
-    data_interval_start = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
+    data_interval_end = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    data_interval_start = data_interval_end - dt.timedelta(hours=1)
 
     (events, _, _) = await generate_test_events_in_clickhouse(
         client=clickhouse_client,
@@ -116,8 +116,8 @@ async def test_iter_records_handles_duplicates(clickhouse_client):
 async def test_iter_records_can_exclude_events(clickhouse_client):
     """Test the rows returned by iter_records can exclude events."""
     team_id = randint(1, 1000000)
-    data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:31:00.000000+00:00")
-    data_interval_start = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
+    data_interval_end = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    data_interval_start = data_interval_end - dt.timedelta(hours=1)
 
     (events, _, _) = await generate_test_events_in_clickhouse(
         client=clickhouse_client,
@@ -151,8 +151,8 @@ async def test_iter_records_can_exclude_events(clickhouse_client):
 async def test_iter_records_can_include_events(clickhouse_client):
     """Test the rows returned by iter_records can include events."""
     team_id = randint(1, 1000000)
-    data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:31:00.000000+00:00")
-    data_interval_start = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
+    data_interval_end = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    data_interval_start = data_interval_end - dt.timedelta(hours=1)
 
     (events, _, _) = await generate_test_events_in_clickhouse(
         client=clickhouse_client,
@@ -248,8 +248,8 @@ async def test_iter_records_ignores_timestamp_predicates(clickhouse_client):
 async def test_iter_records_with_single_field_and_alias(clickhouse_client, field):
     """Test iter_records can return a single aliased field."""
     team_id = randint(1, 1000000)
-    data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:31:00.000000+00:00")
-    data_interval_start = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
+    data_interval_end = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    data_interval_start = data_interval_end - dt.timedelta(hours=1)
 
     (events, _, _) = await generate_test_events_in_clickhouse(
         client=clickhouse_client,
@@ -297,8 +297,8 @@ async def test_iter_records_with_single_field_and_alias(clickhouse_client, field
 async def test_iter_records_can_flatten_properties(clickhouse_client):
     """Test iter_records can flatten properties as indicated by a field expression."""
     team_id = randint(1, 1000000)
-    data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:31:00.000000+00:00")
-    data_interval_start = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
+    data_interval_end = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    data_interval_start = data_interval_end - dt.timedelta(hours=1)
 
     (events, _, _) = await generate_test_events_in_clickhouse(
         client=clickhouse_client,
@@ -344,8 +344,8 @@ async def test_iter_records_can_flatten_properties(clickhouse_client):
 async def test_iter_records_uses_extra_query_parameters(clickhouse_client):
     """Test iter_records can flatten properties as indicated by a field expression."""
     team_id = randint(1, 1000000)
-    data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:31:00.000000+00:00")
-    data_interval_start = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
+    data_interval_end = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    data_interval_start = data_interval_end - dt.timedelta(hours=1)
 
     (events, _, _) = await generate_test_events_in_clickhouse(
         client=clickhouse_client,

--- a/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_bigquery_batch_export_workflow.py
@@ -21,6 +21,7 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.batch_exports.service import (
+    BackfillDetails,
     BatchExportModel,
     BatchExportSchema,
     BigQueryBatchExportInputs,
@@ -91,7 +92,7 @@ async def assert_clickhouse_records_in_bigquery(
     batch_export_model: BatchExportModel | BatchExportSchema | None = None,
     use_json_type: bool = False,
     sort_key: str = "event",
-    is_backfill: bool = False,
+    backfill_details: BackfillDetails | None = None,
     expect_duplicates: bool = False,
     expected_fields: list[str] | None = None,
 ) -> None:
@@ -166,7 +167,7 @@ async def assert_clickhouse_records_in_bigquery(
             exclude_events=exclude_events,
             include_events=include_events,
             destination_default_fields=bigquery_default_fields(),
-            is_backfill=is_backfill,
+            backfill_details=backfill_details,
             use_latest_schema=True,
         ):
             for record in record_batch.select(schema_column_names).to_pylist():
@@ -1271,8 +1272,12 @@ async def test_bigquery_export_workflow_backfill_earliest_persons(
         data_interval_end=data_interval_end.isoformat(),
         interval=interval,
         batch_export_model=model,
-        is_backfill=True,
-        is_earliest_backfill=True,
+        backfill_details=BackfillDetails(
+            backfill_id=str(uuid.uuid4()),
+            start_at=None,
+            end_at=data_interval_end.isoformat(),
+            is_earliest_backfill=True,
+        ),
         **bigquery_batch_export.destination.config,
     )
     _, persons = generate_test_data

--- a/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_postgres_batch_export_workflow.py
@@ -663,7 +663,7 @@ async def test_postgres_export_workflow_without_events(
     "data_interval_start",
     # This is hardcoded relative to the `data_interval_end` used in all or most tests, since that's also
     # passed to `generate_test_data` to determine the timestamp for the generated data.
-    [dt.datetime(2023, 4, 24, 15, 0, 0, tzinfo=dt.UTC)],
+    [dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0) - dt.timedelta(hours=24)],
     indirect=True,
 )
 @pytest.mark.parametrize("interval", ["hour"], indirect=True)
@@ -687,6 +687,12 @@ async def test_postgres_export_workflow_backfill_earliest_persons(
     We expect persons outside the batch interval to also be backfilled (i.e. persons that were updated
     more than an hour ago) when setting `is_earliest_backfill=True`.
     """
+    backfill_details = BackfillDetails(
+        backfill_id=str(uuid.uuid4()),
+        is_earliest_backfill=True,
+        start_at=None,
+        end_at=data_interval_end.isoformat(),
+    )
     workflow_id = str(uuid.uuid4())
     inputs = PostgresBatchExportInputs(
         team_id=ateam.pk,
@@ -694,12 +700,7 @@ async def test_postgres_export_workflow_backfill_earliest_persons(
         data_interval_end=data_interval_end.isoformat(),
         interval=interval,
         batch_export_model=model,
-        backfill_details=BackfillDetails(
-            backfill_id=str(uuid.uuid4()),
-            is_earliest_backfill=True,
-            start_at=None,
-            end_at=data_interval_end.isoformat(),
-        ),
+        backfill_details=backfill_details,
         **postgres_batch_export.destination.config,
     )
     _, persons = generate_test_data
@@ -748,6 +749,7 @@ async def test_postgres_export_workflow_backfill_earliest_persons(
         batch_export_model=model,
         exclude_events=exclude_events,
         sort_key="person_id",
+        backfill_details=backfill_details,
     )
 
 

--- a/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_redshift_batch_export_workflow.py
@@ -18,7 +18,11 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog import constants
-from posthog.batch_exports.service import BatchExportModel, BatchExportSchema
+from posthog.batch_exports.service import (
+    BackfillDetails,
+    BatchExportModel,
+    BatchExportSchema,
+)
 from posthog.temporal.batch_exports.batch_exports import (
     finish_batch_export_run,
     iter_model_records,
@@ -81,7 +85,7 @@ async def assert_clickhouse_records_in_redshfit(
     include_events: list[str] | None = None,
     properties_data_type: str = "varchar",
     sort_key: str = "event",
-    is_backfill: bool = False,
+    backfill_details: BackfillDetails | None = None,
     expected_duplicates_threshold: float = 0.0,
     expected_fields: list[str] | None = None,
 ):
@@ -158,7 +162,7 @@ async def assert_clickhouse_records_in_redshfit(
             exclude_events=exclude_events,
             include_events=include_events,
             destination_default_fields=redshift_default_fields(),
-            is_backfill=is_backfill,
+            backfill_details=backfill_details,
             use_latest_schema=True,
         ):
             for record in record_batch.select(schema_column_names).to_pylist():

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -5,6 +5,7 @@ import functools
 import io
 import json
 import os
+import re
 import uuid
 from dataclasses import asdict
 from unittest import mock
@@ -2237,110 +2238,56 @@ async def test_insert_into_s3_activity_when_using_distributed_events_recent_tabl
         )
 
 
-class MockClickHouseClient:
-    """Helper class to mock ClickHouse client with Arrow record batches."""
-
-    def __init__(self):
-        self.mock_client = mock.AsyncMock(spec=ClickHouseClient)
-        self.mock_client_cm = mock.AsyncMock()
-        self.mock_client_cm.__aenter__.return_value = self.mock_client
-        self.mock_client_cm.__aexit__.return_value = None
-
-    def expect_query_string(self, expected_query_string: str) -> None:
-        """Assert that the executed query contains the expected string."""
-        assert self.mock_client.astream_query_as_arrow.call_count == 1
-        call_args = self.mock_client.astream_query_as_arrow.call_args
-        query = call_args[0][0]  # First positional argument of the first call
-        assert expected_query_string in query
-
-
-class MockArrowRecordBatchIterator:
-    """Helper class to create a mock Arrow record batch iterator."""
-
-    def __init__(self):
-        # Create schema based on the columns in SELECT_FROM_DISTRIBUTED_EVENTS_RECENT
-        self.schema = pa.schema(
-            [
-                ("team_id", pa.int64()),
-                ("timestamp", pa.timestamp("us")),
-                ("event", pa.string()),
-                ("distinct_id", pa.string()),
-                ("uuid", pa.string()),
-                ("_inserted_at", pa.timestamp("us")),
-                ("created_at", pa.timestamp("us")),
-                ("elements_chain", pa.string()),
-                ("person_id", pa.string()),
-                ("properties", pa.string()),  # JSON string
-                ("person_properties", pa.string()),  # JSON string
-                ("set", pa.string()),  # JSON string
-                ("set_once", pa.string()),  # JSON string
-            ]
-        )
-
-        # Create arrays with one row of dummy data
-        now = dt.datetime.now(dt.UTC)
-        arrays = [
-            pa.array([1]),  # team_id
-            pa.array([now]),  # timestamp
-            pa.array(["test_event"]),  # event
-            pa.array(["test_distinct_id"]),  # distinct_id
-            pa.array([str(uuid.uuid4())]),  # uuid
-            pa.array([now]),  # _inserted_at
-            pa.array([now]),  # created_at
-            pa.array(["div > button"]),  # elements_chain
-            pa.array([str(uuid.uuid4())]),  # person_id
-            pa.array([json.dumps({"prop1": "value1"})]),  # properties
-            pa.array([json.dumps({"person_prop1": "value1"})]),  # person_properties
-            pa.array([json.dumps({"set1": "value1"})]),  # set
-            pa.array([json.dumps({"set_once1": "value1"})]),  # set_once
-        ]
-        self.batch = pa.RecordBatch.from_arrays(arrays, schema=self.schema)
-        self.called = False
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        if not self.called:
-            self.called = True
-            return self.batch
-        raise StopAsyncIteration
-
-
-@contextlib.contextmanager
-def mock_clickhouse_client_with_arrow():
-    """Context manager to mock ClickHouse client with Arrow record batches."""
-    mock_client = MockClickHouseClient()
-    mock_client.mock_client.astream_query_as_arrow.return_value = MockArrowRecordBatchIterator()
-
-    with patch("posthog.temporal.batch_exports.spmc.get_client", return_value=mock_client.mock_client_cm):
-        yield mock_client
-
-
-async def test_insert_into_s3_activity_executes_the_expected_query(
+@pytest.mark.parametrize("interval", ["day", "every 5 minutes"], indirect=True)
+@pytest.mark.parametrize(
+    "model",
+    [
+        BatchExportModel(name="events", schema=None),
+    ],
+)
+@pytest.mark.parametrize("is_backfill", [False, True])
+@pytest.mark.parametrize("backfill_within_last_6_days", [False, True])
+@pytest.mark.parametrize(
+    "data_interval_end", [dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=dt.UTC)]
+)
+async def test_insert_into_s3_activity_executes_the_expected_query_for_events_model(
     clickhouse_client,
     bucket_name,
     minio_client,
+    interval,
     activity_environment,
     data_interval_start,
     data_interval_end,
     generate_test_data,
     ateam,
+    model: BatchExportModel,
+    is_backfill: bool,
+    backfill_within_last_6_days: bool,
 ):
-    """Test that the insert_into_s3_activity executes the expected ClickHouse query."""
-    model = BatchExportModel(name="events", schema=None)
+    """Test that the insert_into_s3_activity executes the expected ClickHouse query when the model is an events model.
+
+    The query used for the events model is quite complex, and depends on a number of factors:
+    - If it's a backfill
+    - How far in the past we're backfilling
+    - If it's a 5 min batch export
+    """
+
+    if not is_backfill and backfill_within_last_6_days:
+        pytest.skip("No need to test backfill within last 6 days for non-backfill")
+
+    expected_table = "events"
+    if not is_backfill and interval == "every 5 minutes":
+        expected_table = "events_recent"
+
+    if backfill_within_last_6_days:
+        backfill_start_at = data_interval_end - dt.timedelta(days=3)
+    else:
+        backfill_start_at = data_interval_end - dt.timedelta(days=10)
+
     compression = None
     exclude_events = None
     file_format = "JSONLines"
-
     prefix = str(uuid.uuid4())
-
-    batch_export_schema: BatchExportSchema | None = None
-    batch_export_model: BatchExportModel | None = None
-    if isinstance(model, BatchExportModel):
-        batch_export_model = model
-    elif model is not None:
-        batch_export_schema = model
 
     insert_inputs = S3InsertInputs(
         bucket_name=bucket_name,
@@ -2355,10 +2302,105 @@ async def test_insert_into_s3_activity_executes_the_expected_query(
         compression=compression,
         exclude_events=exclude_events,
         file_format=file_format,
-        batch_export_schema=batch_export_schema,
-        batch_export_model=batch_export_model,
+        batch_export_schema=None,
+        batch_export_model=model,
+        is_backfill=is_backfill,
+        backfill_details=BackfillDetails(
+            backfill_id=str(uuid.uuid4()),
+            start_at=backfill_start_at,
+            end_at=data_interval_end,
+            is_earliest_backfill=False,
+        )
+        if is_backfill
+        else None,
     )
 
-    with mock_clickhouse_client_with_arrow() as mock_client:
+    class MockClickHouseClient:
+        """Helper class to mock ClickHouse client."""
+
+        def __init__(self):
+            self.mock_client = mock.AsyncMock(spec=ClickHouseClient)
+            self.mock_client_cm = mock.AsyncMock()
+            self.mock_client_cm.__aenter__.return_value = self.mock_client
+            self.mock_client_cm.__aexit__.return_value = None
+
+            # Set up the mock to return our async iterator
+            self.mock_client.astream_query_as_arrow.return_value = self._create_record_batch_iterator()
+
+        def expect_query_string(self, expected_query_string: str) -> None:
+            """Assert that the executed query contains the expected string."""
+            assert self.mock_client.astream_query_as_arrow.call_count == 1
+            call_args = self.mock_client.astream_query_as_arrow.call_args
+            query = call_args[0][0]  # First positional argument of the first call
+            assert expected_query_string in query
+
+        def expect_select_from_table(self, table_name: str) -> None:
+            """Assert that the executed query selects from the expected table.
+
+            Args:
+                table_name: The name of the table to check for in the FROM clause.
+
+            The method handles different formatting of the FROM clause, including newlines
+            and varying amounts of whitespace.
+            """
+            assert self.mock_client.astream_query_as_arrow.call_count == 1
+            call_args = self.mock_client.astream_query_as_arrow.call_args
+            query = call_args[0][0]  # First positional argument of the first call
+
+            # Create a pattern that matches "FROM" followed by optional whitespace/newlines and then the table name
+            pattern = rf"FROM\s+{re.escape(table_name)}"
+            assert re.search(pattern, query, re.IGNORECASE), f"Query does not select FROM {table_name}"
+
+        @staticmethod
+        def _create_test_record_batch() -> pa.RecordBatch:
+            """Create a record batch with test data."""
+            schema = pa.schema(
+                [
+                    ("team_id", pa.int64()),
+                    ("timestamp", pa.timestamp("us")),
+                    ("event", pa.string()),
+                    ("distinct_id", pa.string()),
+                    ("uuid", pa.string()),
+                    ("_inserted_at", pa.timestamp("us")),
+                    ("created_at", pa.timestamp("us")),
+                    ("elements_chain", pa.string()),
+                    ("person_id", pa.string()),
+                    ("properties", pa.string()),  # JSON string
+                    ("person_properties", pa.string()),  # JSON string
+                    ("set", pa.string()),  # JSON string
+                    ("set_once", pa.string()),  # JSON string
+                ]
+            )
+
+            now = dt.datetime.now(dt.UTC)
+            arrays = [
+                pa.array([1]),  # team_id
+                pa.array([now]),  # timestamp
+                pa.array(["test_event"]),  # event
+                pa.array(["test_distinct_id"]),  # distinct_id
+                pa.array([str(uuid.uuid4())]),  # uuid
+                pa.array([now]),  # _inserted_at
+                pa.array([now]),  # created_at
+                pa.array(["div > button"]),  # elements_chain
+                pa.array([str(uuid.uuid4())]),  # person_id
+                pa.array([json.dumps({"prop1": "value1"})]),  # properties
+                pa.array([json.dumps({"person_prop1": "value1"})]),  # person_properties
+                pa.array([json.dumps({"set1": "value1"})]),  # set
+                pa.array([json.dumps({"set_once1": "value1"})]),  # set_once
+            ]
+            return pa.RecordBatch.from_arrays(arrays, schema=schema)
+
+        async def _create_record_batch_iterator(self):
+            """Create an async iterator that yields a single record batch with test data."""
+            yield self._create_test_record_batch()
+
+    @contextlib.contextmanager
+    def mock_clickhouse_client():
+        """Context manager to mock ClickHouse client."""
+        mock_client = MockClickHouseClient()
+        with patch("posthog.temporal.batch_exports.spmc.get_client", return_value=mock_client.mock_client_cm):
+            yield mock_client
+
+    with mock_clickhouse_client() as mock_client:
         await activity_environment.run(insert_into_s3_activity, insert_inputs)
-        mock_client.expect_query_string("FROM\n        events")
+        mock_client.expect_select_from_table(expected_table)

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -1828,7 +1828,7 @@ async def test_insert_into_s3_activity_resumes_from_heartbeat(
     We mock the upload_part method to raise a `RequestTimeout` error after the first part has been uploaded.
     We then resume from the heartbeat and expect the activity to resume from where it left off.
     """
-    data_interval_end = dt.datetime.fromisoformat("2023-04-20T14:30:00.000000+00:00")
+    data_interval_end = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
     data_interval_start = data_interval_end - s3_batch_export.interval_time_delta
 
     n_expected_parts = 3

--- a/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_s3_batch_export_workflow.py
@@ -2252,13 +2252,6 @@ async def test_insert_into_s3_activity_executes_the_expected_query_for_events_mo
             # Set up the mock to return our async iterator
             self.mock_client.astream_query_as_arrow.return_value = self._create_record_batch_iterator()
 
-        def expect_query_string(self, expected_query_string: str) -> None:
-            """Assert that the executed query contains the expected string."""
-            assert self.mock_client.astream_query_as_arrow.call_count == 1
-            call_args = self.mock_client.astream_query_as_arrow.call_args
-            query = call_args[0][0]  # First positional argument of the first call
-            assert expected_query_string in query
-
         def expect_select_from_table(self, table_name: str) -> None:
             """Assert that the executed query selects from the expected table.
 

--- a/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
@@ -424,7 +424,7 @@ async def test_snowflake_export_workflow_exports_events(
     It should update the batch export run status to completed, as well as updating the record
     count.
     """
-    data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
+    data_interval_end = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
     data_interval_end_str = data_interval_end.strftime("%Y-%m-%d_%H-%M-%S")
     data_interval_start = data_interval_end - snowflake_batch_export.interval_time_delta
 

--- a/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
+++ b/posthog/temporal/tests/batch_exports/test_snowflake_batch_export_workflow.py
@@ -516,7 +516,7 @@ async def test_snowflake_export_workflow_without_events(ateam, snowflake_batch_e
     inputs = SnowflakeBatchExportInputs(
         team_id=ateam.pk,
         batch_export_id=str(snowflake_batch_export.id),
-        data_interval_end="2023-03-20 14:40:00.000000",
+        data_interval_end=dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0).isoformat(),
         interval=interval,
         **snowflake_batch_export.destination.config,
     )
@@ -581,7 +581,7 @@ async def test_snowflake_export_workflow_without_events(ateam, snowflake_batch_e
 async def test_snowflake_export_workflow_raises_error_on_put_fail(
     clickhouse_client, ateam, snowflake_batch_export, interval
 ):
-    data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
+    data_interval_end = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
     data_interval_start = data_interval_end - snowflake_batch_export.interval_time_delta
 
     _ = await generate_test_events_in_clickhouse(
@@ -647,7 +647,7 @@ async def test_snowflake_export_workflow_raises_error_on_put_fail(
 async def test_snowflake_export_workflow_raises_error_on_copy_fail(
     clickhouse_client, ateam, snowflake_batch_export, interval
 ):
-    data_interval_end = dt.datetime.fromisoformat("2023-04-25T14:30:00.000000+00:00")
+    data_interval_end = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, second=0, microsecond=0)
     data_interval_start = data_interval_end - snowflake_batch_export.interval_time_delta
 
     _ = await generate_test_events_in_clickhouse(

--- a/posthog/temporal/tests/batch_exports/test_spmc.py
+++ b/posthog/temporal/tests/batch_exports/test_spmc.py
@@ -120,7 +120,7 @@ async def test_record_batch_producer_uses_extra_query_parameters(clickhouse_clie
     producer_task = await producer.start(
         queue=queue,
         team_id=team_id,
-        is_backfill=False,
+        backfill_details=None,
         model_name="events",
         full_range=(data_interval_start, data_interval_end),
         done_ranges=[],

--- a/posthog/temporal/tests/batch_exports/test_spmc.py
+++ b/posthog/temporal/tests/batch_exports/test_spmc.py
@@ -120,6 +120,7 @@ async def test_record_batch_producer_uses_extra_query_parameters(clickhouse_clie
     producer_task = await producer.start(
         queue=queue,
         team_id=team_id,
+        is_backfill=False,
         backfill_details=None,
         model_name="events",
         full_range=(data_interval_start, data_interval_end),

--- a/posthog/temporal/tests/batch_exports/test_spmc.py
+++ b/posthog/temporal/tests/batch_exports/test_spmc.py
@@ -179,18 +179,21 @@ def test_slice_record_batch_in_half():
         # isn't a backfill so should use distributed_events_recent table
         {
             "is_backfill": False,
+            "data_interval_start": dt.datetime.now(tz=dt.UTC) - dt.timedelta(days=1),
             "use_distributed_events_recent_table": True,
         },
         # is a backfill within the last 6 days so should use distributed_events_recent table
         {
             "is_backfill": True,
             "backfill_start_at": dt.datetime.now(tz=dt.UTC) - dt.timedelta(days=1),
+            "data_interval_start": dt.datetime.now(tz=dt.UTC) - dt.timedelta(days=1),
             "use_distributed_events_recent_table": True,
         },
         # is a backfill outside the last 6 days so shouldn't use distributed_events_recent table
         {
             "is_backfill": True,
             "backfill_start_at": dt.datetime.now(tz=dt.UTC) - dt.timedelta(days=7),
+            "data_interval_start": dt.datetime.now(tz=dt.UTC) - dt.timedelta(days=1),
             "use_distributed_events_recent_table": False,
         },
     ],
@@ -207,7 +210,9 @@ def test_use_distributed_events_recent_table(test_data: dict[str, typing.Any]):
         else None
     )
     assert (
-        use_distributed_events_recent_table(test_data["is_backfill"], backfill_details)
+        use_distributed_events_recent_table(
+            test_data["is_backfill"], backfill_details, data_interval_start=test_data["data_interval_start"]
+        )
         == test_data["use_distributed_events_recent_table"]
     )
 

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.test import override_settings
 from dlt.common.configuration.specs.aws_credentials import AwsCredentials
 from dlt.common.libs.deltalake import get_delta_tables
+from dlt.common.normalizers.naming.snake_case import NamingConvention
 from freezegun.api import freeze_time
 
 from posthog import constants
@@ -22,8 +23,8 @@ from posthog.hogql.database.database import create_hogql_database
 from posthog.models import Team
 from posthog.temporal.data_modeling.run_workflow import (
     BuildDagActivityInputs,
-    ModelNode,
     CreateTableActivityInputs,
+    ModelNode,
     RunDagActivityInputs,
     RunWorkflow,
     RunWorkflowInputs,
@@ -38,10 +39,9 @@ from posthog.temporal.data_modeling.run_workflow import (
 )
 from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse
 from posthog.warehouse.models.datawarehouse_saved_query import DataWarehouseSavedQuery
-from posthog.warehouse.models.table import DataWarehouseTable
 from posthog.warehouse.models.modeling import DataWarehouseModelPath
+from posthog.warehouse.models.table import DataWarehouseTable
 from posthog.warehouse.util import database_sync_to_async
-from dlt.common.normalizers.naming.snake_case import NamingConvention
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
 
@@ -286,6 +286,7 @@ async def pageview_events(clickhouse_client, ateam):
         count=50,
         count_outside_range=0,
         distinct_ids=["a", "b"],
+        table="sharded_events",
     )
     return (events, events_from_other_team)
 

--- a/posthog/temporal/tests/test_encryption_codec.py
+++ b/posthog/temporal/tests/test_encryption_codec.py
@@ -58,7 +58,7 @@ async def test_payloads_are_encrypted():
     # input to the workflow (inputs).
     expected_results = (
         no_op_result_str,
-        {"arg": input_str, "is_backfill": False},
+        {"arg": input_str, "backfill_details": None},
         dataclasses.asdict(inputs),
     )
 

--- a/posthog/temporal/tests/test_encryption_codec.py
+++ b/posthog/temporal/tests/test_encryption_codec.py
@@ -50,7 +50,7 @@ async def test_payloads_are_encrypted():
         arg=input_str,
         batch_export_id="123",
         team_id=1,
-        is_backfill=False,
+        backfill_details=None,
     )
 
     # The no-op Workflow can only produce a limited set of results, so we'll check if the events match any of these.

--- a/posthog/temporal/tests/utils/events.py
+++ b/posthog/temporal/tests/utils/events.py
@@ -158,9 +158,9 @@ async def generate_test_events_in_clickhouse(
     distinct_ids: list[str] | None = None,
     duplicate: bool = False,
     batch_size: int = 10000,
-    table: str = "sharded_events",
+    table: str = "events_recent",
 ) -> tuple[list[EventValues], list[EventValues], list[EventValues]]:
-    """Insert test events into the sharded_events table.
+    """Insert test events into the given table.
 
     These events are used in most batch exports tests, so we have a function here to generate
     multiple events with different characteristics.
@@ -182,6 +182,9 @@ async def generate_test_events_in_clickhouse(
         properties: A properties dictionary for events.
         person_properties: A person_properties for events.
         duplicate: Generate and insert duplicate events.
+        batch_size: The number of events to insert in a single query.
+        table: The table to insert the events into (defaults to events_recent, since this is used by the majority of
+            batch exports, except for backfills older than 6 days).
     """
     possible_datetimes = list(date_range(start_time, end_time, dt.timedelta(minutes=1)))
 


### PR DESCRIPTION
Currently we always query `events` for backfills, and use the `timestamp` column as the filter. However, we use `events_recent` for regular runs, with `inserted_at` as the filter. This means if a run fails or needs to be re-run for some reason, if we run a backfill, it won't run the same query as it originally did, which could lead to discrepancies. Since we have event data in `events_recent` for the last 7 days, it would make sense to use this table and filter on `inserted_at` when backfilling recent data.

## Changes

### Main logical change

Use `distributed_events_recent` for backfills that are entirely within the last 6 days (we choose 6 days to give ourselves a buffer to ensure we're not running into issues with deleted events). We want to consider the _entire_ backfill duration as otherwise this could lead to unexpected behaviour where the backfill is running different queries depending on which interval it's running.

### Consequential changes

We need to know the backfill start and end dates in addition to the individual interval start and end dates.

To handle this, and to think ahead to when we'll also need to accept a `backfill_id` so we can store this against an individual run, I'm creating a `BackfillDetails` dataclass that is added to the inputs.

Therefore, we need to update the workflow inputs to accept these new dates. In theory this should be straightforward, however we also need to consider backfills that are currently in progress.

For continuous exports that are already set up in Temporal everything should continue to work fine, as `backfill_details` is optional and defaults to `None`.

The one place I think it could be an issue is for backfills that are in progress at the time of the deployment: The backfill workflow will be creating workflows with the old inputs but the workers could be running the new code which is not expecting the old inputs.
Therefore I need to include both the old and new inputs to all the workflows to handle this migration: the workflows should accept `is_backfill`, `is_earliest_backfill` and also `backfill_details`, taking the inputs first from `backfill_details` if present, otherwise defaulting to the old arguments.

Once we're confident all existing backfills have completed we can remove the old arguments

### Cleanup/refactoring

I've refactored the workflow/activity inputs to inherit from a base class, so it is clear which inputs are common across all batch exports and which are specific to the destination.

I'm removing the previous `BATCH_EXPORT_DISTRIBUTED_EVENTS_RECENT_ROLLOUT` setting since this has already been rolled out to 100% of teams

### Testing

Since we're now using `distributed_events_recent` (or `events_recent`) for the majority of our batch exports (and for all the realtime batch exports) it means a lot of tests were failing because the fixtures are inserting into `sharded_events`.

I think it makes sense for our tests to now use `events_recent` by default. This requires [updating the default `data_interval_end` to be the current day](https://github.com/PostHog/posthog/pull/28323/files#diff-3c97a7e281adf43587104003f8de324f11daea4f5eae9e730ef9b78be52bf988R278).

I also [added a test](https://github.com/PostHog/posthog/pull/28323/files#diff-edeee6f7aa5bc8c2ef2b97cdf49a8f9a21dec563b572a81d7a5906726c0727b8R2175) to `test_s3_batch_export_workflow.py` to assert batch exports are selecting from the expected table, since the logic is becoming quite complex.

## Does this work well for both Cloud and self-hosted?

Should do.

## How did you test this code?

Automated tests
