### PR TITLE
fix: Improve customer.io format

### DIFF
--- a/posthog/cdp/templates/customerio/template_customerio.py
+++ b/posthog/cdp/templates/customerio/template_customerio.py
@@ -17,17 +17,14 @@ template: HogFunctionTemplate = HogFunctionTemplate(
 let action := inputs.action
 let name := event.event
 
-let hasIdentifier := false
 
-for (let key, value in inputs.identifiers) {
-    if (not empty(value)) {
-        hasIdentifier := true
-    }
+if (empty(inputs.identifier_value) or empty(inputs.identifier_key)) {
+    print('No identifier set. Skipping as identifier is required.')
+    return
 }
 
-if (not hasIdentifier) {
-    print('No identifier set. Skipping as at least 1 identifier is needed.')
-    return
+let identifiers = {
+    inputs.identifier_key: inputs.identifier_value
 }
 
 if (action == 'automatic') {
@@ -66,7 +63,7 @@ let res := fetch(f'https://{inputs.host}/api/v2/entity', {
         'type': 'person',
         'action': action,
         'name': name,
-        'identifiers': inputs.identifiers,
+        'identifiers': identifiers,
         'attributes': attributes,
         'timestamp': timestamp
     }
@@ -113,13 +110,34 @@ if (res.status >= 400) {
             "required": True,
         },
         {
-            "key": "identifiers",
-            "type": "dictionary",
-            "label": "Identifiers",
-            "description": "You can choose to fill this from an `email` property or an `id` property. If the value is empty nothing will be sent. See here for more information: https://customer.io/docs/api/track/#operation/entity",
-            "default": {
-                "email": "{person.properties.email}",
-            },
+            "key": "identifier_key",
+            "type": "choice",
+            "label": "Identifier key",
+            "description": "The kind of identifier to be used. See here for more information: https://customer.io/docs/api/track/#operation/entity",
+            "default": "email",
+            "choices": [
+                {
+                    "label": "Email",
+                    "value": "email",
+                },
+                {
+                    "label": "ID",
+                    "value": "id",
+                },
+                {
+                    "label": "Customer.io ID",
+                    "value": "cio_id",
+                },
+            ],
+            "secret": False,
+            "required": True,
+        },
+        {
+            "key": "identifier_value",
+            "type": "string",
+            "label": "Identifier value",
+            "description": "The value to be used for the identifier. If the value is empty nothing will be sent. See here for more information: https://customer.io/docs/api/track/#operation/entity",
+            "default": "{person.properties.email}",
             "secret": False,
             "required": True,
         },

--- a/posthog/cdp/templates/customerio/template_customerio.py
+++ b/posthog/cdp/templates/customerio/template_customerio.py
@@ -23,7 +23,7 @@ if (empty(inputs.identifier_value) or empty(inputs.identifier_key)) {
     return
 }
 
-let identifiers = {
+let identifiers := {
     inputs.identifier_key: inputs.identifier_value
 }
 

--- a/posthog/cdp/templates/customerio/test_template_customerio.py
+++ b/posthog/cdp/templates/customerio/test_template_customerio.py
@@ -17,7 +17,8 @@ def create_inputs(**kwargs):
         "host": "track.customer.io",
         "action": "automatic",
         "include_all_properties": False,
-        "identifiers": {"email": "example@posthog.com"},
+        "identifier_key": "email",
+        "identifier_value": "example@posthog.com",
         "attributes": {"name": "example"},
     }
     inputs.update(kwargs)
@@ -112,12 +113,10 @@ class TestTemplateCustomerio(BaseHogFunctionTemplateTest):
             assert self.get_mock_fetch_calls()[0][1]["body"]["name"] == event_name
 
     def test_function_requires_identifier(self):
-        self.run_function(inputs=create_inputs(identifiers={"email": None, "id": ""}))
+        self.run_function(inputs=create_inputs(identifier_key="email", identifier_value=""))
 
         assert not self.get_mock_fetch_calls()
-        assert self.get_mock_print_calls() == snapshot(
-            [("No identifier set. Skipping as at least 1 identifier is needed.",)]
-        )
+        assert self.get_mock_print_calls() == snapshot([("No identifier set. Skipping as identifier is required.",)])
 
     def test_function_errors_on_bad_status(self):
         self.mock_fetch_response = lambda *args: {"status": 400, "body": {"error": "error"}}  # type: ignore


### PR DESCRIPTION
## Problem

Got some feedback that it is misleading how our template works suggesting that multiple identifiers for customer.io can be used - which they cannot.

## Changes

* Modifies it to have two values for the identifiers to choose explicitly

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
