### PR TITLE
fix(batch-exports): Always use not materialized properties

### DIFF
--- a/posthog/temporal/batch_exports/spmc.py
+++ b/posthog/temporal/batch_exports/spmc.py
@@ -16,7 +16,11 @@ from posthog.hogql.hogql import ast
 from posthog.hogql.parser import parse_expr
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
 from posthog.hogql.property import property_to_expr
-from posthog.schema import EventPropertyFilter
+from posthog.schema import (
+    EventPropertyFilter,
+    HogQLQueryModifiers,
+    MaterializationMode,
+)
 from posthog.temporal.batch_exports.heartbeat import BatchExportRangeHeartbeatDetails, DateRange
 from posthog.temporal.batch_exports.metrics import (
     get_bytes_exported_metric,
@@ -856,6 +860,7 @@ def compose_filters_clause(
         limit_top_select=False,
         within_non_hogql_query=True,
         values=values or {},
+        modifiers=HogQLQueryModifiers(materializationMode=MaterializationMode.DISABLED),
     )
     context.database = create_hogql_database(team.id, context.modifiers)
 

--- a/posthog/temporal/tests/batch_exports/test_spmc.py
+++ b/posthog/temporal/tests/batch_exports/test_spmc.py
@@ -232,6 +232,13 @@ def test_use_events_recent(test_data: dict[str, typing.Any]):
         ),
         (
             [
+                {"key": "$current_url", "operator": "icontains", "type": "event", "value": "https://posthog.com"},
+            ],
+            """ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), %(hogql_val_1)s), 0)""",
+            {"hogql_val_0": "$current_url", "hogql_val_1": "%https://posthog.com%"},
+        ),
+        (
+            [
                 {"key": "$browser", "operator": "exact", "type": "event", "value": ["Firefox"]},
                 {"key": "test", "operator": "exact", "type": "event", "value": ["Test"]},
             ],


### PR DESCRIPTION
## Problem

HogQL printing is using materialized columns, which are not present in `events_recent`.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Set materialization mode to disabled, so queries always resolve to extracting from properties.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

Unfortunately, I couldn't figure out how to materialize a column using existing test utilities in our test within 10 minutes, so I gave up. We have tests for `MaterializedMode.DISABLED` which cover this scenario, so I'm trusting those. I did add an additional unit test case to our unit test, but without materialized columns, `MaterializedMode.DISABLED` is already implied.

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
