### PR TITLE
fix: typo in experiments code snippet

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
+++ b/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
@@ -83,7 +83,7 @@ export function JSSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
                 <b>Test that it works</b>
             </div>
             <CodeSnippet language={Language.JavaScript} wrap>
-                {`posthog.featureFlags.overrideFeatureFlags({ flags: {'${flagKey}': '${variant}'})`}
+                {`posthog.featureFlags.overrideFeatureFlags({ flags: {'${flagKey}': '${variant}'}})`}
             </CodeSnippet>
         </div>
     )

--- a/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
+++ b/frontend/src/scenes/experiments/ExperimentCodeSnippets.tsx
@@ -83,7 +83,7 @@ export function JSSnippet({ flagKey, variant }: SnippetProps): JSX.Element {
                 <b>Test that it works</b>
             </div>
             <CodeSnippet language={Language.JavaScript} wrap>
-                {`posthog.featureFlags.overrideFeatureFlags({ flags: {'${flagKey}': '${variant}'}})`}
+                {`posthog.featureFlags.overrideFeatureFlags({ flags: {'${flagKey}': '${variant}'} })`}
             </CodeSnippet>
         </div>
     )
@@ -120,7 +120,7 @@ function App() {
 }
 
 // You can also test your code by overriding the feature flag:
-posthog.featureFlags.overrideFeatureFlags({ flags: {'${flagKey}': '${variant}'})`}
+posthog.featureFlags.overrideFeatureFlags({ flags: {'${flagKey}': '${variant}'} })`}
             </CodeSnippet>
         </>
     )


### PR DESCRIPTION
Missing bracket in snippet for testing out that feature flags works. 

Raised by a customer here: https://posthoghelp.zendesk.com/agent/tickets/24699 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26425)
