### PR TITLE
feat(self-managed-swap-backend): Swap backend for self managed sources

### DIFF
--- a/frontend/src/scenes/data-warehouse/new/dataWarehouseTableLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/new/dataWarehouseTableLogic.tsx
@@ -1,5 +1,5 @@
 import { lemonToast } from '@posthog/lemon-ui'
-import { actions, connect, events, kea, listeners, path, props, reducers } from 'kea'
+import { actions, afterMount, connect, events, kea, listeners, path, props, reducers } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import { router } from 'kea-router'
@@ -45,6 +45,14 @@ export const dataWarehouseTableLogic = kea<dataWarehouseTableLogicType>([
         setDataTableQuery: (query: DataTableNode) => ({ query }),
     }),
     loaders(({ props }) => ({
+        tables: [
+            [] as DataWarehouseTable[],
+            {
+                loadTables: async () => {
+                    return await api.dataWarehouseTables.list().then((response) => response.results)
+                },
+            },
+        ],
         table: {
             loadTable: async () => {
                 if (props.id && props.id !== 'new') {
@@ -66,12 +74,14 @@ export const dataWarehouseTableLogic = kea<dataWarehouseTableLogicType>([
         createTableSuccess: async ({ table }) => {
             lemonToast.success(<>Table {table.name} created</>)
             actions.loadDatabase()
+            actions.loadTables()
             router.actions.replace(urls.dataWarehouse())
         },
         updateTableSuccess: async ({ table }) => {
             lemonToast.success(<>Table {table.name} updated</>)
             actions.editingTable(false)
             actions.loadDatabase()
+            actions.loadTables()
             router.actions.replace(urls.dataWarehouse())
         },
     })),
@@ -86,6 +96,12 @@ export const dataWarehouseTableLogic = kea<dataWarehouseTableLogicType>([
             null as DataTableNode | null,
             {
                 setDataTableQuery: (_, { query }) => query,
+            },
+        ],
+        tables: [
+            [] as DataWarehouseTable[],
+            {
+                loadTablesSuccess: (_, { tables }) => tables,
             },
         ],
     }),
@@ -138,4 +154,7 @@ export const dataWarehouseTableLogic = kea<dataWarehouseTableLogicType>([
             actions.loadTable()
         },
     })),
+    afterMount(({ actions }) => {
+        actions.loadTables()
+    }),
 ])

--- a/frontend/src/scenes/data-warehouse/settings/DataWarehouseSelfManagedSourcesTable.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/DataWarehouseSelfManagedSourcesTable.tsx
@@ -52,6 +52,12 @@ export function DataWarehouseSelfManagedSourcesTable(): JSX.Element {
                     },
                 },
                 {
+                    title: 'Format',
+                    dataIndex: 'format',
+                    key: 'format',
+                    render: (_, item) => item.format,
+                },
+                {
                     key: 'actions',
                     width: 0,
                     render: (_, item) => (

--- a/frontend/src/scenes/data-warehouse/settings/DataWarehouseSelfManagedSourcesTable.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/DataWarehouseSelfManagedSourcesTable.tsx
@@ -1,6 +1,7 @@
-import { LemonButton, LemonDialog, LemonTable } from '@posthog/lemon-ui'
+import { LemonButton, LemonDialog, LemonTable, Tooltip } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
 import { TZLabel } from 'lib/components/TZLabel'
+import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { dataWarehouseTableLogic } from 'scenes/data-warehouse/new/dataWarehouseTableLogic'
 import { DataWarehouseSourceIcon, mapUrlToProvider } from 'scenes/data-warehouse/settings/DataWarehouseSourceIcon'
@@ -52,40 +53,51 @@ export function DataWarehouseSelfManagedSourcesTable(): JSX.Element {
                 },
                 {
                     key: 'actions',
+                    width: 0,
                     render: (_, item) => (
                         <div className="flex flex-row justify-end">
-                            <LemonButton
-                                data-attr={`refresh-data-warehouse-${item.name}`}
-                                key={`refresh-data-warehouse-${item.name}`}
-                                onClick={() => refreshSelfManagedTableSchema(item.id)}
-                            >
-                                Update schema from source
-                            </LemonButton>
-                            <LemonButton
-                                status="danger"
-                                data-attr={`delete-data-warehouse-${item.name}`}
-                                key={`delete-data-warehouse-${item.name}`}
-                                onClick={() => {
-                                    LemonDialog.open({
-                                        title: 'Delete table?',
-                                        description:
-                                            'Table deletion cannot be undone. All views and joins related to this table will be deleted.',
+                            <div>
+                                <More
+                                    overlay={
+                                        <>
+                                            <Tooltip title="Update schema from source">
+                                                <LemonButton
+                                                    data-attr={`refresh-data-warehouse-${item.name}`}
+                                                    key={`refresh-data-warehouse-${item.name}`}
+                                                    onClick={() => refreshSelfManagedTableSchema(item.id)}
+                                                >
+                                                    Reload
+                                                </LemonButton>
+                                            </Tooltip>
+                                            <LemonButton
+                                                status="danger"
+                                                data-attr={`delete-data-warehouse-${item.name}`}
+                                                key={`delete-data-warehouse-${item.name}`}
+                                                onClick={() => {
+                                                    LemonDialog.open({
+                                                        title: 'Delete table?',
+                                                        description:
+                                                            'Table deletion cannot be undone. All views and joins related to this table will be deleted.',
 
-                                        primaryButton: {
-                                            children: 'Delete',
-                                            status: 'danger',
-                                            onClick: () => {
-                                                deleteSelfManagedTable(item.id)
-                                            },
-                                        },
-                                        secondaryButton: {
-                                            children: 'Cancel',
-                                        },
-                                    })
-                                }}
-                            >
-                                Delete
-                            </LemonButton>
+                                                        primaryButton: {
+                                                            children: 'Delete',
+                                                            status: 'danger',
+                                                            onClick: () => {
+                                                                deleteSelfManagedTable(item.id)
+                                                            },
+                                                        },
+                                                        secondaryButton: {
+                                                            children: 'Cancel',
+                                                        },
+                                                    })
+                                                }}
+                                            >
+                                                Delete
+                                            </LemonButton>
+                                        </>
+                                    }
+                                />
+                            </div>
                         </div>
                     ),
                 },

--- a/frontend/src/scenes/data-warehouse/settings/DataWarehouseSelfManagedSourcesTable.tsx
+++ b/frontend/src/scenes/data-warehouse/settings/DataWarehouseSelfManagedSourcesTable.tsx
@@ -1,34 +1,33 @@
 import { LemonButton, LemonDialog, LemonTable } from '@posthog/lemon-ui'
 import { useActions, useValues } from 'kea'
+import { TZLabel } from 'lib/components/TZLabel'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import { dataWarehouseTableLogic } from 'scenes/data-warehouse/new/dataWarehouseTableLogic'
 import { DataWarehouseSourceIcon, mapUrlToProvider } from 'scenes/data-warehouse/settings/DataWarehouseSourceIcon'
 import { urls } from 'scenes/urls'
 
-import { DatabaseSchemaDataWarehouseTable } from '~/queries/schema'
 import { PipelineNodeTab, PipelineStage } from '~/types'
 
 import { dataWarehouseSettingsLogic } from './dataWarehouseSettingsLogic'
 
 export function DataWarehouseSelfManagedSourcesTable(): JSX.Element {
-    const { selfManagedTables } = useValues(dataWarehouseSettingsLogic)
     const { deleteSelfManagedTable, refreshSelfManagedTableSchema } = useActions(dataWarehouseSettingsLogic)
+    const { tables } = useValues(dataWarehouseTableLogic())
 
     return (
         <LemonTable
-            dataSource={selfManagedTables}
+            dataSource={tables}
             pagination={{ pageSize: 10 }}
             columns={[
                 {
                     width: 0,
-                    render: (_, item: DatabaseSchemaDataWarehouseTable) => (
-                        <DataWarehouseSourceIcon type={mapUrlToProvider(item.url_pattern)} />
-                    ),
+                    render: (_, item) => <DataWarehouseSourceIcon type={mapUrlToProvider(item.url_pattern)} />,
                 },
                 {
                     title: 'Source',
                     dataIndex: 'name',
                     key: 'name',
-                    render: (_, item: DatabaseSchemaDataWarehouseTable) => (
+                    render: (_, item) => (
                         <LemonTableLink
                             to={urls.pipelineNode(
                                 PipelineStage.Source,
@@ -40,8 +39,20 @@ export function DataWarehouseSelfManagedSourcesTable(): JSX.Element {
                     ),
                 },
                 {
+                    title: 'Created at',
+                    dataIndex: 'created_at',
+                    key: 'created_at',
+                    render: (_, item) => {
+                        return item.created_at ? (
+                            <TZLabel time={item.created_at} formatDate="MMM DD, YYYY" formatTime="HH:mm" />
+                        ) : (
+                            'N/A'
+                        )
+                    },
+                },
+                {
                     key: 'actions',
-                    render: (_, item: DatabaseSchemaDataWarehouseTable) => (
+                    render: (_, item) => (
                         <div className="flex flex-row justify-end">
                             <LemonButton
                                 data-attr={`refresh-data-warehouse-${item.name}`}

--- a/frontend/src/scenes/data-warehouse/settings/dataWarehouseSettingsLogic.ts
+++ b/frontend/src/scenes/data-warehouse/settings/dataWarehouseSettingsLogic.ts
@@ -5,6 +5,7 @@ import api, { ApiMethodOptions, PaginatedResponse } from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import posthog from 'posthog-js'
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
+import { dataWarehouseTableLogic } from 'scenes/data-warehouse/new/dataWarehouseTableLogic'
 
 import { DatabaseSchemaDataWarehouseTable } from '~/queries/schema'
 import { ExternalDataSource, ExternalDataSourceSchema } from '~/types'
@@ -17,7 +18,7 @@ export const dataWarehouseSettingsLogic = kea<dataWarehouseSettingsLogicType>([
     path(['scenes', 'data-warehouse', 'settings', 'dataWarehouseSettingsLogic']),
     connect(() => ({
         values: [databaseTableListLogic, ['dataWarehouseTables']],
-        actions: [databaseTableListLogic, ['loadDatabase']],
+        actions: [databaseTableListLogic, ['loadDatabase'], dataWarehouseTableLogic, ['loadTables']],
     })),
     actions({
         deleteSource: (source: ExternalDataSource) => ({ source }),
@@ -136,13 +137,9 @@ export const dataWarehouseSettingsLogic = kea<dataWarehouseSettingsLogicType>([
     listeners(({ actions, values, cache }) => ({
         deleteSelfManagedTable: async ({ tableId }) => {
             await api.dataWarehouseTables.delete(tableId)
+            lemonToast.success('Schema deleted')
             actions.loadDatabase()
-        },
-        refreshSelfManagedTableSchema: async ({ tableId }) => {
-            lemonToast.info('Updating schema...')
-            await api.dataWarehouseTables.refreshSchema(tableId)
-            lemonToast.success('Schema updated')
-            actions.loadDatabase()
+            actions.loadTables()
         },
         deleteSource: async ({ source }) => {
             await api.externalDataSources.delete(source.id)
@@ -150,6 +147,12 @@ export const dataWarehouseSettingsLogic = kea<dataWarehouseSettingsLogicType>([
             actions.sourceLoadingFinished(source)
 
             posthog.capture('source deleted', { sourceType: source.source_type })
+        },
+        refreshSelfManagedTableSchema: async ({ tableId }) => {
+            lemonToast.info('Updating schema...')
+            await api.dataWarehouseTables.refreshSchema(tableId)
+            lemonToast.success('Schema updated')
+            actions.loadDatabase()
         },
         reloadSource: async ({ source }) => {
             // Optimistic UI updates before sending updates to the backend

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4084,6 +4084,7 @@ export interface DataWarehouseTable {
     id: string
     name: string
     format: DataWarehouseTableTypes
+    created_at?: string
     url_pattern: string
     credential: DataWarehouseCredential
     external_data_source?: ExternalDataSource


### PR DESCRIPTION
## Problem

Little cohesion and perf issues for self managed sources make them not look the best together when viewed at once.

> Note: Unexpectedly, this made "new" sources appear in my local environment. 

This must be merged **after** PR https://github.com/PostHog/posthog/pull/28111

<img width="821" alt="image" src="https://github.com/user-attachments/assets/0e338c1b-7d79-4db8-8a1d-9053a6ae2ab6" />

Previously we relied on the `/query` endpoint response to list self-managed sources, that query is a bit slow because it brings down the entire cumulative model that can be interacted with.

This solution references the postgres table model and gives us additional column details that we can table render. It's also a bit faster to interact with.

## Does this work well for both Cloud and self-hosted?
Yes