### PR TITLE
fix(trends): Fixed trends first time user matching event

### DIFF
--- a/posthog/hogql_queries/insights/trends/aggregation_operations.py
+++ b/posthog/hogql_queries/insights/trends/aggregation_operations.py
@@ -118,7 +118,7 @@ class AggregationOperations(DataWarehouseInsightQueryMixin):
         return self.series.math in ["weekly_active", "monthly_active"]
 
     def is_first_time_ever_math(self):
-        return self.series.math == "first_time_for_user"
+        return self.series.math in {"first_time_for_user", "first_matching_event_for_user"}
 
     def is_first_matching_event(self):
         return self.series.math == "first_matching_event_for_user"
@@ -465,7 +465,6 @@ class AggregationOperations(DataWarehouseInsightQueryMixin):
         events_where_clause: ast.Expr,
         sample_value: ast.RatioExpr,
         event_name_filter: ast.Expr | None = None,
-        is_first_matching_event: bool = False,
     ):
         date_placeholders = self.query_date_range.to_placeholders()
         date_from = parse_expr(
@@ -479,6 +478,7 @@ class AggregationOperations(DataWarehouseInsightQueryMixin):
 
         events_query = ast.SelectQuery(select=[])
         parent_select = self._first_time_parent_query(events_query)
+        is_first_matching_event = self.is_first_matching_event()
 
         class QueryOrchestrator:
             events_query_builder: FirstTimeForUserEventsQueryAlternator

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -5108,7 +5108,7 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             team=self.team,
             event="$pageview",
             distinct_id="p1",
-            timestamp="2020-01-06T12:00:00Z",
+            timestamp="2020-01-06T13:00:00Z",
             properties={"$browser": "Firefox"},
         )
 

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -5083,6 +5083,13 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             distinct_ids=["p1"],
             properties={},
         )
+        _create_person(
+            team=self.team,
+            distinct_ids=["p2"],
+            properties={},
+        )
+
+        # these events outside date range should be ignored
         _create_event(
             team=self.team,
             event="$pageview",
@@ -5090,6 +5097,22 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-06T12:00:00Z",
             properties={"$browser": "Chrome"},
         )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="p2",
+            timestamp="2020-01-06T12:00:00Z",
+            properties={"$browser": "Firefox"},
+        )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="p1",
+            timestamp="2020-01-06T12:00:00Z",
+            properties={"$browser": "Firefox"},
+        )
+
+        # only this event for p1 should be included
         _create_event(
             team=self.team,
             event="$pageview",
@@ -5111,6 +5134,16 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-10T12:00:00Z",
             properties={"$browser": "Firefox"},
         )
+
+        # only this event for p2 should be included
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="p2",
+            timestamp="2020-01-10T12:00:00Z",
+            properties={"$browser": "Firefox"},
+        )
+
         _create_event(
             team=self.team,
             event="$pageview",
@@ -5118,6 +5151,14 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             timestamp="2020-01-11T12:00:00Z",
             properties={"$browser": "Firefox"},
         )
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="p2",
+            timestamp="2020-01-11T12:00:00Z",
+            properties={"$browser": "Firefox"},
+        )
+
         flush_persons_and_events()
 
         response = self._run_trends_query(
@@ -5134,18 +5175,17 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             BreakdownFilter(breakdown_type=BreakdownType.EVENT, breakdown="$browser"),
         )
 
-        assert len(response.results) == 1
-        assert response.results[0]["count"] == 1
-        assert response.results[0]["data"] == [0, 0, 1, 0]
-
         # one for each breakdown value
         assert len(response.results) == 2
 
         # chrome
         assert response.results[0]["breakdown_value"] == "Chrome"
-        assert response.results[0]["count"] == 12
-        assert response.results[0]["data"] == [0, 0, 3, 3, 3, 0, 1, 0, 1, 0, 1, 0]
+        assert response.results[0]["count"] == 1
+        # match on 8th (p1) for first day in time range
+        assert response.results[0]["data"] == [1, 0, 0, 0]
 
         # firefox
         assert response.results[1]["breakdown_value"] == "Firefox"
-        assert response.results[1]["count"] == 4
+        assert response.results[1]["count"] == 1
+        # match on 10th (p2) for third day in time range
+        assert response.results[1]["data"] == [0, 0, 1, 0]

--- a/posthog/hogql_queries/insights/trends/trends_query_builder.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_builder.py
@@ -296,13 +296,11 @@ class TrendsQueryBuilder(DataWarehouseInsightQueryMixin):
         # Just complex series aggregation
         elif self._aggregation_operation.requires_query_orchestration() and (
             self._aggregation_operation.is_first_time_ever_math()
-            or self._aggregation_operation.is_first_matching_event()
         ):
             return self._aggregation_operation.get_first_time_math_query_orchestrator(
                 events_where_clause=events_filter,
                 sample_value=self._sample_value(),
                 event_name_filter=self._event_or_action_where_expr(),
-                is_first_matching_event=self._aggregation_operation.is_first_matching_event(),
             ).build()
         elif self._aggregation_operation.requires_query_orchestration():
             return self._aggregation_operation.get_actors_query_orchestrator(

--- a/posthog/hogql_queries/insights/utils/aggregations.py
+++ b/posthog/hogql_queries/insights/utils/aggregations.py
@@ -81,9 +81,10 @@ class FirstTimeForUserEventsQueryAlternator(QueryAlternator):
         aggregation_filters = date_from if filters is None else ast.And(exprs=[date_from, filters])
         min_timestamp_expr = (
             ast.Call(name="min", args=[ast.Field(chain=["timestamp"])])
-            if not is_first_matching_event or filters is None
-            else ast.Call(name="minIf", args=[ast.Field(chain=["timestamp"]), filters])
+            if not is_first_matching_event
+            else ast.Call(name="minIf", args=[ast.Field(chain=["timestamp"]), aggregation_filters])
         )
+
         return [
             ast.Alias(
                 alias="min_timestamp",


### PR DESCRIPTION
## Problem
The recently added first time matching event for trends was broken.
The existing test case for it never added events outside the date range, so it wasn't testing the feature correctly. The logic breaks when the test is fixed.

Also this feature was breaking (giving incorrect results) when breakdowns were added (see https://posthoghelp.zendesk.com/agent/tickets/24110 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26688))

## Changes
Fixes both of the above. `is_first_time_ever_math` is used in a lot of different scenarios and I think the overrides should be used for either `first_time_for_user`, or `first_matching_event_for_user`. 

Let me know if there's other edge cases that I might have missed.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?
Yes
<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Added tests
<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
