### PR TITLE
fix: billing - fix bg color for usage gauge

### DIFF
--- a/frontend/src/scenes/billing/BillingGauge.scss
+++ b/frontend/src/scenes/billing/BillingGauge.scss
@@ -10,7 +10,8 @@
         font-size: 0.8rem;
         line-height: 1rem;
         white-space: nowrap;
-        border-left: 1px solid var(--border-primary);
+        background-color: var(--bg-light);
+        border-left: 1px solid var(--border-light);
 
         &--bottom {
             top: 100%;
@@ -57,6 +58,12 @@
                 var(--data-color-1-hover) 0.5rem,
                 var(--data-color-1-hover) 1rem
             );
+        }
+    }
+
+    &.BillingGaugeItem--addon {
+        .BillingGaugeItem__info {
+            background-color: var(--bg-primary);
         }
     }
 }

--- a/frontend/src/scenes/billing/BillingGauge.tsx
+++ b/frontend/src/scenes/billing/BillingGauge.tsx
@@ -16,16 +16,20 @@ type BillingGaugeItemProps = {
     item: BillingGaugeItemType
     maxValue: number
     isWithinUsageLimit: boolean
+    isAddon: boolean
 }
 
-const BillingGaugeItem = ({ item, maxValue, isWithinUsageLimit }: BillingGaugeItemProps): JSX.Element => {
+const BillingGaugeItem = ({ item, maxValue, isWithinUsageLimit, isAddon }: BillingGaugeItemProps): JSX.Element => {
     const width = `${(item.value / maxValue) * 100}%`
 
     return (
         <div
             className={clsx(
                 `BillingGaugeItem BillingGaugeItem--${item.type}`,
-                { 'BillingGaugeItem--within-usage-limit': isWithinUsageLimit },
+                {
+                    'BillingGaugeItem--within-usage-limit': isWithinUsageLimit,
+                    'BillingGaugeItem--addon': isAddon,
+                },
                 'absolute top-0 left-0 bottom-0 h-2'
             )}
             // eslint-disable-next-line react/forbid-dom-props
@@ -62,11 +66,18 @@ export function BillingGauge({ items, product }: BillingGaugeProps): JSX.Element
         return Math.max(100, ...items.map((item) => item.value)) * 1.3
     }, [items])
     const isWithinUsageLimit = (product.percentage_usage ?? 0) <= 1
+    const isAddon = !('addons' in product)
 
     return (
         <div className="relative h-2 bg-border-light my-16">
             {items.map((item, i) => (
-                <BillingGaugeItem key={i} item={item} maxValue={maxValue} isWithinUsageLimit={isWithinUsageLimit} />
+                <BillingGaugeItem
+                    key={i}
+                    item={item}
+                    maxValue={maxValue}
+                    isWithinUsageLimit={isWithinUsageLimit}
+                    isAddon={isAddon}
+                />
             ))}
         </div>
     )


### PR DESCRIPTION
## Problem

The info label in the usage gauge had a transparent background, causing some issues when they overlapped. This fixes that by applying a plain background, checking if it's a product or an addon.

## Changes

![image](https://github.com/user-attachments/assets/013a5bdc-c718-45a8-a1db-f88a66dafe1e)


👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

Yes

## How did you test this code?

On my local instance.
