### PR TITLE
chore(no-code experiments): refactor (2)

### DIFF
--- a/frontend/src/toolbar/experiments/ExperimentsEditingToolbarMenu.tsx
+++ b/frontend/src/toolbar/experiments/ExperimentsEditingToolbarMenu.tsx
@@ -105,10 +105,10 @@ export const ExperimentsEditingToolbarMenu = (): JSX.Element => {
                                     <LemonCollapse
                                         size="medium"
                                         activeKey={selectedVariant}
-                                        onChange={(variant) => {
-                                            if (variant) {
-                                                selectVariant(variant)
-                                                applyVariant(selectedVariant, variant)
+                                        onChange={(newVariant) => {
+                                            if (newVariant) {
+                                                selectVariant(newVariant)
+                                                applyVariant(newVariant)
                                             }
                                         }}
                                         panels={Object.keys(experimentForm.variants || {})

--- a/frontend/src/toolbar/experiments/WebExperimentTransformField.tsx
+++ b/frontend/src/toolbar/experiments/WebExperimentTransformField.tsx
@@ -130,8 +130,10 @@ export function WebExperimentTransformField({
                                     const originalHtmlState = experimentForm.original_html_state?.[transform.selector]
                                     if (originalHtmlState) {
                                         const element = document.querySelector(transform.selector) as HTMLElement
-                                        element.innerHTML = originalHtmlState.innerHTML
-                                        element.textContent = originalHtmlState.textContent
+                                        if (element) {
+                                            element.innerHTML = originalHtmlState.innerHTML
+                                            element.textContent = originalHtmlState.textContent
+                                        }
                                     }
 
                                     // Copy the original html state to the new transform, and delete the previously selected content type
@@ -223,14 +225,26 @@ export function WebExperimentTransformField({
                         <LemonTextArea
                             onChange={(value) => {
                                 if (experimentForm.variants) {
-                                    const webVariant = experimentForm.variants[variant]
-                                    if (webVariant && transform.selector) {
-                                        webVariant.transforms[transformIndex].css = value
-                                        const element = document.querySelector(transform.selector) as HTMLElement
+                                    // Create new variants object with updated CSS
+                                    const updatedVariants = {
+                                        ...experimentForm.variants,
+                                        [variant]: {
+                                            ...experimentForm.variants[variant],
+                                            transforms: experimentForm.variants[variant].transforms.map((t, i) =>
+                                                i === transformIndex ? { ...t, css: value } : t
+                                            ),
+                                        },
+                                    }
+                                    setExperimentFormValue('variants', updatedVariants)
+
+                                    // Update DOM
+                                    const element = transform.selector
+                                        ? (document.querySelector(transform.selector) as HTMLElement)
+                                        : null
+                                    if (element) {
                                         element.setAttribute('style', value)
                                     }
                                 }
-                                setExperimentFormValue('variants', experimentForm.variants)
                             }}
                             value={transform.css || ''}
                         />

--- a/frontend/src/toolbar/experiments/WebExperimentTransformField.tsx
+++ b/frontend/src/toolbar/experiments/WebExperimentTransformField.tsx
@@ -24,15 +24,13 @@ export function WebExperimentTransformField({
     transformIndex,
     transform,
 }: WebExperimentTransformFieldProps): JSX.Element {
-    const [selectedContentType, setSelectedContentType] = useState(
-        transform.html && transform.html.length > 0 ? 'html' : 'text'
-    )
     const { experimentForm, inspectingElement, selectedVariant, selectedElementType } = useValues(experimentsTabLogic)
     const { setExperimentFormValue, selectVariant, selectElementType, inspectForElementWithIndex } =
         useActions(experimentsTabLogic)
 
     const [editSelectorShowing, setEditSelectorShowing] = useState(false)
 
+    const selectedContentType = transform.html ? 'html' : 'text'
     return (
         <>
             <div className="flex-1 mb-2">
@@ -106,129 +104,139 @@ export function WebExperimentTransformField({
                     />
                 </div>
             )}
-            <div className="mt-4">
-                <LemonLabel>Content</LemonLabel>
-                <LemonSegmentedButton
-                    className="mb-1"
-                    fullWidth
-                    options={[
-                        {
-                            value: 'text',
-                            label: 'Text',
-                            icon: <IconMessage />,
-                        },
-                        {
-                            value: 'html',
-                            label: 'HTML',
-                            icon: <IconCode />,
-                        },
-                    ]}
-                    onChange={(newSelectedContentType) => {
-                        setSelectedContentType(newSelectedContentType)
-                        const variantConfig = experimentForm.variants[variant]
-                        if (variantConfig && transform.selector) {
-                            const element = document.querySelector(transform.selector) as HTMLElement
-                            if (element) {
-                                const newTransform = {
-                                    ...transform,
-                                }
-
-                                if (newSelectedContentType === 'html') {
-                                    newTransform.html =
-                                        experimentForm.original_html_state?.[transform.selector]?.innerHTML
-                                    delete newTransform.text
-                                }
-                                if (newSelectedContentType === 'text' && element.textContent) {
-                                    newTransform.text =
-                                        experimentForm.original_html_state?.[transform.selector]?.textContent
-                                    delete newTransform.html
-                                }
-
-                                const updatedVariants = {
-                                    ...experimentForm.variants,
-                                    [variant]: {
-                                        ...variantConfig,
-                                        transforms: variantConfig.transforms.map((t, i) =>
-                                            i === transformIndex ? newTransform : t
-                                        ),
-                                    },
-                                }
-                                setExperimentFormValue('variants', updatedVariants)
-                            }
-                        }
-                    }}
-                    value={selectedContentType}
-                />
-                {selectedContentType == 'text' && (
-                    <LemonTextArea
-                        onChange={(value) => {
-                            // Update state
-                            const updatedVariants = {
-                                ...experimentForm.variants,
-                                [variant]: {
-                                    ...experimentForm.variants[variant],
-                                    transforms: experimentForm.variants[variant].transforms.map((t, i) =>
-                                        i === transformIndex ? { ...t, text: value } : t
-                                    ),
+            {transform.selector && (
+                <div>
+                    <div className="mt-4">
+                        <LemonLabel>Content</LemonLabel>
+                        <LemonSegmentedButton
+                            className="mb-1"
+                            fullWidth
+                            options={[
+                                {
+                                    value: 'text',
+                                    label: 'Text',
+                                    icon: <IconMessage />,
                                 },
-                            }
-                            setExperimentFormValue('variants', updatedVariants)
-
-                            // Update DOM
-                            const element = transform.selector
-                                ? (document.querySelector(transform.selector) as HTMLElement)
-                                : null
-                            if (element) {
-                                element.innerText = value
-                            }
-                        }}
-                        value={transform.text}
-                    />
-                )}
-                {selectedContentType == 'html' && (
-                    <LemonTextArea
-                        onChange={(value) => {
-                            // Update state
-                            const updatedVariants = {
-                                ...experimentForm.variants,
-                                [variant]: {
-                                    ...experimentForm.variants[variant],
-                                    transforms: experimentForm.variants[variant].transforms.map((t, i) =>
-                                        i === transformIndex ? { ...t, html: value } : t
-                                    ),
+                                {
+                                    value: 'html',
+                                    label: 'HTML',
+                                    icon: <IconCode />,
                                 },
-                            }
-                            setExperimentFormValue('variants', updatedVariants)
+                            ]}
+                            onChange={(newSelectedContentType) => {
+                                const variantConfig = experimentForm.variants[variant]
+                                if (variantConfig && transform.selector) {
+                                    // Before changing the content type, restore the original html state for this selector
+                                    const originalHtmlState = experimentForm.original_html_state?.[transform.selector]
+                                    if (originalHtmlState) {
+                                        const element = document.querySelector(transform.selector) as HTMLElement
+                                        element.innerHTML = originalHtmlState.innerHTML
+                                        element.textContent = originalHtmlState.textContent
+                                    }
 
-                            // Update DOM
-                            const element = transform.selector
-                                ? (document.querySelector(transform.selector) as HTMLElement)
-                                : null
-                            if (element) {
-                                element.innerHTML = value
-                            }
-                        }}
-                        value={transform.html}
-                    />
-                )}
-            </div>
-            <div className="mt-4">
-                <LemonLabel>CSS</LemonLabel>
-                <LemonTextArea
-                    onChange={(value) => {
-                        if (experimentForm.variants) {
-                            const webVariant = experimentForm.variants[variant]
-                            if (webVariant && transform.selector) {
-                                webVariant.transforms[transformIndex].css = value
-                                const element = document.querySelector(transform.selector) as HTMLElement
-                                element.setAttribute('style', value)
-                            }
-                        }
-                        setExperimentFormValue('variants', experimentForm.variants)
-                    }}
-                    value={transform.css || ''}
-                />
-            </div>
+                                    // Copy the original html state to the new transform, and delete the previously selected content type
+                                    const element = document.querySelector(transform.selector) as HTMLElement
+                                    if (element) {
+                                        const newTransform = { ...transform }
+
+                                        if (newSelectedContentType === 'html') {
+                                            newTransform.html =
+                                                experimentForm.original_html_state?.[transform.selector]?.innerHTML
+                                            delete newTransform.text
+                                        }
+                                        if (newSelectedContentType === 'text' && element.textContent) {
+                                            newTransform.text =
+                                                experimentForm.original_html_state?.[transform.selector]?.textContent
+                                            delete newTransform.html
+                                        }
+
+                                        const updatedVariants = {
+                                            ...experimentForm.variants,
+                                            [variant]: {
+                                                ...variantConfig,
+                                                transforms: variantConfig.transforms.map((t, i) =>
+                                                    i === transformIndex ? newTransform : t
+                                                ),
+                                            },
+                                        }
+                                        setExperimentFormValue('variants', updatedVariants)
+                                    }
+                                }
+                            }}
+                            value={selectedContentType}
+                        />
+                        {selectedContentType == 'text' && (
+                            <LemonTextArea
+                                onChange={(value) => {
+                                    // Update state
+                                    const updatedVariants = {
+                                        ...experimentForm.variants,
+                                        [variant]: {
+                                            ...experimentForm.variants[variant],
+                                            transforms: experimentForm.variants[variant].transforms.map((t, i) =>
+                                                i === transformIndex ? { ...t, text: value } : t
+                                            ),
+                                        },
+                                    }
+                                    setExperimentFormValue('variants', updatedVariants)
+
+                                    // Update DOM
+                                    const element = transform.selector
+                                        ? (document.querySelector(transform.selector) as HTMLElement)
+                                        : null
+                                    if (element) {
+                                        element.innerText = value
+                                    }
+                                }}
+                                value={transform.text}
+                            />
+                        )}
+                        {selectedContentType == 'html' && (
+                            <LemonTextArea
+                                onChange={(value) => {
+                                    // Update state
+                                    const updatedVariants = {
+                                        ...experimentForm.variants,
+                                        [variant]: {
+                                            ...experimentForm.variants[variant],
+                                            transforms: experimentForm.variants[variant].transforms.map((t, i) =>
+                                                i === transformIndex ? { ...t, html: value } : t
+                                            ),
+                                        },
+                                    }
+                                    setExperimentFormValue('variants', updatedVariants)
+
+                                    // Update DOM
+                                    const element = transform.selector
+                                        ? (document.querySelector(transform.selector) as HTMLElement)
+                                        : null
+                                    if (element) {
+                                        element.innerHTML = value
+                                    }
+                                }}
+                                value={transform.html}
+                            />
+                        )}
+                    </div>
+                    <div className="mt-4">
+                        <LemonLabel>CSS</LemonLabel>
+                        <LemonTextArea
+                            onChange={(value) => {
+                                if (experimentForm.variants) {
+                                    const webVariant = experimentForm.variants[variant]
+                                    if (webVariant && transform.selector) {
+                                        webVariant.transforms[transformIndex].css = value
+                                        const element = document.querySelector(transform.selector) as HTMLElement
+                                        element.setAttribute('style', value)
+                                    }
+                                }
+                                setExperimentFormValue('variants', experimentForm.variants)
+                            }}
+                            value={transform.css || ''}
+                        />
+                    </div>
+                </div>
+            )}
         </>
     )
 }

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.test.ts
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.test.ts
@@ -309,7 +309,7 @@ describe('experimentsTabLogic', () => {
                 .then(() => {
                     theExperimentsTabLogic.actions.selectExperiment(2)
                     const element = createTestDocument()
-                    theExperimentsTabLogic.actions.applyVariant('', 'test')
+                    theExperimentsTabLogic.actions.applyVariant('test')
                     expect(element.innerText).toEqual('Hello world')
                 })
         })
@@ -322,27 +322,10 @@ describe('experimentsTabLogic', () => {
                 .then(() => {
                     theExperimentsTabLogic.actions.selectExperiment(2)
                     const element = createTestDocument()
-                    theExperimentsTabLogic.actions.applyVariant('', 'test')
+                    theExperimentsTabLogic.actions.applyVariant('test')
                     expect(element.innerText).toEqual('Hello world')
-                    theExperimentsTabLogic.actions.applyVariant('test', 'test2')
+                    theExperimentsTabLogic.actions.applyVariant('test2')
                     expect(element.innerText).toEqual('Goodbye world')
-                })
-        })
-
-        it('can reset to control', async () => {
-            await expectLogic(theExperimentsLogic, () => {
-                theExperimentsLogic.actions.getExperiments()
-            })
-                .delay(0)
-                .then(() => {
-                    theExperimentsTabLogic.actions.selectExperiment(2)
-                    const element = createTestDocument()
-                    theExperimentsTabLogic.actions.applyVariant('', 'test')
-                    expect(element.innerText).toEqual('Hello world')
-                    theExperimentsTabLogic.actions.applyVariant('test', 'test2')
-                    expect(element.innerText).toEqual('Goodbye world')
-                    theExperimentsTabLogic.actions.applyVariant('test2', 'control')
-                    expect(element.innerText).toEqual('original')
                 })
         })
     })

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
@@ -374,8 +374,8 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
                     selectedVariant.transforms?.forEach((transform) => {
                         if (transform.selector) {
                             const elements = document.querySelectorAll(transform.selector)
-                            elements.forEach((elements) => {
-                                const htmlElement = elements as HTMLElement
+                            elements.forEach((element) => {
+                                const htmlElement = element as HTMLElement
                                 if (htmlElement) {
                                     if (transform.html) {
                                         htmlElement.innerHTML = transform.html

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
@@ -325,10 +325,8 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
                             transforms: currentVariant.transforms.map((t, i) =>
                                 i === index
                                     ? {
-                                          ...t,
                                           selector,
                                           text: element.textContent || t.text,
-                                          //   html: element.innerHTML, We set one or the other!
                                       }
                                     : t
                             ),

--- a/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
+++ b/frontend/src/toolbar/experiments/experimentsTabLogic.tsx
@@ -10,7 +10,7 @@ import { toolbarLogic } from '~/toolbar/bar/toolbarLogic'
 import { experimentsLogic } from '~/toolbar/experiments/experimentsLogic'
 import { toolbarConfigLogic } from '~/toolbar/toolbarConfigLogic'
 import { toolbarPosthogJS } from '~/toolbar/toolbarPosthogJS'
-import { WebExperiment, WebExperimentDraftType, WebExperimentForm, WebExperimentTransform } from '~/toolbar/types'
+import { WebExperiment, WebExperimentDraftType, WebExperimentForm } from '~/toolbar/types'
 import { elementToQuery } from '~/toolbar/utils'
 import { Experiment, ExperimentIdType } from '~/types'
 
@@ -71,9 +71,8 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
         removeVariant: (variant: string) => ({
             variant,
         }),
-        applyVariant: (current_variant: string, variant: string) => ({
-            current_variant,
-            variant,
+        applyVariant: (newVariantKey: string) => ({
+            newVariantKey,
         }),
         addNewElement: (variant: string) => ({ variant }),
         removeElement: (variant: string, index: number) => ({ variant, index }),
@@ -184,9 +183,9 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
                     ...formValues,
                 }
 
-                // this property is used in the editor to undo transforms
-                // don't need to roundtrip this to the server.
-                delete experimentToSave.undo_transforms
+                // This property is only used in the editor to undo transforms
+                delete experimentToSave.original_html_state
+
                 const { apiURL, temporaryToken } = values
                 const { selectedExperimentId } = values
 
@@ -307,6 +306,17 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
                         return
                     }
 
+                    // Restore original html state for previous selector
+                    const previousSelector = currentVariant.transforms[index].selector
+                    if (previousSelector) {
+                        const originalHtmlState = values.experimentForm.original_html_state?.[previousSelector]
+                        if (originalHtmlState) {
+                            const element = document.querySelector(previousSelector) as HTMLElement
+                            element.innerHTML = originalHtmlState.innerHTML
+                            element.textContent = originalHtmlState.textContent
+                        }
+                    }
+
                     // Update state
                     const updatedVariants = {
                         ...values.experimentForm.variants,
@@ -344,66 +354,44 @@ export const experimentsTabLogic = kea<experimentsTabLogicType>([
                 actions.rebalanceRolloutPercentage()
             }
         },
-        applyVariant: ({ current_variant, variant }) => {
+        applyVariant: ({ newVariantKey }) => {
             if (values.experimentForm && values.experimentForm.variants) {
-                const selectedVariant = values.experimentForm.variants[variant]
+                const selectedVariant = values.experimentForm.variants[newVariantKey]
                 if (selectedVariant) {
-                    if (values.experimentForm.undo_transforms === undefined) {
-                        values.experimentForm.undo_transforms = []
-                    }
-
-                    // run the undo transforms first.
-                    values.experimentForm.undo_transforms?.forEach((transform) => {
-                        if (transform.selector) {
-                            const elements = document.querySelectorAll(transform.selector)
-                            elements.forEach((elements) => {
-                                const htmlElement = elements as HTMLElement
+                    // Restore original HTML state
+                    Object.entries(values.experimentForm.original_html_state || {}).forEach(
+                        ([selector, originalState]) => {
+                            const elements = document.querySelectorAll(selector)
+                            elements.forEach((element) => {
+                                const htmlElement = element as HTMLElement
                                 if (htmlElement) {
-                                    if (transform.html) {
-                                        htmlElement.innerHTML = transform.html
-                                    }
-
-                                    if (transform.css) {
-                                        htmlElement.setAttribute('style', transform.css)
-                                    }
-
-                                    if (transform.text) {
-                                        htmlElement.innerText = transform.text
-                                    }
+                                    htmlElement.innerHTML = originalState.innerHTML
+                                    htmlElement.textContent = originalState.textContent
                                 }
                             })
                         }
-                    })
+                    )
 
+                    // Apply variant transforms
                     selectedVariant.transforms?.forEach((transform) => {
                         if (transform.selector) {
-                            const undoTransform: WebExperimentTransform = {
-                                selector: transform.selector,
-                            }
                             const elements = document.querySelectorAll(transform.selector)
                             elements.forEach((elements) => {
                                 const htmlElement = elements as HTMLElement
                                 if (htmlElement) {
                                     if (transform.html) {
-                                        undoTransform.html = htmlElement.innerHTML
                                         htmlElement.innerHTML = transform.html
                                     }
 
                                     if (transform.css) {
-                                        undoTransform.css = htmlElement.getAttribute('style') || ' '
                                         htmlElement.setAttribute('style', transform.css)
                                     }
 
                                     if (transform.text) {
-                                        undoTransform.text = htmlElement.innerText
                                         htmlElement.innerText = transform.text
                                     }
                                 }
                             })
-
-                            if ((current_variant === 'control' || current_variant === '') && variant !== 'control') {
-                                values.experimentForm.undo_transforms?.push(undoTransform)
-                            }
                         }
                     })
                 }

--- a/frontend/src/toolbar/types.ts
+++ b/frontend/src/toolbar/types.ts
@@ -87,8 +87,7 @@ export type WebExperimentDraftType = Omit<
 
 export interface WebExperimentForm extends WebExperimentDraftType {
     variants: Record<string, WebExperimentVariant>
-    undo_transforms?: WebExperimentTransform[]
-    original_html_state: Record<string, any>
+    original_html_state?: Record<string, any>
 }
 
 export interface ActionStepForm extends ActionStepType {


### PR DESCRIPTION
Part of https://github.com/PostHog/posthog/issues/28205

## Changes
- Undo transforms when the variant tab is changed
- Undo transforms when the content type selector (text/html) is changed
- Only render the inputs when a selector is selected
- Other small cleanups

https://www.loom.com/share/942c1c0cf5ff41a99979a22bffd088fa?sid=096012b5-037a-4164-b076-b6561bb4ee85

## How did you test this code?
👀 