### PR TITLE
fix: Fix creation flag for migration

### DIFF
--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -155,8 +155,8 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         instance = cast(Optional[HogFunction], self.context.get("instance", self.instance))
 
         hog_type = attrs.get("type", instance.type if instance else "destination")
-        is_create = (
-            self.context.get("is_create") or self.context.get("view") and self.context["view"].action == "create"
+        is_create = self.context.get("is_create") or (
+            self.context.get("view") and self.context["view"].action == "create"
         )
 
         template_id = attrs.get("template_id", instance.template_id if instance else None)

--- a/posthog/api/hog_function.py
+++ b/posthog/api/hog_function.py
@@ -155,7 +155,9 @@ class HogFunctionSerializer(HogFunctionMinimalSerializer):
         instance = cast(Optional[HogFunction], self.context.get("instance", self.instance))
 
         hog_type = attrs.get("type", instance.type if instance else "destination")
-        is_create = self.context.get("view") and self.context["view"].action == "create"
+        is_create = (
+            self.context.get("is_create") or self.context.get("view") and self.context["view"].action == "create"
+        )
 
         template_id = attrs.get("template_id", instance.template_id if instance else None)
         template = HogFunctionTemplates.template(template_id) if template_id else None

--- a/posthog/cdp/migrations.py
+++ b/posthog/cdp/migrations.py
@@ -75,7 +75,12 @@ def migrate_batch(legacy_plugins: Any, kind: str, test_mode: bool, dry_run: bool
 
             teams_cache[plugin_config["team_id"]] = team
 
-            serializer_context = {"team": team, "get_team": (lambda t=team: t), "bypass_addon_check": True}
+            serializer_context = {
+                "team": team,
+                "get_team": (lambda t=team: t),
+                "bypass_addon_check": True,
+                "is_create": True,
+            }
 
             icon_url = (
                 plugin_config["plugin__icon"] or f"https://raw.githubusercontent.com/PostHog/{plugin_id}/main/logo.png"
@@ -177,6 +182,7 @@ def migrate_legacy_plugins(
         raise ValueError(f"Invalid kind: {kind}")
 
     if team_ids:
+        team_ids = [int(id) for id in team_ids.split(",")]
         legacy_plugins = legacy_plugins.filter(team_id__in=team_ids)
 
     if limit:


### PR DESCRIPTION
## Problem

Edge case issue where the serializer doesn't know it is in creation mode and so doesn't pull the values from the template.

## Changes

* Fixes this

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
