### PR TITLE
feat: Added flag for test functions

### DIFF
--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -8,7 +8,7 @@ import {
     HogFunctionType,
     HogFunctionTypeType,
 } from '../../cdp/types'
-import { createInvocation, fixLogDeduplication, isLegacyPluginHogFunction } from '../../cdp/utils'
+import { CDP_TEST_ID, createInvocation, fixLogDeduplication, isLegacyPluginHogFunction } from '../../cdp/utils'
 import { KAFKA_APP_METRICS_2, KAFKA_LOG_ENTRIES } from '../../config/kafka-topics'
 import { runInstrumentedFunction } from '../../main/utils'
 import { AppMetric2Type, Hub, TimestampFormat } from '../../types'
@@ -202,7 +202,7 @@ export class HogTransformerService {
 
                 // For now, execute each transformation function in sequence
                 for (const hogFunction of teamHogFunctions) {
-                    if (runTestFunctions && !hogFunction.name.includes('CDP-TEST-HIDDEN')) {
+                    if (runTestFunctions && !hogFunction.name.includes(CDP_TEST_ID)) {
                         continue
                     }
                     const transformationIdentifier = `${hogFunction.name} (${hogFunction.id})`

--- a/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/plugin-server/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -202,7 +202,8 @@ export class HogTransformerService {
 
                 // For now, execute each transformation function in sequence
                 for (const hogFunction of teamHogFunctions) {
-                    if (runTestFunctions && !hogFunction.name.includes(CDP_TEST_ID)) {
+                    if (hogFunction.name.includes(CDP_TEST_ID) && !runTestFunctions) {
+                        // Skip test functions if we're not running in test mode
                         continue
                     }
                     const transformationIdentifier = `${hogFunction.name} (${hogFunction.id})`

--- a/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
+++ b/plugin-server/src/cdp/services/legacy-plugin-executor.service.ts
@@ -18,7 +18,7 @@ import {
 } from '../legacy-plugins/types'
 import { sanitizeLogMessage } from '../services/hog-executor.service'
 import { HogFunctionInvocation, HogFunctionInvocationResult } from '../types'
-import { isLegacyPluginHogFunction } from '../utils'
+import { CDP_TEST_ID, isLegacyPluginHogFunction } from '../utils'
 
 const pluginExecutionDuration = new Histogram({
     name: 'cdp_plugin_execution_duration_ms',
@@ -109,7 +109,7 @@ export class LegacyPluginExecutorService {
             logs: [],
         }
 
-        const isTestFunction = invocation.hogFunction.name.includes('[CDP-TEST-HIDDEN]')
+        const isTestFunction = invocation.hogFunction.name.includes(CDP_TEST_ID)
 
         const addLog = (level: 'debug' | 'warn' | 'error' | 'info', ...args: any[]) => {
             result.logs.push({

--- a/plugin-server/src/cdp/utils.ts
+++ b/plugin-server/src/cdp/utils.ts
@@ -25,6 +25,8 @@ import {
     HogFunctionType,
 } from './types'
 
+// ID of functions that are hidden from normal users and used by us for special testing
+// For example, transformations use this to only run if in comparison mode
 export const CDP_TEST_ID = '[CDP-TEST-HIDDEN]'
 
 export const PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = [

--- a/plugin-server/src/cdp/utils.ts
+++ b/plugin-server/src/cdp/utils.ts
@@ -25,6 +25,8 @@ import {
     HogFunctionType,
 } from './types'
 
+export const CDP_TEST_ID = '[CDP-TEST-HIDDEN]'
+
 export const PERSON_DEFAULT_DISPLAY_NAME_PROPERTIES = [
     'email',
     'Email',

--- a/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
+++ b/plugin-server/src/worker/ingestion/event-pipeline/compareToHogTransformStep.ts
@@ -63,7 +63,7 @@ export async function compareToHogTransformStep(
     try {
         // TRICKY: We really want to make sure that the other event is unaffected
         const clonedEvent = cloneObject(prePluginsEvent)
-        const result = await hogTransformer.transformEvent(clonedEvent)
+        const result = await hogTransformer.transformEvent(clonedEvent, true)
         const hogEvent = result.event
 
         if (!hogEvent || !postPluginsEvent) {


### PR DESCRIPTION
## Problem

We want to turn on hog transforms for new users whilst still having the ability to run our comparison tests.

## Changes

* Adds a flag for the transform function to only run hidden ones if specifically set

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
