### PR TITLE
chore: check for GNU version of sed in build-schema-python

### DIFF
--- a/bin/build-schema-python.sh
+++ b/bin/build-schema-python.sh
@@ -20,11 +20,12 @@ ruff check --fix posthog/schema.py
 
 # Replace class Foo(str, Enum) with class Foo(StrEnum) for proper handling in format strings in python 3.11
 # Remove this when https://github.com/koxudaxi/datamodel-code-generator/issues/1313 is resolved
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    # sed needs `-i` to be followed by `''` on macOS
-    sed -i '' -e 's/str, Enum/StrEnum/g' posthog/schema.py
-    sed -i '' 's/from enum import Enum/from enum import Enum, StrEnum/g' posthog/schema.py
-else
+if sed --version 2>&1 | grep -q GNU; then
+    # GNU sed
     sed -i -e 's/str, Enum/StrEnum/g' posthog/schema.py
     sed -i 's/from enum import Enum/from enum import Enum, StrEnum/g' posthog/schema.py
+else
+    # BSD/macOS sed
+    sed -i '' -e 's/str, Enum/StrEnum/g' posthog/schema.py
+    sed -i '' 's/from enum import Enum/from enum import Enum, StrEnum/g' posthog/schema.py
 fi


### PR DESCRIPTION
## Problem
`bin/build-schema-python.sh` does not work on my mac as I happen to have the GNU version of sed installed.

## Changes
Check for GNU version of `sed`  directly instead of the proxy check `"$OSTYPE" == "darwin"`

## How did you test this code?
* ran `bin/build-schema-python.sh`
