### PR TITLE
chore: access control improvements

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
@@ -8,6 +8,8 @@ import {
     LemonSelect,
     LemonSelectProps,
     LemonTable,
+    LemonTag,
+    Tooltip,
 } from '@posthog/lemon-ui'
 import { BindLogic, useActions, useAsyncActions, useValues } from 'kea'
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
@@ -136,8 +138,12 @@ function AccessControlObjectUsers(): JSX.Element | null {
             key: 'level',
             title: 'Level',
             width: 0,
-            render: function LevelRender(_, { access_level, organization_member }) {
-                return (
+            render: function LevelRender(_, { access_level, organization_member, resource }) {
+                return resource === 'organization' ? (
+                    <Tooltip title="Organization owners and admins have access to all resources in the organization">
+                        <LemonTag type="muted">Organization admin</LemonTag>
+                    </Tooltip>
+                ) : (
                     <div className="my-1">
                         <SimplLevelComponent
                             size="small"
@@ -154,8 +160,8 @@ function AccessControlObjectUsers(): JSX.Element | null {
         {
             key: 'remove',
             width: 0,
-            render: (_, { organization_member }) => {
-                return (
+            render: (_, { organization_member, resource }) => {
+                return resource === 'organization' ? null : (
                     <RemoveAccessButton
                         subject="member"
                         onConfirm={() =>

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/accessControlLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/accessControlLogic.ts
@@ -255,9 +255,14 @@ export const accessControlLogic = kea<accessControlLogicType>([
         accessControlMembers: [
             (s) => [s.accessControls, s.organizationAdminsAsAccessControlMembers],
             (accessControls, organizationAdminsAsAccessControlMembers): AccessControlTypeMember[] => {
-                const members = (accessControls?.access_controls || []).filter(
-                    (accessControl) => !!accessControl.organization_member
-                ) as AccessControlTypeMember[]
+                const members = (accessControls?.access_controls || [])
+                    .filter((accessControl) => !!accessControl.organization_member)
+                    .filter(
+                        (accessControl) =>
+                            !organizationAdminsAsAccessControlMembers.some(
+                                (admin) => admin.organization_member === accessControl.organization_member
+                            )
+                    ) as AccessControlTypeMember[]
                 return organizationAdminsAsAccessControlMembers.concat(members)
             },
         ],

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/accessControlLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/accessControlLogic.ts
@@ -3,6 +3,7 @@ import { actions, afterMount, connect, kea, key, listeners, path, props, selecto
 import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
+import { OrganizationMembershipLevel } from 'lib/constants'
 import { toSentenceCase } from 'lib/utils'
 import posthog from 'posthog-js'
 import { membersLogic } from 'scenes/organization/membersLogic'
@@ -156,6 +157,7 @@ export const accessControlLogic = kea<accessControlLogicType>([
                 return props.resource as AccessControlResourceType
             },
         ],
+
         endpoint: [
             () => [(_, props) => props],
             (props): string => {
@@ -166,6 +168,7 @@ export const accessControlLogic = kea<accessControlLogicType>([
                 return `api/projects/@current/${props.resource}s/${props.resource_id}/access_controls`
             },
         ],
+
         humanReadableResource: [
             () => [(_, props) => props],
             (props): string => {
@@ -213,6 +216,7 @@ export const accessControlLogic = kea<accessControlLogicType>([
                 return options
             },
         ],
+
         accessControlDefault: [
             (s) => [s.accessControls, s.accessControlDefaultLevel],
             (accessControls, accessControlDefaultLevel): AccessControlTypeProject => {
@@ -227,12 +231,34 @@ export const accessControlLogic = kea<accessControlLogicType>([
             },
         ],
 
+        organizationAdmins: [
+            (s) => [s.sortedMembers],
+            (members): OrganizationMemberType[] => {
+                return members?.filter((member) => member.level >= OrganizationMembershipLevel.Admin) ?? []
+            },
+        ],
+
+        organizationAdminsAsAccessControlMembers: [
+            (s) => [s.organizationAdmins],
+            (organizationAdmins): AccessControlTypeMember[] => {
+                return organizationAdmins.map((admin) => ({
+                    organization_member: admin.id,
+                    access_level: 'admin',
+                    created_by: null,
+                    created_at: new Date().toISOString(),
+                    updated_at: new Date().toISOString(),
+                    resource: 'organization',
+                }))
+            },
+        ],
+
         accessControlMembers: [
-            (s) => [s.accessControls],
-            (accessControls): AccessControlTypeMember[] => {
-                return (accessControls?.access_controls || []).filter(
+            (s) => [s.accessControls, s.organizationAdminsAsAccessControlMembers],
+            (accessControls, organizationAdminsAsAccessControlMembers): AccessControlTypeMember[] => {
+                const members = (accessControls?.access_controls || []).filter(
                     (accessControl) => !!accessControl.organization_member
                 ) as AccessControlTypeMember[]
+                return organizationAdminsAsAccessControlMembers.concat(members)
             },
         ],
 
@@ -267,11 +293,13 @@ export const accessControlLogic = kea<accessControlLogicType>([
         ],
 
         addableMembers: [
-            (s) => [s.sortedMembers, s.accessControlMembers],
-            (members, accessControlMembers): any[] => {
+            (s) => [s.sortedMembers, s.accessControlMembers, s.organizationAdmins],
+            (members, accessControlMembers, organizationAdmins): any[] => {
                 return members
                     ? members.filter(
-                          (member) => !accessControlMembers.find((ac) => ac.organization_member === member.id)
+                          (member) =>
+                              !accessControlMembers.find((ac) => ac.organization_member === member.id) &&
+                              !organizationAdmins.find((admin) => admin.id === member.id)
                       )
                     : []
             },

--- a/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
+++ b/frontend/src/scenes/dashboard/DashboardCollaborators.tsx
@@ -68,6 +68,13 @@ export function DashboardCollaboration({ dashboardId }: { dashboardId: Dashboard
 
     return (
         <PayGateMini feature={AvailableFeature.ADVANCED_PERMISSIONS}>
+            {newAccessControl && (
+                <LemonBanner type="warning" className="mb-4">
+                    We've upgraded our access control system but this dashboard is using a legacy version that can't be
+                    automatically upgraded. Please reach out to support if you're interested in migrating to the new
+                    system.
+                </LemonBanner>
+            )}
             {(!canEditDashboard || !canRestrictDashboard) && (
                 <LemonBanner type="info" className="mb-4">
                     {canEditDashboard


### PR DESCRIPTION
## Changes

Follow along for RBAC changes: https://github.com/PostHog/posthog/issues/24512

1. Add a note to legacy dashboard access control about the upgrade since it can't be done automatically

![Screenshot 2025-02-07 at 12 19 33 PM](https://github.com/user-attachments/assets/d19a3d47-96f5-41d0-8294-a943f80ddc09)

2. Show admins/owners in the members access list to make it more explicit. Why? Org admins and org have access to all projects and resources so they don't need to be added but they aren't shown in the list of members with access and they are shown in the "addable member" list. This change makes it more explicit so they can't be added and they are always shown in the member list. It's not a perfect solution and open to feedback but we need to make some sort of change here. 

![Screenshot 2025-02-07 at 12 14 58 PM](https://github.com/user-attachments/assets/862db590-ea8f-43c5-9e7c-0c481057e97e)

![Screenshot 2025-02-07 at 12 15 02 PM](https://github.com/user-attachments/assets/9b79cec8-3763-4b56-9ac0-4938985cb11c)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

It doesn't have an impact.

## How did you test this code?

Manually
