### PR TITLE
fix(batch_imports): fix remainder line handling

### DIFF
--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -113,7 +113,7 @@ impl Job {
         if let Err(e) = next_commit {
             // If we fail to commit, we just log and bail out - the job will be paused if it needs to be,
             // but this pod should restart, in case it's sink is in some bad state
-            error!("Failed to commit chunk: {}", e);
+            error!("Failed to commit chunk: {:?}", e);
             return Err(e);
         }
 
@@ -127,13 +127,13 @@ impl Job {
             Err(e) => {
                 // If we fail to fetch and parse, we need to pause the job (assuming manual intervention is required) and
                 // return an Ok(None) - this pod can continue to process other jobs, it just can't work on this one
-                error!("Failed to fetch and parse chunk: {}", e);
+                error!("Failed to fetch and parse chunk: {:?}", e);
                 self.model
                     .lock()
                     .await
                     .pause(
                         self.context.clone(),
-                        format!("Failed to fetch and parse chunk: {}", e),
+                        format!("Failed to fetch and parse chunk: {:?}", e),
                     )
                     .await?;
                 return Ok(None);


### PR DESCRIPTION
When splitting the input chunk into lines to try and parse as json objects, I was assuming the bytes following the final newline character in the input chunk was a valid utf8 string, but of course it isn't, because we have no way of knowing a chunk boundary doesn't split a utf8 multibyte sequence in half. This fixes that.