### PR TITLE
feat(cdp): make json validation great again

### DIFF
--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
@@ -17,6 +17,8 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { CodeEditorResizeable } from 'lib/monaco/CodeEditorResizable'
+import { editor, MarkerSeverity } from 'monaco-editor'
+import { useRef } from 'react'
 
 import { hogFunctionConfigurationLogic } from './hogFunctionConfigurationLogic'
 import { hogFunctionTestLogic } from './hogFunctionTestLogic'
@@ -28,14 +30,83 @@ const HogFunctionTestEditor = ({
     value: string
     onChange?: (value?: string) => void
 }): JSX.Element => {
+    const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
+    const decorationsRef = useRef<string[]>([]) // Track decoration IDs
+
+    const handleValidation = (newValue: string): void => {
+        if (!editorRef.current?.getModel()) {
+            return
+        }
+        const model = editorRef.current.getModel()!
+
+        // First clear everything
+        editor.setModelMarkers(model, 'owner', [])
+
+        // Clear existing decorations and get new empty array of IDs
+        decorationsRef.current = editorRef.current.deltaDecorations(decorationsRef.current, [])
+
+        // Now validate with clean state
+        try {
+            JSON.parse(newValue)
+            // Valid JSON - keep decorations cleared
+        } catch (err: any) {
+            // Invalid JSON - add new decoration
+            const match = err.message.match(/position (\d+)/)
+            if (match) {
+                const position = parseInt(match[1], 10)
+                const pos = model.getPositionAt(position)
+
+                // Set error marker
+                editor.setModelMarkers(model, 'owner', [
+                    {
+                        startLineNumber: pos.lineNumber,
+                        startColumn: pos.column,
+                        endLineNumber: pos.lineNumber,
+                        endColumn: pos.column + 1,
+                        message: err.message,
+                        severity: MarkerSeverity.Error,
+                    },
+                ])
+
+                // Set new decoration and store the IDs
+                decorationsRef.current = editorRef.current.deltaDecorations(decorationsRef.current, [
+                    {
+                        range: {
+                            startLineNumber: pos.lineNumber,
+                            startColumn: 1,
+                            endLineNumber: pos.lineNumber,
+                            endColumn: model.getLineLength(pos.lineNumber) + 1,
+                        },
+                        options: {
+                            isWholeLine: true,
+                            className: 'bg-danger-highlight',
+                            glyphMarginClassName: 'text-danger flex items-center justify-center',
+                            glyphMarginHoverMessage: { value: err.message },
+                        },
+                    },
+                ])
+
+                // Scroll to error
+                editorRef.current.revealLineInCenter(pos.lineNumber)
+            }
+        }
+    }
+
     return (
         <CodeEditorResizeable
             language="json"
             value={value}
             height={400}
-            onChange={onChange}
+            onChange={(newValue) => {
+                onChange?.(newValue)
+                handleValidation(newValue ?? '')
+            }}
+            onMount={(editor) => {
+                editorRef.current = editor
+                handleValidation(value)
+            }}
             options={{
-                lineNumbers: 'off',
+                lineNumbers: 'on',
                 minimap: {
                     enabled: false,
                 },
@@ -49,10 +120,11 @@ const HogFunctionTestEditor = ({
                     showKeywords: false,
                 },
                 scrollbar: {
-                    vertical: 'hidden',
-                    verticalScrollbarSize: 0,
+                    vertical: 'auto',
+                    verticalScrollbarSize: 14,
                 },
                 folding: true,
+                glyphMargin: true,
             }}
         />
     )
@@ -71,6 +143,7 @@ export function HogFunctionTest(): JSX.Element {
         testInvocation,
         testResultMode,
         sortedTestsResult,
+        jsonError,
     } = useValues(hogFunctionTestLogic(logicProps))
     const {
         submitTestInvocation,
@@ -353,6 +426,8 @@ export function HogFunctionTest(): JSX.Element {
                     </>
                 )}
             </div>
+
+            {jsonError && <LemonBanner type="error">JSON Error: {jsonError}</LemonBanner>}
         </Form>
     )
 }

--- a/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/HogFunctionTest.tsx
@@ -17,7 +17,7 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { CodeEditorResizeable } from 'lib/monaco/CodeEditorResizable'
-import { editor, MarkerSeverity } from 'monaco-editor'
+import { editor as monacoEditor, MarkerSeverity } from 'monaco-editor'
 import { useRef } from 'react'
 
 import { hogFunctionConfigurationLogic } from './hogFunctionConfigurationLogic'
@@ -30,7 +30,7 @@ const HogFunctionTestEditor = ({
     value: string
     onChange?: (value?: string) => void
 }): JSX.Element => {
-    const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
+    const editorRef = useRef<monacoEditor.IStandaloneCodeEditor | null>(null)
     const decorationsRef = useRef<string[]>([]) // Track decoration IDs
 
     const handleValidation = (newValue: string): void => {
@@ -40,7 +40,7 @@ const HogFunctionTestEditor = ({
         const model = editorRef.current.getModel()!
 
         // First clear everything
-        editor.setModelMarkers(model, 'owner', [])
+        monacoEditor.setModelMarkers(model, 'owner', [])
 
         // Clear existing decorations and get new empty array of IDs
         decorationsRef.current = editorRef.current.deltaDecorations(decorationsRef.current, [])
@@ -57,7 +57,7 @@ const HogFunctionTestEditor = ({
                 const pos = model.getPositionAt(position)
 
                 // Set error marker
-                editor.setModelMarkers(model, 'owner', [
+                monacoEditor.setModelMarkers(model, 'owner', [
                     {
                         startLineNumber: pos.lineNumber,
                         startColumn: pos.column,

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
@@ -4,6 +4,7 @@ import { forms } from 'kea-forms'
 import api from 'lib/api'
 import { tryJsonParse } from 'lib/utils'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
+import { editor, MarkerSeverity } from 'monaco-editor'
 
 import { groupsModel } from '~/models/groupsModel'
 import { HogFunctionInvocationGlobals, HogFunctionTestInvocationResult } from '~/types'
@@ -85,6 +86,13 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
         deleteSavedGlobals: (index: number) => ({ index }),
         setTestResultMode: (mode: 'raw' | 'diff') => ({ mode }),
         receiveExampleGlobals: (globals: HogFunctionInvocationGlobals | null) => ({ globals }),
+        setJsonError: (error: string | null) => ({ error }),
+        validateJson: (
+            value: string,
+            monacoEditor: editor.IStandaloneCodeEditor | null,
+            currentDecorations: string[]
+        ) => ({ value, monacoEditor, currentDecorations }),
+        setDecorationIds: (decorationIds: string[]) => ({ decorationIds }),
     }),
     reducers({
         expanded: [
@@ -116,6 +124,21 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
                 deleteSavedGlobals: (state, { index }) => state.filter((_, i) => i !== index),
             },
         ],
+
+        jsonError: [
+            null as string | null,
+            {
+                setJsonError: (_, { error }) => error,
+            },
+        ],
+
+        currentDecorationIds: [
+            [] as string[],
+            {
+                setDecorationIds: (_, { decorationIds }) => decorationIds,
+                setJsonError: () => [], // Clear decorations when error state changes
+            },
+        ],
     }),
     listeners(({ values, actions }) => ({
         loadSampleGlobalsSuccess: () => {
@@ -136,6 +159,66 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
                 actions.setTestInvocationValue('globals', JSON.stringify(event, null, 2))
             } else {
                 actions.setTestInvocationValue('globals', JSON.stringify(globals, null, 2))
+            }
+        },
+
+        validateJson: ({ value, monacoEditor, currentDecorations }) => {
+            if (!monacoEditor?.getModel()) {
+                return
+            }
+
+            const model = monacoEditor.getModel()!
+
+            try {
+                // Try parsing the JSON
+                JSON.parse(value)
+                // If valid, ensure everything is cleared
+                actions.setJsonError(null)
+                editor.setModelMarkers(model, 'owner', [])
+                monacoEditor.deltaDecorations(currentDecorations, [])
+            } catch (err: any) {
+                actions.setJsonError(err.message)
+
+                const match = err.message.match(/position (\d+)/)
+                if (!match) {
+                    return
+                }
+
+                const position = parseInt(match[1], 10)
+                const pos = model.getPositionAt(position)
+
+                // Set single error marker
+                editor.setModelMarkers(model, 'owner', [
+                    {
+                        startLineNumber: pos.lineNumber,
+                        startColumn: pos.column,
+                        endLineNumber: pos.lineNumber,
+                        endColumn: pos.column + 1,
+                        message: err.message,
+                        severity: MarkerSeverity.Error,
+                    },
+                ])
+
+                // Set single error decoration
+                monacoEditor.deltaDecorations(currentDecorations, [
+                    {
+                        range: {
+                            startLineNumber: pos.lineNumber,
+                            startColumn: 1,
+                            endLineNumber: pos.lineNumber,
+                            endColumn: model.getLineLength(pos.lineNumber) + 1,
+                        },
+                        options: {
+                            isWholeLine: true,
+                            className: 'bg-danger-highlight',
+                            glyphMarginClassName: 'text-danger flex items-center justify-center',
+                            glyphMarginHoverMessage: { value: err.message },
+                        },
+                    },
+                ])
+
+                // Scroll to error
+                monacoEditor.revealLineInCenter(pos.lineNumber)
             }
         },
     })),

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
@@ -4,7 +4,7 @@ import { forms } from 'kea-forms'
 import api from 'lib/api'
 import { tryJsonParse } from 'lib/utils'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
-import { editor, MarkerSeverity } from 'monaco-editor'
+import { editor as monacoEditor, MarkerSeverity } from 'monaco-editor'
 
 import { groupsModel } from '~/models/groupsModel'
 import { HogFunctionInvocationGlobals, HogFunctionTestInvocationResult } from '~/types'
@@ -89,7 +89,7 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
         setJsonError: (error: string | null) => ({ error }),
         validateJson: (
             value: string,
-            monacoEditor: editor.IStandaloneCodeEditor | null,
+            monacoEditor: monacoEditor.IStandaloneCodeEditor | null,
             currentDecorations: string[]
         ) => ({ value, monacoEditor, currentDecorations }),
         setDecorationIds: (decorationIds: string[]) => ({ decorationIds }),
@@ -174,7 +174,7 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
                 JSON.parse(value)
                 // If valid, ensure everything is cleared
                 actions.setJsonError(null)
-                editor.setModelMarkers(model, 'owner', [])
+                monacoEditor.deltaDecorations(model, 'owner', [])
                 monacoEditor.deltaDecorations(currentDecorations, [])
             } catch (err: any) {
                 actions.setJsonError(err.message)
@@ -188,7 +188,7 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
                 const pos = model.getPositionAt(position)
 
                 // Set single error marker
-                editor.setModelMarkers(model, 'owner', [
+                monacoEditor.deltaDecorations(model, 'owner', [
                     {
                         startLineNumber: pos.lineNumber,
                         startColumn: pos.column,

--- a/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
+++ b/frontend/src/scenes/pipeline/hogfunctions/hogFunctionTestLogic.tsx
@@ -4,7 +4,7 @@ import { forms } from 'kea-forms'
 import api from 'lib/api'
 import { tryJsonParse } from 'lib/utils'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
-import { editor as monacoEditor, MarkerSeverity } from 'monaco-editor'
+import { editor, MarkerSeverity } from 'monaco-editor'
 
 import { groupsModel } from '~/models/groupsModel'
 import { HogFunctionInvocationGlobals, HogFunctionTestInvocationResult } from '~/types'
@@ -89,7 +89,7 @@ export const hogFunctionTestLogic = kea<hogFunctionTestLogicType>([
         setJsonError: (error: string | null) => ({ error }),
         validateJson: (
             value: string,
-            monacoEditor: monacoEditor.IStandaloneCodeEditor | null,
+            monacoEditor: editor.IStandaloneCodeEditor | null,
             currentDecorations: string[]
         ) => ({ value, monacoEditor, currentDecorations }),
         setDecorationIds: (decorationIds: string[]) => ({ decorationIds }),


### PR DESCRIPTION
## Problem

Currently we have no indication on what is wrong with the JSON but we only get an error saying its invalid. Bad UX means unhappy customers.

c.f. https://posthog.slack.com/archives/C06GG249PR6/p1737888911523479

<img width="643" alt="Screenshot 2025-02-07 at 12 28 50" src="https://github.com/user-attachments/assets/9c41fa82-33be-434c-b84c-b4a63544a550" />

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- now json errors are tracked across the editor
- on error we now get a detailed error message on what is wrong and how you can fix it 
- on error we get a indication (marking corrupt lines red) and jumping straight to them 
- having multiple errors in the file leads to jumping from error to error until you fix everything 
- you do not need to 'run test' anymore to get the error but you get it right away 
- errors are cleared once they are fixed

![2025-02-07 12 23 27](https://github.com/user-attachments/assets/a9192f21-34cc-4f0c-b593-42710fbb5608)

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
