### PR TITLE
fix: add missing parentheses

### DIFF
--- a/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/svelte.tsx
+++ b/frontend/src/scenes/onboarding/sdks/sdk-install-instructions/svelte.tsx
@@ -34,7 +34,7 @@ onMount(() => {
     )
   }
   return
-};`}
+});`}
         </CodeSnippet>
     )
 }


### PR DESCRIPTION
## Changes

Svelte onboarding code missing parentheses.

Reported from a customer: https://posthoghelp.zendesk.com/agent/tickets/24748 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26612)
