### PR TITLE
feat(ci): Push the built docker image to ECR and tag it

### DIFF
--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -78,7 +78,7 @@ runs:
           run: |
               TAGS="posthog/posthog:${{ github.sha }}"
               if [[ "${{ inputs.push-image }}" == "true" ]]; then
-                TAGS="$TAGS,${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:commit-${{ github.sha }}"
+                TAGS="$TAGS,${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:pr-commit-${{ github.sha }}"
               fi
               if [[ "${{ inputs.pr-number }}" != "" ]]; then
                 TAGS="$TAGS,${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:pr-${{ inputs.pr-number }}"

--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -13,11 +13,11 @@ inputs:
         default: false
         description: Whether to push the built image - requires aws-access-key and aws-access-secret
     aws-access-key:
-        required: false
-        description: AWS key to log into ECR
+        required: ${{ inputs.push-image == 'true' }}
+        description: AWS key to log into ECR (required when push-image is true)
     aws-access-secret:
-        required: false
-        description: AWS secret to log into ECR
+        required: ${{ inputs.push-image == 'true' }}
+        description: AWS secret to log into ECR (required when push-image is true)
     dockerhub-username:
         required: false
         description: Dockerhub username for pushing image

--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -8,6 +8,26 @@ inputs:
         required: false
         default: 'false'
         description: Whether to save the image in the Depot ephemeral registry after building it
+    push-image:
+        required: false
+        default: false
+        description: Whether to push the built image - requires aws-access-key and aws-access-secret
+    aws-access-key:
+        required: false
+        description: AWS key to log into ECR
+    aws-access-secret:
+        required: false
+        description: AWS secret to log into ECR
+    dockerhub-username:
+        required: false
+        description: Dockerhub username for pushing image
+    dockerhub-password:
+        required: false
+        description: Dockerhub password for pushing image
+    pr-number:
+        required: false
+        default: ''
+        description: PR number for tagging the image
 
 outputs:
     tag:
@@ -23,15 +43,49 @@ runs:
         - name: Checkout
           uses: actions/checkout@v4
 
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3
+
+        - name: Set up QEMU
+          uses: docker/setup-qemu-action@v3
+
         - name: Set up Depot CLI
           uses: depot/setup-action@v1
+
+        - name: Configure AWS credentials
+          if: ${{ inputs.push-image == 'true' }}
+          uses: aws-actions/configure-aws-credentials@v4
+          with:
+              aws-access-key-id: ${{ inputs.aws-access-key }}
+              aws-secret-access-key: ${{ inputs.aws-access-secret }}
+              aws-region: us-east-1
+
+        - name: Login to DockerHub
+          if: ${{ inputs.push-image == 'true' }}
+          uses: docker/login-action@v3
+          with:
+              username: ${{ inputs.dockerhub-username }}
+              password: ${{ inputs.dockerhub-password }}
+
+        - name: Login to Amazon ECR
+          if: ${{ inputs.push-image == 'true' }}
+          id: aws-ecr
+          uses: aws-actions/amazon-ecr-login@v2
 
         - name: Emit image tag
           id: emit
           shell: bash
-          run: echo "tag=posthog/posthog:${{ github.sha }}" >> $GITHUB_OUTPUT
+          run: |
+              TAGS="posthog/posthog:${{ github.sha }}"
+              if [[ "${{ inputs.push-image }}" == "true" ]]; then
+                TAGS="$TAGS,${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:commit-${{ github.sha }}"
+              fi
+              if [[ "${{ inputs.pr-number }}" != "" ]]; then
+                TAGS="$TAGS,${{ steps.aws-ecr.outputs.registry }}/posthog-cloud:pr-${{ inputs.pr-number }}"
+              fi
+              echo "tag=$TAGS" >> $GITHUB_OUTPUT
 
-        - name: Build image # We don't push this because we use Depot cache as the communication channel
+        - name: Build image
           id: build
           uses: depot/build-push-action@v1
           with:
@@ -41,5 +95,6 @@ runs:
               platforms: linux/amd64,linux/arm64
               build-args: COMMIT_HASH=${{ github.sha }}
               save: ${{ inputs.save }}
+              push: ${{ inputs.push-image }}
           env:
               ACTIONS_ID_TOKEN_REQUEST_URL: ${{ inputs.actions-id-token-request-url }}

--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -13,10 +13,10 @@ inputs:
         default: false
         description: Whether to push the built image - requires aws-access-key and aws-access-secret
     aws-access-key:
-        required: ${{ inputs.push-image == 'true' }}
+        required: false
         description: AWS key to log into ECR (required when push-image is true)
     aws-access-secret:
-        required: ${{ inputs.push-image == 'true' }}
+        required: false
         description: AWS secret to log into ECR (required when push-image is true)
     dockerhub-username:
         required: false

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -41,6 +41,12 @@ jobs:
               uses: ./.github/actions/build-n-cache-image
               with:
                   actions-id-token-request-url: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}
+                  push-image: true
+                  aws-access-key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-access-secret: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
+                  dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+                  pr-number: ${{ github.event.number }}
 
     deploy_preview:
         name: Deploy preview environment


### PR DESCRIPTION
## Problem
- I want to be able to deploy a built image in the `dev` env before I merge a PR

## Changes
- Push the built image from the e2e tests to ECR and tag it with the commit and PR numbers
- This allows me to select the image from ECR and deploy it via argocd
- Coming next:
  - ECR lifecycle policy to delete images tagged with `pr-` and `commit-` after 7 days so that we don't clog up ECR with a billion images 
- (pulled this out of https://github.com/PostHog/posthog/pull/28335)

## How did you test this code?
Been using this to test warehouse pipeline changes in https://github.com/PostHog/posthog/pull/28335