### PR TITLE
fix: Fixed url normalization for actors query

### DIFF
--- a/posthog/hogql_queries/insights/trends/breakdown.py
+++ b/posthog/hogql_queries/insights/trends/breakdown.py
@@ -245,7 +245,9 @@ class Breakdown:
 
             if not isinstance(lookup_values, list):
                 actors_filter = self._get_actors_query_where_expr(
-                    breakdown_value=self._breakdown_filter.breakdown,
+                    breakdown_value=str(
+                        self._breakdown_filter.breakdown
+                    ),  # all other value types were excluded already
                     breakdown_type=self._breakdown_filter.breakdown_type,
                     normalize_url=self._breakdown_filter.breakdown_normalize_url,
                     lookup_value=str(

--- a/posthog/hogql_queries/insights/trends/breakdown.py
+++ b/posthog/hogql_queries/insights/trends/breakdown.py
@@ -229,6 +229,7 @@ class Breakdown:
                     actors_filter = self._get_actors_query_where_expr(
                         breakdown_value=breakdown.property,
                         breakdown_type=breakdown.type,
+                        normalize_url=breakdown.normalize_url,
                         lookup_value=str(
                             lookup_value
                         ),  # numeric values are only in cohorts, so it's a safe convertion here
@@ -244,10 +245,9 @@ class Breakdown:
 
             if not isinstance(lookup_values, list):
                 actors_filter = self._get_actors_query_where_expr(
-                    breakdown_value=str(
-                        self._breakdown_filter.breakdown
-                    ),  # all other value types were excluded already
+                    breakdown_value=self._breakdown_filter.breakdown,
                     breakdown_type=self._breakdown_filter.breakdown_type,
+                    normalize_url=self._breakdown_filter.breakdown_normalize_url,
                     lookup_value=str(
                         lookup_values
                     ),  # numeric values are only in cohorts, so it's a safe convertion here
@@ -265,6 +265,7 @@ class Breakdown:
         breakdown_value: str,
         breakdown_type: BreakdownType | MultipleBreakdownType | None,
         lookup_value: str,
+        normalize_url: bool | None = None,
         histogram_bin_count: int | None = None,
         group_type_index: int | None = None,
     ):
@@ -325,7 +326,7 @@ class Breakdown:
                 raise ValueError("Breakdown value must be a valid JSON array if the the bin count is selected.")
 
         return ast.CompareOperation(
-            left=self.get_replace_null_values_transform(left),
+            left=self._get_breakdown_values_transform(left, normalize_url=normalize_url),
             op=ast.CompareOperationOp.Eq,
             right=ast.Constant(value=lookup_value),
         )


### PR DESCRIPTION
## Problem

When we were making a query for the Actors modal, we weren't normalizing the URL paths in the actors query when the setting was turned on. This was causing inconsistencies between the data shown in the actor modal and the data shown in the charts.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Does this work well for both Cloud and self-hosted?

<!-- Yes / no / it doesn't have an impact. -->

## How did you test this code?
Added a test for it.
