### PR TITLE
feat(cdp): add pii hashing transformation

### DIFF
--- a/plugin-server/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.test.ts
@@ -1,0 +1,182 @@
+import { HogFunctionInvocationGlobals } from '../../../types'
+import { TemplateTester } from '../../test/test-helpers'
+import { template } from './pii-hashing.template'
+
+interface EventResult {
+    properties: {
+        [key: string]: any
+    }
+}
+
+describe('pii-hashing.template', () => {
+    const tester = new TemplateTester(template)
+    let mockGlobals: HogFunctionInvocationGlobals
+
+    beforeEach(async () => {
+        await tester.beforeEach()
+    })
+
+    it('should hash property values', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $email: 'test@example.com',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToHash: {
+                    $email: '{event.properties.$email}',
+                },
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as EventResult).properties.$email).toMatch(/^[a-f0-9]{64}$/)
+        expect((response.execResult as EventResult).properties.$email).not.toBe('test@example.com')
+    })
+
+    it('should handle multiple properties', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $email: 'test@example.com',
+                    $phone: '+1234567890',
+                    safe_property: 'keep-me',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToHash: {
+                    $email: '{event.properties.$email}',
+                    $phone: '{event.properties.$phone}',
+                },
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as EventResult).properties.$email).toMatch(/^[a-f0-9]{64}/)
+        expect((response.execResult as EventResult).properties.$phone).toMatch(/^[a-f0-9]{64}/)
+        expect((response.execResult as EventResult).properties.safe_property).toBe('keep-me')
+    })
+
+    it('should handle empty values gracefully', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    safe_property: 'keep-me',
+                    $email: undefined,
+                    $phone: undefined,
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToHash: {
+                    $email: '{event.properties.$email}',
+                    $phone: '{event.properties.$phone}',
+                },
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as EventResult).properties.safe_property).toBe('keep-me')
+        expect((response.execResult as EventResult).properties.$email).toBeUndefined()
+        expect((response.execResult as EventResult).properties.$phone).toBeUndefined()
+    })
+
+    it('should handle empty propertiesToHash dictionary', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $email: 'test@example.com',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToHash: {},
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as EventResult).properties.$email).toBe('test@example.com')
+    })
+
+    it('should handle invalid property paths gracefully', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $email: 'test@example.com',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToHash: {
+                    $email: '{event.properties.nonexistent}',
+                    $phone: '{event.properties.user.phone}',
+                    $ssn: '{event.properties.deeply.nested.invalid.path}',
+                },
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        // Original properties should remain unchanged
+        expect((response.execResult as EventResult).properties.$email).toBe('test@example.com')
+        // Invalid paths should not create new properties
+        expect((response.execResult as EventResult).properties.$phone).toBeUndefined()
+        expect((response.execResult as EventResult).properties.$ssn).toBeUndefined()
+    })
+
+    it('should handle various property names and paths', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $email: 'test@example.com',
+                    regular_field: 'sensitive-data',
+                    custom_field: 'another-secret',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToHash: {
+                    regular_field: '{event.properties.regular_field}',
+                    custom_field: '{event.properties.$email}', // Map to different source
+                    $email: '{event.properties.custom_field}', // Cross-property mapping
+                },
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        // Check each property is hashed
+        expect((response.execResult as EventResult).properties.regular_field).toMatch(/^[a-f0-9]{64}$/)
+        expect((response.execResult as EventResult).properties.custom_field).toMatch(/^[a-f0-9]{64}$/)
+        expect((response.execResult as EventResult).properties.$email).toMatch(/^[a-f0-9]{64}$/)
+        // Verify original values are not present
+        expect((response.execResult as EventResult).properties.regular_field).not.toBe('sensitive-data')
+        expect((response.execResult as EventResult).properties.custom_field).not.toBe('test@example.com')
+        expect((response.execResult as EventResult).properties.$email).not.toBe('another-secret')
+    })
+})

--- a/plugin-server/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.test.ts
@@ -3,6 +3,7 @@ import { TemplateTester } from '../../test/test-helpers'
 import { template } from './pii-hashing.template'
 
 interface EventResult {
+    distinct_id?: string
     properties: {
         [key: string]: any
     }
@@ -245,5 +246,186 @@ describe('pii-hashing.template', () => {
         const result = response.execResult as EventResult
         expect(result.properties.user.email).toBe('test@example.com')
         expect(result.properties.user.contact).toBeUndefined()
+    })
+
+    it('should hash distinct_id when enabled', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                distinct_id: 'user123',
+                properties: {
+                    $email: 'test@example.com',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToHash: {
+                    Email: '$email',
+                },
+                hashDistinctId: true,
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as EventResult).distinct_id).toMatch(/^[a-f0-9]{64}$/)
+        expect((response.execResult as EventResult).distinct_id).not.toBe('user123')
+    })
+
+    it('should not hash distinct_id when disabled', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                distinct_id: 'user123',
+                properties: {
+                    $email: 'test@example.com',
+                },
+            },
+        })
+
+        const response = await tester.invoke(
+            {
+                propertiesToHash: {
+                    Email: '$email',
+                },
+                hashDistinctId: false,
+            },
+            mockGlobals
+        )
+
+        expect(response.finished).toBe(true)
+        expect(response.error).toBeUndefined()
+        expect((response.execResult as EventResult).distinct_id).toBe('user123')
+    })
+
+    it('should hash values with salt when provided', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                properties: {
+                    $email: 'test@example.com',
+                },
+            },
+        })
+
+        const response1 = await tester.invoke(
+            {
+                propertiesToHash: {
+                    Email: '$email',
+                },
+                salt: 'mysalt123',
+            },
+            mockGlobals
+        )
+
+        const response2 = await tester.invoke(
+            {
+                propertiesToHash: {
+                    Email: '$email',
+                },
+                salt: 'differentSalt',
+            },
+            mockGlobals
+        )
+
+        expect(response1.finished).toBe(true)
+        expect(response2.finished).toBe(true)
+
+        const hash1 = (response1.execResult as EventResult).properties.$email
+        const hash2 = (response2.execResult as EventResult).properties.$email
+
+        // Both should be valid hashes
+        expect(hash1).toMatch(/^[a-f0-9]{64}$/)
+        expect(hash2).toMatch(/^[a-f0-9]{64}$/)
+
+        // Different salts should produce different hashes for the same value
+        expect(hash1).not.toBe(hash2)
+    })
+
+    it('should hash distinct_id with salt', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                distinct_id: 'user123',
+                properties: {},
+            },
+        })
+
+        const response1 = await tester.invoke(
+            {
+                propertiesToHash: {},
+                hashDistinctId: true,
+                salt: 'salt1',
+            },
+            mockGlobals
+        )
+
+        const response2 = await tester.invoke(
+            {
+                propertiesToHash: {},
+                hashDistinctId: true,
+                salt: 'salt2',
+            },
+            mockGlobals
+        )
+
+        expect(response1.finished).toBe(true)
+        expect(response2.finished).toBe(true)
+
+        const hash1 = (response1.execResult as EventResult).distinct_id
+        const hash2 = (response2.execResult as EventResult).distinct_id
+
+        // Both should be valid hashes
+        expect(hash1).toMatch(/^[a-f0-9]{64}$/)
+        expect(hash2).toMatch(/^[a-f0-9]{64}$/)
+
+        // Different salts should produce different hashes
+        expect(hash1).not.toBe(hash2)
+        // Original value should be hashed
+        expect(hash1).not.toBe('user123')
+        expect(hash2).not.toBe('user123')
+    })
+
+    it('should produce consistent hashes with the same salt', async () => {
+        mockGlobals = tester.createGlobals({
+            event: {
+                distinct_id: 'user123',
+                properties: {
+                    $email: 'test@example.com',
+                },
+            },
+        })
+
+        const response1 = await tester.invoke(
+            {
+                propertiesToHash: {
+                    Email: '$email',
+                },
+                hashDistinctId: true,
+                salt: 'same-salt',
+            },
+            mockGlobals
+        )
+
+        const response2 = await tester.invoke(
+            {
+                propertiesToHash: {
+                    Email: '$email',
+                },
+                hashDistinctId: true,
+                salt: 'same-salt',
+            },
+            mockGlobals
+        )
+
+        expect(response1.finished).toBe(true)
+        expect(response2.finished).toBe(true)
+
+        // Same salt should produce same hashes
+        expect((response1.execResult as EventResult).distinct_id).toBe(
+            (response2.execResult as EventResult).distinct_id
+        )
+        expect((response1.execResult as EventResult).properties.$email).toBe(
+            (response2.execResult as EventResult).properties.$email
+        )
     })
 })

--- a/plugin-server/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.test.ts
+++ b/plugin-server/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.test.ts
@@ -28,9 +28,7 @@ describe('pii-hashing.template', () => {
 
         const response = await tester.invoke(
             {
-                propertiesToHash: {
-                    Email: '$email',
-                },
+                propertiesToHash: '$email',
             },
             mockGlobals
         )
@@ -54,18 +52,15 @@ describe('pii-hashing.template', () => {
 
         const response = await tester.invoke(
             {
-                propertiesToHash: {
-                    Email: '$email',
-                    Phone: '$phone',
-                },
+                propertiesToHash: '$email,$phone',
             },
             mockGlobals
         )
 
         expect(response.finished).toBe(true)
         expect(response.error).toBeUndefined()
-        expect((response.execResult as EventResult).properties.$email).toMatch(/^[a-f0-9]{64}/)
-        expect((response.execResult as EventResult).properties.$phone).toMatch(/^[a-f0-9]{64}/)
+        expect((response.execResult as EventResult).properties.$email).toMatch(/^[a-f0-9]{64}$/)
+        expect((response.execResult as EventResult).properties.$phone).toMatch(/^[a-f0-9]{64}$/)
         expect((response.execResult as EventResult).properties.safe_property).toBe('keep-me')
     })
 
@@ -82,10 +77,7 @@ describe('pii-hashing.template', () => {
 
         const response = await tester.invoke(
             {
-                propertiesToHash: {
-                    Email: '$email',
-                    Phone: '$phone',
-                },
+                propertiesToHash: '$email,$phone',
             },
             mockGlobals
         )
@@ -97,7 +89,7 @@ describe('pii-hashing.template', () => {
         expect((response.execResult as EventResult).properties.$phone).toBeUndefined()
     })
 
-    it('should handle empty propertiesToHash dictionary', async () => {
+    it('should handle empty propertiesToHash array', async () => {
         mockGlobals = tester.createGlobals({
             event: {
                 properties: {
@@ -108,7 +100,7 @@ describe('pii-hashing.template', () => {
 
         const response = await tester.invoke(
             {
-                propertiesToHash: {},
+                propertiesToHash: '',
             },
             mockGlobals
         )
@@ -129,11 +121,7 @@ describe('pii-hashing.template', () => {
 
         const response = await tester.invoke(
             {
-                propertiesToHash: {
-                    Email: 'nonexistent',
-                    Phone: 'user.phone',
-                    Ssn: 'deeply.nested.invalid.path',
-                },
+                propertiesToHash: 'nonexistent,user.phone,deeply.nested.invalid.path',
             },
             mockGlobals
         )
@@ -161,10 +149,7 @@ describe('pii-hashing.template', () => {
 
         const response = await tester.invoke(
             {
-                propertiesToHash: {
-                    ip: '$set.$ip',
-                    email: '$set.$email',
-                },
+                propertiesToHash: '$set.$ip,$set.$email',
             },
             mockGlobals
         )
@@ -196,11 +181,7 @@ describe('pii-hashing.template', () => {
 
         const response = await tester.invoke(
             {
-                propertiesToHash: {
-                    Email: 'user.contact.$email',
-                    Phone: 'user.contact.$phone',
-                    SSN: '$set.profile.ssn',
-                },
+                propertiesToHash: 'user.contact.$email,user.contact.$phone,$set.profile.ssn',
             },
             mockGlobals
         )
@@ -232,9 +213,7 @@ describe('pii-hashing.template', () => {
 
         const response = await tester.invoke(
             {
-                propertiesToHash: {
-                    Email: 'user.contact.email', // nonexistent nested path
-                },
+                propertiesToHash: 'user.contact.email', // nonexistent nested path
             },
             mockGlobals
         )
@@ -260,9 +239,7 @@ describe('pii-hashing.template', () => {
 
         const response = await tester.invoke(
             {
-                propertiesToHash: {
-                    Email: '$email',
-                },
+                propertiesToHash: '$email',
                 hashDistinctId: true,
             },
             mockGlobals
@@ -286,9 +263,7 @@ describe('pii-hashing.template', () => {
 
         const response = await tester.invoke(
             {
-                propertiesToHash: {
-                    Email: '$email',
-                },
+                propertiesToHash: '$email',
                 hashDistinctId: false,
             },
             mockGlobals
@@ -310,9 +285,7 @@ describe('pii-hashing.template', () => {
 
         const response1 = await tester.invoke(
             {
-                propertiesToHash: {
-                    Email: '$email',
-                },
+                propertiesToHash: '$email',
                 salt: 'mysalt123',
             },
             mockGlobals
@@ -320,9 +293,7 @@ describe('pii-hashing.template', () => {
 
         const response2 = await tester.invoke(
             {
-                propertiesToHash: {
-                    Email: '$email',
-                },
+                propertiesToHash: '$email',
                 salt: 'differentSalt',
             },
             mockGlobals
@@ -352,7 +323,7 @@ describe('pii-hashing.template', () => {
 
         const response1 = await tester.invoke(
             {
-                propertiesToHash: {},
+                propertiesToHash: '',
                 hashDistinctId: true,
                 salt: 'salt1',
             },
@@ -361,7 +332,7 @@ describe('pii-hashing.template', () => {
 
         const response2 = await tester.invoke(
             {
-                propertiesToHash: {},
+                propertiesToHash: '',
                 hashDistinctId: true,
                 salt: 'salt2',
             },
@@ -397,9 +368,7 @@ describe('pii-hashing.template', () => {
 
         const response1 = await tester.invoke(
             {
-                propertiesToHash: {
-                    Email: '$email',
-                },
+                propertiesToHash: '$email',
                 hashDistinctId: true,
                 salt: 'same-salt',
             },
@@ -408,9 +377,7 @@ describe('pii-hashing.template', () => {
 
         const response2 = await tester.invoke(
             {
-                propertiesToHash: {
-                    Email: '$email',
-                },
+                propertiesToHash: '$email',
                 hashDistinctId: true,
                 salt: 'same-salt',
             },

--- a/plugin-server/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.ts
@@ -37,7 +37,7 @@ return returnEvent
             label: 'Properties to Hash',
             description: 'Add property paths to hash',
             default: {
-                Ip: 'properties.$ip',
+                Ip: '$ip',
             },
             secret: false,
             required: true,

--- a/plugin-server/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.ts
@@ -21,10 +21,10 @@ if (empty(propertiesToHash)) {
 let returnEvent := event
 
 // Hash each property value
-for (let propName, path in propertiesToHash) {
-    let value := path
-    if (notEmpty(value) and value != propName) {  // Check if path resolved to a value
-        returnEvent.properties[propName] := sha256Hex(toString(value))
+for (let _, path in propertiesToHash) {
+    let value := event.properties[path]
+    if (notEmpty(value)) { 
+        returnEvent.properties[path] := sha256Hex(toString(value))
     }
 }
 
@@ -35,10 +35,9 @@ return returnEvent
             key: 'propertiesToHash',
             type: 'dictionary',
             label: 'Properties to Hash',
-            description: 'Add property names to hash (e.g., "$email", "$ip", "$device_type").',
+            description: 'Add property paths to hash',
             default: {
-                $email: '{event.properties.$email}',
-                $ip: '{event.properties.$ip}',
+                Ip: 'properties.$ip',
             },
             secret: false,
             required: true,

--- a/plugin-server/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.ts
@@ -1,0 +1,47 @@
+import { HogFunctionTemplate } from '../../types'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'alpha',
+    type: 'transformation',
+    id: 'template-pii-hashing',
+    name: 'PII Data Hashing',
+    description:
+        'This transformation hashes sensitive personal data (PII) like email, phone numbers, etc. using SHA-256 to protect user privacy.',
+    icon_url: '/static/hedgehog/builder-hog-02.png',
+    category: ['Custom'],
+    hog: `
+// Get the properties to hash from inputs
+let propertiesToHash := inputs.propertiesToHash
+if (empty(propertiesToHash)) {
+    return event
+}
+
+// Create a copy of the event to modify
+let returnEvent := event
+
+// Hash each property value
+for (let propName, path in propertiesToHash) {
+    let value := path
+    if (notEmpty(value) and value != propName) {  // Check if path resolved to a value
+        returnEvent.properties[propName] := sha256Hex(toString(value))
+    }
+}
+
+return returnEvent
+`,
+    inputs_schema: [
+        {
+            key: 'propertiesToHash',
+            type: 'dictionary',
+            label: 'Properties to Hash',
+            description: 'Add property names to hash (e.g., "$email", "$ip", "$device_type").',
+            default: {
+                $email: '{event.properties.$email}',
+                $ip: '{event.properties.$ip}',
+            },
+            secret: false,
+            required: true,
+        },
+    ],
+}

--- a/plugin-server/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.ts
+++ b/plugin-server/src/cdp/templates/_transformations/pii-hashing/pii-hashing.template.ts
@@ -69,7 +69,7 @@ return returnEvent
             key: 'propertiesToHash',
             type: 'dictionary',
             label: 'Properties to Hash',
-            description: 'Add property paths to hash (use dot notation for nested properties, e.g. "user.email")',
+            description: 'Add property paths to hash (use dot notation for nested properties, e.g. "$set.$email")',
             default: {
                 Ip: '$ip',
             },

--- a/plugin-server/src/cdp/templates/index.ts
+++ b/plugin-server/src/cdp/templates/index.ts
@@ -4,9 +4,9 @@ import { template as botDetectionTemplate } from './_transformations/bot-detecti
 import { template as defaultTransformationTemplate } from './_transformations/default/default.template'
 import { template as geoipTemplate } from './_transformations/geoip/geoip.template'
 import { template as ipAnonymizationTemplate } from './_transformations/ip-anonymization/ip-anonymization.template'
+import { template as piiHashingTemplate } from './_transformations/pii-hashing/pii-hashing.template'
 import { template as removeNullPropertiesTemplate } from './_transformations/remove-null-properties/remove-null-properties.template'
 import { HogFunctionTemplate } from './types'
-
 export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [webhookTemplate]
 
 export const HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS: HogFunctionTemplate[] = [
@@ -14,6 +14,7 @@ export const HOG_FUNCTION_TEMPLATES_TRANSFORMATIONS: HogFunctionTemplate[] = [
     geoipTemplate,
     ipAnonymizationTemplate,
     removeNullPropertiesTemplate,
+    piiHashingTemplate,
     botDetectionTemplate,
 ]
 


### PR DESCRIPTION
## Problem

we want a way to hash PII through transformations, also on nested values e.g. `properties.$ip` or `properties.$set.$email`

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- introduced new transformation that can hash any field in `properties.`
- we handle nested properties as well e.g. `properties.$set.$default_browser`
- you also hash the distinct_id
- you can optionally provide a salt 

![2025-02-12 17 10 52](https://github.com/user-attachments/assets/636dbdfe-1878-49dc-8609-cde9bd71f433)


<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?

- written tests
- tested locally

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
