### PR TITLE
fix(cdp/linkedin): do not include an empty conversionValue object

### DIFF
--- a/posthog/cdp/templates/linkedin_ads/template_linkedin_ads.py
+++ b/posthog/cdp/templates/linkedin_ads/template_linkedin_ads.py
@@ -20,12 +20,13 @@ let body := {
     'eventId' : inputs.eventId
 }
 
-if (not empty(inputs.currencyCode)) {
+if (not empty(inputs.conversionValue) or not empty(inputs.conversionValue)) {
     body.conversionValue := {}
+}
+if (not empty(inputs.currencyCode)) {
     body.conversionValue.currencyCode := inputs.currencyCode
 }
 if (not empty(inputs.conversionValue)) {
-    body.conversionValue := {}
     body.conversionValue.amount := inputs.conversionValue
 }
 

--- a/posthog/cdp/templates/linkedin_ads/template_linkedin_ads.py
+++ b/posthog/cdp/templates/linkedin_ads/template_linkedin_ads.py
@@ -20,7 +20,7 @@ let body := {
     'eventId' : inputs.eventId
 }
 
-if (not empty(inputs.conversionValue) or not empty(inputs.conversionValue)) {
+if (not empty(inputs.conversionValue) or not empty(inputs.currencyCode)) {
     body.conversionValue := {}
 }
 if (not empty(inputs.currencyCode)) {

--- a/posthog/cdp/templates/linkedin_ads/template_linkedin_ads.py
+++ b/posthog/cdp/templates/linkedin_ads/template_linkedin_ads.py
@@ -13,7 +13,6 @@ template: HogFunctionTemplate = HogFunctionTemplate(
 let body := {
     'conversion': f'urn:lla:llaPartnerConversion:{inputs.conversionRuleId}',
     'conversionHappenedAt': inputs.conversionDateTime,
-    'conversionValue': {},
     'user': {
         'userIds': [],
         'userInfo': {}
@@ -22,9 +21,11 @@ let body := {
 }
 
 if (not empty(inputs.currencyCode)) {
+    body.conversionValue := {}
     body.conversionValue.currencyCode := inputs.currencyCode
 }
 if (not empty(inputs.conversionValue)) {
+    body.conversionValue := {}
     body.conversionValue.amount := inputs.conversionValue
 }
 

--- a/posthog/cdp/templates/linkedin_ads/test_template_linkedin_ads.py
+++ b/posthog/cdp/templates/linkedin_ads/test_template_linkedin_ads.py
@@ -43,7 +43,6 @@ class TestTemplateLinkedInAds(BaseHogFunctionTemplateTest):
                     "body": {
                         "conversion": "urn:lla:llaPartnerConversion:conversion-rule-12345",
                         "conversionHappenedAt": 1737464596570,
-                        "conversionValue": {"currencyCode": "USD", "amount": "100"},
                         "user": {
                             "userIds": [
                                 {

--- a/posthog/cdp/templates/linkedin_ads/test_template_linkedin_ads.py
+++ b/posthog/cdp/templates/linkedin_ads/test_template_linkedin_ads.py
@@ -60,6 +60,43 @@ class TestTemplateLinkedInAds(BaseHogFunctionTemplateTest):
                             },
                         },
                         "eventId": "event-12345",
+                        "conversionValue": {"currencyCode": "USD", "amount": "100"},
+                    },
+                },
+            )
+        )
+
+    def test_does_not_contain_an_empty_conversion_value_object(self):
+        self.run_function(self._inputs(conversionValue=None, currencyCode=None))
+        assert self.get_mock_fetch_calls()[0] == snapshot(
+            (
+                "https://api.linkedin.com/rest/conversionEvents",
+                {
+                    "method": "POST",
+                    "headers": {
+                        "Authorization": "Bearer oauth-1234",
+                        "Content-Type": "application/json",
+                        "LinkedIn-Version": "202409",
+                    },
+                    "body": {
+                        "conversion": "urn:lla:llaPartnerConversion:conversion-rule-12345",
+                        "conversionHappenedAt": 1737464596570,
+                        "user": {
+                            "userIds": [
+                                {
+                                    "idType": "SHA256_EMAIL",
+                                    "idValue": "3edfaed7454eedb3c72bad566901af8bfbed1181816dde6db91dfff0f0cffa98",
+                                },
+                                {"idType": "LINKEDIN_FIRST_PARTY_ADS_TRACKING_UUID", "idValue": "abc"},
+                            ],
+                            "userInfo": {
+                                "lastName": "AI",
+                                "firstName": "Max",
+                                "companyName": "PostHog",
+                                "countryCode": "US",
+                            },
+                        },
+                        "eventId": "event-12345",
                     },
                 },
             )


### PR DESCRIPTION
## Problem

LinkedIn does not accept empty `conversionValue` object's.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

added test
