### PR TITLE
fix: initialise primary_sink_health status

### DIFF
--- a/rust/capture/src/sinks/fallback.rs
+++ b/rust/capture/src/sinks/fallback.rs
@@ -60,6 +60,7 @@ impl FallbackSink {
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
         let primary_is_healthy = Arc::new(AtomicBool::new(true));
         let thread_healthy = primary_is_healthy.clone();
+        gauge!("capture_primary_sink_health").set(1.0);
 
         // Asynchronously update primary health status every 10 seconds
         // this means if the primary starts failing we'll stop trying to send to it until it recovers.


### PR DESCRIPTION
## Problem
this was previously only being set when the status first became healthy or recovered

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
