### PR TITLE
feat(web-analytics): Deprecated sessions properties

### DIFF
--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -1563,12 +1563,12 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
         },
         $exit_current_url: {
             label: 'Exit URL',
-            description: 'The last URL visited in this session.',
+            description: 'The last URL visited in this session. (deprecated, use $end_current_url)',
             examples: ['https://example.com/interesting-article?parameter=true'],
         },
         $exit_pathname: {
             label: 'Exit pathname',
-            description: 'The last pathname visited in this session.',
+            description: 'The last pathname visited in this session. (deprecated, use $end_pathname)',
             examples: ['https://example.com/interesting-article?parameter=true'],
         },
         $pageview_count: {

--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -1559,7 +1559,7 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
         $end_pathname: {
             label: 'Entry pathname',
             description: 'The first pathname visited in this session.',
-            examples: ['/interesting-article?parameter=true'],
+            examples: ['/interesting-article'],
         },
         $exit_current_url: {
             label: 'Exit URL',
@@ -1569,7 +1569,7 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
         $exit_pathname: {
             label: 'Exit pathname',
             description: 'The last pathname visited in this session. (deprecated, use $end_pathname)',
-            examples: ['https://example.com/interesting-article?parameter=true'],
+            examples: ['/interesting-article'],
         },
         $pageview_count: {
             label: 'Pageview count',

--- a/frontend/src/lib/taxonomy.tsx
+++ b/frontend/src/lib/taxonomy.tsx
@@ -1553,12 +1553,12 @@ export const CORE_FILTER_DEFINITIONS_BY_GROUP = {
         },
         $end_current_url: {
             label: 'Entry URL',
-            description: 'The first URL visited in this session.',
+            description: 'The last URL visited in this session.',
             examples: ['https://example.com/interesting-article?parameter=true'],
         },
         $end_pathname: {
             label: 'Entry pathname',
-            description: 'The first pathname visited in this session.',
+            description: 'The last pathname visited in this session.',
             examples: ['/interesting-article'],
         },
         $exit_current_url: {


### PR DESCRIPTION
## Problem

These don't appear in searches but do appear elsewhere, just make it clear that it's deprecated

## Changes

Add deprecation to text

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?
n/a
