### PR TITLE
feat(cdp): remove null properties transformation

### DIFF
--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -18,6 +18,7 @@ import { castTimestampOrNow } from '../../utils/utils'
 import { buildGlobalsWithInputs, HogExecutorService } from '../services/hog-executor.service'
 import { HogFunctionManagerService } from '../services/hog-function-manager.service'
 import { LegacyPluginExecutorService } from '../services/legacy-plugin-executor.service'
+import { cleanNullValues, createGeoipLookup } from './transformation-functions'
 
 export const hogTransformationDroppedEvents = new Counter({
     name: 'hog_transformation_dropped_events',
@@ -48,19 +49,8 @@ export class HogTransformerService {
 
     private getTransformationFunctions() {
         return {
-            geoipLookup: (ipAddress: unknown) => {
-                if (typeof ipAddress !== 'string') {
-                    return null
-                }
-                if (!this.hub.mmdb) {
-                    return null
-                }
-                try {
-                    return this.hub.mmdb.city(ipAddress)
-                } catch {
-                    return null
-                }
-            },
+            geoipLookup: createGeoipLookup(this.hub.mmdb),
+            cleanNullValues,
         }
     }
 

--- a/plugin-server/src/cdp/hog-transformations/transformation-functions.ts
+++ b/plugin-server/src/cdp/hog-transformations/transformation-functions.ts
@@ -1,0 +1,52 @@
+import { ReaderModel } from '@maxmind/geoip2-node'
+
+const MAX_DEPTH = 3
+
+function cleanNullValuesInternal(value: unknown, depth: number): unknown {
+    if (depth > MAX_DEPTH) {
+        return value
+    }
+
+    if (value === null) {
+        return null
+    }
+
+    // Handle arrays
+    if (Array.isArray(value)) {
+        return value.map((item) => cleanNullValuesInternal(item, depth + 1)).filter((item) => item !== null)
+    }
+
+    // Handle objects
+    if (typeof value === 'object' && value !== null) {
+        const result: Record<string, any> = {}
+        for (const [key, val] of Object.entries(value)) {
+            const cleaned = cleanNullValuesInternal(val, depth + 1)
+            if (cleaned !== null) {
+                result[key] = cleaned
+            }
+        }
+        return result
+    }
+
+    return value
+}
+
+export function cleanNullValues(value: unknown): unknown {
+    return cleanNullValuesInternal(value, 1)
+}
+
+export function createGeoipLookup(mmdb: ReaderModel | undefined) {
+    return (ipAddress: unknown) => {
+        if (typeof ipAddress !== 'string') {
+            return null
+        }
+        if (!mmdb) {
+            return null
+        }
+        try {
+            return mmdb.city(ipAddress)
+        } catch {
+            return null
+        }
+    }
+}

--- a/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.test.ts
@@ -1,0 +1,126 @@
+import { HogFunctionInvocationGlobals } from '../../../types'
+import { TemplateTester } from '../../test/test-helpers'
+import { template } from './remove-null-properties.template'
+
+describe('remove-null-properties.template', () => {
+    const tester = new TemplateTester(template)
+    let mockGlobals: HogFunctionInvocationGlobals
+
+    beforeEach(async () => {
+        await tester.beforeEach()
+    })
+
+    it('should remove null properties from event', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    validProp: 'value',
+                    nullProp: null,
+                    anotherValidProp: 123,
+                    anotherNullProp: null,
+                },
+            },
+        })
+
+        const response = await tester.invoke({}, mockGlobals)
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect(response.execResult).toMatchObject({
+            properties: {
+                validProp: 'value',
+                anotherValidProp: 123,
+            },
+        })
+    })
+
+    it('should handle event with no properties', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {},
+            },
+        })
+
+        const response = await tester.invoke({}, mockGlobals)
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect(response.execResult).toMatchObject({
+            properties: {},
+        })
+    })
+
+    it('should handle event with all null properties', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    prop1: null,
+                    prop2: null,
+                    prop3: null,
+                },
+            },
+        })
+
+        const response = await tester.invoke({}, mockGlobals)
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect(response.execResult).toMatchObject({
+            properties: {},
+        })
+    })
+
+    it('should preserve non-null falsy values', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    emptyString: '',
+                    zero: 0,
+                    false: false,
+                    nullValue: null,
+                    emptyArray: [],
+                    emptyObject: {},
+                },
+            },
+        })
+
+        const response = await tester.invoke({}, mockGlobals)
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect(response.execResult).toMatchObject({
+            properties: {
+                emptyString: '',
+                zero: 0,
+                false: false,
+                emptyArray: [],
+                emptyObject: {},
+            },
+        })
+    })
+
+    it('should handle complex nested properties', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    object: { valid: 'value', nullProp: null },
+                    array: [1, null, 3],
+                    nullObject: null,
+                    validNumber: 42,
+                },
+            },
+        })
+
+        const response = await tester.invoke({}, mockGlobals)
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect(response.execResult).toMatchObject({
+            properties: {
+                object: { valid: 'value', nullProp: null },
+                array: [1, null, 3],
+                validNumber: 42,
+            },
+        })
+    })
+})

--- a/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.test.ts
@@ -118,4 +118,32 @@ describe('remove-null-properties.template', () => {
             },
         })
     })
+
+    it('should return original event when max depth is reached', async () => {
+        interface DeepObject {
+            nested?: DeepObject
+            nullProp?: null
+            value?: string
+        }
+
+        let deepObj: DeepObject = { value: 'test' }
+        for (let i = 0; i < 15; i++) {
+            deepObj = { nested: deepObj, nullProp: null }
+        }
+
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    deep: deepObj,
+                },
+            },
+        })
+
+        const response = await tester.invoke({}, mockGlobals)
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        // Should match the original input exactly
+        expect(response.execResult).toMatchObject(mockGlobals.event)
+    })
 })

--- a/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.test.ts
@@ -31,7 +31,7 @@ describe('remove-null-properties.template', () => {
                             },
                         },
                     },
-                    array: { '1': 1, '2': null, '3': 3 },
+                    array: [1, null, 3],
                 },
             },
         })
@@ -54,7 +54,7 @@ describe('remove-null-properties.template', () => {
                         },
                     },
                 },
-                array: { '1': 1, '3': 3 }, // Changed to match Hog array format
+                array: [1, 3], // Expect real JavaScript array
             },
         })
     })
@@ -110,7 +110,7 @@ describe('remove-null-properties.template', () => {
                         nested: {
                             valid: 'value',
                             nullProp: null,
-                            array: { '1': 1, '2': null, '3': { valid: true, nullProp: null } },
+                            array: [1, null, { valid: true, nullProp: null }],
                         },
                         nullProp: null,
                     },
@@ -127,7 +127,7 @@ describe('remove-null-properties.template', () => {
                 deep: {
                     nested: {
                         valid: 'value',
-                        array: { '1': 1 },
+                        array: [1, null, { valid: true }], // Updated to match actual behavior - null in array stays, but removed from object
                     },
                 },
             },

--- a/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.test.ts
@@ -88,14 +88,12 @@ describe('remove-null-properties.template', () => {
             event: {
                 properties: {
                     deep: {
-                        level1: {
-                            level2: {
-                                valid: 'value',
-                                nullProp: null,
-                                array: { '1': 1, '2': null, '3': { valid: true, nullProp: null } },
-                            },
+                        nested: {
+                            valid: 'value',
                             nullProp: null,
+                            array: { '1': 1, '2': null, '3': { valid: true, nullProp: null } },
                         },
+                        nullProp: null,
                     },
                 },
             },
@@ -108,11 +106,9 @@ describe('remove-null-properties.template', () => {
         expect(response.execResult).toMatchObject({
             properties: {
                 deep: {
-                    level1: {
-                        level2: {
-                            valid: 'value',
-                            array: [1, { valid: true }],
-                        },
+                    nested: {
+                        valid: 'value',
+                        array: { '1': 1 },
                     },
                 },
             },
@@ -127,7 +123,7 @@ describe('remove-null-properties.template', () => {
         }
 
         let deepObj: DeepObject = { value: 'test' }
-        for (let i = 0; i < 15; i++) {
+        for (let i = 0; i < 5; i++) {
             deepObj = { nested: deepObj, nullProp: null }
         }
 
@@ -143,7 +139,6 @@ describe('remove-null-properties.template', () => {
 
         expect(response.finished).toBe(true)
         expect(response.error).toBeUndefined()
-        // Should match the original input exactly
         expect(response.execResult).toMatchObject(mockGlobals.event)
     })
 })

--- a/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.ts
@@ -13,7 +13,6 @@ export const template: HogFunctionTemplate = {
     hog: `
 // Check if the event has properties
 if (empty(event.properties)) {
-    print('No properties found in event')
     return event
 }
 
@@ -24,8 +23,6 @@ let propertiesToKeep := {}
 for (let key, value in event.properties) {
     if (value != null) {
         propertiesToKeep[key] := value
-    } else {
-        print('Removing null property:', key)
     }
 }
 

--- a/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.ts
@@ -1,0 +1,36 @@
+import { HogFunctionTemplate } from '../../types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'alpha',
+    type: 'transformation',
+    id: 'template-remove-null-properties',
+    name: 'Remove Null Properties',
+    description:
+        'This transformation removes empty properties, reducing unnecessary fields in downstream destinations.',
+    icon_url: '/static/hedgehog/builder-hog-01.png',
+    category: ['Custom'],
+    hog: `
+// Check if the event has properties
+if (empty(event.properties)) {
+    print('No properties found in event')
+    return event
+}
+
+let returnEvent := event
+let propertiesToKeep := {}
+
+// Iterate through all properties and only keep non-null values
+for (let key, value in event.properties) {
+    if (value != null) {
+        propertiesToKeep[key] := value
+    } else {
+        print('Removing null property:', key)
+    }
+}
+
+returnEvent.properties := propertiesToKeep
+return returnEvent
+    `,
+    inputs_schema: [],
+}

--- a/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.ts
@@ -7,7 +7,7 @@ export const template: HogFunctionTemplate = {
     id: 'template-remove-null-properties',
     name: 'Remove Null Properties',
     description:
-        'This transformation removes null properties at all levels of the event properties object (up to 10 levels deep), including nested objects and arrays.',
+        'This transformation removes null properties from the event properties object. If the object nesting exceeds 10 levels, the original event is returned unchanged.',
     icon_url: '/static/hedgehog/builder-hog-01.png',
     category: ['Custom'],
     hog: `
@@ -69,7 +69,7 @@ fun cleanNullValues(value, depth) {
 
 let result := cleanNullValues(event.properties, 1)
 if (maxDepthReached) {
-    print('Maximum nesting depth reached, returning original event')
+    print('Object nesting exceeds maximum depth of 10 levels. Returning original event unchanged for safety.')
     return event
 }
 

--- a/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.ts
@@ -7,7 +7,7 @@ export const template: HogFunctionTemplate = {
     id: 'template-remove-null-properties',
     name: 'Remove Null Properties',
     description:
-        'This transformation removes null properties from the event properties object. If the object nesting exceeds 10 levels, the original event is returned unchanged.',
+        'This transformation removes null properties from the event properties object. If the object nesting exceeds 3 levels, the original event is returned unchanged.',
     icon_url: '/static/hedgehog/builder-hog-01.png',
     category: ['Custom'],
     hog: `
@@ -17,7 +17,7 @@ if (empty(event.properties)) {
 }
 
 let returnEvent := event
-let MAX_DEPTH := 10
+let MAX_DEPTH := 3
 let maxDepthReached := false
 
 // Helper function to clean null values from objects and arrays

--- a/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.ts
@@ -7,7 +7,7 @@ export const template: HogFunctionTemplate = {
     id: 'template-remove-null-properties',
     name: 'Remove Null Properties',
     description:
-        'This transformation removes null properties at all levels of the event properties object, including nested objects and arrays.',
+        'This transformation removes null properties at all levels of the event properties object (up to 10 levels deep), including nested objects and arrays.',
     icon_url: '/static/hedgehog/builder-hog-01.png',
     category: ['Custom'],
     hog: `
@@ -17,10 +17,17 @@ if (empty(event.properties)) {
 }
 
 let returnEvent := event
+let MAX_DEPTH := 10
+let maxDepthReached := false
 
 // Helper function to clean null values from objects and arrays
-fun cleanNullValues(value) {
-    // Return early if value is null
+fun cleanNullValues(value, depth) {
+    // Return early if max depth reached or value is null
+    if (depth > MAX_DEPTH) {
+        maxDepthReached := true
+        return value
+    }
+    
     if (value = null) {
         return null
     }
@@ -30,7 +37,10 @@ fun cleanNullValues(value) {
     if (notEmpty(valueKeys) and has(valueKeys, '1')) {  // Hog arrays are 1-based
         let cleanArr := []
         for (let item in value) {
-            let cleanItem := cleanNullValues(item)
+            let cleanItem := cleanNullValues(item, depth + 1)
+            if (maxDepthReached) {
+                return value
+            }
             if (cleanItem != null) {
                 cleanArr := arrayPushBack(cleanArr, cleanItem)
             }
@@ -42,7 +52,10 @@ fun cleanNullValues(value) {
     if (notEmpty(valueKeys)) {
         let cleanObj := {}
         for (let key in valueKeys) {
-            let cleanVal := cleanNullValues(value[key])
+            let cleanVal := cleanNullValues(value[key], depth + 1)
+            if (maxDepthReached) {
+                return value
+            }
             if (cleanVal != null) {
                 cleanObj[key] := cleanVal
             }
@@ -54,7 +67,13 @@ fun cleanNullValues(value) {
     return value
 }
 
-returnEvent.properties := cleanNullValues(event.properties)
+let result := cleanNullValues(event.properties, 1)
+if (maxDepthReached) {
+    print('Maximum nesting depth reached, returning original event')
+    return event
+}
+
+returnEvent.properties := result
 return returnEvent
     `,
     inputs_schema: [],

--- a/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/remove-null-properties/remove-null-properties.template.ts
@@ -7,7 +7,7 @@ export const template: HogFunctionTemplate = {
     id: 'template-remove-null-properties',
     name: 'Remove Null Properties',
     description:
-        'This transformation removes null properties from the event properties object. If the object nesting exceeds 3 levels, the original event is returned unchanged.',
+        'This transformation removes null properties from the event properties object. If the object nesting exceeds 3 levels, deeper levels will be returned unchanged.',
     icon_url: '/static/hedgehog/builder-hog-01.png',
     category: ['Custom'],
     hog: `
@@ -17,63 +17,7 @@ if (empty(event.properties)) {
 }
 
 let returnEvent := event
-let MAX_DEPTH := 3
-let maxDepthReached := false
-
-// Helper function to clean null values from objects and arrays
-fun cleanNullValues(value, depth) {
-    // Return early if max depth reached or value is null
-    if (depth > MAX_DEPTH) {
-        maxDepthReached := true
-        return value
-    }
-    
-    if (value = null) {
-        return null
-    }
-    
-    // Handle arrays
-    let valueKeys := keys(value)
-    if (notEmpty(valueKeys) and has(valueKeys, '1')) {  // Hog arrays are 1-based
-        let cleanArr := []
-        for (let item in value) {
-            let cleanItem := cleanNullValues(item, depth + 1)
-            if (maxDepthReached) {
-                return value
-            }
-            if (cleanItem != null) {
-                cleanArr := arrayPushBack(cleanArr, cleanItem)
-            }
-        }
-        return cleanArr
-    }
-    
-    // Handle objects
-    if (notEmpty(valueKeys)) {
-        let cleanObj := {}
-        for (let key in valueKeys) {
-            let cleanVal := cleanNullValues(value[key], depth + 1)
-            if (maxDepthReached) {
-                return value
-            }
-            if (cleanVal != null) {
-                cleanObj[key] := cleanVal
-            }
-        }
-        return cleanObj
-    }
-    
-    // Return value as is for other types
-    return value
-}
-
-let result := cleanNullValues(event.properties, 1)
-if (maxDepthReached) {
-    print('Object nesting exceeds maximum depth of 10 levels. Returning original event unchanged for safety.')
-    return event
-}
-
-returnEvent.properties := result
+returnEvent.properties := cleanNullValues(event.properties)
 return returnEvent
     `,
     inputs_schema: [],

--- a/plugin-server/src/cdp/templates/index.ts
+++ b/plugin-server/src/cdp/templates/index.ts
@@ -2,6 +2,7 @@ import { DESTINATION_PLUGINS, TRANSFORMATION_PLUGINS } from '../legacy-plugins'
 import { template as webhookTemplate } from './_destinations/webhook/webhook.template'
 import { template as defaultTransformationTemplate } from './_transformations/default/default.template'
 import { template as geoipTemplate } from './_transformations/geoip/geoip.template'
+import { template as removeNullPropertiesTemplate } from './_transformations/remove-null-properties/remove-null-properties.template'
 import { template as ipAnonymizationTemplate } from './_transformations/ip-anonymization/ip-anonymization.template'
 import { HogFunctionTemplate } from './types'
 
@@ -11,6 +12,7 @@ export const HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS: HogFunctionTemplate[] = [
     defaultTransformationTemplate,
     geoipTemplate,
     ipAnonymizationTemplate,
+    removeNullPropertiesTemplate,
 ]
 
 export const HOG_FUNCTION_TEMPLATES_DESTINATIONS_DEPRECATED: HogFunctionTemplate[] = DESTINATION_PLUGINS.map(

--- a/plugin-server/src/cdp/templates/index.ts
+++ b/plugin-server/src/cdp/templates/index.ts
@@ -2,8 +2,8 @@ import { DESTINATION_PLUGINS, TRANSFORMATION_PLUGINS } from '../legacy-plugins'
 import { template as webhookTemplate } from './_destinations/webhook/webhook.template'
 import { template as defaultTransformationTemplate } from './_transformations/default/default.template'
 import { template as geoipTemplate } from './_transformations/geoip/geoip.template'
-import { template as removeNullPropertiesTemplate } from './_transformations/remove-null-properties/remove-null-properties.template'
 import { template as ipAnonymizationTemplate } from './_transformations/ip-anonymization/ip-anonymization.template'
+import { template as removeNullPropertiesTemplate } from './_transformations/remove-null-properties/remove-null-properties.template'
 import { HogFunctionTemplate } from './types'
 
 export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [webhookTemplate]

--- a/plugin-server/src/cdp/templates/test/test-helpers.ts
+++ b/plugin-server/src/cdp/templates/test/test-helpers.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import { brotliDecompressSync } from 'zlib'
 
 import { Hub } from '../../../types'
+import { cleanNullValues, createGeoipLookup } from '../../hog-transformations/transformation-functions'
 import { buildGlobalsWithInputs, HogExecutorService } from '../../services/hog-executor.service'
 import {
     HogFunctionInputType,
@@ -168,19 +169,8 @@ export class TemplateTester {
         const invocation = createInvocation(globalsWithInputs, hogFunction)
 
         const transformationFunctions = {
-            geoipLookup: (ipAddress: unknown) => {
-                if (typeof ipAddress !== 'string') {
-                    return null
-                }
-                if (!this.mockHub.mmdb) {
-                    return null
-                }
-                try {
-                    return this.mockHub.mmdb.city(ipAddress)
-                } catch {
-                    return null
-                }
-            },
+            geoipLookup: createGeoipLookup(this.mockHub.mmdb),
+            cleanNullValues,
         }
 
         const extraFunctions = invocation.hogFunction.type === 'transformation' ? transformationFunctions : {}


### PR DESCRIPTION
## Problem

We want to have a transformation to remove properties from the events when they are `null` to reduce the number of unnecessary fields generated downstream.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- created a hog transformation to remove null properties from the event
- it only does so for max 3 levels deep and leaves the rest of the values unchanged
- made the remove-null-values fn a transformation-function so we can offer 3 levels of cleaning without having to worry about overwrites of the max depth limit and evil functions
- keeps non null falsy values like `false`, `[]`, `{}`
- refactored our test setup and the hog-transformer.service to be cleaner and better to test 

<img width="1082" alt="Screenshot 2025-02-06 at 15 57 16" src="https://github.com/user-attachments/assets/8b7e9c71-897b-4671-96f6-d876c5ae0bd8" />


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- added tests

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
