### PR TITLE
fix: allow org creation for dev

### DIFF
--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -925,6 +925,7 @@ def get_can_create_org(user: Union["AbstractBaseUser", "AnonymousUser"]) -> bool
     - if on PostHog Cloud
     - if running end-to-end tests
     - if there's no organization yet
+    - if DEBUG is True
     - if an appropriate license is active and MULTI_ORG_ENABLED is True
     """
     from posthog.models.organization import Organization
@@ -933,6 +934,7 @@ def get_can_create_org(user: Union["AbstractBaseUser", "AnonymousUser"]) -> bool
         is_cloud()  # There's no limit of organizations on Cloud
         or (settings.DEMO and user.is_anonymous)  # Demo users can have a single demo org, but not more
         or settings.E2E_TESTING
+        or settings.DEBUG
         or not Organization.objects.filter(for_internal_metrics=False).exists()  # Definitely can create an org if zero
     ):
         return True


### PR DESCRIPTION
## Problem

We currently block org creation in dev, makes it hard when testing onboarding scenarios

## Changes

Allow creating orgs when `DEBUG=True`

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Manually
