### PR TITLE
feat(cdp): add ip anon transformation

### DIFF
--- a/plugin-server/src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.test.ts
@@ -48,12 +48,12 @@ describe('ip-anonymization.template', () => {
 
     it('should handle invalid IP address format', async () => {
         const invalidIPs = [
-            '89.160.20',  // missing octet
-            '',           // empty string
-            'abc.def.ghi.jkl',  // non-numeric
-            '256.256.256.256',  // values > 255
-            '1.2.3.4.5',  // too many octets
-            'not an ip'
+            '89.160.20', // missing octet
+            '', // empty string
+            'abc.def.ghi.jkl', // non-numeric
+            '256.256.256.256', // values > 255
+            '1.2.3.4.5', // too many octets
+            'not an ip',
         ]
 
         for (const invalidIP of invalidIPs) {
@@ -71,7 +71,7 @@ describe('ip-anonymization.template', () => {
             expect(response.error).toBeUndefined()
             expect(response.execResult).toMatchObject({
                 properties: {
-                    $ip: invalidIP,  // should return unchanged
+                    $ip: invalidIP,
                 },
             })
         }

--- a/plugin-server/src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.test.ts
@@ -47,24 +47,34 @@ describe('ip-anonymization.template', () => {
     })
 
     it('should handle invalid IP address format', async () => {
-        mockGlobals = tester.createGlobals({
-            event: {
-                properties: {
-                    $ip: '89.160.20', // Invalid IP - missing octet
+        const invalidIPs = [
+            '89.160.20',  // missing octet
+            '',           // empty string
+            'abc.def.ghi.jkl',  // non-numeric
+            '256.256.256.256',  // values > 255
+            '1.2.3.4.5',  // too many octets
+            'not an ip'
+        ]
+
+        for (const invalidIP of invalidIPs) {
+            mockGlobals = tester.createGlobals({
+                event: {
+                    properties: {
+                        $ip: invalidIP,
+                    },
                 },
-            },
-        })
+            })
 
-        const response = await tester.invoke({}, mockGlobals)
+            const response = await tester.invoke({}, mockGlobals)
 
-        expect(response.finished).toBe(true)
-        expect(response.error).toBeUndefined()
-        // Should return unchanged event when IP format is invalid
-        expect(response.execResult).toMatchObject({
-            properties: {
-                $ip: '89.160.20',
-            },
-        })
+            expect(response.finished).toBe(true)
+            expect(response.error).toBeUndefined()
+            expect(response.execResult).toMatchObject({
+                properties: {
+                    $ip: invalidIP,  // should return unchanged
+                },
+            })
+        }
     })
 
     it('should handle various IPv4 formats', async () => {

--- a/plugin-server/src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.test.ts
@@ -1,0 +1,97 @@
+import { HogFunctionInvocationGlobals } from '../../../types'
+import { TemplateTester } from '../../test/test-helpers'
+import { template } from './ip-anonymization.template'
+
+describe('ip-anonymization.template', () => {
+    const tester = new TemplateTester(template)
+    let mockGlobals: HogFunctionInvocationGlobals
+
+    beforeEach(async () => {
+        await tester.beforeEach()
+    })
+
+    it('should anonymize IPv4 address by zeroing last octet', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $ip: '89.160.20.129',
+                },
+            },
+        })
+
+        const response = await tester.invoke({}, mockGlobals)
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect(response.execResult).toMatchObject({
+            properties: {
+                $ip: '89.160.20.0',
+            },
+        })
+    })
+
+    it('should handle event with no IP address', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {},
+            },
+        })
+
+        const response = await tester.invoke({}, mockGlobals)
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect(response.execResult).toMatchObject({
+            properties: {},
+        })
+    })
+
+    it('should handle invalid IP address format', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $ip: '89.160.20', // Invalid IP - missing octet
+                },
+            },
+        })
+
+        const response = await tester.invoke({}, mockGlobals)
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        // Should return unchanged event when IP format is invalid
+        expect(response.execResult).toMatchObject({
+            properties: {
+                $ip: '89.160.20',
+            },
+        })
+    })
+
+    it('should handle various IPv4 formats', async () => {
+        const testCases = [
+            { input: '192.168.1.1', expected: '192.168.1.0' },
+            { input: '10.0.0.255', expected: '10.0.0.0' },
+            { input: '172.16.254.1', expected: '172.16.254.0' },
+        ]
+
+        for (const testCase of testCases) {
+            mockGlobals = tester.createGlobals({
+                event: {
+                    properties: {
+                        $ip: testCase.input,
+                    },
+                },
+            })
+
+            const response = await tester.invoke({}, mockGlobals)
+
+            expect(response.finished).toBe(true)
+            expect(response.error).toBeUndefined()
+            expect(response.execResult).toMatchObject({
+                properties: {
+                    $ip: testCase.expected,
+                },
+            })
+        }
+    })
+})

--- a/plugin-server/src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.ts
@@ -1,0 +1,47 @@
+import { HogFunctionTemplate } from '../../types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'alpha',
+    type: 'transformation',
+    id: 'template-ip-anonymization',
+    name: 'IP Anonymization',
+    description:
+        'This transformation sets the last octet of an IP address to zero (e.g., 12.214.31.144 → 12.214.31.0), protecting user privacy and reducing disclosure risk.',
+    icon_url: '/static/hedgehog/builder-hog-01.png',
+    category: ['Custom'],
+    hog: `
+// Check if the event has an IP address
+if (empty(event.properties?.$ip)) {
+    print('No IP address found in event')
+    return event
+}
+
+let ip := event.properties.$ip
+let parts := splitByString('.', ip)
+
+// Check if we have a valid IPv4 address
+if (length(parts) = 4) {
+    // Replace the last octet with '0'
+    let anonymizedIp := concat(
+        parts[1], 
+        '.', 
+        parts[2], 
+        '.', 
+        parts[3], 
+        '.0'
+    )
+    
+    let returnEvent := event
+    returnEvent.properties.$ip := anonymizedIp
+    
+    print('Anonymized IP', ip, '->', anonymizedIp)
+    return returnEvent
+}
+
+// If we don't have a valid IPv4, return original event
+print('Invalid IPv4 address format:', ip)
+return event
+    `,
+    inputs_schema: [],
+}

--- a/plugin-server/src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.ts
@@ -34,13 +34,10 @@ if (length(parts) = 4) {
     
     let returnEvent := event
     returnEvent.properties.$ip := anonymizedIp
-    
-    print('Anonymized IP', ip, '->', anonymizedIp)
     return returnEvent
 }
 
 // If we don't have a valid IPv4, return original event
-print('Invalid IPv4 address format:', ip)
 return event
     `,
     inputs_schema: [],

--- a/plugin-server/src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/ip-anonymization/ip-anonymization.template.ts
@@ -20,25 +20,27 @@ if (empty(event.properties?.$ip)) {
 let ip := event.properties.$ip
 let parts := splitByString('.', ip)
 
-// Check if we have a valid IPv4 address
-if (length(parts) = 4) {
-    // Replace the last octet with '0'
-    let anonymizedIp := concat(
-        parts[1], 
-        '.', 
-        parts[2], 
-        '.', 
-        parts[3], 
-        '.0'
-    )
-    
-    let returnEvent := event
-    returnEvent.properties.$ip := anonymizedIp
-    return returnEvent
+// Check if we have exactly 4 parts for IPv4
+if (length(parts) != 4) {
+    print('Invalid IP address format: wrong number of octets')
+    return event
 }
 
-// If we don't have a valid IPv4, return original event
-return event
+// Validate each octet is a number between 0 and 255
+for (let i := 1; i <= 4; i := i + 1) {
+    let octet := toInt(parts[i])
+    if (octet = null or octet < 0 or octet > 255) {
+        print('Invalid IP address: octets must be numbers between 0 and 255')
+        return event
+    }
+}
+
+// Replace the last octet with '0'
+let anonymizedIp := concat(parts[1], '.', parts[2], '.', parts[3], '.0')
+    
+let returnEvent := event
+returnEvent.properties.$ip := anonymizedIp
+return returnEvent
     `,
     inputs_schema: [],
 }

--- a/plugin-server/src/cdp/templates/index.ts
+++ b/plugin-server/src/cdp/templates/index.ts
@@ -2,6 +2,7 @@ import { DESTINATION_PLUGINS, TRANSFORMATION_PLUGINS } from '../legacy-plugins'
 import { template as webhookTemplate } from './_destinations/webhook/webhook.template'
 import { template as defaultTransformationTemplate } from './_transformations/default/default.template'
 import { template as geoipTemplate } from './_transformations/geoip/geoip.template'
+import { template as ipAnonymizationTemplate } from './_transformations/ip-anonymization/ip-anonymization.template'
 import { HogFunctionTemplate } from './types'
 
 export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [webhookTemplate]
@@ -9,6 +10,7 @@ export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [webho
 export const HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS: HogFunctionTemplate[] = [
     defaultTransformationTemplate,
     geoipTemplate,
+    ipAnonymizationTemplate,
 ]
 
 export const HOG_FUNCTION_TEMPLATES_DESTINATIONS_DEPRECATED: HogFunctionTemplate[] = DESTINATION_PLUGINS.map(


### PR DESCRIPTION
## Problem

We want to offer the same (or better) transformations as competitors.
IP anonymization transformation but uses string splitting instead of regex for performance. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- added IPv4 anonymization hog transformation

<img width="1094" alt="Screenshot 2025-02-06 at 15 02 46" src="https://github.com/user-attachments/assets/28038c30-ae5c-4e79-a0dc-e34c371dc8c9" />

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- added tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
