### PR TITLE
fix: take users to onboarding for new orgs

### DIFF
--- a/frontend/src/scenes/organizationLogic.tsx
+++ b/frontend/src/scenes/organizationLogic.tsx
@@ -7,9 +7,11 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { isUserLoggedIn } from 'lib/utils'
 import { getAppContext } from 'lib/utils/getAppContext'
 
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { AvailableFeature, OrganizationType } from '~/types'
 
 import type { organizationLogicType } from './organizationLogicType'
+import { urls } from './urls'
 import { userLogic } from './userLogic'
 
 export type OrganizationUpdatePayload = Partial<
@@ -114,7 +116,8 @@ export const organizationLogic = kea<organizationLogicType>([
             }
         },
         createOrganizationSuccess: () => {
-            window.location.href = '/organization/members'
+            sidePanelStateLogic.findMounted()?.actions.closeSidePanel()
+            window.location.href = urls.products()
         },
         updateOrganizationSuccess: () => {
             lemonToast.success('Your configuration has been saved')

--- a/frontend/src/scenes/projectLogic.ts
+++ b/frontend/src/scenes/projectLogic.ts
@@ -10,6 +10,7 @@ import { ProjectType } from '~/types'
 
 import { organizationLogic } from './organizationLogic'
 import type { projectLogicType } from './projectLogicType'
+import { urls } from './urls'
 import { userLogic } from './userLogic'
 
 export const projectLogic = kea<projectLogicType>([
@@ -132,7 +133,7 @@ export const projectLogic = kea<projectLogicType>([
         },
         createProjectSuccess: ({ currentProject }) => {
             if (currentProject) {
-                actions.switchTeam(currentProject.id)
+                actions.switchTeam(currentProject.id, urls.products())
             }
         },
 

--- a/frontend/src/scenes/userLogic.ts
+++ b/frontend/src/scenes/userLogic.ts
@@ -8,6 +8,7 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { getAppContext } from 'lib/utils/getAppContext'
 import posthog from 'posthog-js'
 
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { AvailableFeature, OrganizationBasicType, ProductKey, UserRole, UserTheme, UserType } from '~/types'
 
 import { urls } from './urls'
@@ -27,7 +28,7 @@ export const userLogic = kea<userLogicType>([
         updateUser: (user: Partial<UserType>, successCallback?: () => void) => ({ user, successCallback }),
         setUserScenePersonalisation: (scene: DashboardCompatibleScenes, dashboard: number) => ({ scene, dashboard }),
         updateHasSeenProductIntroFor: (productKey: ProductKey, value: boolean) => ({ productKey, value }),
-        switchTeam: (teamId: string | number) => ({ teamId }),
+        switchTeam: (teamId: string | number, destination?: string) => ({ teamId, destination }),
     })),
     forms(({ actions }) => ({
         userDetails: {
@@ -181,6 +182,9 @@ export const userLogic = kea<userLogicType>([
             }
             await breakpoint(10)
             await api.update('api/users/@me/', { set_current_organization: organizationId })
+
+            sidePanelStateLogic.findMounted()?.actions.closeSidePanel()
+
             window.location.href = destination || '/'
         },
         updateHasSeenProductIntroFor: async ({ productKey, value }, breakpoint) => {
@@ -196,8 +200,10 @@ export const userLogic = kea<userLogicType>([
                     actions.loadUser()
                 })
         },
-        switchTeam: ({ teamId }) => {
-            window.location.href = urls.project(teamId)
+        switchTeam: ({ teamId, destination }) => {
+            sidePanelStateLogic.findMounted()?.actions.closeSidePanel()
+
+            window.location.href = destination || urls.project(teamId)
         },
     })),
     selectors({


### PR DESCRIPTION
## Problem

Users are taken to member settings for org creation which confuses them quite a lot.

## Changes

Take them straight to onboarding after org creation.

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

Created some orgs locally.
