### PR TITLE
fix(editor-3001): fix limit text

### DIFF
--- a/frontend/src/queries/nodes/DataNode/LoadNext.tsx
+++ b/frontend/src/queries/nodes/DataNode/LoadNext.tsx
@@ -70,10 +70,6 @@ export function LoadNext({ query }: LoadNextProps): JSX.Element {
 export function LoadPreviewText(): JSX.Element {
     const { numberOfRows, hasMoreData } = useValues(dataNodeLogic)
 
-    if (!hasMoreData) {
-        return <></>
-    }
-
     return (
         <>
             Showing {hasMoreData && (numberOfRows ?? 0) > 1 ? 'first ' : ' '}

--- a/frontend/src/queries/nodes/DataNode/LoadNext.tsx
+++ b/frontend/src/queries/nodes/DataNode/LoadNext.tsx
@@ -28,6 +28,11 @@ export function LoadNext({ query }: LoadNextProps): JSX.Element {
                 // If the number of rows is greater than the default page size, it's handled by pagination component
                 return ''
             }
+            if (numberOfRows && numberOfRows < dataLimit) {
+                return `Showing ${numberOfRows === 1 ? '' : 'all'} ${numberOfRows === 1 ? 'one' : numberOfRows} ${
+                    numberOfRows === 1 ? 'entry' : 'entries'
+                }`
+            }
             return `Default limit of ${dataLimit} rows reached`
         } else if (isHogQLQuery(query) && !canLoadNextData && hasMoreData && dataLimit) {
             return `Default limit of ${dataLimit} rows reached. Try adding a LIMIT clause to adjust.`

--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -20,7 +20,7 @@ interface TableProps {
     cachedResults: HogQLQueryResponse | undefined
 }
 
-export const DEFAULT_PAGE_SIZE = 2000
+export const DEFAULT_PAGE_SIZE = 500
 
 export const Table = (props: TableProps): JSX.Element => {
     const { isDarkModeOn } = useValues(themeLogic)


### PR DESCRIPTION
## Problem

- default limit isn't compared correctly

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- use the right values for comparison when showing limit copy at the end of table
- also adjustments on paging and where text is shown

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
