### PR TITLE
fix(error): make cymbal use transactions

### DIFF
--- a/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
+++ b/frontend/src/scenes/error-tracking/ErrorTrackingScene.tsx
@@ -8,6 +8,7 @@ import { Sparkline } from 'lib/components/Sparkline'
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { humanFriendlyLargeNumber } from 'lib/utils'
+import { posthog } from 'posthog-js'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -209,7 +210,7 @@ const Header = (): JSX.Element => {
                     {user?.is_staff ? (
                         <LemonButton
                             onClick={() => {
-                                throw Error('Oh my!')
+                                posthog.captureException(new Error('Oh my!'))
                             }}
                         >
                             Send an exception

--- a/rust/batch-import-worker/src/emit/kafka.rs
+++ b/rust/batch-import-worker/src/emit/kafka.rs
@@ -68,7 +68,7 @@ impl Emitter for KafkaEmitter {
 impl<'a> Transaction<'a> for KafkaEmitterTransaction<'a> {
     async fn emit(&self, data: &[InternallyCapturedEvent]) -> Result<(), Error> {
         self.inner
-            .send_keyed_iter_to_kafka(&self.topic, |e| Some(e.inner.key()), data.iter())
+            .send_keyed_iter_to_kafka(self.topic, |e| Some(e.inner.key()), data.iter())
             .await?;
 
         self.count.fetch_add(data.len(), Ordering::SeqCst);

--- a/rust/batch-import-worker/src/emit/mod.rs
+++ b/rust/batch-import-worker/src/emit/mod.rs
@@ -8,13 +8,14 @@ pub mod kafka;
 
 #[async_trait]
 pub trait Emitter: Send + Sync {
-    async fn begin_write(&mut self) -> Result<(), Error> {
-        Ok(())
-    }
+    async fn begin_write<'a>(&'a mut self) -> Result<Box<dyn Transaction<'a> + 'a>, Error>;
+}
 
+#[async_trait]
+pub trait Transaction<'a>: Send + Sync {
     async fn emit(&self, data: &[InternallyCapturedEvent]) -> Result<(), Error>;
 
-    async fn commit_write(&mut self) -> Result<(), Error> {
+    async fn commit_write(self: Box<Self>) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -25,6 +26,14 @@ pub struct StdoutEmitter {
 
 #[async_trait]
 impl Emitter for StdoutEmitter {
+    async fn begin_write<'a>(&'a mut self) -> Result<Box<dyn Transaction<'a> + 'a>, Error> {
+        let to_store: &'a Self = self;
+        Ok(Box::new(to_store))
+    }
+}
+
+#[async_trait]
+impl<'a> Transaction<'a> for &'a StdoutEmitter {
     async fn emit(&self, data: &[InternallyCapturedEvent]) -> Result<(), Error> {
         for event in data {
             if self.as_json {
@@ -41,6 +50,14 @@ pub struct NoOpEmitter;
 
 #[async_trait]
 impl Emitter for NoOpEmitter {
+    async fn begin_write<'a>(&'a mut self) -> Result<Box<dyn Transaction<'a> + 'a>, Error> {
+        let to_store: &'a Self = self;
+        Ok(Box::new(to_store))
+    }
+}
+
+#[async_trait]
+impl<'a> Transaction<'a> for &'a NoOpEmitter {
     async fn emit(&self, _data: &[InternallyCapturedEvent]) -> Result<(), Error> {
         Ok(())
     }
@@ -63,6 +80,14 @@ impl FileEmitter {
 
 #[async_trait]
 impl Emitter for FileEmitter {
+    async fn begin_write<'a>(&'a mut self) -> Result<Box<dyn Transaction<'a> + 'a>, Error> {
+        let to_store: &'a Self = self;
+        Ok(Box::new(to_store))
+    }
+}
+
+#[async_trait]
+impl<'a> Transaction<'a> for &'a FileEmitter {
     async fn emit(&self, data: &[InternallyCapturedEvent]) -> Result<(), Error> {
         info!("Writing {} events to file {}", data.len(), self.path);
         let mut file = tokio::fs::OpenOptions::new()

--- a/rust/common/kafka/src/config.rs
+++ b/rust/common/kafka/src/config.rs
@@ -32,18 +32,27 @@ pub struct ConsumerConfig {
     // We default to "earliest" for this, but if you're bringing up a new service, you probably want "latest"
     #[envconfig(default = "earliest")]
     pub kafka_consumer_offset_reset: String, // earliest, latest
+
+    // Note: consumers used in a transactional fashion should disable auto offset commits,
+    // as their offsets should be committed via the transactional producer. All consumers
+    // disable auto offset storing.
+    pub kafka_consumer_auto_commit: bool,
 }
 
 impl ConsumerConfig {
-    /// Because the consumer config is application specific, we
+    /// Because the consumer config is so application specific, we
     /// can't set good defaults in the derive macro, so we expose a way
     /// for users to set them here before init'ing their main config struct
-    pub fn set_defaults(consumer_group: &str, consumer_topic: &str) {
+    pub fn set_defaults(consumer_group: &str, consumer_topic: &str, auto_commit: bool) {
         if std::env::var("KAFKA_CONSUMER_GROUP").is_err() {
             std::env::set_var("KAFKA_CONSUMER_GROUP", consumer_group);
         };
         if std::env::var("KAFKA_CONSUMER_TOPIC").is_err() {
             std::env::set_var("KAFKA_CONSUMER_TOPIC", consumer_topic);
         };
+
+        if std::env::var("KAFKA_CONSUMER_AUTO_COMMIT").is_err() {
+            std::env::set_var("KAFKA_CONSUMER_AUTO_COMMIT", auto_commit.to_string());
+        }
     }
 }

--- a/rust/common/kafka/src/config.rs
+++ b/rust/common/kafka/src/config.rs
@@ -35,7 +35,7 @@ pub struct ConsumerConfig {
 
     // Note: consumers used in a transactional fashion should disable auto offset commits,
     // as their offsets should be committed via the transactional producer. All consumers
-    // disable auto offset storing.
+    // disable auto offset /storing/.
     pub kafka_consumer_auto_commit: bool,
 }
 

--- a/rust/common/kafka/src/kafka_producer.rs
+++ b/rust/common/kafka/src/kafka_producer.rs
@@ -14,6 +14,12 @@ pub struct KafkaContext {
     liveness: HealthHandle,
 }
 
+impl From<HealthHandle> for KafkaContext {
+    fn from(value: HealthHandle) -> Self {
+        KafkaContext { liveness: value }
+    }
+}
+
 impl rdkafka::ClientContext for KafkaContext {
     fn stats(&self, _: rdkafka::Statistics) {
         // Signal liveness, as the main rdkafka loop is running and calling us
@@ -56,8 +62,7 @@ pub async fn create_kafka_producer(
     };
 
     debug!("rdkafka configuration: {:?}", client_config);
-    let api: FutureProducer<KafkaContext> =
-        client_config.create_with_context(KafkaContext { liveness })?;
+    let api: FutureProducer<KafkaContext> = client_config.create_with_context(liveness.into())?;
 
     // "Ping" the Kafka brokers by requesting metadata
     match api

--- a/rust/common/kafka/src/transaction.rs
+++ b/rust/common/kafka/src/transaction.rs
@@ -33,12 +33,7 @@ impl TransactionalProducer<DefaultClientContext> {
         transactional_id: &str,
         timeout: Duration,
     ) -> Result<Self, KafkaError> {
-        Self::with_context(
-            config,
-            transactional_id,
-            timeout,
-            DefaultClientContext::default(),
-        )
+        Self::with_context(config, transactional_id, timeout, DefaultClientContext)
     }
 }
 

--- a/rust/cymbal/src/config.rs
+++ b/rust/cymbal/src/config.rs
@@ -88,7 +88,12 @@ pub struct Config {
 
 impl Config {
     pub fn init_with_defaults() -> Result<Self, envconfig::Error> {
-        ConsumerConfig::set_defaults("error-tracking-rs", "exception_symbolification_events");
+        // Our consumer is used in a transaction, so we disable offset commits.
+        ConsumerConfig::set_defaults(
+            "error-tracking-rs",
+            "exception_symbolification_events",
+            false,
+        );
         let res = Self::init_from_env()?;
         init_global_state(&res);
         Ok(res)

--- a/rust/cymbal/src/main.rs
+++ b/rust/cymbal/src/main.rs
@@ -112,7 +112,8 @@ async fn main() {
             Ok(txn) => txn,
             Err(e) => {
                 error!("Failed to start kafka transaction, {:?}", e);
-                return;
+                error!("Failed to start kafka transaction, will panic to trigger restart: {:?}", e);
+                panic!("Failed to start kafka transaction: {:?}", e);
             }
         };
 

--- a/rust/cymbal/src/main.rs
+++ b/rust/cymbal/src/main.rs
@@ -127,12 +127,19 @@ async fn main() {
         let metadata = context.kafka_consumer.metadata();
 
         // TODO - probably being over-explicit with the error handling here, and could instead
-        // let this function return an error and use the question mark operator, but it's good
+        // let main return an error and use the question mark operator, but it's good
         // to be explicit about places we drop things at the top level, so
         match txn.associate_offsets(offsets, &metadata) {
             Ok(_) => {}
             Err(e) => {
-                error!("Failed to commit kafka transaction, {:?}", e);
+                error!(
+                    "Failed to associate offsets with kafka transaction, {:?}",
+                    e
+                );
+                panic!(
+                    "Failed to associate offsets with kafka transaction, {:?}",
+                    e
+                );
             }
         }
 
@@ -140,6 +147,7 @@ async fn main() {
             Ok(_) => {}
             Err(e) => {
                 error!("Failed to commit kafka transaction, {:?}", e);
+                panic!("Failed to commit kafka transaction, {:?}", e);
             }
         }
 

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -162,7 +162,7 @@ impl TeamFilterMode {
 
 impl Config {
     pub fn init_with_defaults() -> Result<Self, envconfig::Error> {
-        ConsumerConfig::set_defaults("property-defs-rs", "clickhouse_events_json");
+        ConsumerConfig::set_defaults("property-defs-rs", "clickhouse_events_json", true);
         Config::init_from_env()
     }
 }


### PR DESCRIPTION
Bit of doing in this one, and I need to test it more thoroughly, but it should mean we can safely ignore those offset store errors, even if we can't totally root cause them (although I suspect this will also be the starting point of starting to root cause them too).