### PR TITLE
fix(hogvm): fix arrayMap js translation

### DIFF
--- a/posthog/hogql/compiler/javascript.py
+++ b/posthog/hogql/compiler/javascript.py
@@ -552,7 +552,7 @@ class JavaScriptCompiler(Visitor):
         self._end_scope()
         self.stl_functions.add("__lambda")
         # we wrap it in __lambda() to make the function anonymous (a true lambda without a name)
-        return f"__lambda(({params_code}) => {expr_code})"
+        return f"__lambda(({params_code}) => ({expr_code}))"
 
     def visit_dict(self, node: ast.Dict):
         items = []


### PR DESCRIPTION
## Problem

needed for: https://github.com/PostHog/posthog/pull/28369

This hog code:
```
{arrayMap(product -> ({ 'content_id': product.product_id, 'price': product.price, 'content_category': product.category, 'content_name': product.name, 'brand': product.brand, 'quantity': product.quantity }), event.properties.products)}
```

Results in the following js code:
```
try {
  newInputs["eventProperties"] = {
    "value": toFloat(((__getProperty(__getProperty(__getGlobal("event"), "properties", true), "value", true) ?? __getProperty(__getProperty(__getGlobal("event"), "properties", true), "revenue", true)) ?? __getProperty(__getProperty(__getGlobal("event"), "properties", true), "price", true))),
    "shop_id": __getProperty(__getProperty(__getGlobal("event"), "properties", true), "shop_id", true),
    "contents": arrayMap(__lambda((product) => {      <----- Parenthesis missing here 
      "content_id": __getProperty(product, "product_id", true),
        "price": __getProperty(product, "price", true),
          "content_category": __getProperty(product, "category", true),
            "content_name": __getProperty(product, "name", true),
              "brand": __getProperty(product, "brand", true),
                "quantity": __getProperty(product, "quantity", true)
    }), __getProperty(__getProperty(__getGlobal("event"), "properties", true), "products", true)),
    "currency": (__getProperty(__getProperty(__getGlobal("event"), "properties", true), "currency", true) ?? "USD"),
    "order_id": __getProperty(__getProperty(__getGlobal("event"), "properties", true), "order_id", true),
    "num_items": length((__getProperty(__getProperty(__getGlobal("event"), "properties", true), "products", true) ?? [])),
    "content_ids": arrayMap(__lambda((product) => __getProperty(product, "product_id", true)), __getProperty(__getProperty(__getGlobal("event"), "properties", true), "products", true)),
    "description": __getProperty(__getProperty(__getGlobal("event"), "properties", true), "name", true),
    "search_string": (__getProperty(__getProperty(__getGlobal("event"), "properties", true), "query", true) ?? __getProperty(__getProperty(__getGlobal("event"), "properties", true), "search_string", true))
  };
} catch (e) {
  console.error(e)
}
```

That code is failing with
```
config.js:127 Uncaught SyntaxError: Unexpected token ':' (at config.js:127:492)
```

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
