### PR TITLE
fix(assistant): use sonar-pro as a search model

### DIFF
--- a/ee/hogai/memory/nodes.py
+++ b/ee/hogai/memory/nodes.py
@@ -182,7 +182,7 @@ class MemoryInitializerNode(MemoryInitializerContextMixin, AssistantNode):
         return re.sub(r"\[\d+\]", "", message)
 
     def _model(self):
-        return ChatPerplexity(model="llama-3.1-sonar-large-128k-online", temperature=0, streaming=True)
+        return ChatPerplexity(model="sonar-pro", temperature=0, streaming=True)
 
 
 class MemoryInitializerInterruptNode(AssistantNode):


### PR DESCRIPTION
## Problem

Perplexity models based on Llama will soon stop working.

## Changes

I've experimented with all models. Reasoning model will need prompt changes, as it doesn't correctly ground sources. `sonar` (subjectively) looks worse than `sonar-pro` in business details with almost the same inference speed.

## Does this work well for both Cloud and self-hosted?

No

## How did you test this code?

Manual testing