### PR TITLE
fix: Allow transforming the distinct_id

### DIFF
--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -257,6 +257,18 @@ export class HogTransformerService {
                         event.event = transformedEvent.event
                     }
 
+                    if ('distinct_id' in transformedEvent) {
+                        if (typeof transformedEvent.distinct_id !== 'string') {
+                            status.error('⚠️', 'Invalid transformation result - distinct_id must be a string', {
+                                function_id: hogFunction.id,
+                                distinct_id: transformedEvent.distinct_id,
+                            })
+                            transformationsFailed.push(transformationIdentifier)
+                            continue
+                        }
+                        event.distinct_id = transformedEvent.distinct_id
+                    }
+
                     transformationsSucceeded.push(transformationIdentifier)
                 }
 


### PR DESCRIPTION
## Problem

Noticed some plugins modify the distinct_id (for example anonymization) which we didnt support

## Changes

* Adds support as well as a test to cover all of this for the future

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
