### PR TITLE
fix: Call toString in test

### DIFF
--- a/posthog/temporal/tests/batch_exports/test_spmc.py
+++ b/posthog/temporal/tests/batch_exports/test_spmc.py
@@ -234,7 +234,7 @@ def test_use_events_recent(test_data: dict[str, typing.Any]):
             [
                 {"key": "$current_url", "operator": "icontains", "type": "event", "value": "https://posthog.com"},
             ],
-            """ifNull(ilike(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', ''), %(hogql_val_1)s), 0)""",
+            """ifNull(ilike(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, %(hogql_val_0)s), ''), 'null'), '^"|"$', '')), %(hogql_val_1)s), 0)""",
             {"hogql_val_0": "$current_url", "hogql_val_1": "%https://posthog.com%"},
         ),
         (


### PR DESCRIPTION
## Problem

PR #28297 broke one of the `test_spmc.py` tests. Likely was missed from the PR as it wasn't updated to latest `master` which included a new test. The fix is just to add the `toString` call that the PR introduced.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

* Add `toString` call in test.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
